### PR TITLE
feat: telegram reply chain infrastructure

### DIFF
--- a/docs/plans/2026-03-26-mattermost-reply-chain-implementation.md
+++ b/docs/plans/2026-03-26-mattermost-reply-chain-implementation.md
@@ -1,0 +1,137 @@
+# Mattermost Reply Chain Implementation
+
+**Date:** 2026-03-26
+**Status:** Design Document
+**Approach:** Cache-Only (Option B)
+
+## Overview
+
+Implement reply chain tracking for Mattermost by integrating with the existing message-cache infrastructure. This approach caches messages as they arrive via WebSocket and builds reply chains from the cache, matching the Telegram implementation pattern.
+
+## Design Decisions
+
+### Why Cache-Only?
+
+- **Simplicity:** Leverages existing, tested infrastructure
+- **Performance:** No API calls required for chain building
+- **Consistency:** Same behavior as Telegram provider
+- **Trade-off:** Messages sent before bot startup won't be in cache
+
+## Implementation Plan
+
+### 1. Update MattermostPostSchema
+
+Add `root_id` and `parent_id` fields to capture reply relationships:
+
+```typescript
+const MattermostPostSchema = z.object({
+  id: z.string(),
+  user_id: z.string(),
+  channel_id: z.string(),
+  message: z.string(),
+  user_name: z.string().optional(),
+  root_id: z.string().optional(), // NEW: Root post of thread
+  parent_id: z.string().optional(), // NEW: Direct parent post
+})
+```
+
+**Location:** `src/chat/mattermost/index.ts:20-26`
+
+### 2. Cache Incoming Messages
+
+Import and use `cacheMessage()` in `handlePostedEvent()`:
+
+```typescript
+import { cacheMessage } from '../../message-cache/index.js'
+
+// In handlePostedEvent() after post validation:
+const replyToMessageId = post.parent_id || post.root_id || undefined
+
+cacheMessage({
+  messageId: post.id,
+  contextId: post.channel_id,
+  authorId: post.user_id,
+  authorUsername: post.user_name,
+  text: post.message,
+  replyToMessageId,
+  timestamp: Date.now(),
+})
+```
+
+**Location:** `src/chat/mattermost/index.ts:139-165`
+
+### 3. Populate replyToMessageId in IncomingMessage
+
+Add the reply chain identifier to the message object:
+
+```typescript
+const msg: IncomingMessage = {
+  user: {
+    id: post.user_id,
+    username: post.user_name ?? null,
+    isAdmin,
+  },
+  contextId: post.channel_id,
+  contextType,
+  isMentioned,
+  text: post.message,
+  commandMatch: command?.match,
+  messageId: post.id,
+  replyToMessageId, // NEW
+}
+```
+
+**Location:** `src/chat/mattermost/index.ts:153-165`
+
+## Data Flow
+
+```
+Mattermost WebSocket receives posted event
+    ↓
+Parse post JSON (including root_id, parent_id)
+    ↓
+Extract replyToMessageId = parent_id || root_id
+    ↓
+Cache message via cacheMessage()
+    ↓
+Create IncomingMessage with replyToMessageId
+    ↓
+Process message - chain builder can now trace replies
+```
+
+## Error Handling
+
+- **Schema validation failure:** Silently skip message (existing behavior)
+- **Cache write failure:** Log warning, continue processing (non-critical)
+- **Missing parent_id/root_id:** Treat as standalone message (undefined replyToMessageId)
+
+## Testing Strategy
+
+1. **Unit tests:** Verify schema parsing with/without reply fields
+2. **Integration tests:** Full flow with cached messages and chain building
+3. **Mock WebSocket events:** Test various reply scenarios
+
+## Files Modified
+
+- `src/chat/mattermost/index.ts` - Schema update, caching, replyToMessageId population
+
+## Files Reused (No Changes)
+
+- `src/message-cache/cache.ts` - In-memory cache
+- `src/message-cache/persistence.ts` - SQLite persistence
+- `src/message-cache/chain.ts` - Chain builder
+- `src/db/schema.ts` - messageMetadata table
+
+## Success Criteria
+
+- [ ] Mattermost posts with `parent_id`/`root_id` populate `replyToMessageId`
+- [ ] Messages are cached and persisted to SQLite
+- [ ] `buildReplyChain()` returns correct chain for Mattermost messages
+- [ ] All existing Mattermost tests pass
+- [ ] New tests cover reply chain scenarios
+
+## References
+
+- Telegram implementation: `docs/plans/2026-03-26-telegram-reply-chain-infrastructure.md`
+- Mattermost API: `docs/plans/2026-03-26-mattermost-chain-history.md`
+- Existing cache: `src/message-cache/`

--- a/docs/plans/2026-03-26-mattermost-reply-chain-implementation.md
+++ b/docs/plans/2026-03-26-mattermost-reply-chain-implementation.md
@@ -1,27 +1,22 @@
-# Mattermost Reply Chain Implementation
+# Mattermost Reply Chain Implementation Plan
 
-**Date:** 2026-03-26
-**Status:** Design Document
-**Approach:** Cache-Only (Option B)
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-## Overview
+**Goal:** Integrate Mattermost message caching with existing message-cache infrastructure to enable reply chain tracking.
 
-Implement reply chain tracking for Mattermost by integrating with the existing message-cache infrastructure. This approach caches messages as they arrive via WebSocket and builds reply chains from the cache, matching the Telegram implementation pattern.
+**Architecture:** Extend the Mattermost provider's Zod schema to capture `root_id` and `parent_id`, cache each incoming message via `cacheMessage()`, and populate `replyToMessageId` in `IncomingMessage`. Follows the exact pattern used in Telegram provider.
 
-## Design Decisions
+**Tech Stack:** TypeScript, Zod, SQLite (Drizzle ORM)
 
-### Why Cache-Only?
+---
 
-- **Simplicity:** Leverages existing, tested infrastructure
-- **Performance:** No API calls required for chain building
-- **Consistency:** Same behavior as Telegram provider
-- **Trade-off:** Messages sent before bot startup won't be in cache
+## Task 1: Update MattermostPostSchema with Reply Fields
 
-## Implementation Plan
+**Files:**
 
-### 1. Update MattermostPostSchema
+- Modify: `src/chat/mattermost/index.ts:20-26`
 
-Add `root_id` and `parent_id` fields to capture reply relationships:
+**Step 1: Add root_id and parent_id to schema**
 
 ```typescript
 const MattermostPostSchema = z.object({
@@ -35,18 +30,48 @@ const MattermostPostSchema = z.object({
 })
 ```
 
-**Location:** `src/chat/mattermost/index.ts:20-26`
+**Step 2: Run typecheck**
 
-### 2. Cache Incoming Messages
+Run: `bun typecheck`
 
-Import and use `cacheMessage()` in `handlePostedEvent()`:
+Expected: No type errors
+
+**Step 3: Commit**
+
+```bash
+git add src/chat/mattermost/index.ts
+git commit -m "feat(mattermost): add root_id and parent_id to post schema
+
+Enables reply chain tracking via message cache"
+```
+
+---
+
+## Task 2: Cache Incoming Messages
+
+**Files:**
+
+- Modify: `src/chat/mattermost/index.ts` (add import and cache call)
+
+**Step 1: Add cacheMessage import**
+
+After line 3 (after logger import), add:
 
 ```typescript
 import { cacheMessage } from '../../message-cache/index.js'
+```
 
-// In handlePostedEvent() after post validation:
+**Step 2: Cache message in handlePostedEvent**
+
+Locate `handlePostedEvent` method (lines 133-181). After line 139 (after post validation), add caching logic:
+
+```typescript
+const postResult = MattermostPostSchema.safeParse(JSON.parse(postJson))
+if (!postResult.success) return
+const post = postResult.data
+
+// Cache message for reply chain tracking
 const replyToMessageId = post.parent_id || post.root_id || undefined
-
 cacheMessage({
   messageId: post.id,
   contextId: post.channel_id,
@@ -58,11 +83,43 @@ cacheMessage({
 })
 ```
 
-**Location:** `src/chat/mattermost/index.ts:139-165`
+**Step 3: Run typecheck**
 
-### 3. Populate replyToMessageId in IncomingMessage
+Run: `bun typecheck`
 
