### PR TITLE
feat: implement custom instructions (save/list/delete via LLM tools)

### DIFF
--- a/src/cache-db.ts
+++ b/src/cache-db.ts
@@ -1,7 +1,7 @@
-import { eq, and, sql } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 
 import { getDrizzleDb } from './db/drizzle.js'
-import { conversationHistory, memorySummary, memoryFacts, userConfig, users } from './db/schema.js'
+import { conversationHistory, memorySummary, memoryFacts, userConfig, userInstructions, users } from './db/schema.js'
 import { logger } from './logger.js'
 
 const log = logger.child({ scope: 'cache-db' })
@@ -126,6 +126,41 @@ export function syncWorkspaceToDb(userId: string, workspaceId: string): void {
       log.error(
         { userId, error: error instanceof Error ? error.message : String(error) },
         'Failed to sync workspace to DB',
+      )
+    }
+  })
+}
+
+export function syncInstructionToDb(contextId: string, instruction: { id: string; text: string }): void {
+  queueMicrotask(() => {
+    try {
+      const db = getDrizzleDb()
+      db.insert(userInstructions)
+        .values({ id: instruction.id, contextId, text: instruction.text, createdAt: new Date().toISOString() })
+        .onConflictDoNothing()
+        .run()
+      log.debug({ contextId, id: instruction.id }, 'Instruction synced to DB')
+    } catch (error) {
+      log.error(
+        { contextId, error: error instanceof Error ? error.message : String(error) },
+        'Failed to sync instruction to DB',
+      )
+    }
+  })
+}
+
+export function deleteInstructionFromDb(contextId: string, id: string): void {
+  queueMicrotask(() => {
+    try {
+      const db = getDrizzleDb()
+      db.delete(userInstructions)
+        .where(and(eq(userInstructions.id, id), eq(userInstructions.contextId, contextId)))
+        .run()
+      log.debug({ contextId, id }, 'Instruction deleted from DB')
+    } catch (error) {
+      log.error(
+        { contextId, error: error instanceof Error ? error.message : String(error) },
+        'Failed to delete instruction from DB',
       )
     }
   })

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,10 +1,18 @@
 import { type ModelMessage } from 'ai'
 import { sql } from 'drizzle-orm'
 
-import { syncConfigToDb, syncFactToDb, syncHistoryToDb, syncSummaryToDb, syncWorkspaceToDb } from './cache-db.js'
+import {
+  deleteInstructionFromDb,
+  syncConfigToDb,
+  syncFactToDb,
+  syncHistoryToDb,
+  syncInstructionToDb,
+  syncSummaryToDb,
+  syncWorkspaceToDb,
+} from './cache-db.js'
 import { parseHistoryFromDb } from './cache-helpers.js'
 import { getDrizzleDb } from './db/drizzle.js'
-import { conversationHistory, memoryFacts, memorySummary, userConfig, users } from './db/schema.js'
+import { conversationHistory, memoryFacts, memorySummary, userConfig, userInstructions, users } from './db/schema.js'
 import { logger } from './logger.js'
 
 const log = logger.child({ scope: 'cache' })
@@ -15,6 +23,7 @@ type UserCache = {
   history: ModelMessage[]
   summary: string | null
   facts: Array<{ identifier: string; title: string; url: string; last_seen: string }>
+  instructions: Array<{ id: string; text: string; createdAt: string }> | null
   config: Map<string, string | null>
   workspaceId: string | null
   tools: unknown
@@ -58,6 +67,7 @@ function getOrCreateCache(userId: string): UserCache {
       history: [],
       summary: null,
       facts: [],
+      instructions: null,
       config: new Map(),
       workspaceId: null,
       tools: null,
@@ -245,4 +255,36 @@ export function clearCachedHistoryFlag(userId: string): void {
   }
   cache.config.delete('history_loaded')
   log.debug({ userId }, 'History loaded flag cleared')
+}
+
+// --- Instructions Cache ---
+
+export function getCachedInstructions(contextId: string): readonly { id: string; text: string; createdAt: string }[] {
+  const cache = getOrCreateCache(contextId)
+  if (cache.instructions === null) {
+    log.debug({ contextId }, 'Loading instructions from DB into cache')
+    const rows = getDrizzleDb()
+      .select({ id: userInstructions.id, text: userInstructions.text, createdAt: userInstructions.createdAt })
+      .from(userInstructions)
+      .where(sql`${userInstructions.contextId} = ${contextId}`)
+      .orderBy(sql`${userInstructions.createdAt} ASC`)
+      .all()
+    cache.instructions = rows
+  }
+  return cache.instructions
+}
+
+export function addCachedInstruction(contextId: string, instruction: { id: string; text: string }): void {
+  const cache = getOrCreateCache(contextId)
+  cache.instructions ??= []
+  cache.instructions.push({ ...instruction, createdAt: new Date().toISOString() })
+  syncInstructionToDb(contextId, instruction)
+}
+
+export function deleteCachedInstruction(contextId: string, id: string): void {
+  const cache = getOrCreateCache(contextId)
+  if (cache.instructions !== null) {
+    cache.instructions = cache.instructions.filter((i) => i.id !== id)
+  }
+  deleteInstructionFromDb(contextId, id)
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -13,6 +13,7 @@ import { migration008GroupMembers } from './migrations/008_group_members.js'
 import { migration009RecurringTasks } from './migrations/009_recurring_tasks.js'
 import { migration010RecurringTaskOccurrences } from './migrations/010_recurring_task_occurrences.js'
 import { migration011ProactiveAlerts } from './migrations/011_proactive_alerts.js'
+import { migration012UserInstructions } from './migrations/012_user_instructions.js'
 
 const DB_PATH = process.env['DB_PATH'] ?? 'papai.db'
 
@@ -51,6 +52,7 @@ const MIGRATIONS = [
   migration009RecurringTasks,
   migration010RecurringTaskOccurrences,
   migration011ProactiveAlerts,
+  migration012UserInstructions,
 ] as const
 
 export const initDb = (): void => {

--- a/src/db/migrations/012_user_instructions.ts
+++ b/src/db/migrations/012_user_instructions.ts
@@ -1,0 +1,18 @@
+import type { Database } from 'bun:sqlite'
+
+import type { Migration } from '../migrate.js'
+
+export const migration012UserInstructions: Migration = {
+  id: '012_user_instructions',
+  up(db: Database): void {
+    db.run(`
+      CREATE TABLE user_instructions (
+        id TEXT PRIMARY KEY,
+        context_id TEXT NOT NULL,
+        text TEXT NOT NULL,
+        created_at TEXT DEFAULT (datetime('now')) NOT NULL
+      )
+    `)
+    db.run('CREATE INDEX idx_user_instructions_context ON user_instructions(context_id)')
+  },
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -171,4 +171,19 @@ export type Reminder = typeof reminders.$inferSelect
 export type UserBriefingState = typeof userBriefingState.$inferSelect
 export type AlertStateRow = typeof alertState.$inferSelect
 
+export const userInstructions = sqliteTable(
+  'user_instructions',
+  {
+    id: text('id').primaryKey(),
+    contextId: text('context_id').notNull(),
+    text: text('text').notNull(),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [index('idx_user_instructions_context').on(table.contextId)],
+)
+
+export type UserInstruction = typeof userInstructions.$inferSelect
+
 export type GroupMember = typeof groupMembers.$inferSelect

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -1,0 +1,83 @@
+import { randomUUIDv7 } from 'bun'
+
+import { addCachedInstruction, deleteCachedInstruction, getCachedInstructions } from './cache.js'
+import { logger } from './logger.js'
+
+const log = logger.child({ scope: 'instructions' })
+
+const MAX_INSTRUCTIONS = 20
+const DUPLICATE_THRESHOLD = 0.8
+
+type SaveResult =
+  | { status: 'saved'; instruction: { id: string; text: string } }
+  | { status: 'duplicate' }
+  | { status: 'cap_reached' }
+
+type DeleteResult = { status: 'deleted' } | { status: 'not_found' }
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/\W+/)
+      .filter((w) => w.length > 0),
+  )
+}
+
+function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1
+  let intersection = 0
+  for (const word of a) {
+    if (b.has(word)) intersection++
+  }
+  const union = a.size + b.size - intersection
+  return union === 0 ? 1 : intersection / union
+}
+
+function isDuplicate(newText: string, existing: readonly { text: string }[]): boolean {
+  const newTokens = tokenize(newText)
+  return existing.some((e) => jaccardSimilarity(newTokens, tokenize(e.text)) >= DUPLICATE_THRESHOLD)
+}
+
+export function saveInstruction(contextId: string, text: string): SaveResult {
+  log.debug({ contextId }, 'saveInstruction called')
+  const existing = getCachedInstructions(contextId)
+
+  if (existing.length >= MAX_INSTRUCTIONS) {
+    log.warn({ contextId, count: existing.length }, 'Instruction cap reached')
+    return { status: 'cap_reached' }
+  }
+
+  if (isDuplicate(text, existing)) {
+    log.info({ contextId }, 'Duplicate instruction detected')
+    return { status: 'duplicate' }
+  }
+
+  const id = randomUUIDv7()
+  addCachedInstruction(contextId, { id, text })
+  log.info({ contextId, id }, 'Instruction saved')
+  return { status: 'saved', instruction: { id, text } }
+}
+
+export function buildInstructionsBlock(contextId: string): string {
+  const items = listInstructions(contextId)
+  return items.length === 0 ? '' : `=== Custom instructions ===\n${items.map((i) => `- ${i.text}`).join('\n')}\n\n`
+}
+
+export function listInstructions(contextId: string): readonly { id: string; text: string }[] {
+  log.debug({ contextId }, 'listInstructions called')
+  return getCachedInstructions(contextId)
+}
+
+export function deleteInstruction(contextId: string, id: string): DeleteResult {
+  log.debug({ contextId, id }, 'deleteInstruction called')
+  const existing = getCachedInstructions(contextId)
+  const found = existing.some((i) => i.id === id)
+  if (!found) {
+    log.warn({ contextId, id }, 'Instruction not found for deletion')
+    return { status: 'not_found' }
+  }
+  deleteCachedInstruction(contextId, id)
+  log.info({ contextId, id }, 'Instruction deleted')
+  return { status: 'deleted' }
+}

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -6,12 +6,14 @@ import { logger } from './logger.js'
 const log = logger.child({ scope: 'instructions' })
 
 const MAX_INSTRUCTIONS = 20
+const MAX_INSTRUCTION_LENGTH = 500
 const DUPLICATE_THRESHOLD = 0.8
 
 type SaveResult =
   | { status: 'saved'; instruction: { id: string; text: string } }
   | { status: 'duplicate' }
   | { status: 'cap_reached' }
+  | { status: 'invalid'; message: string }
 
 type DeleteResult = { status: 'deleted' } | { status: 'not_found' }
 
@@ -39,8 +41,23 @@ function isDuplicate(newText: string, existing: readonly { text: string }[]): bo
   return existing.some((e) => jaccardSimilarity(newTokens, tokenize(e.text)) >= DUPLICATE_THRESHOLD)
 }
 
+function normalizeText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
 export function saveInstruction(contextId: string, text: string): SaveResult {
   log.debug({ contextId }, 'saveInstruction called')
+
+  const normalized = normalizeText(text)
+  if (normalized.length === 0) {
+    log.warn({ contextId }, 'Empty instruction rejected')
+    return { status: 'invalid', message: 'Instruction text cannot be empty.' }
+  }
+  if (normalized.length > MAX_INSTRUCTION_LENGTH) {
+    log.warn({ contextId, length: normalized.length }, 'Instruction too long')
+    return { status: 'invalid', message: `Instruction text exceeds the ${MAX_INSTRUCTION_LENGTH}-character limit.` }
+  }
+
   const existing = getCachedInstructions(contextId)
 
   if (existing.length >= MAX_INSTRUCTIONS) {
@@ -48,15 +65,15 @@ export function saveInstruction(contextId: string, text: string): SaveResult {
     return { status: 'cap_reached' }
   }
 
-  if (isDuplicate(text, existing)) {
+  if (isDuplicate(normalized, existing)) {
     log.info({ contextId }, 'Duplicate instruction detected')
     return { status: 'duplicate' }
   }
 
   const id = randomUUIDv7()
-  addCachedInstruction(contextId, { id, text })
+  addCachedInstruction(contextId, { id, text: normalized })
   log.info({ contextId, id }, 'Instruction saved')
-  return { status: 'saved', instruction: { id, text } }
+  return { status: 'saved', instruction: { id, text: normalized } }
 }
 
 export function buildInstructionsBlock(contextId: string): string {

--- a/src/llm-orchestrator.ts
+++ b/src/llm-orchestrator.ts
@@ -1,7 +1,6 @@
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { APICallError } from '@ai-sdk/provider'
-import { generateText, stepCountIs, type ToolSet } from 'ai'
-import { type ModelMessage } from 'ai'
+import { generateText, stepCountIs, type ModelMessage, type ToolSet } from 'ai'
 
 import { getCachedHistory, getCachedTools, setCachedTools } from './cache.js'
 import type { ReplyFn } from './chat/types.js'
@@ -9,6 +8,7 @@ import { getConfig } from './config.js'
 import { buildMessagesWithMemory, runTrimInBackground, shouldTriggerTrim } from './conversation.js'
 import { getUserMessage, isAppError } from './errors.js'
 import { appendHistory, saveHistory } from './history.js'
+import { buildInstructionsBlock } from './instructions.js'
 import { logger } from './logger.js'
 import { extractFactsFromSdkResults, upsertFact } from './memory.js'
 import * as briefingService from './proactive/briefing.js'
@@ -69,8 +69,8 @@ RELATION TYPES — map user language to the correct type when calling add_task_r
 
 OUTPUT RULES:
 - When referencing tasks or projects, format them as Markdown links: [Task title](url). Never output raw IDs.
-- Keep replies short and friendly.
-- Don't use tables.`
+- Keep replies short and friendly. Don't use tables.
+- When the user expresses a persistent preference ("always", "never", "from now on"), call save_instruction. To list them, call list_instructions. To remove one, call list_instructions first, then delete_instruction.`
 
 const buildBasePrompt = (timezone: string): string => {
   const localDate = getLocalDateString(timezone)
@@ -107,12 +107,10 @@ REMINDERS — The user can set reminders that fire at specific times:
 
 ${STATIC_RULES}`
 }
-
-const buildSystemPrompt = (provider: TaskProvider, timezone: string): string => {
+const buildSystemPrompt = (provider: TaskProvider, timezone: string, contextId: string): string => {
   const base = buildBasePrompt(timezone)
   const addendum = provider.getPromptAddendum()
-  if (addendum === '') return base
-  return `${base}\n\n${addendum}`
+  return `${buildInstructionsBlock(contextId)}${addendum === '' ? base : `${base}\n\n${addendum}`}`
 }
 
 const buildOpenAI = (apiKey: string, baseURL: string): ReturnType<typeof createOpenAICompatible> =>
@@ -233,7 +231,7 @@ const callLlm = async (
   )
   const result = await generateText({
     model,
-    system: buildSystemPrompt(provider, timezone),
+    system: buildSystemPrompt(provider, timezone, contextId),
     messages: messagesWithMemory,
     tools,
     stopWhen: stepCountIs(25),

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,7 @@ import { makeDeleteStatusTool } from './delete-status.js'
 import { makeDeleteTaskTool } from './delete-task.js'
 import { makeGetCommentsTool } from './get-comments.js'
 import { makeGetTaskTool } from './get-task.js'
+import { makeDeleteInstructionTool, makeListInstructionsTool, makeSaveInstructionTool } from './instructions.js'
 import { makeListLabelsTool } from './list-labels.js'
 import { makeListProjectsTool } from './list-projects.js'
 import { makeListRecurringTasksTool } from './list-recurring-tasks.js'
@@ -141,6 +142,13 @@ function maybeAddDeleteTool(tools: ToolSet, provider: TaskProvider): void {
   }
 }
 
+function addInstructionTools(tools: ToolSet, contextId: string | undefined): void {
+  if (contextId === undefined) return
+  tools['save_instruction'] = makeSaveInstructionTool(contextId)
+  tools['list_instructions'] = makeListInstructionsTool(contextId)
+  tools['delete_instruction'] = makeDeleteInstructionTool(contextId)
+}
+
 function addRecurringTools(tools: ToolSet, userId: string | undefined): void {
   if (userId === undefined) return
   tools['create_recurring_task'] = makeCreateRecurringTaskTool(userId)
@@ -162,6 +170,7 @@ export function makeTools(provider: TaskProvider, userId?: string): ToolSet {
   maybeAddStatusTools(tools, provider)
   maybeAddDeleteTool(tools, provider)
   addRecurringTools(tools, userId)
+  addInstructionTools(tools, userId)
   if (userId !== undefined) {
     const proactiveTools = makeProactiveTools(userId, provider)
     Object.assign(tools, proactiveTools)

--- a/src/tools/instructions.ts
+++ b/src/tools/instructions.ts
@@ -1,0 +1,54 @@
+import { tool } from 'ai'
+import type { ToolSet } from 'ai'
+import { z } from 'zod'
+
+import { deleteInstruction, listInstructions, saveInstruction } from '../instructions.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ scope: 'tool:instructions' })
+
+export function makeSaveInstructionTool(contextId: string): ToolSet[string] {
+  return tool({
+    description:
+      'Save a persistent behavioral preference. Call this when the user expresses how the bot should always behave.',
+    inputSchema: z.object({
+      text: z.string().describe('The instruction as a short, clear statement, e.g. "Always reply in Spanish"'),
+    }),
+    execute: ({ text }) => {
+      log.debug({ contextId }, 'save_instruction tool called')
+      const result = saveInstruction(contextId, text)
+      if (result.status === 'saved') {
+        log.info({ contextId, id: result.instruction.id }, 'Instruction saved via tool')
+      }
+      return result
+    },
+  })
+}
+
+export function makeListInstructionsTool(contextId: string): ToolSet[string] {
+  return tool({
+    description: 'List all custom instructions for this context.',
+    inputSchema: z.object({}),
+    execute: () => {
+      log.debug({ contextId }, 'list_instructions tool called')
+      const instructions = listInstructions(contextId)
+      log.info({ contextId, count: instructions.length }, 'Instructions listed via tool')
+      return { instructions }
+    },
+  })
+}
+
+export function makeDeleteInstructionTool(contextId: string): ToolSet[string] {
+  return tool({
+    description: 'Delete a custom instruction by ID. Call list_instructions first to find the ID.',
+    inputSchema: z.object({
+      id: z.string().describe('The instruction ID to delete'),
+    }),
+    execute: ({ id }) => {
+      log.debug({ contextId, id }, 'delete_instruction tool called')
+      const result = deleteInstruction(contextId, id)
+      log.info({ contextId, id, status: result.status }, 'delete_instruction completed')
+      return result
+    },
+  })
+}

--- a/src/tools/instructions.ts
+++ b/src/tools/instructions.ts
@@ -12,7 +12,11 @@ export function makeSaveInstructionTool(contextId: string): ToolSet[string] {
     description:
       'Save a persistent behavioral preference. Call this when the user expresses how the bot should always behave.',
     inputSchema: z.object({
-      text: z.string().describe('The instruction as a short, clear statement, e.g. "Always reply in Spanish"'),
+      text: z
+        .string()
+        .min(1)
+        .max(500)
+        .describe('The instruction as a short, clear statement, e.g. "Always reply in Spanish"'),
     }),
     execute: ({ text }) => {
       log.debug({ contextId }, 'save_instruction tool called')
@@ -31,7 +35,8 @@ export function makeListInstructionsTool(contextId: string): ToolSet[string] {
     inputSchema: z.object({}),
     execute: () => {
       log.debug({ contextId }, 'list_instructions tool called')
-      const instructions = listInstructions(contextId)
+      const rawInstructions = listInstructions(contextId)
+      const instructions = rawInstructions.map(({ id, text }) => ({ id, text }))
       log.info({ contextId, count: instructions.length }, 'Instructions listed via tool')
       return { instructions }
     },

--- a/tests/instructions-cache.test.ts
+++ b/tests/instructions-cache.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect, beforeEach } from 'bun:test'
+
+import { mockLogger, mockDrizzle, setupTestDb, getTestDb } from './utils/test-helpers.js'
+
+mockLogger()
+mockDrizzle()
+
+import { _userCaches } from '../src/cache.js'
+import { getCachedInstructions, addCachedInstruction, deleteCachedInstruction } from '../src/cache.js'
+import { userInstructions } from '../src/db/schema.js'
+
+beforeEach(async () => {
+  _userCaches.clear()
+  await setupTestDb()
+})
+
+describe('instructions cache', () => {
+  test('getCachedInstructions returns empty array for new context', () => {
+    const result = getCachedInstructions('ctx-1')
+    expect(result).toEqual([])
+  })
+
+  test('addCachedInstruction stores instruction and retrieves it', () => {
+    addCachedInstruction('ctx-1', { id: 'i-1', text: 'Always reply in Spanish' })
+    const result = getCachedInstructions('ctx-1')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.text).toBe('Always reply in Spanish')
+  })
+
+  test('addCachedInstruction allows more than 20 (cap is in instructions module)', () => {
+    for (let i = 0; i < 21; i++) {
+      addCachedInstruction('ctx-1', { id: `i-${i}`, text: `Instruction ${i}` })
+    }
+    expect(getCachedInstructions('ctx-1').length).toBe(21)
+  })
+
+  test('deleteCachedInstruction removes by id', () => {
+    addCachedInstruction('ctx-1', { id: 'i-1', text: 'First' })
+    addCachedInstruction('ctx-1', { id: 'i-2', text: 'Second' })
+    deleteCachedInstruction('ctx-1', 'i-1')
+    const result = getCachedInstructions('ctx-1')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.id).toBe('i-2')
+  })
+
+  test('deleteCachedInstruction is a no-op for unknown id', () => {
+    addCachedInstruction('ctx-1', { id: 'i-1', text: 'First' })
+    deleteCachedInstruction('ctx-1', 'unknown')
+    expect(getCachedInstructions('ctx-1')).toHaveLength(1)
+  })
+
+  test('lazy loads from DB on first access', () => {
+    // Pre-seed DB directly
+    const db = getTestDb()
+    db.insert(userInstructions)
+      .values({ id: 'db-1', contextId: 'ctx-db', text: 'From DB', createdAt: new Date().toISOString() })
+      .run()
+    _userCaches.clear()
+
+    const result = getCachedInstructions('ctx-db')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.text).toBe('From DB')
+  })
+})

--- a/tests/instructions.test.ts
+++ b/tests/instructions.test.ts
@@ -23,6 +23,50 @@ describe('saveInstruction', () => {
     }
   })
 
+  test('normalizes whitespace and trims text', () => {
+    const result = saveInstruction('ctx-1', '  Always  reply   in  Spanish  ')
+    expect(result.status).toBe('saved')
+    if (result.status === 'saved') {
+      expect(result.instruction.text).toBe('Always reply in Spanish')
+    }
+  })
+
+  test('collapses newlines and tabs into single spaces', () => {
+    const result = saveInstruction('ctx-1', 'Always reply\n\nin\tSpanish')
+    expect(result.status).toBe('saved')
+    if (result.status === 'saved') {
+      expect(result.instruction.text).toBe('Always reply in Spanish')
+    }
+  })
+
+  test('rejects empty string', () => {
+    const result = saveInstruction('ctx-1', '')
+    expect(result.status).toBe('invalid')
+  })
+
+  test('rejects whitespace-only string', () => {
+    const result = saveInstruction('ctx-1', '   \n\t  ')
+    expect(result.status).toBe('invalid')
+  })
+
+  test('rejects text exceeding 500 characters', () => {
+    const longText = 'a'.repeat(501)
+    const result = saveInstruction('ctx-1', longText)
+    expect(result.status).toBe('invalid')
+  })
+
+  test('accepts text at exactly 500 characters', () => {
+    const text = 'a'.repeat(500)
+    const result = saveInstruction('ctx-1', text)
+    expect(result.status).toBe('saved')
+  })
+
+  test('detects duplicates that differ only by whitespace', () => {
+    saveInstruction('ctx-1', 'Always reply in Spanish')
+    const result = saveInstruction('ctx-1', '  Always  reply  in  Spanish  ')
+    expect(result.status).toBe('duplicate')
+  })
+
   test('returns duplicate when >80% word overlap with existing', () => {
     saveInstruction('ctx-1', 'Always reply in Spanish')
     const result = saveInstruction('ctx-1', 'Always reply in spanish language')

--- a/tests/instructions.test.ts
+++ b/tests/instructions.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect, beforeEach } from 'bun:test'
+
+import { mockLogger, mockDrizzle, setupTestDb } from './utils/test-helpers.js'
+
+mockLogger()
+mockDrizzle()
+
+import { _userCaches } from '../src/cache.js'
+import { saveInstruction, listInstructions, deleteInstruction } from '../src/instructions.js'
+
+beforeEach(async () => {
+  _userCaches.clear()
+  await setupTestDb()
+})
+
+describe('saveInstruction', () => {
+  test('stores instruction and returns it', () => {
+    const result = saveInstruction('ctx-1', 'Always reply in Spanish')
+    expect(result.status).toBe('saved')
+    if (result.status === 'saved') {
+      expect(result.instruction.text).toBe('Always reply in Spanish')
+      expect(result.instruction.id).toBeDefined()
+    }
+  })
+
+  test('returns duplicate when >80% word overlap with existing', () => {
+    saveInstruction('ctx-1', 'Always reply in Spanish')
+    const result = saveInstruction('ctx-1', 'Always reply in spanish language')
+    expect(result.status).toBe('duplicate')
+  })
+
+  test('returns cap_reached when 20 instructions already stored', () => {
+    for (let i = 0; i < 20; i++) {
+      saveInstruction('ctx-1', `Unique instruction number ${i} about topic ${i}`)
+    }
+    const result = saveInstruction('ctx-1', 'One more unique instruction here')
+    expect(result.status).toBe('cap_reached')
+  })
+
+  test('different contexts are isolated', () => {
+    saveInstruction('ctx-1', 'Always reply in Spanish')
+    expect(listInstructions('ctx-2')).toHaveLength(0)
+  })
+})
+
+describe('listInstructions', () => {
+  test('returns empty array when no instructions', () => {
+    expect(listInstructions('ctx-1')).toEqual([])
+  })
+
+  test('returns all saved instructions', () => {
+    saveInstruction('ctx-1', 'Always reply in Spanish')
+    saveInstruction('ctx-1', 'Use high priority by default')
+    const result = listInstructions('ctx-1')
+    expect(result).toHaveLength(2)
+  })
+})
+
+describe('deleteInstruction', () => {
+  test('removes instruction by id', () => {
+    const r = saveInstruction('ctx-1', 'Always reply in Spanish')
+    if (r.status !== 'saved') throw new Error('expected saved')
+    deleteInstruction('ctx-1', r.instruction.id)
+    expect(listInstructions('ctx-1')).toHaveLength(0)
+  })
+
+  test('returns not_found for unknown id', () => {
+    const result = deleteInstruction('ctx-1', 'nonexistent-id')
+    expect(result.status).toBe('not_found')
+  })
+
+  test('returns deleted for known id', () => {
+    const r = saveInstruction('ctx-1', 'Always reply in Spanish')
+    if (r.status !== 'saved') throw new Error('expected saved')
+    const result = deleteInstruction('ctx-1', r.instruction.id)
+    expect(result.status).toBe('deleted')
+  })
+})

--- a/tests/llm-orchestrator-system-prompt.test.ts
+++ b/tests/llm-orchestrator-system-prompt.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect, beforeEach } from 'bun:test'
+
+import { mockLogger, mockDrizzle, setupTestDb } from './utils/test-helpers.js'
+
+mockLogger()
+mockDrizzle()
+
+import { _userCaches } from '../src/cache.js'
+import { saveInstruction, buildInstructionsBlock } from '../src/instructions.js'
+
+beforeEach(async () => {
+  _userCaches.clear()
+  await setupTestDb()
+})
+
+describe('buildInstructionsBlock', () => {
+  test('includes custom instructions block when instructions exist', () => {
+    saveInstruction('ctx-1', 'Always reply in Spanish')
+    saveInstruction('ctx-1', 'Use high priority by default')
+    const block = buildInstructionsBlock('ctx-1')
+    expect(block).toContain('=== Custom instructions ===')
+    expect(block).toContain('- Always reply in Spanish')
+    expect(block).toContain('- Use high priority by default')
+  })
+
+  test('returns empty string when no instructions', () => {
+    const block = buildInstructionsBlock('ctx-1')
+    expect(block).toBe('')
+  })
+
+  test('formats instructions as bullet list', () => {
+    saveInstruction('ctx-1', 'Always reply in Spanish')
+    const block = buildInstructionsBlock('ctx-1')
+    expect(block).toStartWith('=== Custom instructions ===\n- Always reply in Spanish')
+  })
+})

--- a/tests/tools/instructions.test.ts
+++ b/tests/tools/instructions.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect, beforeEach } from 'bun:test'
+
+import { mockLogger, mockDrizzle, setupTestDb } from '../utils/test-helpers.js'
+
+mockLogger()
+mockDrizzle()
+
+import { _userCaches } from '../../src/cache.js'
+import { saveInstruction } from '../../src/instructions.js'
+import {
+  makeSaveInstructionTool,
+  makeListInstructionsTool,
+  makeDeleteInstructionTool,
+} from '../../src/tools/instructions.js'
+
+beforeEach(async () => {
+  _userCaches.clear()
+  await setupTestDb()
+})
+
+async function exec(
+  tool: ReturnType<typeof makeSaveInstructionTool>,
+  input: Record<string, unknown>,
+): Promise<unknown> {
+  if (!tool.execute) throw new Error('Tool execute is undefined')
+  const result: unknown = await tool.execute(input, { toolCallId: '1', messages: [] })
+  return result
+}
+
+describe('save_instruction tool', () => {
+  test('returns confirmation on save', async () => {
+    const tool = makeSaveInstructionTool('ctx-1')
+    const result = await exec(tool, { text: 'Always reply in Spanish' })
+    expect(result).toHaveProperty('status', 'saved')
+  })
+
+  test('returns duplicate message', async () => {
+    saveInstruction('ctx-1', 'Always reply in Spanish')
+    const tool = makeSaveInstructionTool('ctx-1')
+    const result = await exec(tool, { text: 'Always reply in spanish language' })
+    expect(result).toHaveProperty('status', 'duplicate')
+  })
+
+  test('returns cap_reached message', async () => {
+    for (let i = 0; i < 20; i++) {
+      saveInstruction('ctx-1', `Unique instruction number ${i} about topic ${i}`)
+    }
+    const tool = makeSaveInstructionTool('ctx-1')
+    const result = await exec(tool, { text: 'One more unique instruction here' })
+    expect(result).toHaveProperty('status', 'cap_reached')
+  })
+})
+
+describe('list_instructions tool', () => {
+  test('returns empty list', async () => {
+    const tool = makeListInstructionsTool('ctx-1')
+    const result = await exec(tool, {})
+    expect(result).toHaveProperty('instructions', [])
+  })
+
+  test('returns stored instructions', async () => {
+    saveInstruction('ctx-1', 'Always reply in Spanish')
+    const tool = makeListInstructionsTool('ctx-1')
+    const result = await exec(tool, {})
+    expect(result).toHaveProperty('instructions')
+  })
+})
+
+describe('delete_instruction tool', () => {
+  test('returns deleted confirmation', async () => {
+    const r = saveInstruction('ctx-1', 'Always reply in Spanish')
+    if (r.status !== 'saved') throw new Error('expected saved')
+    const tool = makeDeleteInstructionTool('ctx-1')
+    const result = await exec(tool, { id: r.instruction.id })
+    expect(result).toHaveProperty('status', 'deleted')
+  })
+
+  test('returns not_found message', async () => {
+    const tool = makeDeleteInstructionTool('ctx-1')
+    const result = await exec(tool, { id: 'unknown' })
+    expect(result).toHaveProperty('status', 'not_found')
+  })
+})

--- a/tests/utils/test-helpers.ts
+++ b/tests/utils/test-helpers.ts
@@ -22,6 +22,7 @@ import { migration008GroupMembers } from '../../src/db/migrations/008_group_memb
 import { migration009RecurringTasks } from '../../src/db/migrations/009_recurring_tasks.js'
 import { migration010RecurringTaskOccurrences } from '../../src/db/migrations/010_recurring_task_occurrences.js'
 import { migration011ProactiveAlerts } from '../../src/db/migrations/011_proactive_alerts.js'
+import { migration012UserInstructions } from '../../src/db/migrations/012_user_instructions.js'
 import * as schema from '../../src/db/schema.js'
 import type { AppError } from '../../src/errors.js'
 import { getUserMessage } from '../../src/errors.js'
@@ -39,6 +40,7 @@ const ALL_MIGRATIONS: readonly Migration[] = [
   migration009RecurringTasks,
   migration010RecurringTaskOccurrences,
   migration011ProactiveAlerts,
+  migration012UserInstructions,
 ]
 
 // ============================================================================


### PR DESCRIPTION
Add persistent behavioral preferences that users can teach the bot via
natural language. Instructions are stored per-context in SQLite, cached
in-memory, and injected into the system prompt.

- Add migration 012 for user_instructions table
- Add cache layer (getCachedInstructions, addCachedInstruction, deleteCachedInstruction)
- Add instructions module with duplicate detection (Jaccard similarity)
- Add save_instruction, list_instructions, delete_instruction LLM tools
- Inject custom instructions block at top of system prompt
- Add CUSTOM INSTRUCTIONS guidance to STATIC_RULES
- Add comprehensive tests for all layers

https://claude.ai/code/session_01UiCegpUhW6i93Qbp1fvEeG