### PR TITLE
feat: execution modes for deferred prompts

### DIFF
--- a/docs/plans/2026-03-26-deferred-prompt-execution-modes-implementation.md
+++ b/docs/plans/2026-03-26-deferred-prompt-execution-modes-implementation.md
@@ -1,0 +1,1405 @@
+# Deferred Prompt Execution Modes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Introduce three execution modes (lightweight, context, full) for deferred prompts so that fire-time resource loading scales with prompt complexity.
+
+**Architecture:** The creating LLM classifies each prompt at creation time into a mode and produces a delivery brief + optional context snapshot. At fire time, a dispatcher routes to one of three execution functions, each loading only the resources its mode requires. A new `execution_metadata` JSON column on both prompt tables stores the classification.
+
+**Tech Stack:** Bun, Drizzle ORM (SQLite), Vercel AI SDK, Zod v4, pino
+
+---
+
+### Task 1: Database Migration — Add `execution_metadata` Column
+
+**Files:**
+
+- Create: `src/db/migrations/016_execution_metadata.ts`
+- Modify: `src/db/index.ts:19,61` (add import and register migration)
+
+**Step 1: Write the migration file**
+
+```typescript
+// src/db/migrations/016_execution_metadata.ts
+import type { Database } from 'bun:sqlite'
+
+import type { Migration } from '../migrate.js'
+
+export const migration016ExecutionMetadata: Migration = {
+  id: '016_execution_metadata',
+  up(db: Database): void {
+    db.run(`ALTER TABLE scheduled_prompts ADD COLUMN execution_metadata TEXT NOT NULL DEFAULT '{}'`)
+    db.run(`ALTER TABLE alert_prompts ADD COLUMN execution_metadata TEXT NOT NULL DEFAULT '{}'`)
+  },
+}
+```
+
+**Step 2: Register the migration in `src/db/index.ts`**
+
+Add after line 19:
+
+```typescript
+import { migration016ExecutionMetadata } from './migrations/016_execution_metadata.js'
+```
+
+Add `migration016ExecutionMetadata` to the end of the `MIGRATIONS` array (after `migration015DropBackgroundEvents`).
+
+**Step 3: Run typecheck to verify**
+
+Run: `bun typecheck`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add src/db/migrations/016_execution_metadata.ts src/db/index.ts
+git commit -m "feat(db): add execution_metadata column to deferred prompt tables"
+```
+
+---
+
+### Task 2: Update Drizzle Schema
+
+**Files:**
+
+- Modify: `src/db/schema.ts:120-155` (add column to both tables)
+
+**Step 1: Add `executionMetadata` column to `scheduledPrompts`**
+
+In `src/db/schema.ts`, inside the `scheduledPrompts` table definition (after `lastExecutedAt` on line 132), add:
+
+```typescript
+    executionMetadata: text('execution_metadata').notNull().default('{}'),
+```
+
+**Step 2: Add `executionMetadata` column to `alertPrompts`**
+
+In `src/db/schema.ts`, inside the `alertPrompts` table definition (after `cooldownMinutes` on line 152), add:
+
+```typescript
+    executionMetadata: text('execution_metadata').notNull().default('{}'),
+```
+
+**Step 3: Run typecheck to verify**
+
+Run: `bun typecheck`
+Expected: PASS — `ScheduledPromptRow` and `AlertPromptRow` are inferred types, so they auto-gain `executionMetadata: string`.
+
+**Step 4: Commit**
+
+```bash
+git add src/db/schema.ts
+git commit -m "feat(schema): add executionMetadata column to scheduled and alert prompt tables"
+```
+
+---
+
+### Task 3: Update Domain Types
+
+**Files:**
+
+- Modify: `src/deferred-prompts/types.ts:71-95`
+
+**Step 1: Add `ExecutionMetadata` type and `executionMetadataSchema`**
+
+After the `alertConditionSchema` export (line 69) and before the domain types comment (line 71), add:
+
+```typescript
+// --- Execution metadata ---
+
+export const EXECUTION_MODES = ['lightweight', 'context', 'full'] as const
+export type ExecutionMode = (typeof EXECUTION_MODES)[number]
+
+export const executionMetadataSchema = z.object({
+  mode: z.enum(EXECUTION_MODES),
+  delivery_brief: z.string(),
+  context_snapshot: z.string().nullable().default(null),
+})
+
+export type ExecutionMetadata = z.infer<typeof executionMetadataSchema>
+
+export const DEFAULT_EXECUTION_METADATA: ExecutionMetadata = {
+  mode: 'full',
+  delivery_brief: '',
+  context_snapshot: null,
+}
+```
+
+**Step 2: Add `executionMetadata` field to `ScheduledPrompt` type**
+
+Add after `lastExecutedAt` (line 82):
+
+```typescript
+executionMetadata: ExecutionMetadata
+```
+
+**Step 3: Add `executionMetadata` field to `AlertPrompt` type**
+
+Add after `cooldownMinutes` (line 94):
+
+```typescript
+executionMetadata: ExecutionMetadata
+```
+
+**Step 4: Run typecheck**
+
+Run: `bun typecheck`
+Expected: FAIL — `toScheduledPrompt` and `toAlertPrompt` mappers don't set the new field yet. That's expected, we fix them in Task 4.
+
+**Step 5: Commit**
+
+```bash
+git add src/deferred-prompts/types.ts
+git commit -m "feat(types): add ExecutionMetadata type and schema for deferred prompts"
+```
+
+---
+
+### Task 4: Update Row Mappers in `scheduled.ts` and `alerts.ts`
+
+**Files:**
+
+- Modify: `src/deferred-prompts/scheduled.ts:19-31` (toScheduledPrompt)
+- Modify: `src/deferred-prompts/alerts.ts:15-25` (toAlertPrompt)
+
+**Step 1: Update `toScheduledPrompt` in `scheduled.ts`**
+
+Add import at the top of `src/deferred-prompts/scheduled.ts`:
+
+```typescript
+import { DEFAULT_EXECUTION_METADATA, executionMetadataSchema, type ExecutionMetadata } from './types.js'
+```
+
+Replace the existing `toScheduledPrompt` function (lines 19-31):
+
+```typescript
+function parseExecutionMetadata(raw: string): ExecutionMetadata {
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    const result = executionMetadataSchema.safeParse(parsed)
+    return result.success ? result.data : DEFAULT_EXECUTION_METADATA
+  } catch {
+    return DEFAULT_EXECUTION_METADATA
+  }
+}
+
+function toScheduledPrompt(row: ScheduledPromptRow): ScheduledPrompt {
+  return {
+    type: 'scheduled',
+    id: row.id,
+    userId: row.userId,
+    prompt: row.prompt,
+    fireAt: row.fireAt,
+    cronExpression: row.cronExpression,
+    status: toStatus(row.status),
+    createdAt: row.createdAt,
+    lastExecutedAt: row.lastExecutedAt,
+    executionMetadata: parseExecutionMetadata(row.executionMetadata),
+  }
+}
+```
+
+**Step 2: Update `createScheduledPrompt` to accept and store `executionMetadata`**
+
+Change the function signature (line 33) to accept an optional `executionMetadata` parameter:
+
+```typescript
+export function createScheduledPrompt(
+  userId: string,
+  prompt: string,
+  schedule: { fireAt: string; cronExpression?: string },
+  executionMetadata?: ExecutionMetadata,
+): ScheduledPrompt {
+```
+
+In the `db.insert` values (line 45), add:
+
+```typescript
+      executionMetadata: JSON.stringify(executionMetadata ?? DEFAULT_EXECUTION_METADATA),
+```
+
+**Step 3: Update `updateScheduledPrompt` to accept `executionMetadata`**
+
+Add `executionMetadata?: ExecutionMetadata` to the `updates` parameter type (line 113):
+
+```typescript
+  updates: { prompt?: string; fireAt?: string; cronExpression?: string; executionMetadata?: ExecutionMetadata },
+```
+
+In `buildUpdateValues`, add handling for executionMetadata:
+
+```typescript
+if (updates.executionMetadata !== undefined) values.executionMetadata = JSON.stringify(updates.executionMetadata)
+```
+
+**Step 4: Update `toAlertPrompt` in `alerts.ts`**
+
+Add import at the top of `src/deferred-prompts/alerts.ts`:
+
+```typescript
+import {
+  alertConditionSchema,
+  DEFAULT_EXECUTION_METADATA,
+  executionMetadataSchema,
+  type AlertCondition,
+  type AlertPrompt,
+  type ExecutionMetadata,
+  type LeafCondition,
+} from './types.js'
+```
+
+Add the same `parseExecutionMetadata` helper (or extract to a shared function in `types.ts`). Then update `toAlertPrompt`:
+
+```typescript
+const toAlertPrompt = (row: AlertPromptRow): AlertPrompt => ({
+  type: 'alert',
+  id: row.id,
+  userId: row.userId,
+  prompt: row.prompt,
+  condition: alertConditionSchema.parse(JSON.parse(row.condition)),
+  status: parseStatus(row.status),
+  createdAt: row.createdAt,
+  lastTriggeredAt: row.lastTriggeredAt,
+  cooldownMinutes: row.cooldownMinutes,
+  executionMetadata: parseExecutionMetadata(row.executionMetadata),
+})
+```
+
+**Step 5: Update `createAlertPrompt` to accept and store `executionMetadata`**
+
+Change the function signature to accept an optional `executionMetadata` parameter:
+
+```typescript
+export const createAlertPrompt = (
+  userId: string,
+  prompt: string,
+  condition: AlertCondition,
+  cooldownMinutes?: number,
+  executionMetadata?: ExecutionMetadata,
+): AlertPrompt => {
+```
+
+In the `db.insert` values, add:
+
+```typescript
+      executionMetadata: JSON.stringify(executionMetadata ?? DEFAULT_EXECUTION_METADATA),
+```
+
+**Step 6: Update `updateAlertPrompt` to accept `executionMetadata`**
+
+Add `executionMetadata?: ExecutionMetadata` to the updates parameter:
+
+```typescript
+  updates: { prompt?: string; condition?: AlertCondition; cooldownMinutes?: number; executionMetadata?: ExecutionMetadata },
+```
+
+Add handling in the set block:
+
+```typescript
+if (updates.executionMetadata !== undefined) set.executionMetadata = JSON.stringify(updates.executionMetadata)
+```
+
+**Step 7: Run typecheck**
+
+Run: `bun typecheck`
+Expected: PASS
+
+**Step 8: Run existing tests**
+
+Run: `bun test tests/deferred-prompts/`
+Expected: PASS — existing tests don't set `executionMetadata`, so the default `'{}'` applies and `parseExecutionMetadata` returns `DEFAULT_EXECUTION_METADATA`.
+
+**Step 9: Commit**
+
+```bash
+git add src/deferred-prompts/scheduled.ts src/deferred-prompts/alerts.ts
+git commit -m "feat(deferred): update row mappers and CRUD to handle executionMetadata"
+```
+
+---
+
+### Task 5: Update Migration Test
+
+**Files:**
+
+- Modify: `tests/deferred-prompts/migration.test.ts`
+- Modify: `tests/utils/test-helpers.ts:28,50` (add migration import and registration)
+
+**Step 1: Add migration to test helpers**
+
+In `tests/utils/test-helpers.ts`, add the import after line 28:
+
+```typescript
+import { migration016ExecutionMetadata } from '../../src/db/migrations/016_execution_metadata.js'
+```
+
+Add `migration016ExecutionMetadata` to the end of the `ALL_MIGRATIONS` array (after line 50).
+
+**Step 2: Add migration to `tests/deferred-prompts/migration.test.ts`**
+
+Add the import after line 19:
+
+```typescript
+import { migration016ExecutionMetadata } from '../../src/db/migrations/016_execution_metadata.js'
+```
+
+Add `migration016ExecutionMetadata` to the `ALL_MIGRATIONS` array.
+
+Add a new test:
+
+```typescript
+describe('migration 016: execution metadata', () => {
+  let db: Database
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    runMigrations(db, [...ALL_MIGRATIONS])
+  })
+
+  afterAll(() => {
+    db.close()
+  })
+
+  test('adds execution_metadata to scheduled_prompts', () => {
+    const columns = getColumnNames(db, 'scheduled_prompts')
+    expect(columns).toContain('execution_metadata')
+  })
+
+  test('adds execution_metadata to alert_prompts', () => {
+    const columns = getColumnNames(db, 'alert_prompts')
+    expect(columns).toContain('execution_metadata')
+  })
+
+  test('default value is empty JSON object', () => {
+    db.run(
+      "INSERT INTO scheduled_prompts (id, user_id, prompt, fire_at, status) VALUES ('t1', 'u1', 'test', '2026-01-01T00:00:00Z', 'active')",
+    )
+    const row = db
+      .query<{ execution_metadata: string }, []>("SELECT execution_metadata FROM scheduled_prompts WHERE id = 't1'")
+      .get()
+    expect(row?.execution_metadata).toBe('{}')
+  })
+})
+```
+
+**Step 3: Run the migration test**
+
+Run: `bun test tests/deferred-prompts/migration.test.ts`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add tests/deferred-prompts/migration.test.ts tests/utils/test-helpers.ts
+git commit -m "test(migration): add tests for execution_metadata column migration"
+```
+
+---
+
+### Task 6: Update Tool Schemas — Add `execution` Parameter
+
+**Files:**
+
+- Modify: `src/deferred-prompts/tools.ts:31,114,189-224,257-276`
+
+**Step 1: Add execution schema and import**
+
+Add to the imports from `./types.js`:
+
+```typescript
+import {
+  alertConditionSchema,
+  DEFAULT_EXECUTION_METADATA,
+  executionMetadataSchema,
+  type AlertCondition,
+  type CancelResult,
+  type CreateResult,
+  type ExecutionMetadata,
+  type GetResult,
+  type ListResult,
+  type UpdateResult,
+} from './types.js'
+```
+
+**Step 2: Update `CreateInput` type**
+
+Change the `CreateInput` type (line 31) to include `execution`:
+
+```typescript
+type CreateInput = {
+  prompt: string
+  schedule?: ScheduleInput
+  condition?: AlertCondition
+  cooldown_minutes?: number
+  execution?: { mode: 'lightweight' | 'context' | 'full'; delivery_brief: string; context_snapshot?: string }
+}
+```
+
+**Step 3: Pass `executionMetadata` to `createScheduled` and `createAlert`**
+
+In `executeCreate` (line 83), parse the execution input and pass it through:
+
+```typescript
+function executeCreate(userId: string, input: CreateInput): CreateResult {
+  const hasSchedule = input.schedule !== undefined
+  const hasCondition = input.condition !== undefined
+  log.debug({ userId, hasSchedule, hasCondition }, 'create_deferred_prompt called')
+  if (hasSchedule && hasCondition) return { error: 'Provide either a schedule or a condition, not both.' }
+  if (!hasSchedule && !hasCondition) {
+    return { error: 'Provide either a schedule (for time-based) or a condition (for event-based).' }
+  }
+
+  let executionMetadata: ExecutionMetadata = DEFAULT_EXECUTION_METADATA
+  if (input.execution !== undefined) {
+    const parseResult = executionMetadataSchema.safeParse(input.execution)
+    if (parseResult.success) {
+      executionMetadata = parseResult.data
+    } else {
+      log.warn({ userId, error: parseResult.error.message }, 'Invalid execution metadata, using default')
+    }
+  }
+
+  if (hasSchedule) return createScheduled(userId, input.prompt, input.schedule!, executionMetadata)
+  return createAlert(userId, input.prompt, input.condition, input.cooldown_minutes, executionMetadata)
+}
+```
+
+**Step 4: Update `createScheduled` to pass through `executionMetadata`**
+
+Change the `createScheduled` function signature:
+
+```typescript
+function createScheduled(userId: string, prompt: string, schedule: ScheduleInput, executionMetadata: ExecutionMetadata): CreateResult {
+```
+
+Pass it to `createScheduledPrompt`:
+
+```typescript
+const result = createScheduledPrompt(userId, prompt, { fireAt, cronExpression }, executionMetadata)
+```
+
+**Step 5: Update `createAlert` to pass through `executionMetadata`**
+
+Change the `createAlert` function signature:
+
+```typescript
+function createAlert(userId: string, prompt: string, condition: unknown, cooldownMinutes: number | undefined, executionMetadata: ExecutionMetadata): CreateResult {
+```
+
+Pass it to `createAlertPrompt`:
+
+```typescript
+const result = createAlertPrompt(userId, prompt, parseResult.data, cooldownMinutes, executionMetadata)
+```
+
+**Step 6: Update `UpdateInput` type and handlers**
+
+Add `execution` to `UpdateInput`:
+
+```typescript
+type UpdateInput = {
+  id: string
+  prompt?: string
+  schedule?: ScheduleInput
+  condition?: AlertCondition
+  cooldown_minutes?: number
+  execution?: { mode: 'lightweight' | 'context' | 'full'; delivery_brief: string; context_snapshot?: string }
+}
+```
+
+In `updateScheduledFields`, parse and pass `executionMetadata`:
+
+```typescript
+if (input.execution !== undefined) {
+  const parseResult = executionMetadataSchema.safeParse(input.execution)
+  if (parseResult.success) updates.executionMetadata = parseResult.data
+}
+```
+
+Same for `updateAlertFields`.
+
+**Step 7: Update tool descriptions and input schemas**
+
+In `makeCreateTool`, add the `execution` parameter to `inputSchema` and update the description:
+
+```typescript
+function makeCreateTool(userId: string): ToolSet[string] {
+  return tool({
+    description:
+      'Create a scheduled task or monitoring alert. Provide either a schedule (for time-based) or a condition (for event-based), not both. Always classify the execution mode based on what the prompt needs at fire time.',
+    inputSchema: z.object({
+      prompt: z.string().describe('What to do/say when this fires — not scheduling meta-instructions'),
+      schedule: scheduleSchema.optional().describe('Time-based trigger (one-time or recurring)'),
+      condition: alertConditionSchema.optional().describe('Event-based trigger condition'),
+      cooldown_minutes: cooldownSchema,
+      execution: z
+        .object({
+          mode: z
+            .enum(['lightweight', 'context', 'full'])
+            .describe(
+              'lightweight: simple reminders/nudges needing no tools or history. context: needs conversation history but no tools. full: needs live task tracker operations.',
+            ),
+          delivery_brief: z
+            .string()
+            .describe('Freeform instructions for the executing LLM: intent, tone, key details, entities to reference.'),
+          context_snapshot: z
+            .string()
+            .optional()
+            .describe(
+              'When the user references something from the current conversation, distill only the relevant parts into a summary here.',
+            ),
+        })
+        .optional()
+        .describe('Execution mode classification and delivery instructions for the firing LLM.'),
+    }),
+    execute: (input: CreateInput) => {
+      try {
+        return executeCreate(userId, input)
+      } catch (e) {
+        logAndRethrow('create_deferred_prompt', e)
+      }
+    },
+  })
+}
+```
+
+In `makeUpdateTool`, add the same `execution` schema as optional.
+
+**Step 8: Run typecheck and tests**
+
+Run: `bun typecheck && bun test tests/deferred-prompts/tools.test.ts`
+Expected: PASS — existing tests don't provide `execution`, so it defaults.
+
+**Step 9: Commit**
+
+```bash
+git add src/deferred-prompts/tools.ts
+git commit -m "feat(tools): add execution parameter to create/update deferred prompt tools"
+```
+
+---
+
+### Task 7: Write Failing Tests for Execution Mode Dispatch
+
+**Files:**
+
+- Create: `tests/deferred-prompts/execution-modes.test.ts`
+
+**Step 1: Write the test file**
+
+```typescript
+// tests/deferred-prompts/execution-modes.test.ts
+//
+// Mocked modules: ai, @ai-sdk/openai-compatible, ../src/logger.js, ../src/db/drizzle.js
+// (Uses mockLogger + mockDrizzle helpers; mocks ai + openai-compatible directly)
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+import type { ModelMessage } from 'ai'
+
+import { mockLogger, mockDrizzle, setupTestDb } from '../utils/test-helpers.js'
+
+mockLogger()
+mockDrizzle()
+
+// Track generateText calls
+type GenerateTextResult = {
+  text: string
+  toolCalls: unknown[]
+  toolResults: unknown[]
+  response: { messages: ModelMessage[] }
+}
+type GenerateTextCall = { model: unknown; system: unknown; messages: unknown[]; tools: unknown }
+const generateTextCalls: GenerateTextCall[] = []
+
+let generateTextImpl = (args: GenerateTextCall): Promise<GenerateTextResult> => {
+  generateTextCalls.push(args)
+  return Promise.resolve({ text: 'Mock response', toolCalls: [], toolResults: [], response: { messages: [] } })
+}
+
+void mock.module('ai', () => ({
+  generateText: (args: GenerateTextCall): Promise<GenerateTextResult> => generateTextImpl(args),
+  tool: (opts: unknown): unknown => opts,
+  stepCountIs: (_n: number): unknown => undefined,
+}))
+
+void mock.module('@ai-sdk/openai-compatible', () => ({
+  createOpenAICompatible:
+    (opts: { name: string; apiKey: string; baseURL: string }): ((modelId: string) => string) =>
+    (modelId: string): string =>
+      `${opts.name}:${modelId}`,
+}))
+
+import { setConfig } from '../../src/config.js'
+import { appendHistory } from '../../src/history.js'
+import type { ExecutionMetadata } from '../../src/deferred-prompts/types.js'
+
+// Import after mocks
+import { dispatchExecution } from '../../src/deferred-prompts/proactive-llm.js'
+import { createMockProvider } from '../tools/mock-provider.js'
+
+const USER_ID = 'exec-mode-user'
+
+function setupUserConfig(opts?: { smallModel?: string }): void {
+  setConfig(USER_ID, 'llm_apikey', 'test-key')
+  setConfig(USER_ID, 'llm_baseurl', 'http://localhost:11434/v1')
+  setConfig(USER_ID, 'main_model', 'main-model')
+  setConfig(USER_ID, 'timezone', 'UTC')
+  if (opts?.smallModel !== undefined) {
+    setConfig(USER_ID, 'small_model', opts.smallModel)
+  }
+}
+
+afterAll(() => {
+  mock.restore()
+})
+
+beforeEach(async () => {
+  await setupTestDb()
+  generateTextCalls.length = 0
+  generateTextImpl = (args: GenerateTextCall): Promise<GenerateTextResult> => {
+    generateTextCalls.push(args)
+    return Promise.resolve({ text: 'Mock response', toolCalls: [], toolResults: [], response: { messages: [] } })
+  }
+})
+
+describe('dispatchExecution', () => {
+  describe('lightweight mode', () => {
+    const metadata: ExecutionMetadata = {
+      mode: 'lightweight',
+      delivery_brief: 'Friendly hydration reminder',
+      context_snapshot: null,
+    }
+
+    test('uses small_model when configured', async () => {
+      setupUserConfig({ smallModel: 'small-model' })
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      expect(generateTextCalls).toHaveLength(1)
+      expect(generateTextCalls[0]!.model).toContain('small-model')
+    })
+
+    test('falls back to main_model when small_model not set', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      expect(generateTextCalls).toHaveLength(1)
+      expect(generateTextCalls[0]!.model).toContain('main-model')
+    })
+
+    test('does not include tools', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      expect(generateTextCalls[0]!.tools).toBeUndefined()
+    })
+
+    test('uses minimal system prompt', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      const system = generateTextCalls[0]!.system as string
+      expect(system).toContain('[PROACTIVE EXECUTION]')
+      expect(system).not.toContain('DEFERRED PROMPTS')
+    })
+
+    test('includes delivery brief in messages', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      const systemMsgs = messages.filter((m) => m.role === 'system')
+      expect(systemMsgs.some((m) => typeof m.content === 'string' && m.content.includes('[DELIVERY BRIEF]'))).toBe(true)
+      expect(
+        systemMsgs.some((m) => typeof m.content === 'string' && m.content.includes('Friendly hydration reminder')),
+      ).toBe(true)
+    })
+
+    test('wraps prompt in deferred task delimiters', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      const userMsgs = messages.filter((m) => m.role === 'user')
+      expect(userMsgs.some((m) => typeof m.content === 'string' && m.content.includes('===DEFERRED_TASK==='))).toBe(
+        true,
+      )
+      expect(userMsgs.some((m) => typeof m.content === 'string' && m.content.includes('drink water'))).toBe(true)
+    })
+
+    test('does not load conversation history', async () => {
+      setupUserConfig()
+      // Add history that should NOT appear in lightweight mode
+      appendHistory(USER_ID, [{ role: 'user', content: 'old message' }])
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      expect(messages.some((m) => typeof m.content === 'string' && m.content.includes('old message'))).toBe(false)
+    })
+
+    test('includes context snapshot when present', async () => {
+      setupUserConfig()
+      const withSnapshot: ExecutionMetadata = { ...metadata, context_snapshot: 'User discussed migration' }
+      await dispatchExecution(USER_ID, 'scheduled', 'remind about migration', withSnapshot, () => null)
+      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      const systemMsgs = messages.filter((m) => m.role === 'system')
+      expect(
+        systemMsgs.some((m) => typeof m.content === 'string' && m.content.includes('[CONTEXT FROM CREATION TIME]')),
+      ).toBe(true)
+    })
+
+    test('omits context snapshot message when null', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      expect(
+        messages.some(
+          (m) => typeof m.content === 'string' && String(m.content).includes('[CONTEXT FROM CREATION TIME]'),
+        ),
+      ).toBe(false)
+    })
+  })
+
+  describe('context mode', () => {
+    const metadata: ExecutionMetadata = {
+      mode: 'context',
+      delivery_brief: 'Remind about the standup discussion',
+      context_snapshot: 'Discussed Q2 sprint priorities',
+    }
+
+    test('uses main_model', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'standup reminder', metadata, () => null)
+      expect(generateTextCalls[0]!.model).toContain('main-model')
+    })
+
+    test('loads conversation history', async () => {
+      setupUserConfig()
+      appendHistory(USER_ID, [{ role: 'user', content: 'history message' }])
+      await dispatchExecution(USER_ID, 'scheduled', 'standup reminder', metadata, () => null)
+      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      expect(messages.some((m) => typeof m.content === 'string' && m.content.includes('history message'))).toBe(true)
+    })
+
+    test('does not include tools', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'standup reminder', metadata, () => null)
+      expect(generateTextCalls[0]!.tools).toBeUndefined()
+    })
+
+    test('uses minimal system prompt', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'standup reminder', metadata, () => null)
+      const system = generateTextCalls[0]!.system as string
+      expect(system).toContain('[PROACTIVE EXECUTION]')
+    })
+  })
+
+  describe('full mode', () => {
+    const metadata: ExecutionMetadata = {
+      mode: 'full',
+      delivery_brief: 'Check overdue tasks grouped by project',
+      context_snapshot: null,
+    }
+
+    test('uses main_model', async () => {
+      setupUserConfig()
+      const provider = createMockProvider()
+      await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => provider)
+      expect(generateTextCalls[0]!.model).toContain('main-model')
+    })
+
+    test('includes tools', async () => {
+      setupUserConfig()
+      const provider = createMockProvider()
+      await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => provider)
+      expect(generateTextCalls[0]!.tools).toBeDefined()
+    })
+
+    test('uses full system prompt', async () => {
+      setupUserConfig()
+      const provider = createMockProvider()
+      await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => provider)
+      const system = generateTextCalls[0]!.system as string
+      // Full system prompt includes provider-specific content
+      expect(system.length).toBeGreaterThan(200)
+    })
+
+    test('loads conversation history', async () => {
+      setupUserConfig()
+      const provider = createMockProvider()
+      appendHistory(USER_ID, [{ role: 'user', content: 'full mode history' }])
+      await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => provider)
+      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      expect(messages.some((m) => typeof m.content === 'string' && m.content.includes('full mode history'))).toBe(true)
+    })
+
+    test('returns error when provider cannot be built', async () => {
+      setupUserConfig()
+      const result = await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => null)
+      expect(result).toContain('task provider not configured')
+    })
+  })
+
+  describe('fallback behavior', () => {
+    test('treats empty metadata as full mode', async () => {
+      setupUserConfig()
+      const emptyMetadata: ExecutionMetadata = { mode: 'full', delivery_brief: '', context_snapshot: null }
+      const provider = createMockProvider()
+      await dispatchExecution(USER_ID, 'scheduled', 'test', emptyMetadata, () => provider)
+      expect(generateTextCalls[0]!.tools).toBeDefined()
+    })
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test tests/deferred-prompts/execution-modes.test.ts`
+Expected: FAIL — `dispatchExecution` doesn't exist yet in `proactive-llm.ts`.
+
+**Step 3: Commit**
+
+```bash
+git add tests/deferred-prompts/execution-modes.test.ts
+git commit -m "test(deferred): add failing tests for execution mode dispatch"
+```
+
+---
+
+### Task 8: Implement Three Execution Functions and Dispatcher
+
+**Files:**
+
+- Modify: `src/deferred-prompts/proactive-llm.ts` (major refactor)
+
+**Step 1: Add the minimal system prompt builder**
+
+Add after `formatLocalTime` function:
+
+```typescript
+function buildMinimalSystemPrompt(type: 'scheduled' | 'alert', timezone: string): string {
+  const { currentTime, displayTimezone } = formatLocalTime(timezone)
+  return [
+    '[PROACTIVE EXECUTION]',
+    `Current time: ${currentTime} (${displayTimezone})`,
+    `Trigger type: ${type}`,
+    '',
+    'A deferred prompt has fired. Deliver the result warmly and conversationally.',
+    'Do not mention scheduling, triggers, or system events.',
+    'Do not create new deferred prompts.',
+  ].join('\n')
+}
+```
+
+**Step 2: Add message construction helpers**
+
+```typescript
+import type { ExecutionMetadata } from './types.js'
+
+function buildMetadataMessages(metadata: ExecutionMetadata): ModelMessage[] {
+  const messages: ModelMessage[] = [{ role: 'system', content: `[DELIVERY BRIEF]\n${metadata.delivery_brief}` }]
+  if (metadata.context_snapshot !== null) {
+    messages.push({ role: 'system', content: `[CONTEXT FROM CREATION TIME]\n${metadata.context_snapshot}` })
+  }
+  return messages
+}
+
+function wrapPrompt(prompt: string): string {
+  return `===DEFERRED_TASK===\n${prompt}\n===END_DEFERRED_TASK===`
+}
+```
+
+**Step 3: Implement `invokeLightweight`**
+
+```typescript
+async function invokeLightweight(
+  userId: string,
+  type: 'scheduled' | 'alert',
+  prompt: string,
+  metadata: ExecutionMetadata,
+): Promise<string> {
+  log.debug({ userId, mode: 'lightweight' }, 'invokeLightweight called')
+
+  const config = getLlmConfig(userId)
+  if (typeof config === 'string') return config
+
+  const smallModel = getConfig(userId, 'small_model')
+  const modelId = smallModel ?? config.mainModel
+
+  const model = createOpenAICompatible({ name: 'openai-compatible', ...config })(modelId)
+  const timezone = getConfig(userId, 'timezone') ?? 'UTC'
+  const systemPrompt = buildMinimalSystemPrompt(type, timezone)
+
+  const messages: ModelMessage[] = [...buildMetadataMessages(metadata), { role: 'user', content: wrapPrompt(prompt) }]
+
+  log.debug({ userId, modelId, mode: 'lightweight' }, 'Calling generateText')
+  const result = await generateText({ model, system: systemPrompt, messages })
+
+  const assistantMessages = result.response.messages
+  if (assistantMessages.length > 0) {
+    appendHistory(userId, assistantMessages)
+    log.debug({ userId, count: assistantMessages.length }, 'Lightweight response appended to history')
+  }
+
+  return result.text ?? 'Done.'
+}
+```
+
+**Step 4: Implement `invokeWithContext`**
+
+```typescript
+async function invokeWithContext(
+  userId: string,
+  type: 'scheduled' | 'alert',
+  prompt: string,
+  metadata: ExecutionMetadata,
+): Promise<string> {
+  log.debug({ userId, mode: 'context' }, 'invokeWithContext called')
+
+  const config = getLlmConfig(userId)
+  if (typeof config === 'string') return config
+
+  const model = createOpenAICompatible({ name: 'openai-compatible', ...config })(config.mainModel)
+  const timezone = getConfig(userId, 'timezone') ?? 'UTC'
+  const systemPrompt = buildMinimalSystemPrompt(type, timezone)
+
+  const history = getCachedHistory(userId)
+  const { messages: messagesWithMemory } = buildMessagesWithMemory(userId, history)
+  const messages: ModelMessage[] = [
+    ...messagesWithMemory,
+    ...buildMetadataMessages(metadata),
+    { role: 'user', content: wrapPrompt(prompt) },
+  ]
+
+  log.debug(
+    { userId, mainModel: config.mainModel, historyLength: history.length, mode: 'context' },
+    'Calling generateText',
+  )
+  const result = await generateText({ model, system: systemPrompt, messages })
+
+  const assistantMessages = result.response.messages
+  if (assistantMessages.length > 0) {
+    appendHistory(userId, assistantMessages)
+    log.debug({ userId, count: assistantMessages.length }, 'Context response appended to history')
+
+    const updatedHistory = [...history, ...assistantMessages]
+    if (shouldTriggerTrim(updatedHistory)) {
+      void runTrimInBackground(userId, updatedHistory)
+    }
+  }
+
+  return result.text ?? 'Done.'
+}
+```
+
+**Step 5: Refactor `invokeLlmWithHistory` into `invokeFull`**
+
+Rename `invokeLlmWithHistory` to `invokeFull` and add delivery brief + context snapshot injection:
+
+```typescript
+async function invokeFull(
+  userId: string,
+  type: 'scheduled' | 'alert',
+  prompt: string,
+  metadata: ExecutionMetadata,
+  buildProviderFn: BuildProviderFn,
+  matchedTasksSummary?: string,
+): Promise<string> {
+  log.debug({ userId, mode: 'full' }, 'invokeFull called')
+
+  const config = getLlmConfig(userId)
+  if (typeof config === 'string') return config
+
+  const provider = buildProviderFn(userId)
+  if (provider === null) {
+    log.warn({ userId }, 'Could not build task provider for deferred prompt')
+    return 'Deferred prompt skipped: task provider not configured.'
+  }
+
+  const model = createOpenAICompatible({ name: 'openai-compatible', ...config })(config.mainModel)
+  const tools = makeTools(provider, userId, 'proactive')
+  const timezone = getConfig(userId, 'timezone') ?? 'UTC'
+  const systemPrompt = buildSystemPrompt(provider, timezone, userId)
+
+  const trigger = buildProactiveTrigger(type, prompt, timezone, matchedTasksSummary)
+
+  const history = getCachedHistory(userId)
+  const { messages: messagesWithMemory } = buildMessagesWithMemory(userId, history)
+  const finalMessages: ModelMessage[] = [
+    ...messagesWithMemory,
+    { role: 'system', content: trigger.systemContext },
+    ...buildMetadataMessages(metadata),
+    { role: 'user', content: trigger.userContent },
+  ]
+
+  log.debug(
+    { userId, mainModel: config.mainModel, historyLength: history.length, mode: 'full' },
+    'Calling generateText',
+  )
+  const result = await generateText({
+    model,
+    system: systemPrompt,
+    messages: finalMessages,
+    tools,
+    stopWhen: stepCountIs(25),
+  })
+
+  persistProactiveResults(userId, result, history)
+  return result.text ?? 'Done.'
+}
+```
+
+**Step 6: Implement the dispatcher**
+
+```typescript
+export async function dispatchExecution(
+  userId: string,
+  type: 'scheduled' | 'alert',
+  prompt: string,
+  metadata: ExecutionMetadata,
+  buildProviderFn: BuildProviderFn,
+  matchedTasksSummary?: string,
+): Promise<string> {
+  log.debug({ userId, mode: metadata.mode }, 'dispatchExecution called')
+
+  switch (metadata.mode) {
+    case 'lightweight':
+      return invokeLightweight(userId, type, prompt, metadata)
+    case 'context':
+      return invokeWithContext(userId, type, prompt, metadata)
+    case 'full':
+      return invokeFull(userId, type, prompt, metadata, buildProviderFn, matchedTasksSummary)
+  }
+}
+```
+
+**Step 7: Keep `invokeLlmWithHistory` as a backward-compatible wrapper**
+
+For any callers that still use it (poller.ts), keep a thin wrapper until the poller is updated in Task 9:
+
+```typescript
+export async function invokeLlmWithHistory(
+  userId: string,
+  trigger: ProactiveTrigger,
+  buildProviderFn: BuildProviderFn,
+): Promise<string> {
+  return invokeFull(userId, 'scheduled', trigger.userContent, DEFAULT_EXECUTION_METADATA, buildProviderFn)
+}
+```
+
+**Step 8: Run the tests**
+
+Run: `bun test tests/deferred-prompts/execution-modes.test.ts`
+Expected: PASS
+
+Run: `bun test tests/deferred-prompts/`
+Expected: PASS — all existing tests still pass because `invokeLlmWithHistory` is preserved.
+
+**Step 9: Commit**
+
+```bash
+git add src/deferred-prompts/proactive-llm.ts
+git commit -m "feat(deferred): implement three execution functions and dispatcher"
+```
+
+---
+
+### Task 9: Update Poller to Use Dispatcher
+
+**Files:**
+
+- Modify: `src/deferred-prompts/poller.ts`
+
+**Step 1: Update imports**
+
+Replace:
+
+```typescript
+import {
+  buildProactiveTrigger,
+  invokeLlmWithHistory,
+  type BuildProviderFn,
+  type ProactiveTrigger,
+} from './proactive-llm.js'
+```
+
+With:
+
+```typescript
+import { dispatchExecution, type BuildProviderFn } from './proactive-llm.js'
+```
+
+**Step 2: Update `executeScheduledPromptsForUser`**
+
+Replace the `buildMergedTrigger` + `invokeLlmWithHistory` call with the dispatcher:
+
+```typescript
+async function executeScheduledPromptsForUser(
+  userId: string,
+  prompts: ScheduledPrompt[],
+  chat: ChatProvider,
+  buildProviderFn: BuildProviderFn,
+): Promise<void> {
+  const timezone = getConfig(userId, 'timezone') ?? 'UTC'
+  const promptIds = prompts.map((p) => p.id)
+
+  log.debug({ userId, promptCount: prompts.length, promptIds }, 'Executing merged scheduled prompts')
+
+  // For merged prompts, use first prompt's metadata (or merge into combined prompt)
+  const combinedPrompt =
+    prompts.length === 1 ? prompts[0]!.prompt : prompts.map((p, i) => `${String(i + 1)}. "${p.prompt}"`).join('\n')
+
+  // Use first prompt's execution metadata; merged prompts fall back to full mode
+  const metadata =
+    prompts.length === 1
+      ? prompts[0]!.executionMetadata
+      : { mode: 'full' as const, delivery_brief: '', context_snapshot: null }
+
+  let response: string
+  try {
+    response = await dispatchExecution(userId, 'scheduled', combinedPrompt, metadata, buildProviderFn)
+    await chat.sendMessage(userId, response)
+  } catch (error) {
+    const errMsg = error instanceof Error ? error.message : String(error)
+    log.error({ userId, promptIds, error: errMsg }, 'Scheduled prompt LLM invocation failed')
+    response = `Failed: ${errMsg}`
+    await chat.sendMessage(userId, `I ran into an error while working on that: ${errMsg}`)
+  }
+
+  finalizeAllPrompts(prompts, new Date().toISOString(), timezone)
+}
+```
+
+**Step 3: Update `executeSingleAlert`**
+
+Replace the `buildProactiveTrigger` + `invokeLlmWithHistory` call:
+
+```typescript
+async function executeSingleAlert(
+  alert: ReturnType<typeof getEligibleAlertPrompts>[number],
+  userId: string,
+  tasks: Task[],
+  snapshots: Map<string, string>,
+  chat: ChatProvider,
+  buildProviderFn: BuildProviderFn,
+  evalNow: Date,
+): Promise<void> {
+  const matchedTasks = tasks.filter((task) => evaluateCondition(alert.condition, task, snapshots, evalNow))
+  if (matchedTasks.length === 0) return
+
+  const conditionDesc = describeCondition(alert.condition)
+  const taskList = matchedTasks.map((t) => `- [${t.title}](${t.url})${formatTaskStatus(t.status)}`).join('\n')
+  const matchedTasksSummary = `Alert condition: ${conditionDesc}\n${taskList}`
+
+  let response: string
+  try {
+    response = await dispatchExecution(
+      userId,
+      'alert',
+      alert.prompt,
+      alert.executionMetadata,
+      buildProviderFn,
+      matchedTasksSummary,
+    )
+    await chat.sendMessage(userId, response)
+  } catch (error) {
+    const errMsg = error instanceof Error ? error.message : String(error)
+    log.error({ id: alert.id, userId, error: errMsg }, 'Alert prompt LLM invocation failed')
+    response = `Failed: ${errMsg}`
+    await chat.sendMessage(userId, `Sorry, something went wrong while preparing this update: ${errMsg}`)
+  }
+
+  const now = new Date().toISOString()
+  updateAlertTriggerTime(alert.id, userId, now)
+  log.info({ id: alert.id, userId, matchedCount: matchedTasks.length }, 'Alert triggered')
+}
+```
+
+**Step 4: Remove `buildMergedTrigger` function**
+
+It's no longer needed — the merging logic is inline in `executeScheduledPromptsForUser`.
+
+**Step 5: Remove unused imports**
+
+Remove `type ProactiveTrigger` and `buildProactiveTrigger` from the import if they are no longer used. Remove the `import type { Task }` if it's only used in the alert function which now uses `evaluateCondition` directly.
+
+**Step 6: Run tests**
+
+Run: `bun test tests/deferred-prompts/poller.test.ts`
+Expected: PASS
+
+Run: `bun test tests/deferred-prompts/`
+Expected: PASS
+
+**Step 7: Run full check**
+
+Run: `bun typecheck && bun test`
+Expected: PASS
+
+**Step 8: Commit**
+
+```bash
+git add src/deferred-prompts/poller.ts
+git commit -m "feat(poller): use dispatchExecution instead of invokeLlmWithHistory"
+```
+
+---
+
+### Task 10: Clean Up — Remove Backward Compatibility Wrapper
+
+**Files:**
+
+- Modify: `src/deferred-prompts/proactive-llm.ts`
+
+**Step 1: Check for remaining callers of `invokeLlmWithHistory`**
+
+Run: `grep -r "invokeLlmWithHistory" src/ tests/ --include="*.ts" -l`
+
+If the only references are the definition and possibly old test files, remove the wrapper.
+
+**Step 2: Remove the wrapper function**
+
+Delete the `invokeLlmWithHistory` export wrapper added in Task 8. Update the export to only expose `dispatchExecution`, `buildProactiveTrigger`, `BuildProviderFn`, and `ProactiveTrigger`.
+
+**Step 3: Update any remaining test imports**
+
+If `tests/deferred-prompts/poller.test.ts` or other tests still import `invokeLlmWithHistory`, update them to use `dispatchExecution`.
+
+**Step 4: Run full suite**
+
+Run: `bun typecheck && bun test`
+Expected: PASS
+
+**Step 5: Run full check**
+
+Run: `bun check:verbose`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add src/deferred-prompts/proactive-llm.ts tests/
+git commit -m "refactor(deferred): remove invokeLlmWithHistory backward compat wrapper"
+```
+
+---
+
+### Task 11: Add Tool Tests for `execution` Parameter
+
+**Files:**
+
+- Modify: `tests/deferred-prompts/tools.test.ts`
+
+**Step 1: Add tests for create with execution metadata**
+
+Add to the `create_deferred_prompt` describe block:
+
+```typescript
+test('creates with execution metadata', async () => {
+  const t = getTools()['create_deferred_prompt']!
+  if (!t.execute) throw new Error('Tool execute is undefined')
+  const result: unknown = await t.execute(
+    {
+      prompt: 'Drink water',
+      schedule: { fire_at: futureFireAt() },
+      execution: {
+        mode: 'lightweight',
+        delivery_brief: 'Simple hydration reminder',
+      },
+    },
+    toolCtx,
+  )
+  expect(result).toHaveProperty('status', 'created')
+})
+
+test('creates without execution metadata (backward compat)', async () => {
+  const t = getTools()['create_deferred_prompt']!
+  if (!t.execute) throw new Error('Tool execute is undefined')
+  const result: unknown = await t.execute({ prompt: 'Remind me', schedule: { fire_at: futureFireAt() } }, toolCtx)
+  expect(result).toHaveProperty('status', 'created')
+})
+
+test('persists execution metadata in scheduled prompt', async () => {
+  const t = getTools()['create_deferred_prompt']!
+  if (!t.execute) throw new Error('Tool execute is undefined')
+  const result: unknown = await t.execute(
+    {
+      prompt: 'Check tasks',
+      schedule: { fire_at: futureFireAt() },
+      execution: {
+        mode: 'context',
+        delivery_brief: 'Remind about standup',
+        context_snapshot: 'Sprint planning discussion',
+      },
+    },
+    toolCtx,
+  )
+  const id = extractId(result)
+
+  const getTool = getTools()['get_deferred_prompt']!
+  if (!getTool.execute) throw new Error('Tool execute is undefined')
+  const detail: unknown = await getTool.execute({ id }, toolCtx)
+  expect(detail).toHaveProperty('executionMetadata')
+  const meta = Reflect.get(detail as object, 'executionMetadata') as {
+    mode: string
+    delivery_brief: string
+    context_snapshot: string | null
+  }
+  expect(meta.mode).toBe('context')
+  expect(meta.delivery_brief).toBe('Remind about standup')
+  expect(meta.context_snapshot).toBe('Sprint planning discussion')
+})
+```
+
+**Step 2: Add tests for update with execution metadata**
+
+```typescript
+test('updates execution metadata on scheduled prompt', async () => {
+  const tools = getTools()
+  const createTool = tools['create_deferred_prompt']!
+  if (!createTool.execute) throw new Error('Tool execute is undefined')
+  const created: unknown = await createTool.execute({ prompt: 'Test', schedule: { fire_at: futureFireAt() } }, toolCtx)
+  const id = extractId(created)
+
+  const updateTool = tools['update_deferred_prompt']!
+  if (!updateTool.execute) throw new Error('Tool execute is undefined')
+  const result: unknown = await updateTool.execute(
+    { id, execution: { mode: 'full', delivery_brief: 'Updated brief' } },
+    toolCtx,
+  )
+  expect(result).toHaveProperty('status', 'updated')
+})
+```
+
+**Step 3: Run tests**
+
+Run: `bun test tests/deferred-prompts/tools.test.ts`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add tests/deferred-prompts/tools.test.ts
+git commit -m "test(tools): add tests for execution parameter on deferred prompt tools"
+```
+
+---
+
+### Task 12: Final Verification
+
+**Files:** None (verification only)
+
+**Step 1: Run full test suite**
+
+Run: `bun test`
+Expected: PASS
+
+**Step 2: Run full checks**
+
+Run: `bun check:verbose`
+Expected: PASS
+
+**Step 3: Run knip for dead code**
+
+Run: `bun knip`
+Expected: No new unused exports. If `invokeLlmWithHistory` or `buildMergedTrigger` show up, they were successfully removed.
+
+**Step 4: Commit if any cleanup was needed**
+
+```bash
+git add -A
+git commit -m "chore: final cleanup for execution modes"
+```

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -17,6 +17,7 @@ import { migration012UserInstructions } from './migrations/012_user_instructions
 import { migration013DeferredPrompts } from './migrations/013_deferred_prompts.js'
 import { migration014BackgroundEvents } from './migrations/014_background_events.js'
 import { migration015DropBackgroundEvents } from './migrations/015_drop_background_events.js'
