### PR TITLE
feat: announce new version to users with Kaneo accounts on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "papai",
+  "version": "3.2.0",
   "private": true,
   "description": "papai — an intelligent Telegram bot for managing Kaneo tasks with LLM.",
   "type": "module",

--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -25,12 +25,16 @@ function isVersionAnnounced(version: string): boolean {
   return row !== null
 }
 
-function markVersionAnnounced(version: string): void {
-  getDb().run('INSERT OR IGNORE INTO version_announcements (version, announced_at) VALUES (?, ?)', [
+function markVersionAnnounced(version: string): boolean {
+  const result = getDb().run('INSERT OR IGNORE INTO version_announcements (version, announced_at) VALUES (?, ?)', [
     version,
     new Date().toISOString(),
   ])
-  log.info({ version }, 'Version marked as announced')
+  const inserted = typeof result.changes === 'number' ? result.changes > 0 : false
+  if (inserted) {
+    log.info({ version }, 'Version marked as announced')
+  }
+  return inserted
 }
 
 function getUsersWithKaneoAccount(): number[] {
@@ -42,11 +46,6 @@ function getUsersWithKaneoAccount(): number[] {
 
 export async function announceNewVersion(): Promise<void> {
   log.debug({ version: VERSION }, 'Checking if version announcement is needed')
-
-  if (isVersionAnnounced(VERSION)) {
-    log.debug({ version: VERSION }, 'Version already announced, skipping')
-    return
-  }
 
   let changelogContent: string
   try {
@@ -66,6 +65,12 @@ export async function announceNewVersion(): Promise<void> {
   if (users.length === 0) {
     log.info({ version: VERSION }, 'No users with Kaneo account, skipping announcement')
     markVersionAnnounced(VERSION)
+    return
+  }
+
+  const claimed = markVersionAnnounced(VERSION)
+  if (!claimed) {
+    log.debug({ version: VERSION }, 'Version already announced, skipping')
     return
   }
 
@@ -89,6 +94,5 @@ export async function announceNewVersion(): Promise<void> {
     }
   }
 
-  markVersionAnnounced(VERSION)
   log.info({ version: VERSION, successCount, totalUsers: users.length }, 'Version announcement complete')
 }

--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -1,13 +1,14 @@
+import packageJson from '../package.json' with { type: 'json' }
 import { bot } from './bot.js'
+import { readChangelogFile } from './changelog-reader.js'
 import { getDb } from './db/index.js'
 import { logger } from './logger.js'
-import packageJson from '../package.json' with { type: 'json' }
 
 const log = logger.child({ scope: 'announcements' })
 
 const VERSION: string = packageJson.version
 
-function extractChangelogSection(version: string, content: string): string | null {
+export function extractChangelogSection(version: string, content: string): string | null {
   const lines = content.split('\n')
   const headerPrefix = `## [${version}]`
   const startIdx = lines.findIndex((line) => line.startsWith(headerPrefix))
@@ -16,13 +17,6 @@ function extractChangelogSection(version: string, content: string): string | nul
   const endIdx = lines.findIndex((line, idx) => idx > startIdx && line.startsWith('## ['))
   const sectionLines = endIdx === -1 ? lines.slice(startIdx + 1) : lines.slice(startIdx + 1, endIdx)
   return sectionLines.join('\n').trim()
-}
-
-function isVersionAnnounced(version: string): boolean {
-  const row = getDb()
-    .query<{ version: string }, [string]>('SELECT version FROM version_announcements WHERE version = ?')
-    .get(version)
-  return row !== null
 }
 
 function markVersionAnnounced(version: string): boolean {
@@ -49,7 +43,7 @@ export async function announceNewVersion(): Promise<void> {
 
   let changelogContent: string
   try {
-    changelogContent = await Bun.file(new URL('../CHANGELOG.md', import.meta.url)).text()
+    changelogContent = await readChangelogFile()
   } catch (error) {
     log.warn({ error: error instanceof Error ? error.message : String(error) }, 'Could not read CHANGELOG.md')
     return

--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -1,7 +1,8 @@
+import packageJson from '../package.json' with { type: 'json' }
 import { bot } from './bot.js'
 import { getDb } from './db/index.js'
 import { logger } from './logger.js'
-import packageJson from '../package.json' with { type: 'json' }
+import { formatLlmOutput } from './utils/format.js'
 
 const log = logger.child({ scope: 'announcements' })
 
@@ -16,13 +17,6 @@ function extractChangelogSection(version: string, content: string): string | nul
   const endIdx = lines.findIndex((line, idx) => idx > startIdx && line.startsWith('## ['))
   const sectionLines = endIdx === -1 ? lines.slice(startIdx + 1) : lines.slice(startIdx + 1, endIdx)
   return sectionLines.join('\n').trim()
-}
-
-function isVersionAnnounced(version: string): boolean {
-  const row = getDb()
-    .query<{ version: string }, [string]>('SELECT version FROM version_announcements WHERE version = ?')
-    .get(version)
-  return row !== null
 }
 
 function markVersionAnnounced(version: string): boolean {
@@ -77,13 +71,12 @@ export async function announceNewVersion(): Promise<void> {
   log.info({ version: VERSION, userCount: users.length }, 'Sending version announcement to users')
 
   const message = `🆕 papai v${VERSION} has been released!\n\n${changelogSection}`
-  const MAX_LENGTH = 4096
-  const truncated = message.length > MAX_LENGTH ? `${message.slice(0, MAX_LENGTH - 3)}...` : message
+  const formatted = formatLlmOutput(message)
 
   let successCount = 0
   for (const userId of users) {
     try {
-      await bot.api.sendMessage(userId, truncated)
+      await bot.api.sendMessage(userId, formatted.text, { entities: formatted.entities })
       successCount++
       log.debug({ userId, version: VERSION }, 'Announcement sent to user')
     } catch (error) {

--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -1,0 +1,94 @@
+import { bot } from './bot.js'
+import { getDb } from './db/index.js'
+import { logger } from './logger.js'
+import packageJson from '../package.json' with { type: 'json' }
+
+const log = logger.child({ scope: 'announcements' })
+
+const VERSION: string = packageJson.version
+
+function extractChangelogSection(version: string, content: string): string | null {
+  const lines = content.split('\n')
+  const headerPrefix = `## [${version}]`
+  const startIdx = lines.findIndex((line) => line.startsWith(headerPrefix))
+  if (startIdx === -1) return null
+
+  const endIdx = lines.findIndex((line, idx) => idx > startIdx && line.startsWith('## ['))
+  const sectionLines = endIdx === -1 ? lines.slice(startIdx + 1) : lines.slice(startIdx + 1, endIdx)
+  return sectionLines.join('\n').trim()
+}
+
+function isVersionAnnounced(version: string): boolean {
+  const row = getDb()
+    .query<{ version: string }, [string]>('SELECT version FROM version_announcements WHERE version = ?')
+    .get(version)
+  return row !== null
+}
+
+function markVersionAnnounced(version: string): void {
+  getDb().run('INSERT OR IGNORE INTO version_announcements (version, announced_at) VALUES (?, ?)', [
+    version,
+    new Date().toISOString(),
+  ])
+  log.info({ version }, 'Version marked as announced')
+}
+
+function getUsersWithKaneoAccount(): number[] {
+  return getDb()
+    .query<{ user_id: number }, [string]>('SELECT DISTINCT user_id FROM user_config WHERE key = ?')
+    .all('kaneo_apikey')
+    .map((row) => row.user_id)
+}
+
+export async function announceNewVersion(): Promise<void> {
+  log.debug({ version: VERSION }, 'Checking if version announcement is needed')
+
+  if (isVersionAnnounced(VERSION)) {
+    log.debug({ version: VERSION }, 'Version already announced, skipping')
+    return
+  }
+
+  let changelogContent: string
+  try {
+    changelogContent = await Bun.file(new URL('../CHANGELOG.md', import.meta.url)).text()
+  } catch (error) {
+    log.warn({ error: error instanceof Error ? error.message : String(error) }, 'Could not read CHANGELOG.md')
+    return
+  }
+
+  const changelogSection = extractChangelogSection(VERSION, changelogContent)
+  if (changelogSection === null) {
+    log.warn({ version: VERSION }, 'No changelog section found for version, skipping announcement')
+    return
+  }
+
+  const users = getUsersWithKaneoAccount()
+  if (users.length === 0) {
+    log.info({ version: VERSION }, 'No users with Kaneo account, skipping announcement')
+    markVersionAnnounced(VERSION)
+    return
+  }
+
+  log.info({ version: VERSION, userCount: users.length }, 'Sending version announcement to users')
+
+  const message = `🆕 papai v${VERSION} has been released!\n\n${changelogSection}`
+  const MAX_LENGTH = 4096
+  const truncated = message.length > MAX_LENGTH ? `${message.slice(0, MAX_LENGTH - 3)}...` : message
+
+  let successCount = 0
+  for (const userId of users) {
+    try {
+      await bot.api.sendMessage(userId, truncated)
+      successCount++
+      log.debug({ userId, version: VERSION }, 'Announcement sent to user')
+    } catch (error) {
+      log.warn(
+        { userId, version: VERSION, error: error instanceof Error ? error.message : String(error) },
+        'Failed to send announcement to user',
+      )
+    }
+  }
+
+  markVersionAnnounced(VERSION)
+  log.info({ version: VERSION, successCount, totalUsers: users.length }, 'Version announcement complete')
+}

--- a/src/changelog-reader.ts
+++ b/src/changelog-reader.ts
@@ -1,0 +1,3 @@
+export function readChangelogFile(): Promise<string> {
+  return Bun.file(new URL('../CHANGELOG.md', import.meta.url)).text()
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -7,6 +7,7 @@ import { migration002ConversationHistory } from './migrations/002_conversation_h
 import { migration003MultiuserSupport } from './migrations/003_multiuser_support.js'
 import { migration004KaneoWorkspace } from './migrations/004_kaneo_workspace.js'
 import { migration005RenameConfigKeys } from './migrations/005_rename_config_keys.js'
+import { migration006VersionAnnouncements } from './migrations/006_version_announcements.js'
 
 export const DB_PATH = process.env['DB_PATH'] ?? 'papai.db'
 
@@ -39,6 +40,7 @@ const MIGRATIONS = [
   migration003MultiuserSupport,
   migration004KaneoWorkspace,
   migration005RenameConfigKeys,
+  migration006VersionAnnouncements,
 ] as const
 
 export const initDb = (): void => {

--- a/src/db/migrations/006_version_announcements.ts
+++ b/src/db/migrations/006_version_announcements.ts
@@ -1,0 +1,15 @@
+import type { Database } from 'bun:sqlite'
+
+import type { Migration } from '../migrate.js'
+
+export const migration006VersionAnnouncements: Migration = {
+  id: '006_version_announcements',
+  up(db: Database): void {
+    db.run(`
+      CREATE TABLE IF NOT EXISTS version_announcements (
+        version TEXT PRIMARY KEY,
+        announced_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `)
+  },
+}

--- a/src/db/migrations/006_version_announcements.ts
+++ b/src/db/migrations/006_version_announcements.ts
@@ -8,7 +8,7 @@ export const migration006VersionAnnouncements: Migration = {
     db.run(`
       CREATE TABLE IF NOT EXISTS version_announcements (
         version TEXT PRIMARY KEY,
-        announced_at TEXT NOT NULL DEFAULT (datetime('now'))
+        announced_at TEXT NOT NULL
       )
     `)
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { announceNewVersion } from './announcements.js'
 import { bot } from './bot.js'
 import { setCommands } from './commands/index.js'
 import { closeDb, initDb } from './db/index.js'
@@ -36,6 +37,7 @@ void bot.start({
   onStart: () => {
     log.info('papai is running and listening for messages.')
     void setCommands(bot, adminId)
+    void announceNewVersion()
   },
 })
 

--- a/tests/announcements.test.ts
+++ b/tests/announcements.test.ts
@@ -1,0 +1,232 @@
+import { mock, describe, expect, test, beforeEach } from 'bun:test'
+
+// --- Mock for db (must come before importing announcements.ts) ---
+const announcedVersions = new Set<string>()
+const userConfigRows: Array<{ user_id: number }> = []
+
+class MockDatabase {
+  run(sql: string, params?: (string | number | null)[]): { changes: number } {
+    if (sql.includes('INSERT OR IGNORE INTO version_announcements') && params !== undefined) {
+      const version = String(params[0])
+      if (announcedVersions.has(version)) {
+        return { changes: 0 }
+      }
+      announcedVersions.add(version)
+      return { changes: 1 }
+    }
+    return { changes: 0 }
+  }
+
+  query(sql: string): {
+    get: (...args: (string | number)[]) => Record<string, unknown> | null
+    all: (...args: (string | number)[]) => Array<Record<string, unknown>>
+  } {
+    if (sql.includes('SELECT DISTINCT user_id FROM user_config')) {
+      return {
+        get: (): null => null,
+        all: (): Array<Record<string, unknown>> => userConfigRows,
+      }
+    }
+    return { get: (): null => null, all: (): Array<Record<string, unknown>> => [] }
+  }
+}
+
+const mockDb = new MockDatabase()
+
+void mock.module('../src/db/index.js', () => ({
+  getDb: (): MockDatabase => mockDb,
+  DB_PATH: ':memory:',
+  initDb: (): void => {},
+}))
+
+// --- Mock for bot: delegate to sendMessageImpl so tests can override behavior ---
+const sentMessages: Array<{ userId: number; text: string }> = []
+let sendMessageImpl: (userId: number, text: string) => Promise<void> = (
+  userId: number,
+  text: string,
+): Promise<void> => {
+  sentMessages.push({ userId, text })
+  return Promise.resolve()
+}
+
+void mock.module('../src/bot.js', () => ({
+  bot: {
+    api: {
+      sendMessage: (userId: number, text: string): Promise<void> => sendMessageImpl(userId, text),
+    },
+  },
+}))
+
+// --- Mock for changelog-reader (controlled per-test via changelogProvider) ---
+let changelogProvider: (() => Promise<string>) | null = null
+
+void mock.module('../src/changelog-reader.js', () => ({
+  readChangelogFile: (): Promise<string> => {
+    if (changelogProvider === null) {
+      return Promise.reject(new Error('CHANGELOG.md not found'))
+    }
+    return changelogProvider()
+  },
+}))
+
+import packageJson from '../package.json' with { type: 'json' }
+import { announceNewVersion, extractChangelogSection } from '../src/announcements.js'
+
+const VERSION: string = packageJson.version
+
+// Canonical CHANGELOG fixture aligned with the actual package version
+const CHANGELOG = `# Changelog
+
+## [${VERSION}] - 2026-01-01
+
+### Added
+- Feature A
+
+### Fixed
+- Bug B
+
+## [0.0.1] - 2025-01-01
+
+### Added
+- Feature X
+`
+
+// ---------------------------------------------------------------------------
+// Unit tests for extractChangelogSection
+// ---------------------------------------------------------------------------
+
+describe('extractChangelogSection', () => {
+  test('returns section content for a matching version', () => {
+    const result = extractChangelogSection(VERSION, CHANGELOG)
+    expect(result).toContain('Feature A')
+    expect(result).toContain('Bug B')
+  })
+
+  test('does not include the next version header in the section', () => {
+    const result = extractChangelogSection(VERSION, CHANGELOG)
+    expect(result).not.toContain('## [0.0.1]')
+  })
+
+  test('returns null when version is not found', () => {
+    const result = extractChangelogSection('9.9.9', CHANGELOG)
+    expect(result).toBeNull()
+  })
+
+  test('returns section for last version in file (no following header boundary)', () => {
+    const result = extractChangelogSection('0.0.1', CHANGELOG)
+    expect(result).not.toBeNull()
+    expect(result).toContain('Feature X')
+  })
+
+  test('returns null for empty changelog', () => {
+    const result = extractChangelogSection(VERSION, '')
+    expect(result).toBeNull()
+  })
+
+  test('returns empty string when section has no body lines between two headers', () => {
+    const tightChangelog = `## [${VERSION}] - 2026-01-01\n## [0.0.1] - 2025-01-01\n`
+    const result = extractChangelogSection(VERSION, tightChangelog)
+    expect(result).toBe('')
+  })
+
+  test('trims leading and trailing blank lines from section', () => {
+    const changelogWithPadding = `## [${VERSION}] - 2026-01-01\n\n\n### Added\n- X\n\n\n`
+    const result = extractChangelogSection(VERSION, changelogWithPadding)
+    expect(result).not.toBeNull()
+    expect(result!.startsWith('\n')).toBe(false)
+    expect(result!.endsWith('\n')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration-style tests for announceNewVersion
+// ---------------------------------------------------------------------------
+
+describe('announceNewVersion', () => {
+  beforeEach(() => {
+    announcedVersions.clear()
+    sentMessages.length = 0
+    userConfigRows.length = 0
+    changelogProvider = null
+    sendMessageImpl = (userId: number, text: string): Promise<void> => {
+      sentMessages.push({ userId, text })
+      return Promise.resolve()
+    }
+  })
+
+  test('sends announcement to all users with Kaneo accounts', async () => {
+    userConfigRows.push({ user_id: 101 }, { user_id: 102 })
+    changelogProvider = (): Promise<string> => Promise.resolve(CHANGELOG)
+
+    await announceNewVersion()
+
+    expect(sentMessages).toHaveLength(2)
+    expect(sentMessages[0]?.userId).toBe(101)
+    expect(sentMessages[1]?.userId).toBe(102)
+    expect(sentMessages[0]?.text).toContain(VERSION)
+  })
+
+  test('does not send announcement twice for the same version', async () => {
+    userConfigRows.push({ user_id: 101 })
+    changelogProvider = (): Promise<string> => Promise.resolve(CHANGELOG)
+
+    await announceNewVersion()
+    await announceNewVersion()
+
+    expect(sentMessages).toHaveLength(1)
+  })
+
+  test('marks version as announced even when no users have Kaneo accounts', async () => {
+    changelogProvider = (): Promise<string> => Promise.resolve(CHANGELOG)
+
+    await announceNewVersion()
+
+    expect(sentMessages).toHaveLength(0)
+    expect(announcedVersions.has(VERSION)).toBe(true)
+  })
+
+  test('returns early without sending when CHANGELOG.md cannot be read', async () => {
+    userConfigRows.push({ user_id: 101 })
+    changelogProvider = null
+
+    await announceNewVersion()
+
+    expect(sentMessages).toHaveLength(0)
+    expect(announcedVersions.has(VERSION)).toBe(false)
+  })
+
+  test('returns early without sending when version is missing from changelog', async () => {
+    userConfigRows.push({ user_id: 101 })
+    changelogProvider = (): Promise<string> =>
+      Promise.resolve('# Changelog\n\n## [0.0.1] - 2024-01-01\n\n- old stuff\n')
+
+    await announceNewVersion()
+
+    expect(sentMessages).toHaveLength(0)
+    expect(announcedVersions.has(VERSION)).toBe(false)
+  })
+
+  test('continues sending to remaining users when one send fails', async () => {
+    const failedIds: number[] = []
+    let callCount = 0
+
+    sendMessageImpl = (userId: number, text: string): Promise<void> => {
+      callCount++
+      if (callCount === 1) {
+        failedIds.push(userId)
+        return Promise.reject(new Error('Telegram API error'))
+      }
+      sentMessages.push({ userId, text })
+      return Promise.resolve()
+    }
+
+    userConfigRows.push({ user_id: 201 }, { user_id: 202 })
+    changelogProvider = (): Promise<string> => Promise.resolve(CHANGELOG)
+
+    await announceNewVersion()
+
+    expect(failedIds).toHaveLength(1)
+    expect(sentMessages).toHaveLength(1)
+    expect(sentMessages[0]?.userId).toBe(202)
+  })
+})


### PR DESCRIPTION
On each startup, checks if the current version (from package.json) has been announced. If not, sends a message with the CHANGELOG section for that version to all registered users who have a kaneo_apikey configured. Announced versions are tracked in a new version_announcements DB table (migration 006) so each version is announced only once.

https://claude.ai/code/session_019y8BFosu3R9S97kHTqsdTa