### PR TITLE
Add Docker + GitHub Actions deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,15 @@ jobs:
     outputs:
       image: ${{ steps.meta.outputs.tags }}
       digest: ${{ steps.push.outputs.digest }}
+      image_name: ${{ steps.lowercase.outputs.image_name }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Lowercase image name
+        id: lowercase
+        run: |
+          echo "image_name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -66,8 +73,8 @@ jobs:
           port: ${{ secrets.SSH_PORT || 22 }}
           script: |
             cd ${{ secrets.DEPLOY_PATH }}
-            IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" \
+            IMAGE="${{ env.REGISTRY }}/${{ needs.build-and-push.outputs.image_name }}@${{ needs.build-and-push.outputs.digest }}" \
               docker compose pull
-            IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" \
+            IMAGE="${{ env.REGISTRY }}/${{ needs.build-and-push.outputs.image_name }}@${{ needs.build-and-push.outputs.digest }}" \
               docker compose up -d --remove-orphans
             docker image prune -f

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,13 +80,15 @@ jobs:
           echo "$SSH_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           trap 'rm -f ~/.ssh/id_rsa' EXIT
-          echo "$SSH_HOST_KEY" >> ~/.ssh/known_hosts
+          printf '%s\n' "$SSH_HOST_KEY" >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
           ssh -i ~/.ssh/id_rsa -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" "
             set -e
             mkdir -p ~/${GITHUB_REPOSITORY##*/}
             cd ~/${GITHUB_REPOSITORY##*/}
-            printf 'TELEGRAM_BOT_TOKEN=%s\nTELEGRAM_USER_ID=%s\n' '$TELEGRAM_BOT_TOKEN' '$TELEGRAM_USER_ID' > .env
-            IMAGE='$IMAGE' docker compose pull
-            IMAGE='$IMAGE' docker compose up -d --remove-orphans
+            printf 'TELEGRAM_BOT_TOKEN=%s\nTELEGRAM_USER_ID=%s\n' \"$TELEGRAM_BOT_TOKEN\" \"$TELEGRAM_USER_ID\" > .env
+            chmod 600 .env
+            IMAGE=\"$IMAGE\" docker compose pull
+            IMAGE=\"$IMAGE\" docker compose up -d --remove-orphans
             docker image prune -f
           "

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,15 +64,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     environment: production
-    env:
-      SSH_USER: ${{ secrets.SSH_USER }}
-      DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
     steps:
       - name: Deploy via SSH
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-          SSH_PORT: ${{ secrets.SSH_PORT || '22' }}
+          SSH_HOST: ${{ vars.SSH_HOST }}
+          SSH_PORT: ${{ vars.SSH_PORT || '22' }}
+          SSH_USER: ${{ vars.SSH_USER }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_USER_ID: ${{ secrets.TELEGRAM_USER_ID }}
           IMAGE: ${{ env.REGISTRY }}/${{ needs.build-and-push.outputs.image_name }}@${{ needs.build-and-push.outputs.digest }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy
 
 on:
-  push:
-    branches: [master]
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -34,8 +34,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,8 +80,10 @@ jobs:
           mkdir -p ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
+          trap 'rm -f ~/.ssh/id_rsa' EXIT
           ssh-keyscan -p "$SSH_PORT" -H "$SSH_HOST" >> ~/.ssh/known_hosts
           ssh -i ~/.ssh/id_rsa -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" "
+            set -e
             cd '$DEPLOY_PATH'
             printf 'TELEGRAM_BOT_TOKEN=%s\nTELEGRAM_USER_ID=%s\n' '$TELEGRAM_BOT_TOKEN' '$TELEGRAM_USER_ID' > .env
             IMAGE='$IMAGE' docker compose pull

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,10 +68,10 @@ jobs:
       - name: Deploy via SSH
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_HOST_KEY: ${{ secrets.SSH_HOST_KEY }}
           SSH_HOST: ${{ vars.SSH_HOST }}
           SSH_PORT: ${{ vars.SSH_PORT || '22' }}
           SSH_USER: ${{ vars.SSH_USER }}
-          DEPLOY_PATH: ${{ vars.DEPLOY_PATH }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_USER_ID: ${{ secrets.TELEGRAM_USER_ID }}
           IMAGE: ${{ env.REGISTRY }}/${{ needs.build-and-push.outputs.image_name }}@${{ needs.build-and-push.outputs.digest }}
@@ -80,10 +80,11 @@ jobs:
           echo "$SSH_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           trap 'rm -f ~/.ssh/id_rsa' EXIT
-          ssh-keyscan -p "$SSH_PORT" -H "$SSH_HOST" >> ~/.ssh/known_hosts
+          echo "$SSH_HOST_KEY" >> ~/.ssh/known_hosts
           ssh -i ~/.ssh/id_rsa -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" "
             set -e
-            cd '$DEPLOY_PATH'
+            mkdir -p ~/${GITHUB_REPOSITORY##*/}
+            cd ~/${GITHUB_REPOSITORY##*/}
             printf 'TELEGRAM_BOT_TOKEN=%s\nTELEGRAM_USER_ID=%s\n' '$TELEGRAM_BOT_TOKEN' '$TELEGRAM_USER_ID' > .env
             IMAGE='$IMAGE' docker compose pull
             IMAGE='$IMAGE' docker compose up -d --remove-orphans

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,18 +64,27 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     environment: production
+    env:
+      SSH_USER: ${{ secrets.SSH_USER }}
+      DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
     steps:
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          port: ${{ secrets.SSH_PORT || 22 }}
-          script: |
-            cd ${{ secrets.DEPLOY_PATH }}
-            IMAGE="${{ env.REGISTRY }}/${{ needs.build-and-push.outputs.image_name }}@${{ needs.build-and-push.outputs.digest }}" \
-              docker compose pull
-            IMAGE="${{ env.REGISTRY }}/${{ needs.build-and-push.outputs.image_name }}@${{ needs.build-and-push.outputs.digest }}" \
-              docker compose up -d --remove-orphans
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_PORT: ${{ secrets.SSH_PORT || '22' }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_USER_ID: ${{ secrets.TELEGRAM_USER_ID }}
+          IMAGE: ${{ env.REGISTRY }}/${{ needs.build-and-push.outputs.image_name }}@${{ needs.build-and-push.outputs.digest }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -p "$SSH_PORT" -H "$SSH_HOST" >> ~/.ssh/known_hosts
+          ssh -i ~/.ssh/id_rsa -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" "
+            cd '$DEPLOY_PATH'
+            printf 'TELEGRAM_BOT_TOKEN=%s\nTELEGRAM_USER_ID=%s\n' '$TELEGRAM_BOT_TOKEN' '$TELEGRAM_USER_ID' > .env
+            IMAGE='$IMAGE' docker compose pull
+            IMAGE='$IMAGE' docker compose up -d --remove-orphans
             docker image prune -f
+          "

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,73 @@
+name: Deploy
+
+on:
+  push:
+    branches: [master]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build & Push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.meta.outputs.tags }}
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    environment: production
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          port: ${{ secrets.SSH_PORT || 22 }}
+          script: |
+            cd ${{ secrets.DEPLOY_PATH }}
+            IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" \
+              docker compose pull
+            IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" \
+              docker compose up -d --remove-orphans
+            docker image prune -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1-alpine AS base
+FROM oven/bun:1-alpine@sha256:32f1fcccb1523960b254c4f80973bee1a910d60be000a45c20c9129a1efcffee AS base
 WORKDIR /app
 
 FROM base AS deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1-alpine AS base
+WORKDIR /app
+
+FROM base AS deps
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production
+
+FROM base AS final
+COPY --from=deps /app/node_modules ./node_modules
+COPY src ./src
+COPY package.json tsconfig.json ./
+
+ENV NODE_ENV=production
+
+CMD ["bun", "run", "src/index.ts"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   papai:
-    image: ${IMAGE:-ghcr.io/wKich/papai:latest}
+    image: ${IMAGE:-ghcr.io/wkich/papai:latest}
     restart: unless-stopped
     env_file:
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  papai:
+    image: ${IMAGE:-ghcr.io/wKich/papai:latest}
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      DB_PATH: /data/papai.db
+    volumes:
+      - papai-data:/data
+
+volumes:
+  papai-data:

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,8 @@ export const CONFIG_KEYS: readonly ConfigKey[] = [
 
 const SENSITIVE_KEYS: ReadonlySet<ConfigKey> = new Set(['linear_key', 'openai_key'])
 
-const db = new Database('papai.db')
+const DB_PATH = process.env['DB_PATH'] ?? 'papai.db'
+const db = new Database(DB_PATH)
 db.run('CREATE TABLE IF NOT EXISTS config (key TEXT PRIMARY KEY, value TEXT NOT NULL)')
 
 export function setConfig(key: ConfigKey, value: string): void {


### PR DESCRIPTION
- Dockerfile: multi-stage Bun image (deps → final), production-only install
- docker-compose.yml: service with named volume for SQLite persistence, IMAGE env var override
- src/config.ts: read DB_PATH from env (defaults to papai.db) for configurable db location
- .github/workflows/deploy.yml: on push to master — build & push to GHCR, then SSH deploy via docker compose pull + up

Required GitHub secrets: SSH_HOST, SSH_USER, SSH_PRIVATE_KEY, DEPLOY_PATH
Optional: SSH_PORT (defaults to 22)

https://claude.ai/code/session_01RXaeGHKy8pehc5KNssV6gX