### PR TITLE
fix: improve test isolation and standardize mock patterns (Phase 6)

### DIFF
--- a/docs/TESTING_METHODOLOGY.md
+++ b/docs/TESTING_METHODOLOGY.md
@@ -942,6 +942,76 @@ For each tool, verify:
 
 ---
 
-_Document generated: 2026-03-12_  
-_Based on: API_COMPLIANCE_ANALYSIS.md_  
+## 11. Mock Patterns & Test Isolation
+
+### 11.1 When to Use Each Mock Pattern
+
+| Pattern                           | When to Use                                                                 | Example                                                                             |
+| --------------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `setMockFetch` / `restoreFetch`   | HTTP-level tests for providers (Kaneo, YouTrack)                            | `setMockFetch((url, init) => ...)` in `beforeEach`, `restoreFetch()` in `afterEach` |
+| `mock.module()` with mutable impl | Replacing entire modules (`ai`, `drizzle`, provider dependencies)           | `let impl = defaultImpl; void mock.module('ai', () => ({ fn: () => impl() }))`      |
+| `spyOn()`                         | Partial module mocking where you need the original implementation available | `spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null)`                      |
+
+### 11.2 Preferred: Mutable Implementation Pattern for `mock.module()`
+
+Use a `let` variable for the implementation so tests can override behaviour per-test. Reset in `beforeEach`:
+
+```typescript
+const defaultImpl = () => Promise.resolve({ data: 'default' })
+let myImpl = defaultImpl
+
+void mock.module('../src/my-module.js', () => ({
+  myFunction: (...args) => myImpl(...args),
+}))
+
+describe('tests', () => {
+  beforeEach(() => {
+    myImpl = defaultImpl // reset before each test
+  })
+
+  test('custom behaviour', () => {
+    myImpl = () => Promise.reject(new Error('fail'))
+    // test error handling...
+  })
+})
+```
+
+### 11.3 Mandatory Restoration Patterns
+
+- **`setMockFetch`**: Always call `restoreFetch()` in `afterEach`
+- **`spyOn`**: Always call `spy.mockRestore()` in `afterEach` — never inline in test body (fragile if test throws)
+- **`mock.module`**: Call `mock.restore()` in `afterAll` if the module is also imported by other test files
+- **Mutable impl vars**: Reset to default in `beforeEach`
+
+### 11.4 Shared Test Helpers
+
+Use these helpers from `tests/utils/test-helpers.ts` instead of writing ad-hoc mocks:
+
+| Helper              | Purpose                                                              |
+| ------------------- | -------------------------------------------------------------------- |
+| `mockLogger()`      | Stubs logger — safe because every test file that needs it calls this |
+| `mockDrizzle()`     | Stubs `getDrizzleDb` — the standard way to mock the database         |
+| `setupTestDb()`     | Creates in-memory SQLite with all migrations                         |
+| `createMockReply()` | Creates a mock `ReplyFn` that captures text calls                    |
+
+For provider tests, use helpers from `tests/test-helpers.ts`:
+
+| Helper                          | Purpose                                                |
+| ------------------------------- | ------------------------------------------------------ |
+| `setMockFetch(handler)`         | Replace `globalThis.fetch` with a mock handler         |
+| `restoreFetch()`                | Restore original `globalThis.fetch`                    |
+| `createMockTask(overrides)`     | Create a mock task matching `CreateTaskResponseSchema` |
+| `createMockActivity(overrides)` | Create a mock activity matching `ActivityItemSchema`   |
+| `createMockProject(overrides)`  | Create a mock project                                  |
+| `createMockLabel(overrides)`    | Create a mock label                                    |
+| `createMockColumn(overrides)`   | Create a mock column                                   |
+
+### 11.5 YouTrack Fetch Mock Note
+
+YouTrack tests use a local `installFetchMock` function that is functionally equivalent to `setMockFetch`/`restoreFetch`. Both save/restore `originalFetch`, so isolation is fine. Unifying them is a nice-to-have but low priority since both work correctly.
+
+---
+
+_Document generated: 2026-03-12_
+_Based on: API_COMPLIANCE_ANALYSIS.md_
 _Next review: On next API change or monthly_

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -13,7 +13,11 @@
     "src/errors.ts",
     "src/config.ts",
     "src/memory.ts",
