### PR TITLE
docs: add GraphQL task API middleware design

### DIFF
--- a/docs/graphql-task-middleware-alternatives.md
+++ b/docs/graphql-task-middleware-alternatives.md
@@ -1,0 +1,144 @@
+# Alternatives to GraphQL — Survey
+
+Status: Research addendum to `graphql-task-middleware-design.md`
+Branch: `claude/graphql-task-api-middleware-sWwTN`
+
+## Why this addendum
+
+The GraphQL design solves both problems (tool sprawl + LLM-driven filtering) but it brings a parser, an executor, a query language, and a validate-retry loop into the bot. This document surveys non-GraphQL options against the same goals so the choice is informed.
+
+Goals (recap):
+
+- **G1.** Reduce tool surface — today ~25 tools, the read side dominates accidental complexity.
+- **G2.** Move filtering from LLM-orchestrated tool chains into deterministic code, so questions like "open high-priority tasks assigned to me with their last comment" become one round-trip.
+- **G3.** Keep mutations as typed JSON tools (capability-gated, auditable — `src/tools/CLAUDE.md`).
+- **G4.** Stay portable across providers with very different filter capability (YouTrack DSL vs Kaneo project-only listing).
+
+## Approaches considered
+
+### A. Rich structured-JSON filter tool (typed Zod)
+
+One `query_tasks` tool whose Zod input is a flat filter:
+
+```ts
+{
+  text?: string
+  projectIds?: string[]
+  statusIn?: string[]
+  priorityIn?: ('no-priority'|'low'|'medium'|'high'|'urgent')[]
+  assigneeIn?: string[]   // 'me' resolved server-side
+  labelIn?: string[]
+  dueBefore?: string; dueAfter?: string
+  createdAfter?: string
+  hasDueDate?: boolean
+  sort?: 'createdAt'|'dueDate'|'priority'
+  order?: 'asc'|'desc'
+  limit?: number
+  fields?: ('description'|'labels'|'relations')[]
+  includeComments?: 'none'|'last'|'all'
+}
+```
+
+- **Reliability:** highest of any option. OpenAI Structured Outputs and Anthropic tool-use are RLHF-trained on exactly this shape; JSON Schema *guarantees* shape conformance. Field names are self-documenting from the schema the SDK already sends to the model.
+- **Tokens:** one tool definition replaces 6-7 read tools. A typical call is ~40-80 tokens vs 3-6 round-trips today.
+- **Composability:** good but bounded. The example question is one call iff `includeComments:'last'` exists in the schema. Anything not pre-modeled (e.g. "tasks blocked by tasks I closed yesterday") still needs multiple calls — but those queries are rare in chatbot UX.
+- **Cost:** very low. Aligns with the existing Zod-everywhere convention. ~300 LOC.
+- **Where it falls down:** arbitrary boolean nesting, cross-entity joins, ad-hoc aggregations. You add fields over time as needs surface.
+
+### B. Tool namespacing / dynamic tool loading / RAG over tools
+
+MCP tool groups, Anthropic's Tool Search Tool, RAG-MCP (arXiv 2505.03275: tool selection 13.6% → 43.1% with retrieval). Anthropic's own benchmark: 77k tool catalog → 8.7k tokens (~85% reduction).
+
+But: those wins are measured against catalogs of **hundreds**. Anthropic explicitly recommends Tool Search "when your agent needs access to 30 or more tools." papai has ~25, *below* the threshold. You'd pay an extra round-trip per request for marginal benefit.
+
+Crucially this is **orthogonal to G2** — it changes which tools are visible, not how filters work. N+1 chains stay. **Defer; revisit if tool count crosses ~40 or a third provider lands.**
+
+### C. JSONLogic / Mongo-style predicate DSL
+
+`{"and":[{"status":{"$in":["open"]}},{"priority":"high"}]}`. Used by Linear, Notion, Sift.
+
+- **Reliability:** worse than A. The `$in`/`$and` sigils aren't first-class in JSON Schema, so structured-output enforcement is partial — "object with `$in` key" validates, "valid Mongo expression tree" doesn't. Failure modes are silent: a typo in `$gte` becomes a semantic bug, not a schema error. Elastic's own docs note Query DSL needs few-shot examples to author reliably.
+- **Token cost:** comparable for simple, worse for nested.
+- **Composability:** strictly more flexible than A; still no joins.
+- **Cost:** medium — write the predicate evaluator twice (translate to YouTrack DSL; interpret in-memory for Kaneo). Capability-gating individual operators is awkward.
+
+Net: strictly dominated by A for papai's use case.
+
+### D. JQL / YouTrack-DSL passthrough
+
+LLM emits `"#Unresolved priority: Critical assignee: me"` directly. Reliability is surprisingly OK because YouTrack/JQL are well-represented in pretraining. **Kills G4** — Kaneo has no equivalent, forcing per-provider system prompts. Only viable as a *fallback* tool (`youtrack_raw_query`) gated on `TASK_PROVIDER=youtrack` for the long tail that A can't express.
+
+### E. Code execution as a tool (sandboxed JS/Python)
+
+Anthropic's Code Execution with MCP (Nov 2025): the model writes code that calls tools as functions, filters in-sandbox, returns only the answer. Anthropic's benchmark: **150k → 2k tokens (~99% reduction)** on a 20-lookup task.
+
+- **Reliability:** strong on Claude (RLHF-tuned). Weaker on arbitrary OpenAI-compatible models — and papai's LLM is *user-configurable*, so we can't assume Claude. Vercel AI SDK doesn't yet wrap `code_execution_20260120` (vercel/ai#12794).
+- **Composability:** maximum — arbitrary joins, aggregations, last-comment lookups.
+- **Cost:** high. Sandbox infra, security review, prompt-injection surface (untrusted task descriptions feed into code).
+- **Verdict:** overkill for ~25 tools and two providers. Skip for now; reconsider if papai standardizes on Claude.
+
+### F. Server-side resolver behind a typed Zod filter — i.e. A with an explicit translation layer
+
+This is option A *with* a per-provider adapter layer that translates the Zod filter to YouTrack's issue-query DSL (server-side pushdown) or to a Kaneo `listTasks` + in-memory predicate (fallback). Capability-gating per provider is natural — drop a Zod field if the provider can't honor it; the LLM never sees provider-specific syntax.
+
+This is **the same backend** as the GraphQL plan minus the parser/executor and minus the SDL-in-prompt cost. The reduction in tools is identical. The difference is the LLM speaks JSON Schema instead of GraphQL strings.
+
+### G. Fewer, fatter polymorphic tools — `read(entity, filter, fields)`
+
+One read tool with a discriminated union per entity (`task`/`project`/`label`/`comment`). Anthropic's "writing tools for agents" guide explicitly recommends consolidating overlapping tools. Risk: a single tool that does everything has a less informative name and per-entity differences leak into the description. **Best applied as a refactor of read-side only**, keeping mutations as discrete typed tools so error messages and capability gating stay sharp.
+
+## Comparison table
+
+| Option | LLM reliability | Token cost | Composability | Impl cost | Provider portability | Mutations safe |
+|---|---|---|---|---|---|---|
+| **A. Typed Zod filter** | ★★★★★ | ★★★★★ | ★★★ | ★★★★★ | ★★★★ | ✓ |
+| **F. = A + resolver layer** | ★★★★★ | ★★★★★ | ★★★ | ★★★★ | ★★★★★ | ✓ |
+| **G. Polymorphic `read`** | ★★★★ | ★★★★ | ★★★ | ★★★★ | ★★★★ | ✓ |
+| C. JSONLogic | ★★★ | ★★★★ | ★★★★ | ★★★ | ★★★ | ✓ |
+| GraphQL (prior doc) | ★★★ | ★★★ | ★★★★★ | ★★ | ★★★★★ | ✓ (mut. stay typed) |
+| D. DSL passthrough | ★★★★ (YT only) | ★★★★★ | ★★★★ | ★★★★★ | ★ | ✓ |
+| B. Dynamic tool loading | ★★★★ | depends | n/a (orthogonal) | ★★★ | ★★★★ | ✓ |
+| E. Code execution | ★★★ (model-dependent) | ★★★★★ | ★★★★★ | ★ | ★★★★ | ⚠ sandbox |
+
+## Recommendation for papai
+
+**Primary: Option F — typed Zod filter with a server-side per-provider resolver.**
+
+Rationale:
+
+1. **Higher reliability than GraphQL** — structured-output JSON Schema enforcement is stronger than GraphQL string validation, and is what every OpenAI-compatible provider has been RLHF-trained on. No parse/validate/retry loop needed.
+2. **Same backend wins as GraphQL** — the resolver translates filter → YouTrack DSL (push-down) or → Kaneo `listTasks` + predicate (fallback). This is identical to §4.2 of the GraphQL doc; only the front door differs.
+3. **Same tool-surface reduction** — collapses `search_tasks`, `list_tasks`, `get_task`, `get_comments`, `list_projects`, `list_labels`, `list_statuses` into one `query_tasks` plus a small `query_projects` (or fold into the same tool with `entity:` discriminator per option G).
+4. **Cheaper implementation** — no `graphql` dependency, no SDL inlined in the tool description, no parser, no executor, no introspection helper. ~300 LOC vs ~500.
+5. **Aligns with `src/tools/CLAUDE.md`** — every tool already uses Zod schemas; this is the natural extension, not a new paradigm in the codebase.
+6. **Capability gating is natural** — fields drop out of the Zod schema (or are validated to error) when the provider lacks the capability, mirroring how tools are gated today in `src/tools/index.ts:187-192`.
+
+**Secondary (opt-in): Option D for YouTrack power users.** Add `youtrack_raw_query` only when `TASK_PROVIDER=youtrack`, behind an env flag, for the long tail F cannot express. Costs nothing if unused.
+
+**Defer: Option B (dynamic tool loading).** Revisit when the tool count crosses ~40 or a third provider lands.
+
+**Skip: C, E.** Strictly dominated for papai's scale and model-portability constraints.
+
+## What changes vs the GraphQL design doc
+
+The architecture diagram, the file layout under `src/graphql/` → `src/query/`, the per-provider pushdown planners (`pushdown/youtrack.ts`, `pushdown/kaneo.ts`), the test plan, the rollout phases — **all reusable**. Only the front door changes:
+
+| GraphQL design | Typed-filter design |
+|---|---|
+| `query_tasks(graphql: string, variables?)` | `query_tasks(filter, sort?, limit?, includeComments?, fields?)` |
+| Tool description inlines ~80 lines of SDL + 4 examples | Tool description is one paragraph + Zod schema (auto-rendered by AI SDK) |
+| `graphql` dep, `parse()`+`validate()`, retry loop | None — JSON Schema enforced by the model runtime |
+| SDL field selection (`{ id title comments(limit:5){body} }`) | `fields: ['description','labels']`, `includeComments: 'last'` enums |
+| Free composition (any boolean nesting) | Fixed flat AND-of-INs filter; long tail goes to `youtrack_raw_query` if enabled |
+
+The GraphQL doc remains valid as a Phase-3 escape hatch *if* users start asking compositional questions the typed filter can't express. But based on the research, that day is unlikely to arrive soon, and Option F captures ~95% of the value at ~60% of the cost.
+
+## References
+
+- Anthropic — Writing tools for agents: https://www.anthropic.com/engineering/writing-tools-for-agents
+- Anthropic — Advanced tool use: https://www.anthropic.com/engineering/advanced-tool-use
+- Anthropic — Code execution with MCP: https://www.anthropic.com/engineering/code-execution-with-mcp
+- RAG-MCP: https://arxiv.org/html/2505.03275v1
+- Speakeasy — 100x token reduction with dynamic toolsets: https://www.speakeasy.com/blog/100x-token-reduction-dynamic-toolsets
+- Elastic — Query DSL with LLMs: https://www.elastic.co/search-labs/blog/elastic-query-dsl-structured-datasets
+- vercel/ai#12794 (code execution support): https://github.com/vercel/ai/issues/12794

