### PR TITLE
Potential fix for code scanning alert no. 18: Clear-text logging of sensitive information

### DIFF
--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -59,7 +59,7 @@ export async function announceNewVersion(
     return
   }
 
-  log.info({ version: VERSION, adminUserId }, 'Sending version announcement to admin')
+  log.info({ version: VERSION }, 'Sending version announcement to admin')
 
   const message = `🆕 papai v${VERSION} has been released!\n\n${changelogSection}`
   const success = await sendAnnouncementToAdmin(adminUserId, message, chat)


### PR DESCRIPTION
Potential fix for [https://github.com/wKich/papai/security/code-scanning/18](https://github.com/wKich/papai/security/code-scanning/18)

In general, the fix is to stop logging the sensitive `adminUserId` value and instead either omit it entirely or replace it with a less sensitive surrogate, such as a boolean indicating whether an admin is configured. We must keep existing behavior otherwise unchanged: announcements should still be sent, and logging should still indicate that an announcement is being sent, but without exposing the raw admin identifier.

The single best minimal change is to modify the `log.info` call on line 62 in `announceNewVersion` in `src/announcements.ts` so that it no longer includes `adminUserId`. The simplest option is to log only the version, which is already logged elsewhere, or potentially add a non‑sensitive flag like `adminUserConfigured: true`. This requires no new imports, methods, or types. All other uses of `adminUserId` (as function arguments, to send messages, etc.) remain intact; only the log context is changed.

Concretely:
- In `src/announcements.ts`, replace `log.info({ version: VERSION, adminUserId }, 'Sending version announcement to admin')` with a version that omits `adminUserId`, e.g. `log.info({ version: VERSION }, 'Sending version announcement to admin')` (or optionally with `adminUserConfigured: true` instead of the raw ID).
- No other files or lines need modification for this particular CodeQL finding.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