-    "src/users.ts"
+    "src/users.ts",
+    "src/cron.ts",
+    "src/recurring.ts",
+    "src/history.ts",
+    "src/conversation.ts"
   ],
   "coverageAnalysis": "perTest",
   "incremental": true,

--- a/tests/conversation.test.ts
+++ b/tests/conversation.test.ts
@@ -1,4 +1,4 @@
-import { mock, describe, expect, test, beforeEach, spyOn } from 'bun:test'
+import { mock, describe, expect, test, beforeEach, afterEach, spyOn } from 'bun:test'
 
 import type { ModelMessage } from 'ai'
 
@@ -9,12 +9,16 @@ import { flushMicrotasks } from './test-helpers.js'
 
 // Mock the ai module for trimWithMemoryModel
 type GenerateTextResult = { text: string }
-let generateTextImpl = (): Promise<GenerateTextResult> =>
+const defaultGenerateTextImpl = (): Promise<GenerateTextResult> =>
   Promise.resolve({ text: JSON.stringify({ keep_indices: [0, 1], summary: 'Updated summary text' }) })
+let generateTextImpl = defaultGenerateTextImpl
 
 void mock.module('ai', () => ({
   generateText: (..._args: unknown[]): Promise<GenerateTextResult> => generateTextImpl(),
 }))
