### PR TITLE
Add /announce admin command to send announcements to all registered users

### DIFF
--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -46,8 +46,21 @@ export function registerAdminCommands(chat: ChatProvider, adminUserId: string): 
     await handleUsersCommand(reply, msg.user.id, adminUserId)
   }
 
+  const announceHandler: CommandHandler = async (msg, reply) => {
+    if (msg.contextType === 'group') {
+      await reply.text('This command is only available in direct messages.')
+      return
+    }
+    if (!checkAdmin(msg.user.id)) {
+      await reply.text('Only the admin can send announcements.')
+      return
+    }
+    await handleAnnounce(chat, reply, msg)
+  }
+
   chat.registerCommand('user', userHandler)
   chat.registerCommand('users', usersHandler)
+  chat.registerCommand('announce', announceHandler)
 }
 
 async function handleUserCommand(
@@ -146,4 +159,36 @@ async function handleUserRemove(
   removeUser(parsed.value)
   log.info({ adminId, identifier: parsed.value }, '/user remove command executed')
   await reply.text(`User ${identifier} removed.`)
+}
+
+async function handleAnnounce(chat: ChatProvider, reply: ReplyFn, msg: IncomingMessage): Promise<void> {
+  const message = (msg.commandMatch ?? '').trim()
+  if (message === '') {
+    await reply.text('Usage: /announce <message>')
+    return
+  }
+
+  const users = listUsers()
+  if (users.length === 0) {
+    await reply.text('No authorized users to announce to.')
+    return
+  }
+
+  const results = await Promise.allSettled(
+    users.map(async (user) => {
+      await chat.sendMessage(user.platform_user_id, message)
+      return true
+    }),
+  )
+
+  const successCount = results.filter((r) => r.status === 'fulfilled').length
+  const failCount = results.filter((r) => r.status === 'rejected').length
+
+  log.info({ userId: msg.user.id, successCount, failCount, totalUsers: users.length }, '/announce command executed')
+
+  if (failCount === 0) {
+    await reply.text(`Announcement sent to ${successCount} user(s).`)
+  } else {
+    await reply.text(`Announcement sent to ${successCount} user(s). Failed to deliver to ${failCount} user(s).`)
+  }
 }

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -1,7 +1,11 @@
+import pLimit from 'p-limit'
+
 import type { ChatProvider, CommandHandler, IncomingMessage, ReplyFn } from '../chat/types.js'
 import { logger } from '../logger.js'
 import { provisionAndConfigure } from '../providers/kaneo/provision.js'
 import { addUser, listUsers, removeUser } from '../users.js'
+
+const MAX_CONCURRENT_SENDS = 5
 
 const log = logger.child({ scope: 'admin' })
 
@@ -46,8 +50,7 @@ export function registerAdminCommands(chat: ChatProvider, adminUserId: string): 
     await handleUsersCommand(reply, msg.user.id, adminUserId)
   }
 