-Add the reply chain identifier to the message object:
+Expected: No type errors
+
+**Step 4: Commit**
+
+```bash
+git add src/chat/mattermost/index.ts
+git commit -m "feat(mattermost): cache incoming messages
+
+- Cache every message via cacheMessage()
+- Extract replyToMessageId from parent_id/root_id
+- Enables reply chain building for Mattermost"
+```
+
+---
+
+## Task 3: Populate replyToMessageId in IncomingMessage
+
+**Files:**
+
+- Modify: `src/chat/mattermost/index.ts:153-165`
+
+**Step 1: Calculate replyToMessageId before creating IncomingMessage**
+
+Before the `const msg: IncomingMessage = {` block, ensure we have the replyToMessageId:
+
+```typescript
+// Already calculated in Task 2, reuse it here
+const replyToMessageId = post.parent_id || post.root_id || undefined
+```
+
+**Step 2: Add replyToMessageId to IncomingMessage**
+
+Modify the IncomingMessage object (lines 153-165) to include replyToMessageId:
 
 ```typescript
 const msg: IncomingMessage = {
@@ -81,57 +138,271 @@ const msg: IncomingMessage = {
 }
 ```
 
-**Location:** `src/chat/mattermost/index.ts:153-165`
+**Step 3: Run typecheck**
 
-## Data Flow
+Run: `bun typecheck`
 
-```
-Mattermost WebSocket receives posted event
-    ↓
-Parse post JSON (including root_id, parent_id)
-    ↓
-Extract replyToMessageId = parent_id || root_id
-    ↓
-Cache message via cacheMessage()
-    ↓
-Create IncomingMessage with replyToMessageId
-    ↓
-Process message - chain builder can now trace replies
+Expected: No type errors
+
+**Step 4: Commit**
+
+```bash
+git add src/chat/mattermost/index.ts
+git commit -m "feat(mattermost): populate replyToMessageId in IncomingMessage
+
+- Extract reply chain identifier from parent_id/root_id
+- Pass to bot for reply chain tracking"
 ```
 
-## Error Handling
+---
 
-- **Schema validation failure:** Silently skip message (existing behavior)
-- **Cache write failure:** Log warning, continue processing (non-critical)
-- **Missing parent_id/root_id:** Treat as standalone message (undefined replyToMessageId)
+## Task 4: Write Unit Tests for Schema Parsing
 
-## Testing Strategy
+**Files:**
 
-1. **Unit tests:** Verify schema parsing with/without reply fields
-2. **Integration tests:** Full flow with cached messages and chain building
-3. **Mock WebSocket events:** Test various reply scenarios
+- Create: `tests/chat/mattermost/schema.test.ts`
 
-## Files Modified
+**Step 1: Create test file**
 
-- `src/chat/mattermost/index.ts` - Schema update, caching, replyToMessageId population
+```typescript
+import { describe, test, expect } from 'bun:test'
+import { z } from 'zod'
 
-## Files Reused (No Changes)
+const MattermostPostSchema = z.object({
+  id: z.string(),
+  user_id: z.string(),
+  channel_id: z.string(),
+  message: z.string(),
+  user_name: z.string().optional(),
+  root_id: z.string().optional(),
+  parent_id: z.string().optional(),
+})
 
-- `src/message-cache/cache.ts` - In-memory cache
-- `src/message-cache/persistence.ts` - SQLite persistence
-- `src/message-cache/chain.ts` - Chain builder
-- `src/db/schema.ts` - messageMetadata table
+describe('MattermostPostSchema', () => {
+  test('should parse basic post without reply fields', () => {
+    const post = {
+      id: 'post123',
+      user_id: 'user456',
+      channel_id: 'channel789',
+      message: 'Hello world',
+    }
 
-## Success Criteria
+    const result = MattermostPostSchema.safeParse(post)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.root_id).toBeUndefined()
+      expect(result.data.parent_id).toBeUndefined()
+    }
+  })
 
-- [ ] Mattermost posts with `parent_id`/`root_id` populate `replyToMessageId`
-- [ ] Messages are cached and persisted to SQLite
-- [ ] `buildReplyChain()` returns correct chain for Mattermost messages
-- [ ] All existing Mattermost tests pass
-- [ ] New tests cover reply chain scenarios
+  test('should parse reply post with root_id and parent_id', () => {
+    const post = {
+      id: 'reply789',
+      user_id: 'user456',
+      channel_id: 'channel789',
+      message: 'This is a reply',
+      user_name: 'testuser',
+      root_id: 'root123',
+      parent_id: 'parent456',
+    }
 
-## References
+    const result = MattermostPostSchema.safeParse(post)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.root_id).toBe('root123')
+      expect(result.data.parent_id).toBe('parent456')
+    }
+  })
 
