### PR TITLE
Add path-scoped agent-agnostic instruction files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,19 @@
 # Copilot Instructions
 
+## Path-scoped guidelines
+
+Detailed conventions are in `.github/instructions/*.instructions.md` files, auto-loaded by glob:
+
+| File | Scope | Covers |
+|------|-------|--------|
+| `general.instructions.md` | `src/**` | Runtime, linting, logging, error handling, imports |
+| `providers.instructions.md` | `src/providers/**` | TaskProvider interface, operations, schemas, error classification |
+| `tools.instructions.md` | `src/tools/**` | Tool definitions, capability gating, destructive actions |
+| `commands.instructions.md` | `src/commands/**` | Command handler pattern, auth checks, ReplyFn |
+| `chat-adapters.instructions.md` | `src/chat/**` | ChatProvider interface, platform adapters |
+| `testing.instructions.md` | `tests/**` | Test helpers, mocking rules, mock pollution prevention |
+| `e2e-testing.instructions.md` | `tests/e2e/**` | E2E test structure, KaneoTestClient, Docker-based tests |
+
 ## No lint-disable comments
 
 Never suppress lint or type errors with disable comments. Fix the underlying issue instead.

--- a/.github/instructions/chat-adapters.instructions.md
+++ b/.github/instructions/chat-adapters.instructions.md
@@ -1,0 +1,32 @@
+---
+applyTo: "src/chat/**"
+---
+
+# Chat Adapter Conventions
+
+## Interface
+
+All chat adapters implement `ChatProvider` from `src/chat/types.ts`:
+
+```typescript
+interface ChatProvider {
+  name: string
+  registerCommand(name: string, handler: CommandHandler): void
+  onMessage(handler: (msg: IncomingMessage, reply: ReplyFn) => Promise<void>): void
+  sendMessage(contextId: string, text: string): Promise<void>
+  start(): Promise<void>
+  stop(): Promise<void>
+}
+```
+
+## Registration
+
+Adapters register in `src/chat/registry.ts` via `createChatProvider(name)`. Built-in: `telegram`, `mattermost`.
+
+## Rules
+
+- Platform-specific code stays inside the adapter directory (`telegram/`, `mattermost/`)
+- Adapters must map platform events to `IncomingMessage` and provide a `ReplyFn`
+- `ReplyFn` methods: `text`, `formatted`, `file`, `typing`, `redactMessage`, `buttons`
+- No business logic in adapters — they only bridge the platform to the bot layer
+- Formatting helpers (e.g. `telegram/format.ts`) convert LLM markdown to platform-native format

--- a/.github/instructions/commands.instructions.md
+++ b/.github/instructions/commands.instructions.md
@@ -1,0 +1,39 @@
+---
+applyTo: "src/commands/**"
+---
+
+# Command Handler Conventions
+
+## Pattern
+
+Commands are platform-agnostic handlers registered via `ChatProvider.registerCommand()`:
+
+```typescript
+export function registerXCommand(chat: ChatProvider): void {
+  const handler: CommandHandler = async (msg, reply, auth) => {
+    if (!auth.allowed) return  // Early auth check — always first
+    // Command logic...
+    await reply.text('Response')
+  }
+  chat.registerCommand('commandname', handler)
+}
+```
+
+## Rules
+
+- **Auth check first**: Always check `auth.allowed` before any logic
+- **No platform imports**: Command handlers must not import Telegram, Mattermost, or any platform-specific code
+- **Use injected `reply`**: Send responses via `reply.text()`, `reply.formatted()`, `reply.buttons()`, `reply.file()` — never platform APIs directly
+- **Admin commands**: Check `auth.isBotAdmin` for admin-only commands
+- **Group context**: Check `msg.contextType` and `auth.isGroupAdmin` for group-specific behavior
+- **Message data**: Access user info via `msg.user` (`{ id, username, isAdmin }`), context via `msg.contextId` and `msg.contextType`
+
+## Types
+
+- `CommandHandler`: `(msg: IncomingMessage, reply: ReplyFn, auth: AuthorizationResult) => Promise<void>`
+- `IncomingMessage`: `{ user: ChatUser, contextId: string, contextType: 'dm' | 'group', text: string, commandMatch: string, ... }`
+- `ReplyFn`: `{ text, formatted, file, typing, redactMessage, buttons }`
+
+## Registration
+
+Commands are registered in `src/bot.ts` via `setupBot(chat, adminUserId)`. Add new command registrations there.

--- a/.github/instructions/e2e-testing.instructions.md
+++ b/.github/instructions/e2e-testing.instructions.md
@@ -1,0 +1,42 @@
+---
+applyTo: "tests/e2e/**"
+---
+
+# E2E Testing Conventions
+
+E2E tests run against a real Kaneo instance in Docker. Global setup is handled automatically by `bun-test-setup.ts` — individual test files only need test logic.
+
+## Test Structure
+
+```typescript
+import { beforeEach, describe, expect, test } from 'bun:test'
+import type { KaneoConfig } from '../../src/providers/kaneo/client.js'
+import { createTestClient, type KaneoTestClient } from './kaneo-test-client.js'
+
+describe('Feature', () => {
+  let testClient: KaneoTestClient
+  let kaneoConfig: KaneoConfig
+
+  beforeEach(async () => {
+    testClient = createTestClient()
+    kaneoConfig = testClient.getKaneoConfig()
+    await testClient.cleanup()
+  })
+
+  test('does something', async () => {
+    const project = await testClient.createTestProject()
+    const task = await createTask(kaneoConfig, { title: 'Test', projectId: project.id })
+    testClient.trackTask(task.id)  // Track for automatic cleanup
+    expect(task.title).toBe('Test')
+  })
+})
+```
+
+## Rules
+
+- Use `KaneoTestClient` from `./kaneo-test-client.ts` for resource management
+- **Always** call `testClient.trackTask(taskId)` for tasks created outside the test client
+- Clean up in `beforeEach` via `testClient.cleanup()` — not `afterEach`
+- No `beforeAll`/`afterAll` needed — global setup handles Docker lifecycle
+- Do NOT mock anything — these tests hit real APIs
+- E2E tests are excluded from `bun test` via `bunfig.toml` — run with `bun test:e2e`

