### PR TITLE
test: implement Phase 4 common-sense scenario gap tests (~41 new tests)

### DIFF
--- a/tests/commands/admin.test.ts
+++ b/tests/commands/admin.test.ts
@@ -19,9 +19,20 @@ mockLogger()
 // Mock getDrizzleDb BEFORE importing source modules
 mockDrizzle()
 
-// Mock provisionAndConfigure to bypass Kaneo HTTP calls
+// Mock provisionAndConfigure with mutable implementation
+type ProvisionResult = {
+  status: string
+  email?: string
+  password?: string
+  kaneoUrl?: string
+  apiKey?: string
+  workspaceId?: string
+  error?: string
+}
+let provisionImpl = (): Promise<ProvisionResult> => Promise.resolve({ status: 'skipped' })
+
 void mock.module('../../src/providers/kaneo/provision.js', () => ({
-  provisionAndConfigure: (): Promise<{ status: string }> => Promise.resolve({ status: 'skipped' }),
+  provisionAndConfigure: (..._args: unknown[]): Promise<ProvisionResult> => provisionImpl(),
 }))
 
 const ADMIN_ID = 'admin-001'
@@ -34,6 +45,9 @@ describe('Admin Commands', () => {
 
     // Add admin user to DB
     addUser(ADMIN_ID, ADMIN_ID)
+
+    // Reset provision mock to default
+    provisionImpl = (): Promise<ProvisionResult> => Promise.resolve({ status: 'skipped' })
 
     commandHandlers = new Map()
     const mockChat: ChatProvider = {
@@ -105,6 +119,65 @@ describe('Admin Commands', () => {
         storageContextId: ADMIN_ID,
       })
       expect(getReplies()[0]).toContain('Usage: /user add')
+    })
+
+    test('provision success replies with email, password, and URL', async () => {
+      provisionImpl = (): Promise<ProvisionResult> =>
+        Promise.resolve({
+          status: 'provisioned',
+          email: 'bot-user@test.com',
+          password: 'abc123',
+          kaneoUrl: 'https://kaneo.test',
+          apiKey: 'key',
+          workspaceId: 'ws-1',
+        })
+
+      const handler = commandHandlers.get('user')
+      expect(handler).toBeDefined()
+      const { reply, getReplies } = createMockReply()
+      await handler!(createDmMessage(ADMIN_ID, 'add 12345'), reply, {
+        allowed: true,
+        isBotAdmin: true,
+        isGroupAdmin: false,
+        storageContextId: ADMIN_ID,
+      })
+      const replies = getReplies()
+      expect(replies.some((r) => r.includes('bot-user@test.com'))).toBe(true)
+      expect(replies.some((r) => r.includes('abc123'))).toBe(true)
+      expect(replies.some((r) => r.includes('kaneo.test'))).toBe(true)
+      expect(isAuthorized('12345')).toBe(true)
+    })
+
+    test('provision failure replies with failure note', async () => {
+      provisionImpl = (): Promise<ProvisionResult> =>
+        Promise.resolve({ status: 'failed', error: 'KANEO_CLIENT_URL not set' })
+
+      const handler = commandHandlers.get('user')
+      expect(handler).toBeDefined()
+      const { reply, getReplies } = createMockReply()
+      await handler!(createDmMessage(ADMIN_ID, 'add 67890'), reply, {
+        allowed: true,
+        isBotAdmin: true,
+        isGroupAdmin: false,
+        storageContextId: ADMIN_ID,
+      })
+      const replies = getReplies()
+      expect(replies.some((r) => r.includes('auto-provisioning failed'))).toBe(true)
+      expect(isAuthorized('67890')).toBe(true)
+    })
+
+    test('rejects invalid identifier format with specific error', async () => {
+      const handler = commandHandlers.get('user')
+      expect(handler).toBeDefined()
+      const { reply, getReplies } = createMockReply()
+      await handler!(createDmMessage(ADMIN_ID, 'add some@invalid!id'), reply, {
+        allowed: true,
+        isBotAdmin: true,
+        isGroupAdmin: false,
+        storageContextId: ADMIN_ID,
+      })
+      expect(getReplies()[0]).toContain('Invalid identifier')
+      expect(isAuthorized('some@invalid!id')).toBe(false)
     })
   })
 

--- a/tests/commands/group.test.ts
+++ b/tests/commands/group.test.ts
@@ -107,6 +107,22 @@ describe('group commands', () => {
       lastReply = textCalls[0] ?? null
       expect(lastReply).toBe('User 12345 added to this group.')
     })
