### PR TITLE
feat: add recurring task occurrences tracking and completion hook

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -11,6 +11,7 @@ import { migration006VersionAnnouncements } from './migrations/006_version_annou
 import { migration007PlatformUserId } from './migrations/007_platform_user_id.js'
 import { migration008GroupMembers } from './migrations/008_group_members.js'
 import { migration009RecurringTasks } from './migrations/009_recurring_tasks.js'
+import { migration010RecurringTaskOccurrences } from './migrations/010_recurring_task_occurrences.js'
 
 const DB_PATH = process.env['DB_PATH'] ?? 'papai.db'
 
@@ -47,6 +48,7 @@ const MIGRATIONS = [
   migration007PlatformUserId,
   migration008GroupMembers,
   migration009RecurringTasks,
+  migration010RecurringTaskOccurrences,
 ] as const
 
 export const initDb = (): void => {

--- a/src/db/migrations/010_recurring_task_occurrences.ts
+++ b/src/db/migrations/010_recurring_task_occurrences.ts
@@ -1,0 +1,19 @@
+import type { Database } from 'bun:sqlite'
+
+import type { Migration } from '../migrate.js'
+
+export const migration010RecurringTaskOccurrences: Migration = {
+  id: '010_recurring_task_occurrences',
+  up(db: Database): void {
+    db.run(`
+      CREATE TABLE recurring_task_occurrences (
+        id TEXT PRIMARY KEY,
+        template_id TEXT NOT NULL,
+        task_id TEXT NOT NULL,
+        created_at TEXT DEFAULT (datetime('now')) NOT NULL
+      )
+    `)
+    db.run('CREATE INDEX idx_recurring_occurrences_template ON recurring_task_occurrences(template_id)')
+    db.run('CREATE INDEX idx_recurring_occurrences_task ON recurring_task_occurrences(task_id)')
+  },
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -101,6 +101,23 @@ export const recurringTasks = sqliteTable(
   ],
 )
 
+export const recurringTaskOccurrences = sqliteTable(
+  'recurring_task_occurrences',
+  {
+    id: text('id').primaryKey(),
+    templateId: text('template_id').notNull(),
+    taskId: text('task_id').notNull(),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index('idx_recurring_occurrences_template').on(table.templateId),
+    index('idx_recurring_occurrences_task').on(table.taskId),
+  ],
+)
+
 export type RecurringTask = typeof recurringTasks.$inferSelect
+export type RecurringTaskOccurrence = typeof recurringTaskOccurrences.$inferSelect
 
 export type GroupMember = typeof groupMembers.$inferSelect

--- a/src/recurring-occurrences.ts
+++ b/src/recurring-occurrences.ts
@@ -1,0 +1,49 @@
+import { eq } from 'drizzle-orm'
+
+import { getDrizzleDb } from './db/drizzle.js'
+import { recurringTaskOccurrences } from './db/schema.js'
+import { logger } from './logger.js'
+import { getRecurringTask } from './recurring.js'
+import type { RecurringTaskRecord } from './types/recurring.js'
+
+const log = logger.child({ scope: 'recurring-occurrences' })
+const generateId = (): string => crypto.randomUUID()
+
+/** Status values that indicate a task is completed (case-insensitive substring match). */
+export const COMPLETION_STATUSES = ['done', 'completed', 'closed', 'resolved'] as const
+
+/** Record an occurrence linking a template to a created task. */
+export const recordOccurrence = (templateId: string, taskId: string): void => {
+  log.debug({ templateId, taskId }, 'recordOccurrence called')
+
+  const id = generateId()
+  const db = getDrizzleDb()
+  db.insert(recurringTaskOccurrences).values({ id, templateId, taskId, createdAt: new Date().toISOString() }).run()
+
+  log.info({ templateId, taskId }, 'Occurrence recorded')
+}
+
+/** Find the recurring template that generated a given task (via occurrences table). */
+export const findTemplateByTaskId = (taskId: string): RecurringTaskRecord | null => {
+  log.debug({ taskId }, 'findTemplateByTaskId called')
+
+  const db = getDrizzleDb()
+  const occurrence = db
+    .select({ templateId: recurringTaskOccurrences.templateId })
+    .from(recurringTaskOccurrences)
+    .where(eq(recurringTaskOccurrences.taskId, taskId))
+    .get()
+
+  if (occurrence === undefined) {
+    log.debug({ taskId }, 'No occurrence found for task')
+    return null
+  }
+
+  return getRecurringTask(occurrence.templateId)
+}
+
+/** Check whether a status string indicates task completion. */
+export const isCompletionStatus = (status: string): boolean => {
+  const lower = status.toLowerCase()
+  return COMPLETION_STATUSES.some((s) => lower.includes(s))
+}

--- a/src/recurring.ts
+++ b/src/recurring.ts
@@ -7,6 +7,12 @@ import { logger } from './logger.js'
 import type { RecurringTaskInput, RecurringTaskRecord, TriggerType } from './types/recurring.js'
 
 export type { TriggerType, RecurringTaskInput, RecurringTaskRecord } from './types/recurring.js'
+export {
+  COMPLETION_STATUSES,
+  findTemplateByTaskId,
+  isCompletionStatus,
+  recordOccurrence,
+} from './recurring-occurrences.js'
 
 const log = logger.child({ scope: 'recurring' })
 const generateId = (): string => crypto.randomUUID()
@@ -260,10 +266,8 @@ export const deleteRecurringTask = (id: string): boolean => {
   return true
 }
 
-/** Get all enabled recurring tasks with nextRun <= now (for the scheduler). */
 export const getDueRecurringTasks = (): RecurringTaskRecord[] => {
   log.debug('getDueRecurringTasks called')
-
   const now = new Date().toISOString()
   const db = getDrizzleDb()
   const rows = db
@@ -276,10 +280,8 @@ export const getDueRecurringTasks = (): RecurringTaskRecord[] => {
   return rows.map(toRecord)
 }
 
-/** Mark a recurring task as executed and compute nextRun. */
 export const markExecuted = (id: string): void => {
   log.debug({ id }, 'markExecuted called')
-
   const db = getDrizzleDb()
   const existing = db.select().from(recurringTasks).where(eq(recurringTasks.id, id)).get()
   if (existing === undefined) return

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -11,6 +11,7 @@ import { logger } from './logger.js'
 import { createProvider } from './providers/registry.js'
 import type { TaskProvider } from './providers/types.js'
 import type { Task } from './providers/types.js'
+import { recordOccurrence } from './recurring-occurrences.js'
 import { type RecurringTaskRecord, getDueRecurringTasks, getRecurringTask, markExecuted } from './recurring.js'
 import { getKaneoWorkspace } from './users.js'
 
@@ -115,6 +116,7 @@ const executeRecurringTask = async (task: RecurringTaskRecord): Promise<void> =>
     )
 
     await applyLabels(provider, created.id, task.labels)
+    recordOccurrence(task.id, created.id)
     markExecuted(task.id)
     await notifyUser(task.userId, created)
   } catch (error) {
@@ -150,6 +152,7 @@ export const createMissedTasks = async (recurringTaskId: string, missedDates: re
         dueDate,
       })
       await applyLabels(provider, newTask.id, task.labels)
+      recordOccurrence(recurringTaskId, newTask.id)
       log.debug({ recurringTaskId, createdTaskId: newTask.id, dueDate }, 'Missed task created')
       return true
     } catch (error) {

--- a/src/tools/completion-hook.ts
+++ b/src/tools/completion-hook.ts
@@ -1,0 +1,86 @@
+import { logger } from '../logger.js'
+import type { TaskProvider } from '../providers/types.js'
+import { findTemplateByTaskId, isCompletionStatus, recordOccurrence } from '../recurring-occurrences.js'
+import type { RecurringTaskRecord } from '../recurring.js'
+import { markExecuted } from '../recurring.js'
+
+const log = logger.child({ scope: 'completion-hook' })
+
+export type CompletionHookFn = (taskId: string, newStatus: string, provider: TaskProvider) => Promise<void>
+
+const applyLabels = async (provider: TaskProvider, taskId: string, labels: readonly string[]): Promise<void> => {
+  if (labels.length === 0) return
+  if (!provider.capabilities.has('labels.assign') || provider.addTaskLabel === undefined) return
+
+  const results = await Promise.allSettled(labels.map((labelId) => provider.addTaskLabel!(taskId, labelId)))
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i]!
+    if (result.status === 'rejected') {
+      log.warn({ taskId, labelId: labels[i], error: result.reason }, 'Failed to apply label')
+    }
+  }
+}
+
+const createNextOccurrence = async (
+  template: RecurringTaskRecord,
+  taskId: string,
+  provider: TaskProvider,
+): Promise<void> => {
+  try {
+    const created = await provider.createTask({
+      projectId: template.projectId,
+      title: template.title,
+      description: template.description ?? undefined,
+      priority: template.priority ?? undefined,
+      status: template.status ?? undefined,
+      assignee: template.assignee ?? undefined,
+    })
+
+    await applyLabels(provider, created.id, template.labels)
+    recordOccurrence(template.id, created.id)
+    markExecuted(template.id)
+
+    log.info(
+      { templateId: template.id, createdTaskId: created.id, title: template.title },
+      'On-complete recurring task instance created',
+    )
+  } catch (error) {
+    log.error(
+      { templateId: template.id, taskId, error: error instanceof Error ? error.message : String(error) },
+      'Failed to create on_complete recurring task instance',
+    )
+  }
+}
+
+/**
+ * After a task is updated to a completion status, check if it was generated
+ * from an on_complete recurring template. If so, fire the next occurrence.
+ */
+export const completionHook: CompletionHookFn = async (
+  taskId: string,
+  newStatus: string,
+  provider: TaskProvider,
+): Promise<void> => {
+  if (!isCompletionStatus(newStatus)) return
+
+  log.debug({ taskId, newStatus }, 'Completion status detected, checking for recurring template')
+
+  const template = findTemplateByTaskId(taskId)
+  if (template === null) {
+    log.debug({ taskId }, 'No recurring template found for completed task')
+    return
+  }
+
+  if (template.triggerType !== 'on_complete') {
+    log.debug({ taskId, templateId: template.id, triggerType: template.triggerType }, 'Template is not on_complete')
+    return
+  }
+
+  if (!template.enabled) {
+    log.debug({ taskId, templateId: template.id }, 'Template is paused, skipping on_complete fire')
+    return
+  }
+
+  log.info({ taskId, templateId: template.id, title: template.title }, 'Firing on_complete recurring task')
+  await createNextOccurrence(template, taskId, provider)
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,7 @@ import { makeAddTaskLabelTool } from './add-task-label.js'
 import { makeAddTaskRelationTool } from './add-task-relation.js'
 import { makeArchiveProjectTool } from './archive-project.js'
 import { makeArchiveTaskTool } from './archive-task.js'
+import { completionHook } from './completion-hook.js'
 import { makeCreateLabelTool } from './create-label.js'
 import { makeCreateProjectTool } from './create-project.js'
 import { makeCreateRecurringTaskTool } from './create-recurring-task.js'
@@ -41,7 +42,7 @@ import { makeUpdateTaskTool } from './update-task.js'
 function makeCoreTools(provider: TaskProvider): ToolSet {
   return {
     create_task: makeCreateTaskTool(provider),
-    update_task: makeUpdateTaskTool(provider),
+    update_task: makeUpdateTaskTool(provider, completionHook),
     search_tasks: makeSearchTasksTool(provider),
     list_tasks: makeListTasksTool(provider),
     get_task: makeGetTaskTool(provider),

--- a/src/tools/update-task.ts
+++ b/src/tools/update-task.ts
@@ -4,10 +4,11 @@ import { z } from 'zod'
 
 import { logger } from '../logger.js'
 import type { TaskProvider } from '../providers/types.js'
+import type { CompletionHookFn } from './completion-hook.js'
 
 const log = logger.child({ scope: 'tool:update-task' })
 
-export function makeUpdateTaskTool(provider: TaskProvider): ToolSet[string] {
+export function makeUpdateTaskTool(provider: TaskProvider, completionHook?: CompletionHookFn): ToolSet[string] {
   return tool({
     description: "Update an existing task's status, priority, assignee, due date, title, description, or project.",
     inputSchema: z.object({
@@ -38,6 +39,11 @@ export function makeUpdateTaskTool(provider: TaskProvider): ToolSet[string] {
           assignee: userId,
         })
         log.info({ taskId }, 'Task updated via tool')
+
+        if (completionHook !== undefined && task.status !== undefined) {
+          await completionHook(taskId, task.status, provider)
+        }
+
         return task
       } catch (error) {
         log.error(

--- a/tests/recurring.test.ts
+++ b/tests/recurring.test.ts
@@ -42,11 +42,14 @@ void mock.module('../src/db/drizzle.js', () => ({
 import {
   createRecurringTask,
   deleteRecurringTask,
+  findTemplateByTaskId,
   getDueRecurringTasks,
   getRecurringTask,
+  isCompletionStatus,
   listRecurringTasks,
   markExecuted,
   pauseRecurringTask,
+  recordOccurrence,
   resumeRecurringTask,
   skipNextOccurrence,
   updateRecurringTask,
@@ -86,6 +89,18 @@ beforeEach(() => {
   `)
   testSqlite.run('CREATE INDEX idx_recurring_tasks_user ON recurring_tasks(user_id)')
   testSqlite.run('CREATE INDEX idx_recurring_tasks_enabled_next ON recurring_tasks(enabled, next_run)')
+
+  // Create recurring_task_occurrences table
+  testSqlite.run(`
+    CREATE TABLE recurring_task_occurrences (
+      id TEXT PRIMARY KEY,
+      template_id TEXT NOT NULL,
+      task_id TEXT NOT NULL,
+      created_at TEXT DEFAULT (datetime('now')) NOT NULL
+    )
+  `)
+  testSqlite.run('CREATE INDEX idx_recurring_occurrences_template ON recurring_task_occurrences(template_id)')
+  testSqlite.run('CREATE INDEX idx_recurring_occurrences_task ON recurring_task_occurrences(task_id)')
 })
 
 describe('createRecurringTask', () => {
@@ -435,5 +450,81 @@ describe('markExecuted', () => {
     expect(updated).not.toBeNull()
     expect(updated!.lastRun).not.toBeNull()
     expect(updated!.nextRun).not.toBeNull()
+  })
+})
+
+describe('recordOccurrence', () => {
+  test('records an occurrence linking template to task', () => {
+    const task = createRecurringTask({
+      userId: USER_ID,
+      projectId: PROJECT_ID,
+      title: 'Test',
+      triggerType: 'cron',
+      cronExpression: '0 9 * * 1',
+    })
+
+    recordOccurrence(task.id, 'external-task-123')
+
+    const row = testSqlite
+      .query<{ template_id: string; task_id: string }, [string]>(
+        'SELECT template_id, task_id FROM recurring_task_occurrences WHERE task_id = ?',
+      )
+      .get('external-task-123')
+
+    expect(row).not.toBeUndefined()
+    expect(row!.template_id).toBe(task.id)
+    expect(row!.task_id).toBe('external-task-123')
+  })
+})
+
+describe('findTemplateByTaskId', () => {
+  test('returns template when task_id matches an occurrence', () => {
+    const task = createRecurringTask({
+      userId: USER_ID,
+      projectId: PROJECT_ID,
+      title: 'Weekly Sync',
+      triggerType: 'cron',
+      cronExpression: '0 9 * * 1',
+    })
+
+    recordOccurrence(task.id, 'ext-task-1')
+
+    const found = findTemplateByTaskId('ext-task-1')
+    expect(found).not.toBeNull()
+    expect(found!.id).toBe(task.id)
+    expect(found!.title).toBe('Weekly Sync')
+  })
+
+  test('returns null when task_id has no occurrence', () => {
+    const found = findTemplateByTaskId('nonexistent-task')
+    expect(found).toBeNull()
+  })
+})
+
+describe('isCompletionStatus', () => {
+  test('matches done status', () => {
+    expect(isCompletionStatus('done')).toBe(true)
+    expect(isCompletionStatus('Done')).toBe(true)
+    expect(isCompletionStatus('DONE')).toBe(true)
+  })
+
+  test('matches completed status', () => {
+    expect(isCompletionStatus('completed')).toBe(true)
+    expect(isCompletionStatus('Completed')).toBe(true)
+  })
+
+  test('matches closed status', () => {
+    expect(isCompletionStatus('closed')).toBe(true)
+  })
+
+  test('matches resolved status', () => {
+    expect(isCompletionStatus('resolved')).toBe(true)
+  })
+
+  test('does not match non-completion statuses', () => {
+    expect(isCompletionStatus('in-progress')).toBe(false)
+    expect(isCompletionStatus('todo')).toBe(false)
+    expect(isCompletionStatus('to-do')).toBe(false)
+    expect(isCompletionStatus('in-review')).toBe(false)
   })
 })

--- a/tests/tools/completion-hook.test.ts
+++ b/tests/tools/completion-hook.test.ts
@@ -1,0 +1,179 @@
+import { mock, describe, expect, test, beforeEach } from 'bun:test'
+
+import { mockLogger } from '../utils/test-helpers.js'
+
+mockLogger()
+
+import type { RecurringTaskRecord } from '../../src/types/recurring.js'
+
+// Mutable state for controlling recurring.js behavior
+let findTemplateByTaskIdResult: RecurringTaskRecord | null = null
+let recordOccurrenceCalls: Array<{ templateId: string; taskId: string }> = []
+let markExecutedCalls: string[] = []
+
+void mock.module('../../src/recurring.js', () => ({
+  findTemplateByTaskId: (_taskId: string): RecurringTaskRecord | null => findTemplateByTaskIdResult,
+  isCompletionStatus: (status: string): boolean => {
+    const lower = status.toLowerCase()
+    return ['done', 'completed', 'closed', 'resolved'].some((s) => lower.includes(s))
+  },
+  recordOccurrence: (templateId: string, taskId: string): void => {
+    recordOccurrenceCalls.push({ templateId, taskId })
+  },
+  markExecuted: (id: string): void => {
+    markExecutedCalls.push(id)
+  },
+  COMPLETION_STATUSES: ['done', 'completed', 'closed', 'resolved'],
+  createRecurringTask: (): null => null,
+  getRecurringTask: (): null => null,
+  listRecurringTasks: (): RecurringTaskRecord[] => [],
+  updateRecurringTask: (): null => null,
+  pauseRecurringTask: (): null => null,
+  resumeRecurringTask: (): null => null,
+  skipNextOccurrence: (): null => null,
+  deleteRecurringTask: (): boolean => false,
+  getDueRecurringTasks: (): RecurringTaskRecord[] => [],
+}))
+
+import { completionHook } from '../../src/tools/completion-hook.js'
+import { createMockProvider } from './mock-provider.js'
+
+const TEMPLATE_ID = 'template-1'
+const PROJECT_ID = 'project-1'
+
+const makeTemplate = (overrides: Partial<RecurringTaskRecord> = {}): RecurringTaskRecord => ({
+  id: TEMPLATE_ID,
+  userId: 'user-1',
+  projectId: PROJECT_ID,
+  title: 'Deploy review',
+  description: null,
+  priority: 'high',
+  status: null,
+  assignee: 'alice',
+  labels: ['label-1'],
+  triggerType: 'on_complete',
+  cronExpression: null,
+  timezone: 'UTC',
+  enabled: true,
+  catchUp: false,
+  lastRun: null,
+  nextRun: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  ...overrides,
+})
+
+beforeEach(() => {
+  findTemplateByTaskIdResult = null
+  recordOccurrenceCalls = []
+  markExecutedCalls = []
+})
+
+describe('completionHook', () => {
+  test('fires when status transitions to done and on_complete template exists', async () => {
+    const createTask = mock(() =>
+      Promise.resolve({
+        id: 'new-task-1',
+        title: 'Deploy review',
+        status: 'todo',
+        url: 'https://test.com/task/new-1',
+      }),
+    )
+    const provider = createMockProvider({ createTask })
+
+    findTemplateByTaskIdResult = makeTemplate()
+
+    await completionHook('completed-task-1', 'done', provider)
+
+    expect(createTask).toHaveBeenCalledTimes(1)
+    const calls = createTask.mock.calls
+    if (calls.length === 0) throw new Error('Expected createTask to be called')
+    const firstArg: unknown = calls[0]
+    expect(firstArg).toMatchObject([
+      {
+        projectId: PROJECT_ID,
+        title: 'Deploy review',
+        priority: 'high',
+        assignee: 'alice',
+      },
+    ])
+
+    // Should have recorded the new occurrence
+    expect(recordOccurrenceCalls).toHaveLength(1)
+    expect(recordOccurrenceCalls[0]).toEqual({ templateId: TEMPLATE_ID, taskId: 'new-task-1' })
+
+    // Should have marked the template as executed
+    expect(markExecutedCalls).toEqual([TEMPLATE_ID])
+  })
+
+  test('does not fire when no matching template exists', async () => {
+    const createTask = mock(() => Promise.resolve({ id: 'x', title: 'x', status: 'todo', url: 'https://test.com' }))
+    const provider = createMockProvider({ createTask })
+
+    findTemplateByTaskIdResult = null
+
+    await completionHook('unknown-task', 'done', provider)
+
+    expect(createTask).not.toHaveBeenCalled()
+    expect(recordOccurrenceCalls).toHaveLength(0)
+  })
+
+  test('does not fire for non-completion statuses', async () => {
+    const createTask = mock(() => Promise.resolve({ id: 'x', title: 'x', status: 'todo', url: 'https://test.com' }))
+    const provider = createMockProvider({ createTask })
+
+    findTemplateByTaskIdResult = makeTemplate()
+
+    await completionHook('task-1', 'in-progress', provider)
+
+    expect(createTask).not.toHaveBeenCalled()
+  })
+
+  test('does not fire for cron-based templates', async () => {
+    const createTask = mock(() => Promise.resolve({ id: 'x', title: 'x', status: 'todo', url: 'https://test.com' }))
+    const provider = createMockProvider({ createTask })
+
+    findTemplateByTaskIdResult = makeTemplate({
+      triggerType: 'cron',
+      cronExpression: '0 9 * * 1',
+    })
+
+    await completionHook('cron-task-1', 'done', provider)
+
+    expect(createTask).not.toHaveBeenCalled()
+  })
+
+  test('does not fire when template is paused', async () => {
+    const createTask = mock(() => Promise.resolve({ id: 'x', title: 'x', status: 'todo', url: 'https://test.com' }))
+    const provider = createMockProvider({ createTask })
+
+    findTemplateByTaskIdResult = makeTemplate({ enabled: false })
+
+    await completionHook('paused-task-1', 'done', provider)
+
+    expect(createTask).not.toHaveBeenCalled()
+  })
+
+  test('applies labels when provider supports it', async () => {
+    const createTask = mock(() =>
+      Promise.resolve({ id: 'new-task-1', title: 'Test', status: 'todo', url: 'https://test.com' }),
+    )
+    const addTaskLabel = mock(() => Promise.resolve({ taskId: 'new-task-1', labelId: 'label-1' }))
+    const provider = createMockProvider({ createTask, addTaskLabel })
+
+    findTemplateByTaskIdResult = makeTemplate({ labels: ['label-1', 'label-2'] })
+
+    await completionHook('task-1', 'done', provider)
+
+    expect(addTaskLabel).toHaveBeenCalledTimes(2)
+  })
+
+  test('no error when completionHook is not provided to makeUpdateTaskTool', async () => {
+    const { makeUpdateTaskTool } = await import('../../src/tools/update-task.js')
+    const provider = createMockProvider()
+
+    // Should not throw when completionHook is omitted
+    const tool = makeUpdateTaskTool(provider)
+    expect(tool.description).toContain('Update')
+  })
+})

--- a/tests/utils/test-helpers.ts
+++ b/tests/utils/test-helpers.ts
@@ -19,6 +19,8 @@ import { migration005RenameConfigKeys } from '../../src/db/migrations/005_rename
 import { migration006VersionAnnouncements } from '../../src/db/migrations/006_version_announcements.js'
 import { migration007PlatformUserId } from '../../src/db/migrations/007_platform_user_id.js'
 import { migration008GroupMembers } from '../../src/db/migrations/008_group_members.js'
+import { migration009RecurringTasks } from '../../src/db/migrations/009_recurring_tasks.js'
+import { migration010RecurringTaskOccurrences } from '../../src/db/migrations/010_recurring_task_occurrences.js'
 import * as schema from '../../src/db/schema.js'
 import type { AppError } from '../../src/errors.js'
 import { getUserMessage } from '../../src/errors.js'
@@ -33,6 +35,8 @@ const ALL_MIGRATIONS: readonly Migration[] = [
   migration006VersionAnnouncements,
   migration007PlatformUserId,
   migration008GroupMembers,
+  migration009RecurringTasks,
+  migration010RecurringTaskOccurrences,
 ]
 
 // ============================================================================


### PR DESCRIPTION
Implements the missing pieces from Phase 08 (Recurring Work Automation):

- Add `recurring_task_occurrences` table (migration 010) to track which
  tasks were generated from which recurring template
- Add completion hook to `update-task` tool that detects when a task
  transitions to a done status and auto-fires the next occurrence for
  `on_complete` recurring templates
- Record occurrences in the scheduler when cron-based tasks fire
- Add `recordOccurrence`, `findTemplateByTaskId`, and `isCompletionStatus`
  functions in a new `recurring-occurrences.ts` module
- Add comprehensive tests for the completion hook and occurrence tracking

https://claude.ai/code/session_01TqdK9bTsfgHoHFLm49tVHF