-  const announceHandler: CommandHandler = async (msg, reply, auth) => {
-    if (!auth.allowed) return
+  const announceHandler: CommandHandler = async (msg, reply) => {
     if (msg.contextType === 'group') {
       await reply.text('This command is only available in direct messages.')
       return
@@ -175,15 +178,26 @@ async function handleAnnounce(chat: ChatProvider, reply: ReplyFn, msg: IncomingM
     return
   }
 
+  const limit = pLimit(MAX_CONCURRENT_SENDS)
   const results = await Promise.allSettled(
-    users.map(async (user) => {
-      await chat.sendMessage(user.platform_user_id, message)
-      return true
-    }),
+    users.map((user) =>
+      limit(async () => {
+        await chat.sendMessage(user.platform_user_id, message)
+        return user.platform_user_id
+      }),
+    ),
   )
 
   const successCount = results.filter((r) => r.status === 'fulfilled').length
   const failCount = results.filter((r) => r.status === 'rejected').length
+
+  // Log individual failures at warn level
+  results.forEach((result) => {
+    if (result.status === 'rejected') {
+      const errorMsg = result.reason instanceof Error ? result.reason.message : String(result.reason)
+      log.warn({ userId: msg.user.id, error: errorMsg }, 'Failed to send announcement')
+    }
+  })
 
   log.info({ userId: msg.user.id, successCount, failCount, totalUsers: users.length }, '/announce command executed')
 

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -46,7 +46,8 @@ export function registerAdminCommands(chat: ChatProvider, adminUserId: string): 
     await handleUsersCommand(reply, msg.user.id, adminUserId)
   }
 
-  const announceHandler: CommandHandler = async (msg, reply) => {
+  const announceHandler: CommandHandler = async (msg, reply, auth) => {
+    if (!auth.allowed) return
     if (msg.contextType === 'group') {
       await reply.text('This command is only available in direct messages.')
       return
@@ -168,7 +169,7 @@ async function handleAnnounce(chat: ChatProvider, reply: ReplyFn, msg: IncomingM
     return
   }
 
-  const users = listUsers()
+  const users = listUsers().filter((u) => !u.platform_user_id.startsWith('placeholder-'))
   if (users.length === 0) {
     await reply.text('No authorized users to announce to.')
     return

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -24,6 +24,7 @@ const DM_ADMIN_HELP = [
   '/users — List authorized users',
   "/clear <user_id> — Clear a specific user's history",
   "/clear all — Clear all users' history",
+  '/announce <message> — Send announcement to all users',
 ].join('\n')
 
 function getDmHelpText(isAdmin: boolean): string {

--- a/tests/commands/admin.test.ts
+++ b/tests/commands/admin.test.ts
@@ -38,6 +38,25 @@ void mock.module('../../src/providers/kaneo/provision.js', () => ({
 
 const ADMIN_ID = 'admin-001'
 
+// Helper to create a mock ChatProvider with custom sendMessage behavior and capture handlers
+function createMockChatWithHandler(sendMessageImpl: (userId: string, markdown: string) => Promise<void>): {
+  mockChat: ChatProvider
+  handlers: Map<string, CommandHandler>
+} {
+  const handlers = new Map<string, CommandHandler>()
+  const mockChat: ChatProvider = {
+    name: 'mock',
+    registerCommand: (name: string, handler: CommandHandler): void => {
+      handlers.set(name, handler)
+    },
+    onMessage: (): void => {},
+    sendMessage: sendMessageImpl,
+    start: (): Promise<void> => Promise.resolve(),
+    stop: (): Promise<void> => Promise.resolve(),
+  }
+  return { mockChat, handlers }
+}
+
 describe('Admin Commands', () => {
   let commandHandlers: Map<string, CommandHandler>
 
@@ -296,22 +315,10 @@ describe('Admin Commands', () => {
       addUser('user-a', ADMIN_ID)
       addUser('user-b', ADMIN_ID)
       const sentMessages: Array<{ userId: string; markdown: string }> = []
-      const mockChat: ChatProvider = {
-        name: 'mock',
-        registerCommand: (): void => {},
-        onMessage: (): void => {},
-        sendMessage: (userId: string, markdown: string): Promise<void> => {
-          sentMessages.push({ userId, markdown })
-          return Promise.resolve()
-        },
-        start: (): Promise<void> => Promise.resolve(),
-        stop: (): Promise<void> => Promise.resolve(),
-      }
-      // Re-register to capture the announce handler with the sendMessage-tracking mock
-      const handlers = new Map<string, CommandHandler>()
-      mockChat.registerCommand = (name: string, handler: CommandHandler): void => {
-        handlers.set(name, handler)
-      }
+      const { mockChat, handlers } = createMockChatWithHandler((userId, markdown) => {
+        sentMessages.push({ userId, markdown })
+        return Promise.resolve()
+      })
       registerAdminCommands(mockChat, ADMIN_ID)
       const handler = handlers.get('announce')
       expect(handler).toBeDefined()
@@ -373,24 +380,13 @@ describe('Admin Commands', () => {
       addUser('user-a', ADMIN_ID)
       addUser('user-b', ADMIN_ID)
       const sentMessages: string[] = []
-      const mockChat: ChatProvider = {
-        name: 'mock',
-        registerCommand: (): void => {},
-        onMessage: (): void => {},
-        sendMessage: (userId: string, _markdown: string): Promise<void> => {
-          if (userId === 'user-a') {
-            return Promise.reject(new Error('User blocked bot'))
-          }
-          sentMessages.push(userId)
-          return Promise.resolve()
-        },
-        start: (): Promise<void> => Promise.resolve(),
-        stop: (): Promise<void> => Promise.resolve(),
-      }
-      const handlers = new Map<string, CommandHandler>()
-      mockChat.registerCommand = (name: string, handler: CommandHandler): void => {
-        handlers.set(name, handler)
-      }
+      const { mockChat, handlers } = createMockChatWithHandler((userId) => {
+        if (userId === 'user-a') {
+          return Promise.reject(new Error('User blocked bot'))
+        }
+        sentMessages.push(userId)
+        return Promise.resolve()
+      })
       registerAdminCommands(mockChat, ADMIN_ID)
       const handler = handlers.get('announce')
       expect(handler).toBeDefined()
@@ -421,39 +417,15 @@ describe('Admin Commands', () => {
       expect(getReplies()[0]).toContain('No authorized users')
     })
 
-    test('returns immediately when not allowed', async () => {
-      const handler = commandHandlers.get('announce')
-      expect(handler).toBeDefined()
-      const { reply, getReplies } = createMockReply()
-      await handler!(createDmMessage('stranger', 'Hello'), reply, {
-        allowed: false,
-        isBotAdmin: false,
-        isGroupAdmin: false,
-        storageContextId: 'stranger',
-      })
-      expect(getReplies()).toHaveLength(0)
-    })
-
     test('skips placeholder users when sending announcements', async () => {
       addUser('user-a', ADMIN_ID)
       // Add a placeholder (username-only authorization, no real platform ID)
       addUser(`placeholder-${crypto.randomUUID()}`, ADMIN_ID, 'pending-user')
       const sentUserIds: string[] = []
-      const mockChat: ChatProvider = {
-        name: 'mock',
-        registerCommand: (): void => {},
-        onMessage: (): void => {},
-        sendMessage: (userId: string, _markdown: string): Promise<void> => {
-          sentUserIds.push(userId)
-          return Promise.resolve()
-        },
-        start: (): Promise<void> => Promise.resolve(),
-        stop: (): Promise<void> => Promise.resolve(),
-      }
-      const handlers = new Map<string, CommandHandler>()
-      mockChat.registerCommand = (name: string, handler: CommandHandler): void => {
-        handlers.set(name, handler)
-      }
+      const { mockChat, handlers } = createMockChatWithHandler((userId) => {
+        sentUserIds.push(userId)
+        return Promise.resolve()
+      })
       registerAdminCommands(mockChat, ADMIN_ID)
       const handler = handlers.get('announce')
       expect(handler).toBeDefined()

--- a/tests/commands/admin.test.ts
+++ b/tests/commands/admin.test.ts
@@ -377,7 +377,7 @@ describe('Admin Commands', () => {
         name: 'mock',
         registerCommand: (): void => {},
         onMessage: (): void => {},
-        sendMessage: (userId: string): Promise<void> => {
+        sendMessage: (userId: string, _markdown: string): Promise<void> => {
           if (userId === 'user-a') {
             return Promise.reject(new Error('User blocked bot'))
           }
@@ -419,6 +419,55 @@ describe('Admin Commands', () => {
         storageContextId: ADMIN_ID,
       })
       expect(getReplies()[0]).toContain('No authorized users')
+    })
+
+    test('returns immediately when not allowed', async () => {
+      const handler = commandHandlers.get('announce')
+      expect(handler).toBeDefined()
+      const { reply, getReplies } = createMockReply()
+      await handler!(createDmMessage('stranger', 'Hello'), reply, {
+        allowed: false,
+        isBotAdmin: false,
+        isGroupAdmin: false,
+        storageContextId: 'stranger',
+      })
+      expect(getReplies()).toHaveLength(0)
+    })
+
+    test('skips placeholder users when sending announcements', async () => {
+      addUser('user-a', ADMIN_ID)
+      // Add a placeholder (username-only authorization, no real platform ID)
+      addUser(`placeholder-${crypto.randomUUID()}`, ADMIN_ID, 'pending-user')
+      const sentUserIds: string[] = []
+      const mockChat: ChatProvider = {
+        name: 'mock',
+        registerCommand: (): void => {},
+        onMessage: (): void => {},
+        sendMessage: (userId: string, _markdown: string): Promise<void> => {
+          sentUserIds.push(userId)
+          return Promise.resolve()
+        },
+        start: (): Promise<void> => Promise.resolve(),
+        stop: (): Promise<void> => Promise.resolve(),
+      }
+      const handlers = new Map<string, CommandHandler>()
+      mockChat.registerCommand = (name: string, handler: CommandHandler): void => {
+        handlers.set(name, handler)
+      }
+      registerAdminCommands(mockChat, ADMIN_ID)
+      const handler = handlers.get('announce')
+      expect(handler).toBeDefined()
+      const { reply } = createMockReply()
+      await handler!(createDmMessage(ADMIN_ID, 'Hello'), reply, {
+        allowed: true,
+        isBotAdmin: true,
+        isGroupAdmin: false,
+        storageContextId: ADMIN_ID,
+      })
+      // Placeholder ID should not be in sent messages
+      expect(sentUserIds.every((id) => !id.startsWith('placeholder-'))).toBe(true)
+      // Only admin + user-a should receive the message
+      expect(sentUserIds.length).toBe(2)
     })
   })
 })

--- a/tests/commands/admin.test.ts
+++ b/tests/commands/admin.test.ts
@@ -6,6 +6,7 @@ import * as schema from '../../src/db/schema.js'
 import { addUser, isAuthorized, listUsers } from '../../src/users.js'
 import {
   createDmMessage,
+  createGroupMessage,
   createMockReply,
   getTestDb,
   mockDrizzle,
@@ -287,6 +288,137 @@ describe('Admin Commands', () => {
         storageContextId: 'other-user',
       })
       expect(getReplies()[0]).toBe('Only the admin can list users.')
+    })
+  })
+
+  describe('/announce', () => {
+    test('sends announcement to all registered users', async () => {
+      addUser('user-a', ADMIN_ID)
+      addUser('user-b', ADMIN_ID)
+      const sentMessages: Array<{ userId: string; markdown: string }> = []
+      const mockChat: ChatProvider = {
+        name: 'mock',
+        registerCommand: (): void => {},
+        onMessage: (): void => {},
+        sendMessage: (userId: string, markdown: string): Promise<void> => {
+          sentMessages.push({ userId, markdown })
+          return Promise.resolve()
+        },
+        start: (): Promise<void> => Promise.resolve(),
+        stop: (): Promise<void> => Promise.resolve(),
+      }
+      // Re-register to capture the announce handler with the sendMessage-tracking mock
+      const handlers = new Map<string, CommandHandler>()
+      mockChat.registerCommand = (name: string, handler: CommandHandler): void => {
+        handlers.set(name, handler)
+      }
+      registerAdminCommands(mockChat, ADMIN_ID)
+      const handler = handlers.get('announce')
+      expect(handler).toBeDefined()
+      const { reply, getReplies } = createMockReply()
+      await handler!(createDmMessage(ADMIN_ID, 'Hello everyone!'), reply, {
+        allowed: true,
+        isBotAdmin: true,
+        isGroupAdmin: false,
+        storageContextId: ADMIN_ID,
+      })
+      // Should send to all users (admin + user-a + user-b)
+      expect(sentMessages.length).toBe(3)
+      expect(sentMessages.every((m) => m.markdown.includes('Hello everyone!'))).toBe(true)
+      // Should confirm to admin
+      expect(getReplies()[0]).toContain('3')
+    })
+
+    test('rejects non-admin caller', async () => {
+      addUser('other-user', ADMIN_ID)
+      const handler = commandHandlers.get('announce')
+      expect(handler).toBeDefined()
+      const { reply, getReplies } = createMockReply()
+      await handler!(createDmMessage('other-user', 'Hello'), reply, {
+        allowed: true,
+        isBotAdmin: false,
+        isGroupAdmin: false,
+        storageContextId: 'other-user',
+      })
+      expect(getReplies()[0]).toBe('Only the admin can send announcements.')
+    })
+
+    test('rejects in group context', async () => {
+      const handler = commandHandlers.get('announce')
+      expect(handler).toBeDefined()
+      const { reply, getReplies } = createMockReply()
+      await handler!(createGroupMessage(ADMIN_ID, 'Hello', false, 'group-1'), reply, {
+        allowed: true,
+        isBotAdmin: true,
+        isGroupAdmin: false,
+        storageContextId: 'group-1',
+      })
+      expect(getReplies()[0]).toBe('This command is only available in direct messages.')
+    })
+
+    test('shows usage when message is empty', async () => {
+      const handler = commandHandlers.get('announce')
+      expect(handler).toBeDefined()
+      const { reply, getReplies } = createMockReply()
+      await handler!(createDmMessage(ADMIN_ID, ''), reply, {
+        allowed: true,
+        isBotAdmin: true,
+        isGroupAdmin: false,
+        storageContextId: ADMIN_ID,
+      })
+      expect(getReplies()[0]).toContain('Usage:')
+    })
+
+    test('handles send failures gracefully', async () => {
+      addUser('user-a', ADMIN_ID)
+      addUser('user-b', ADMIN_ID)
+      const sentMessages: string[] = []
+      const mockChat: ChatProvider = {
+        name: 'mock',
+        registerCommand: (): void => {},
+        onMessage: (): void => {},
+        sendMessage: (userId: string): Promise<void> => {
+          if (userId === 'user-a') {
+            return Promise.reject(new Error('User blocked bot'))
+          }
+          sentMessages.push(userId)
+          return Promise.resolve()
+        },
+        start: (): Promise<void> => Promise.resolve(),
+        stop: (): Promise<void> => Promise.resolve(),
+      }
+      const handlers = new Map<string, CommandHandler>()
+      mockChat.registerCommand = (name: string, handler: CommandHandler): void => {
+        handlers.set(name, handler)
+      }
+      registerAdminCommands(mockChat, ADMIN_ID)
+      const handler = handlers.get('announce')
+      expect(handler).toBeDefined()
+      const { reply, getReplies } = createMockReply()
+      await handler!(createDmMessage(ADMIN_ID, 'Important update'), reply, {
+        allowed: true,
+        isBotAdmin: true,
+        isGroupAdmin: false,
+        storageContextId: ADMIN_ID,
+      })
+      // Should report partial success (2 out of 3 sent - admin + user-b, user-a failed)
+      const replyText = getReplies()[0]
+      expect(replyText).toContain('2')
+      expect(replyText).toContain('1')
+    })
+
+    test('reports when no users exist', async () => {
+      getTestDb().delete(schema.users).run()
+      const handler = commandHandlers.get('announce')
+      expect(handler).toBeDefined()
+      const { reply, getReplies } = createMockReply()
+      await handler!(createDmMessage(ADMIN_ID, 'Hello'), reply, {
+        allowed: true,
+        isBotAdmin: true,
+        isGroupAdmin: false,
+        storageContextId: ADMIN_ID,
+      })
+      expect(getReplies()[0]).toContain('No authorized users')
     })
   })
 })


### PR DESCRIPTION
Admin can use `/announce <message>` to broadcast a message to all authorized
users via chat.sendMessage. Handles partial delivery failures gracefully and
reports success/failure counts.

https://claude.ai/code/session_017GCj95og7CP1Zk6fSMeMaa