### PR TITLE
feat: implement two-tier conversation history persistence

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -28,7 +28,8 @@
     {
       "files": ["tests/**/*.ts"],
       "rules": {
-        "max-lines-per-function": "off"
+        "max-lines-per-function": "off",
+        "max-lines": "off"
       }
     }
   ]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@
 
 ## Phase 3: Persistence & Context
 
-- [ ] [Database migration framework](docs/plans/2026-03-05-db-migrations.md) — lightweight versioned migration runner in `src/db/`, single shared `Database` instance, prerequisite for all schema changes
+- [x] [Database migration framework](docs/plans/2026-03-05-db-migrations.md) — lightweight versioned migration runner in `src/db/`, single shared `Database` instance, prerequisite for all schema changes
 - [x] [Conversation history persistence](docs/plans/2026-03-05-conversation-history-persistence.md) — SQLite-backed two-tier memory: smart-trimmed working window (50-100 messages, memory-model-selected) + rolling summary + structured Linear entity facts
 - [x] ~~User preference storage — default project, default priority~~ (Not planned)
 - [x] ~~Session continuity across bot restarts~~ (Covered by conversation history persistence)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@
 ## Phase 3: Persistence & Context
 
 - [ ] [Database migration framework](docs/plans/2026-03-05-db-migrations.md) — lightweight versioned migration runner in `src/db/`, single shared `Database` instance, prerequisite for all schema changes
-- [ ] [Conversation history persistence](docs/plans/2026-03-05-conversation-history-persistence.md) — two-tier memory: verbatim working window (50 messages) + rolling LLM summary + structured Linear entity facts, all in SQLite
+- [x] [Conversation history persistence](docs/plans/2026-03-05-conversation-history-persistence.md) — SQLite-backed two-tier memory: smart-trimmed working window (50-100 messages, memory-model-selected) + rolling summary + structured Linear entity facts
 - [x] ~~User preference storage — default project, default priority~~ (Not planned)
 - [x] ~~Session continuity across bot restarts~~ (Covered by conversation history persistence)
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -9,7 +9,7 @@ import { buildMessagesWithMemory, trimAndSummarise } from './conversation.js'
 import { getUserMessage, isAppError } from './errors.js'
 import { clearHistory, loadHistory, saveHistory } from './history.js'
 import { logger } from './logger.js'
-import { clearFacts, clearSummary, extractFactsFromSdkResults, loadFacts, upsertFact } from './memory.js'
+import { clearFacts, clearSummary, extractFactsFromSdkResults, upsertFact } from './memory.js'
 import { makeTools } from './tools/index.js'
 import { formatLlmOutput } from './utils/format.js'
 