+
+    test('adduser persists member in DB', async () => {
+      const handler = commandHandlers.get('group')
+      expect(handler).toBeDefined()
+
+      const { reply } = createMockReply()
+      await handler!(
+        createGroupMessage('admin1', 'adduser @user1', true),
+        reply,
+        createAuth('admin1', { isGroupAdmin: true }),
+      )
+
+      const { listGroupMembers } = await import('../../src/groups.js')
+      const members = listGroupMembers('group1')
+      expect(members.some((m) => m.user_id === 'user1')).toBe(true)
+    })
   })
 
   describe('deluser', () => {
@@ -174,6 +190,25 @@ describe('group commands', () => {
 
       lastReply = textCalls[0] ?? null
       expect(lastReply).toBe('User nonexistent removed from this group.')
+    })
+
+    test('deluser removes member from DB', async () => {
+      const { addGroupMember, listGroupMembers, isGroupMember } = await import('../../src/groups.js')
+      addGroupMember('group1', 'user1', 'admin1')
+
+      const handler = commandHandlers.get('group')
+      expect(handler).toBeDefined()
+
+      const { reply } = createMockReply()
+      await handler!(
+        createGroupMessage('admin1', 'deluser user1', true),
+        reply,
+        createAuth('admin1', { isGroupAdmin: true }),
+      )
+
+      const members = listGroupMembers('group1')
+      expect(members.some((m) => m.user_id === 'user1')).toBe(false)
+      expect(isGroupMember('group1', 'user1')).toBe(false)
     })
   })
 

--- a/tests/commands/set.test.ts
+++ b/tests/commands/set.test.ts
@@ -98,4 +98,28 @@ describe('/set Command', () => {
     expect(textCalls).toHaveLength(0)
     expect(getConfig('unauthorized-user', 'main_model')).toBeNull()
   })
+
+  test('stores value that contains spaces', async () => {
+    expect(setHandler).not.toBeNull()
+    const { reply, textCalls } = createMockReply()
+    await setHandler!(
+      createDmMessage(USER_ID, 'llm_baseurl https://example.com/v1 extra'),
+      reply,
+      createAuth(USER_ID, true),
+    )
+    expect(textCalls[0]).toBe('Set llm_baseurl successfully.')
+    expect(getConfig(USER_ID, 'llm_baseurl')).toBe('https://example.com/v1 extra')
+  })
+
+  test('overwrites existing config value', async () => {
+    expect(setHandler).not.toBeNull()
+    const { reply: reply1, textCalls: textCalls1 } = createMockReply()
+    await setHandler!(createDmMessage(USER_ID, 'main_model gpt-4o'), reply1, createAuth(USER_ID, true))
+    expect(textCalls1[0]).toBe('Set main_model successfully.')
+
+    const { reply: reply2, textCalls: textCalls2 } = createMockReply()
+    await setHandler!(createDmMessage(USER_ID, 'main_model gpt-4o-mini'), reply2, createAuth(USER_ID, true))
+    expect(textCalls2[0]).toBe('Set main_model successfully.')
+    expect(getConfig(USER_ID, 'main_model')).toBe('gpt-4o-mini')
+  })
 })

--- a/tests/conversation.test.ts
+++ b/tests/conversation.test.ts
@@ -52,6 +52,35 @@ describe('shouldTriggerTrim', () => {
     }))
     expect(shouldTriggerTrim(messages)).toBe(false)
   })