+
+// Helper type for spy instances that need cleanup
+type SpyInstance = { mockRestore: () => void }
 
 describe('shouldTriggerTrim', () => {
   const makeMessages = (count: number, userEvery = 2): ModelMessage[] =>
@@ -85,10 +89,19 @@ describe('shouldTriggerTrim', () => {
 describe('buildMessagesWithMemory', () => {
   const mockSummaries = new Map<string, string>()
   const mockFacts = new Map<string, Array<{ identifier: string; title: string; url: string; last_seen: string }>>()
+  let getCachedSummarySpy: ReturnType<typeof spyOn<typeof cacheModule, 'getCachedSummary'>>
+  let getCachedFactsSpy: ReturnType<typeof spyOn<typeof cacheModule, 'getCachedFacts'>>
 
   beforeEach(() => {
     mockSummaries.clear()
     mockFacts.clear()
+    getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null)
+    getCachedFactsSpy = spyOn(cacheModule, 'getCachedFacts').mockReturnValue([])
+  })
+
+  afterEach(() => {
+    getCachedSummarySpy.mockRestore()
+    getCachedFactsSpy.mockRestore()
   })
 
   test('returns history unchanged when no summary and no facts', () => {
@@ -97,24 +110,17 @@ describe('buildMessagesWithMemory', () => {
       { role: 'assistant', content: 'Hi there' },
     ]
 
-    const getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null)
-    const getCachedFactsSpy = spyOn(cacheModule, 'getCachedFacts').mockReturnValue([])
-
     const result = buildMessagesWithMemory('user1', history)
 
     expect(result.messages).toEqual(history)
     expect(result.memoryMsg).toBeNull()
-
-    getCachedSummarySpy.mockRestore()
-    getCachedFactsSpy.mockRestore()
   })
 
   test('prepends system message with summary when summary is present', () => {
     const history: ModelMessage[] = [{ role: 'user', content: 'Hello' }]
     mockSummaries.set('user1', 'User worked on mobile app project')
 
-    const getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(mockSummaries.get('user1')!)
-    const getCachedFactsSpy = spyOn(cacheModule, 'getCachedFacts').mockReturnValue([])
+    getCachedSummarySpy.mockReturnValue(mockSummaries.get('user1')!)
 
     const result = buildMessagesWithMemory('user1', history)
 
@@ -122,17 +128,13 @@ describe('buildMessagesWithMemory', () => {
     const firstMsg = result.messages[0]!
     expect(firstMsg.role).toBe('system')
     expect(firstMsg.content).toContain('User worked on mobile app project')
-
-    getCachedSummarySpy.mockRestore()
-    getCachedFactsSpy.mockRestore()
   })
 
   test('prepends system message with facts when facts are present', () => {
     const history: ModelMessage[] = [{ role: 'user', content: 'Hello' }]
     mockFacts.set('user1', [{ identifier: '#42', title: 'Fix login bug', url: '', last_seen: '2026-03-01T00:00:00Z' }])
 
-    const getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null)
-    const getCachedFactsSpy = spyOn(cacheModule, 'getCachedFacts').mockReturnValue(mockFacts.get('user1')!)
+    getCachedFactsSpy.mockReturnValue(mockFacts.get('user1')!)
 
     const result = buildMessagesWithMemory('user1', history)
 
@@ -140,9 +142,6 @@ describe('buildMessagesWithMemory', () => {
     const firstMsg = result.messages[0]!
     expect(firstMsg.role).toBe('system')
     expect(firstMsg.content).toContain('#42')
-
-    getCachedSummarySpy.mockRestore()
-    getCachedFactsSpy.mockRestore()
   })
 
   test('prepends single system message with both summary and facts when both present', () => {
@@ -150,8 +149,8 @@ describe('buildMessagesWithMemory', () => {
     mockSummaries.set('user1', 'User worked on mobile app project')
     mockFacts.set('user1', [{ identifier: '#42', title: 'Fix login bug', url: '', last_seen: '2026-03-01T00:00:00Z' }])
 
-    const getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(mockSummaries.get('user1')!)
-    const getCachedFactsSpy = spyOn(cacheModule, 'getCachedFacts').mockReturnValue(mockFacts.get('user1')!)
+    getCachedSummarySpy.mockReturnValue(mockSummaries.get('user1')!)
+    getCachedFactsSpy.mockReturnValue(mockFacts.get('user1')!)
 
     const result = buildMessagesWithMemory('user1', history)
 
@@ -160,26 +159,19 @@ describe('buildMessagesWithMemory', () => {
     expect(systemMsg.role).toBe('system')
     expect(systemMsg.content).toContain('User worked on mobile app project')
     expect(systemMsg.content).toContain('#42')
-
-    getCachedSummarySpy.mockRestore()
-    getCachedFactsSpy.mockRestore()
   })
 
   test('does not mutate original history array', () => {
     const history: ModelMessage[] = [{ role: 'user', content: 'Hello' }]
     mockSummaries.set('user1', 'Summary text')
 
-    const getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(mockSummaries.get('user1')!)
-    const getCachedFactsSpy = spyOn(cacheModule, 'getCachedFacts').mockReturnValue([])
+    getCachedSummarySpy.mockReturnValue(mockSummaries.get('user1')!)
 
     const originalLength = history.length
     buildMessagesWithMemory('user1', history)
 
     expect(history).toHaveLength(originalLength)
     expect(history[0]).toEqual({ role: 'user', content: 'Hello' })
-
-    getCachedSummarySpy.mockRestore()
-    getCachedFactsSpy.mockRestore()
   })
 })
 
@@ -187,11 +179,25 @@ describe('runTrimInBackground', () => {
   const mockSummaries = new Map<string, string>()
   const mockHistories = new Map<string, ModelMessage[]>()
   const mockConfigs = new Map<string, Map<string, string | null>>()
+  const spies: SpyInstance[] = []
+
+  function trackSpy<T extends SpyInstance>(spy: T): T {
+    spies.push(spy)
+    return spy
+  }
 
   beforeEach(() => {
+    generateTextImpl = defaultGenerateTextImpl
     mockSummaries.clear()
     mockHistories.clear()
     mockConfigs.clear()
+  })
+
+  afterEach(() => {
+    for (const spy of spies) {
+      spy.mockRestore()
+    }
+    spies.length = 0
   })
 
   test('success path: calls trimWithMemoryModel, saves summary, and updates history', async () => {
@@ -210,34 +216,30 @@ describe('runTrimInBackground', () => {
       ]),
     )
 
-    const getCachedConfigSpy = spyOn(cacheModule, 'getCachedConfig').mockImplementation(
-      (userId: string, key: string) => mockConfigs.get(userId)?.get(key) ?? null,
+    trackSpy(
+      spyOn(cacheModule, 'getCachedConfig').mockImplementation(
+        (userId: string, key: string) => mockConfigs.get(userId)?.get(key) ?? null,
+      ),
     )
-    const getCachedHistorySpy = spyOn(cacheModule, 'getCachedHistory').mockImplementation(
-      (userId: string) => mockHistories.get(userId) ?? [],
+    trackSpy(
+      spyOn(cacheModule, 'getCachedHistory').mockImplementation((userId: string) => mockHistories.get(userId) ?? []),
     )
-    const setCachedHistorySpy = spyOn(cacheModule, 'setCachedHistory').mockImplementation(
-      (userId: string, messages: readonly ModelMessage[]) => {
+    trackSpy(
+      spyOn(cacheModule, 'setCachedHistory').mockImplementation((userId: string, messages: readonly ModelMessage[]) => {
         mockHistories.set(userId, [...messages])
-      },
+      }),
     )
-    const setCachedSummarySpy = spyOn(cacheModule, 'setCachedSummary').mockImplementation(
-      (userId: string, summary: string) => {
+    trackSpy(
+      spyOn(cacheModule, 'setCachedSummary').mockImplementation((userId: string, summary: string) => {
         mockSummaries.set(userId, summary)
-      },
+      }),
     )
-    const getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null)
+    trackSpy(spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null))
 
     await runTrimInBackground('user1', history)
     await flushMicrotasks()
 
     expect(mockSummaries.get('user1')).toBe('Updated summary text')
-
-    getCachedConfigSpy.mockRestore()
-    getCachedHistorySpy.mockRestore()
-    setCachedHistorySpy.mockRestore()
-    setCachedSummarySpy.mockRestore()
-    getCachedSummarySpy.mockRestore()
   })
 
   test('preserves new messages added during async trim', async () => {
@@ -264,19 +266,21 @@ describe('runTrimInBackground', () => {
       return Promise.resolve({ text: JSON.stringify({ keep_indices: [0], summary: 'Trimmed' }) })
     }
 
-    const getCachedConfigSpy = spyOn(cacheModule, 'getCachedConfig').mockImplementation(
-      (userId: string, key: string) => mockConfigs.get(userId)?.get(key) ?? null,
+    trackSpy(
+      spyOn(cacheModule, 'getCachedConfig').mockImplementation(
+        (userId: string, key: string) => mockConfigs.get(userId)?.get(key) ?? null,
+      ),
     )
-    const getCachedHistorySpy = spyOn(cacheModule, 'getCachedHistory').mockImplementation(
-      (userId: string) => mockHistories.get(userId) ?? [],
+    trackSpy(
+      spyOn(cacheModule, 'getCachedHistory').mockImplementation((userId: string) => mockHistories.get(userId) ?? []),
     )
-    const setCachedHistorySpy = spyOn(cacheModule, 'setCachedHistory').mockImplementation(
-      (userId: string, messages: readonly ModelMessage[]) => {
+    trackSpy(
+      spyOn(cacheModule, 'setCachedHistory').mockImplementation((userId: string, messages: readonly ModelMessage[]) => {
         mockHistories.set(userId, [...messages])
-      },
+      }),
     )
-    const setCachedSummarySpy = spyOn(cacheModule, 'setCachedSummary').mockImplementation(() => {})
-    const getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null)
+    trackSpy(spyOn(cacheModule, 'setCachedSummary').mockImplementation(() => {}))
+    trackSpy(spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null))
 
     await runTrimInBackground('user1', history)
     await flushMicrotasks()
@@ -284,26 +288,17 @@ describe('runTrimInBackground', () => {
     const finalHistory = mockHistories.get('user1')
     expect(finalHistory).toBeDefined()
     expect(finalHistory!.length).toBeGreaterThanOrEqual(1)
-
-    getCachedConfigSpy.mockRestore()
-    getCachedHistorySpy.mockRestore()
-    setCachedHistorySpy.mockRestore()
-    setCachedSummarySpy.mockRestore()
-    getCachedSummarySpy.mockRestore()
   })
 
   test('config-missing path: logs warning and returns without calling trim', async () => {
     const history: ModelMessage[] = [{ role: 'user', content: 'Hello' }]
     mockHistories.set('user1', [...history])
 
-    const getCachedConfigSpy = spyOn(cacheModule, 'getCachedConfig').mockReturnValue(null)
-    const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {})
+    trackSpy(spyOn(cacheModule, 'getCachedConfig').mockReturnValue(null))
+    trackSpy(spyOn(logger, 'warn').mockImplementation(() => {}))
 
     await runTrimInBackground('user1', history)
     await flushMicrotasks()
-
-    getCachedConfigSpy.mockRestore()
-    warnSpy.mockRestore()
   })
 
   test('handles trimWithMemoryModel failure gracefully', async () => {
@@ -323,26 +318,22 @@ describe('runTrimInBackground', () => {
 
     generateTextImpl = (): Promise<GenerateTextResult> => Promise.reject(new Error('LLM API error'))
 
-    const getCachedConfigSpy = spyOn(cacheModule, 'getCachedConfig').mockImplementation(
-      (userId: string, key: string) => mockConfigs.get(userId)?.get(key) ?? null,
+    trackSpy(
+      spyOn(cacheModule, 'getCachedConfig').mockImplementation(
+        (userId: string, key: string) => mockConfigs.get(userId)?.get(key) ?? null,
+      ),
     )
-    const getCachedHistorySpy = spyOn(cacheModule, 'getCachedHistory').mockImplementation(
-      (userId: string) => mockHistories.get(userId) ?? [],
+    trackSpy(
+      spyOn(cacheModule, 'getCachedHistory').mockImplementation((userId: string) => mockHistories.get(userId) ?? []),
     )
-    const setCachedHistorySpy = spyOn(cacheModule, 'setCachedHistory').mockImplementation(() => {})
-    const getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null)
-    const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {})
+    trackSpy(spyOn(cacheModule, 'setCachedHistory').mockImplementation(() => {}))
+    trackSpy(spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null))
+    trackSpy(spyOn(logger, 'warn').mockImplementation(() => {}))
 
     await runTrimInBackground('user1', history)
     await flushMicrotasks()
 
     expect(mockHistories.get('user1')).toEqual(history)
-
-    getCachedConfigSpy.mockRestore()
-    getCachedHistorySpy.mockRestore()
-    setCachedHistorySpy.mockRestore()
-    getCachedSummarySpy.mockRestore()
-    warnSpy.mockRestore()
   })
 
   test('concurrent calls for same user — both complete without corruption', async () => {
@@ -370,19 +361,23 @@ describe('runTrimInBackground', () => {
     generateTextImpl = (): Promise<GenerateTextResult> =>
       Promise.resolve({ text: JSON.stringify({ keep_indices: [0], summary: 'Concurrent trim summary' }) })
 
-    const getCachedConfigSpy = spyOn(cacheModule, 'getCachedConfig').mockImplementation(
-      (userId: string, key: string) => concurrentConfigs.get(userId)?.get(key) ?? null,
+    trackSpy(
+      spyOn(cacheModule, 'getCachedConfig').mockImplementation(
+        (userId: string, key: string) => concurrentConfigs.get(userId)?.get(key) ?? null,
+      ),
     )
-    const getCachedHistorySpy = spyOn(cacheModule, 'getCachedHistory').mockImplementation(
-      (userId: string) => concurrentHistories.get(userId) ?? [],
+    trackSpy(
+      spyOn(cacheModule, 'getCachedHistory').mockImplementation(
+        (userId: string) => concurrentHistories.get(userId) ?? [],
+      ),
     )
-    const setCachedHistorySpy = spyOn(cacheModule, 'setCachedHistory').mockImplementation(
-      (userId: string, messages: readonly ModelMessage[]) => {
+    trackSpy(
+      spyOn(cacheModule, 'setCachedHistory').mockImplementation((userId: string, messages: readonly ModelMessage[]) => {
         concurrentHistories.set(userId, [...messages])
-      },
+      }),
     )
-    const setCachedSummarySpy = spyOn(cacheModule, 'setCachedSummary').mockImplementation(() => {})
-    const getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null)
+    trackSpy(spyOn(cacheModule, 'setCachedSummary').mockImplementation(() => {}))
+    trackSpy(spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null))
 
     // Fire both concurrently
     await Promise.all([runTrimInBackground('user1', history1), runTrimInBackground('user1', history2)])
@@ -392,12 +387,6 @@ describe('runTrimInBackground', () => {
     const finalHistory = concurrentHistories.get('user1')
     expect(finalHistory).toBeDefined()
     expect(Array.isArray(finalHistory)).toBe(true)
-
-    getCachedConfigSpy.mockRestore()
-    getCachedHistorySpy.mockRestore()
-    setCachedHistorySpy.mockRestore()
-    setCachedSummarySpy.mockRestore()
-    getCachedSummarySpy.mockRestore()
   })
 })
 
@@ -424,10 +413,19 @@ describe('Story 3: Context retained at message 50+', () => {
 describe('Story 5: Summary injected into context', () => {
   const mockSummaries = new Map<string, string>()
   const mockFacts = new Map<string, Array<{ identifier: string; title: string; url: string; last_seen: string }>>()
+  let getCachedSummarySpy: ReturnType<typeof spyOn<typeof cacheModule, 'getCachedSummary'>>
+  let getCachedFactsSpy: ReturnType<typeof spyOn<typeof cacheModule, 'getCachedFacts'>>
 
   beforeEach(() => {
     mockSummaries.clear()
     mockFacts.clear()
+    getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null)
+    getCachedFactsSpy = spyOn(cacheModule, 'getCachedFacts').mockReturnValue([])
+  })
+
+  afterEach(() => {
+    getCachedSummarySpy.mockRestore()
+    getCachedFactsSpy.mockRestore()
   })
 
   test('buildMessagesWithMemory includes summary in system message for LLM context', () => {
@@ -435,8 +433,7 @@ describe('Story 5: Summary injected into context', () => {
     const summary = 'User worked on mobile app project'
     mockSummaries.set('user1', summary)
 
-    const getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(summary)
-    const getCachedFactsSpy = spyOn(cacheModule, 'getCachedFacts').mockReturnValue([])
+    getCachedSummarySpy.mockReturnValue(summary)
 
     const result = buildMessagesWithMemory('user1', history)
 
@@ -446,25 +443,18 @@ describe('Story 5: Summary injected into context', () => {
     expect(systemMsg.content).toContain(summary)
     expect(result.memoryMsg).toBeDefined()
     expect(result.memoryMsg!.content).toContain(summary)
-
-    getCachedSummarySpy.mockRestore()
-    getCachedFactsSpy.mockRestore()
   })
 
   test('LLM would have access to summary when responding to "what were we working on?"', () => {
     const history: ModelMessage[] = [{ role: 'user', content: 'What were we working on?' }]
     mockSummaries.set('user1', 'User was working on task #42: Fix login bug in the mobile app')
 
-    const getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(mockSummaries.get('user1')!)
-    const getCachedFactsSpy = spyOn(cacheModule, 'getCachedFacts').mockReturnValue([])
+    getCachedSummarySpy.mockReturnValue(mockSummaries.get('user1')!)
 
     const result = buildMessagesWithMemory('user1', history)
 
     const systemMsg = result.messages[0]!
     expect(systemMsg.content).toContain('Fix login bug')
     expect(systemMsg.content).toContain('#42')
-
-    getCachedSummarySpy.mockRestore()
-    getCachedFactsSpy.mockRestore()
   })
 })

--- a/tests/group-context-isolation.test.ts
+++ b/tests/group-context-isolation.test.ts
@@ -1,49 +1,17 @@
-import { Database } from 'bun:sqlite'
 import { afterAll, mock, describe, expect, test, beforeEach } from 'bun:test'
 
-import { drizzle } from 'drizzle-orm/bun-sqlite'
+import { mockLogger, setupTestDb, mockDrizzle } from './utils/test-helpers.js'
 
-import * as schema from '../src/db/schema.js'
+mockLogger()
+mockDrizzle()
 
-// --- Test database setup with Drizzle ---
-let testDb: ReturnType<typeof drizzle<typeof schema>>
-let testSqlite: Database
-
-// Mock getDrizzleDb to return our test database
-void mock.module('../src/db/drizzle.js', () => ({
-  getDrizzleDb: (): ReturnType<typeof drizzle<typeof schema>> => testDb,
-}))
-
-// Import after mock is set up
 import { checkAuthorizationExtended } from '../src/bot.js'
 import { addGroupMember } from '../src/groups.js'
 import { addUser } from '../src/users.js'
 
 describe('group context isolation', () => {
-  beforeEach(() => {
-    testSqlite = new Database(':memory:')
-    testDb = drizzle(testSqlite, { schema })
-
-    // Create tables using Drizzle's schema
-    testSqlite.run(`
-      CREATE TABLE users (
-        platform_user_id TEXT PRIMARY KEY,
-        username TEXT UNIQUE,
-        added_at TEXT NOT NULL DEFAULT (datetime('now')),
-        added_by TEXT NOT NULL,
-        kaneo_workspace_id TEXT
-      )
-    `)
-
-    testSqlite.run(`
-      CREATE TABLE group_members (
-        group_id TEXT NOT NULL,
-        user_id TEXT NOT NULL,
-        added_by TEXT NOT NULL,
-        added_at TEXT NOT NULL DEFAULT (datetime('now')),
-        PRIMARY KEY (group_id, user_id)
-      )
-    `)
+  beforeEach(async () => {
+    await setupTestDb()
   })
 
   test('two groups have independent storage contexts', () => {

--- a/tests/providers/kaneo/comment-resource.test.ts
+++ b/tests/providers/kaneo/comment-resource.test.ts
@@ -6,7 +6,7 @@ import { mockLogger } from '../../utils/test-helpers.js'
 mockLogger()
 
 import type { KaneoConfig } from '../../../src/providers/kaneo/client.js'
-import { createMockActivityForList, restoreFetch, setMockFetch } from '../../test-helpers.js'
+import { createMockActivity, restoreFetch, setMockFetch } from '../../test-helpers.js'
 import { CommentResource } from './test-resources.js'
 
 describe('CommentResource', () => {
@@ -38,7 +38,7 @@ describe('CommentResource', () => {
         return Promise.resolve(
           new Response(
             JSON.stringify([
-              createMockActivityForList({
+              createMockActivity({
                 id: 'comment-1',
                 taskId: 'task-1',
                 type: 'comment',
@@ -71,7 +71,7 @@ describe('CommentResource', () => {
         return Promise.resolve(
           new Response(
             JSON.stringify([
-              createMockActivityForList({
+              createMockActivity({
                 id: 'comment-2',
                 taskId: 'task-1',
                 type: 'comment',
@@ -101,7 +101,7 @@ describe('CommentResource', () => {
         return Promise.resolve(
           new Response(
             JSON.stringify([
-              createMockActivityForList({
+              createMockActivity({
                 id: 'comment-3',
                 taskId: 'task-1',
                 type: 'comment',
@@ -139,19 +139,19 @@ describe('CommentResource', () => {
         Promise.resolve(
           new Response(
             JSON.stringify([
-              createMockActivityForList({
+              createMockActivity({
                 id: 'act-1',
                 type: 'comment',
                 content: 'Comment 1',
                 createdAt: '2026-03-01T00:00:00Z',
               }),
-              createMockActivityForList({
+              createMockActivity({
                 id: 'act-2',
                 type: 'status_changed',
                 content: 'Status changed',
                 createdAt: '2026-03-01T00:00:00Z',
               }),
-              createMockActivityForList({
+              createMockActivity({
                 id: 'act-3',
                 type: 'comment',
                 content: 'Comment 2',
@@ -176,13 +176,13 @@ describe('CommentResource', () => {
         Promise.resolve(
           new Response(
             JSON.stringify([
-              createMockActivityForList({
+              createMockActivity({
                 id: 'act-1',
                 type: 'comment',
                 content: 'Valid comment',
                 createdAt: '2026-03-01T00:00:00Z',
               }),
-              createMockActivityForList({
+              createMockActivity({
                 id: 'act-2',
                 type: 'comment',
                 content: null,
@@ -206,7 +206,7 @@ describe('CommentResource', () => {
         Promise.resolve(
           new Response(
             JSON.stringify([
-              createMockActivityForList({
+              createMockActivity({
                 id: 'act-1',
                 type: 'status_changed',
                 content: 'Changed',
@@ -229,7 +229,7 @@ describe('CommentResource', () => {
         Promise.resolve(
           new Response(
             JSON.stringify([
-              createMockActivityForList({
+              createMockActivity({
                 id: 'act-1',
                 type: 'comment',
                 content: 'Test',
@@ -277,7 +277,7 @@ describe('CommentResource', () => {
         return Promise.resolve(
           new Response(
             JSON.stringify([
-              createMockActivityForList({
+              createMockActivity({
                 id: 'comment-1',
                 taskId: 'task-1',
                 type: 'comment',

--- a/tests/providers/kaneo/task-status.test.ts
+++ b/tests/providers/kaneo/task-status.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 
 import { mockLogger } from '../../utils/test-helpers.js'
 
@@ -8,24 +8,33 @@ mockLogger()
 import { getUserMessage } from '../../../src/errors.js'
 import { KaneoClassifiedError } from '../../../src/providers/kaneo/classify-error.js'
 import type { KaneoConfig } from '../../../src/providers/kaneo/client.js'
-import { validateStatus } from '../../../src/providers/kaneo/task-status.js'
 import { restoreFetch } from '../../test-helpers.js'
 
+type ColumnEntry = { id: string; name: string; order: number }
+
+const defaultColumns: ColumnEntry[] = [
+  { id: 'col-1', name: 'To Do', order: 0 },
+  { id: 'col-2', name: 'In Progress', order: 1 },
+  { id: 'col-3', name: 'Done', order: 2 },
+]
+
+let listColumnsImpl: (config: KaneoConfig, projectId: string) => Promise<ColumnEntry[]>
+
 void mock.module('../../../src/providers/kaneo/list-columns.js', () => ({
-  listColumns: mock(() =>
-    Promise.resolve([
-      { id: 'col-1', name: 'To Do', order: 0 },
-      { id: 'col-2', name: 'In Progress', order: 1 },
-      { id: 'col-3', name: 'Done', order: 2 },
-    ]),
-  ),
+  listColumns: (...args: [KaneoConfig, string]): Promise<ColumnEntry[]> => listColumnsImpl(...args),
 }))
+
+import { validateStatus } from '../../../src/providers/kaneo/task-status.js'
 
 describe('validateStatus', () => {
   const mockConfig: KaneoConfig = {
     apiKey: 'test-key',
     baseUrl: 'https://test.kaneo.app',
   }
+
+  beforeEach(() => {
+    listColumnsImpl = (): Promise<ColumnEntry[]> => Promise.resolve(defaultColumns)
+  })
 
   afterEach(() => {
     restoreFetch()
@@ -93,6 +102,18 @@ describe('validateStatus', () => {
         expect(message).toContain('In Progress')
         expect(message).toContain('Done')
       }
+    })
+  })
+
+  describe('with custom project columns', () => {
+    test('validates against custom project columns', async () => {
+      listColumnsImpl = (): Promise<ColumnEntry[]> =>
+        Promise.resolve([
+          { id: 'col-x', name: 'Backlog', order: 0 },
+          { id: 'col-y', name: 'Shipped', order: 1 },
+        ])
+      const result = await validateStatus(mockConfig, 'proj-1', 'Backlog')
+      expect(result).toBe('backlog')
     })
   })
 

--- a/tests/providers/kaneo/task-status.test.ts
+++ b/tests/providers/kaneo/task-status.test.ts
@@ -18,10 +18,10 @@ const defaultColumns: ColumnEntry[] = [
   { id: 'col-3', name: 'Done', order: 2 },
 ]
 
-let listColumnsImpl: (config: KaneoConfig, projectId: string) => Promise<ColumnEntry[]>
+let listColumnsImpl: (opts: { config: KaneoConfig; projectId: string }) => Promise<ColumnEntry[]>
 
 void mock.module('../../../src/providers/kaneo/list-columns.js', () => ({
-  listColumns: (...args: [KaneoConfig, string]): Promise<ColumnEntry[]> => listColumnsImpl(...args),
+  listColumns: (opts: { config: KaneoConfig; projectId: string }): Promise<ColumnEntry[]> => listColumnsImpl(opts),
 }))
 
 import { validateStatus } from '../../../src/providers/kaneo/task-status.js'

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -135,23 +135,6 @@ export function createMockActivity(overrides: Partial<ActivityItem> = {}): Activ
   }
 }
 
-// Activity mock with string createdAt for list endpoint
-export function createMockActivityForList(overrides: Partial<ActivityItem> = {}): ActivityItem {
-  return {
-    id: 'act-1',
-    taskId: 'task-1',
-    type: 'comment',
-    createdAt: '2026-03-01T00:00:00Z',
-    userId: null,
-    content: 'Test comment',
-    externalUserName: null,
-    externalUserAvatar: null,
-    externalSource: null,
-    externalUrl: null,
-    ...overrides,
-  } as ActivityItem
-}
-
 // Complete column mock matching ColumnSchema
 export function createMockColumn(overrides: Partial<Column> = {}): Column {
   return {


### PR DESCRIPTION
- Reset generateTextImpl in beforeEach to prevent cross-test leakage
- Move all spy restoration from inline test bodies to afterEach blocks
- Replace manual DDL in group-context-isolation with setupTestDb/migrations
- Make listColumns mock configurable per-test via mutable impl pattern
- Remove duplicate createMockActivityForList (identical to createMockActivity)
- Add mock pattern documentation to TESTING_METHODOLOGY.md
- Expand StrykerJS mutate scope: add cron, recurring, history, conversation

https://claude.ai/code/session_01KdPNZwvc2qn2hD7sDgvFVb