@@ -74,18 +74,11 @@ const persistFactsFromResults = (
   const newFacts = extractFactsFromSdkResults(toolCalls, toolResults)
   if (newFacts.length === 0) return
 
-  const existingFacts = loadFacts(userId)
-  const existingById = new Map(existingFacts.map((f) => [f.identifier, f]))
-
-  let upsertCount = 0
   for (const fact of newFacts) {
-    // Always upsert to ensure metadata like `last_seen` is refreshed,
-    // even when title and URL have not changed.
     upsertFact(userId, fact)
-    upsertCount++
   }
 
-  log.info({ userId, factsExtracted: newFacts.length, factsUpserted: upsertCount }, 'Facts extracted and persisted')
+  log.info({ userId, factsExtracted: newFacts.length, factsUpserted: newFacts.length }, 'Facts extracted and persisted')
 }
 
 const callLlm = async (ctx: Context, userId: number, history: readonly ModelMessage[]): Promise<void> => {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -6,7 +6,19 @@ import { Bot, type Context } from 'grammy'
 
 import { CONFIG_KEYS, getAllConfig, getConfig, isConfigKey, maskValue, setConfig } from './config.js'
 import { getUserMessage, isAppError } from './errors.js'
+import { clearHistory, loadHistory, saveHistory } from './history.js'
 import { logger } from './logger.js'
+import {
+  buildMemoryContextMessage,
+  clearFacts,
+  clearSummary,
+  extractFacts,
+  loadFacts,
+  loadSummary,
+  saveSummary,
+  trimWithMemoryModel,
+  upsertFact,
+} from './memory.js'
 import { makeTools } from './tools/index.js'
 
 const log = logger.child({ scope: 'bot' })
@@ -33,8 +45,6 @@ If you need context (like project IDs), call list_projects first.`
 const bot = new Bot(process.env['TELEGRAM_BOT_TOKEN']!)
 const allowedUserId = parseInt(process.env['TELEGRAM_USER_ID']!, 10)
 
-const conversationHistory = new Map<number, readonly ModelMessage[]>()
-
 const checkAuthorization = (userId: number | undefined): userId is number => {
   log.debug({ userId, allowedUserId }, 'Checking authorization')
   if (userId === undefined || userId !== allowedUserId) {
@@ -48,27 +58,63 @@ const checkAuthorization = (userId: number | undefined): userId is number => {
 
 const getOrCreateHistory = (userId: number): readonly ModelMessage[] => {
   log.debug({ userId }, 'getOrCreateHistory called')
-  const existing = conversationHistory.has(userId)
-  log.debug(
-    { userId, exists: existing, currentSize: conversationHistory.get(userId)?.length },
-    'Getting conversation history',
-  )
-  if (!existing) {
-    conversationHistory.set(userId, [] as readonly ModelMessage[])
-    log.info({ userId }, 'New conversation history initialized')
-  }
-  return conversationHistory.get(userId)!
-}
-
-const trimHistory = (history: readonly ModelMessage[], userId: number): readonly ModelMessage[] => {
-  log.debug({ userId, historyLength: history.length }, 'trimHistory called')
-  if (history.length > 100) {
-    const removedCount = history.length - 100
-    const trimmed = history.slice(history.length - 100)
-    log.warn({ userId, removedCount, newSize: trimmed.length }, 'Conversation history truncated')
-    return trimmed
+  const history = loadHistory(userId)
+  log.debug({ userId, messageCount: history.length }, 'Conversation history loaded')
+  if (history.length === 0) {
+    log.info({ userId }, 'No existing conversation history')
   }
   return history
+}
+
+// Working memory limits
+const WORKING_MEMORY_CAP = 100
+const TRIM_MIN = 50
+const TRIM_MAX = 100
+const SMART_TRIM_INTERVAL = 10
+
+const trimAndSummarise = async (history: readonly ModelMessage[], userId: number): Promise<readonly ModelMessage[]> => {
+  log.debug({ userId, historyLength: history.length }, 'trimAndSummarise called')
+
+  const userMessageCount = history.filter((m) => m.role === 'user').length
+  const periodicTrim = userMessageCount > 0 && userMessageCount % SMART_TRIM_INTERVAL === 0 && history.length > TRIM_MIN
+  const hardCapTrim = history.length >= WORKING_MEMORY_CAP
+
+  if (!periodicTrim && !hardCapTrim) {
+    return history
+  }
+
+  const reason = hardCapTrim ? 'hard cap reached' : `periodic (${userMessageCount} user messages)`
+  log.warn({ userId, historyLength: history.length, reason }, 'Smart trim triggered')
+
+  const openaiKey = getConfig('openai_key')
+  const openaiBaseUrl = getConfig('openai_base_url')
+  const openaiModel = getConfig('openai_model')
+  // Use dedicated memory_model if configured; fall back to the main model.
+  const memoryModel = getConfig('memory_model') ?? openaiModel
+
+  if (openaiKey !== null && openaiBaseUrl !== null && memoryModel !== null) {
+    try {
+      const existing = loadSummary(userId)
+      const { trimmedMessages, summary } = await trimWithMemoryModel(history, TRIM_MIN, TRIM_MAX, existing, {
+        apiKey: openaiKey,
+        baseUrl: openaiBaseUrl,
+        model: memoryModel,
+      })
+      saveSummary(userId, summary)
+      log.info({ userId, retained: trimmedMessages.length }, 'Smart trim complete')
+      return trimmedMessages
+    } catch (error) {
+      log.warn(
+        { userId, error: error instanceof Error ? error.message : String(error) },
+        'Smart trim failed — falling back to positional slice',
+      )
+    }
+  } else {
+    log.warn({ userId }, 'LLM config not available — falling back to positional slice')
+  }
+
+  // Fallback: keep the most recent messages within hard limit
+  return history.slice(-WORKING_MEMORY_CAP)
 }
 
 const buildOpenAI = (apiKey: string, baseURL: string): ReturnType<typeof createOpenAICompatible> =>
@@ -91,18 +137,39 @@ const callLlm = async (ctx: Context, userId: number, history: readonly ModelMess
   const model = buildOpenAI(openaiKey, openaiBaseUrl)(openaiModel)
   const tools = makeTools({ linearKey, linearTeamId })
 
-  log.debug({ userId, historyLength: history.length }, 'Calling generateText')
+  // Inject Tier 2 memory context
+  const summary = loadSummary(userId)
+  const facts = loadFacts(userId)
+  const memoryMsg = buildMemoryContextMessage(summary, facts)
+  const messagesWithMemory = memoryMsg !== null ? [memoryMsg, ...history] : [...history]
+
+  log.debug({ userId, historyLength: history.length, hasMemory: memoryMsg !== null }, 'Calling generateText')
   const result = await generateText({
     model,
     system: SYSTEM_PROMPT,
-    messages: [...history],
+    messages: messagesWithMemory,
     tools,
     stopWhen: stepCountIs(25),
   })
 
   log.debug({ userId, toolCalls: result.toolCalls?.length, usage: result.usage }, 'LLM response received')
+
+  // Extract and persist facts from tool results
+  const toolCallEntries = result.toolCalls.map((tc) => ({
+    toolName: tc.toolName,
+    args: tc.args,
+  }))
+  const toolResultEntries = result.toolResults.map((tr) => ({ toolName: tr.toolName, result: tr.result }))
+  const newFacts = extractFacts(toolCallEntries, toolResultEntries)
+  for (const fact of newFacts) {
+    upsertFact(userId, fact)
+  }
+  if (newFacts.length > 0) {
+    log.info({ userId, factsExtracted: newFacts.length }, 'Facts extracted and persisted')
+  }
+
   const assistantText = result.text
-  conversationHistory.set(userId, [...history, ...result.response.messages])
+  saveHistory(userId, [...history, ...result.response.messages])
   await ctx.reply(assistantText || 'Done.')
   log.info(
     { userId, responseLength: assistantText?.length ?? 0, toolCalls: result.toolCalls?.length ?? 0 },
@@ -114,13 +181,13 @@ const processMessage = async (ctx: Context, userId: number, userText: string): P
   log.debug({ userId, userText }, 'processMessage called')
   log.info({ userId, messageLength: userText.length }, 'Message received from user')
 
-  const history = trimHistory([...getOrCreateHistory(userId), { role: 'user', content: userText }], userId)
-  conversationHistory.set(userId, history)
+  const history = await trimAndSummarise([...getOrCreateHistory(userId), { role: 'user', content: userText }], userId)
+  saveHistory(userId, history)
 
   try {
     await callLlm(ctx, userId, history)
   } catch (error) {
-    conversationHistory.set(userId, history.slice(0, -1))
+    saveHistory(userId, history.slice(0, -1))
 
     if (isAppError(error)) {
       const userMessage = getUserMessage(error)
@@ -195,6 +262,19 @@ bot.command('config', async (ctx) => {
   })
   log.info({ userId }, '/config command executed')
   await ctx.reply(lines.join('\n'))
+})
+
+bot.command('clear', async (ctx) => {
+  const userId = ctx.from?.id
+  if (!checkAuthorization(userId)) {
+    return
+  }
+  log.debug({ userId }, '/clear command called')
+  clearHistory(userId)
+  clearSummary(userId)
+  clearFacts(userId)
+  log.info({ userId }, '/clear command executed — all memory tiers cleared')
+  await ctx.reply('Conversation history and memory cleared.')
 })
 
 bot.on('message:text', async (ctx) => {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -12,7 +12,7 @@ import {
   buildMemoryContextMessage,
   clearFacts,
   clearSummary,
-  extractFacts,
+  extractFactsFromSdkResults,
   loadFacts,
   loadSummary,
   saveSummary,
@@ -120,9 +120,36 @@ const trimAndSummarise = async (history: readonly ModelMessage[], userId: number
 const buildOpenAI = (apiKey: string, baseURL: string): ReturnType<typeof createOpenAICompatible> =>
   createOpenAICompatible({ name: 'openai-compatible', apiKey, baseURL })
 
-const callLlm = async (ctx: Context, userId: number, history: readonly ModelMessage[]): Promise<void> => {
+const checkRequiredConfig = (): string[] => {
   const requiredKeys = ['openai_key', 'openai_base_url', 'openai_model', 'linear_key', 'linear_team_id'] as const
-  const missing = requiredKeys.filter((k) => getConfig(k) === null)
+  return requiredKeys.filter((k) => getConfig(k) === null)
+}
+
+type MessagesWithMemory = { messages: ModelMessage[]; memoryMsg: { role: 'system'; content: string } | null }
+
+const buildMessagesWithMemory = (userId: number, history: readonly ModelMessage[]): MessagesWithMemory => {
+  const summary = loadSummary(userId)
+  const facts = loadFacts(userId)
+  const memoryMsg = buildMemoryContextMessage(summary, facts)
+  return { messages: memoryMsg === null ? [...history] : [memoryMsg, ...history], memoryMsg }
+}
+
+const persistFactsFromResults = (
+  userId: number,
+  toolCalls: Array<{ toolName: string; input: unknown }>,
+  toolResults: Array<{ toolName: string; output: unknown }>,
+): void => {
+  const newFacts = extractFactsFromSdkResults(toolCalls, toolResults)
+  for (const fact of newFacts) {
+    upsertFact(userId, fact)
+  }
+  if (newFacts.length > 0) {
+    log.info({ userId, factsExtracted: newFacts.length }, 'Facts extracted and persisted')
+  }
+}
+
+const callLlm = async (ctx: Context, userId: number, history: readonly ModelMessage[]): Promise<void> => {
+  const missing = checkRequiredConfig()
   if (missing.length > 0) {
     log.warn({ userId, missing }, 'Missing required config keys')
     await ctx.reply(`Missing configuration: ${missing.join(', ')}.\nUse /set <key> <value> to configure.`)
@@ -137,11 +164,7 @@ const callLlm = async (ctx: Context, userId: number, history: readonly ModelMess
   const model = buildOpenAI(openaiKey, openaiBaseUrl)(openaiModel)
   const tools = makeTools({ linearKey, linearTeamId })
 
-  // Inject Tier 2 memory context
-  const summary = loadSummary(userId)
-  const facts = loadFacts(userId)
-  const memoryMsg = buildMemoryContextMessage(summary, facts)
-  const messagesWithMemory = memoryMsg !== null ? [memoryMsg, ...history] : [...history]
+  const { messages: messagesWithMemory, memoryMsg } = buildMessagesWithMemory(userId, history)
 
   log.debug({ userId, historyLength: history.length, hasMemory: memoryMsg !== null }, 'Calling generateText')
   const result = await generateText({
@@ -153,20 +176,7 @@ const callLlm = async (ctx: Context, userId: number, history: readonly ModelMess
   })
 
   log.debug({ userId, toolCalls: result.toolCalls?.length, usage: result.usage }, 'LLM response received')
-
-  // Extract and persist facts from tool results
-  const toolCallEntries = result.toolCalls.map((tc) => ({
-    toolName: tc.toolName,
-    args: tc.args,
-  }))
-  const toolResultEntries = result.toolResults.map((tr) => ({ toolName: tr.toolName, result: tr.result }))
-  const newFacts = extractFacts(toolCallEntries, toolResultEntries)
-  for (const fact of newFacts) {
-    upsertFact(userId, fact)
-  }
-  if (newFacts.length > 0) {
-    log.info({ userId, factsExtracted: newFacts.length }, 'Facts extracted and persisted')
-  }
+  persistFactsFromResults(userId, result.toolCalls, result.toolResults)
 
   const assistantText = result.text
   saveHistory(userId, [...history, ...result.response.messages])

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -5,20 +5,11 @@ import { type ModelMessage } from 'ai'
 import { Bot, type Context } from 'grammy'
 
 import { CONFIG_KEYS, getAllConfig, getConfig, isConfigKey, maskValue, setConfig } from './config.js'
+import { buildMessagesWithMemory, trimAndSummarise } from './conversation.js'
 import { getUserMessage, isAppError } from './errors.js'
 import { clearHistory, loadHistory, saveHistory } from './history.js'
 import { logger } from './logger.js'
-import {
-  buildMemoryContextMessage,
-  clearFacts,
-  clearSummary,
-  extractFactsFromSdkResults,
-  loadFacts,
-  loadSummary,
-  saveSummary,
-  trimWithMemoryModel,
-  upsertFact,
-} from './memory.js'
+import { clearFacts, clearSummary, extractFactsFromSdkResults, loadFacts, upsertFact } from './memory.js'
 import { makeTools } from './tools/index.js'
 import { formatLlmOutput } from './utils/format.js'
 
@@ -67,57 +58,6 @@ const getOrCreateHistory = (userId: number): readonly ModelMessage[] => {
   return history
 }
 
-// Working memory limits
-const WORKING_MEMORY_CAP = 100
-const TRIM_MIN = 50
-const TRIM_MAX = 100
-const SMART_TRIM_INTERVAL = 10
-
-const trimAndSummarise = async (history: readonly ModelMessage[], userId: number): Promise<readonly ModelMessage[]> => {
-  log.debug({ userId, historyLength: history.length }, 'trimAndSummarise called')
-
-  const userMessageCount = history.filter((m) => m.role === 'user').length
-  const periodicTrim = userMessageCount > 0 && userMessageCount % SMART_TRIM_INTERVAL === 0 && history.length > TRIM_MIN
-  const hardCapTrim = history.length >= WORKING_MEMORY_CAP
-
-  if (!periodicTrim && !hardCapTrim) {
-    return history
-  }
-
-  const reason = hardCapTrim ? 'hard cap reached' : `periodic (${userMessageCount} user messages)`
-  log.warn({ userId, historyLength: history.length, reason }, 'Smart trim triggered')
-
-  const openaiKey = getConfig('openai_key')
-  const openaiBaseUrl = getConfig('openai_base_url')
-  const openaiModel = getConfig('openai_model')
-  // Use dedicated memory_model if configured; fall back to the main model.
-  const memoryModel = getConfig('memory_model') ?? openaiModel
-
-  if (openaiKey !== null && openaiBaseUrl !== null && memoryModel !== null) {
-    try {
-      const existing = loadSummary(userId)
-      const { trimmedMessages, summary } = await trimWithMemoryModel(history, TRIM_MIN, TRIM_MAX, existing, {
-        apiKey: openaiKey,
-        baseUrl: openaiBaseUrl,
-        model: memoryModel,
-      })
-      saveSummary(userId, summary)
-      log.info({ userId, retained: trimmedMessages.length }, 'Smart trim complete')
-      return trimmedMessages
-    } catch (error) {
-      log.warn(
-        { userId, error: error instanceof Error ? error.message : String(error) },
-        'Smart trim failed — falling back to positional slice',
-      )
-    }
-  } else {
-    log.warn({ userId }, 'LLM config not available — falling back to positional slice')
-  }
-
-  // Fallback: keep the most recent messages within hard limit
-  return history.slice(-WORKING_MEMORY_CAP)
-}
-
 const buildOpenAI = (apiKey: string, baseURL: string): ReturnType<typeof createOpenAICompatible> =>
   createOpenAICompatible({ name: 'openai-compatible', apiKey, baseURL })
 
@@ -126,27 +66,27 @@ const checkRequiredConfig = (): string[] => {
   return requiredKeys.filter((k) => getConfig(k) === null)
 }
 
-type MessagesWithMemory = { messages: ModelMessage[]; memoryMsg: { role: 'system'; content: string } | null }
-
-const buildMessagesWithMemory = (userId: number, history: readonly ModelMessage[]): MessagesWithMemory => {
-  const summary = loadSummary(userId)
-  const facts = loadFacts(userId)
-  const memoryMsg = buildMemoryContextMessage(summary, facts)
-  return { messages: memoryMsg === null ? [...history] : [memoryMsg, ...history], memoryMsg }
-}
-
 const persistFactsFromResults = (
   userId: number,
   toolCalls: Array<{ toolName: string; input: unknown }>,
   toolResults: Array<{ toolName: string; output: unknown }>,
 ): void => {
   const newFacts = extractFactsFromSdkResults(toolCalls, toolResults)
+  if (newFacts.length === 0) return
+
+  const existingFacts = loadFacts(userId)
+  const existingById = new Map(existingFacts.map((f) => [f.identifier, f]))
+
+  let upsertCount = 0
   for (const fact of newFacts) {
-    upsertFact(userId, fact)
+    const existing = existingById.get(fact.identifier)
+    if (existing === undefined || existing.title !== fact.title || existing.url !== fact.url) {
+      upsertFact(userId, fact)
+      upsertCount++
+    }
   }
-  if (newFacts.length > 0) {
-    log.info({ userId, factsExtracted: newFacts.length }, 'Facts extracted and persisted')
-  }
+
+  log.info({ userId, factsExtracted: newFacts.length, factsUpserted: upsertCount }, 'Facts extracted and persisted')
 }
 
 const callLlm = async (ctx: Context, userId: number, history: readonly ModelMessage[]): Promise<void> => {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -79,11 +79,10 @@ const persistFactsFromResults = (
 
   let upsertCount = 0
   for (const fact of newFacts) {
-    const existing = existingById.get(fact.identifier)
-    if (existing === undefined || existing.title !== fact.title || existing.url !== fact.url) {
-      upsertFact(userId, fact)
-      upsertCount++
-    }
+    // Always upsert to ensure metadata like `last_seen` is refreshed,
+    // even when title and URL have not changed.
+    upsertFact(userId, fact)
+    upsertCount++
   }
 
   log.info({ userId, factsExtracted: newFacts.length, factsUpserted: upsertCount }, 'Facts extracted and persisted')

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,13 @@ import { logger } from './logger.js'
 
 const log = logger.child({ scope: 'config' })
 
-export type ConfigKey = 'linear_key' | 'linear_team_id' | 'openai_key' | 'openai_base_url' | 'openai_model'
+export type ConfigKey =
+  | 'linear_key'
+  | 'linear_team_id'
+  | 'openai_key'
+  | 'openai_base_url'
+  | 'openai_model'
+  | 'memory_model'
 
 export const CONFIG_KEYS: readonly ConfigKey[] = [
   'linear_key',
@@ -11,6 +17,7 @@ export const CONFIG_KEYS: readonly ConfigKey[] = [
   'openai_key',
   'openai_base_url',
   'openai_model',
+  'memory_model',
 ]
 
 const SENSITIVE_KEYS: ReadonlySet<ConfigKey> = new Set(['linear_key', 'openai_key'])

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -1,0 +1,71 @@
+import { type ModelMessage } from 'ai'
+
+import { getConfig } from './config.js'
+import { logger } from './logger.js'
+import { buildMemoryContextMessage, loadFacts, loadSummary, saveSummary, trimWithMemoryModel } from './memory.js'
+
+const log = logger.child({ scope: 'conversation' })
+
+// Working memory limits - based on typical LLM context window constraints
+// WORKING_MEMORY_CAP: Hard ceiling to prevent unbounded token growth (100 messages ≈ 10-20k tokens)
+// TRIM_MIN/TRIM_MAX: Range for smart trim - keeps enough context (50) while allowing flexibility (100)
+// SMART_TRIM_INTERVAL: Trigger trim every N user messages to balance cost vs. relevance
+const WORKING_MEMORY_CAP = 100
+const TRIM_MIN = 50
+const TRIM_MAX = 100
+const SMART_TRIM_INTERVAL = 10
+
+type MessagesWithMemory = { messages: ModelMessage[]; memoryMsg: { role: 'system'; content: string } | null }
+
+export const buildMessagesWithMemory = (userId: number, history: readonly ModelMessage[]): MessagesWithMemory => {
+  const summary = loadSummary(userId)
+  const facts = loadFacts(userId)
+  const memoryMsg = buildMemoryContextMessage(summary, facts)
+  return { messages: memoryMsg === null ? [...history] : [memoryMsg, ...history], memoryMsg }
+}
+
+export const trimAndSummarise = async (
+  history: readonly ModelMessage[],
+  userId: number,
+): Promise<readonly ModelMessage[]> => {
+  log.debug({ userId, historyLength: history.length }, 'trimAndSummarise called')
+
+  const userMessageCount = history.filter((m) => m.role === 'user').length
+  const periodicTrim = userMessageCount > 0 && userMessageCount % SMART_TRIM_INTERVAL === 0 && history.length > TRIM_MIN
+  const hardCapTrim = history.length >= WORKING_MEMORY_CAP
+
+  if (!periodicTrim && !hardCapTrim) {
+    return history
+  }
+
+  const reason = hardCapTrim ? 'hard cap reached' : `periodic (${userMessageCount} user messages)`
+  log.warn({ userId, historyLength: history.length, reason }, 'Smart trim triggered')
+
+  const openaiKey = getConfig('openai_key')
+  const openaiBaseUrl = getConfig('openai_base_url')
+  const openaiModel = getConfig('openai_model')
+  const memoryModel = getConfig('memory_model') ?? openaiModel
+
+  if (openaiKey !== null && openaiBaseUrl !== null && memoryModel !== null) {
+    try {
+      const existing = loadSummary(userId)
+      const { trimmedMessages, summary } = await trimWithMemoryModel(history, TRIM_MIN, TRIM_MAX, existing, {
+        apiKey: openaiKey,
+        baseUrl: openaiBaseUrl,
+        model: memoryModel,
+      })
+      saveSummary(userId, summary)
+      log.info({ userId, retained: trimmedMessages.length }, 'Smart trim complete')
+      return trimmedMessages
+    } catch (error) {
+      log.warn(
+        { userId, error: error instanceof Error ? error.message : String(error) },
+        'Smart trim failed — falling back to positional slice',
+      )
+    }
+  } else {
+    log.warn({ userId }, 'LLM config not available — falling back to positional slice')
+  }
+
+  return history.slice(-WORKING_MEMORY_CAP)
+}

--- a/src/db/migrations/002_conversation_history.ts
+++ b/src/db/migrations/002_conversation_history.ts
@@ -30,5 +30,11 @@ export const migration002ConversationHistory: Migration = {
         PRIMARY KEY (user_id, identifier)
       )
     `)
