### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,10 @@ addUser(adminUserId, adminUserId)
 
 const chatProvider = createChatProvider(process.env['CHAT_PROVIDER']!)
 
-log.info({ adminUserId, chatProvider: process.env['CHAT_PROVIDER'], taskProvider: TASK_PROVIDER }, 'Starting papai...')
+log.info(
+  { adminUserConfigured: Boolean(adminUserId), chatProvider: process.env['CHAT_PROVIDER'], taskProvider: TASK_PROVIDER },
+  'Starting papai...'
+)
 
 setupBot(chatProvider, adminUserId)
 


### PR DESCRIPTION
Potential fix for [https://github.com/wKich/papai/security/code-scanning/8](https://github.com/wKich/papai/security/code-scanning/8)

In general, to fix clear-text logging of sensitive information, avoid including raw sensitive values (IDs, tokens, secrets) in log messages. Either omit them, replace them with generic placeholders, or, when necessary, log a non-reversible, truncated, or otherwise non-identifying representation.

Here, the problematic log line is:

```ts
log.info({ adminUserId, chatProvider: process.env['CHAT_PROVIDER'], taskProvider: TASK_PROVIDER }, 'Starting papai...')
```

We should stop logging the raw `adminUserId` value coming from `process.env['ADMIN_USER_ID']`. The simplest fix that preserves the purpose of this log (observability of configuration) is:

- Remove the `adminUserId` field from the structured log, and keep only non-sensitive configuration (`chatProvider` and `taskProvider`), or
- Replace `adminUserId` with a non-sensitive indication, such as a boolean flag `hasAdminUserId: Boolean(adminUserId)`.

I’ll choose to remove the raw value and instead log a boolean `adminUserConfigured` so we still know whether it was set, without disclosing the identifier. This requires only changing the object literal on line 60; no new imports or additional methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
