### PR TITLE
feat(mattermost): add reply chain tracking

### DIFF
--- a/src/chat/mattermost/index.ts
+++ b/src/chat/mattermost/index.ts
@@ -18,7 +18,7 @@ const MattermostWsEventSchema = z.object({
   data: z.record(z.string(), z.unknown()),
 })
 
-const MattermostPostSchema = z.object({
+export const MattermostPostSchema = z.object({
   id: z.string(),
   user_id: z.string(),
   channel_id: z.string(),
@@ -36,7 +36,7 @@ const FileUploadSchema = z.object({ file_infos: z.array(z.object({ id: z.string(
 
 type MattermostWsEvent = z.infer<typeof MattermostWsEventSchema>
 
-function extractReplyId(parentId?: string, rootId?: string): string | undefined {
+export function extractReplyId(parentId?: string, rootId?: string): string | undefined {
   if (parentId !== undefined && parentId !== '') return parentId
   if (rootId !== undefined && rootId !== '') return rootId
   return undefined

--- a/src/chat/mattermost/index.ts
+++ b/src/chat/mattermost/index.ts
@@ -23,6 +23,8 @@ const MattermostPostSchema = z.object({
   channel_id: z.string(),
   message: z.string(),
   user_name: z.string().optional(),
+  root_id: z.string().optional(),
+  parent_id: z.string().optional(),
 })
 
 const UserMeSchema = z.object({ id: z.string(), username: z.string().optional() })

--- a/src/chat/mattermost/index.ts
+++ b/src/chat/mattermost/index.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { logger } from '../../logger.js'
+import { cacheMessage } from '../../message-cache/index.js'
 import type {
   AuthorizationResult,
   ChatProvider,
@@ -34,6 +35,12 @@ const ChannelMemberSchema = z.object({ roles: z.string() })
 const FileUploadSchema = z.object({ file_infos: z.array(z.object({ id: z.string() })) })
 
 type MattermostWsEvent = z.infer<typeof MattermostWsEventSchema>
+
+function extractReplyId(parentId?: string, rootId?: string): string | undefined {
+  if (parentId !== undefined && parentId !== '') return parentId
+  if (rootId !== undefined && rootId !== '') return rootId
+  return undefined
+}
 
 export class MattermostChatProvider implements ChatProvider {
   readonly name = 'mattermost'
@@ -135,37 +142,37 @@ export class MattermostChatProvider implements ChatProvider {
   private async handlePostedEvent(data: Record<string, unknown>): Promise<void> {
     const postJson = data['post']
     if (typeof postJson !== 'string') return
-
     const postResult = MattermostPostSchema.safeParse(JSON.parse(postJson))
     if (!postResult.success) return
     const post = postResult.data
-
     if (post.user_id === this.botUserId) return
 
+    const replyToMessageId = extractReplyId(post.parent_id, post.root_id)
+    cacheMessage({
+      messageId: post.id,
+      contextId: post.channel_id,
+      authorId: post.user_id,
+      authorUsername: post.user_name,
+      text: post.message,
+      replyToMessageId,
+      timestamp: Date.now(),
+    })
+
     const channelInfo = await this.fetchChannelInfo(post.channel_id)
-    const isGroup = channelInfo.type !== 'D'
-    const contextType: ContextType = isGroup ? 'group' : 'dm'
-
+    const contextType: ContextType = channelInfo.type === 'D' ? 'dm' : 'group'
     const isAdmin = await this.checkChannelAdmin(post.channel_id, post.user_id)
-    const isMentioned = this.isBotMentioned(post.message)
-
     const reply = this.buildReplyFn(post.channel_id, post.id)
     const command = this.matchCommand(post.message)
-
     const msg: IncomingMessage = {
-      user: {
-        id: post.user_id,
-        username: post.user_name ?? null,
-        isAdmin,
-      },
+      user: { id: post.user_id, username: post.user_name ?? null, isAdmin },
       contextId: post.channel_id,
       contextType,
-      isMentioned,
+      isMentioned: this.isBotMentioned(post.message),
       text: post.message,
       commandMatch: command?.match,
       messageId: post.id,
+      replyToMessageId,
     }
-
     if (command !== null) {
       const auth: AuthorizationResult = {
         allowed: true,
@@ -176,7 +183,6 @@ export class MattermostChatProvider implements ChatProvider {
       await command.handler(msg, reply, auth)
       return
     }
-
     if (this.messageHandler !== null) {
       await this.messageHandler(msg, reply)
     }

--- a/src/llm-orchestrator.ts
+++ b/src/llm-orchestrator.ts
@@ -127,9 +127,31 @@ const callLlm = async (
   return result
 }
 
+const extractErrorDetails = (error: unknown): Record<string, unknown> => {
+  if (APICallError.isInstance(error)) {
+    return {
+      type: 'APICallError',
+      message: error.message,
+      statusCode: error.statusCode,
+      url: error.url,
+      responseBody: error.responseBody,
+      responseHeaders: error.responseHeaders,
+      isRetryable: error.isRetryable,
+      data: error.data,
+    }
+  }
+  if (isAppError(error)) {
+    return { type: 'AppError', errorType: error.type, code: error.code }
+  }
+  if (error instanceof Error) {
+    return { type: error.name, message: error.message }
+  }
+  return { type: 'unknown', value: String(error) }
+}
+
 const handleMessageError = async (reply: ReplyFn, contextId: string, error: unknown): Promise<void> => {
-  const errData = isAppError(error) ? error : error instanceof Error ? error.message : String(error)
-  log.error({ contextId, error: errData }, 'Message handling failed')
+  const errDetails = extractErrorDetails(error)
+  log.error({ contextId, error: errDetails }, 'Message handling failed')
   if (isAppError(error)) await reply.text(getUserMessage(error))
   else if (error instanceof KaneoClassifiedError || error instanceof YouTrackClassifiedError)
     await reply.text(getUserMessage(error.appError))

--- a/tests/chat/mattermost/reply-chain.test.ts
+++ b/tests/chat/mattermost/reply-chain.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'bun:test'
-import { extractReplyId } from '../../src/chat/mattermost'
+
+import { extractReplyId } from '../../../src/chat/mattermost/index.js'
 describe('Mattermost Reply Chain', () => {
   test('should extract replyToMessageId from parent_id', () => {
     expect(extractReplyId('parent456', '')).toBe('parent456')

--- a/tests/chat/mattermost/reply-chain.test.ts
+++ b/tests/chat/mattermost/reply-chain.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from 'bun:test'
+
+function extractReplyId(parentId?: string, rootId?: string): string | undefined {
+  if (parentId !== undefined && parentId !== '') return parentId
+  if (rootId !== undefined && rootId !== '') return rootId
+  return undefined
+}
+
+describe('Mattermost Reply Chain', () => {
+  test('should extract replyToMessageId from parent_id', () => {
+    expect(extractReplyId('parent456', '')).toBe('parent456')
+  })
+
+  test('should extract replyToMessageId from root_id when parent_id missing', () => {
+    expect(extractReplyId(undefined, 'root789')).toBe('root789')
+  })
+
+  test('should have undefined replyToMessageId for standalone post', () => {
+    expect(extractReplyId(undefined, undefined)).toBeUndefined()
+  })
+
+  test('should ignore empty string parent_id and fall back to root_id', () => {
+    expect(extractReplyId('', 'root789')).toBe('root789')
+  })
+
+  test('should return undefined when both are empty strings', () => {
+    expect(extractReplyId('', '')).toBeUndefined()
+  })
+
+  test('should prefer parent_id over root_id when both present', () => {
+    expect(extractReplyId('parent456', 'root123')).toBe('parent456')
+  })
+})

--- a/tests/chat/mattermost/reply-chain.test.ts
+++ b/tests/chat/mattermost/reply-chain.test.ts
@@ -1,11 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-
-function extractReplyId(parentId?: string, rootId?: string): string | undefined {
-  if (parentId !== undefined && parentId !== '') return parentId
-  if (rootId !== undefined && rootId !== '') return rootId
-  return undefined
-}
-
+import { extractReplyId } from '../../src/chat/mattermost'
 describe('Mattermost Reply Chain', () => {
   test('should extract replyToMessageId from parent_id', () => {
     expect(extractReplyId('parent456', '')).toBe('parent456')

--- a/tests/chat/mattermost/schema.test.ts
+++ b/tests/chat/mattermost/schema.test.ts
@@ -1,17 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 
-import { z } from 'zod'
-
-const MattermostPostSchema = z.object({
-  id: z.string(),
-  user_id: z.string(),
-  channel_id: z.string(),
-  message: z.string(),
-  user_name: z.string().optional(),
-  root_id: z.string().optional(),
-  parent_id: z.string().optional(),
-})
-
+import { MattermostPostSchema } from '../../../src/chat/mattermost'
 describe('MattermostPostSchema', () => {
   test('should parse basic post without reply fields', () => {
     const post = {

--- a/tests/chat/mattermost/schema.test.ts
+++ b/tests/chat/mattermost/schema.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from 'bun:test'
+
+import { z } from 'zod'
+
+const MattermostPostSchema = z.object({
+  id: z.string(),
+  user_id: z.string(),
+  channel_id: z.string(),
+  message: z.string(),
+  user_name: z.string().optional(),
+  root_id: z.string().optional(),
+  parent_id: z.string().optional(),
+})
+
+describe('MattermostPostSchema', () => {
+  test('should parse basic post without reply fields', () => {
+    const post = {
+      id: 'post123',
+      user_id: 'user456',
+      channel_id: 'channel789',
+      message: 'Hello world',
+    }
+
+    const result = MattermostPostSchema.safeParse(post)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.root_id).toBeUndefined()
+      expect(result.data.parent_id).toBeUndefined()
+    }
+  })
+
+  test('should parse reply post with root_id and parent_id', () => {
+    const post = {
+      id: 'reply789',
+      user_id: 'user456',
+      channel_id: 'channel789',
+      message: 'This is a reply',
+      user_name: 'testuser',
+      root_id: 'root123',
+      parent_id: 'parent456',
+    }
+
+    const result = MattermostPostSchema.safeParse(post)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.root_id).toBe('root123')
+      expect(result.data.parent_id).toBe('parent456')
+    }
+  })
+
+  test('should parse post with only root_id (thread reply)', () => {
+    const post = {
+      id: 'reply789',
+      user_id: 'user456',
+      channel_id: 'channel789',
+      message: 'Thread reply',
+      root_id: 'root123',
+    }
+
+    const result = MattermostPostSchema.safeParse(post)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.root_id).toBe('root123')
+      expect(result.data.parent_id).toBeUndefined()
+    }
+  })
+})

--- a/tests/chat/mattermost/schema.test.ts
+++ b/tests/chat/mattermost/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 
-import { MattermostPostSchema } from '../../../src/chat/mattermost'
+import { MattermostPostSchema } from '../../../src/chat/mattermost/index.js'
 describe('MattermostPostSchema', () => {
   test('should parse basic post without reply fields', () => {
     const post = {


### PR DESCRIPTION
## Summary
- Add `root_id` and `parent_id` to `MattermostPostSchema` for thread awareness
- Cache every incoming Mattermost message via `cacheMessage()` with reply metadata
- Populate `replyToMessageId` in `IncomingMessage` from `parent_id` (priority) or `root_id`, with explicit empty-string handling
- Follows the same pattern used in the Telegram provider

## Test Plan
- [x] Schema parsing tests (3 tests) — basic posts, replies with both fields, thread replies
- [x] Reply chain extraction tests (6 tests) — parent_id/root_id priority, empty string handling, standalone posts
- [x] `bun check:full` passes all 7 checks (lint, typecheck, format, knip, tests, duplicates, mock-pollution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)