+
+  test('returns false for exactly 50 messages with 25 user messages (boundary)', () => {
+    const messages = makeMessages(50)
+    // 50 messages with userEvery=2 → 25 user messages
+    // 50 > TRIM_MIN(50) is false (strict greater), so periodic cannot trigger
+    expect(shouldTriggerTrim(messages)).toBe(false)
+  })
+
+  test('returns false for 51 messages with 26 user messages (not divisible by 10)', () => {
+    const messages = makeMessages(51)
+    // 51 messages with userEvery=2 → 26 user messages
+    // 26 % 10 !== 0, so periodic is false. 51 < 100 so hard cap is false.
+    expect(shouldTriggerTrim(messages)).toBe(false)
+  })
+
+  test('returns true for 51 messages with 20 user messages (periodic trigger at boundary)', () => {
+    // Create 51 messages where exactly 20 are 'user' and 31 are 'assistant'
+    const messages: ModelMessage[] = []
+    for (let i = 0; i < 20; i++) {
+      messages.push({ role: 'user', content: `User msg ${i}` })
+    }
+    for (let i = 0; i < 31; i++) {
+      messages.push({ role: 'assistant', content: `Asst msg ${i}` })
+    }
+    // Verify: 20 user messages, 51 total, 20 % 10 === 0, 51 > 50
+    const actualUserCount = messages.filter((m) => m.role === 'user').length
+    expect(actualUserCount).toBe(20)
+    expect(shouldTriggerTrim(messages)).toBe(true)
+  })
 })
 
 describe('buildMessagesWithMemory', () => {
@@ -315,6 +344,61 @@ describe('runTrimInBackground', () => {
     setCachedHistorySpy.mockRestore()
     getCachedSummarySpy.mockRestore()
     warnSpy.mockRestore()
+  })
+
+  test('concurrent calls for same user — both complete without corruption', async () => {
+    const history1: ModelMessage[] = [
+      { role: 'user', content: 'First conversation' },
+      { role: 'assistant', content: 'Response 1' },
+    ]
+    const history2: ModelMessage[] = [
+      { role: 'user', content: 'Second conversation' },
+      { role: 'assistant', content: 'Response 2' },
+    ]
+
+    const concurrentHistories = new Map<string, ModelMessage[]>()
+    const concurrentConfigs = new Map<string, Map<string, string | null>>()
+    concurrentHistories.set('user1', [...history1])
+    concurrentConfigs.set(
+      'user1',
+      new Map([
+        ['llm_apikey', 'test-key'],
+        ['llm_baseurl', 'http://test.com'],
+        ['small_model', 'test-model'],
+      ]),
+    )
+
+    generateTextImpl = (): Promise<GenerateTextResult> =>
+      Promise.resolve({ output: { keep_indices: [0], summary: 'Concurrent trim summary' } })
+
+    const getCachedConfigSpy = spyOn(cacheModule, 'getCachedConfig').mockImplementation(
+      (userId: string, key: string) => concurrentConfigs.get(userId)?.get(key) ?? null,
+    )
+    const getCachedHistorySpy = spyOn(cacheModule, 'getCachedHistory').mockImplementation(
+      (userId: string) => concurrentHistories.get(userId) ?? [],
+    )
+    const setCachedHistorySpy = spyOn(cacheModule, 'setCachedHistory').mockImplementation(
+      (userId: string, messages: readonly ModelMessage[]) => {
+        concurrentHistories.set(userId, [...messages])
+      },
+    )
+    const setCachedSummarySpy = spyOn(cacheModule, 'setCachedSummary').mockImplementation(() => {})
+    const getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null)
+
+    // Fire both concurrently
+    await Promise.all([runTrimInBackground('user1', history1), runTrimInBackground('user1', history2)])
+    await flushMicrotasks()
+
+    // Neither should throw; final history is valid
+    const finalHistory = concurrentHistories.get('user1')
+    expect(finalHistory).toBeDefined()
+    expect(Array.isArray(finalHistory)).toBe(true)
+
+    getCachedConfigSpy.mockRestore()
+    getCachedHistorySpy.mockRestore()
+    setCachedHistorySpy.mockRestore()
+    setCachedSummarySpy.mockRestore()
+    getCachedSummarySpy.mockRestore()
   })
 })
 

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -50,6 +50,13 @@ describe('parseCron', () => {
     // */-1 does not match the step regex so produces no values → parseCron returns null
     expect(parseCron('*/-1 * * * *')).toBeNull()
   })
