### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,8 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: build-and-push
     environment: production
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/wKich/papai/security/code-scanning/4](https://github.com/wKich/papai/security/code-scanning/4)

To fix the problem, explicitly define `permissions` for the `deploy` job so that the `GITHUB_TOKEN` has the least privilege required. The job only uses `actions/checkout@v4`, which needs read access to the repository contents. It does not interact with pull requests, issues, or other GitHub resources. Therefore, the best fix is to add `permissions: contents: read` under the `deploy` job.

Concretely, in `.github/workflows/deploy.yml`, within the `jobs:` section, locate the `deploy:` job definition beginning at line 70 (`deploy:` and `name: Deploy` on line 71). Immediately under the `runs-on: ubuntu-latest` (line 72), add a `permissions` block:

```yaml
    permissions:
      contents: read
```

This keeps existing behavior (the job still has enough permission to run `actions/checkout`), while ensuring the `GITHUB_TOKEN` is not granted unnecessary write permissions. No imports or additional methods are needed, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