+
+    // Composite index for efficient lookup of user's facts sorted by last_seen
+    db.run(`
+      CREATE INDEX IF NOT EXISTS idx_memory_facts_user_lastseen
+      ON memory_facts(user_id, last_seen DESC)
+    `)
   },
 }

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,0 +1,58 @@
+import { type ModelMessage } from 'ai'
+
+import { getDb } from './db/index.js'
+import { logger } from './logger.js'
+
+const log = logger.child({ scope: 'history' })
+
+// Minimal validation — we trust our own serialisation but guard against corrupt rows.
+const isMessageArray = (value: unknown): value is ModelMessage[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'object' && item !== null && 'role' in item)
+
+export function loadHistory(userId: number): readonly ModelMessage[] {
+  log.debug({ userId }, 'loadHistory called')
+  const row = getDb()
+    .query<{ messages: string }, [number]>('SELECT messages FROM conversation_history WHERE user_id = ?')
+    .get(userId)
+
+  if (row === null) {
+    log.debug({ userId }, 'No persisted history found')
+    return []
+  }
+
+  if (typeof row.messages !== 'string') {
+    log.warn({ userId }, 'Corrupt history row — resetting')
+    return []
+  }
+
+  try {
+    const raw: unknown = JSON.parse(row.messages)
+    if (!isMessageArray(raw)) {
+      log.warn({ userId }, 'Invalid history format — resetting')
+      return []
+    }
+    log.info({ userId, messageCount: raw.length }, 'History loaded')
+    return raw
+  } catch (error) {
+    log.warn(
+      { userId, error: error instanceof Error ? error.message : String(error) },
+      'Failed to parse history JSON — resetting',
+    )
+    return []
+  }
+}
+
+export function saveHistory(userId: number, messages: readonly ModelMessage[]): void {
+  log.debug({ userId, messageCount: messages.length }, 'saveHistory called')
+  getDb().run('INSERT OR REPLACE INTO conversation_history (user_id, messages) VALUES (?, ?)', [
+    userId,
+    JSON.stringify(messages),
+  ])
+  log.info({ userId, messageCount: messages.length }, 'History saved')
+}
+
+export function clearHistory(userId: number): void {
+  log.debug({ userId }, 'clearHistory called')
+  getDb().run('DELETE FROM conversation_history WHERE user_id = ?', [userId])
+  log.info({ userId }, 'History cleared')
+}

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,0 +1,246 @@
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import { generateObject } from 'ai'
+import { type ModelMessage } from 'ai'
+import { z } from 'zod'
+
+import { getDb } from './db/index.js'
+import { logger } from './logger.js'
+
+const log = logger.child({ scope: 'memory' })
+
+const FACTS_CAP = 50
+
+export type MemoryFact = {
+  readonly identifier: string
+  readonly title: string
+  readonly url: string
+  readonly last_seen: string
+}
+
+export type ModelConfig = {
+  readonly apiKey: string
+  readonly baseUrl: string
+  readonly model: string
+}
+
+// --- Summary persistence ---
+
+export function loadSummary(userId: number): string | null {
+  log.debug({ userId }, 'loadSummary called')
+  const row = getDb()
+    .query<{ summary: string }, [number]>('SELECT summary FROM memory_summary WHERE user_id = ?')
+    .get(userId)
+  return row?.summary ?? null
+}
+
+export function saveSummary(userId: number, summary: string): void {
+  log.debug({ userId, summaryLength: summary.length }, 'saveSummary called')
+  getDb().run('INSERT OR REPLACE INTO memory_summary (user_id, summary, updated_at) VALUES (?, ?, ?)', [
+    userId,
+    summary,
+    new Date().toISOString(),
+  ])
+  log.info({ userId, summaryLength: summary.length }, 'Summary saved')
+}
+
+export function clearSummary(userId: number): void {
+  log.debug({ userId }, 'clearSummary called')
+  getDb().run('DELETE FROM memory_summary WHERE user_id = ?', [userId])
+  log.info({ userId }, 'Summary cleared')
+}
+
+// --- Fact persistence ---
+
+export function loadFacts(userId: number): readonly MemoryFact[] {
+  log.debug({ userId }, 'loadFacts called')
+  const rows = getDb()
+    .query<MemoryFact, [number]>(
+      'SELECT identifier, title, url, last_seen FROM memory_facts WHERE user_id = ? ORDER BY last_seen DESC',
+    )
+    .all(userId)
+  return rows
+}
+
+export function upsertFact(userId: number, fact: Omit<MemoryFact, 'last_seen'>): void {
+  log.debug({ userId, identifier: fact.identifier }, 'upsertFact called')
+  const now = new Date().toISOString()
+  getDb().run(
+    'INSERT OR REPLACE INTO memory_facts (user_id, identifier, title, url, last_seen) VALUES (?, ?, ?, ?, ?)',
+    [userId, fact.identifier, fact.title, fact.url, now],
+  )
+  // Evict oldest facts beyond cap
+  getDb().run(
+    `DELETE FROM memory_facts WHERE user_id = ? AND identifier NOT IN (
+      SELECT identifier FROM memory_facts WHERE user_id = ? ORDER BY last_seen DESC LIMIT ?
+    )`,
+    [userId, userId, FACTS_CAP],
+  )
+  log.info({ userId, identifier: fact.identifier }, 'Fact upserted')
+}
+
+export function clearFacts(userId: number): void {
+  log.debug({ userId }, 'clearFacts called')
+  getDb().run('DELETE FROM memory_facts WHERE user_id = ?', [userId])
+  log.info({ userId }, 'Facts cleared')
+}
+
+// --- Rule-based fact extraction ---
+
+type ToolCallEntry = { toolName: string; args: unknown }
+type ToolResultEntry = { toolName: string; result: unknown }
+
+const IssueResultSchema = z.looseObject({
+  identifier: z.string(),
+  title: z.string().optional(),
+  url: z.string().optional(),
+})
+
+export function extractFacts(
+  _toolCalls: readonly ToolCallEntry[],
+  toolResults: readonly ToolResultEntry[],
+): readonly Omit<MemoryFact, 'last_seen'>[] {
+  const facts: Omit<MemoryFact, 'last_seen'>[] = []
+
+  for (const result of toolResults) {
+    if (['create_issue', 'update_issue', 'get_issue'].includes(result.toolName)) {
+      const parsed = IssueResultSchema.safeParse(result.result)
+      if (parsed.success) {
+        facts.push({
+          identifier: parsed.data.identifier,
+          title: parsed.data.title ?? parsed.data.identifier,
+          url: parsed.data.url ?? '',
+        })
+      }
+    }
+
+    if (result.toolName === 'search_issues') {
+      const items = z.array(IssueResultSchema).safeParse(result.result)
+      if (items.success) {
+        for (const item of items.data.slice(0, 3)) {
+          facts.push({
+            identifier: item.identifier,
+            title: item.title ?? item.identifier,
+            url: item.url ?? '',
+          })
+        }
+      }
+    }
+  }
+
+  return facts
+}
+
+// --- Smart trimming with memory model ---
+
+const TrimResultSchema = z.object({
+  keep_indices: z.array(z.number().int().nonnegative()),
+  summary: z.string(),
+})
+
+export type TrimResult = {
+  readonly trimmedMessages: readonly ModelMessage[]
+  readonly summary: string
+}
+
+const TRIM_PROMPT = `You are a conversation memory manager. The following conversation history has grown too long ({TOTAL} messages).
+
+Your task:
+1. Select between 50 and 100 message indices (0-based) to retain verbatim. Choose fewer (~50) when many threads are resolved and the history is repetitive. Choose more (~100) when conversations are active and many topics are still open. Prefer messages about active unresolved Linear issues, recent decisions, ongoing threads, and stated preferences. Drop messages about completed tasks, resolved clarifications, and abandoned threads.
+2. Write an updated summary (max 200 words) for all messages NOT retained. Incorporate the previous summary. Preserve: issue identifiers (e.g. ENG-42), project names, decisions, priorities, preferences.
+
+Previous summary:
+{PREVIOUS_SUMMARY}
+
+Conversation (index: [role] content):
+{MESSAGES}
+
+Return JSON exactly matching the schema.`
+
+export async function trimWithMemoryModel(
+  history: readonly ModelMessage[],
+  trimMin: number,
+  trimMax: number,
+  previousSummary: string | null,
+  config: ModelConfig,
+): Promise<TrimResult> {
+  log.debug(
+    { messageCount: history.length, trimMin, trimMax, hasPrevious: previousSummary !== null },
+    'trimWithMemoryModel called',
+  )
+
+  const model = createOpenAICompatible({
+    name: 'openai-compatible',
+    apiKey: config.apiKey,
+    baseURL: config.baseUrl,
+  })(config.model)
+
+  const messagesText = history
+    .map((m, i) => `${i}: [${m.role}] ${typeof m.content === 'string' ? m.content : JSON.stringify(m.content)}`)
+    .join('\n')
+
+  const prompt = TRIM_PROMPT.replace(/\{TOTAL\}/g, String(history.length))
+    .replace('{PREVIOUS_SUMMARY}', previousSummary ?? '(none)')
+    .replace('{MESSAGES}', messagesText)
+
+  const result = await generateObject({
+    model,
+    schema: TrimResultSchema,
+    prompt,
+  })
+
+  let selected = [...new Set(result.object.keep_indices)]
+    .filter((i) => i >= 0 && i < history.length)
+    .sort((a, b) => a - b)
+
+  // Clamp to [trimMin, trimMax]: if too few, pad with most-recent messages not already selected
+  if (selected.length > trimMax) {
+    selected = selected.slice(selected.length - trimMax)
+  } else if (selected.length < trimMin) {
+    const selectedSet = new Set(selected)
+    const candidates = Array.from({ length: history.length }, (_, i) => i)
+      .filter((i) => !selectedSet.has(i))
+      .reverse()
+    for (const i of candidates) {
+      if (selected.length >= trimMin) break
+      selected.push(i)
+    }
+    selected.sort((a, b) => a - b)
+  }
+
+  const trimmedMessages = selected.map((i) => history[i]!)
+
+  log.info(
+    {
+      retained: trimmedMessages.length,
+      dropped: history.length - trimmedMessages.length,
+      summaryLength: result.object.summary.length,
+    },
+    'Memory model trim complete',
+  )
+
+  return { trimmedMessages, summary: result.object.summary }
+}
+
+// --- Context message builder ---
+
+export function buildMemoryContextMessage(
+  summary: string | null,
+  facts: readonly MemoryFact[],
+): { role: 'system'; content: string } | null {
+  const parts: string[] = []
+
+  if (summary !== null && summary.length > 0) {
+    parts.push(`Summary: ${summary}`)
+  }
+
+  if (facts.length > 0) {
+    const lines = facts.map((f) => `- ${f.identifier}: "${f.title}" — last seen ${f.last_seen.slice(0, 10)}`)
+    parts.push(`Recently accessed issues:\n${lines.join('\n')}`)
+  }
+
+  if (parts.length === 0) {
+    return null
+  }
+
+  return { role: 'system', content: `=== Memory context ===\n${parts.join('\n\n')}` }
+}

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -286,7 +286,7 @@ export function buildMemoryContextMessage(
 
   if (facts.length > 0) {
     const lines = facts.map((f) => `- ${f.identifier}: "${f.title}" — last seen ${f.last_seen.slice(0, 10)}`)
-    parts.push(`Recently accessed issues:\n${lines.join('\n')}`)
+    parts.push(`Recently accessed Linear entities:\n${lines.join('\n')}`)
   }
 
   if (parts.length === 0) {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -64,18 +64,30 @@ export function loadFacts(userId: number): readonly MemoryFact[] {
 export function upsertFact(userId: number, fact: Omit<MemoryFact, 'last_seen'>): void {
   log.debug({ userId, identifier: fact.identifier }, 'upsertFact called')
   const now = new Date().toISOString()
-  getDb().run(
-    'INSERT OR REPLACE INTO memory_facts (user_id, identifier, title, url, last_seen) VALUES (?, ?, ?, ?, ?)',
-    [userId, fact.identifier, fact.title, fact.url, now],
-  )
-  // Evict oldest facts beyond cap
-  getDb().run(
-    `DELETE FROM memory_facts WHERE user_id = ? AND identifier NOT IN (
-      SELECT identifier FROM memory_facts WHERE user_id = ? ORDER BY last_seen DESC LIMIT ?
-    )`,
-    [userId, userId, FACTS_CAP],
-  )
-  log.info({ userId, identifier: fact.identifier }, 'Fact upserted')
+  const db = getDb()
+
+  // Atomic transaction: insert/replace fact then evict oldest beyond cap
+  db.run('BEGIN TRANSACTION')
+  try {
+    db.run('INSERT OR REPLACE INTO memory_facts (user_id, identifier, title, url, last_seen) VALUES (?, ?, ?, ?, ?)', [
+      userId,
+      fact.identifier,
+      fact.title,
+      fact.url,
+      now,
+    ])
+    db.run(
+      `DELETE FROM memory_facts WHERE user_id = ? AND identifier NOT IN (
+        SELECT identifier FROM memory_facts WHERE user_id = ? ORDER BY last_seen DESC LIMIT ?
+      )`,
+      [userId, userId, FACTS_CAP],
+    )
+    db.run('COMMIT')
+    log.info({ userId, identifier: fact.identifier }, 'Fact upserted')
+  } catch (error) {
+    db.run('ROLLBACK')
+    throw error
+  }
 }
 
 export function clearFacts(userId: number): void {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,5 +1,5 @@
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
-import { generateObject } from 'ai'
+import { generateText, Output } from 'ai'
 import { type ModelMessage } from 'ai'
 import { z } from 'zod'
 
@@ -95,6 +95,12 @@ const IssueResultSchema = z.looseObject({
   url: z.string().optional(),
 })
 
+const ProjectResultSchema = z.looseObject({
+  id: z.string(),
+  name: z.string(),
+  url: z.string().optional(),
+})
+
 export function extractFacts(
   _toolCalls: readonly ToolCallEntry[],
   toolResults: readonly ToolResultEntry[],
@@ -125,9 +131,40 @@ export function extractFacts(
         }
       }
     }
+
+    if (result.toolName === 'create_project') {
+      const parsed = ProjectResultSchema.safeParse(result.result)
+      if (parsed.success) {
+        facts.push({
+          identifier: `proj:${parsed.data.id}`,
+          title: parsed.data.name,
+          url: parsed.data.url ?? '',
+        })
+      }
+    }
   }
 
   return facts
+}
+
+// Wrapper to accept SDK result types directly without unsafe assignments
+// SDK v5 uses input/output properties typed as any
+export function extractFactsFromSdkResults(
+  toolCalls: Array<{ toolName: string; input: unknown }>,
+  toolResults: Array<{ toolName: string; output: unknown }>,
+): readonly Omit<MemoryFact, 'last_seen'>[] {
+  // Map SDK types to internal types safely
+  const callEntries: ToolCallEntry[] = []
+  for (const tc of toolCalls) {
+    callEntries.push({ toolName: tc.toolName, args: tc.input })
+  }
+
+  const resultEntries: ToolResultEntry[] = []
+  for (const tr of toolResults) {
+    resultEntries.push({ toolName: tr.toolName, result: tr.output })
+  }
+
+  return extractFacts(callEntries, resultEntries)
 }
 
 // --- Smart trimming with memory model ---
@@ -156,6 +193,27 @@ Conversation (index: [role] content):
 
 Return JSON exactly matching the schema.`
 
+function clampIndices(selected: number[], trimMin: number, trimMax: number, historyLength: number): number[] {
+  if (selected.length > trimMax) {
+    return selected.slice(selected.length - trimMax)
+  }
+  if (selected.length < trimMin) {
+    const selectedSet = new Set(selected)
+    const candidates = Array.from({ length: historyLength }, (_, i) => i)
+      .filter((i) => !selectedSet.has(i))
+      .reverse()
+    for (const i of candidates) {
+      if (selected.length >= trimMin) break
+      selected.push(i)
+    }
+    selected.sort((a, b) => a - b)
+  }
+  return selected
+}
+
+const buildMemoryModel = (config: ModelConfig): ReturnType<ReturnType<typeof createOpenAICompatible>> =>
+  createOpenAICompatible({ name: 'openai-compatible', apiKey: config.apiKey, baseURL: config.baseUrl })(config.model)
+
 export async function trimWithMemoryModel(
   history: readonly ModelMessage[],
   trimMin: number,
@@ -168,12 +226,6 @@ export async function trimWithMemoryModel(
     'trimWithMemoryModel called',
   )
 
-  const model = createOpenAICompatible({
-    name: 'openai-compatible',
-    apiKey: config.apiKey,
-    baseURL: config.baseUrl,
-  })(config.model)
-
   const messagesText = history
     .map((m, i) => `${i}: [${m.role}] ${typeof m.content === 'string' ? m.content : JSON.stringify(m.content)}`)
     .join('\n')
@@ -182,43 +234,30 @@ export async function trimWithMemoryModel(
     .replace('{PREVIOUS_SUMMARY}', previousSummary ?? '(none)')
     .replace('{MESSAGES}', messagesText)
 
-  const result = await generateObject({
-    model,
-    schema: TrimResultSchema,
+  const result = await generateText({
+    model: buildMemoryModel(config),
+    output: Output.object({ schema: TrimResultSchema }),
     prompt,
   })
 
-  let selected = [...new Set(result.object.keep_indices)]
-    .filter((i) => i >= 0 && i < history.length)
-    .sort((a, b) => a - b)
-
-  // Clamp to [trimMin, trimMax]: if too few, pad with most-recent messages not already selected
-  if (selected.length > trimMax) {
-    selected = selected.slice(selected.length - trimMax)
-  } else if (selected.length < trimMin) {
-    const selectedSet = new Set(selected)
-    const candidates = Array.from({ length: history.length }, (_, i) => i)
-      .filter((i) => !selectedSet.has(i))
-      .reverse()
-    for (const i of candidates) {
-      if (selected.length >= trimMin) break
-      selected.push(i)
-    }
-    selected.sort((a, b) => a - b)
-  }
-
+  const selected = clampIndices(
+    [...new Set(result.output.keep_indices)].filter((i) => i >= 0 && i < history.length).sort((a, b) => a - b),
+    trimMin,
+    trimMax,
+    history.length,
+  )
   const trimmedMessages = selected.map((i) => history[i]!)
 
   log.info(
     {
       retained: trimmedMessages.length,
       dropped: history.length - trimmedMessages.length,
-      summaryLength: result.object.summary.length,
+      summaryLength: result.output.summary.length,
     },
     'Memory model trim complete',
   )
 
-  return { trimmedMessages, summary: result.object.summary }
+  return { trimmedMessages, summary: result.output.summary }
 }
 
 // --- Context message builder ---

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -21,7 +21,8 @@ describe('bot message formatting', () => {
     const result = formatLlmOutput('**bold** text')
     expect(result.text).toBe('bold text')
     expect(result.entities).toHaveLength(1)
-    expect(result.entities[0].type).toBe('bold')
+    const firstEntity = result.entities[0]!
+    expect(firstEntity.type).toBe('bold')
   })
 
   test('formatLlmOutput handles plain text', () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -139,9 +139,10 @@ describe('CONFIG_KEYS', () => {
     expect(CONFIG_KEYS).toContain('openai_key')
     expect(CONFIG_KEYS).toContain('openai_base_url')
     expect(CONFIG_KEYS).toContain('openai_model')
+    expect(CONFIG_KEYS).toContain('memory_model')
   })
 
   test('has correct length', () => {
-    expect(CONFIG_KEYS).toHaveLength(5)
+    expect(CONFIG_KEYS).toHaveLength(6)
   })
 })

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -23,7 +23,7 @@ class MockDatabase {
       return {
         get: (userId: number): { messages: string } | null => {
           const messages = mockStore.get(userId)
-          return messages !== undefined ? { messages } : null
+          return messages === undefined ? null : { messages }
         },
         all: (): unknown[] => [],
       }

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -91,7 +91,9 @@ describe('loadHistory', () => {
     expect(result).toHaveLength(1)
     const first = result[0]
     expect(first).toBeDefined()
-    expect('toolCalls' in first).toBe(true)
+    if (first !== undefined) {
+      expect('toolCalls' in first).toBe(true)
+    }
   })
 })
 

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -1,0 +1,141 @@
+import { mock, describe, expect, test, beforeEach } from 'bun:test'
+
+// --- bun:sqlite mock (must come before importing history.ts) ---
+const mockStore = new Map<number, string>()
+const runCalls: Array<{ sql: string; params?: unknown[] }> = []
+
+class MockDatabase {
+  run(sql: string, params?: unknown[]): void {
+    runCalls.push({ sql, params })
+    if (sql.includes('INSERT OR REPLACE INTO conversation_history') && params !== undefined) {
+      const userId = Number(params[0])
+      const messages = String(params[1])
+      mockStore.set(userId, messages)
+    }
+    if (sql.includes('DELETE FROM conversation_history') && params !== undefined) {
+      const userId = Number(params[0])
+      mockStore.delete(userId)
+    }
+  }
+
+  query(sql: string): { get: (userId: number) => { messages: string } | null; all: () => unknown[] } {
+    if (sql.includes('SELECT messages FROM conversation_history')) {
+      return {
+        get: (userId: number): { messages: string } | null => {
+          const messages = mockStore.get(userId)
+          return messages !== undefined ? { messages } : null
+        },
+        all: (): unknown[] => [],
+      }
+    }
+    return { get: (): null => null, all: (): unknown[] => [] }
+  }
+}
+
+const mockDb = new MockDatabase()
+
+void mock.module('../src/db/index.js', () => ({
+  getDb: (): MockDatabase => mockDb,
+  DB_PATH: ':memory:',
+  initDb: (): void => {},
+}))
+// --- end mock ---
+
+import type { ModelMessage } from 'ai'
+
+import { loadHistory, saveHistory, clearHistory } from '../src/history.js'
+
+describe('loadHistory', () => {
+  beforeEach(() => {
+    mockStore.clear()
+    runCalls.length = 0
+  })
+
+  test('returns empty array when no row exists', () => {
+    const result = loadHistory(999)
+    expect(result).toEqual([])
+  })
+
+  test('returns deserialised messages for valid row', () => {
+    const messages = [
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi there' },
+    ]
+    mockStore.set(1, JSON.stringify(messages))
+
+    const result = loadHistory(1)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({ role: 'user', content: 'hello' })
+    expect(result[1]).toEqual({ role: 'assistant', content: 'hi there' })
+  })
+
+  test('returns empty array for corrupt JSON', () => {
+    mockStore.set(2, 'not-valid-json')
+
+    const result = loadHistory(2)
+    expect(result).toEqual([])
+  })
+
+  test('returns empty array when messages lack role field', () => {
+    mockStore.set(3, JSON.stringify([{ content: 'no role' }]))
+
+    const result = loadHistory(3)
+    expect(result).toEqual([])
+  })
+
+  test('preserves extra fields', () => {
+    const messages = [{ role: 'assistant', content: 'hi', toolCalls: [{ id: '1' }] }]
+    mockStore.set(4, JSON.stringify(messages))
+
+    const result = loadHistory(4)
+    expect(result).toHaveLength(1)
+    const first = result[0]
+    expect(first).toBeDefined()
+    expect('toolCalls' in first).toBe(true)
+  })
+})
+
+describe('saveHistory', () => {
+  beforeEach(() => {
+    mockStore.clear()
+    runCalls.length = 0
+  })
+
+  test('persists messages as JSON', () => {
+    const messages: ModelMessage[] = [{ role: 'user', content: 'test' }]
+    saveHistory(10, messages)
+
+    const saved = mockStore.get(10)
+    expect(saved).toBeDefined()
+    expect(JSON.parse(saved!)).toEqual(messages)
+  })
+
+  test('calls INSERT OR REPLACE', () => {
+    const empty: ModelMessage[] = []
+    saveHistory(10, empty)
+
+    const insertCall = runCalls.find((c) => c.sql.includes('INSERT OR REPLACE INTO conversation_history'))
+    expect(insertCall).toBeDefined()
+  })
+})
+
+describe('clearHistory', () => {
+  beforeEach(() => {
+    mockStore.clear()
+    runCalls.length = 0
+  })
+
+  test('removes entry from store', () => {
+    mockStore.set(20, JSON.stringify([]))
+    clearHistory(20)
+    expect(mockStore.has(20)).toBe(false)
+  })
+
+  test('calls DELETE statement', () => {
+    clearHistory(20)
+
+    const deleteCall = runCalls.find((c) => c.sql.includes('DELETE FROM conversation_history'))
+    expect(deleteCall).toBeDefined()
+    expect(deleteCall!.params).toEqual([20])
+  })
+})

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -1,0 +1,326 @@
+import { mock, describe, expect, test, beforeEach } from 'bun:test'
+
+// --- bun:sqlite mock (must come before importing memory.ts) ---
+const mockSummaryStore = new Map<number, string>()
+const mockFactsStore = new Map<string, Array<{ identifier: string; title: string; url: string; last_seen: string }>>()
+const runCalls: Array<{ sql: string; params?: unknown[] }> = []
+
+class MockDatabase {
+  run(sql: string, params?: unknown[]): void {
+    runCalls.push({ sql, params })
+    if (sql.includes('INSERT OR REPLACE INTO memory_summary') && params !== undefined) {
+      mockSummaryStore.set(Number(params[0]), String(params[1]))
+    }
+    if (sql.includes('DELETE FROM memory_summary') && params !== undefined) {
+      mockSummaryStore.delete(Number(params[0]))
+    }
+    if (sql.includes('DELETE FROM memory_facts') && !sql.includes('NOT IN') && params !== undefined) {
+      mockFactsStore.delete(String(params[0]))
+    }
+  }
+
+  query(sql: string): {
+    get: (userId: number) => { summary: string } | null
+    all: (userId?: number) => unknown[]
+  } {
+    if (sql.includes('SELECT summary FROM memory_summary')) {
+      return {
+        get: (userId: number): { summary: string } | null => {
+          const s = mockSummaryStore.get(userId)
+          if (s === undefined) return null
+          return { summary: s }
+        },
+        all: (): unknown[] => [],
+      }
+    }
+    if (sql.includes('SELECT identifier, title')) {
+      return {
+        get: (): null => null,
+        all: (userId?: number): unknown[] => {
+          if (userId === undefined) return []
+          return mockFactsStore.get(String(userId)) ?? []
+        },
+      }
+    }
+    return { get: (): null => null, all: (): unknown[] => [] }
+  }
+}
+
+const mockDb = new MockDatabase()
+
+void mock.module('../src/db/index.js', () => ({
+  getDb: (): MockDatabase => mockDb,
+  DB_PATH: ':memory:',
+  initDb: (): void => {},
+}))
+
+type GenerateObjectResult = { object: { keep_indices: number[]; summary: string } }
+
+let generateObjectImpl = (): Promise<GenerateObjectResult> =>
+  Promise.resolve({ object: { keep_indices: [0, 1], summary: 'Updated summary text' } })
+
+void mock.module('ai', () => ({
+  generateObject: (..._args: unknown[]): Promise<GenerateObjectResult> => generateObjectImpl(),
+}))
+// --- end mocks ---
+
+import {
+  buildMemoryContextMessage,
+  extractFacts,
+  loadSummary,
+  saveSummary,
+  clearSummary,
+  clearFacts,
+  trimWithMemoryModel,
+} from '../src/memory.js'
+
+describe('loadSummary', () => {
+  beforeEach(() => {
+    mockSummaryStore.clear()
+    runCalls.length = 0
+  })
+
+  test('returns null when no row exists', () => {
+    expect(loadSummary(999)).toBeNull()
+  })
+
+  test('returns summary string when row exists', () => {
+    mockSummaryStore.set(1, 'Previous conversation summary')
+    expect(loadSummary(1)).toBe('Previous conversation summary')
+  })
+})
+
+describe('saveSummary', () => {
+  beforeEach(() => {
+    mockSummaryStore.clear()
+    runCalls.length = 0
+  })
+
+  test('persists summary', () => {
+    saveSummary(1, 'Test summary')
+    expect(mockSummaryStore.get(1)).toBe('Test summary')
+  })
+
+  test('calls INSERT OR REPLACE', () => {
+    saveSummary(1, 'Test')
+    const call = runCalls.find((c) => c.sql.includes('INSERT OR REPLACE INTO memory_summary'))
+    expect(call).toBeDefined()
+  })
+})
+
+describe('clearSummary', () => {
+  beforeEach(() => {
+    mockSummaryStore.clear()
+    runCalls.length = 0
+  })
+
+  test('removes summary', () => {
+    mockSummaryStore.set(1, 'Summary')
+    clearSummary(1)
+    expect(mockSummaryStore.has(1)).toBe(false)
+  })
+})
+
+describe('clearFacts', () => {
+  beforeEach(() => {
+    mockFactsStore.clear()
+    runCalls.length = 0
+  })
+
+  test('calls DELETE on memory_facts', () => {
+    clearFacts(1)
+    const call = runCalls.find((c) => c.sql.includes('DELETE FROM memory_facts') && !c.sql.includes('NOT IN'))
+    expect(call).toBeDefined()
+    expect(call!.params).toEqual([1])
+  })
+})
+
+describe('buildMemoryContextMessage', () => {
+  test('returns null when both summary and facts are empty', () => {
+    expect(buildMemoryContextMessage(null, [])).toBeNull()
+  })
+
+  test('returns null for empty string summary and no facts', () => {
+    expect(buildMemoryContextMessage('', [])).toBeNull()
+  })
+
+  test('returns system message with summary only', () => {
+    const result = buildMemoryContextMessage('User created ENG-42', [])
+    expect(result).not.toBeNull()
+    expect(result!.role).toBe('system')
+    expect(result!.content).toContain('Summary: User created ENG-42')
+    expect(result!.content).toContain('=== Memory context ===')
+  })
+
+  test('returns system message with facts only', () => {
+    const facts = [
+      {
+        identifier: 'ENG-42',
+        title: 'Fix login',
+        url: 'https://linear.app/ENG-42',
+        last_seen: '2026-03-01T00:00:00Z',
+      },
+    ]
+    const result = buildMemoryContextMessage(null, facts)
+    expect(result).not.toBeNull()
+    expect(result!.content).toContain('ENG-42')
+    expect(result!.content).toContain('Fix login')
+    expect(result!.content).toContain('Recently accessed issues')
+  })
+
+  test('returns combined message with both summary and facts', () => {
+    const facts = [{ identifier: 'ENG-42', title: 'Fix login', url: '', last_seen: '2026-03-01T00:00:00Z' }]
+    const result = buildMemoryContextMessage('Previous summary', facts)
+    expect(result).not.toBeNull()
+    expect(result!.content).toContain('Summary: Previous summary')
+    expect(result!.content).toContain('ENG-42')
+  })
+
+  test('formats last_seen date as YYYY-MM-DD', () => {
+    const facts = [{ identifier: 'ENG-1', title: 'Test', url: '', last_seen: '2026-03-05T14:30:00Z' }]
+    const result = buildMemoryContextMessage(null, facts)
+    expect(result!.content).toContain('last seen 2026-03-05')
+  })
+})
+
+describe('extractFacts', () => {
+  test('extracts fact from create_issue result', () => {
+    const results = [
+      {
+        toolName: 'create_issue',
+        result: { identifier: 'ENG-42', title: 'New issue', url: 'https://linear.app/ENG-42' },
+      },
+    ]
+    const facts = extractFacts([], results)
+    expect(facts).toHaveLength(1)
+    expect(facts[0]!.identifier).toBe('ENG-42')
+    expect(facts[0]!.title).toBe('New issue')
+    expect(facts[0]!.url).toBe('https://linear.app/ENG-42')
+  })
+
+  test('extracts fact from update_issue result', () => {
+    const results = [{ toolName: 'update_issue', result: { identifier: 'ENG-38', url: 'https://linear.app/ENG-38' } }]
+    const facts = extractFacts([], results)
+    expect(facts).toHaveLength(1)
+    expect(facts[0]!.identifier).toBe('ENG-38')
+    // no title → falls back to identifier
+    expect(facts[0]!.title).toBe('ENG-38')
+  })
+
+  test('extracts fact from get_issue result', () => {
+    const results = [{ toolName: 'get_issue', result: { identifier: 'ENG-10', title: 'Details', url: '' } }]
+    const facts = extractFacts([], results)
+    expect(facts).toHaveLength(1)
+    expect(facts[0]!.identifier).toBe('ENG-10')
+  })
+
+  test('extracts up to 3 facts from search_issues result', () => {
+    const items = [
+      { identifier: 'ENG-1', title: 'A' },
+      { identifier: 'ENG-2', title: 'B' },
+      { identifier: 'ENG-3', title: 'C' },
+      { identifier: 'ENG-4', title: 'D' },
+    ]
+    const results = [{ toolName: 'search_issues', result: items }]
+    const facts = extractFacts([], results)
+    expect(facts).toHaveLength(3)
+    expect(facts.map((f) => f.identifier)).toEqual(['ENG-1', 'ENG-2', 'ENG-3'])
+  })
+
+  test('returns empty array for unknown tool', () => {
+    const results = [{ toolName: 'unknown_tool', result: { identifier: 'X' } }]
+    const facts = extractFacts([], results)
+    expect(facts).toEqual([])
+  })
+
+  test('returns empty array for malformed result', () => {
+    const results = [{ toolName: 'create_issue', result: { no_identifier: true } }]
+    const facts = extractFacts([], results)
+    expect(facts).toEqual([])
+  })
+})
+
+describe('trimWithMemoryModel', () => {
+  const makeMessages = (count: number): Array<{ role: 'user' | 'assistant'; content: string }> =>
+    Array.from({ length: count }, (_, i) => ({
+      role: i % 2 === 0 ? ('user' as const) : ('assistant' as const),
+      content: `Message ${i}`,
+    }))
+
+  test('returns trimmed messages and summary', async () => {
+    const history = makeMessages(5)
+    generateObjectImpl = (): Promise<GenerateObjectResult> =>
+      Promise.resolve({ object: { keep_indices: [0, 2, 4], summary: 'Test summary' } })
+
+    const result = await trimWithMemoryModel(history, 2, 10, null, {
+      apiKey: 'key',
+      baseUrl: 'http://localhost',
+      model: 'test-model',
+    })
+
+    expect(result.trimmedMessages).toHaveLength(3)
+    expect(result.trimmedMessages[0]).toEqual(history[0])
+    expect(result.trimmedMessages[1]).toEqual(history[2])
+    expect(result.trimmedMessages[2]).toEqual(history[4])
+    expect(result.summary).toBe('Test summary')
+  })
+
+  test('filters out-of-range indices', async () => {
+    const history = makeMessages(3)
+    generateObjectImpl = (): Promise<GenerateObjectResult> =>
+      Promise.resolve({ object: { keep_indices: [0, 1, 99], summary: 'Summary' } })
+
+    const result = await trimWithMemoryModel(history, 1, 10, null, {
+      apiKey: 'key',
+      baseUrl: 'http://localhost',
+      model: 'test-model',
+    })
+
+    // 99 is out of range — filtered out
+    expect(result.trimmedMessages).toHaveLength(2)
+  })
+
+  test('deduplicates indices', async () => {
+    const history = makeMessages(5)
+    generateObjectImpl = (): Promise<GenerateObjectResult> =>
+      Promise.resolve({ object: { keep_indices: [1, 1, 2], summary: 'Summary' } })
+
+    const result = await trimWithMemoryModel(history, 1, 10, null, {
+      apiKey: 'key',
+      baseUrl: 'http://localhost',
+      model: 'test-model',
+    })
+
+    expect(result.trimmedMessages).toHaveLength(2)
+    expect(result.trimmedMessages[0]).toEqual(history[1])
+    expect(result.trimmedMessages[1]).toEqual(history[2])
+  })
+
+  test('pads to trimMin when model returns too few indices', async () => {
+    const history = makeMessages(10)
+    generateObjectImpl = (): Promise<GenerateObjectResult> =>
+      Promise.resolve({ object: { keep_indices: [0, 1], summary: 'Summary' } })
+
+    const result = await trimWithMemoryModel(history, 5, 10, null, {
+      apiKey: 'key',
+      baseUrl: 'http://localhost',
+      model: 'test-model',
+    })
+
+    expect(result.trimmedMessages.length).toBeGreaterThanOrEqual(5)
+  })
+
+  test('caps at trimMax when model returns too many indices', async () => {
+    const history = makeMessages(10)
+    generateObjectImpl = (): Promise<GenerateObjectResult> =>
+      Promise.resolve({ object: { keep_indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], summary: 'Summary' } })
+
+    const result = await trimWithMemoryModel(history, 1, 3, null, {
+      apiKey: 'key',
+      baseUrl: 'http://localhost',
+      model: 'test-model',
+    })
+
+    expect(result.trimmedMessages).toHaveLength(3)
+  })
+})

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -14,6 +14,30 @@ class MockDatabase {
     if (sql.includes('DELETE FROM memory_summary') && params !== undefined) {
       mockSummaryStore.delete(Number(params[0]))
     }
+    if (sql.includes('INSERT OR REPLACE INTO memory_facts') && params !== undefined) {
+      const userId = String(params[0])
+      const fact = {
+        identifier: String(params[1]),
+        title: String(params[2]),
+        url: String(params[3]),
+        last_seen: String(params[4]),
+      }
+      const existing = mockFactsStore.get(userId) ?? []
+      const filtered = existing.filter((f) => f.identifier !== fact.identifier)
+      filtered.push(fact)
+      mockFactsStore.set(userId, filtered)
+    }
+    if (sql.includes('DELETE FROM memory_facts') && sql.includes('NOT IN') && params !== undefined) {
+      const userId = String(params[0])
+      const cap = Number(params[2])
+      const facts = mockFactsStore.get(userId) ?? []
+      if (facts.length > cap) {
+        // Sort by last_seen DESC and keep only top 'cap' facts
+        const sorted = facts.sort((a, b) => b.last_seen.localeCompare(a.last_seen))
+        const toKeep = sorted.slice(0, cap)
+        mockFactsStore.set(userId, toKeep)
+      }
+    }
     if (sql.includes('DELETE FROM memory_facts') && !sql.includes('NOT IN') && params !== undefined) {
       mockFactsStore.delete(String(params[0]))
     }
@@ -38,7 +62,9 @@ class MockDatabase {
         get: (): null => null,
         all: (userId?: number): unknown[] => {
           if (userId === undefined) return []
-          return mockFactsStore.get(String(userId)) ?? []
+          const facts = mockFactsStore.get(String(userId)) ?? []
+          // Sort by last_seen DESC as real DB would
+          return facts.sort((a, b) => b.last_seen.localeCompare(a.last_seen))
         },
       }
     }
@@ -54,13 +80,14 @@ void mock.module('../src/db/index.js', () => ({
   initDb: (): void => {},
 }))
 
-type GenerateObjectResult = { object: { keep_indices: number[]; summary: string } }
+type GenerateTextResult = { output: { keep_indices: number[]; summary: string } }
 
-let generateObjectImpl = (): Promise<GenerateObjectResult> =>
-  Promise.resolve({ object: { keep_indices: [0, 1], summary: 'Updated summary text' } })
+let generateTextImpl = (): Promise<GenerateTextResult> =>
+  Promise.resolve({ output: { keep_indices: [0, 1], summary: 'Updated summary text' } })
 
 void mock.module('ai', () => ({
-  generateObject: (..._args: unknown[]): Promise<GenerateObjectResult> => generateObjectImpl(),
+  generateText: (..._args: unknown[]): Promise<GenerateTextResult> => generateTextImpl(),
+  Output: { object: ({ schema }: { schema: unknown }): { schema: unknown } => ({ schema }) },
 }))
 // --- end mocks ---
 
@@ -69,6 +96,8 @@ import {
   extractFacts,
   loadSummary,
   saveSummary,
+  loadFacts,
+  upsertFact,
   clearSummary,
   clearFacts,
   trimWithMemoryModel,
@@ -238,6 +267,91 @@ describe('extractFacts', () => {
     const facts = extractFacts([], results)
     expect(facts).toEqual([])
   })
+
+  test('extracts fact from create_project result', () => {
+    const results = [
+      {
+        toolName: 'create_project',
+        result: { id: 'proj-123', name: 'Backend Migration', url: 'https://linear.app/project/proj-123' },
+      },
+    ]
+    const facts = extractFacts([], results)
+    expect(facts).toHaveLength(1)
+    expect(facts[0]!.identifier).toBe('proj:proj-123')
+    expect(facts[0]!.title).toBe('Backend Migration')
+    expect(facts[0]!.url).toBe('https://linear.app/project/proj-123')
+  })
+
+  test('extracts create_project fact without url', () => {
+    const results = [{ toolName: 'create_project', result: { id: 'proj-456', name: 'Frontend Refactor' } }]
+    const facts = extractFacts([], results)
+    expect(facts).toHaveLength(1)
+    expect(facts[0]!.identifier).toBe('proj:proj-456')
+    expect(facts[0]!.title).toBe('Frontend Refactor')
+    expect(facts[0]!.url).toBe('')
+  })
+
+  test('ignores malformed create_project result', () => {
+    const results = [{ toolName: 'create_project', result: { no_id: true, name: 'Test' } }]
+    const facts = extractFacts([], results)
+    expect(facts).toEqual([])
+  })
+})
+
+describe('upsertFact eviction', () => {
+  beforeEach(() => {
+    mockFactsStore.clear()
+    mockSummaryStore.clear()
+    runCalls.length = 0
+  })
+
+  test('evicts oldest facts when exceeding FACTS_CAP', () => {
+    const userId = 999
+    // Insert 52 facts (over the 50 cap)
+    for (let i = 0; i < 52; i++) {
+      upsertFact(userId, {
+        identifier: `ENG-${i}`,
+        title: `Issue ${i}`,
+        url: `https://linear.app/ENG-${i}`,
+      })
+    }
+
+    const facts = loadFacts(userId)
+    // Should be capped at 50 (FACTS_CAP)
+    expect(facts).toHaveLength(50)
+    // Verify the facts are returned sorted by last_seen DESC
+    for (let i = 1; i < facts.length; i++) {
+      expect(facts[i]!.last_seen <= facts[i - 1]!.last_seen).toBe(true)
+    }
+
+    // Cleanup
+    clearFacts(userId)
+  })
+
+  test('updates last_seen on duplicate fact insert', () => {
+    const userId = 999
+    const fact = { identifier: 'ENG-100', title: 'Test Issue', url: '' }
+
+    upsertFact(userId, fact)
+    const firstLoad = loadFacts(userId)
+    const firstSeen = firstLoad[0]!.last_seen
+
+    // Small delay to ensure different timestamp
+    const start = Date.now()
+    while (Date.now() - start < 10) {
+      // busy wait
+    }
+
+    upsertFact(userId, fact)
+    const secondLoad = loadFacts(userId)
+    const secondSeen = secondLoad[0]!.last_seen
+
+    expect(secondSeen).not.toBe(firstSeen)
+    expect(secondLoad).toHaveLength(1)
+
+    // Cleanup
+    clearFacts(userId)
+  })
 })
 
 describe('trimWithMemoryModel', () => {
@@ -249,8 +363,8 @@ describe('trimWithMemoryModel', () => {
 
   test('returns trimmed messages and summary', async () => {
     const history = makeMessages(5)
-    generateObjectImpl = (): Promise<GenerateObjectResult> =>
-      Promise.resolve({ object: { keep_indices: [0, 2, 4], summary: 'Test summary' } })
+    generateTextImpl = (): Promise<GenerateTextResult> =>
+      Promise.resolve({ output: { keep_indices: [0, 2, 4], summary: 'Test summary' } })
 
     const result = await trimWithMemoryModel(history, 2, 10, null, {
       apiKey: 'key',
@@ -267,8 +381,8 @@ describe('trimWithMemoryModel', () => {
 
   test('filters out-of-range indices', async () => {
     const history = makeMessages(3)
-    generateObjectImpl = (): Promise<GenerateObjectResult> =>
-      Promise.resolve({ object: { keep_indices: [0, 1, 99], summary: 'Summary' } })
+    generateTextImpl = (): Promise<GenerateTextResult> =>
+      Promise.resolve({ output: { keep_indices: [0, 1, 99], summary: 'Summary' } })
 
     const result = await trimWithMemoryModel(history, 1, 10, null, {
       apiKey: 'key',
@@ -282,8 +396,8 @@ describe('trimWithMemoryModel', () => {
 
   test('deduplicates indices', async () => {
     const history = makeMessages(5)
-    generateObjectImpl = (): Promise<GenerateObjectResult> =>
-      Promise.resolve({ object: { keep_indices: [1, 1, 2], summary: 'Summary' } })
+    generateTextImpl = (): Promise<GenerateTextResult> =>
+      Promise.resolve({ output: { keep_indices: [1, 1, 2], summary: 'Summary' } })
 
     const result = await trimWithMemoryModel(history, 1, 10, null, {
       apiKey: 'key',
@@ -298,8 +412,8 @@ describe('trimWithMemoryModel', () => {
 
   test('pads to trimMin when model returns too few indices', async () => {
     const history = makeMessages(10)
-    generateObjectImpl = (): Promise<GenerateObjectResult> =>
-      Promise.resolve({ object: { keep_indices: [0, 1], summary: 'Summary' } })
+    generateTextImpl = (): Promise<GenerateTextResult> =>
+      Promise.resolve({ output: { keep_indices: [0, 1], summary: 'Summary' } })
 
     const result = await trimWithMemoryModel(history, 5, 10, null, {
       apiKey: 'key',
@@ -312,8 +426,8 @@ describe('trimWithMemoryModel', () => {
 
   test('caps at trimMax when model returns too many indices', async () => {
     const history = makeMessages(10)
-    generateObjectImpl = (): Promise<GenerateObjectResult> =>
-      Promise.resolve({ object: { keep_indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], summary: 'Summary' } })
+    generateTextImpl = (): Promise<GenerateTextResult> =>
+      Promise.resolve({ output: { keep_indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], summary: 'Summary' } })
 
     const result = await trimWithMemoryModel(history, 1, 3, null, {
       apiKey: 'key',

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -328,7 +328,7 @@ describe('upsertFact eviction', () => {
     clearFacts(userId)
   })
 
-  test('updates last_seen on duplicate fact insert', () => {
+  test('updates last_seen on duplicate fact insert', async () => {
     const userId = 999
     const fact = { identifier: 'ENG-100', title: 'Test Issue', url: '' }
 
@@ -337,10 +337,7 @@ describe('upsertFact eviction', () => {
     const firstSeen = firstLoad[0]!.last_seen
 
     // Small delay to ensure different timestamp
-    const start = Date.now()
-    while (Date.now() - start < 10) {
-      // busy wait
-    }
+    await Bun.sleep(10)
 
     upsertFact(userId, fact)
     const secondLoad = loadFacts(userId)


### PR DESCRIPTION
Replace in-memory conversation history with SQLite-backed persistence:

Tier 1 (working memory): Verbatim message history in conversation_history table with smart trimming via memory model (50-100 messages retained based on topical relevance) every 10 user messages, hard cap at 100.

Tier 2 (long-term memory): Rolling prose summary in memory_summary table updated on each trim, plus structured Linear entity facts extracted rule-based from tool results (create/update/get/search issues).

Both tiers injected as synthetic system message on every LLM call.

- Add src/history.ts — load/save/clear conversation history
- Add src/memory.ts — summary, facts, smart trimming, context builder
- Update src/bot.ts — replace Map with SQLite persistence, /clear command
- Add memory_model config key for dedicated trim model
- Add tests for history and memory modules (138 tests, 0 failures)

https://claude.ai/code/session_012NuQRewbrV1xmP2ATm3246