+import { migration016ExecutionMetadata } from './migrations/016_execution_metadata.js'
 
 const DB_PATH = process.env['DB_PATH'] ?? 'papai.db'
 
@@ -59,6 +60,7 @@ const MIGRATIONS = [
   migration013DeferredPrompts,
   migration014BackgroundEvents,
   migration015DropBackgroundEvents,
+  migration016ExecutionMetadata,
 ] as const
 
 export const initDb = (): void => {

--- a/src/db/migrations/016_execution_metadata.ts
+++ b/src/db/migrations/016_execution_metadata.ts
@@ -1,0 +1,11 @@
+import type { Database } from 'bun:sqlite'
+
+import type { Migration } from '../migrate.js'
+
+export const migration016ExecutionMetadata: Migration = {
+  id: '016_execution_metadata',
+  up(db: Database): void {
+    db.run(`ALTER TABLE scheduled_prompts ADD COLUMN execution_metadata TEXT NOT NULL DEFAULT '{}'`)
+    db.run(`ALTER TABLE alert_prompts ADD COLUMN execution_metadata TEXT NOT NULL DEFAULT '{}'`)
+  },
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -130,6 +130,7 @@ export const scheduledPrompts = sqliteTable(
       .notNull()
       .default(sql`(datetime('now'))`),
     lastExecutedAt: text('last_executed_at'),
+    executionMetadata: text('execution_metadata').notNull().default('{}'),
   },
   (table) => [
     index('idx_scheduled_prompts_user').on(table.userId),
@@ -150,6 +151,7 @@ export const alertPrompts = sqliteTable(
       .default(sql`(datetime('now'))`),
     lastTriggeredAt: text('last_triggered_at'),
     cooldownMinutes: integer('cooldown_minutes').notNull().default(60),
+    executionMetadata: text('execution_metadata').notNull().default('{}'),
   },
   (table) => [index('idx_alert_prompts_user').on(table.userId), index('idx_alert_prompts_status').on(table.status)],
 )

--- a/src/deferred-prompts/alerts.ts
+++ b/src/deferred-prompts/alerts.ts
@@ -7,7 +7,7 @@ import type { Task } from '../providers/types.js'
 import {
   alertConditionSchema,
   DEFAULT_EXECUTION_METADATA,
-  executionMetadataSchema,
+  parseExecutionMetadata,
   type AlertCondition,
   type AlertPrompt,
   type ExecutionMetadata,
@@ -19,16 +19,6 @@ const log = logger.child({ scope: 'deferred:alerts' })
 // --- Row mapper ---
 
 const parseStatus = (raw: string): AlertPrompt['status'] => (raw === 'cancelled' ? 'cancelled' : 'active')
-
-function parseExecutionMetadata(raw: string): ExecutionMetadata {
-  try {
-    const parsed: unknown = JSON.parse(raw)
-    const result = executionMetadataSchema.safeParse(parsed)
-    return result.success ? result.data : DEFAULT_EXECUTION_METADATA
-  } catch {
-    return DEFAULT_EXECUTION_METADATA
-  }
-}
 
 const toAlertPrompt = (row: AlertPromptRow): AlertPrompt => ({
   type: 'alert',

--- a/src/deferred-prompts/alerts.ts
+++ b/src/deferred-prompts/alerts.ts
@@ -4,13 +4,31 @@ import { getDrizzleDb } from '../db/drizzle.js'
 import { alertPrompts, type AlertPromptRow } from '../db/schema.js'
 import { logger } from '../logger.js'
 import type { Task } from '../providers/types.js'
-import { alertConditionSchema, type AlertCondition, type AlertPrompt, type LeafCondition } from './types.js'
+import {
+  alertConditionSchema,
+  DEFAULT_EXECUTION_METADATA,
+  executionMetadataSchema,
+  type AlertCondition,
+  type AlertPrompt,
+  type ExecutionMetadata,
+  type LeafCondition,
+} from './types.js'
 
 const log = logger.child({ scope: 'deferred:alerts' })
 
 // --- Row mapper ---
 
 const parseStatus = (raw: string): AlertPrompt['status'] => (raw === 'cancelled' ? 'cancelled' : 'active')
+
+function parseExecutionMetadata(raw: string): ExecutionMetadata {
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    const result = executionMetadataSchema.safeParse(parsed)
+    return result.success ? result.data : DEFAULT_EXECUTION_METADATA
+  } catch {
+    return DEFAULT_EXECUTION_METADATA
+  }
+}
 
 const toAlertPrompt = (row: AlertPromptRow): AlertPrompt => ({
   type: 'alert',
@@ -22,6 +40,7 @@ const toAlertPrompt = (row: AlertPromptRow): AlertPrompt => ({
   createdAt: row.createdAt,
   lastTriggeredAt: row.lastTriggeredAt,
   cooldownMinutes: row.cooldownMinutes,
+  executionMetadata: parseExecutionMetadata(row.executionMetadata),
 })
 
 // --- CRUD ---
@@ -31,6 +50,7 @@ export const createAlertPrompt = (
   prompt: string,
   condition: AlertCondition,
   cooldownMinutes?: number,
+  executionMetadata?: ExecutionMetadata,
 ): AlertPrompt => {
   log.debug({ userId, cooldownMinutes }, 'createAlertPrompt called')
   const id = crypto.randomUUID()
@@ -46,6 +66,7 @@ export const createAlertPrompt = (
       createdAt: new Date().toISOString(),
       lastTriggeredAt: null,
       cooldownMinutes: cooldownMinutes ?? 60,
+      executionMetadata: JSON.stringify(executionMetadata ?? DEFAULT_EXECUTION_METADATA),
     })
     .run()
 
@@ -87,7 +108,12 @@ export const getAlertPrompt = (id: string, userId: string): AlertPrompt | null =
 export const updateAlertPrompt = (
   id: string,
   userId: string,
-  updates: { prompt?: string; condition?: AlertCondition; cooldownMinutes?: number },
+  updates: {
+    prompt?: string
+    condition?: AlertCondition
+    cooldownMinutes?: number
+    executionMetadata?: ExecutionMetadata
+  },
 ): AlertPrompt | null => {
   log.debug({ id, userId, updates: Object.keys(updates) }, 'updateAlertPrompt called')
   const db = getDrizzleDb()
@@ -109,6 +135,7 @@ export const updateAlertPrompt = (
     set.condition = JSON.stringify(updates.condition)
   }
   if (updates.cooldownMinutes !== undefined) set.cooldownMinutes = updates.cooldownMinutes
+  if (updates.executionMetadata !== undefined) set.executionMetadata = JSON.stringify(updates.executionMetadata)
 
   db.update(alertPrompts)
     .set(set)

--- a/src/deferred-prompts/poller.ts
+++ b/src/deferred-prompts/poller.ts
@@ -7,11 +7,10 @@ import { logger } from '../logger.js'
 import type { Task } from '../providers/types.js'
 import { describeCondition, evaluateCondition, getEligibleAlertPrompts, updateAlertTriggerTime } from './alerts.js'
 import { alertsNeedFullTasks, enrichTasks, fetchAllTasks } from './fetch-tasks.js'
-import { invokeLlmWithHistory, type BuildProviderFn } from './proactive-llm.js'
-import { buildProactiveTrigger, type ProactiveTrigger } from './proactive-trigger.js'
+import { dispatchExecution, type BuildProviderFn } from './proactive-llm.js'
 import { advanceScheduledPrompt, completeScheduledPrompt, getScheduledPromptsDue } from './scheduled.js'
 import { getSnapshotsForUser, updateSnapshots } from './snapshots.js'
-import type { ScheduledPrompt } from './types.js'
+import type { ExecutionMetadata, ExecutionMode, ScheduledPrompt } from './types.js'
 
 const log = logger.child({ scope: 'deferred:poller' })
 
@@ -58,12 +57,24 @@ function finalizeRecurring(prompt: ScheduledPrompt, now: string, timezone: strin
   )
 }
 
-function buildMergedTrigger(prompts: ScheduledPrompt[], timezone: string): ProactiveTrigger {
-  if (prompts.length === 1) {
-    return buildProactiveTrigger('scheduled', prompts[0]!.prompt, timezone)
+const MODE_PRIORITY: Record<ExecutionMode, number> = { lightweight: 0, context: 1, full: 2 }
+const MODE_BY_PRIORITY: ExecutionMode[] = ['lightweight', 'context', 'full']
+
+function mergeExecutionMetadata(prompts: ScheduledPrompt[]): ExecutionMetadata {
+  let maxPriority = 0
+  const briefs: string[] = []
+  const snapshots: string[] = []
+  for (const p of prompts) {
+    const m = p.executionMetadata
+    maxPriority = Math.max(maxPriority, MODE_PRIORITY[m.mode])
+    if (m.delivery_brief !== '') briefs.push(m.delivery_brief)
+    if (m.context_snapshot !== null) snapshots.push(m.context_snapshot)
   }
-  const combined = prompts.map((p, i) => `${String(i + 1)}. "${p.prompt}"`).join('\n')
-  return buildProactiveTrigger('scheduled', combined, timezone)
+  return {
+    mode: MODE_BY_PRIORITY[maxPriority]!,
+    delivery_brief: briefs.join('\n---\n'),
+    context_snapshot: snapshots.length > 0 ? snapshots.join('\n---\n') : null,
+  }
 }
 
 function finalizeAllPrompts(prompts: ScheduledPrompt[], now: string, timezone: string): void {
@@ -84,14 +95,16 @@ async function executeScheduledPromptsForUser(
   buildProviderFn: BuildProviderFn,
 ): Promise<void> {
   const timezone = getConfig(userId, 'timezone') ?? 'UTC'
-  const trigger = buildMergedTrigger(prompts, timezone)
+  const metadata = mergeExecutionMetadata(prompts)
+  const mergedPrompt =
+    prompts.length === 1 ? prompts[0]!.prompt : prompts.map((p, i) => `${String(i + 1)}. "${p.prompt}"`).join('\n')
   const promptIds = prompts.map((p) => p.id)
 
-  log.debug({ userId, promptCount: prompts.length, promptIds }, 'Executing merged scheduled prompts')
+  log.debug({ userId, promptCount: prompts.length, promptIds, mode: metadata.mode }, 'Executing scheduled prompts')
 
   let response: string
   try {
-    response = await invokeLlmWithHistory(userId, trigger, buildProviderFn)
+    response = await dispatchExecution(userId, 'scheduled', mergedPrompt, metadata, buildProviderFn)
     await chat.sendMessage(userId, response)
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error)
@@ -142,15 +155,20 @@ async function executeSingleAlert(
   const matchedTasks = tasks.filter((task) => evaluateCondition(alert.condition, task, snapshots, evalNow))
   if (matchedTasks.length === 0) return
 
-  const timezone = getConfig(userId, 'timezone') ?? 'UTC'
   const conditionDesc = describeCondition(alert.condition)
   const taskList = matchedTasks.map((t) => `- [${t.title}](${t.url})${formatTaskStatus(t.status)}`).join('\n')
   const matchedTasksSummary = `Alert condition: ${conditionDesc}\n${taskList}`
-  const trigger = buildProactiveTrigger('alert', alert.prompt, timezone, matchedTasksSummary)
 
   let response: string
   try {
-    response = await invokeLlmWithHistory(userId, trigger, buildProviderFn)
+    response = await dispatchExecution(
+      userId,
+      'alert',
+      alert.prompt,
+      alert.executionMetadata,
+      buildProviderFn,
+      matchedTasksSummary,
+    )
     await chat.sendMessage(userId, response)
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error)

--- a/src/deferred-prompts/poller.ts
+++ b/src/deferred-prompts/poller.ts
@@ -7,12 +7,8 @@ import { logger } from '../logger.js'
 import type { Task } from '../providers/types.js'
 import { describeCondition, evaluateCondition, getEligibleAlertPrompts, updateAlertTriggerTime } from './alerts.js'
 import { alertsNeedFullTasks, enrichTasks, fetchAllTasks } from './fetch-tasks.js'
-import {
-  buildProactiveTrigger,
-  invokeLlmWithHistory,
-  type BuildProviderFn,
-  type ProactiveTrigger,
-} from './proactive-llm.js'
+import { invokeLlmWithHistory, type BuildProviderFn } from './proactive-llm.js'
+import { buildProactiveTrigger, type ProactiveTrigger } from './proactive-trigger.js'
 import { advanceScheduledPrompt, completeScheduledPrompt, getScheduledPromptsDue } from './scheduled.js'
 import { getSnapshotsForUser, updateSnapshots } from './snapshots.js'
 import type { ScheduledPrompt } from './types.js'

--- a/src/deferred-prompts/proactive-llm.ts
+++ b/src/deferred-prompts/proactive-llm.ts
@@ -10,13 +10,12 @@ import { extractFactsFromSdkResults, upsertFact } from '../memory.js'
 import type { TaskProvider } from '../providers/types.js'
 import { buildSystemPrompt } from '../system-prompt.js'
 import { makeTools } from '../tools/index.js'
-import { buildProactiveTrigger, formatLocalTime, type ProactiveTrigger } from './proactive-trigger.js'
-import { DEFAULT_EXECUTION_METADATA, type ExecutionMetadata } from './types.js'
+import { buildProactiveTrigger, formatLocalTime } from './proactive-trigger.js'
+import type { ExecutionMetadata } from './types.js'
 
 const log = logger.child({ scope: 'deferred:proactive-llm' })
 
 export type BuildProviderFn = (userId: string) => TaskProvider | null
-export type { ProactiveTrigger }
 
 type LlmConfig = { apiKey: string; baseURL: string; mainModel: string }
 
@@ -201,14 +200,4 @@ export function dispatchExecution(
     case 'full':
       return invokeFull(userId, type, prompt, metadata, buildProviderFn, matchedTasksSummary)
   }
-}
-
-// --- Backward-compatible wrapper (removed in Task 10) ---
-
-export function invokeLlmWithHistory(
-  userId: string,
-  trigger: ProactiveTrigger,
-  buildProviderFn: BuildProviderFn,
-): Promise<string> {
-  return invokeFull(userId, 'scheduled', trigger.userContent, DEFAULT_EXECUTION_METADATA, buildProviderFn)
 }

--- a/src/deferred-prompts/proactive-llm.ts
+++ b/src/deferred-prompts/proactive-llm.ts
@@ -99,8 +99,11 @@ async function invokeLightweight(
 
   const assistantMessages = result.response.messages
   if (assistantMessages.length > 0) {
+    const history = getCachedHistory(userId)
     appendHistory(userId, assistantMessages)
     log.debug({ userId, count: assistantMessages.length }, 'Lightweight response appended to history')
+    const updatedHistory = [...history, ...assistantMessages]
+    if (shouldTriggerTrim(updatedHistory)) void runTrimInBackground(userId, updatedHistory)
   }
   return result.text ?? 'Done.'
 }

--- a/src/deferred-prompts/proactive-llm.ts
+++ b/src/deferred-prompts/proactive-llm.ts
@@ -10,85 +10,13 @@ import { extractFactsFromSdkResults, upsertFact } from '../memory.js'
 import type { TaskProvider } from '../providers/types.js'
 import { buildSystemPrompt } from '../system-prompt.js'
 import { makeTools } from '../tools/index.js'
+import { buildProactiveTrigger, formatLocalTime, type ProactiveTrigger } from './proactive-trigger.js'
+import { DEFAULT_EXECUTION_METADATA, type ExecutionMetadata } from './types.js'
 
 const log = logger.child({ scope: 'deferred:proactive-llm' })
 
 export type BuildProviderFn = (userId: string) => TaskProvider | null
-
-export type ProactiveTrigger = {
-  /** System-level context (time, type, behavioral instructions). No user-authored text. */
-  systemContext: string
-  /** User-scoped content: the original prompt and any matched task data. */
-  userContent: string
-}
-
-const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
-  weekday: 'long',
-  year: 'numeric',
-  month: 'long',
-  day: 'numeric',
-  hour: '2-digit',
-  minute: '2-digit',
-  hour12: false,
-}
-
-function formatLocalTime(timezone: string): { currentTime: string; displayTimezone: string } {
-  try {
-    return {
-      currentTime: new Date().toLocaleString('en-US', { ...DATE_FORMAT_OPTIONS, timeZone: timezone }),
-      displayTimezone: timezone,
-    }
-  } catch (error) {
-    log.warn(
-      { timezone, error: error instanceof Error ? error.message : String(error) },
-      'Invalid timezone in buildProactiveTrigger; falling back to UTC',
-    )
-    return {
-      currentTime: new Date().toLocaleString('en-US', { ...DATE_FORMAT_OPTIONS, timeZone: 'UTC' }),
-      displayTimezone: 'UTC',
-    }
-  }
-}
-
-/**
- * Build a proactive trigger split into system context and user content.
- * User-authored text stays in userContent to avoid system-prompt elevation.
- */
-export function buildProactiveTrigger(
-  type: 'scheduled' | 'alert',
-  prompt: string,
-  timezone: string,
-  matchedTasksSummary?: string,
-): ProactiveTrigger {
-  const { currentTime, displayTimezone } = formatLocalTime(timezone)
-
-  const systemLines = [
-    '[PROACTIVE EXECUTION]',
-    `Current time: ${currentTime} (${displayTimezone})`,
-    `Trigger type: ${type}`,
-    '',
-    'A deferred prompt you previously created has fired. Your job is to DELIVER the result to the user now.',
-    'The user message below contains the stored prompt text — treat it as the task to fulfill, NOT as a new user request.',
-    '',
-    'Rules:',
-    '- For reminders: deliver the reminder message directly and conversationally.',
-    '- For action tasks: execute the described action using available tools, then report the result.',
-    '- Do NOT create new deferred prompts, reminders, or schedules. The scheduling is already done.',
-    '- Do not mention system events, triggers, cron jobs, or that this was scheduled.',
-    '- Be warm and conversational, as if you just remembered something relevant.',
-  ]
-
-  const userLines = ['===DEFERRED_TASK===', prompt, '===END_DEFERRED_TASK===']
-
-  if (matchedTasksSummary !== undefined) {
-    userLines.push('', 'Matched tasks:', matchedTasksSummary)
-  }
-
-  return {
-    systemContext: systemLines.join('\n'),
-    userContent: userLines.join('\n'),
-  }
-}
+export type { ProactiveTrigger }
 
 type LlmConfig = { apiKey: string; baseURL: string; mainModel: string }
 
@@ -110,38 +38,115 @@ type LlmResult = Awaited<ReturnType<typeof generateText>>
 
 function persistProactiveResults(userId: string, result: LlmResult, history: readonly ModelMessage[]): void {
   const newFacts = extractFactsFromSdkResults(result.toolCalls, result.toolResults)
-  if (newFacts.length > 0) {
-    for (const fact of newFacts) upsertFact(userId, fact)
-    log.info({ userId, factsExtracted: newFacts.length }, 'Facts persisted from proactive tool results')
+  for (const fact of newFacts) upsertFact(userId, fact)
+  if (newFacts.length > 0)
+    log.info({ userId, factsExtracted: newFacts.length }, 'Facts persisted from proactive results')
+
+  const msgs = result.response.messages
+  if (msgs.length > 0) {
+    appendHistory(userId, msgs)
+    const updated = [...history, ...msgs]
+    if (shouldTriggerTrim(updated)) void runTrimInBackground(userId, updated)
   }
+  log.debug({ userId, toolCalls: result.toolCalls?.length }, 'Proactive LLM response received')
+}
+
+// --- Minimal system prompt (shared by lightweight and context modes) ---
+
+function buildMinimalSystemPrompt(type: 'scheduled' | 'alert', timezone: string): string {
+  const { currentTime, displayTimezone } = formatLocalTime(timezone)
+  return [
+    '[PROACTIVE EXECUTION]',
+    `Current time: ${currentTime} (${displayTimezone})`,
+    `Trigger type: ${type}`,
+    '',
+    'A deferred prompt has fired. Deliver the result warmly and conversationally.',
+    'Do not mention scheduling, triggers, or system events.',
+    'Do not create new deferred prompts.',
+  ].join('\n')
+}
+
+// --- Message construction helpers ---
+
+function buildMetadataMessages(m: ExecutionMetadata): ModelMessage[] {
+  const msgs: ModelMessage[] = [{ role: 'system', content: `[DELIVERY BRIEF]\n${m.delivery_brief}` }]
+  if (m.context_snapshot !== null)
+    msgs.push({ role: 'system', content: `[CONTEXT FROM CREATION TIME]\n${m.context_snapshot}` })
+  return msgs
+}
+
+const wrapPrompt = (prompt: string): string => `===DEFERRED_TASK===\n${prompt}\n===END_DEFERRED_TASK===`
+
+// --- Three execution functions ---
+
+async function invokeLightweight(
+  userId: string,
+  type: 'scheduled' | 'alert',
+  prompt: string,
+  metadata: ExecutionMetadata,
+): Promise<string> {
+  log.debug({ userId, mode: 'lightweight' }, 'invokeLightweight called')
+  const config = getLlmConfig(userId)
+  if (typeof config === 'string') return config
+
+  const smallModel = getConfig(userId, 'small_model')
+  const modelId = smallModel ?? config.mainModel
+  const model = createOpenAICompatible({ name: 'openai-compatible', ...config })(modelId)
+  const timezone = getConfig(userId, 'timezone') ?? 'UTC'
+  const messages: ModelMessage[] = [...buildMetadataMessages(metadata), { role: 'user', content: wrapPrompt(prompt) }]
+
+  log.debug({ userId, modelId, mode: 'lightweight' }, 'Calling generateText')
+  const result = await generateText({ model, system: buildMinimalSystemPrompt(type, timezone), messages })
 
   const assistantMessages = result.response.messages
   if (assistantMessages.length > 0) {
     appendHistory(userId, assistantMessages)
-    log.debug({ userId, count: assistantMessages.length }, 'Proactive response appended to history')
-
-    const updatedHistory = [...history, ...assistantMessages]
-    if (shouldTriggerTrim(updatedHistory)) {
-      void runTrimInBackground(userId, updatedHistory)
-    }
+    log.debug({ userId, count: assistantMessages.length }, 'Lightweight response appended to history')
   }
-
-  log.debug({ userId, toolCalls: result.toolCalls?.length }, 'Proactive LLM response received')
+  return result.text ?? 'Done.'
 }
 
-/**
- * Invoke the LLM with the user's full conversation history and a proactive trigger.
- * The system context is injected as a system message; the user-authored prompt is
- * injected as a user message to avoid elevating untrusted text to system priority.
- * Neither is saved to history.
- */
-export async function invokeLlmWithHistory(
+async function invokeWithContext(
   userId: string,
-  trigger: ProactiveTrigger,
-  buildProviderFn: BuildProviderFn,
+  type: 'scheduled' | 'alert',
+  prompt: string,
+  metadata: ExecutionMetadata,
 ): Promise<string> {
-  log.debug({ userId }, 'invokeLlmWithHistory called')
+  log.debug({ userId, mode: 'context' }, 'invokeWithContext called')
+  const config = getLlmConfig(userId)
+  if (typeof config === 'string') return config
 
+  const model = createOpenAICompatible({ name: 'openai-compatible', ...config })(config.mainModel)
+  const timezone = getConfig(userId, 'timezone') ?? 'UTC'
+  const history = getCachedHistory(userId)
+  const { messages: messagesWithMemory } = buildMessagesWithMemory(userId, history)
+  const messages: ModelMessage[] = [
+    ...messagesWithMemory,
+    ...buildMetadataMessages(metadata),
+    { role: 'user', content: wrapPrompt(prompt) },
+  ]
+
+  log.debug({ userId, mainModel: config.mainModel, historyLength: history.length, mode: 'context' }, 'generateText')
+  const result = await generateText({ model, system: buildMinimalSystemPrompt(type, timezone), messages })
+
+  const assistantMessages = result.response.messages
+  if (assistantMessages.length > 0) {
+    appendHistory(userId, assistantMessages)
+    const updatedHistory = [...history, ...assistantMessages]
+    if (shouldTriggerTrim(updatedHistory)) void runTrimInBackground(userId, updatedHistory)
+  }
+  return result.text ?? 'Done.'
+}
+
+async function invokeFull(
+  userId: string,
+  type: 'scheduled' | 'alert',
+  prompt: string,
+  metadata: ExecutionMetadata,
+  buildProviderFn: BuildProviderFn,
+  matchedTasksSummary?: string,
+): Promise<string> {
+  log.debug({ userId, mode: 'full' }, 'invokeFull called')
   const config = getLlmConfig(userId)
   if (typeof config === 'string') return config
 
@@ -155,16 +160,17 @@ export async function invokeLlmWithHistory(
   const tools = makeTools(provider, userId, 'proactive')
   const timezone = getConfig(userId, 'timezone') ?? 'UTC'
   const systemPrompt = buildSystemPrompt(provider, timezone, userId)
-
+  const trigger = buildProactiveTrigger(type, prompt, timezone, matchedTasksSummary)
   const history = getCachedHistory(userId)
   const { messages: messagesWithMemory } = buildMessagesWithMemory(userId, history)
   const finalMessages: ModelMessage[] = [
     ...messagesWithMemory,
     { role: 'system', content: trigger.systemContext },
+    ...buildMetadataMessages(metadata),
     { role: 'user', content: trigger.userContent },
   ]
 
-  log.debug({ userId, mainModel: config.mainModel, historyLength: history.length }, 'Calling generateText')
+  log.debug({ userId, mainModel: config.mainModel, historyLength: history.length, mode: 'full' }, 'generateText')
   const result = await generateText({
     model,
     system: systemPrompt,
@@ -172,7 +178,37 @@ export async function invokeLlmWithHistory(
     tools,
     stopWhen: stepCountIs(25),
   })
-
   persistProactiveResults(userId, result, history)
   return result.text ?? 'Done.'
+}
+
+// --- Dispatcher ---
+
+export function dispatchExecution(
+  userId: string,
+  type: 'scheduled' | 'alert',
+  prompt: string,
+  metadata: ExecutionMetadata,
+  buildProviderFn: BuildProviderFn,
+  matchedTasksSummary?: string,
+): Promise<string> {
+  log.debug({ userId, mode: metadata.mode }, 'dispatchExecution called')
+  switch (metadata.mode) {
+    case 'lightweight':
+      return invokeLightweight(userId, type, prompt, metadata)
+    case 'context':
+      return invokeWithContext(userId, type, prompt, metadata)
+    case 'full':
+      return invokeFull(userId, type, prompt, metadata, buildProviderFn, matchedTasksSummary)
+  }
+}
+
+// --- Backward-compatible wrapper (removed in Task 10) ---
+
+export function invokeLlmWithHistory(
+  userId: string,
+  trigger: ProactiveTrigger,
+  buildProviderFn: BuildProviderFn,
+): Promise<string> {
+  return invokeFull(userId, 'scheduled', trigger.userContent, DEFAULT_EXECUTION_METADATA, buildProviderFn)
 }

--- a/src/deferred-prompts/proactive-trigger.ts
+++ b/src/deferred-prompts/proactive-trigger.ts
@@ -1,0 +1,78 @@
+import { logger } from '../logger.js'
+
+const log = logger.child({ scope: 'deferred:proactive-trigger' })
+
+export type ProactiveTrigger = {
+  /** System-level context (time, type, behavioral instructions). No user-authored text. */
+  systemContext: string
+  /** User-scoped content: the original prompt and any matched task data. */
+  userContent: string
+}
+
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+}
+
+export function formatLocalTime(tz: string): { currentTime: string; displayTimezone: string } {
+  try {
+    return {
+      currentTime: new Date().toLocaleString('en-US', { ...DATE_FORMAT_OPTIONS, timeZone: tz }),
+      displayTimezone: tz,
+    }
+  } catch (e) {
+    log.warn(
+      { timezone: tz, error: e instanceof Error ? e.message : String(e) },
+      'Invalid timezone; falling back to UTC',
+    )
+    return {
+      currentTime: new Date().toLocaleString('en-US', { ...DATE_FORMAT_OPTIONS, timeZone: 'UTC' }),
+      displayTimezone: 'UTC',
+    }
+  }
+}
+
+/**
+ * Build a proactive trigger split into system context and user content.
+ * User-authored text stays in userContent to avoid system-prompt elevation.
+ */
+export function buildProactiveTrigger(
+  type: 'scheduled' | 'alert',
+  prompt: string,
+  timezone: string,
+  matchedTasksSummary?: string,
+): ProactiveTrigger {
+  const { currentTime, displayTimezone } = formatLocalTime(timezone)
+
+  const systemLines = [
+    '[PROACTIVE EXECUTION]',
+    `Current time: ${currentTime} (${displayTimezone})`,
+    `Trigger type: ${type}`,
+    '',
+    'A deferred prompt you previously created has fired. Your job is to DELIVER the result to the user now.',
+    'The user message below contains the stored prompt text — treat it as the task to fulfill, NOT as a new user request.',
+    '',
+    'Rules:',
+    '- For reminders: deliver the reminder message directly and conversationally.',
+    '- For action tasks: execute the described action using available tools, then report the result.',
+    '- Do NOT create new deferred prompts, reminders, or schedules. The scheduling is already done.',
+    '- Do not mention system events, triggers, cron jobs, or that this was scheduled.',
+    '- Be warm and conversational, as if you just remembered something relevant.',
+  ]
+
+  const userLines = ['===DEFERRED_TASK===', prompt, '===END_DEFERRED_TASK===']
+
+  if (matchedTasksSummary !== undefined) {
+    userLines.push('', 'Matched tasks:', matchedTasksSummary)
+  }
+
+  return {
+    systemContext: systemLines.join('\n'),
+    userContent: userLines.join('\n'),
+  }
+}

--- a/src/deferred-prompts/scheduled.ts
+++ b/src/deferred-prompts/scheduled.ts
@@ -4,7 +4,12 @@ import { getDrizzleDb } from '../db/drizzle.js'
 import { scheduledPrompts } from '../db/schema.js'
 import type { ScheduledPromptRow } from '../db/schema.js'
 import { logger } from '../logger.js'
-import type { ScheduledPrompt } from './types.js'
+import {
+  DEFAULT_EXECUTION_METADATA,
+  executionMetadataSchema,
+  type ExecutionMetadata,
+  type ScheduledPrompt,
+} from './types.js'
 
 const log = logger.child({ scope: 'deferred:scheduled' })
 
@@ -14,6 +19,16 @@ function isValidStatus(value: string): value is ScheduledPrompt['status'] {
 
 function toStatus(value: string): ScheduledPrompt['status'] {
   return isValidStatus(value) ? value : 'active'
+}
+
+function parseExecutionMetadata(raw: string): ExecutionMetadata {
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    const result = executionMetadataSchema.safeParse(parsed)
+    return result.success ? result.data : DEFAULT_EXECUTION_METADATA
+  } catch {
+    return DEFAULT_EXECUTION_METADATA
+  }
 }
 
 function toScheduledPrompt(row: ScheduledPromptRow): ScheduledPrompt {
@@ -27,6 +42,7 @@ function toScheduledPrompt(row: ScheduledPromptRow): ScheduledPrompt {
     status: toStatus(row.status),
     createdAt: row.createdAt,
     lastExecutedAt: row.lastExecutedAt,
+    executionMetadata: parseExecutionMetadata(row.executionMetadata),
   }
 }
 
@@ -34,6 +50,7 @@ export function createScheduledPrompt(
   userId: string,
   prompt: string,
   schedule: { fireAt: string; cronExpression?: string },
+  executionMetadata?: ExecutionMetadata,
 ): ScheduledPrompt {
   log.debug({ userId, hasCron: schedule.cronExpression !== undefined }, 'createScheduledPrompt called')
 
@@ -49,6 +66,7 @@ export function createScheduledPrompt(
       fireAt,
       cronExpression: schedule.cronExpression ?? null,
       status: 'active',
+      executionMetadata: JSON.stringify(executionMetadata ?? DEFAULT_EXECUTION_METADATA),
     })
     .run()
 
@@ -99,18 +117,20 @@ function buildUpdateValues(updates: {
   prompt?: string
   fireAt?: string
   cronExpression?: string
+  executionMetadata?: ExecutionMetadata
 }): Partial<typeof scheduledPrompts.$inferInsert> {
   const values: Partial<typeof scheduledPrompts.$inferInsert> = {}
   if (updates.prompt !== undefined) values.prompt = updates.prompt
   if (updates.fireAt !== undefined) values.fireAt = new Date(updates.fireAt).toISOString()
   if (updates.cronExpression !== undefined) values.cronExpression = updates.cronExpression
+  if (updates.executionMetadata !== undefined) values.executionMetadata = JSON.stringify(updates.executionMetadata)
   return values
 }
 
 export function updateScheduledPrompt(
   id: string,
   userId: string,
-  updates: { prompt?: string; fireAt?: string; cronExpression?: string },
+  updates: { prompt?: string; fireAt?: string; cronExpression?: string; executionMetadata?: ExecutionMetadata },
 ): ScheduledPrompt | null {
   log.debug({ id, userId }, 'updateScheduledPrompt called')
 

--- a/src/deferred-prompts/scheduled.ts
+++ b/src/deferred-prompts/scheduled.ts
@@ -6,7 +6,7 @@ import type { ScheduledPromptRow } from '../db/schema.js'
 import { logger } from '../logger.js'
 import {
   DEFAULT_EXECUTION_METADATA,
-  executionMetadataSchema,
+  parseExecutionMetadata,
   type ExecutionMetadata,
   type ScheduledPrompt,
 } from './types.js'
@@ -19,16 +19,6 @@ function isValidStatus(value: string): value is ScheduledPrompt['status'] {
 
 function toStatus(value: string): ScheduledPrompt['status'] {
   return isValidStatus(value) ? value : 'active'
-}
-
-function parseExecutionMetadata(raw: string): ExecutionMetadata {
-  try {
-    const parsed: unknown = JSON.parse(raw)
-    const result = executionMetadataSchema.safeParse(parsed)
-    return result.success ? result.data : DEFAULT_EXECUTION_METADATA
-  } catch {
-    return DEFAULT_EXECUTION_METADATA
-  }
 }
 
 function toScheduledPrompt(row: ScheduledPromptRow): ScheduledPrompt {

--- a/src/deferred-prompts/tool-handlers.ts
+++ b/src/deferred-prompts/tool-handlers.ts
@@ -1,0 +1,232 @@
+import { getConfig } from '../config.js'
+import { nextCronOccurrence, parseCron } from '../cron.js'
+import { logger } from '../logger.js'
+import { localDatetimeToUtc, utcToLocal } from '../utils/datetime.js'
+import { cancelAlertPrompt, createAlertPrompt, getAlertPrompt, listAlertPrompts, updateAlertPrompt } from './alerts.js'
+import {
+  cancelScheduledPrompt,
+  createScheduledPrompt,
+  getScheduledPrompt,
+  listScheduledPrompts,
+  updateScheduledPrompt,
+} from './scheduled.js'
+import {
+  alertConditionSchema,
+  DEFAULT_EXECUTION_METADATA,
+  executionMetadataSchema,
+  type AlertCondition,
+  type CancelResult,
+  type CreateResult,
+  type ExecutionMetadata,
+  type GetResult,
+  type ListResult,
+  type ScheduleInput,
+  type UpdateResult,
+} from './types.js'
+
+const log = logger.child({ scope: 'deferred:tools' })
+
+// --- Input types ---
+
+export type CreateInput = {
+  prompt: string
+  schedule?: ScheduleInput
+  condition?: AlertCondition
+  cooldown_minutes?: number
+  execution?: { mode: 'lightweight' | 'context' | 'full'; delivery_brief: string; context_snapshot?: string }
+}
+
+export type UpdateInput = {
+  id: string
+  prompt?: string
+  schedule?: ScheduleInput
+  condition?: AlertCondition
+  cooldown_minutes?: number
+  execution?: { mode: 'lightweight' | 'context' | 'full'; delivery_brief: string; context_snapshot?: string }
+}
+
+export type ListInput = { type?: 'scheduled' | 'alert'; status?: 'active' | 'completed' | 'cancelled' }
+
+// --- Handlers ---
+
+function createScheduled(
+  userId: string,
+  prompt: string,
+  schedule: ScheduleInput,
+  executionMetadata: ExecutionMetadata,
+): CreateResult {
+  const hasFireAt = schedule.fire_at !== undefined
+  const hasCron = schedule.cron !== undefined && schedule.cron !== ''
+  const timezone = getConfig(userId, 'timezone') ?? 'UTC'
+
+  if (hasFireAt) {
+    const { date, time } = schedule.fire_at!
+    const utcStr = localDatetimeToUtc(date, time, timezone)
+    const fireDate = new Date(utcStr)
+    if (Number.isNaN(fireDate.getTime())) return { error: `Invalid fire_at date/time: '${date}T${time}'` }
+    if (fireDate.getTime() <= Date.now()) return { error: 'fire_at must be a future date and time.' }
+  }
+
+  let cronExpression: string | undefined
+  if (hasCron) {
+    if (parseCron(schedule.cron!) === null) return { error: `Invalid cron expression: '${schedule.cron!}'` }
+    cronExpression = schedule.cron!
+  }
+
+  let fireAt: string
+  if (hasFireAt) {
+    fireAt = localDatetimeToUtc(schedule.fire_at!.date, schedule.fire_at!.time, timezone)
+  } else if (hasCron) {
+    const next = nextCronOccurrence(parseCron(cronExpression!)!, new Date(), timezone)
+    if (next === null) return { error: 'Could not compute next occurrence for the given cron expression.' }
+    fireAt = next.toISOString()
+  } else {
+    return { error: 'Schedule must include either fire_at or cron.' }
+  }
+
+  const result = createScheduledPrompt(userId, prompt, { fireAt, cronExpression }, executionMetadata)
+  log.info({ id: result.id, userId, type: 'scheduled' }, 'Deferred prompt created')
+  return {
+    status: 'created',
+    type: 'scheduled',
+    id: result.id,
+    fireAt: utcToLocal(result.fireAt, timezone) ?? result.fireAt,
+    cronExpression: result.cronExpression,
+  }
+}
+
+function createAlert(
+  userId: string,
+  prompt: string,
+  condition: unknown,
+  cooldownMinutes: number | undefined,
+  executionMetadata: ExecutionMetadata,
+): CreateResult {
+  const parseResult = alertConditionSchema.safeParse(condition)
+  if (!parseResult.success) return { error: `Invalid condition: ${parseResult.error.message}` }
+
+  const result = createAlertPrompt(userId, prompt, parseResult.data, cooldownMinutes, executionMetadata)
+  log.info({ id: result.id, userId, type: 'alert' }, 'Deferred prompt created')
+  return { status: 'created', type: 'alert', id: result.id, cooldownMinutes: result.cooldownMinutes }
+}
+
+function parseExecution(
+  input: { mode: 'lightweight' | 'context' | 'full'; delivery_brief: string; context_snapshot?: string } | undefined,
+): ExecutionMetadata {
+  if (input === undefined) return DEFAULT_EXECUTION_METADATA
+  const parseResult = executionMetadataSchema.safeParse(input)
+  if (parseResult.success) return parseResult.data
+  log.warn({ error: parseResult.error.message }, 'Invalid execution metadata, using default')
+  return DEFAULT_EXECUTION_METADATA
+}
+
+export function executeCreate(userId: string, input: CreateInput): CreateResult {
+  const hasSchedule = input.schedule !== undefined
+  const hasCondition = input.condition !== undefined
+  log.debug({ userId, hasSchedule, hasCondition }, 'create_deferred_prompt called')
+  if (hasSchedule && hasCondition) return { error: 'Provide either a schedule or a condition, not both.' }
+  if (!hasSchedule && !hasCondition) {
+    return { error: 'Provide either a schedule (for time-based) or a condition (for event-based).' }
+  }
+
+  const executionMetadata = parseExecution(input.execution)
+
+  if (hasSchedule) return createScheduled(userId, input.prompt, input.schedule!, executionMetadata)
+  return createAlert(userId, input.prompt, input.condition, input.cooldown_minutes, executionMetadata)
+}
+
+export function executeList(
+  userId: string,
+  input: { type?: 'scheduled' | 'alert'; status?: 'active' | 'completed' | 'cancelled' },
+): ListResult {
+  log.debug({ userId, type: input.type, status: input.status }, 'list_deferred_prompts called')
+  const prompts: ListResult['prompts'] = []
+  if (input.type !== 'alert') prompts.push(...listScheduledPrompts(userId, input.status))
+  if (input.type !== 'scheduled') prompts.push(...listAlertPrompts(userId, input.status))
+  log.info({ userId, count: prompts.length }, 'Listed deferred prompts')
+  return { prompts }
+}
+
+export function executeGet(userId: string, input: { id: string }): GetResult {
+  log.debug({ userId, id: input.id }, 'get_deferred_prompt called')
+  return (
+    getScheduledPrompt(input.id, userId) ?? getAlertPrompt(input.id, userId) ?? { error: 'Deferred prompt not found.' }
+  )
+}
+
+function updateScheduledFields(id: string, userId: string, input: UpdateInput): UpdateResult {
+  if (input.condition !== undefined)
+    return { error: 'Cannot apply a condition to a scheduled prompt. Use schedule fields instead.' }
+  const updates: { prompt?: string; fireAt?: string; cronExpression?: string; executionMetadata?: ExecutionMetadata } =
+    {}
+  if (input.prompt !== undefined) updates.prompt = input.prompt
+  if (input.schedule !== undefined) {
+    if (input.schedule.fire_at !== undefined) {
+      const { date, time } = input.schedule.fire_at
+      const timezone = getConfig(userId, 'timezone') ?? 'UTC'
+      const utcStr = localDatetimeToUtc(date, time, timezone)
+      const fireAtDate = new Date(utcStr)
+      if (Number.isNaN(fireAtDate.getTime())) return { error: `Invalid fire_at: '${date}T${time}'` }
+      if (fireAtDate.getTime() <= Date.now()) return { error: 'fire_at must be in the future.' }
+      updates.fireAt = utcStr
+    }
+    if (input.schedule.cron !== undefined) {
+      if (parseCron(input.schedule.cron) === null) return { error: `Invalid cron expression: '${input.schedule.cron}'` }
+      updates.cronExpression = input.schedule.cron
+    }
+  }
+  if (input.execution !== undefined) {
+    const parseResult = executionMetadataSchema.safeParse(input.execution)
+    if (parseResult.success) updates.executionMetadata = parseResult.data
+  }
+  const result = updateScheduledPrompt(id, userId, updates)
+  if (result === null) return { error: 'Deferred prompt not found.' }
+  log.info({ id, userId }, 'Scheduled prompt updated via tool')
+  return { ...result, status: 'updated' as const }
+}
+
+function updateAlertFields(id: string, userId: string, input: UpdateInput): UpdateResult {
+  if (input.schedule !== undefined)
+    return { error: 'Cannot apply a schedule to an alert prompt. Use condition fields instead.' }
+  const updates: {
+    prompt?: string
+    condition?: AlertCondition
+    cooldownMinutes?: number
+    executionMetadata?: ExecutionMetadata
+  } = {}
+  if (input.prompt !== undefined) updates.prompt = input.prompt
+  if (input.condition !== undefined) {
+    const parseResult = alertConditionSchema.safeParse(input.condition)
+    if (!parseResult.success) return { error: `Invalid condition: ${parseResult.error.message}` }
+    updates.condition = parseResult.data
+  }
+  if (input.cooldown_minutes !== undefined) updates.cooldownMinutes = input.cooldown_minutes
+  if (input.execution !== undefined) {
+    const parseResult = executionMetadataSchema.safeParse(input.execution)
+    if (parseResult.success) updates.executionMetadata = parseResult.data
+  }
+  const result = updateAlertPrompt(id, userId, updates)
+  if (result === null) return { error: 'Deferred prompt not found.' }
+  log.info({ id, userId }, 'Alert prompt updated via tool')
+  return { ...result, status: 'updated' as const }
+}
+
+export function executeUpdate(userId: string, input: UpdateInput): UpdateResult {
+  log.debug({ userId, id: input.id }, 'update_deferred_prompt called')
+  if (getScheduledPrompt(input.id, userId) !== null) return updateScheduledFields(input.id, userId, input)
+  if (getAlertPrompt(input.id, userId) !== null) return updateAlertFields(input.id, userId, input)
+  return { error: 'Deferred prompt not found.' }
+}
+
+export function executeCancel(userId: string, input: { id: string }): CancelResult {
+  log.debug({ userId, id: input.id }, 'cancel_deferred_prompt called')
+  if (cancelScheduledPrompt(input.id, userId) !== null) {
+    log.info({ id: input.id, userId, type: 'scheduled' }, 'Deferred prompt cancelled')
+    return { status: 'cancelled', id: input.id }
+  }
+  if (cancelAlertPrompt(input.id, userId) !== null) {
+    log.info({ id: input.id, userId, type: 'alert' }, 'Deferred prompt cancelled')
+    return { status: 'cancelled', id: input.id }
+  }
+  return { error: 'Deferred prompt not found.' }
+}

--- a/src/deferred-prompts/tools.ts
+++ b/src/deferred-prompts/tools.ts
@@ -2,216 +2,36 @@ import { tool } from 'ai'
 import type { ToolSet } from 'ai'
 import { z } from 'zod'
 
-import { getConfig } from '../config.js'
-import { nextCronOccurrence, parseCron } from '../cron.js'
 import { logger } from '../logger.js'
-import { localDatetimeToUtc, utcToLocal } from '../utils/datetime.js'
-import { cancelAlertPrompt, createAlertPrompt, getAlertPrompt, listAlertPrompts, updateAlertPrompt } from './alerts.js'
 import {
-  cancelScheduledPrompt,
-  createScheduledPrompt,
-  getScheduledPrompt,
-  listScheduledPrompts,
-  updateScheduledPrompt,
-} from './scheduled.js'
-import {
-  alertConditionSchema,
-  type AlertCondition,
-  type CancelResult,
-  type CreateResult,
-  type GetResult,
-  type ListResult,
-  type UpdateResult,
-} from './types.js'
+  executeCancel,
+  executeCreate,
+  executeGet,
+  executeList,
+  executeUpdate,
+  type CreateInput,
+  type ListInput,
+  type UpdateInput,
+} from './tool-handlers.js'
+import { alertConditionSchema, cooldownSchema, executionInputSchema, scheduleSchema } from './types.js'
 
 const log = logger.child({ scope: 'deferred:tools' })
-
-type FireAtInput = { date: string; time: string }
-type ScheduleInput = { fire_at?: FireAtInput; cron?: string }
-type CreateInput = { prompt: string; schedule?: ScheduleInput; condition?: AlertCondition; cooldown_minutes?: number }
-
-function createScheduled(userId: string, prompt: string, schedule: ScheduleInput): CreateResult {
-  const hasFireAt = schedule.fire_at !== undefined
-  const hasCron = schedule.cron !== undefined && schedule.cron !== ''
-  const timezone = getConfig(userId, 'timezone') ?? 'UTC'
-
-  if (hasFireAt) {
-    const { date, time } = schedule.fire_at!
-    const utcStr = localDatetimeToUtc(date, time, timezone)
-    const fireDate = new Date(utcStr)
-    if (Number.isNaN(fireDate.getTime())) return { error: `Invalid fire_at date/time: '${date}T${time}'` }
-    if (fireDate.getTime() <= Date.now()) return { error: 'fire_at must be a future date and time.' }
-  }
-
-  let cronExpression: string | undefined
-  if (hasCron) {
-    if (parseCron(schedule.cron!) === null) return { error: `Invalid cron expression: '${schedule.cron!}'` }
-    cronExpression = schedule.cron!
-  }
-
-  let fireAt: string
-  if (hasFireAt) {
-    fireAt = localDatetimeToUtc(schedule.fire_at!.date, schedule.fire_at!.time, timezone)
-  } else if (hasCron) {
-    const next = nextCronOccurrence(parseCron(cronExpression!)!, new Date(), timezone)
-    if (next === null) return { error: 'Could not compute next occurrence for the given cron expression.' }
-    fireAt = next.toISOString()
-  } else {
-    return { error: 'Schedule must include either fire_at or cron.' }
-  }
-
-  const result = createScheduledPrompt(userId, prompt, { fireAt, cronExpression })
-  log.info({ id: result.id, userId, type: 'scheduled' }, 'Deferred prompt created')
-  return {
-    status: 'created',
-    type: 'scheduled',
-    id: result.id,
-    fireAt: utcToLocal(result.fireAt, timezone) ?? result.fireAt,
-    cronExpression: result.cronExpression,
-  }
-}
-
-function createAlert(userId: string, prompt: string, condition: unknown, cooldownMinutes?: number): CreateResult {
-  const parseResult = alertConditionSchema.safeParse(condition)
-  if (!parseResult.success) return { error: `Invalid condition: ${parseResult.error.message}` }
-
-  const result = createAlertPrompt(userId, prompt, parseResult.data, cooldownMinutes)
-  log.info({ id: result.id, userId, type: 'alert' }, 'Deferred prompt created')
-  return { status: 'created', type: 'alert', id: result.id, cooldownMinutes: result.cooldownMinutes }
-}
-
-function executeCreate(userId: string, input: CreateInput): CreateResult {
-  const hasSchedule = input.schedule !== undefined
-  const hasCondition = input.condition !== undefined
-  log.debug({ userId, hasSchedule, hasCondition }, 'create_deferred_prompt called')
-  if (hasSchedule && hasCondition) return { error: 'Provide either a schedule or a condition, not both.' }
-  if (!hasSchedule && !hasCondition) {
-    return { error: 'Provide either a schedule (for time-based) or a condition (for event-based).' }
-  }
-  if (hasSchedule) return createScheduled(userId, input.prompt, input.schedule!)
-  return createAlert(userId, input.prompt, input.condition, input.cooldown_minutes)
-}
-
-function executeList(
-  userId: string,
-  input: { type?: 'scheduled' | 'alert'; status?: 'active' | 'completed' | 'cancelled' },
-): ListResult {
-  log.debug({ userId, type: input.type, status: input.status }, 'list_deferred_prompts called')
-  const prompts: ListResult['prompts'] = []
-  if (input.type !== 'alert') prompts.push(...listScheduledPrompts(userId, input.status))
-  if (input.type !== 'scheduled') prompts.push(...listAlertPrompts(userId, input.status))
-  log.info({ userId, count: prompts.length }, 'Listed deferred prompts')
-  return { prompts }
-}
-
-function executeGet(userId: string, input: { id: string }): GetResult {
-  log.debug({ userId, id: input.id }, 'get_deferred_prompt called')
-  return (
-    getScheduledPrompt(input.id, userId) ?? getAlertPrompt(input.id, userId) ?? { error: 'Deferred prompt not found.' }
-  )
-}
-
-type UpdateInput = {
-  id: string
-  prompt?: string
-  schedule?: ScheduleInput
-  condition?: AlertCondition
-  cooldown_minutes?: number
-}
-
-function updateScheduledFields(id: string, userId: string, input: UpdateInput): UpdateResult {
-  if (input.condition !== undefined)
-    return { error: 'Cannot apply a condition to a scheduled prompt. Use schedule fields instead.' }
-  const updates: { prompt?: string; fireAt?: string; cronExpression?: string } = {}
-  if (input.prompt !== undefined) updates.prompt = input.prompt
-  if (input.schedule !== undefined) {
-    if (input.schedule.fire_at !== undefined) {
-      const { date, time } = input.schedule.fire_at
-      const timezone = getConfig(userId, 'timezone') ?? 'UTC'
-      const utcStr = localDatetimeToUtc(date, time, timezone)
-      const fireAtDate = new Date(utcStr)
-      if (Number.isNaN(fireAtDate.getTime())) return { error: `Invalid fire_at: '${date}T${time}'` }
-      if (fireAtDate.getTime() <= Date.now()) return { error: 'fire_at must be in the future.' }
-      updates.fireAt = utcStr
-    }
-    if (input.schedule.cron !== undefined) {
-      if (parseCron(input.schedule.cron) === null) return { error: `Invalid cron expression: '${input.schedule.cron}'` }
-      updates.cronExpression = input.schedule.cron
-    }
-  }
-  const result = updateScheduledPrompt(id, userId, updates)
-  if (result === null) return { error: 'Deferred prompt not found.' }
-  log.info({ id, userId }, 'Scheduled prompt updated via tool')
-  return { ...result, status: 'updated' as const }
-}
-
-function updateAlertFields(id: string, userId: string, input: UpdateInput): UpdateResult {
-  if (input.schedule !== undefined)
-    return { error: 'Cannot apply a schedule to an alert prompt. Use condition fields instead.' }
-  const updates: { prompt?: string; condition?: AlertCondition; cooldownMinutes?: number } = {}
-  if (input.prompt !== undefined) updates.prompt = input.prompt
-  if (input.condition !== undefined) {
-    const parseResult = alertConditionSchema.safeParse(input.condition)
-    if (!parseResult.success) return { error: `Invalid condition: ${parseResult.error.message}` }
-    updates.condition = parseResult.data
-  }
-  if (input.cooldown_minutes !== undefined) updates.cooldownMinutes = input.cooldown_minutes
-  const result = updateAlertPrompt(id, userId, updates)
-  if (result === null) return { error: 'Deferred prompt not found.' }
-  log.info({ id, userId }, 'Alert prompt updated via tool')
-  return { ...result, status: 'updated' as const }
-}
-
-function executeUpdate(userId: string, input: UpdateInput): UpdateResult {
-  log.debug({ userId, id: input.id }, 'update_deferred_prompt called')
-  if (getScheduledPrompt(input.id, userId) !== null) return updateScheduledFields(input.id, userId, input)
-  if (getAlertPrompt(input.id, userId) !== null) return updateAlertFields(input.id, userId, input)
-  return { error: 'Deferred prompt not found.' }
-}
-
-function executeCancel(userId: string, input: { id: string }): CancelResult {
-  log.debug({ userId, id: input.id }, 'cancel_deferred_prompt called')
-  if (cancelScheduledPrompt(input.id, userId) !== null) {
-    log.info({ id: input.id, userId, type: 'scheduled' }, 'Deferred prompt cancelled')
-    return { status: 'cancelled', id: input.id }
-  }
-  if (cancelAlertPrompt(input.id, userId) !== null) {
-    log.info({ id: input.id, userId, type: 'alert' }, 'Deferred prompt cancelled')
-    return { status: 'cancelled', id: input.id }
-  }
-  return { error: 'Deferred prompt not found.' }
-}
 
 function logAndRethrow(name: string, error: unknown): never {
   log.error({ error: error instanceof Error ? error.message : String(error), tool: name }, 'Tool execution failed')
   throw error
 }
-const scheduleSchema = z.object({
-  fire_at: z
-    .object({
-      date: z.string().describe("Date in YYYY-MM-DD format (user's local date)"),
-      time: z.string().describe("Time in HH:MM 24-hour format (user's local time)"),
-    })
-    .optional()
-    .describe("One-time trigger in user's local time — tool handles UTC conversion"),
-  cron: z.string().optional().describe('5-field cron expression for recurring execution in local time'),
-})
-const cooldownSchema = z
-  .number()
-  .int()
-  .min(1)
-  .optional()
-  .describe('Minimum minutes between alert triggers (default: 60)')
-type ListInput = { type?: 'scheduled' | 'alert'; status?: 'active' | 'completed' | 'cancelled' }
+
 function makeCreateTool(userId: string): ToolSet[string] {
   return tool({
     description:
-      'Create a scheduled task or monitoring alert. Provide either a schedule (for time-based) or a condition (for event-based), not both.',
+      'Create a scheduled task or monitoring alert. Provide either a schedule (for time-based) or a condition (for event-based), not both. Always classify the execution mode based on what the prompt needs at fire time.',
     inputSchema: z.object({
       prompt: z.string().describe('What to do/say when this fires — not scheduling meta-instructions'),
       schedule: scheduleSchema.optional().describe('Time-based trigger (one-time or recurring)'),
       condition: alertConditionSchema.optional().describe('Event-based trigger condition'),
       cooldown_minutes: cooldownSchema,
+      execution: executionInputSchema,
     }),
     execute: (input: CreateInput) => {
       try {
@@ -264,6 +84,7 @@ function makeUpdateTool(userId: string): ToolSet[string] {
       schedule: scheduleSchema.optional().describe('Updated time-based trigger'),
       condition: alertConditionSchema.optional().describe('Updated event-based trigger condition'),
       cooldown_minutes: cooldownSchema,
+      execution: executionInputSchema,
     }),
     execute: (input: UpdateInput) => {
       try {

--- a/src/deferred-prompts/types.ts
+++ b/src/deferred-prompts/types.ts
@@ -68,6 +68,25 @@ export const alertConditionSchema: z.ZodType<AlertCondition> = z.union([
   }),
 ])
 
+// --- Execution metadata ---
+
+export const EXECUTION_MODES = ['lightweight', 'context', 'full'] as const
+export type ExecutionMode = (typeof EXECUTION_MODES)[number]
+
+export const executionMetadataSchema = z.object({
+  mode: z.enum(EXECUTION_MODES),
+  delivery_brief: z.string(),
+  context_snapshot: z.string().nullable().default(null),
+})
+
+export type ExecutionMetadata = z.infer<typeof executionMetadataSchema>
+
+export const DEFAULT_EXECUTION_METADATA: ExecutionMetadata = {
+  mode: 'full',
+  delivery_brief: '',
+  context_snapshot: null,
+}
+
 // --- Domain types ---
 
 export type ScheduledPrompt = {
@@ -80,6 +99,7 @@ export type ScheduledPrompt = {
   status: 'active' | 'completed' | 'cancelled'
   createdAt: string
   lastExecutedAt: string | null
+  executionMetadata: ExecutionMetadata
 }
 
 export type AlertPrompt = {
@@ -92,6 +112,7 @@ export type AlertPrompt = {
   createdAt: string
   lastTriggeredAt: string | null
   cooldownMinutes: number
+  executionMetadata: ExecutionMetadata
 }
 
 // --- Tool result types ---

--- a/src/deferred-prompts/types.ts
+++ b/src/deferred-prompts/types.ts
@@ -87,6 +87,59 @@ export const DEFAULT_EXECUTION_METADATA: ExecutionMetadata = {
   context_snapshot: null,
 }
 
+export function parseExecutionMetadata(raw: string): ExecutionMetadata {
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    const result = executionMetadataSchema.safeParse(parsed)
+    return result.success ? result.data : DEFAULT_EXECUTION_METADATA
+  } catch {
+    return DEFAULT_EXECUTION_METADATA
+  }
+}
+
+// --- Tool input schemas ---
+
+export type FireAtInput = { date: string; time: string }
+export type ScheduleInput = { fire_at?: FireAtInput; cron?: string }
+
+export const scheduleSchema = z.object({
+  fire_at: z
+    .object({
+      date: z.string().describe("Date in YYYY-MM-DD format (user's local date)"),
+      time: z.string().describe("Time in HH:MM 24-hour format (user's local time)"),
+    })
+    .optional()
+    .describe("One-time trigger in user's local time — tool handles UTC conversion"),
+  cron: z.string().optional().describe('5-field cron expression for recurring execution in local time'),
+})
+
+export const cooldownSchema = z
+  .number()
+  .int()
+  .min(1)
+  .optional()
+  .describe('Minimum minutes between alert triggers (default: 60)')
+
+export const executionInputSchema = z
+  .object({
+    mode: z
+      .enum(EXECUTION_MODES)
+      .describe(
+        'lightweight: simple reminders/nudges needing no tools or history. context: needs conversation history but no tools. full: needs live task tracker operations.',
+      ),
+    delivery_brief: z
+      .string()
+      .describe('Freeform instructions for the executing LLM: intent, tone, key details, entities to reference.'),
+    context_snapshot: z
+      .string()
+      .optional()
+      .describe(
+        'When the user references something from the current conversation, distill only the relevant parts into a summary here.',
+      ),
+  })
+  .optional()
+  .describe('Execution mode classification and delivery instructions for the firing LLM.')
+
 // --- Domain types ---
 
 export type ScheduledPrompt = {

--- a/tests/deferred-prompts/execution-modes.test.ts
+++ b/tests/deferred-prompts/execution-modes.test.ts
@@ -1,0 +1,253 @@
+// tests/deferred-prompts/execution-modes.test.ts
+//
+// Mocked modules: ai, @ai-sdk/openai-compatible, ../src/logger.js, ../src/db/drizzle.js
+// (Uses mockLogger + mockDrizzle helpers; mocks ai + openai-compatible directly)
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+import type { ModelMessage } from 'ai'
+
+import { mockLogger, mockDrizzle, setupTestDb } from '../utils/test-helpers.js'
+
+mockLogger()
+mockDrizzle()
+
+// Track generateText calls
+type GenerateTextResult = {
+  text: string
+  toolCalls: unknown[]
+  toolResults: unknown[]
+  response: { messages: ModelMessage[] }
+}
+type GenerateTextCall = { model: unknown; system: unknown; messages: unknown[]; tools: unknown }
+const generateTextCalls: GenerateTextCall[] = []
+
+let generateTextImpl = (args: GenerateTextCall): Promise<GenerateTextResult> => {
+  generateTextCalls.push(args)
+  return Promise.resolve({ text: 'Mock response', toolCalls: [], toolResults: [], response: { messages: [] } })
+}
+
+void mock.module('ai', () => ({
+  generateText: (args: GenerateTextCall): Promise<GenerateTextResult> => generateTextImpl(args),
+  tool: (opts: unknown): unknown => opts,
+  stepCountIs: (_n: number): unknown => undefined,
+}))
+
+void mock.module('@ai-sdk/openai-compatible', () => ({
+  createOpenAICompatible:
+    (opts: { name: string; apiKey: string; baseURL: string }): ((modelId: string) => string) =>
+    (modelId: string): string =>
+      `${opts.name}:${modelId}`,
+}))
+
+import { setConfig } from '../../src/config.js'
+// Import after mocks
+import { dispatchExecution } from '../../src/deferred-prompts/proactive-llm.js'
+import type { ExecutionMetadata } from '../../src/deferred-prompts/types.js'
+import { appendHistory } from '../../src/history.js'
+import { createMockProvider } from '../tools/mock-provider.js'
+
+const USER_ID = 'exec-mode-user'
+
+function setupUserConfig(opts?: { smallModel?: string }): void {
+  setConfig(USER_ID, 'llm_apikey', 'test-key')
+  setConfig(USER_ID, 'llm_baseurl', 'http://localhost:11434/v1')
+  setConfig(USER_ID, 'main_model', 'main-model')
+  setConfig(USER_ID, 'timezone', 'UTC')
+  if (opts?.smallModel !== undefined) {
+    setConfig(USER_ID, 'small_model', opts.smallModel)
+  }
+}
+
+afterAll(() => {
+  mock.restore()
+})
+
+beforeEach(async () => {
+  await setupTestDb()
+  generateTextCalls.length = 0
+  generateTextImpl = (args: GenerateTextCall): Promise<GenerateTextResult> => {
+    generateTextCalls.push(args)
+    return Promise.resolve({ text: 'Mock response', toolCalls: [], toolResults: [], response: { messages: [] } })
+  }
+})
+
+describe('dispatchExecution', () => {
+  describe('lightweight mode', () => {
+    const metadata: ExecutionMetadata = {
+      mode: 'lightweight',
+      delivery_brief: 'Friendly hydration reminder',
+      context_snapshot: null,
+    }
+
+    test('uses small_model when configured', async () => {
+      setupUserConfig({ smallModel: 'small-model' })
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      expect(generateTextCalls).toHaveLength(1)
+      expect(generateTextCalls[0]!.model).toContain('small-model')
+    })
+
+    test('falls back to main_model when small_model not set', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      expect(generateTextCalls).toHaveLength(1)
+      expect(generateTextCalls[0]!.model).toContain('main-model')
+    })
+
+    test('does not include tools', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      expect(generateTextCalls[0]!.tools).toBeUndefined()
+    })
+
+    test('uses minimal system prompt', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      const system = generateTextCalls[0]!.system as string
+      expect(system).toContain('[PROACTIVE EXECUTION]')
+      expect(system).not.toContain('DEFERRED PROMPTS')
+    })
+
+    test('includes delivery brief in messages', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      const systemMsgs = messages.filter((m) => m.role === 'system')
+      expect(systemMsgs.some((m) => typeof m.content === 'string' && m.content.includes('[DELIVERY BRIEF]'))).toBe(true)
+      expect(
+        systemMsgs.some((m) => typeof m.content === 'string' && m.content.includes('Friendly hydration reminder')),
+      ).toBe(true)
+    })
+
+    test('wraps prompt in deferred task delimiters', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      const userMsgs = messages.filter((m) => m.role === 'user')
+      expect(userMsgs.some((m) => typeof m.content === 'string' && m.content.includes('===DEFERRED_TASK==='))).toBe(
+        true,
+      )
+      expect(userMsgs.some((m) => typeof m.content === 'string' && m.content.includes('drink water'))).toBe(true)
+    })
+
+    test('does not load conversation history', async () => {
+      setupUserConfig()
+      appendHistory(USER_ID, [{ role: 'user', content: 'old message' }])
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      expect(messages.some((m) => typeof m.content === 'string' && m.content.includes('old message'))).toBe(false)
+    })
+
+    test('includes context snapshot when present', async () => {
+      setupUserConfig()
+      const withSnapshot: ExecutionMetadata = { ...metadata, context_snapshot: 'User discussed migration' }
+      await dispatchExecution(USER_ID, 'scheduled', 'remind about migration', withSnapshot, () => null)
+      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      const systemMsgs = messages.filter((m) => m.role === 'system')
+      expect(
+        systemMsgs.some((m) => typeof m.content === 'string' && m.content.includes('[CONTEXT FROM CREATION TIME]')),
+      ).toBe(true)
+    })
+
+    test('omits context snapshot message when null', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      expect(
+        messages.some(
+          (m) => typeof m.content === 'string' && String(m.content).includes('[CONTEXT FROM CREATION TIME]'),
+        ),
+      ).toBe(false)
+    })
+  })
+
+  describe('context mode', () => {
+    const metadata: ExecutionMetadata = {
+      mode: 'context',
+      delivery_brief: 'Remind about the standup discussion',
+      context_snapshot: 'Discussed Q2 sprint priorities',
+    }
+
+    test('uses main_model', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'standup reminder', metadata, () => null)
+      expect(generateTextCalls[0]!.model).toContain('main-model')
+    })
+
+    test('loads conversation history', async () => {
+      setupUserConfig()
+      appendHistory(USER_ID, [{ role: 'user', content: 'history message' }])
+      await dispatchExecution(USER_ID, 'scheduled', 'standup reminder', metadata, () => null)
+      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      expect(messages.some((m) => typeof m.content === 'string' && m.content.includes('history message'))).toBe(true)
+    })
+
+    test('does not include tools', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'standup reminder', metadata, () => null)
+      expect(generateTextCalls[0]!.tools).toBeUndefined()
+    })
+
+    test('uses minimal system prompt', async () => {
+      setupUserConfig()
+      await dispatchExecution(USER_ID, 'scheduled', 'standup reminder', metadata, () => null)
+      const system = generateTextCalls[0]!.system as string
+      expect(system).toContain('[PROACTIVE EXECUTION]')
+    })
+  })
+
+  describe('full mode', () => {
+    const metadata: ExecutionMetadata = {
+      mode: 'full',
+      delivery_brief: 'Check overdue tasks grouped by project',
+      context_snapshot: null,
+    }
+
+    test('uses main_model', async () => {
+      setupUserConfig()
+      const provider = createMockProvider()
+      await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => provider)
+      expect(generateTextCalls[0]!.model).toContain('main-model')
+    })
+
+    test('includes tools', async () => {
+      setupUserConfig()
+      const provider = createMockProvider()
+      await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => provider)
+      expect(generateTextCalls[0]!.tools).toBeDefined()
+    })
+
+    test('uses full system prompt', async () => {
+      setupUserConfig()
+      const provider = createMockProvider()
+      await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => provider)
+      const system = generateTextCalls[0]!.system as string
+      // Full system prompt includes provider-specific content
+      expect(system.length).toBeGreaterThan(200)
+    })
+
+    test('loads conversation history', async () => {
+      setupUserConfig()
+      const provider = createMockProvider()
+      appendHistory(USER_ID, [{ role: 'user', content: 'full mode history' }])
+      await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => provider)
+      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      expect(messages.some((m) => typeof m.content === 'string' && m.content.includes('full mode history'))).toBe(true)
+    })
+
+    test('returns error when provider cannot be built', async () => {
+      setupUserConfig()
+      const result = await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => null)
+      expect(result).toContain('task provider not configured')
+    })
+  })
+
+  describe('fallback behavior', () => {
+    test('treats empty metadata as full mode', async () => {
+      setupUserConfig()
+      const emptyMetadata: ExecutionMetadata = { mode: 'full', delivery_brief: '', context_snapshot: null }
+      const provider = createMockProvider()
+      await dispatchExecution(USER_ID, 'scheduled', 'test', emptyMetadata, () => provider)
+      expect(generateTextCalls[0]!.tools).toBeDefined()
+    })
+  })
+})

--- a/tests/deferred-prompts/execution-modes.test.ts
+++ b/tests/deferred-prompts/execution-modes.test.ts
@@ -18,7 +18,7 @@ type GenerateTextResult = {
   toolResults: unknown[]
   response: { messages: ModelMessage[] }
 }
-type GenerateTextCall = { model: unknown; system: unknown; messages: unknown[]; tools: unknown }
+type GenerateTextCall = { model: string; system: string; messages: ModelMessage[]; tools: unknown }
 const generateTextCalls: GenerateTextCall[] = []
 
 let generateTextImpl = (args: GenerateTextCall): Promise<GenerateTextResult> => {
@@ -102,7 +102,7 @@ describe('dispatchExecution', () => {
     test('uses minimal system prompt', async () => {
       setupUserConfig()
       await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
-      const system = generateTextCalls[0]!.system as string
+      const system = generateTextCalls[0]!.system
       expect(system).toContain('[PROACTIVE EXECUTION]')
       expect(system).not.toContain('DEFERRED PROMPTS')
     })
@@ -110,7 +110,7 @@ describe('dispatchExecution', () => {
     test('includes delivery brief in messages', async () => {
       setupUserConfig()
       await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
-      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      const messages = generateTextCalls[0]!.messages
       const systemMsgs = messages.filter((m) => m.role === 'system')
       expect(systemMsgs.some((m) => typeof m.content === 'string' && m.content.includes('[DELIVERY BRIEF]'))).toBe(true)
       expect(
@@ -121,7 +121,7 @@ describe('dispatchExecution', () => {
     test('wraps prompt in deferred task delimiters', async () => {
       setupUserConfig()
       await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
-      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      const messages = generateTextCalls[0]!.messages
       const userMsgs = messages.filter((m) => m.role === 'user')
       expect(userMsgs.some((m) => typeof m.content === 'string' && m.content.includes('===DEFERRED_TASK==='))).toBe(
         true,
@@ -133,7 +133,7 @@ describe('dispatchExecution', () => {
       setupUserConfig()
       appendHistory(USER_ID, [{ role: 'user', content: 'old message' }])
       await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
-      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      const messages = generateTextCalls[0]!.messages
       expect(messages.some((m) => typeof m.content === 'string' && m.content.includes('old message'))).toBe(false)
     })
 
@@ -141,7 +141,7 @@ describe('dispatchExecution', () => {
       setupUserConfig()
       const withSnapshot: ExecutionMetadata = { ...metadata, context_snapshot: 'User discussed migration' }
       await dispatchExecution(USER_ID, 'scheduled', 'remind about migration', withSnapshot, () => null)
-      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      const messages = generateTextCalls[0]!.messages
       const systemMsgs = messages.filter((m) => m.role === 'system')
       expect(
         systemMsgs.some((m) => typeof m.content === 'string' && m.content.includes('[CONTEXT FROM CREATION TIME]')),
@@ -151,7 +151,7 @@ describe('dispatchExecution', () => {
     test('omits context snapshot message when null', async () => {
       setupUserConfig()
       await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
-      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      const messages = generateTextCalls[0]!.messages
       expect(
         messages.some(
           (m) => typeof m.content === 'string' && String(m.content).includes('[CONTEXT FROM CREATION TIME]'),
@@ -177,7 +177,7 @@ describe('dispatchExecution', () => {
       setupUserConfig()
       appendHistory(USER_ID, [{ role: 'user', content: 'history message' }])
       await dispatchExecution(USER_ID, 'scheduled', 'standup reminder', metadata, () => null)
-      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      const messages = generateTextCalls[0]!.messages
       expect(messages.some((m) => typeof m.content === 'string' && m.content.includes('history message'))).toBe(true)
     })
 
@@ -190,7 +190,7 @@ describe('dispatchExecution', () => {
     test('uses minimal system prompt', async () => {
       setupUserConfig()
       await dispatchExecution(USER_ID, 'scheduled', 'standup reminder', metadata, () => null)
-      const system = generateTextCalls[0]!.system as string
+      const system = generateTextCalls[0]!.system
       expect(system).toContain('[PROACTIVE EXECUTION]')
     })
   })
@@ -220,7 +220,7 @@ describe('dispatchExecution', () => {
       setupUserConfig()
       const provider = createMockProvider()
       await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => provider)
-      const system = generateTextCalls[0]!.system as string
+      const system = generateTextCalls[0]!.system
       // Full system prompt includes provider-specific content
       expect(system.length).toBeGreaterThan(200)
     })
@@ -230,7 +230,7 @@ describe('dispatchExecution', () => {
       const provider = createMockProvider()
       appendHistory(USER_ID, [{ role: 'user', content: 'full mode history' }])
       await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => provider)
-      const messages = generateTextCalls[0]!.messages as ModelMessage[]
+      const messages = generateTextCalls[0]!.messages
       expect(messages.some((m) => typeof m.content === 'string' && m.content.includes('full mode history'))).toBe(true)
     })
 

--- a/tests/deferred-prompts/migration.test.ts
+++ b/tests/deferred-prompts/migration.test.ts
@@ -54,6 +54,7 @@ describe('migration 013: deferred prompts', () => {
   let db: Database
 
   beforeEach(() => {
+    if (db !== undefined) db.close()
     db = new Database(':memory:')
     runMigrations(db, [...ALL_MIGRATIONS])
   })
@@ -107,6 +108,7 @@ describe('migration 016: execution metadata', () => {
   let db: Database
 
   beforeEach(() => {
+    if (db !== undefined) db.close()
     db = new Database(':memory:')
     runMigrations(db, [...ALL_MIGRATIONS])
   })

--- a/tests/deferred-prompts/migration.test.ts
+++ b/tests/deferred-prompts/migration.test.ts
@@ -17,6 +17,7 @@ import { migration012UserInstructions } from '../../src/db/migrations/012_user_i
 import { migration013DeferredPrompts } from '../../src/db/migrations/013_deferred_prompts.js'
 import { migration014BackgroundEvents } from '../../src/db/migrations/014_background_events.js'
 import { migration015DropBackgroundEvents } from '../../src/db/migrations/015_drop_background_events.js'
+import { migration016ExecutionMetadata } from '../../src/db/migrations/016_execution_metadata.js'
 
 const ALL_MIGRATIONS = [
   migration001Initial,
@@ -34,6 +35,7 @@ const ALL_MIGRATIONS = [
   migration013DeferredPrompts,
   migration014BackgroundEvents,
   migration015DropBackgroundEvents,
+  migration016ExecutionMetadata,
 ]
 
 const getColumnNames = (db: Database, tableName: string): string[] =>
@@ -98,5 +100,38 @@ describe('migration 013: deferred prompts', () => {
     expect(names).not.toContain('reminders')
     expect(names).not.toContain('user_briefing_state')
     expect(names).not.toContain('alert_state')
+  })
+})
+
+describe('migration 016: execution metadata', () => {
+  let db: Database
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    runMigrations(db, [...ALL_MIGRATIONS])
+  })
+
+  afterAll(() => {
+    db.close()
+  })
+
+  test('adds execution_metadata to scheduled_prompts', () => {
+    const columns = getColumnNames(db, 'scheduled_prompts')
+    expect(columns).toContain('execution_metadata')
+  })
+
+  test('adds execution_metadata to alert_prompts', () => {
+    const columns = getColumnNames(db, 'alert_prompts')
+    expect(columns).toContain('execution_metadata')
+  })
+
+  test('default value is empty JSON object', () => {
+    db.run(
+      "INSERT INTO scheduled_prompts (id, user_id, prompt, fire_at, status) VALUES ('t1', 'u1', 'test', '2026-01-01T00:00:00Z', 'active')",
+    )
+    const row = db
+      .query<{ execution_metadata: string }, []>("SELECT execution_metadata FROM scheduled_prompts WHERE id = 't1'")
+      .get()
+    expect(row?.execution_metadata).toBe('{}')
   })
 })

--- a/tests/deferred-prompts/proactive-trigger.test.ts
+++ b/tests/deferred-prompts/proactive-trigger.test.ts
@@ -5,7 +5,7 @@ import { mockDrizzle, mockLogger, setupTestDb } from '../utils/test-helpers.js'
 mockLogger()
 mockDrizzle()
 
-import { buildProactiveTrigger } from '../../src/deferred-prompts/proactive-llm.js'
+import { buildProactiveTrigger } from '../../src/deferred-prompts/proactive-trigger.js'
 import { buildSystemPrompt } from '../../src/system-prompt.js'
 import { createMockProvider } from '../tools/mock-provider.js'
 

--- a/tests/deferred-prompts/tools.test.ts
+++ b/tests/deferred-prompts/tools.test.ts
@@ -311,3 +311,102 @@ describe('cancel_deferred_prompt', () => {
     expect(await cancel.execute({ id: 'non-existent' }, toolCtx)).toHaveProperty('error')
   })
 })
+
+describe('execution metadata', () => {
+  test('creates with execution metadata', async () => {
+    const t = getTools()['create_deferred_prompt']!
+    if (!t.execute) throw new Error('Tool execute is undefined')
+    const result: unknown = await t.execute(
+      {
+        prompt: 'Drink water',
+        schedule: { fire_at: futureFireAt() },
+        execution: { mode: 'lightweight', delivery_brief: 'Simple hydration reminder' },
+      },
+      toolCtx,
+    )
+    expect(result).toHaveProperty('status', 'created')
+  })
+
+  test('creates without execution metadata (backward compat)', async () => {
+    const t = getTools()['create_deferred_prompt']!
+    if (!t.execute) throw new Error('Tool execute is undefined')
+    const result: unknown = await t.execute({ prompt: 'Remind me', schedule: { fire_at: futureFireAt() } }, toolCtx)
+    expect(result).toHaveProperty('status', 'created')
+  })
+
+  test('persists execution metadata in scheduled prompt', async () => {
+    const tools = getTools()
+    const create = tools['create_deferred_prompt']!
+    const get = tools['get_deferred_prompt']!
+    if (!create.execute || !get.execute) throw new Error('Tool execute is undefined')
+
+    const created: unknown = await create.execute(
+      {
+        prompt: 'Check tasks',
+        schedule: { fire_at: futureFireAt() },
+        execution: { mode: 'context', delivery_brief: 'Remind about standup', context_snapshot: 'Sprint discussion' },
+      },
+      toolCtx,
+    )
+    const id = extractId(created)
+    const detail: unknown = await get.execute({ id }, toolCtx)
+
+    expect(detail).toHaveProperty('executionMetadata.mode', 'context')
+    expect(detail).toHaveProperty('executionMetadata.delivery_brief', 'Remind about standup')
+    expect(detail).toHaveProperty('executionMetadata.context_snapshot', 'Sprint discussion')
+  })
+
+  test('persists execution metadata in alert prompt', async () => {
+    const tools = getTools()
+    const create = tools['create_deferred_prompt']!
+    const get = tools['get_deferred_prompt']!
+    if (!create.execute || !get.execute) throw new Error('Tool execute is undefined')
+
+    const created: unknown = await create.execute(
+      {
+        prompt: 'Check overdue',
+        condition: { field: 'task.dueDate', op: 'overdue' },
+        execution: { mode: 'full', delivery_brief: 'Check overdue tasks' },
+      },
+      toolCtx,
+    )
+    const id = extractId(created)
+    const detail: unknown = await get.execute({ id }, toolCtx)
+
+    expect(detail).toHaveProperty('executionMetadata.mode', 'full')
+  })
+
+  test('defaults to full mode when no execution provided', async () => {
+    const tools = getTools()
+    const create = tools['create_deferred_prompt']!
+    const get = tools['get_deferred_prompt']!
+    if (!create.execute || !get.execute) throw new Error('Tool execute is undefined')
+
+    const created: unknown = await create.execute({ prompt: 'No exec', schedule: { fire_at: futureFireAt() } }, toolCtx)
+    const id = extractId(created)
+    const detail: unknown = await get.execute({ id }, toolCtx)
+
+    expect(detail).toHaveProperty('executionMetadata.mode', 'full')
+  })
+
+  test('updates execution metadata on scheduled prompt', async () => {
+    const tools = getTools()
+    const create = tools['create_deferred_prompt']!
+    const update = tools['update_deferred_prompt']!
+    const get = tools['get_deferred_prompt']!
+    if (!create.execute || !update.execute || !get.execute) throw new Error('Tool execute is undefined')
+
+    const created: unknown = await create.execute({ prompt: 'Test', schedule: { fire_at: futureFireAt() } }, toolCtx)
+    const id = extractId(created)
+
+    const result: unknown = await update.execute(
+      { id, execution: { mode: 'lightweight', delivery_brief: 'Updated brief' } },
+      toolCtx,
+    )
+    expect(result).toHaveProperty('status', 'updated')
+
+    const detail: unknown = await get.execute({ id }, toolCtx)
+    expect(detail).toHaveProperty('executionMetadata.mode', 'lightweight')
+    expect(detail).toHaveProperty('executionMetadata.delivery_brief', 'Updated brief')
+  })
+})

--- a/tests/utils/test-helpers.ts
+++ b/tests/utils/test-helpers.ts
@@ -26,6 +26,7 @@ import { migration012UserInstructions } from '../../src/db/migrations/012_user_i
 import { migration013DeferredPrompts } from '../../src/db/migrations/013_deferred_prompts.js'
 import { migration014BackgroundEvents } from '../../src/db/migrations/014_background_events.js'
 import { migration015DropBackgroundEvents } from '../../src/db/migrations/015_drop_background_events.js'
+import { migration016ExecutionMetadata } from '../../src/db/migrations/016_execution_metadata.js'
 import * as schema from '../../src/db/schema.js'
 import type { AppError } from '../../src/errors.js'
 import { getUserMessage } from '../../src/errors.js'
@@ -48,6 +49,7 @@ const ALL_MIGRATIONS: readonly Migration[] = [
   migration013DeferredPrompts,
   migration014BackgroundEvents,
   migration015DropBackgroundEvents,
+  migration016ExecutionMetadata,
 ]
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Introduce three execution modes (lightweight, context, full) for deferred prompts so fire-time resource loading scales with prompt complexity
- The creating LLM classifies each prompt at creation time into a mode and produces a delivery brief + optional context snapshot via a new `execution` tool parameter
- At fire time, a dispatcher routes to one of three execution functions: `invokeLightweight` (small model, no tools/history), `invokeWithContext` (main model + history, no tools), or `invokeFull` (full system prompt, tools, history, fact extraction)
- New `execution_metadata` JSON column on both `scheduled_prompts` and `alert_prompts` tables with backward-compatible defaults

## Test Plan

- [x] 19 new execution mode dispatch tests (lightweight/context/full model selection, tool inclusion, system prompt, history loading, delivery brief/context snapshot injection)
- [x] 6 new tool tests (create/update with execution metadata, persistence, backward compat, default to full mode)
- [x] 3 new migration tests (column existence on both tables, default value)
- [x] All 1504 tests pass (28 new), typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)