+
+  test('parses impossible date (Feb 31) without error', () => {
+    const result = parseCron('0 0 31 2 *')
+    // Parser validates individual field bounds (31 valid for dayOfMonth, 2 valid for month)
+    // but does not validate cross-field combos
+    expect(result).not.toBeNull()
+  })
 })
 
 describe('cron matching via nextCronOccurrence', () => {
@@ -115,6 +122,14 @@ describe('nextCronOccurrence', () => {
     // April (0-indexed)
     expect(next!.getUTCMonth()).toBe(3)
   })
+
+  test('returns null for impossible date (Feb 31 — never occurs)', () => {
+    const cron = parseCron('0 0 31 2 *')!
+    const start = new Date('2026-01-01T00:00:00Z')
+    const result = nextCronOccurrence(cron, start)
+    // Feb never has 31 days — the scanner should exhaust its limit and return null
+    expect(result).toBeNull()
+  })
 })
 
 describe('timezone-aware cron matching', () => {
@@ -142,6 +157,18 @@ describe('timezone-aware cron matching', () => {
     const next = nextCronOccurrence(cron, justBefore, 'Invalid/Timezone')
     expect(next).not.toBeNull()
     expect(next!.getUTCHours()).toBe(9)
+  })
+
+  test('handles spring-forward DST gap (2:30 AM does not exist)', () => {
+    // March 8, 2026: US clocks spring forward 2:00 AM → 3:00 AM
+    const cron = parseCron('30 2 * * *')!
+    // 2026-03-08T06:00:00Z = 1:00 AM ET
+    const before = new Date('2026-03-08T06:00:00Z')
+    const result = nextCronOccurrence(cron, before, 'America/New_York')
+    expect(result).not.toBeNull()
+    // The function should return a valid date — either skipping Mar 8 or adjusting
+    // Document the behavior: result should be after the input
+    expect(result!.getTime()).toBeGreaterThan(before.getTime())
   })
 })
 

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -216,3 +216,31 @@ describe('getUserMessage for system errors', () => {
     expect(getUserMessage(systemError.unexpected(new Error('oops')))).toContain('unexpected')
   })
 })
+
+describe('getUserMessage for missing provider error codes', () => {
+  test('returns correct message for projectNotFound', () => {
+    expect(getUserMessage(providerError.projectNotFound('proj-1'))).toContain('proj-1')
+    expect(getUserMessage(providerError.projectNotFound('proj-1'))).toContain('not found')
+  })
+
+  test('returns correct message for commentNotFound', () => {
+    expect(getUserMessage(providerError.commentNotFound('cmt-1'))).toContain('cmt-1')
+    expect(getUserMessage(providerError.commentNotFound('cmt-1'))).toContain('not found')
+  })
+
+  test('returns correct message for relationNotFound', () => {
+    const msg = getUserMessage(providerError.relationNotFound('t-1', 't-2'))
+    expect(msg).toContain('t-1')
+    expect(msg).toContain('t-2')
+  })
+
+  test('returns correct message for statusNotFound', () => {
+    const msg = getUserMessage(providerError.statusNotFound('in-progress', ['to-do', 'done']))
+    expect(msg).toContain('in-progress')
+    expect(msg).toContain('to-do')
+  })
+
+  test('returns correct message for invalidResponse', () => {
+    expect(getUserMessage(providerError.invalidResponse())).toContain('unexpected response')
+  })
+})

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, mock, describe, expect, test, beforeEach } from 'bun:test'
 
-import type { LanguageModel } from 'ai'
+import type { LanguageModel, ModelMessage } from 'ai'
 import { eq } from 'drizzle-orm'
 
 import * as schema from '../src/db/schema.js'
@@ -537,6 +537,26 @@ describe('trimWithMemoryModel', () => {
     expect(result.trimmedMessages).toHaveLength(2)
     expect(result.trimmedMessages[0]).toEqual(history[0])
     expect(result.trimmedMessages[1]).toEqual(history[2])
+  })
+
+  test('trimWithMemoryModel with empty history returns empty', async () => {
+    generateTextImpl = (): Promise<GenerateTextResult> =>
+      Promise.resolve({ output: { keep_indices: [], summary: 'Empty conversation' } })
+
+    const result = await trimWithMemoryModel([], 0, 10, null, mockModel)
+    expect(result.trimmedMessages).toEqual([])
+    expect(result.summary).toBe('Empty conversation')
+  })
+
+  test('trimWithMemoryModel throws when generateText fails', async () => {
+    generateTextImpl = (): Promise<GenerateTextResult> => Promise.reject(new Error('LLM API failure'))
+
+    const history: ModelMessage[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi' },
+    ]
+
+    await expect(trimWithMemoryModel(history, 0, 10, null, mockModel)).rejects.toThrow('LLM API failure')
   })
 })
 

--- a/tests/providers/kaneo/client.test.ts
+++ b/tests/providers/kaneo/client.test.ts
@@ -198,4 +198,28 @@ describe('kaneoFetch', () => {
       }
     }
   })
+
+  test('throws when fetch itself throws (network failure)', async () => {
+    setMockFetch(() => {
+      throw new TypeError('Failed to fetch')
+    })
+
+    const promise = kaneoFetch(mockConfig, 'GET', '/test', undefined, {}, KaneoTaskResponseSchema)
+    await expect(promise).rejects.toBeInstanceOf(TypeError)
+    await expect(promise).rejects.toThrow('Failed to fetch')
+  })
+
+  test('throws when successful response has invalid JSON body', async () => {
+    setMockFetch(() =>
+      Promise.resolve(
+        new Response('not json', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    )
+
+    const promise = kaneoFetch(mockConfig, 'GET', '/test', undefined, {}, KaneoTaskResponseSchema)
+    await expect(promise).rejects.toThrow()
+  })
 })

