### PR TITLE
Potential fix for code scanning alert no. 16: Clear-text logging of sensitive information

### DIFF
--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -32,12 +32,12 @@ function markVersionAnnounced(version: string): boolean {
 async function sendAnnouncementToAdmin(adminUserId: string, markdown: string, chat: ChatProvider): Promise<boolean> {
   try {
     await chat.sendMessage(adminUserId, markdown)
-    log.debug({ userId: adminUserId, version: VERSION }, 'Announcement sent to admin')
+    log.debug({ version: VERSION }, 'Announcement sent to admin user')
     return true
   } catch (error) {
     log.warn(
-      { userId: adminUserId, version: VERSION, error: error instanceof Error ? error.message : String(error) },
-      'Failed to send announcement to admin',
+      { version: VERSION, error: error instanceof Error ? error.message : String(error) },
+      'Failed to send announcement to admin user',
     )
     return false
   }
@@ -59,7 +59,7 @@ export async function announceNewVersion(
     return
   }
 
-  log.info({ version: VERSION, adminUserId }, 'Sending version announcement to admin')
+  log.info({ version: VERSION }, 'Sending version announcement to admin user')
 
   const message = `🆕 papai v${VERSION} has been released!\n\n${changelogSection}`
   const success = await sendAnnouncementToAdmin(adminUserId, message, chat)


### PR DESCRIPTION
Potential fix for [https://github.com/wKich/papai/security/code-scanning/16](https://github.com/wKich/papai/security/code-scanning/16)

In general, to fix clear‑text logging of sensitive information you either (a) stop logging the sensitive value, or (b) mask or generalize it (e.g., boolean flags, partial IDs, or stable hashes) so that logs remain useful without exposing the raw data. You should ensure that no log message outputs identifiers or secrets that originate from sensitive sources like `process.env`, request headers, or authentication tokens.

For this specific code:

- In `sendAnnouncementToAdmin`, replace `log.debug({ userId: adminUserId, version: VERSION }, 'Announcement sent to admin')` with a log that does not include the concrete admin ID, e.g., `{ adminUserConfigured: true, version: VERSION }` or a fixed string noting it was sent “to admin”.
- In `announceNewVersion`, replace `log.info({ version: VERSION, adminUserId }, 'Sending version announcement to admin')` with a log that omits the actual ID and just records that an admin announcement is being sent.
- This preserves existing behavior (announcement sending, DB writes, etc.) while preventing the admin user ID from being written to logs.
- No new imports or helpers are required; we just change the structured log fields.

All changes are confined to `src/announcements.ts` lines around 32–36 and 62, as per the snippets.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
