### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/wKich/papai/security/code-scanning/11](https://github.com/wKich/papai/security/code-scanning/11)

In general, the fix is to explicitly specify minimal `GITHUB_TOKEN` permissions for jobs that currently rely on repository defaults. This is done by adding a `permissions:` block either at the workflow root (applies to all jobs without their own block) or per job. Since the `security` job already defines custom permissions (including `security-events: write`), the cleanest approach is to add a top‑level `permissions: contents: read` block, and then keep the `security` job’s more permissive block as‑is. The other jobs (`check`, `e2e`, `mutation-testing`) only need read access to repository contents and do not appear to require any write scopes.

Concretely, in `.github/workflows/ci.yml`, add a new root‑level `permissions:` section after the `on:` block (e.g., after line 8) specifying `contents: read`. This will constrain `GITHUB_TOKEN` for all jobs that don’t override permissions, resolving the CodeQL warning for the `check` job and also hardening `e2e` and `mutation-testing`. No additional imports or methods are needed since this is just a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