--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -1,0 +1,47 @@
+---
+applyTo: "src/**"
+---
+
+# General Source Conventions
+
+## Runtime & Language
+
+- **Bun** runtime (not Node) — no build step, TypeScript runs directly
+- **Strict TypeScript** with all safety flags (`tsconfig.json`)
+- **Zod v4** for all runtime validation
+- **Vercel AI SDK** (`ai` package) for LLM integration
+
+## Linting & Formatting
+
+- **oxlint** for linting, **oxfmt** for formatting (NOT ESLint/Prettier)
+- NEVER add lint-disable comments (`eslint-disable`, `@ts-ignore`, `@ts-nocheck`, `oxlint-disable`) — fix the underlying issue
+- Use `param !== undefined` (not `!!param`) for presence checks (strict-boolean-expressions)
+
+## Error Handling
+
+- Use `AppError` discriminated union from `src/errors.ts`
+- Error message extraction: `error instanceof Error ? error.message : String(error)`
+- Provider errors classified via `classify-error.ts` per provider
+- User-facing messages via `getUserMessage(appError)`
+
+## Logging (mandatory — pino with structured JSON)
+
+```typescript
+import { logger } from '../logger.js'
+const log = logger.child({ scope: 'module-name' })
+```
+
+| Level | Use for |
+|-------|---------|
+| `debug` | Function entry with parameters, internal state, API call initiation |
+| `info` | Successful completion of major operations, service call results |
+| `warn` | Invalid input, missing optional data, failed lookups, unauthorized attempts |
+| `error` | Caught exceptions, failed API calls — always include error message + context |
+
+- First argument: structured metadata object. Second argument: message string.
+- Never log API keys, tokens, or personal info.
+
+## Imports
+
+- Use `.js` extension in import paths (Bun ESM resolution)
+- Import types with `import type { ... }` when only used as types

--- a/.github/instructions/providers.instructions.md
+++ b/.github/instructions/providers.instructions.md
@@ -1,0 +1,68 @@
+---
+applyTo: "src/providers/**"
+---
+
+# Provider Conventions
+
+## Interface
+
+All providers implement `TaskProvider` from `src/providers/types.ts`. Core methods are required; optional methods are gated by `Capability` strings (e.g. `'tasks.archive'`, `'comments.create'`).
+
+## Operations
+
+- One file per domain in `operations/` subdirectory (tasks, comments, labels, projects, statuses, relations)
+- Function naming: `[provider][Entity][Action]` — e.g. `kaneoCreateTask`, `createYouTrackTask`
+- Parameters: `config` first, then entity-specific params (often grouped in an object)
+- Return normalized domain types from `src/providers/types.ts` (`Task`, `Project`, `Comment`, `Label`, `Status`)
+- Map provider-specific API responses to normalized types before returning
+
+## Schemas
+
+- Use **Zod v4** for all API request/response validation
+- Place schemas in `schemas/` subdirectory
+- Pattern: enums first, main schema object, then `export type X = z.infer<typeof XSchema>`
+- Use `.nullable()` for optional API fields, `.optional()` for fields that may be absent
+- Compose schemas with `.extend()` for related types at different detail levels
+
+## Error Handling
+
+- Each provider has a `classify-error.ts` that maps HTTP errors to `AppError` (discriminated union from `src/errors.ts`)
+- Use provider-specific `ClassifiedError` class wrapping `AppError`:
+  ```typescript
+  export class KaneoClassifiedError extends Error {
+    constructor(message: string, public readonly appError: AppError) {
+      super(message)
+      this.name = 'KaneoClassifiedError'
+    }
+  }
+  ```
+- Classify by HTTP status: 401/403 → `authFailed`, 404 → entity-specific not-found, 429 → `rateLimited`, 400 → `validationFailed`, 500+ → `unexpected`
+- Preserve context (taskId, projectId, etc.) in classified errors
+- Detect network errors via message pattern matching (`fetch`, `econnrefused`, `enotfound`)
+
+## Client
+
+- Provider-specific fetch wrapper in `client.ts`
+- Config type: `{ baseUrl: string, token/apiKey: string, ... }`
+- Kaneo: generic `kaneoFetch<T>()` with schema validation built in
+- YouTrack: `youtrackFetch()` returns raw data, callers validate with Zod
+
+## Logging (mandatory)
+
+Every function entry must have `logger.debug()` with all input parameters:
+
+```typescript
+const log = logger.child({ scope: 'provider:kaneo:tasks' })
+
+export async function kaneoCreateTask(config: KaneoConfig, workspaceId: string, params: CreateTaskParams): Promise<Task> {
+  log.debug({ workspaceId, title: params.title, projectId: params.projectId }, 'kaneoCreateTask')
+  // ...
+  log.info({ taskId: result.id, title: params.title }, 'Task created')
+  return result
+}
+```
+
+- `debug`: function entry with parameters
+- `info`: successful completion with result identifiers
+- `error`: caught exceptions with `error instanceof Error ? error.message : String(error)`
+- Use `param !== undefined` (not `!!param`) for boolean checks in log context

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,97 @@
+---
+applyTo: "tests/**"
+---
+
+# Testing Conventions
+
+Runtime: **Bun** test runner (`bun:test`). No Jest, no Vitest.
+
+## Test Helpers (use these, don't reinvent)
+
+| Helper | Location | Purpose |
+|--------|----------|---------|
+| `mockLogger()` | `tests/utils/test-helpers.ts` | Stubs pino logger globally |
+| `mockDrizzle()` | `tests/utils/test-helpers.ts` | Stubs `getDrizzleDb` for in-memory SQLite |
+| `setupTestDb()` | `tests/utils/test-helpers.ts` | Creates in-memory SQLite with all migrations |
+| `createMockReply()` | `tests/utils/test-helpers.ts` | Captures `reply.text()` calls for assertions |
+| `createDmMessage()` | `tests/utils/test-helpers.ts` | Factory for DM `IncomingMessage` |
+| `createGroupMessage()` | `tests/utils/test-helpers.ts` | Factory for group `IncomingMessage` |
+| `createAuth()` | `tests/utils/test-helpers.ts` | Factory for `AuthorizationResult` |
+| `createMockChat()` | `tests/utils/test-helpers.ts` | Mock `ChatProvider` capturing command registrations |
+| `mockMessageCache()` | `tests/utils/test-helpers.ts` | Test-local message cache (isolated from production) |
+| `createMockProvider()` | `tests/tools/mock-provider.ts` | Fully-stubbed `TaskProvider` with overridable methods |
+| `createMockTask()` | `tests/test-helpers.ts` | Factory for `Task` with `Partial<Task>` overrides |
+| `createMockProject()` | `tests/test-helpers.ts` | Factory for `Project` with overrides |
+| `createMockLabel()` | `tests/test-helpers.ts` | Factory for `Label` with overrides |
+| `createMockColumn()` | `tests/test-helpers.ts` | Factory for status column with overrides |
+| `schemaValidates()` | `tests/test-helpers.ts` | Tests tool input schemas accept/reject given data |
+| `getToolExecutor()` | `tests/test-helpers.ts` | Extracts tool `execute` function |
+| `setMockFetch()` | `tests/test-helpers.ts` | Global fetch mock for provider API tests |
+| `restoreFetch()` | `tests/test-helpers.ts` | Restores original `globalThis.fetch` |
+| `expectAppError()` | `tests/utils/test-helpers.ts` | Asserts error is `AppError` with expected user message |
+
+## Mocking Rules
+
+- NEVER mock `globalThis.fetch` directly — use `setMockFetch()` / `restoreFetch()` from `tests/test-helpers.ts`
+- NEVER use `spyOn().mockImplementation()` for module mocks — use mutable `let impl` pattern
+- Use `mock()` from `bun:test` for spy functions
+- Register mocks BEFORE importing code under test
+
+### Mutable Implementation Pattern
+
+```typescript
+import { mock } from 'bun:test'
+
+type GenerateTextResult = { output: { keep_indices: number[]; summary: string } }
+let generateTextImpl = (): Promise<GenerateTextResult> =>
+  Promise.resolve({ output: { keep_indices: [0, 1], summary: 'Summary' } })
+
+void mock.module('ai', () => ({
+  generateText: (..._args: unknown[]): Promise<GenerateTextResult> => generateTextImpl(),
+}))
+
+// Now import code under test
+import { functionUnderTest } from '../src/module.js'
+```
+
+Override per-test by reassigning `generateTextImpl`.
+
+## Mock Pollution Prevention
+
+`mock.module()` is global and permanent for the Bun process. This is the #1 source of false test failures.
+
+1. **Check before mocking:** `grep -r "from.*src/foo.js" tests/ --include="*.test.ts" -l` — if other files import it unmocked, your mock will break them
+2. **Mock the narrowest dependency:** Prefer mocking `db/drizzle.js` over `config.js` or `cache.js`
+3. **Always clean up:** Add `afterAll(() => { mock.restore() })` if mocking modules used by other test files
+4. **Verify full suite:** Run `bun test` (not just `bun test tests/your-file.test.ts`) to catch pollution
+5. **Run checker:** `bun run mock-pollution` after adding new mocks
+
+## Test Structure
+
+```typescript
+describe('Feature', () => {
+  beforeEach(() => {
+    mock.restore()
+  })
+
+  describe('specificFunction', () => {
+    test('returns expected result', async () => { ... })
+    test('validates required parameters', () => { ... })
+    test('propagates API errors', async () => { ... })
+  })
+})
+```
+
+## Schema Validation Testing
+
+```typescript
+expect(schemaValidates(tool, {})).toBe(false)           // missing required fields
+expect(schemaValidates(tool, { taskId: 'x' })).toBe(true) // valid input
+```
+
+## Error Assertions
+
+```typescript
+const promise = getToolExecutor(tool)({ taskId: 'x' }, { toolCallId: '1', messages: [] })
+await expect(promise).rejects.toThrow('Expected message')
+```

