### PR TITLE
Potential fix for code scanning alert no. 17: Clear-text logging of sensitive information

### DIFF
--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -32,11 +32,11 @@ function markVersionAnnounced(version: string): boolean {
 async function sendAnnouncementToAdmin(adminUserId: string, markdown: string, chat: ChatProvider): Promise<boolean> {
   try {
     await chat.sendMessage(adminUserId, markdown)
-    log.debug({ userId: adminUserId, version: VERSION }, 'Announcement sent to admin')
+    log.debug({ target: 'admin', version: VERSION }, 'Announcement sent to admin')
     return true
   } catch (error) {
     log.warn(
-      { userId: adminUserId, version: VERSION, error: error instanceof Error ? error.message : String(error) },
+      { target: 'admin', version: VERSION, error: error instanceof Error ? error.message : String(error) },
       'Failed to send announcement to admin',
     )
     return false
@@ -59,7 +59,7 @@ export async function announceNewVersion(
     return
   }
 
-  log.info({ version: VERSION, adminUserId }, 'Sending version announcement to admin')
+  log.info({ version: VERSION, target: 'admin' }, 'Sending version announcement to admin')
 
   const message = `🆕 papai v${VERSION} has been released!\n\n${changelogSection}`
   const success = await sendAnnouncementToAdmin(adminUserId, message, chat)


### PR DESCRIPTION
Potential fix for [https://github.com/wKich/papai/security/code-scanning/17](https://github.com/wKich/papai/security/code-scanning/17)

In general, to fix clear‑text logging of sensitive information, avoid logging raw values derived from `process.env` (or other sensitive sources) and instead either omit them, log only non‑sensitive derivatives (e.g., booleans, categories), or apply explicit redaction/masking.

For this specific case, the problematic part is that `adminUserId` (sourced from `process.env['ADMIN_USER_ID']`) is logged as `userId` and `adminUserId`. The functionality we actually need in logs is to know that an announcement was attempted/sent for “the admin,” not the exact identifier. We can therefore replace those log fields with non‑sensitive representations, such as `adminUserConfigured: true` or `target: 'admin'`, while still logging the version and success/error details. Concretely:
- In `sendAnnouncementToAdmin`, change:
  - `log.debug({ userId: adminUserId, version: VERSION }, 'Announcement sent to admin')`
  - the `log.warn` metadata `{ userId: adminUserId, version: VERSION, error: ... }`
  to variants that do not include `adminUserId`, e.g. `{ target: 'admin', version: VERSION, ... }`.
- In `announceNewVersion`, change
  - `log.info({ version: VERSION, adminUserId }, 'Sending version announcement to admin')`
  to remove the raw `adminUserId`, using a non‑sensitive flag like `{ version: VERSION, adminUserConfigured: Boolean(adminUserId) }` or simply `{ version: VERSION, target: 'admin' }`.

These changes require no new imports or additional methods; they are confined to `src/announcements.ts` and only adjust log metadata objects.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