-- Telegram implementation: `docs/plans/2026-03-26-telegram-reply-chain-infrastructure.md`
-- Mattermost API: `docs/plans/2026-03-26-mattermost-chain-history.md`
-- Existing cache: `src/message-cache/`
+  test('should parse post with only root_id (thread reply)', () => {
+    const post = {
+      id: 'reply789',
+      user_id: 'user456',
+      channel_id: 'channel789',
+      message: 'Thread reply',
+      root_id: 'root123',
+    }
+
+    const result = MattermostPostSchema.safeParse(post)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.root_id).toBe('root123')
+      expect(result.data.parent_id).toBeUndefined()
+    }
+  })
+})
+```
+
+**Step 2: Run tests**
+
+Run: `bun test tests/chat/mattermost/schema.test.ts`
+
+Expected: All tests pass
+
+**Step 3: Commit**
+
+```bash
+git add tests/chat/mattermost/schema.test.ts
+git commit -m "test(mattermost): add schema parsing tests for reply fields
+
+- Test basic post without reply fields
+- Test reply post with root_id and parent_id
+- Test thread reply with only root_id"
+```
+
+---
+
+## Task 5: Write Integration Tests for Message Caching
+
+**Files:**
+
+- Create: `tests/chat/mattermost/reply-chain.test.ts`
+
+**Step 1: Create integration test file**
+
+```typescript
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test'
+import { mock } from 'bun:test'
+import { clearMessageCache, buildReplyChain } from '../../../src/message-cache/index.js'
+
+// Mock the cache module to avoid database dependencies
+void mock.module('../../../src/message-cache/cache.js', () => ({
+  cacheMessage: (msg: unknown) => {
+    // Simple in-memory cache for testing
+    const cache = (globalThis as unknown as { testCache: Map<string, unknown> }).testCache
+    if (!cache) {
+      ;(globalThis as unknown as { testCache: Map<string, unknown> }).testCache = new Map()
+    }
+    const m = msg as { messageId: string }
+    ;(globalThis as unknown as { testCache: Map<string, unknown> }).testCache.set(m.messageId, msg)
+  },
+  getCachedMessage: (id: string) => {
+    return (globalThis as unknown as { testCache: Map<string, unknown> }).testCache?.get(id)
+  },
+  hasCachedMessage: () => false,
+  clearMessageCache: () => {
+    if ((globalThis as unknown as { testCache: Map<string, unknown> }).testCache) {
+      ;(globalThis as unknown as { testCache: Map<string, unknown> }).testCache.clear()
+    }
+  },
+  getMessageCacheSize: () => 0,
+  getAllCachedMessages: () => [],
+}))
+
+describe('Mattermost Reply Chain', () => {
+  beforeEach(() => {
+    clearMessageCache()
+    ;(globalThis as unknown as { testCache?: Map<string, unknown> }).testCache = new Map()
+  })
+
+  afterAll(() => {
+    mock.restore()
+  })
+
+  test('should extract replyToMessageId from parent_id', () => {
+    const post = {
+      id: 'reply123',
+      user_id: 'user456',
+      channel_id: 'channel789',
+      message: 'Reply message',
+      parent_id: 'parent456',
+    }
+
+    const replyToMessageId = post.parent_id || post.root_id || undefined
+    expect(replyToMessageId).toBe('parent456')
+  })
+
+  test('should extract replyToMessageId from root_id when parent_id missing', () => {
+    const post = {
+      id: 'reply123',
+      user_id: 'user456',
+      channel_id: 'channel789',
+      message: 'Thread reply',
+      root_id: 'root789',
+    }
+
+    const replyToMessageId = post.parent_id || post.root_id || undefined
+    expect(replyToMessageId).toBe('root789')
+  })
+
+  test('should have undefined replyToMessageId for standalone post', () => {
+    const post = {
+      id: 'standalone123',
+      user_id: 'user456',
+      channel_id: 'channel789',
+      message: 'Standalone message',
+    }
+
+    const replyToMessageId = post.parent_id || post.root_id || undefined
+    expect(replyToMessageId).toBeUndefined()
+  })
+})
+```
+
+**Step 2: Run tests**
+
+Run: `bun test tests/chat/mattermost/reply-chain.test.ts`
+
+Expected: All tests pass
+
+**Step 3: Commit**
+
+```bash
+git add tests/chat/mattermost/reply-chain.test.ts
+git commit -m "test(mattermost): add reply chain integration tests
+
+- Test replyToMessageId extraction from parent_id/root_id
+- Test standalone messages have undefined replyToMessageId"
+```
+
+---
+
+## Task 6: Run Full Test Suite
+
+**Step 1: Run all tests**
+
+Run: `bun test`
+
+Expected: All tests pass (including existing Mattermost tests)
+
+**Step 2: Run full check**
+
+Run: `bun check:full`
+
+Expected: All checks pass (lint, typecheck, format, knip, tests)
+
+**Step 3: Commit**
+
+```bash
+git add .
+git commit -m "test: verify all tests pass for Mattermost reply chain"
+```
+
+---
+
+## Summary
+
+### Files Modified
+
+- `src/chat/mattermost/index.ts` - Schema update, caching integration, replyToMessageId population
+
+### Files Created
+
+- `tests/chat/mattermost/schema.test.ts` - Schema parsing tests
+- `tests/chat/mattermost/reply-chain.test.ts` - Integration tests
+
+### Key Features
+
+- Mattermost messages now cached with reply metadata
+- `replyToMessageId` populated from `parent_id` || `root_id`
+- Full compatibility with existing chain builder
+- Consistent behavior with Telegram provider
+
+### Verification
+
+After implementation, the following should work:
+
+1. Mattermost messages with `parent_id` populate `replyToMessageId`
+2. Messages cached and persisted to SQLite
+3. `buildReplyChain()` returns correct chains for Mattermost
+4. All tests pass

--- a/src/chat/telegram/index.ts
+++ b/src/chat/telegram/index.ts
@@ -2,6 +2,7 @@ import type { MessageEntity } from '@grammyjs/types/message.js'
 import { Bot, InputFile, type Context } from 'grammy'
 
 import { logger } from '../../logger.js'
+import { cacheMessage } from '../../message-cache/index.js'
 import type {
   AuthorizationResult,
   ChatProvider,
@@ -115,6 +116,25 @@ export class TelegramChatProvider implements ChatProvider {
     const text = ctx.message?.text ?? ''
     const isMentioned = this.isBotMentioned(text, ctx.message?.entities)
 
+    const messageId = ctx.message?.message_id
+    const messageIdStr = messageId === undefined ? undefined : String(messageId)
+
+    const replyToMessageId = ctx.message?.reply_to_message?.message_id
+    const replyToMessageIdStr = replyToMessageId === undefined ? undefined : String(replyToMessageId)
+
+    // Cache message metadata for reply chain tracking
+    if (messageIdStr !== undefined) {
+      cacheMessage({
+        messageId: messageIdStr,
+        contextId,
+        authorId: String(id),
+        authorUsername: ctx.from?.username ?? undefined,
+        text,
+        replyToMessageId: replyToMessageIdStr,
+        timestamp: Date.now(),
+      })
+    }
+
     return {
       user: {
         id: String(id),
@@ -125,7 +145,8 @@ export class TelegramChatProvider implements ChatProvider {
       contextType,
       isMentioned,
       text,
-      messageId: ctx.message?.message_id === undefined ? undefined : String(ctx.message.message_id),
+      messageId: messageIdStr,
+      replyToMessageId: replyToMessageIdStr,
     }
   }
 

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -27,6 +27,8 @@ export type IncomingMessage = {
   commandMatch?: string
   /** platform-specific message ID for deletion */
   messageId?: string
+  /** parent message ID if this is a reply */
+  replyToMessageId?: string
 }
 
 /** Authorization result for message processing. */

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -18,6 +18,7 @@ import { migration013DeferredPrompts } from './migrations/013_deferred_prompts.j
 import { migration014BackgroundEvents } from './migrations/014_background_events.js'
 import { migration015DropBackgroundEvents } from './migrations/015_drop_background_events.js'
 import { migration016ExecutionMetadata } from './migrations/016_execution_metadata.js'
+import { migration017MessageMetadata } from './migrations/017_message_metadata.js'
 
 const DB_PATH = process.env['DB_PATH'] ?? 'papai.db'
 
@@ -61,6 +62,7 @@ const MIGRATIONS = [
   migration014BackgroundEvents,
   migration015DropBackgroundEvents,
   migration016ExecutionMetadata,
+  migration017MessageMetadata,
 ] as const
 
 export const initDb = (): void => {

--- a/src/db/migrations/017_message_metadata.ts
+++ b/src/db/migrations/017_message_metadata.ts
@@ -7,18 +7,18 @@ export const migration017MessageMetadata: Migration = {
   up(db: Database): void {
     db.run(`
       CREATE TABLE message_metadata (
-        message_id TEXT PRIMARY KEY,
         context_id TEXT NOT NULL,
+        message_id TEXT NOT NULL,
         author_id TEXT,
         author_username TEXT,
         text TEXT,
         reply_to_message_id TEXT,
         timestamp INTEGER NOT NULL,
-        expires_at INTEGER NOT NULL
+        expires_at INTEGER NOT NULL,
+        PRIMARY KEY (context_id, message_id)
       )
     `)
-    db.run(`CREATE INDEX idx_message_metadata_context_id ON message_metadata(context_id)`)
     db.run(`CREATE INDEX idx_message_metadata_expires_at ON message_metadata(expires_at)`)
-    db.run(`CREATE INDEX idx_message_metadata_reply_to ON message_metadata(reply_to_message_id)`)
+    db.run(`CREATE INDEX idx_message_metadata_reply_to ON message_metadata(context_id, reply_to_message_id)`)
   },
 }

--- a/src/db/migrations/017_message_metadata.ts
+++ b/src/db/migrations/017_message_metadata.ts
@@ -1,0 +1,24 @@
+import type { Database } from 'bun:sqlite'
+
+import type { Migration } from '../migrate.js'
+
+export const migration017MessageMetadata: Migration = {
+  id: '017_message_metadata',
+  up(db: Database): void {
+    db.run(`
+      CREATE TABLE message_metadata (
+        message_id TEXT PRIMARY KEY,
+        context_id TEXT NOT NULL,
+        author_id TEXT,
+        author_username TEXT,
+        text TEXT,
+        reply_to_message_id TEXT,
+        timestamp INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL
+      )
+    `)
+    db.run(`CREATE INDEX idx_message_metadata_context_id ON message_metadata(context_id)`)
+    db.run(`CREATE INDEX idx_message_metadata_expires_at ON message_metadata(expires_at)`)
+    db.run(`CREATE INDEX idx_message_metadata_reply_to ON message_metadata(reply_to_message_id)`)
+  },
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -195,3 +195,22 @@ export const userInstructions = sqliteTable(
 export type UserInstruction = typeof userInstructions.$inferSelect
 
 export type GroupMember = typeof groupMembers.$inferSelect
+
+export const messageMetadata = sqliteTable(
+  'message_metadata',
+  {
+    messageId: text('message_id').primaryKey(),
+    contextId: text('context_id').notNull(),
+    authorId: text('author_id'),
+    authorUsername: text('author_username'),
+    text: text('text'),
+    replyToMessageId: text('reply_to_message_id'),
+    timestamp: integer('timestamp').notNull(),
+    expiresAt: integer('expires_at').notNull(),
+  },
+  (table) => [
+    index('idx_message_metadata_context_id').on(table.contextId),
+    index('idx_message_metadata_expires_at').on(table.expiresAt),
+    index('idx_message_metadata_reply_to').on(table.replyToMessageId),
+  ],
+)

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -199,8 +199,8 @@ export type GroupMember = typeof groupMembers.$inferSelect
 export const messageMetadata = sqliteTable(
   'message_metadata',
   {
-    messageId: text('message_id').primaryKey(),
     contextId: text('context_id').notNull(),
+    messageId: text('message_id').notNull(),
     authorId: text('author_id'),
     authorUsername: text('author_username'),
     text: text('text'),
@@ -209,8 +209,8 @@ export const messageMetadata = sqliteTable(
     expiresAt: integer('expires_at').notNull(),
   },
   (table) => [
-    index('idx_message_metadata_context_id').on(table.contextId),
+    primaryKey({ columns: [table.contextId, table.messageId] }),
     index('idx_message_metadata_expires_at').on(table.expiresAt),
-    index('idx_message_metadata_reply_to').on(table.replyToMessageId),
+    index('idx_message_metadata_reply_to').on(table.contextId, table.replyToMessageId),
   ],
 )

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { closeDrizzleDb } from './db/drizzle.js'
 import { closeMigrationDbInstance, initDb } from './db/index.js'
 import { startPollers, stopPollers } from './deferred-prompts/poller.js'
 import { logger } from './logger.js'
+import { startMessageCleanupScheduler } from './message-cache/index.js'
 import { buildProviderForUser } from './providers/factory.js'
 import { startScheduler, stopScheduler } from './scheduler.js'
 import { addUser } from './users.js'
@@ -81,6 +82,8 @@ void announceNewVersion(chatProvider)
 startScheduler(chatProvider)
 
 startPollers(chatProvider, (userId) => buildProviderForUser(userId, false))
+
+startMessageCleanupScheduler()
 
 process.on('SIGINT', () => {
   log.info('SIGINT received, shutting down gracefully')

--- a/src/message-cache/cache.ts
+++ b/src/message-cache/cache.ts
@@ -26,29 +26,12 @@ export function getCachedMessage(messageId: string): CachedMessage | undefined {
   return cached
 }
 
+/** @public */
 export function hasCachedMessage(messageId: string): boolean {
   return getCachedMessage(messageId) !== undefined
 }
 
-export function getMessageCacheSize(): number {
-  return messageCache.size
-}
-
+/** @public */
 export function clearMessageCache(): void {
   messageCache.clear()
-}
-
-export function getAllCachedMessages(): CachedMessage[] {
-  const now = Date.now()
-  const valid: CachedMessage[] = []
-
-  for (const [id, msg] of messageCache) {
-    if (now - msg.timestamp <= ONE_WEEK_MS) {
-      valid.push(msg)
-    } else {
-      messageCache.delete(id)
-    }
-  }
-
-  return valid
 }

--- a/src/message-cache/cache.ts
+++ b/src/message-cache/cache.ts
@@ -1,11 +1,32 @@
+import { logger } from '../logger.js'
 import { scheduleMessagePersistence } from './persistence.js'
 import type { CachedMessage } from './types.js'
+
+const log = logger.child({ scope: 'message-cache' })
 
 // In-memory cache: "contextId:messageId" -> CachedMessage
 const messageCache = new Map<string, CachedMessage>()
 
 // 1 week in milliseconds
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+// Sweep expired entries once a day
+setInterval(
+  () => {
+    const now = Date.now()
+    let swept = 0
+    for (const [key, msg] of messageCache) {
+      if (now - msg.timestamp > ONE_WEEK_MS) {
+        messageCache.delete(key)
+        swept++
+      }
+    }
+    if (swept > 0) {
+      log.info({ swept, remaining: messageCache.size }, 'Swept expired message cache entries')
+    }
+  },
+  24 * 60 * 60 * 1000,
+)
 
 function cacheKey(contextId: string, messageId: string): string {
   return `${contextId}:${messageId}`

--- a/src/message-cache/cache.ts
+++ b/src/message-cache/cache.ts
@@ -1,25 +1,29 @@
 import { scheduleMessagePersistence } from './persistence.js'
 import type { CachedMessage } from './types.js'
 
-// In-memory cache: messageId -> CachedMessage
+// In-memory cache: "contextId:messageId" -> CachedMessage
 const messageCache = new Map<string, CachedMessage>()
 
 // 1 week in milliseconds
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
+function cacheKey(contextId: string, messageId: string): string {
+  return `${contextId}:${messageId}`
+}
+
 export function cacheMessage(message: CachedMessage): void {
-  messageCache.set(message.messageId, message)
+  messageCache.set(cacheKey(message.contextId, message.messageId), message)
   scheduleMessagePersistence(message)
 }
 
-export function getCachedMessage(messageId: string): CachedMessage | undefined {
-  const cached = messageCache.get(messageId)
+export function getCachedMessage(contextId: string, messageId: string): CachedMessage | undefined {
+  const cached = messageCache.get(cacheKey(contextId, messageId))
   if (cached === undefined) return undefined
 
   // Check TTL (1 week)
   const now = Date.now()
   if (now - cached.timestamp > ONE_WEEK_MS) {
-    messageCache.delete(messageId)
+    messageCache.delete(cacheKey(contextId, messageId))
     return undefined
   }
 
@@ -27,8 +31,8 @@ export function getCachedMessage(messageId: string): CachedMessage | undefined {
 }
 
 /** @public */
-export function hasCachedMessage(messageId: string): boolean {
-  return getCachedMessage(messageId) !== undefined
+export function hasCachedMessage(contextId: string, messageId: string): boolean {
+  return getCachedMessage(contextId, messageId) !== undefined
 }
 
 /** @public */

--- a/src/message-cache/cache.ts
+++ b/src/message-cache/cache.ts
@@ -1,0 +1,52 @@
+import type { CachedMessage } from './types.js'
+
+// In-memory cache: messageId -> CachedMessage
+const messageCache = new Map<string, CachedMessage>()
+
+// 1 week in milliseconds
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+export function cacheMessage(message: CachedMessage): void {
+  messageCache.set(message.messageId, message)
+}
+
+export function getCachedMessage(messageId: string): CachedMessage | undefined {
+  const cached = messageCache.get(messageId)
+  if (cached === undefined) return undefined
+
+  // Check TTL (1 week)
+  const now = Date.now()
+  if (now - cached.timestamp > ONE_WEEK_MS) {
+    messageCache.delete(messageId)
+    return undefined
+  }
+
+  return cached
+}
+
+export function hasCachedMessage(messageId: string): boolean {
+  return getCachedMessage(messageId) !== undefined
+}
+
+export function getMessageCacheSize(): number {
+  return messageCache.size
+}
+
+export function clearMessageCache(): void {
+  messageCache.clear()
+}
+
+export function getAllCachedMessages(): CachedMessage[] {
+  const now = Date.now()
+  const valid: CachedMessage[] = []
+
+  for (const [id, msg] of messageCache) {
+    if (now - msg.timestamp <= ONE_WEEK_MS) {
+      valid.push(msg)
+    } else {
+      messageCache.delete(id)
+    }
+  }
+
+  return valid
+}

--- a/src/message-cache/cache.ts
+++ b/src/message-cache/cache.ts
@@ -1,3 +1,4 @@
+import { scheduleMessagePersistence } from './persistence.js'
 import type { CachedMessage } from './types.js'
 
 // In-memory cache: messageId -> CachedMessage
@@ -8,6 +9,7 @@ const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
 export function cacheMessage(message: CachedMessage): void {
   messageCache.set(message.messageId, message)
+  scheduleMessagePersistence(message)
 }
 
 export function getCachedMessage(messageId: string): CachedMessage | undefined {

--- a/src/message-cache/chain.ts
+++ b/src/message-cache/chain.ts
@@ -10,7 +10,11 @@ export interface ReplyChainResult {
 }
 
 /** @public */
-export function buildReplyChain(messageId: string, visited: Set<string> = new Set()): ReplyChainResult {
+export function buildReplyChain(
+  contextId: string,
+  messageId: string,
+  visited: Set<string> = new Set(),
+): ReplyChainResult {
   const chain: string[] = []
   let currentId: string | undefined = messageId
   let isComplete = true
@@ -27,7 +31,7 @@ export function buildReplyChain(messageId: string, visited: Set<string> = new Se
 
     visited.add(currentId)
 
-    const message = getCachedMessage(currentId)
+    const message = getCachedMessage(contextId, currentId)
     if (message === undefined) {
       // Message not in cache - chain is broken
       isComplete = false

--- a/src/message-cache/chain.ts
+++ b/src/message-cache/chain.ts
@@ -1,0 +1,54 @@
+import { logger } from '../logger.js'
+import { getCachedMessage } from './cache.js'
+
+const log = logger.child({ scope: 'message-cache:chain' })
+
+export interface ReplyChainResult {
+  chain: string[]
+  isComplete: boolean
+  brokenAt?: string
+}
+
+export function buildReplyChain(messageId: string, visited: Set<string> = new Set()): ReplyChainResult {
+  const chain: string[] = []
+  let currentId: string | undefined = messageId
+  let isComplete = true
+  let brokenAt: string | undefined
+
+  while (currentId !== undefined) {
+    // Cycle detection
+    if (visited.has(currentId)) {
+      log.error({ messageId: currentId, chain }, 'Circular reference detected in reply chain')
+      isComplete = false
+      brokenAt = currentId
+      break
+    }
+
+    visited.add(currentId)
+
+    const message = getCachedMessage(currentId)
+    if (message === undefined) {
+      // Message not in cache - chain is broken
+      isComplete = false
+      brokenAt = currentId
+      log.warn({ messageId: currentId }, 'Message not in cache, stopping chain build')
+      break
+    }
+
+    chain.push(currentId)
+
+    if (message.replyToMessageId === undefined) {
+      // Reached root message
+      break
+    }
+
+    currentId = message.replyToMessageId
+  }
+
+  // Return in chronological order (oldest first)
+  return {
+    chain: chain.reverse(),
+    isComplete,
+    brokenAt,
+  }
+}

--- a/src/message-cache/chain.ts
+++ b/src/message-cache/chain.ts
@@ -9,6 +9,7 @@ export interface ReplyChainResult {
   brokenAt?: string
 }
 
+/** @public */
 export function buildReplyChain(messageId: string, visited: Set<string> = new Set()): ReplyChainResult {
   const chain: string[] = []
   let currentId: string | undefined = messageId

--- a/src/message-cache/index.ts
+++ b/src/message-cache/index.ts
@@ -1,5 +1,5 @@
 export { cacheMessage, getCachedMessage, hasCachedMessage, clearMessageCache } from './cache.js'
 export { buildReplyChain } from './chain.js'
 export { scheduleMessagePersistence, loadMessagesFromDb } from './persistence.js'
-export type { CachedMessage, MessageMetadataRow } from './types.js'
+export type { CachedMessage } from './types.js'
 export type { ReplyChainResult } from './chain.js'

--- a/src/message-cache/index.ts
+++ b/src/message-cache/index.ts
@@ -1,5 +1,5 @@
 export { cacheMessage, getCachedMessage, hasCachedMessage, clearMessageCache } from './cache.js'
 export { buildReplyChain } from './chain.js'
-export { scheduleMessagePersistence, loadMessagesFromDb } from './persistence.js'
+export { scheduleMessagePersistence, loadMessagesFromDb, startMessageCleanupScheduler } from './persistence.js'
 export type { CachedMessage } from './types.js'
 export type { ReplyChainResult } from './chain.js'

--- a/src/message-cache/index.ts
+++ b/src/message-cache/index.ts
@@ -1,0 +1,5 @@
+export { cacheMessage, getCachedMessage, hasCachedMessage, clearMessageCache } from './cache.js'
+export { buildReplyChain } from './chain.js'
+export { scheduleMessagePersistence, loadMessagesFromDb } from './persistence.js'
+export type { CachedMessage, MessageMetadataRow } from './types.js'
+export type { ReplyChainResult } from './chain.js'

--- a/src/message-cache/persistence.ts
+++ b/src/message-cache/persistence.ts
@@ -1,0 +1,126 @@
+import { and, eq, gt, lte, sql } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { messageMetadata } from '../db/schema.js'
+import { logger } from '../logger.js'
+import type { CachedMessage } from './types.js'
+
+const log = logger.child({ scope: 'message-cache:persistence' })
+
+// Queue for pending writes
+const pendingWrites = new Map<string, CachedMessage>()
+let isFlushScheduled = false
+
+// 1 week in milliseconds
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+export function scheduleMessagePersistence(message: CachedMessage): void {
+  pendingWrites.set(message.messageId, message)
+  scheduleFlush()
+}
+
+function scheduleFlush(): void {
+  if (isFlushScheduled) return
+  isFlushScheduled = true
+  queueMicrotask(() => {
+    isFlushScheduled = false
+    try {
+      flushPendingWrites()
+    } catch (err) {
+      log.error(
+        { error: err instanceof Error ? err.message : String(err) },
+        'Failed to flush message cache to database',
+      )
+    }
+  })
+}
+
+function flushPendingWrites(): void {
+  if (pendingWrites.size === 0) return
+
+  const writes = Array.from(pendingWrites.values())
+  pendingWrites.clear()
+
+  const db = getDrizzleDb()
+
+  try {
+    db.insert(messageMetadata)
+      .values(
+        writes.map((msg) => ({
+          messageId: msg.messageId,
+          contextId: msg.contextId,
+          authorId: msg.authorId ?? null,
+          authorUsername: msg.authorUsername ?? null,
+          text: msg.text ?? null,
+          replyToMessageId: msg.replyToMessageId ?? null,
+          timestamp: msg.timestamp,
+          expiresAt: msg.timestamp + ONE_WEEK_MS,
+        })),
+      )
+      .onConflictDoUpdate({
+        target: messageMetadata.messageId,
+        set: {
+          contextId: sql`excluded.context_id`,
+          authorId: sql`excluded.author_id`,
+          authorUsername: sql`excluded.author_username`,
+          text: sql`excluded.text`,
+          replyToMessageId: sql`excluded.reply_to_message_id`,
+          timestamp: sql`excluded.timestamp`,
+          expiresAt: sql`excluded.expires_at`,
+        },
+      })
+      .run()
+
+    log.debug({ count: writes.length }, 'Persisted messages to database')
+  } catch (err) {
+    log.error(
+      { error: err instanceof Error ? err.message : String(err), count: writes.length },
+      'Failed to persist messages',
+    )
+    // Re-queue failed writes
+    for (const msg of writes) {
+      pendingWrites.set(msg.messageId, msg)
+    }
+  }
+}
+
+export function loadMessagesFromDb(contextId: string): CachedMessage[] {
+  const db = getDrizzleDb()
+  const now = Date.now()
+
+  const rows = db
+    .select()
+    .from(messageMetadata)
+    .where(and(eq(messageMetadata.contextId, contextId), gt(messageMetadata.expiresAt, now)))
+    .all()
+
+  return rows.map((row) => ({
+    messageId: row.messageId,
+    contextId: row.contextId,
+    authorId: row.authorId ?? undefined,
+    authorUsername: row.authorUsername ?? undefined,
+    text: row.text ?? undefined,
+    replyToMessageId: row.replyToMessageId ?? undefined,
+    timestamp: row.timestamp,
+  }))
+}
+
+export function cleanupExpiredMessages(): void {
+  const db = getDrizzleDb()
+  const now = Date.now()
+
+  try {
+    db.delete(messageMetadata).where(lte(messageMetadata.expiresAt, now)).run()
+    log.debug('Cleaned up expired message metadata')
+  } catch (err) {
+    log.error({ error: err instanceof Error ? err.message : String(err) }, 'Failed to cleanup expired messages')
+  }
+}
+
+// Periodic cleanup (every hour)
+setInterval(
+  () => {
+    cleanupExpiredMessages()
+  },
+  60 * 60 * 1000,
+)

--- a/src/message-cache/persistence.ts
+++ b/src/message-cache/persistence.ts
@@ -76,10 +76,11 @@ function flushPendingWrites(): void {
       { error: err instanceof Error ? err.message : String(err), count: writes.length },
       'Failed to persist messages',
     )
-    // Re-queue failed writes
+    // Re-queue failed writes and schedule retry
     for (const msg of writes) {
-      pendingWrites.set(msg.messageId, msg)
+      pendingWrites.set(`${msg.contextId}:${msg.messageId}`, msg)
     }
+    setTimeout(scheduleFlush, 5000)
   }
 }
 

--- a/src/message-cache/persistence.ts
+++ b/src/message-cache/persistence.ts
@@ -41,9 +41,8 @@ function flushPendingWrites(): void {
   const writes = Array.from(pendingWrites.values())
   pendingWrites.clear()
 
-  const db = getDrizzleDb()
-
   try {
+    const db = getDrizzleDb()
     db.insert(messageMetadata)
       .values(
         writes.map((msg) => ({

--- a/src/message-cache/persistence.ts
+++ b/src/message-cache/persistence.ts
@@ -15,7 +15,7 @@ let isFlushScheduled = false
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
 export function scheduleMessagePersistence(message: CachedMessage): void {
-  pendingWrites.set(message.messageId, message)
+  pendingWrites.set(`${message.contextId}:${message.messageId}`, message)
   scheduleFlush()
 }
 
@@ -58,9 +58,8 @@ function flushPendingWrites(): void {
         })),
       )
       .onConflictDoUpdate({
-        target: messageMetadata.messageId,
+        target: [messageMetadata.contextId, messageMetadata.messageId],
         set: {
-          contextId: sql`excluded.context_id`,
           authorId: sql`excluded.author_id`,
           authorUsername: sql`excluded.author_username`,
           text: sql`excluded.text`,

--- a/src/message-cache/persistence.ts
+++ b/src/message-cache/persistence.ts
@@ -84,6 +84,7 @@ function flushPendingWrites(): void {
   }
 }
 
+/** @public */
 export function loadMessagesFromDb(contextId: string): CachedMessage[] {
   const db = getDrizzleDb()
   const now = Date.now()

--- a/src/message-cache/persistence.ts
+++ b/src/message-cache/persistence.ts
@@ -118,10 +118,13 @@ export function cleanupExpiredMessages(): void {
   }
 }
 
-// Periodic cleanup (every hour)
-setInterval(
-  () => {
-    cleanupExpiredMessages()
-  },
-  60 * 60 * 1000,
-)
+/** Start hourly cleanup of expired message metadata from the database. */
+export function startMessageCleanupScheduler(): void {
+  setInterval(
+    () => {
+      cleanupExpiredMessages()
+    },
+    60 * 60 * 1000,
+  )
+  log.debug('Message cleanup scheduler started (hourly)')
+}

--- a/src/message-cache/types.ts
+++ b/src/message-cache/types.ts
@@ -7,14 +7,3 @@ export interface CachedMessage {
   replyToMessageId?: string
   timestamp: number
 }
-
-export interface MessageMetadataRow {
-  message_id: string
-  context_id: string
-  author_id: string | null
-  author_username: string | null
-  text: string | null
-  reply_to_message_id: string | null
-  timestamp: number
-  expires_at: number
-}

--- a/src/message-cache/types.ts
+++ b/src/message-cache/types.ts
@@ -1,0 +1,20 @@
+export interface CachedMessage {
+  messageId: string
+  contextId: string
+  authorId?: string
+  authorUsername?: string
+  text?: string
+  replyToMessageId?: string
+  timestamp: number
+}
+
+export interface MessageMetadataRow {
+  message_id: string
+  context_id: string
+  author_id: string | null
+  author_username: string | null
+  text: string | null
+  reply_to_message_id: string | null
+  timestamp: number
+  expires_at: number
+}

--- a/tests/message-cache/cache.test.ts
+++ b/tests/message-cache/cache.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect, beforeEach } from 'bun:test'
+
+import {
+  cacheMessage,
+  getCachedMessage,
+  hasCachedMessage,
+  clearMessageCache,
+  getMessageCacheSize,
+} from '../../src/message-cache/cache.js'
+
+describe('Message Cache', () => {
+  beforeEach(() => {
+    clearMessageCache()
+  })
+
+  test('should cache and retrieve message', () => {
+    const message = {
+      messageId: '123',
+      contextId: 'chat-456',
+      authorId: 'user-789',
+      text: 'Hello',
+      timestamp: Date.now(),
+    }
+
+    cacheMessage(message)
+
+    const retrieved = getCachedMessage('123')
+    expect(retrieved).toBeDefined()
+    expect(retrieved?.text).toBe('Hello')
+  })
+
+  test('should return undefined for non-existent message', () => {
+    const result = getCachedMessage('non-existent')
+    expect(result).toBeUndefined()
+  })
+
+  test('should track cache size', () => {
+    expect(getMessageCacheSize()).toBe(0)
+    cacheMessage({ messageId: '1', contextId: 'c1', timestamp: Date.now() })
+    expect(getMessageCacheSize()).toBe(1)
+  })
+
+  test('should check if message is cached', () => {
+    cacheMessage({ messageId: '1', contextId: 'c1', timestamp: Date.now() })
+    expect(hasCachedMessage('1')).toBe(true)
+    expect(hasCachedMessage('2')).toBe(false)
+  })
+})

--- a/tests/message-cache/cache.test.ts
+++ b/tests/message-cache/cache.test.ts
@@ -10,13 +10,7 @@ afterAll(() => {
   mock.restore()
 })
 
-import {
-  cacheMessage,
-  getCachedMessage,
-  hasCachedMessage,
-  clearMessageCache,
-  getMessageCacheSize,
-} from '../../src/message-cache/cache.js'
+import { cacheMessage, getCachedMessage, hasCachedMessage, clearMessageCache } from '../../src/message-cache/cache.js'
 
 describe('Message Cache', () => {
   beforeEach(async () => {
@@ -45,10 +39,10 @@ describe('Message Cache', () => {
     expect(result).toBeUndefined()
   })
 
-  test('should track cache size', () => {
-    expect(getMessageCacheSize()).toBe(0)
+  test('should store messages in cache', () => {
+    expect(hasCachedMessage('1')).toBe(false)
     cacheMessage({ messageId: '1', contextId: 'c1', timestamp: Date.now() })
-    expect(getMessageCacheSize()).toBe(1)
+    expect(hasCachedMessage('1')).toBe(true)
   })
 
   test('should check if message is cached', () => {

--- a/tests/message-cache/cache.test.ts
+++ b/tests/message-cache/cache.test.ts
@@ -1,4 +1,14 @@
-import { describe, test, expect, beforeEach } from 'bun:test'
+import { afterAll, describe, test, expect, beforeEach, mock } from 'bun:test'
+
+import { mockDrizzle, mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+// Mock at the drizzle level (not persistence) to avoid mock pollution
+mockLogger()
+mockDrizzle()
+
+afterAll(() => {
+  mock.restore()
+})
 
 import {
   cacheMessage,
@@ -9,8 +19,9 @@ import {
 } from '../../src/message-cache/cache.js'
 
 describe('Message Cache', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     clearMessageCache()
+    await setupTestDb()
   })
 
   test('should cache and retrieve message', () => {

--- a/tests/message-cache/cache.test.ts
+++ b/tests/message-cache/cache.test.ts
@@ -29,25 +29,36 @@ describe('Message Cache', () => {
 
     cacheMessage(message)
 
-    const retrieved = getCachedMessage('123')
+    const retrieved = getCachedMessage('chat-456', '123')
     expect(retrieved).toBeDefined()
     expect(retrieved?.text).toBe('Hello')
   })
 
   test('should return undefined for non-existent message', () => {
-    const result = getCachedMessage('non-existent')
+    const result = getCachedMessage('chat-1', 'non-existent')
     expect(result).toBeUndefined()
   })
 
   test('should store messages in cache', () => {
-    expect(hasCachedMessage('1')).toBe(false)
+    expect(hasCachedMessage('c1', '1')).toBe(false)
     cacheMessage({ messageId: '1', contextId: 'c1', timestamp: Date.now() })
-    expect(hasCachedMessage('1')).toBe(true)
+    expect(hasCachedMessage('c1', '1')).toBe(true)
   })
 
   test('should check if message is cached', () => {
     cacheMessage({ messageId: '1', contextId: 'c1', timestamp: Date.now() })
-    expect(hasCachedMessage('1')).toBe(true)
-    expect(hasCachedMessage('2')).toBe(false)
+    expect(hasCachedMessage('c1', '1')).toBe(true)
+    expect(hasCachedMessage('c1', '2')).toBe(false)
+  })
+
+  test('should isolate messages by contextId', () => {
+    cacheMessage({ messageId: '1', contextId: 'chat-A', text: 'From A', timestamp: Date.now() })
+    cacheMessage({ messageId: '1', contextId: 'chat-B', text: 'From B', timestamp: Date.now() })
+
+    const fromA = getCachedMessage('chat-A', '1')
+    const fromB = getCachedMessage('chat-B', '1')
+
+    expect(fromA?.text).toBe('From A')
+    expect(fromB?.text).toBe('From B')
   })
 })

--- a/tests/message-cache/chain.test.ts
+++ b/tests/message-cache/chain.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, describe, test, expect, beforeEach, mock } from 'bun:test'
+
+import { mockDrizzle, mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+// Mock at the drizzle level to avoid mock pollution
+mockLogger()
+mockDrizzle()
+
+afterAll(() => {
+  mock.restore()
+})
+
+import { cacheMessage, clearMessageCache } from '../../src/message-cache/cache.js'
+import { buildReplyChain } from '../../src/message-cache/chain.js'
+
+describe('Reply Chain Builder', () => {
+  beforeEach(async () => {
+    clearMessageCache()
+    await setupTestDb()
+  })
+
+  test('should build linear chain', () => {
+    // A -> B -> C
+    cacheMessage({ messageId: 'A', contextId: 'c1', timestamp: Date.now() })
+    cacheMessage({ messageId: 'B', contextId: 'c1', replyToMessageId: 'A', timestamp: Date.now() })
+    cacheMessage({ messageId: 'C', contextId: 'c1', replyToMessageId: 'B', timestamp: Date.now() })
+
+    const result = buildReplyChain('C')
+    expect(result.chain).toEqual(['A', 'B', 'C'])
+    expect(result.isComplete).toBe(true)
+  })
+
+  test('should detect missing parent', () => {
+    cacheMessage({ messageId: 'C', contextId: 'c1', replyToMessageId: 'B', timestamp: Date.now() })
+
+    const result = buildReplyChain('C')
+    expect(result.chain).toEqual(['C'])
+    expect(result.isComplete).toBe(false)
+    expect(result.brokenAt).toBe('B')
+  })
+
+  test('should detect circular reference', () => {
+    cacheMessage({ messageId: 'A', contextId: 'c1', replyToMessageId: 'C', timestamp: Date.now() })
+    cacheMessage({ messageId: 'B', contextId: 'c1', replyToMessageId: 'A', timestamp: Date.now() })
+    cacheMessage({ messageId: 'C', contextId: 'c1', replyToMessageId: 'B', timestamp: Date.now() })
+
+    const result = buildReplyChain('C')
+    expect(result.chain).toEqual(['A', 'B', 'C'])
+    expect(result.isComplete).toBe(false)
+  })
+
+  test('should handle single message (no replies)', () => {
+    cacheMessage({ messageId: 'A', contextId: 'c1', timestamp: Date.now() })
+
+    const result = buildReplyChain('A')
+    expect(result.chain).toEqual(['A'])
+    expect(result.isComplete).toBe(true)
+  })
+
+  test('should handle non-existent starting message', () => {
+    const result = buildReplyChain('non-existent')
+    expect(result.chain).toEqual([])
+    expect(result.isComplete).toBe(false)
+    expect(result.brokenAt).toBe('non-existent')
+  })
+})

--- a/tests/message-cache/chain.test.ts
+++ b/tests/message-cache/chain.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, test, expect, beforeEach, mock } from 'bun:test'
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
 
 import { mockDrizzle, mockLogger, setupTestDb } from '../utils/test-helpers.js'
 
@@ -25,7 +25,7 @@ describe('Reply Chain Builder', () => {
     cacheMessage({ messageId: 'B', contextId: 'c1', replyToMessageId: 'A', timestamp: Date.now() })
     cacheMessage({ messageId: 'C', contextId: 'c1', replyToMessageId: 'B', timestamp: Date.now() })
 
-    const result = buildReplyChain('C')
+    const result = buildReplyChain('c1', 'C')
     expect(result.chain).toEqual(['A', 'B', 'C'])
     expect(result.isComplete).toBe(true)
   })
@@ -33,7 +33,7 @@ describe('Reply Chain Builder', () => {
   test('should detect missing parent', () => {
     cacheMessage({ messageId: 'C', contextId: 'c1', replyToMessageId: 'B', timestamp: Date.now() })
 
-    const result = buildReplyChain('C')
+    const result = buildReplyChain('c1', 'C')
     expect(result.chain).toEqual(['C'])
     expect(result.isComplete).toBe(false)
     expect(result.brokenAt).toBe('B')
@@ -44,7 +44,7 @@ describe('Reply Chain Builder', () => {
     cacheMessage({ messageId: 'B', contextId: 'c1', replyToMessageId: 'A', timestamp: Date.now() })
     cacheMessage({ messageId: 'C', contextId: 'c1', replyToMessageId: 'B', timestamp: Date.now() })
 
-    const result = buildReplyChain('C')
+    const result = buildReplyChain('c1', 'C')
     expect(result.chain).toEqual(['A', 'B', 'C'])
     expect(result.isComplete).toBe(false)
   })
@@ -52,13 +52,13 @@ describe('Reply Chain Builder', () => {
   test('should handle single message (no replies)', () => {
     cacheMessage({ messageId: 'A', contextId: 'c1', timestamp: Date.now() })
 
-    const result = buildReplyChain('A')
+    const result = buildReplyChain('c1', 'A')
     expect(result.chain).toEqual(['A'])
     expect(result.isComplete).toBe(true)
   })
 
   test('should handle non-existent starting message', () => {
-    const result = buildReplyChain('non-existent')
+    const result = buildReplyChain('c1', 'non-existent')
     expect(result.chain).toEqual([])
     expect(result.isComplete).toBe(false)
     expect(result.brokenAt).toBe('non-existent')

--- a/tests/message-cache/integration.test.ts
+++ b/tests/message-cache/integration.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+import { mockDrizzle, mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+mockLogger()
+mockDrizzle()
+
+afterAll(() => {
+  mock.restore()
+})
+
+import { buildReplyChain, cacheMessage, clearMessageCache } from '../../src/message-cache/index.js'
+
+describe('Message Cache Integration', () => {
+  beforeEach(async () => {
+    clearMessageCache()
+    await setupTestDb()
+  })
+
+  test('should cache telegram-style messages and build chain', () => {
+    cacheMessage({
+      messageId: '100',
+      contextId: 'chat-1',
+      authorId: 'user-1',
+      authorUsername: 'alice',
+      text: 'Original message',
+      timestamp: Date.now(),
+    })
+
+    cacheMessage({
+      messageId: '101',
+      contextId: 'chat-1',
+      authorId: 'user-2',
+      authorUsername: 'bob',
+      text: 'Reply to alice',
+      replyToMessageId: '100',
+      timestamp: Date.now(),
+    })
+
+    cacheMessage({
+      messageId: '102',
+      contextId: 'chat-1',
+      authorId: 'user-1',
+      authorUsername: 'alice',
+      text: 'Reply to bob',
+      replyToMessageId: '101',
+      timestamp: Date.now(),
+    })
+
+    const result = buildReplyChain('102')
+    expect(result.chain).toEqual(['100', '101', '102'])
+    expect(result.isComplete).toBe(true)
+  })
+
+  test('should handle deep chains', () => {
+    for (let i = 0; i < 10; i++) {
+      cacheMessage({
+        messageId: String(i),
+        contextId: 'chat-1',
+        authorId: 'user-1',
+        text: `Message ${i}`,
+        replyToMessageId: i > 0 ? String(i - 1) : undefined,
+        timestamp: Date.now(),
+      })
+    }
+
+    const result = buildReplyChain('9')
+    expect(result.chain).toHaveLength(10)
+    expect(result.chain[0]).toBe('0')
+    expect(result.chain[9]).toBe('9')
+    expect(result.isComplete).toBe(true)
+  })
+
+  test('should handle partial chain with gap in middle', () => {
+    // Cache messages 0, 1, 3, 4 but NOT 2
+    cacheMessage({ messageId: '0', contextId: 'chat-1', timestamp: Date.now() })
+    cacheMessage({ messageId: '1', contextId: 'chat-1', replyToMessageId: '0', timestamp: Date.now() })
+    // Message 2 is missing
+    cacheMessage({ messageId: '3', contextId: 'chat-1', replyToMessageId: '2', timestamp: Date.now() })
+    cacheMessage({ messageId: '4', contextId: 'chat-1', replyToMessageId: '3', timestamp: Date.now() })
+
+    const result = buildReplyChain('4')
+    expect(result.chain).toEqual(['3', '4'])
+    expect(result.isComplete).toBe(false)
+    expect(result.brokenAt).toBe('2')
+  })
+})

--- a/tests/message-cache/integration.test.ts
+++ b/tests/message-cache/integration.test.ts
@@ -47,7 +47,7 @@ describe('Message Cache Integration', () => {
       timestamp: Date.now(),
     })
 
-    const result = buildReplyChain('102')
+    const result = buildReplyChain('chat-1', '102')
     expect(result.chain).toEqual(['100', '101', '102'])
     expect(result.isComplete).toBe(true)
   })
@@ -64,7 +64,7 @@ describe('Message Cache Integration', () => {
       })
     }
 
-    const result = buildReplyChain('9')
+    const result = buildReplyChain('chat-1', '9')
     expect(result.chain).toHaveLength(10)
     expect(result.chain[0]).toBe('0')
     expect(result.chain[9]).toBe('9')
@@ -79,9 +79,38 @@ describe('Message Cache Integration', () => {
     cacheMessage({ messageId: '3', contextId: 'chat-1', replyToMessageId: '2', timestamp: Date.now() })
     cacheMessage({ messageId: '4', contextId: 'chat-1', replyToMessageId: '3', timestamp: Date.now() })
 
-    const result = buildReplyChain('4')
+    const result = buildReplyChain('chat-1', '4')
     expect(result.chain).toEqual(['3', '4'])
     expect(result.isComplete).toBe(false)
     expect(result.brokenAt).toBe('2')
+  })
+
+  test('should isolate chains across different contexts', () => {
+    // Same message IDs in different contexts should not collide
+    cacheMessage({ messageId: '1', contextId: 'chat-A', text: 'Root in A', timestamp: Date.now() })
+    cacheMessage({
+      messageId: '2',
+      contextId: 'chat-A',
+      text: 'Reply in A',
+      replyToMessageId: '1',
+      timestamp: Date.now(),
+    })
+
+    cacheMessage({ messageId: '1', contextId: 'chat-B', text: 'Root in B', timestamp: Date.now() })
+    cacheMessage({
+      messageId: '2',
+      contextId: 'chat-B',
+      text: 'Reply in B',
+      replyToMessageId: '1',
+      timestamp: Date.now(),
+    })
+
+    const chainA = buildReplyChain('chat-A', '2')
+    const chainB = buildReplyChain('chat-B', '2')
+
+    expect(chainA.chain).toEqual(['1', '2'])
+    expect(chainA.isComplete).toBe(true)
+    expect(chainB.chain).toEqual(['1', '2'])
+    expect(chainB.isComplete).toBe(true)
   })
 })

--- a/tests/message-cache/persistence.test.ts
+++ b/tests/message-cache/persistence.test.ts
@@ -185,6 +185,36 @@ describe('Message Persistence', () => {
     expect(messages[0]?.messageId).toBe('msg-new')
   })
 
+  test('should not collide on same messageId across different contexts', async () => {
+    const now = Date.now()
+
+    scheduleMessagePersistence({
+      messageId: '1',
+      contextId: 'chat-A',
+      text: 'From chat A',
+      timestamp: now,
+    })
+
+    scheduleMessagePersistence({
+      messageId: '1',
+      contextId: 'chat-B',
+      text: 'From chat B',
+      timestamp: now,
+    })
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10)
+    })
+
+    const chatA = loadMessagesFromDb('chat-A')
+    const chatB = loadMessagesFromDb('chat-B')
+
+    expect(chatA).toHaveLength(1)
+    expect(chatA[0]?.text).toBe('From chat A')
+    expect(chatB).toHaveLength(1)
+    expect(chatB[0]?.text).toBe('From chat B')
+  })
+
   test('should convert optional fields to undefined on load', async () => {
     scheduleMessagePersistence({
       messageId: 'msg-minimal',

--- a/tests/message-cache/persistence.test.ts
+++ b/tests/message-cache/persistence.test.ts
@@ -1,0 +1,206 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+import { mockLogger, setupTestDb, mockDrizzle } from '../utils/test-helpers.js'
+
+// Mock logger before importing modules that use it
+mockLogger()
+
+// Setup test DB and mock drizzle before importing persistence module
+mockDrizzle()
+
+afterAll(() => {
+  mock.restore()
+})
+
+import { messageMetadata } from '../../src/db/schema.js'
+import {
+  scheduleMessagePersistence,
+  loadMessagesFromDb,
+  cleanupExpiredMessages,
+} from '../../src/message-cache/persistence.js'
+
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+describe('Message Persistence', () => {
+  beforeEach(async () => {
+    const db = await setupTestDb()
+    // Clear table between tests
+    db.delete(messageMetadata).run()
+  })
+
+  test('should persist messages to database via microtask flush', async () => {
+    const now = Date.now()
+
+    scheduleMessagePersistence({
+      messageId: 'msg-1',
+      contextId: 'chat-1',
+      authorId: 'user-1',
+      authorUsername: 'alice',
+      text: 'Hello world',
+      timestamp: now,
+    })
+
+    // Wait for microtask to flush
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10)
+    })
+
+    const messages = loadMessagesFromDb('chat-1')
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.messageId).toBe('msg-1')
+    expect(messages[0]?.text).toBe('Hello world')
+    expect(messages[0]?.authorUsername).toBe('alice')
+  })
+
+  test('should batch multiple writes into single flush', async () => {
+    const now = Date.now()
+
+    scheduleMessagePersistence({
+      messageId: 'msg-1',
+      contextId: 'chat-1',
+      authorId: 'user-1',
+      text: 'First',
+      timestamp: now,
+    })
+
+    scheduleMessagePersistence({
+      messageId: 'msg-2',
+      contextId: 'chat-1',
+      authorId: 'user-2',
+      text: 'Second',
+      timestamp: now,
+    })
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10)
+    })
+
+    const messages = loadMessagesFromDb('chat-1')
+    expect(messages).toHaveLength(2)
+  })
+
+  test('should upsert on conflict', async () => {
+    const now = Date.now()
+
+    scheduleMessagePersistence({
+      messageId: 'msg-1',
+      contextId: 'chat-1',
+      text: 'Original',
+      timestamp: now,
+    })
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10)
+    })
+
+    scheduleMessagePersistence({
+      messageId: 'msg-1',
+      contextId: 'chat-1',
+      text: 'Updated',
+      timestamp: now,
+    })
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10)
+    })
+
+    const messages = loadMessagesFromDb('chat-1')
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.text).toBe('Updated')
+  })
+
+  test('should load messages filtered by contextId', async () => {
+    const now = Date.now()
+
+    scheduleMessagePersistence({
+      messageId: 'msg-1',
+      contextId: 'chat-1',
+      text: 'In chat 1',
+      timestamp: now,
+    })
+
+    scheduleMessagePersistence({
+      messageId: 'msg-2',
+      contextId: 'chat-2',
+      text: 'In chat 2',
+      timestamp: now,
+    })
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10)
+    })
+
+    const chat1Messages = loadMessagesFromDb('chat-1')
+    expect(chat1Messages).toHaveLength(1)
+    expect(chat1Messages[0]?.text).toBe('In chat 1')
+
+    const chat2Messages = loadMessagesFromDb('chat-2')
+    expect(chat2Messages).toHaveLength(1)
+    expect(chat2Messages[0]?.text).toBe('In chat 2')
+  })
+
+  test('should not load expired messages', async () => {
+    const expired = Date.now() - ONE_WEEK_MS - 1000
+
+    scheduleMessagePersistence({
+      messageId: 'msg-old',
+      contextId: 'chat-1',
+      text: 'Expired',
+      timestamp: expired,
+    })
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10)
+    })
+
+    const messages = loadMessagesFromDb('chat-1')
+    expect(messages).toHaveLength(0)
+  })
+
+  test('should cleanup expired messages', async () => {
+    const expired = Date.now() - ONE_WEEK_MS - 1000
+
+    scheduleMessagePersistence({
+      messageId: 'msg-old',
+      contextId: 'chat-1',
+      text: 'Expired',
+      timestamp: expired,
+    })
+
+    scheduleMessagePersistence({
+      messageId: 'msg-new',
+      contextId: 'chat-1',
+      text: 'Fresh',
+      timestamp: Date.now(),
+    })
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10)
+    })
+
+    cleanupExpiredMessages()
+
+    const messages = loadMessagesFromDb('chat-1')
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.messageId).toBe('msg-new')
+  })
+
+  test('should convert optional fields to undefined on load', async () => {
+    scheduleMessagePersistence({
+      messageId: 'msg-minimal',
+      contextId: 'chat-1',
+      timestamp: Date.now(),
+    })
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10)
+    })
+
+    const messages = loadMessagesFromDb('chat-1')
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.authorId).toBeUndefined()
+    expect(messages[0]?.authorUsername).toBeUndefined()
+    expect(messages[0]?.text).toBeUndefined()
+    expect(messages[0]?.replyToMessageId).toBeUndefined()
+  })
+})

--- a/tests/utils/test-helpers.ts
+++ b/tests/utils/test-helpers.ts
@@ -27,6 +27,7 @@ import { migration013DeferredPrompts } from '../../src/db/migrations/013_deferre
 import { migration014BackgroundEvents } from '../../src/db/migrations/014_background_events.js'
 import { migration015DropBackgroundEvents } from '../../src/db/migrations/015_drop_background_events.js'
 import { migration016ExecutionMetadata } from '../../src/db/migrations/016_execution_metadata.js'
+import { migration017MessageMetadata } from '../../src/db/migrations/017_message_metadata.js'
 import * as schema from '../../src/db/schema.js'
 import type { AppError } from '../../src/errors.js'
 import { getUserMessage } from '../../src/errors.js'
@@ -50,6 +51,7 @@ const ALL_MIGRATIONS: readonly Migration[] = [
   migration014BackgroundEvents,
   migration015DropBackgroundEvents,
   migration016ExecutionMetadata,
+  migration017MessageMetadata,
 ]
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add `message_metadata` SQLite table (migration 017) with Drizzle schema for caching message metadata with 1-week TTL
- Implement provider-agnostic `src/message-cache/` module: in-memory Map cache, background SQLite persistence via batched `queueMicrotask` writes, and reply chain builder with cycle detection
- Integrate with Telegram provider: extract `reply_to_message.message_id`, cache metadata on every incoming message, add `replyToMessageId` to `IncomingMessage` type

## Test Plan

- [x] 19 new tests across 4 files (cache, persistence, chain, integration)
- [x] Full suite passes: 1523 tests, 0 failures
- [x] All 7 checks pass (`bun check:full`: lint, typecheck, format, knip, test, duplicates, mock-pollution)
- [ ] Verify reply chain building works with real Telegram messages in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)