--- a/tests/providers/kaneo/task-archive.test.ts
+++ b/tests/providers/kaneo/task-archive.test.ts
@@ -145,6 +145,15 @@ describe('Archive Label Management', () => {
       const result = await isTaskArchived(mockConfig, 'task-1', 'label-archive')
       expect(result).toBe(false)
     })
+
+    test('throws when labels endpoint returns 500', async () => {
+      setMockFetch(() =>
+        Promise.resolve(new Response(JSON.stringify({ error: 'Internal Server Error' }), { status: 500 })),
+      )
+
+      const promise = isTaskArchived(mockConfig, 'task-1', 'label-archive')
+      await expect(promise).rejects.toThrow()
+    })
   })
 
   describe('addArchiveLabel', () => {
@@ -255,6 +264,45 @@ describe('Archive Label Management', () => {
       await addArchiveLabel(mockConfig, 'ws-1', 'task-1')
 
       expect(callCount).toBeGreaterThanOrEqual(3)
+    })
+
+    test('addArchiveLabel when task already has archive label — idempotent', async () => {
+      setMockFetch((_url: string, options: RequestInit) => {
+        if (options.method === 'GET' && _url.includes('/label/workspace/')) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify([{ id: 'label-archive', name: 'archived', color: '#808080', workspaceId: 'ws-1' }]),
+              {
+                status: 200,
+              },
+            ),
+          )
+        }
+        if (options.method === 'GET' && _url.includes('/label/')) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ id: 'label-archive', name: 'archived', color: '#808080' }), {
+              status: 200,
+            }),
+          )
+        }
+        if (options.method === 'POST') {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                id: 'tl-1',
+                name: 'archived',
+                color: '#808080',
+                taskId: 'task-1',
+              }),
+              { status: 200 },
+            ),
+          )
+        }
+        return Promise.resolve(new Response('{}', { status: 200 }))
+      })
+
+      // Should not throw — re-archiving is safe
+      await addArchiveLabel(mockConfig, 'ws-1', 'task-1')
     })
   })
 })

--- a/tests/providers/kaneo/task-relations.test.ts
+++ b/tests/providers/kaneo/task-relations.test.ts
@@ -176,6 +176,112 @@ describe('Task Relations', () => {
       expect(putBody.description).toContain('task-3')
       expect(putBody.description).toContain('task-2')
     })
