### PR TITLE
Potential fix for code scanning alert no. 14: Clear-text logging of sensitive information

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -179,7 +179,7 @@ export function upsertCachedFact(userId: string, fact: { identifier: string; tit
 export function getCachedConfig(userId: string, key: string): string | null {
   const cache = getOrCreateCache(userId)
   if (!cache.config.has(key)) {
-    log.debug({ userId, key }, 'Loading config from DB into cache')
+    log.debug('Loading config from DB into cache')
     const row = getDrizzleDb()
       .select({ value: userConfig.value })
       .from(userConfig)


### PR DESCRIPTION
Potential fix for [https://github.com/wKich/papai/security/code-scanning/14](https://github.com/wKich/papai/security/code-scanning/14)

General fix: Avoid logging raw identifiers or sensitive config keys directly. Instead, either avoid logging them entirely or log only non‑sensitive, derived, or masked forms. We should keep enough information for debugging (e.g. that “some config was loaded”) without including exact user IDs or key names where they may be linked to secrets.

Best concrete fix for this flow:

* In `src/cache.ts`, change the `getCachedConfig` debug log so it no longer logs the raw `userId` and `key`. Replace it with a message that only indicates that config is being loaded, optionally with a coarse “sensitive/non‑sensitive” classification of the key. Since `src/cache.ts` does not know `ConfigKey` or `SENSITIVE_KEYS`, the simplest safe change is to omit both `userId` and `key` from the structured log entirely.
* To retain some value, we can still log that a cache miss occurred and config is being loaded, but without including sensitive fields in the structured data.

This single change in `src/cache.ts` addresses the CodeQL flow from `process.env` via `adminUserId` → `copyAdminLlmConfig` → `getCachedConfig` → logging, because the sink (`log.debug({ userId, key }, ...)`) will no longer contain tainted data. Other logging (e.g. in `src/config.ts`) is not in the reported flow and can remain unchanged unless you choose to further harden it separately.

Specific change:

* File: `src/cache.ts`
  * In `getCachedConfig`, on the `if (!cache.config.has(key))` branch, replace:
    ```ts
    log.debug({ userId, key }, 'Loading config from DB into cache')
    ```
    with something that does not include `userId` or `key`, e.g.:
    ```ts
    log.debug('Loading config from DB into cache')
    ```
  * No new imports or helpers are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