--- a/docs/graphql-task-middleware-design.md
+++ b/docs/graphql-task-middleware-design.md
@@ -1,0 +1,297 @@
+# GraphQL Task API Middleware — Design Document
+
+Status: Draft / RFC
+Author: Claude (research + design)
+Branch: `claude/graphql-task-api-middleware-sWwTN`
+
+## 1. Problem
+
+Today the LLM has ~25 fine-grained task tools (`src/tools/index.ts:54-200`) and the read side is severely limited:
+
+- `search_tasks` only accepts `{ query, projectId?, limit? }` — free-text only.
+- `list_tasks` only accepts `{ projectId }` — returns every task in a project.
+- There is no way to ask "open high-priority tasks assigned to me, due this week, in projects A or B, with their last comment".
+
+To answer such a question the bot has to: `list_projects` → `list_tasks` (per project) → in-memory filter → `get_task` (per id, for relations/labels) → `get_comments` (per id). That is N+1+M tool calls per question, blows the 25-step `stopWhen` budget, wastes tokens, and is slow.
+
+The asymmetry between providers makes this worse:
+
+| Filter | Kaneo native | YouTrack native |
+|---|---|---|
+| project | ✓ query param | ✓ query DSL |
+| text | ✓ `q` | ✓ free text |
+| status | ✗ | ✓ `State:` |
+| priority | ✗ | ✓ `Priority:` |
+| assignee | ✗ | ✓ `Assignee:` |
+| labels/tags | ✗ | ✓ `tag:` |
+| due / created date | ✗ | ✓ date ranges |
+
+YouTrack's `/api/issues?query=…` accepts a powerful issue-query DSL that the current code only uses for `project: {id}` (`src/providers/youtrack/operations/tasks.ts:124`). Kaneo only supports project-scoped listing.
+
+## 2. Goal
+
+Introduce a GraphQL middleware layer that:
+
+1. Lets the LLM express **compositional read queries** in one round-trip with selected fields.
+2. Pushes filters down to the provider when natively supported (YouTrack DSL), and falls back to in-memory filtering when not (Kaneo).
+3. Replaces the read-side tool sprawl with **one** `query_tasks` tool (and one optional `describe_schema` introspection helper), reducing the tool surface from ~25 to ~12.
+4. Leaves **mutations as typed JSON tools** — they are safer, auditable, and capability-gated per `src/tools/CLAUDE.md`.
+
+Non-goals: replacing mutations with GraphQL mutations; building a public GraphQL endpoint; persisted-query infrastructure (future work).
+
+## 3. Research summary — does the LLM handle GraphQL?
+
+Sources: EMNLP 2024 "GraphQL Query Generation" benchmark, IBM IJCAI 2024 "LLM-powered GraphQL Generator", Cato Networks production case study (ZenML LLMOps DB), Weaviate Gorilla, Apollo MCP Server 1.0 docs, Hasura PromptQL.
+
+Key findings:
+
+- **Reads are tractable, mutations are not.** GPT-4-class and Claude can write valid read queries against a small, well-described SDL ~70-90% zero-shot, lifted into the 90s with few-shot examples and a parse+validate+retry loop. Mutations regress sharply — input object shapes are deeper, less self-describing, and a hallucinated field on a mutation has destructive consequences.
+- **SDL beats JSON introspection** (3-5x token savings, more training data).
+- **Schema pruning is the #1 accuracy lever** (Cato). Keep the schema small.
+- **Enums beat free strings** for `status`, `priority`, `relationType` — eliminates a whole class of hallucinations because the LLM enumerates inline from SDL.
+- **Flat filter inputs beat nested AND/OR trees** (Hasura-style nesting is a top failure source).
+- **Field descriptions matter** — `"""docstrings"""` are treated as natural-language hints.
+- **`graphql-js` parse + validate + retry-once** with the validation errors fed back catches ~80% of remaining errors cheaply.
+- **Apollo MCP** (the most mature production pattern) defaults to *curated operation files* rather than full-schema exposure; full introspection mode is opt-in.
+
+Conclusion: a small, hand-curated, flat, enum-rich SDL exposed to the LLM as one tool with a few-shot description and a validate-retry loop is reliable enough for the read side. Mutations stay as typed tools.
+
+## 4. Proposed architecture
+
+```
+LLM ─→ query_tasks(graphql, variables)
+            │
+            ▼
+       graphql-js execute
+            │
+            ▼
+    Resolver layer  ─────────────────┐
+            │                        │
+            ├─ pushdown planner      │
+            │   ├─ YouTrack: build    │
+            │   │   issue-query DSL   │
+            │   └─ Kaneo:  list+      │
+            │       in-memory filter  │
+            ▼                        │
+    TaskProvider (existing) ─────────┘
+            │
+            ▼
+    Kaneo / YouTrack REST
+```
+
+The middleware is **in-process** (`graphql` npm package). No network hop, no schema served externally. The resolvers call the *existing* `TaskProvider` interface — providers are unchanged on day 1.
+
+### 4.1 Schema (initial draft)
+
+```graphql
+"""A task / issue, normalized across providers."""
+type Task {
+  id: ID!
+  number: Int
+  title: String!
+  description: String
+  status: String
+  priority: Priority
+  assignee: String
+  dueDate: String
+  createdAt: String
+  projectId: ID
+  url: String!
+  labels: [Label!]!
+  relations: [TaskRelation!]!
+  comments(limit: Int = 20): [Comment!]!
+}
+
+enum Priority { NO_PRIORITY LOW MEDIUM HIGH URGENT }
+enum RelationType { BLOCKS BLOCKED_BY DUPLICATE DUPLICATE_OF RELATED PARENT }
+enum SortField { CREATED_AT DUE_DATE PRIORITY }
+enum SortOrder { ASC DESC }
+
+type Label    { id: ID! name: String! color: String }
+type Project  { id: ID! name: String! description: String url: String! }
+type Comment  { id: ID! body: String! author: String createdAt: String }
+type TaskRelation { type: RelationType! taskId: ID! }
+
+"""Flat filter input. All fields are AND-combined; list fields are OR within."""
+input TaskFilter {
+  text:        String           # free-text search
+  projectIds:  [ID!]
+  statusIn:    [String!]
+  priorityIn:  [Priority!]
+  assigneeIn:  [String!]
+  labelIn:     [String!]
+  dueBefore:   String           # ISO date
+  dueAfter:    String
+  createdAfter: String
+  hasDueDate:  Boolean
+}
+
+type Query {
+  tasks(
+    filter: TaskFilter
+    sort: SortField = CREATED_AT
+    order: SortOrder = DESC
+    limit: Int = 50
+  ): [Task!]!
+
+  task(id: ID!): Task
+
+  projects: [Project!]!
+  labels: [Label!]!
+  statuses(projectId: ID!): [String!]!
+}
+```
+
+Notes:
+
+- **Flat `TaskFilter`** by design (research finding §3).
+- **Enums for `Priority` / `RelationType`** are reused from `src/providers/types.ts:46-123`.
+- `comments` is a sub-field on `Task`, not a separate root — kills the N+1 chain.
+- No mutations in the schema. Mutations stay as typed tools.
+
+### 4.2 Resolver pushdown
+
+```
+src/graphql/
+  schema.ts            # SDL string + buildSchema()
+  resolvers.ts         # Query.tasks, Query.task, Task.comments, …
+  pushdown/
+    youtrack.ts        # TaskFilter → YouTrack issue-query DSL
+    kaneo.ts           # TaskFilter → { projectId, q } + in-memory predicate
+  validate.ts          # parse + validate, returns errors as strings
+  execute.ts           # graphql() wrapper used by the tool
+```
+
+`pushdown/youtrack.ts` translates `TaskFilter` into the existing query-string DSL. For example:
+
+```ts
+{ statusIn: ['Open','In Progress'], priorityIn: ['HIGH','URGENT'], assigneeIn: ['me'] }
+// → "State: Open, {In Progress} Priority: High, Critical Assignee: me"
+```
+
+It then calls `provider.searchTasks({ query: dsl, projectId, limit })` — the existing path at `src/providers/youtrack/operations/tasks.ts:116-144`, which already accepts a free-form query string. **No new provider method needed for YouTrack pushdown on day 1.**
+
+`pushdown/kaneo.ts` calls `provider.listTasks(projectId)` for each project in `projectIds` (or all projects), then applies a JS predicate. This is no worse than what the LLM already does manually today, and it is now hidden behind a single GraphQL call.
+
+Phase 2 (optional) extends `TaskProvider` with a richer `queryTasks(filter)` so Kaneo can implement server-side filtering when it adds the capability — fully transparent to the LLM.
+
+### 4.3 The `query_tasks` tool
+
+```ts
+// src/tools/query-tasks.ts
+tool({
+  description: `Run a GraphQL read query against the task tracker.
+
+SCHEMA:
+<<inlined SDL — ~80 lines>>
+
+EXAMPLES:
+1. "open high-priority tasks assigned to me"
+   query { tasks(filter:{ statusIn:["Open"], priorityIn:[HIGH,URGENT], assigneeIn:["me"] }) { id title url priority dueDate } }
+
+2. "everything about TASK-42 including last 5 comments and relations"
+   query { task(id:"TASK-42") { title description status priority assignee dueDate labels{name} relations{type taskId} comments(limit:5){author body createdAt} } }
+
+3. "all tasks due this week in project ACME"
+   query { tasks(filter:{ projectIds:["ACME"], dueAfter:"2026-04-06", dueBefore:"2026-04-13" }) { id title dueDate } }
+
+4. "list projects and their open task counts" — fetch projects and filter per id.
+
+Rules:
+- Use only fields in the schema. Do not invent fields.
+- Prefer narrow selection sets; ask for only the fields you need.
+- One query per call. No mutations.`,
+  inputSchema: z.object({
+    query: z.string(),
+    variables: z.record(z.string(), z.unknown()).optional(),
+  }),
+  execute: async ({ query, variables }) => {
+    const errs = validateGraphQL(query)
+    if (errs.length) return { error: 'GraphQL validation failed', details: errs }
+    return await executeGraphQL(query, variables, { provider, userId })
+  },
+})
+```
+
+The validation step uses `graphql-js` `parse()` + `validate(schema, ast)`. On error the tool returns a structured error to the LLM, which retries — the orchestrator's existing 25-step budget covers a one-shot retry. No bespoke retry loop needed in the tool itself.
+
+Optional companion tool `describe_schema(typeName?)` returns the SDL of one type — useful for very large schemas, probably unnecessary at our size but cheap to add.
+
+## 5. Tool surface reduction
+
+Tools removed (replaced by `query_tasks`):
+
+| Removed | Why |
+|---|---|
+| `search_tasks` | `tasks(filter:{text})` |
+| `list_tasks` | `tasks(filter:{projectIds:[…]})` |
+| `get_task` | `task(id)` |
+| `list_projects` | `projects` |
+| `list_labels` | `labels` |
+| `list_statuses` | `statuses(projectId)` |
+| `get_comments` | `task(id){comments}` sub-field |
+
+That is **7 tools removed**, plus the implicit removal of N+1 chains. Tools kept (mutations + introspection):
+
+- `query_tasks`, `describe_schema` *(new)*
+- `create_task`, `update_task`, `delete_task` *(unchanged, capability-gated)*
+- `add_comment`, `update_comment`, `remove_comment`
+- `create_project`, `update_project`, `archive_project`
+- `create_label`, `update_label`, `remove_label`, `add_task_label`, `remove_task_label`
+- `add_task_relation`, `update_task_relation`, `remove_task_relation`
+- `create_status`, `update_status`, `delete_status`, `reorder_statuses`
+
+Net: ~25 → ~22 tools, but the *frequently-invoked* read tools collapse to one, which is the main token-budget and round-trip win.
+
+**Verification of "does GraphQL allow getting rid of a lot of tools": yes for reads (7 tools collapse to 1 plus full filter composability), no for writes** — and the research is unambiguous that we should not try.
+
+## 6. Code changes required
+
+1. **New dependency**: `graphql` (~600KB, well-maintained, no transitive deps). Add to `package.json`.
+2. **New module `src/graphql/`** as laid out in §4.2. ~500 LOC including resolvers.
+3. **New tool `src/tools/query-tasks.ts`** + optional `describe-schema.ts`.
+4. **`src/tools/index.ts`**: in `makeCoreTools`, replace `search_tasks` / `list_tasks` / `get_task` with `query_tasks`. In the capability-gated sections, drop `list_projects`, `list_labels`, `list_statuses`, `get_comments` — but keep their *capabilities* checks so the schema resolvers can refuse fields when the active provider lacks the capability.
+5. **Resolver capability gating**: each resolver checks `provider.capabilities.has('comments.read')` etc. and throws a GraphQL error if the field is unsupported. The schema is the same across providers; capability errors are reported in `errors[]` so the LLM can adapt.
+6. **System prompt update** (`src/prompts/`): add a brief note "use `query_tasks` for any read; it accepts a GraphQL query — see its tool description for the schema and examples".
+7. **No changes to providers on day 1.** YouTrack pushdown reuses `searchTasks`'s existing query-string parameter; Kaneo uses `listTasks` + JS filter.
+8. **Tests** (per `tests/CLAUDE.md`):
+   - `tests/graphql/validate.test.ts` — schema parses; rejects unknown fields.
+   - `tests/graphql/pushdown/youtrack.test.ts` — filter → DSL string snapshots.
+   - `tests/graphql/pushdown/kaneo.test.ts` — filter → in-memory predicate.
+   - `tests/graphql/resolvers.test.ts` — full execution against `MockTaskProvider`.
+   - `tests/tools/query-tasks.test.ts` — tool wraps execute and surfaces validation errors.
+   - E2E: extend existing Kaneo E2E with one GraphQL query.
+
+## 7. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| LLM writes invalid GraphQL | parse+validate, return structured errors, LLM retries within step budget |
+| LLM hallucinates fields | minimal schema; enums; descriptions; few-shot in tool description |
+| Token cost of inlining SDL | SDL is ~80 lines / ~1.5k tokens; cheaper than 7 tool definitions today |
+| Kaneo in-memory filtering on huge projects | document the limitation; phase 2 adds `provider.queryTasks` for server pushdown |
+| YouTrack DSL escaping bugs | translate via a small allow-listed builder, never string-concat user text; cover with snapshot tests |
+| Capability variance across providers | resolvers throw typed GraphQL errors; LLM handles gracefully |
+| Mutation safety regression | **non-issue** — mutations stay as typed tools; this is an explicit design constraint |
+
+## 8. Rollout plan
+
+1. **Phase 1 — additive**: ship `query_tasks` alongside the existing read tools behind a feature flag (env var `GRAPHQL_TOOL=1`). Run both for a release; observe reliability via the existing debug dashboard tool-call telemetry (`src/debug/`).
+2. **Phase 2 — cutover**: remove the seven legacy read tools; update system prompt; bump CHANGELOG with an automatic announcement (`src/announcements.ts`).
+3. **Phase 3 — provider pushdown**: extend `TaskProvider` with optional `queryTasks(filter)`; implement for Kaneo if/when its API supports it. Transparent to the LLM.
+4. **Phase 4 (optional)** — `describe_schema` introspection tool, persisted operations à la Apollo MCP if reliability issues appear at scale.
+
+## 9. Open questions
+
+- Do we want a `count` field (`tasks(filter){…}` returning a connection with `totalCount`)? Useful for "how many open tasks?" without fetching them. Low cost to add.
+- Should `assigneeIn: ["me"]` resolve `me` server-side from the chat user? Probably yes — convenient and avoids the LLM having to know the username.
+- Pagination: do we need cursor pagination, or is `limit` enough? Limit is enough for chatbot UX; defer cursors.
+
+## 10. References
+
+- EMNLP 2024 — GraphQL Query Generation benchmark: https://aclanthology.org/2024.emnlp-industry.117.pdf
+- IBM IJCAI 2024 — LLM-powered GraphQL Generator: https://www.ijcai.org/proceedings/2024/1002.pdf
+- Cato Networks NL→GraphQL case study: https://www.zenml.io/llmops-database/converting-natural-language-to-structured-graphql-queries-using-llms
+- Weaviate Gorilla: https://weaviate.io/blog/weaviate-gorilla-part-1
+- Apollo MCP Server: https://www.apollographql.com/docs/apollo-mcp-server
+- Apollo "Building MCP Tools with GraphQL": https://www.apollographql.com/blog/building-mcp-tools-with-graphql-a-better-way-to-connect-llms-to-your-api


### PR DESCRIPTION
Research-backed design for replacing fine-grained read tools with a
single query_tasks GraphQL tool, while keeping mutations as typed tools.