+
+    test('adds relation with type "blocked_by"', async () => {
+      let putBody: unknown
+
+      setMockFetch((url, options) => {
+        if (url.includes('/task/task-2') && options.method === 'GET') {
+          return Promise.resolve(new Response(JSON.stringify(relatedTaskBase), { status: 200 }))
+        }
+        if (url.includes('/task/task-1') && options.method === 'GET') {
+          return Promise.resolve(new Response(JSON.stringify({ ...taskBase, description: '' }), { status: 200 }))
+        }
+        if (url.includes('/task/description/task-1') && options.method === 'PUT') {
+          putBody = typeof options.body === 'string' ? JSON.parse(options.body) : undefined
+          return Promise.resolve(new Response(JSON.stringify(taskBase), { status: 200 }))
+        }
+        return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+      })
+
+      const resource = new TaskResource(mockConfig)
+      const result = await resource.addRelation('task-1', 'task-2', 'blocked_by')
+      expect(result.type).toBe('blocked_by')
+      expect(putBody).toMatchObject({ description: expect.stringContaining('blocked_by') as unknown })
+    })
+
+    test('adds relation with type "duplicate_of"', async () => {
+      let putBody: unknown
+
+      setMockFetch((url, options) => {
+        if (url.includes('/task/task-2') && options.method === 'GET') {
+          return Promise.resolve(new Response(JSON.stringify(relatedTaskBase), { status: 200 }))
+        }
+        if (url.includes('/task/task-1') && options.method === 'GET') {
+          return Promise.resolve(new Response(JSON.stringify({ ...taskBase, description: '' }), { status: 200 }))
+        }
+        if (url.includes('/task/description/task-1') && options.method === 'PUT') {
+          putBody = typeof options.body === 'string' ? JSON.parse(options.body) : undefined
+          return Promise.resolve(new Response(JSON.stringify(taskBase), { status: 200 }))
+        }
+        return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+      })
+
+      const resource = new TaskResource(mockConfig)
+      const result = await resource.addRelation('task-1', 'task-2', 'duplicate_of')
+      expect(result.type).toBe('duplicate_of')
+      expect(putBody).toMatchObject({ description: expect.stringContaining('duplicate_of') as unknown })
+    })
+
+    test('adds relation with type "parent"', async () => {
+      let putBody: unknown
+
+      setMockFetch((url, options) => {
+        if (url.includes('/task/task-2') && options.method === 'GET') {
+          return Promise.resolve(new Response(JSON.stringify(relatedTaskBase), { status: 200 }))
+        }
+        if (url.includes('/task/task-1') && options.method === 'GET') {
+          return Promise.resolve(new Response(JSON.stringify({ ...taskBase, description: '' }), { status: 200 }))
+        }
+        if (url.includes('/task/description/task-1') && options.method === 'PUT') {
+          putBody = typeof options.body === 'string' ? JSON.parse(options.body) : undefined
+          return Promise.resolve(new Response(JSON.stringify(taskBase), { status: 200 }))
+        }
+        return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+      })
+
+      const resource = new TaskResource(mockConfig)
+      const result = await resource.addRelation('task-1', 'task-2', 'parent')
+      expect(result.type).toBe('parent')
+      expect(putBody).toMatchObject({ description: expect.stringContaining('parent') as unknown })
+    })
+
+    test('adding self-relation (taskId === relatedTaskId) succeeds — no guard', async () => {
+      setMockFetch((url, options) => {
+        if (url.includes('/task/task-1') && options.method === 'GET') {
+          return Promise.resolve(new Response(JSON.stringify({ ...taskBase, description: '' }), { status: 200 }))
+        }
+        if (url.includes('/task/description/task-1') && options.method === 'PUT') {
+          return Promise.resolve(new Response(JSON.stringify(taskBase), { status: 200 }))
+        }
+        return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+      })
+
+      const resource = new TaskResource(mockConfig)
+      const result = await resource.addRelation('task-1', 'task-1', 'blocks')
+      expect(result.taskId).toBe('task-1')
+      expect(result.relatedTaskId).toBe('task-1')
+      expect(result.type).toBe('blocks')
+    })
+
+    test('throws classified error when description update returns 500', async () => {
+      setMockFetch((url, options) => {
+        if (url.includes('/task/task-2') && options.method === 'GET') {
+          return Promise.resolve(new Response(JSON.stringify(relatedTaskBase), { status: 200 }))
+        }
+        if (url.includes('/task/task-1') && options.method === 'GET') {
+          return Promise.resolve(new Response(JSON.stringify({ ...taskBase, description: '' }), { status: 200 }))
+        }
+        if (url.includes('/task/description/task-1') && options.method === 'PUT') {
+          return Promise.resolve(new Response(JSON.stringify({ error: 'Internal Server Error' }), { status: 500 }))
+        }
+        return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+      })
+
+      const resource = new TaskResource(mockConfig)
+      const promise = resource.addRelation('task-1', 'task-2', 'blocks')
+      await expect(promise).rejects.toThrow()
+    })
   })
 
   describe('removeRelation', () => {
@@ -318,6 +424,23 @@ describe('Task Relations', () => {
       }
       expect(putBody.description).toContain('task-3')
       expect(putBody.description).toContain('task-2')
+    })
+
+    test('throws relationNotFound when task description has no frontmatter', async () => {
+      setMockFetch((url, options) => {
+        if (url.includes('/task/task-1') && options.method === 'GET') {
+          return Promise.resolve(
+            new Response(JSON.stringify({ ...taskBase, description: 'Just plain text, no frontmatter' }), {
+              status: 200,
+            }),
+          )
+        }
+        return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+      })
+
+      const resource = new TaskResource(mockConfig)
+      const promise = resource.updateRelation('task-1', 'task-2', 'related')
+      await expect(promise).rejects.toMatchObject({ appError: { code: 'relation-not-found' } })
     })
   })
 })

--- a/tests/providers/kaneo/task-resource.test.ts
+++ b/tests/providers/kaneo/task-resource.test.ts
@@ -719,6 +719,34 @@ describe('TaskResource', () => {
     })
   })
 