--- a/.github/instructions/tools.instructions.md
+++ b/.github/instructions/tools.instructions.md
@@ -1,0 +1,75 @@
+---
+applyTo: "src/tools/**"
+---
+
+# Tool Conventions
+
+## Definition Pattern
+
+Tools use the Vercel AI SDK `tool()` factory from the `ai` package:
+
+```typescript
+import { tool } from 'ai'
+import type { ToolSet } from 'ai'
+import { z } from 'zod'
+
+const log = logger.child({ scope: 'tool:tool-name' })
+
+export function makeToolNameTool(provider: TaskProvider): ToolSet[string] {
+  return tool({
+    description: 'Clear description of what the tool does',
+    inputSchema: z.object({
+      requiredField: z.string().describe('What this field represents'),
+      optionalField: z.string().optional().describe('Optional field description'),
+    }),
+    execute: async ({ requiredField, optionalField }) => {
+      try {
+        const result = await provider.someMethod({ requiredField, optionalField })
+        log.info({ resultId: result.id }, 'Action completed')
+        return result
+      } catch (error) {
+        log.error(
+          { error: error instanceof Error ? error.message : String(error), tool: 'tool_name' },
+          'Tool execution failed',
+        )
+        throw error
+      }
+    },
+  })
+}
+```
+
+## Naming
+
+- Factory function: `make[Action]Tool` — e.g. `makeCreateTaskTool`, `makeSearchTasksTool`
+- Tool key in toolset: `snake_case` — e.g. `create_task`, `search_tasks`, `add_comment`
+- One tool per file in `src/tools/`
+
+## Input Schema
+
+- Use `.describe()` on every field — the LLM reads these descriptions to decide how to call the tool
+- Use Zod v4 types: `z.string()`, `z.number()`, `z.enum()`, `z.boolean()`
+- Mark optional fields with `.optional()`
+- Do NOT add default values in schemas — let the LLM decide
+
+## Capability Gating
+
+Tools are assembled in `src/tools/index.ts` via `makeTools(provider)`. Optional tools are added only if the provider supports the required capability:
+
+```typescript
+if (provider.capabilities.has('tasks.archive')) {
+  tools['archive_task'] = makeArchiveTaskTool(provider)
+}
+```
+
+Core tools (create, get, update, list, search tasks) are always included.
+
+## Destructive Actions
+
+Tools for destructive actions (archive, delete) must include a `confidence` field (0-1 float). If confidence < 0.85, return `{ status: 'confirmation_required', message: '...' }` instead of executing. Never leak the threshold value in the message.
+
+## Logging (mandatory)
+
+- `log.info()` on successful execution with result identifiers
+- `log.error()` on caught exceptions with error message and tool name
+- Error message extraction: `error instanceof Error ? error.message : String(error)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,358 +164,32 @@ Tools are capability-gated: only tools supported by the active provider are expo
 | `delete_status`        | `statuses.delete`   | Delete a status column from a project                                        |
 | `reorder_statuses`     | `statuses.reorder`  | Reorder status columns in a project                                          |
 
-## Logging Requirements (HIGH PRIORITY)
+## Logging
 
-Logging is **mandatory** for debugging and operational visibility. The logger uses pino with structured JSON output. Every significant action, state change, and error must be logged.
+Logging is **mandatory**. Uses pino with structured JSON output. See `src/tools/CLAUDE.md`, `src/providers/CLAUDE.md` for path-specific rules.
 
-### When to Use Each Log Level
+Quick reference:
 
-#### `logger.debug()` — Detailed diagnostics
-
-Use for:
-
-- Function entry points with all input parameters (use `param !== undefined` not `!!param`)
-- Internal state transitions
-- API call initiation and raw responses
-- Authorization checks
-- Tool execution entry
-- Example: `logger.debug({ userId, historyLength }, 'Calling generateText')`
-
-#### `logger.info()` — Significant events
-
-Use for:
-
-- Successful completion of major operations (task created/updated, search completed)
-- External service calls with result summaries
-- User session lifecycle events
-- Example: `logger.info({ taskId, title }, 'Task created')`
-
-#### `logger.warn()` — Unexpected but recoverable
-
-Use for:
-
-- Invalid input that won't crash the app
-- Missing optional data
-- Failed lookups (columns not found)
-- Resource limits reached (history truncation)
-- Unauthorized access attempts
-- API returning incomplete data
-- Example: `logger.warn({ taskId, requestedStatus }, 'Column not found')`
-
-#### `logger.error()` — Failures requiring attention
-
-Use for:
-
-- All caught exceptions
-- Failed external API calls
-- Critical operation failures
-- Always include error message and context
-- Example: `logger.error({ error: error.message, userId }, 'Error generating response')`
-
-### Log Format Rules
-
-1. **Always use structured logging**: Pass metadata as first argument object, message as second
-2. **Include context**: userId, identifiers, counts, booleans for presence checks
-3. **Never log sensitive data**: No API keys, tokens, or personal info in logs
-4. **Use explicit undefined checks**: `field !== undefined` not `!!field` (strict-boolean-expressions)
-5. **Keep messages concise**: One clear action verb phrase
-
-### Required Logging Locations
-
-Every file must import and use the logger. Required log points:
-
-- All function entries in `src/providers/kaneo/`
-- All tool executions in `src/tools/`
-- Message lifecycle in `bot.ts` (receive, process, respond)
-- Authorization checks
-- Error catch blocks
+- `debug`: function entry with parameters, internal state, API calls
+- `info`: successful major operations, service call results
+- `warn`: invalid input, failed lookups, unauthorized attempts
+- `error`: caught exceptions, failed API calls — always include error message + context
+- Format: `logger.debug({ userId, count }, 'Message')` — structured metadata first, message second
+- Use `param !== undefined` not `!!param` (strict-boolean-expressions)
+- Never log API keys, tokens, or personal info
 
 ## Testing
 
-Tests are located in the `tests/` directory:
-
-```
-tests/
-├── *.test.ts         # Unit tests (run with bun run test)
-├── providers/        # Unit tests for src/providers/*
-│   ├── kaneo/
-│   └── youtrack/
-├── tools/            # Unit tests for src/tools/*
-└── e2e/              # E2E tests (run with bun run test:e2e)
-```
-
-For unit tests, use `bun run test`.
-
-### Mocking External Modules
-
-When mocking modules like the Vercel AI SDK, use **module-level mocking** with a mutable function reference instead of `spyOn().mockImplementation()`. This pattern avoids TypeScript type assertion errors and lint violations.
-
-**Pattern (used in `tests/memory.test.ts` and `tests/conversation.test.ts`):**
-
-```typescript
-// Define local type and mutable implementation
-import { mock } from 'bun:test'
-import type { ModelMessage } from 'ai'
-
-type GenerateTextResult = { output: { keep_indices: number[]; summary: string } }
-let generateTextImpl = (): Promise<GenerateTextResult> =>
-  Promise.resolve({ output: { keep_indices: [0, 1], summary: 'Updated summary text' } })
-
-// Mock the module BEFORE importing code that uses it
-void mock.module('ai', () => ({
-  generateText: (..._args: unknown[]): Promise<GenerateTextResult> => generateTextImpl(),
-  Output: { object: ({ schema: s }: { schema: unknown }): { schema: unknown } => ({ schema: s }) },
-}))
-
-// Now import the code under test
-import { runTrimInBackground } from '../src/conversation.js'
-```
-
-**Benefits:**
-
-- No type assertions (`as SomeType`) needed
-- No `typescript-eslint(no-unsafe-type-assertion)` violations
-- Tests control behavior by reassigning `generateTextImpl`
-- Clean TypeScript types without generic complexity
-- Consistent with existing test patterns in the codebase
-
-**Example test with different behaviors:**
-
-```typescript
-test('success case', async () => {
-  // Uses default generateTextImpl
-  await runTrimInBackground('user1', history)
-})
-
-test('error case', async () => {
-  // Override for this test
-  generateTextImpl = (): Promise<GenerateTextResult> => Promise.reject(new Error('LLM API error'))
-  await runTrimInBackground('user1', history)
-})
-
-test('custom response', async () => {
-  generateTextImpl = (): Promise<GenerateTextResult> =>
-    Promise.resolve({ output: { keep_indices: [0], summary: 'Custom' } })
-  await runTrimInBackground('user1', history)
-})
-```
-
-See `tests/memory.test.ts` and `tests/conversation.test.ts` for full examples.
-
-### Mock Pollution Prevention (HIGH PRIORITY)
-
-`mock.module()` in Bun replaces the module **globally for the entire process** — not just for the current test file. When `bun test` runs multiple files in a single process, a mock registered in file A permanently replaces the real module for every subsequent file B, C, D… that imports the same module. This causes tests that pass individually (`bun test tests/foo.test.ts`) to fail when run as part of the full suite (`bun test`).
-
-**This is the #1 source of false test failures in this codebase. Every new test file must follow these rules.**
-
-#### Rule 1: Never mock a module that another test file also imports directly
-
-Before adding `void mock.module('../src/foo.js', ...)` to your test file, check whether other test files import `../src/foo.js` **without** mocking it. If they do, your mock will silently break those tests when the full suite runs.
-
-```bash
-# Check who imports a module you want to mock
-grep -r "from.*src/config.js" tests/ --include="*.test.ts" -l
-```
-
-If the module is already imported directly by other test files, you must either:
-
-- Use dependency injection instead of mocking the module
-- Mock at a lower level (mock the module's dependencies instead)
-- Accept that you need `mock.restore()` cleanup (see Rule 3)
-
-#### Rule 2: Mock the narrowest possible dependency
-
-Don't mock high-level modules (`config.js`, `cache.js`, `history.js`) when you can mock what they depend on (`db/drizzle.js`). High-level module mocks break more consumers.
-
-**Bad** — mocks `config.js`, breaking every other file that imports it:
-
-```typescript
-void mock.module('../src/config.js', () => ({
-  getConfig: () => 'test-value',
-}))
-```
-
-**Good** — mocks only the database layer, letting `config.js` work normally:
-
-```typescript
-void mock.module('../src/db/drizzle.js', () => ({
-  getDrizzleDb: () => testDb,
-}))
-```
-
-#### Rule 3: Always clean up mocks that shadow shared modules
-
-If you must mock a module that other test files also use, register cleanup in `afterAll`:
-
-```typescript
-import { mock, afterAll } from 'bun:test'
-
-void mock.module('../src/config.js', () => ({ getConfig: () => 'test' }))
-
-afterAll(() => {
-  mock.restore()
-})
-```
-
-**Note:** `mock.restore()` restores **all** mocked modules, not just one. Call it in `afterAll` (runs once after all tests in the file), not in `afterEach` (which would break inter-test mock state within the file).
-
-#### Rule 4: Prefer test helpers over ad-hoc mocks
-
-Use the shared helpers that already exist:
-
-| Helper                 | Location                       | Purpose                                                              |
-| ---------------------- | ------------------------------ | -------------------------------------------------------------------- |
-| `mockLogger()`         | `tests/utils/test-helpers.ts`  | Stubs logger — safe because every test file that needs it calls this |
-| `mockDrizzle()`        | `tests/utils/test-helpers.ts`  | Stubs `getDrizzleDb` — the standard way to mock the database         |
-| `setupTestDb()`        | `tests/utils/test-helpers.ts`  | Creates in-memory SQLite with all migrations                         |
-| `createMockProvider()` | `tests/tools/mock-provider.ts` | Creates a mock `TaskProvider` without touching the module registry   |
-
-Before writing a new `void mock.module(...)`, check whether a helper already covers your case.
-
-#### Rule 5: Test files that mock many modules should be self-contained
-
-If a test requires mocking 4+ modules (e.g., `llm-orchestrator-process.test.ts` mocks `config.js`, `cache.js`, `history.js`, `conversation.js`, `memory.js`, `ai`, etc.), that test is high-risk for pollution. Mitigate by:
-
-1. Adding `afterAll(() => { mock.restore() })` at the end of the file
-2. Documenting which modules are mocked in a comment at the top of the file
-3. Verifying the full suite still passes: `bun test` (not just `bun test tests/your-file.test.ts`)
-
-#### Rule 6: Beware transitive mock pollution through source file chains
-
-When test file A mocks `src/db/drizzle.js`, test file B can be affected even if B never imports `drizzle.js` directly — as long as something B imports (e.g. `src/poller.ts`) imports something that imports `drizzle.js`. The `scripts/check-mock-pollution.ts` script detects this automatically (Pattern 3).
-
-To prevent transitive pollution, always add `afterAll(() => { mock.restore() })` to any test that mocks a module imported (directly or indirectly) by source files:
-
-```typescript
-afterAll(() => {
-  mock.restore()
-})
-```
-
-Run `bun run mock-pollution` after adding new mocks to verify the suite is still clean.
-
-#### Quick checklist for new test files
-
-- [ ] Mocks are registered **before** imports of code under test
-- [ ] Only modules that the test directly needs are mocked — no unnecessary overrides
-- [ ] `mock.restore()` is called in `afterAll` if the file mocks modules used by other test files
-- [ ] `bun test` (full suite) passes, not just the individual file
-- [ ] Mutable implementation pattern is used (reassignable `let impl = ...`) instead of inline mock return values that can't be changed per-test
-
-## E2E Testing
-
-E2E tests run against a real Kaneo instance in Docker using the existing `docker-compose.yml` setup. They verify the actual integration between papai's tools and the Kaneo API.
-
-### Prerequisites
-
-Ensure your `.env` file has the required Kaneo environment variables:
-
-- `KANEO_POSTGRES_PASSWORD`
-- `KANEO_AUTH_SECRET`
-- `KANEO_CLIENT_URL`
-
-### Running E2E Tests
-
-```bash
-# Run all e2e tests (Docker containers start/stop automatically)
-bun run test:e2e
-
-# Run in watch mode
-bun run test:e2e:watch
-```
-
-### E2E Test Structure
-
-- `tests/e2e/bun-test-setup.ts` - Global setup (Docker, provisioning) loaded via `--preload`
-- `tests/e2e/global-setup.ts` - Setup logic and config management
-- `tests/e2e/e2e.test.ts` - Orchestrator that imports all test suites
-- `tests/e2e/kaneo-test-client.ts` - Test utilities and resource cleanup
-- `tests/e2e/*.test.ts` - Individual e2e test files (no setup/teardown needed)
-- Uses existing `docker-compose.yml` + `docker-compose.test.yml` (no new compose files needed)
-
-### Writing E2E Tests
-
-Global setup is handled automatically by `bun-test-setup.ts`. Individual test files only need to focus on test logic:
-
-1. Use `KaneoTestClient` for resource management
-2. Call `testClient.trackTask(taskId)` for automatic cleanup
-3. Clean up in `beforeEach` for test isolation
-4. No need for `beforeAll`/`afterAll` - setup is global
-
-Example:
-
-```typescript
-import { beforeEach, describe, expect, test } from 'bun:test'
-import type { KaneoConfig } from '../../src/providers/kaneo/client.js'
-import { createTestClient, type KaneoTestClient } from './kaneo-test-client.js'
-
-describe('My Feature', () => {
-  let testClient: KaneoTestClient
-  let kaneoConfig: KaneoConfig
-
-  beforeEach(async () => {
-    testClient = createTestClient()
-    kaneoConfig = testClient.getKaneoConfig()
-    await testClient.cleanup()
-  })
-
-  test('does something', async () => {
-    // Your test here - example:
-    // const task = await createTask(kaneoConfig, { title: 'Test', projectId })
-    // testClient.trackTask(task.id)
-  })
-})
-```
-
-### Environment Variables
-
-Create `tests/e2e/.env.e2e` from `.env.e2e.example`:
-
-- `E2E_KANEO_URL` - URL of the Kaneo instance (defaults to `KANEO_INTERNAL_URL` or `http://localhost:11337`)
-
-### Running E2E Tests in CI
-
-E2E tests run automatically in GitHub Actions on every push and PR. The CI workflow:
-
-1. Sets up Docker using `docker/setup-buildx-action`
-2. Creates required environment variables (`KANEO_POSTGRES_PASSWORD`, `KANEO_AUTH_SECRET`, `KANEO_CLIENT_URL`)
-3. Runs `bun run test:e2e` which automatically manages Docker containers
-
-The CI configuration is in `.github/workflows/ci.yml`.
-
-### E2E Test Coverage
-
-All Kaneo API operations are covered by E2E tests:
-
-#### Task Operations
-
-- `task-lifecycle.test.ts` - Create, read, update tasks
-- `task-comments.test.ts` - Add, get, update, remove comments
-- `task-relations.test.ts` - blocks, blocked_by, duplicate, related, parent relations
-- `task-archive.test.ts` - Archive with labels
-- `task-search.test.ts` - Search by keyword, status, priority, filters
-
-#### Project Operations
-
-- `project-lifecycle.test.ts` - Create, list, update
-- `project-archive.test.ts` - Archive projects
-
-#### Column Operations
-
-- `column-management.test.ts` - Create, update, delete, reorder columns
-
-#### Label Operations
-
-- `label-management.test.ts` - Create, update labels, add/remove from tasks
-- `label-operations.test.ts` - Full label CRUD and task associations
-
-#### Error Handling
-
-- `error-handling.test.ts` - 404, 400, validation errors, edge cases
-
-#### User Workflows
-
-- `user-workflows.test.ts` - Full lifecycle, project setup, dependencies, sprints, bulk ops
+See `tests/CLAUDE.md` for detailed testing conventions, mocking rules, and mock pollution prevention.
+
+Quick reference:
+
+- `bun test` — unit tests (excludes E2E)
+- `bun test:e2e` — E2E tests (requires Docker)
+- Use shared helpers from `tests/utils/test-helpers.ts` and `tests/tools/mock-provider.ts`
+- Use mutable `let impl` pattern for module mocks (not `spyOn().mockImplementation()`)
+- `mock.module()` is global — always add `afterAll(() => { mock.restore() })` for shared modules
+- Run `bun run mock-pollution` after adding new mocks
 
 ## Key Conventions
 
@@ -527,3 +201,18 @@ All Kaneo API operations are covered by E2E tests:
 - Strict TypeScript (`tsconfig.json` has strict mode + all safety flags)
 - Logging: **pino** with structured JSON output
 - Tests: Located in `tests/` directory, mirroring `src/` structure
+- NEVER add lint-disable comments (`eslint-disable`, `@ts-ignore`, `@ts-nocheck`, `oxlint-disable`) — fix the underlying issue
+- Use `.js` extension in import paths (Bun ESM resolution)
+- Error message extraction: `error instanceof Error ? error.message : String(error)`
+
+## Path-Scoped Conventions
+
+Detailed conventions live in subdirectory `CLAUDE.md` files (loaded by Claude Code and opencode) and `.github/instructions/*.instructions.md` files (loaded by GitHub Copilot):
+
+| Path | Covers |
+|------|--------|
+| `src/providers/CLAUDE.md` | TaskProvider interface, operations, schemas, error classification |
+| `src/tools/CLAUDE.md` | Tool definitions, capability gating, destructive actions |
+| `src/commands/CLAUDE.md` | Command handler pattern, auth checks, ReplyFn |
+| `src/chat/CLAUDE.md` | ChatProvider interface, platform adapters |
+| `tests/CLAUDE.md` | Test helpers, mocking rules, mock pollution, E2E testing |

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@ekroon/opencode-copilot-instructions"]
+}

--- a/src/chat/CLAUDE.md
+++ b/src/chat/CLAUDE.md
@@ -1,0 +1,28 @@
+# Chat Adapter Conventions
+
+## Interface
+
+All chat adapters implement `ChatProvider` from `src/chat/types.ts`:
+
+```typescript
+interface ChatProvider {
+  name: string
+  registerCommand(name: string, handler: CommandHandler): void
+  onMessage(handler: (msg: IncomingMessage, reply: ReplyFn) => Promise<void>): void
+  sendMessage(contextId: string, text: string): Promise<void>
+  start(): Promise<void>
+  stop(): Promise<void>
+}
+```
+
+## Registration
+
+Adapters register in `src/chat/registry.ts` via `createChatProvider(name)`. Built-in: `telegram`, `mattermost`.
+
+## Rules
+
+- Platform-specific code stays inside the adapter directory (`telegram/`, `mattermost/`)
+- Adapters must map platform events to `IncomingMessage` and provide a `ReplyFn`
+- `ReplyFn` methods: `text`, `formatted`, `file`, `typing`, `redactMessage`, `buttons`
+- No business logic in adapters — they only bridge the platform to the bot layer
+- Formatting helpers (e.g. `telegram/format.ts`) convert LLM markdown to platform-native format

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -1,0 +1,35 @@
+# Command Handler Conventions
+
+## Pattern
+
+Commands are platform-agnostic handlers registered via `ChatProvider.registerCommand()`:
+
+```typescript
+export function registerXCommand(chat: ChatProvider): void {
+  const handler: CommandHandler = async (msg, reply, auth) => {
+    if (!auth.allowed) return  // Early auth check — always first
+    // Command logic...
+    await reply.text('Response')
+  }
+  chat.registerCommand('commandname', handler)
+}
+```
+
+## Rules
+
+- **Auth check first**: Always check `auth.allowed` before any logic
+- **No platform imports**: Command handlers must not import Telegram, Mattermost, or any platform-specific code
+- **Use injected `reply`**: Send responses via `reply.text()`, `reply.formatted()`, `reply.buttons()`, `reply.file()` — never platform APIs directly
+- **Admin commands**: Check `auth.isBotAdmin` for admin-only commands
+- **Group context**: Check `msg.contextType` and `auth.isGroupAdmin` for group-specific behavior
+- **Message data**: Access user info via `msg.user` (`{ id, username, isAdmin }`), context via `msg.contextId` and `msg.contextType`
+
+## Types
+
+- `CommandHandler`: `(msg: IncomingMessage, reply: ReplyFn, auth: AuthorizationResult) => Promise<void>`
+- `IncomingMessage`: `{ user: ChatUser, contextId: string, contextType: 'dm' | 'group', text: string, commandMatch: string, ... }`
+- `ReplyFn`: `{ text, formatted, file, typing, redactMessage, buttons }`
+
+## Registration
+
+Commands are registered in `src/bot.ts` via `setupBot(chat, adminUserId)`. Add new command registrations there.

--- a/src/providers/CLAUDE.md
+++ b/src/providers/CLAUDE.md
@@ -1,0 +1,56 @@
+# Provider Conventions
+
+## Interface
+
+All providers implement `TaskProvider` from `src/providers/types.ts`. Core methods are required; optional methods are gated by `Capability` strings (e.g. `'tasks.archive'`, `'comments.create'`).
+
+## Operations
+
+- One file per domain in `operations/` subdirectory (tasks, comments, labels, projects, statuses, relations)
+- Function naming: `[provider][Entity][Action]` — e.g. `kaneoCreateTask`, `createYouTrackTask`
+- Parameters: `config` first, then entity-specific params (often grouped in an object)
+- Return normalized domain types from `src/providers/types.ts` (`Task`, `Project`, `Comment`, `Label`, `Status`)
+- Map provider-specific API responses to normalized types before returning
+
+## Schemas
+
+- Use **Zod v4** for all API request/response validation
+- Place schemas in `schemas/` subdirectory
+- Pattern: enums first, main schema object, then `export type X = z.infer<typeof XSchema>`
+- Use `.nullable()` for optional API fields, `.optional()` for fields that may be absent
+- Compose schemas with `.extend()` for related types at different detail levels
+
+## Error Handling
+
+- Each provider has a `classify-error.ts` that maps HTTP errors to `AppError` (discriminated union from `src/errors.ts`)
+- Use provider-specific `ClassifiedError` class wrapping `AppError`
+- Classify by HTTP status: 401/403 → `authFailed`, 404 → entity-specific not-found, 429 → `rateLimited`, 400 → `validationFailed`, 500+ → `unexpected`
+- Preserve context (taskId, projectId, etc.) in classified errors
+- Detect network errors via message pattern matching (`fetch`, `econnrefused`, `enotfound`)
+
+## Client
+
+- Provider-specific fetch wrapper in `client.ts`
+- Config type: `{ baseUrl: string, token/apiKey: string, ... }`
+- Kaneo: generic `kaneoFetch<T>()` with schema validation built in
+- YouTrack: `youtrackFetch()` returns raw data, callers validate with Zod
+
+## Logging (mandatory)
+
+Every function entry must have `logger.debug()` with all input parameters:
+
+```typescript
+const log = logger.child({ scope: 'provider:kaneo:tasks' })
+
+export async function kaneoCreateTask(config: KaneoConfig, workspaceId: string, params: CreateTaskParams): Promise<Task> {
+  log.debug({ workspaceId, title: params.title, projectId: params.projectId }, 'kaneoCreateTask')
+  // ...
+  log.info({ taskId: result.id, title: params.title }, 'Task created')
+  return result
+}
+```
+
+- `debug`: function entry with parameters
+- `info`: successful completion with result identifiers
+- `error`: caught exceptions with `error instanceof Error ? error.message : String(error)`
+- Use `param !== undefined` (not `!!param`) for boolean checks in log context

--- a/src/tools/CLAUDE.md
+++ b/src/tools/CLAUDE.md
@@ -1,0 +1,71 @@
+# Tool Conventions
+
+## Definition Pattern
+
+Tools use the Vercel AI SDK `tool()` factory from the `ai` package:
+
+```typescript
+import { tool } from 'ai'
+import type { ToolSet } from 'ai'
+import { z } from 'zod'
+
+const log = logger.child({ scope: 'tool:tool-name' })
+
+export function makeToolNameTool(provider: TaskProvider): ToolSet[string] {
+  return tool({
+    description: 'Clear description of what the tool does',
+    inputSchema: z.object({
+      requiredField: z.string().describe('What this field represents'),
+      optionalField: z.string().optional().describe('Optional field description'),
+    }),
+    execute: async ({ requiredField, optionalField }) => {
+      try {
+        const result = await provider.someMethod({ requiredField, optionalField })
+        log.info({ resultId: result.id }, 'Action completed')
+        return result
+      } catch (error) {
+        log.error(
+          { error: error instanceof Error ? error.message : String(error), tool: 'tool_name' },
+          'Tool execution failed',
+        )
+        throw error
+      }
+    },
+  })
+}
+```
+
+## Naming
+
+- Factory function: `make[Action]Tool` — e.g. `makeCreateTaskTool`, `makeSearchTasksTool`
+- Tool key in toolset: `snake_case` — e.g. `create_task`, `search_tasks`, `add_comment`
+- One tool per file in `src/tools/`
+
+## Input Schema
+
+- Use `.describe()` on every field — the LLM reads these descriptions to decide how to call the tool
+- Use Zod v4 types: `z.string()`, `z.number()`, `z.enum()`, `z.boolean()`
+- Mark optional fields with `.optional()`
+- Do NOT add default values in schemas — let the LLM decide
+
+## Capability Gating
+
+Tools are assembled in `src/tools/index.ts` via `makeTools(provider)`. Optional tools are added only if the provider supports the required capability:
+
+```typescript
+if (provider.capabilities.has('tasks.archive')) {
+  tools['archive_task'] = makeArchiveTaskTool(provider)
+}
+```
+
+Core tools (create, get, update, list, search tasks) are always included.
+
+## Destructive Actions
+
+Tools for destructive actions (archive, delete) must include a `confidence` field (0-1 float). If confidence < 0.85, return `{ status: 'confirmation_required', message: '...' }` instead of executing. Never leak the threshold value in the message.
+
+## Logging (mandatory)
+
+- `log.info()` on successful execution with result identifiers
+- `log.error()` on caught exceptions with error message and tool name
+- Error message extraction: `error instanceof Error ? error.message : String(error)`

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,132 @@
+# Testing Conventions
+
+Runtime: **Bun** test runner (`bun:test`). No Jest, no Vitest.
+
+## Test Helpers (use these, don't reinvent)
+
+| Helper | Location | Purpose |
+|--------|----------|---------|
+| `mockLogger()` | `tests/utils/test-helpers.ts` | Stubs pino logger globally |
+| `mockDrizzle()` | `tests/utils/test-helpers.ts` | Stubs `getDrizzleDb` for in-memory SQLite |
+| `setupTestDb()` | `tests/utils/test-helpers.ts` | Creates in-memory SQLite with all migrations |
+| `createMockReply()` | `tests/utils/test-helpers.ts` | Captures `reply.text()` calls for assertions |
+| `createDmMessage()` | `tests/utils/test-helpers.ts` | Factory for DM `IncomingMessage` |
+| `createGroupMessage()` | `tests/utils/test-helpers.ts` | Factory for group `IncomingMessage` |
+| `createAuth()` | `tests/utils/test-helpers.ts` | Factory for `AuthorizationResult` |
+| `createMockChat()` | `tests/utils/test-helpers.ts` | Mock `ChatProvider` capturing command registrations |
+| `mockMessageCache()` | `tests/utils/test-helpers.ts` | Test-local message cache (isolated from production) |
+| `createMockProvider()` | `tests/tools/mock-provider.ts` | Fully-stubbed `TaskProvider` with overridable methods |
+| `createMockTask()` | `tests/test-helpers.ts` | Factory for `Task` with `Partial<Task>` overrides |
+| `createMockProject()` | `tests/test-helpers.ts` | Factory for `Project` with overrides |
+| `createMockLabel()` | `tests/test-helpers.ts` | Factory for `Label` with overrides |
+| `createMockColumn()` | `tests/test-helpers.ts` | Factory for status column with overrides |
+| `schemaValidates()` | `tests/test-helpers.ts` | Tests tool input schemas accept/reject given data |
+| `getToolExecutor()` | `tests/test-helpers.ts` | Extracts tool `execute` function |
+| `setMockFetch()` | `tests/test-helpers.ts` | Global fetch mock for provider API tests |
+| `restoreFetch()` | `tests/test-helpers.ts` | Restores original `globalThis.fetch` |
+| `expectAppError()` | `tests/utils/test-helpers.ts` | Asserts error is `AppError` with expected user message |
+
+## Mocking Rules
+
+- NEVER mock `globalThis.fetch` directly — use `setMockFetch()` / `restoreFetch()` from `tests/test-helpers.ts`
+- NEVER use `spyOn().mockImplementation()` for module mocks — use mutable `let impl` pattern
+- Use `mock()` from `bun:test` for spy functions
+- Register mocks BEFORE importing code under test
+
+### Mutable Implementation Pattern
+
+```typescript
+import { mock } from 'bun:test'
+
+type GenerateTextResult = { output: { keep_indices: number[]; summary: string } }
+let generateTextImpl = (): Promise<GenerateTextResult> =>
+  Promise.resolve({ output: { keep_indices: [0, 1], summary: 'Summary' } })
+
+void mock.module('ai', () => ({
+  generateText: (..._args: unknown[]): Promise<GenerateTextResult> => generateTextImpl(),
+}))
+
+// Now import code under test
+import { functionUnderTest } from '../src/module.js'
+```
+
+Override per-test by reassigning `generateTextImpl`.
+
+## Mock Pollution Prevention (HIGH PRIORITY)
+
+`mock.module()` is global and permanent for the Bun process. This is the #1 source of false test failures.
+
+### Rules
+
+1. **Check before mocking:** `grep -r "from.*src/foo.js" tests/ --include="*.test.ts" -l` — if other files import it unmocked, your mock will break them
+2. **Mock the narrowest dependency:** Prefer mocking `db/drizzle.js` over `config.js` or `cache.js`
+3. **Always clean up:** Add `afterAll(() => { mock.restore() })` if mocking modules used by other test files. `mock.restore()` restores **all** mocked modules — call in `afterAll`, not `afterEach`
+4. **Prefer test helpers:** Check `tests/utils/test-helpers.ts` and `tests/tools/mock-provider.ts` before writing new `mock.module()` calls
+5. **Self-contained heavy mockers:** Files mocking 4+ modules must add `afterAll(() => { mock.restore() })` and document mocked modules at top of file
+6. **Beware transitive pollution:** Mocking `src/db/drizzle.js` affects any file that transitively imports it. Run `bun run mock-pollution` after adding new mocks
+7. **Verify full suite:** Run `bun test` (not just `bun test tests/your-file.test.ts`)
+
+### Checklist for new test files
+
+- [ ] Mocks registered **before** imports of code under test
+- [ ] Only directly needed modules are mocked
+- [ ] `mock.restore()` in `afterAll` if mocking shared modules
+- [ ] `bun test` (full suite) passes
+- [ ] Mutable `let impl` pattern used (not inline return values)
+
+## Test Structure
+
+```typescript
+describe('Feature', () => {
+  beforeEach(() => {
+    mock.restore()
+  })
+
+  describe('specificFunction', () => {
+    test('returns expected result', async () => { ... })
+    test('validates required parameters', () => { ... })
+    test('propagates API errors', async () => { ... })
+  })
+})
+```
+
+## Schema Validation Testing
+
+```typescript
+expect(schemaValidates(tool, {})).toBe(false)           // missing required fields
+expect(schemaValidates(tool, { taskId: 'x' })).toBe(true) // valid input
+```
+
+## E2E Testing
+
+E2E tests run against a real Kaneo instance in Docker. Global setup is handled by `bun-test-setup.ts`.
+
+```typescript
+import { beforeEach, describe, expect, test } from 'bun:test'
+import type { KaneoConfig } from '../../src/providers/kaneo/client.js'
+import { createTestClient, type KaneoTestClient } from './kaneo-test-client.js'
+
+describe('Feature', () => {
+  let testClient: KaneoTestClient
+  let kaneoConfig: KaneoConfig
+
+  beforeEach(async () => {
+    testClient = createTestClient()
+    kaneoConfig = testClient.getKaneoConfig()
+    await testClient.cleanup()
+  })
+
+  test('does something', async () => {
+    const project = await testClient.createTestProject()
+    const task = await createTask(kaneoConfig, { title: 'Test', projectId: project.id })
+    testClient.trackTask(task.id)
+  })
+})
+```
+
+- Use `KaneoTestClient` for resource management
+- **Always** call `testClient.trackTask(taskId)` for tasks created outside the test client
+- Clean up in `beforeEach` — not `afterEach`
+- No `beforeAll`/`afterAll` needed — Docker lifecycle is global
+- Do NOT mock anything in E2E tests
+- Run with `bun test:e2e` (excluded from `bun test`)


### PR DESCRIPTION
Create .github/instructions/*.instructions.md files with YAML frontmatter
applyTo globs, following the strategy from docs/llm-guidance-research.md.
These files provide contextual conventions to any LLM tool (Claude Code,
Copilot, OpenCode, Cursor) only when touching relevant files, keeping the
context window lean.

Files: general (src/**), providers, tools, commands, chat-adapters,
testing, e2e-testing. Updated copilot-instructions.md with a reference
table.

https://claude.ai/code/session_014nFArqwfiKmLR6SaHwySmm