+  describe('get - error paths', () => {
+    test('throws for 404 (task not found)', async () => {
+      setMockFetch(() => Promise.resolve(new Response(JSON.stringify({ error: 'Not found' }), { status: 404 })))
+
+      const resource = new TaskResource(mockConfig)
+      const promise = resource.get('nonexistent-id')
+      await expect(promise).rejects.toThrow()
+    })
+
+    test('throws when projectId does not exist on create', async () => {
+      setMockFetch(() => Promise.resolve(new Response(JSON.stringify({ error: 'Project not found' }), { status: 404 })))
+
+      const resource = new TaskResource(mockConfig)
+      const promise = resource.create({ projectId: 'invalid', title: 'Test' })
+      await expect(promise).rejects.toThrow()
+    })
+
+    test('search returns empty results for empty query string', async () => {
+      setMockFetch(() =>
+        Promise.resolve(new Response(JSON.stringify({ results: [], totalCount: 0, searchQuery: '' }), { status: 200 })),
+      )
+
+      const resource = new TaskResource(mockConfig)
+      const result = await resource.search({ query: '', workspaceId: 'ws-1' })
+      expect(result).toEqual([])
+    })
+  })
+
   describe('archive', () => {
     test('archives task by adding archive label', async () => {
       setMockFetch(() =>

--- a/tests/tools/recurring-tools.test.ts
+++ b/tests/tools/recurring-tools.test.ts
@@ -274,6 +274,26 @@ describe('makeCreateRecurringTaskTool', () => {
     expect(makeCreateRecurringTaskTool('user-1').description).toBeTruthy()
   })
 
+  test('on_complete triggerType ignores cronExpression when both provided', async () => {
+    const tool = makeCreateRecurringTaskTool('user-1')
+    if (!tool.execute) throw new Error('Tool execute is undefined')
+
+    const result: unknown = await tool.execute(
+      {
+        title: 'Test',
+        projectId: 'p-1',
+        triggerType: 'on_complete',
+        cronExpression: '0 9 * * 1',
+      },
+      toolCtx,
+    )
+
+    // Result should not contain an error — on_complete does not require cronExpression validation
+    expect(result).not.toHaveProperty('error')
+    // The schedule should be 'after completion of current instance', not a cron description
+    expect(result).toHaveProperty('schedule', 'after completion of current instance')
+  })
+
   test('re-throws when createRecurringTask throws', async () => {
     onMockCall = () => {
       throw new Error('create failed')

--- a/tests/tools/status-tools.test.ts
+++ b/tests/tools/status-tools.test.ts
@@ -461,5 +461,22 @@ describe('Status Tools', () => {
       const tool = makeReorderStatusesTool(provider)
       expect(schemaValidates(tool, { projectId: 'proj-1' })).toBe(false)
     })
+
+    test('reorderStatuses with empty statuses array', async () => {
+      const reorderStatuses = mock((_projectId: string, _statuses: { id: string; position: number }[]) =>
+        Promise.resolve(),
+      )
+      const provider = createMockProvider({ reorderStatuses })
+
+      const tool = makeReorderStatusesTool(provider)
+      if (!tool.execute) throw new Error('Tool execute is undefined')
+      const result: unknown = await tool.execute(
+        { projectId: 'proj-1', statuses: [] },
+        { toolCallId: '1', messages: [] },
+      )
+
+      expect(reorderStatuses).toHaveBeenCalledWith('proj-1', [])
+      expect(result).toEqual({ success: true })
+    })
   })
 })

--- a/tests/tools/task-label-tools.test.ts
+++ b/tests/tools/task-label-tools.test.ts
@@ -110,6 +110,23 @@ describe('Task Label Tools', () => {
       const tool = makeAddTaskLabelTool(provider)
       expect(schemaValidates(tool, { taskId: 'task-1' })).toBe(false)
     })
+
+    test('adding label already present on task — document behavior', async () => {
+      const addTaskLabel = mock(() => Promise.resolve({ taskId: 'task-1', labelId: 'label-1' }))
+      const provider = createMockProvider({ addTaskLabel })
+
+      const tool = makeAddTaskLabelTool(provider)
+      if (!tool.execute) throw new Error('Tool execute is undefined')
+      const result: unknown = await tool.execute(
+        { taskId: 'task-1', labelId: 'label-1' },
+        { toolCallId: '1', messages: [] },
+      )
+      if (!isTaskLabel(result)) throw new Error('Invalid result')
+
+      expect(result.taskId).toBe('task-1')
+      expect(result.labelId).toBe('label-1')
+      expect(addTaskLabel).toHaveBeenCalledWith('task-1', 'label-1')
+    })
   })
 
   describe('makeRemoveTaskLabelTool', () => {

--- a/tests/tools/task-relation-tools.test.ts
+++ b/tests/tools/task-relation-tools.test.ts
@@ -167,6 +167,51 @@ describe('Task Relation Tools', () => {
       const tool = makeAddTaskRelationTool(provider)
       expect(schemaValidates(tool, { taskId: 'task-1', relatedTaskId: 'task-2', type: 'invalid' })).toBe(false)
     })
+
+    test('adding self-relation (taskId === relatedTaskId) — document behavior', async () => {
+      const addRelation = mock((_taskId: string, _relatedTaskId: string, _type: string) =>
+        Promise.resolve({
+          taskId: 'task-1',
+          relatedTaskId: 'task-1',
+          type: 'blocks',
+        }),
+      )
+      const provider = createMockProvider({ addRelation })
+
+      const tool = makeAddTaskRelationTool(provider)
+      const result: unknown = await tool.execute!(
+        { taskId: 'task-1', relatedTaskId: 'task-1', type: 'blocks' },
+        { toolCallId: '1', messages: [] },
+      )
+      if (!isTaskRelation(result)) throw new Error('Invalid result')
+
+      expect(result.taskId).toBe('task-1')
+      expect(result.relatedTaskId).toBe('task-1')
+      expect(addRelation).toHaveBeenCalledWith('task-1', 'task-1', 'blocks')
+    })
+
+    test('adding duplicate relation (same taskId/relatedTaskId/type) — both calls succeed', async () => {
+      const addRelation = mock((_taskId: string, _relatedTaskId: string, _type: string) =>
+        Promise.resolve({
+          taskId: 'task-1',
+          relatedTaskId: 'task-2',
+          type: 'blocks',
+        }),
+      )
+      const provider = createMockProvider({ addRelation })
+
+      const tool = makeAddTaskRelationTool(provider)
+      await tool.execute!(
+        { taskId: 'task-1', relatedTaskId: 'task-2', type: 'blocks' },
+        { toolCallId: '1', messages: [] },
+      )
+      await tool.execute!(
+        { taskId: 'task-1', relatedTaskId: 'task-2', type: 'blocks' },
+        { toolCallId: '2', messages: [] },
+      )
+
+      expect(addRelation).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe('makeUpdateTaskRelationTool', () => {

--- a/tests/users.test.ts
+++ b/tests/users.test.ts
@@ -52,6 +52,24 @@ describe('addUser', () => {
     const user = testDb.select().from(schema.users).where(eq(schema.users.platformUserId, '111')).get()
     expect(user?.addedBy).toBe('999')
   })
+
+  test('addUser with existing ID and new username overwrites username', () => {
+    addUser('123', 'admin')
+    addUser('123', 'admin', 'newname')
+    const users = listUsers()
+    const user = users.find((u) => u.platform_user_id === '123')
+    expect(user).toBeDefined()
+    expect(user!.username).toBe('newname')
+  })
+
+  test('addUser with existing ID replaces username with null when no username provided', () => {
+    addUser('456', 'admin', 'oldname')
+    addUser('456', 'admin')
+    const users = listUsers()
+    const user = users.find((u) => u.platform_user_id === '456')
+    expect(user).toBeDefined()
+    expect(user!.username).toBeNull()
+  })
 })
 
 describe('removeUser', () => {


### PR DESCRIPTION
Close scenario gaps identified in the Phase 4 test plan: DB state
verification after command mutations, degenerate/edge inputs to tools,
error paths for Kaneo providers, boundary conditions in core modules,
and missing getUserMessage coverage for 5 provider error codes.

- Task 4.1: Command tests verify DB persistence (group adduser/deluser,
  admin provision success/failure/invalid-id, set overwrite/spaces)
- Task 4.2: Tool tests for self-relation, duplicate relation, duplicate
  label, empty reorder array, on_complete with cronExpression
- Task 4.3: Provider error paths — task-resource 404/create-404/empty-search,
  client network failure/invalid-JSON, task-archive idempotent re-archive/500,
  task-relations all 6 types/self-relation/500-on-PUT/no-frontmatter
- Task 4.4: Core module edge cases — shouldTriggerTrim boundary conditions,
  concurrent runTrimInBackground, trimWithMemoryModel empty/throws,
  cron impossible-date/DST-gap, addUser username overwrite,
  getUserMessage for projectNotFound/commentNotFound/relationNotFound/
  statusNotFound/invalidResponse

https://claude.ai/code/session_012BejGMRtmsAu56HJ4knVzz