### PR TITLE
refactor(kaneo): sync update-task with official @kaneo/mcp flow

### DIFF
--- a/src/llm-orchestrator-types.ts
+++ b/src/llm-orchestrator-types.ts
@@ -8,10 +8,7 @@ export interface LlmOrchestratorDeps {
   streamText: typeof streamText
   stepCountIs: typeof stepCountIs
   buildOpenAI: (apiKey: string, baseURL: string) => ReturnType<typeof createOpenAICompatible>
-  buildProviderForUser: {
-    (userId: string, strict: false): TaskProvider | null
-    (userId: string, strict: true): TaskProvider
-  }
+  buildProviderForUser: (userId: string) => TaskProvider
   maybeProvisionKaneo: (reply: ReplyFn, contextId: string, username: string | null) => Promise<void>
 }
 

--- a/src/llm-orchestrator.ts
+++ b/src/llm-orchestrator.ts
@@ -29,8 +29,8 @@ const defaultDeps: LlmOrchestratorDeps = {
   stepCountIs: (...args) => stepCountIs(...args),
   buildOpenAI: (apiKey: string, baseURL: string) =>
     createOpenAICompatible({ name: 'openai-compatible', apiKey, baseURL, fetch: fetchWithoutTimeout }),
-  buildProviderForUser,
-  maybeProvisionKaneo,
+  buildProviderForUser: (userId: string) => buildProviderForUser(userId, true),
+  maybeProvisionKaneo: (reply, contextId, username) => maybeProvisionKaneo(reply, contextId, username),
 }
 
 const TASK_PROVIDER = process.env['TASK_PROVIDER'] ?? 'kaneo'
@@ -159,7 +159,7 @@ const callLlm = async (
   const llmBaseUrl = getConfig(contextId, 'llm_baseurl')!
   const mainModel = getConfig(contextId, 'main_model')!
   const model = deps.buildOpenAI(llmApiKey, llmBaseUrl)(mainModel)
-  const provider = deps.buildProviderForUser(contextId, true)
+  const provider = deps.buildProviderForUser(contextId)
   const tools = getOrCreateTools(contextId, provider)
   const timezone = getConfig(contextId, 'timezone') ?? 'UTC'
   const { messages: messagesWithMemory, memoryMsg } = buildMessagesWithMemory(contextId, history)

--- a/src/providers/kaneo/index.ts
+++ b/src/providers/kaneo/index.ts
@@ -4,6 +4,7 @@ import type {
   Column,
   Comment,
   Label,
+  ListTasksParams,
   Project,
   RelationType,
   Task,
@@ -88,8 +89,8 @@ export class KaneoProvider implements TaskProvider {
     return kaneoUpdateTask(this.config, this.workspaceId, taskId, params)
   }
 
-  listTasks(projectId: string): Promise<TaskListItem[]> {
-    return kaneoListTasks(this.config, this.workspaceId, projectId)
+  listTasks(projectId: string, params?: ListTasksParams): Promise<TaskListItem[]> {
+    return kaneoListTasks(this.config, this.workspaceId, projectId, params)
   }
 
   searchTasks(params: { query: string; projectId?: string; limit?: number }): Promise<TaskSearchResult[]> {

--- a/src/providers/kaneo/list-tasks-query.ts
+++ b/src/providers/kaneo/list-tasks-query.ts
@@ -1,0 +1,17 @@
+import type { ListTasksParams } from '../types.js'
+
+/**
+ * Build the query-string record for `GET /task/tasks/:projectId` from a
+ * `ListTasksParams` object. Mirrors the parameter set accepted by the
+ * upstream @kaneo/mcp `list_tasks` tool.
+ */
+export function buildListTasksQuery(params: ListTasksParams): Record<string, string> {
+  const query: Record<string, string> = {}
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) {
+      continue
+    }
+    query[key] = String(value)
+  }
+  return query
+}

--- a/src/providers/kaneo/list-tasks.ts
+++ b/src/providers/kaneo/list-tasks.ts
@@ -1,4 +1,5 @@
 import { logger } from '../../logger.js'
+import type { ListTasksParams } from '../types.js'
 import { classifyKaneoError } from './classify-error.js'
 import { type KaneoConfig } from './client.js'
 import { KaneoClient } from './kaneo-client.js'
@@ -18,15 +19,17 @@ export interface KaneoTaskListItem {
 export async function listTasks({
   config,
   projectId,
+  params,
 }: {
   config: KaneoConfig
   projectId: string
+  params?: ListTasksParams
 }): Promise<KaneoTaskListItem[]> {
-  log.debug({ projectId }, 'listTasks called')
+  log.debug({ projectId, params }, 'listTasks called')
 
   try {
     const client = new KaneoClient(config)
-    const tasks = await client.tasks.list(projectId)
+    const tasks = await client.tasks.list(projectId, params)
     log.info({ projectId, taskCount: tasks.length }, 'Tasks listed')
     return tasks
   } catch (error) {

--- a/src/providers/kaneo/operations/tasks.ts
+++ b/src/providers/kaneo/operations/tasks.ts
@@ -1,4 +1,4 @@
-import type { Task, TaskListItem, TaskSearchResult } from '../../types.js'
+import type { ListTasksParams, Task, TaskListItem, TaskSearchResult } from '../../types.js'
 import type { KaneoConfig } from '../client.js'
 import { createTask } from '../create-task.js'
 import { deleteTask } from '../delete-task.js'
@@ -74,8 +74,9 @@ export async function kaneoListTasks(
   config: KaneoConfig,
   workspaceId: string,
   projectId: string,
+  params?: ListTasksParams,
 ): Promise<TaskListItem[]> {
-  const results = await listTasks({ config, projectId })
+  const results = await listTasks({ config, projectId, params })
   return results.map((t) => mapTaskListItem(t, buildTaskUrl(config.baseUrl, workspaceId, projectId, t.id)))
 }
 

--- a/src/providers/kaneo/task-resource.ts
+++ b/src/providers/kaneo/task-resource.ts
@@ -158,11 +158,6 @@ export class TaskResource {
     this.log.debug({ taskId, ...params }, 'Updating task')
 
     try {
-      // Validate and normalize status if being updated
-      if (params.status !== undefined) {
-        const existingTask = await this.get(taskId)
-        params.status = await validateStatus(this.config, existingTask.projectId, params.status, this.statusDeps)
-      }
       const task = await performUpdate(this.config, taskId, params, this.statusDeps)
       this.log.info({ taskId, number: task.number }, 'Task updated')
       return task

--- a/src/providers/kaneo/task-resource.ts
+++ b/src/providers/kaneo/task-resource.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod'
 
 import { logger } from '../../logger.js'
+import type { ListTasksParams } from '../types.js'
 import { classifyKaneoError } from './classify-error.js'
 import { type KaneoConfig, kaneoFetch } from './client.js'
 import { parseRelationsFromDescription, type TaskRelation } from './frontmatter.js'
+import { buildListTasksQuery } from './list-tasks-query.js'
 import { type KaneoTaskListItem } from './list-tasks.js'
 import { TaskSchema as KaneoTaskResponseSchema } from './schemas/create-task.js'
 import { type TaskResult, KaneoSearchResponseSchema, TaskResultSchema } from './search-tasks.js'
@@ -60,16 +62,17 @@ export class TaskResource {
     }
   }
 
-  async list(projectId: string): Promise<KaneoTaskListItem[]> {
-    this.log.debug({ projectId }, 'Listing tasks')
+  async list(projectId: string, params?: ListTasksParams): Promise<KaneoTaskListItem[]> {
+    this.log.debug({ projectId, params }, 'Listing tasks')
 
     try {
+      const query: Record<string, string> | undefined = params === undefined ? undefined : buildListTasksQuery(params)
       const result = await kaneoFetch(
         this.config,
         'GET',
         `/task/tasks/${projectId}`,
         undefined,
-        undefined,
+        query,
         GetTasksResponseSchema,
       )
       const rawTasks = result.columns.flatMap((col) => col.tasks).concat(result.plannedTasks)

--- a/src/providers/kaneo/task-update-helpers.ts
+++ b/src/providers/kaneo/task-update-helpers.ts
@@ -1,15 +1,9 @@
-import { z } from 'zod'
-
+import { logger } from '../../logger.js'
 import { type KaneoConfig, kaneoFetch } from './client.js'
-import { TaskSchema } from './schemas/create-task.js'
-import { type TaskStatusDeps, denormalizeStatus } from './task-status.js'
+import { TaskSchema, type CreateTaskResponse } from './schemas/create-task.js'
+import { type TaskStatusDeps, denormalizeStatus, validateStatus } from './task-status.js'
 
-// Local schema for task with projectId (for update responses)
-const TaskWithProjectIdSchema = TaskSchema
-
-const FullTaskSchema = TaskWithProjectIdSchema.extend({
-  position: z.number(),
-})
+const log = logger.child({ scope: 'kaneo:task-update-helpers' })
 
 type TaskUpdateParams = {
   title?: string
@@ -21,72 +15,84 @@ type TaskUpdateParams = {
   userId?: string
 }
 
-/**
- * Single field update for a task
- */
-function singleFieldUpdate(
-  config: KaneoConfig,
-  taskId: string,
-  field: string,
-  value: unknown,
-): Promise<z.infer<typeof TaskWithProjectIdSchema>> {
-  const endpoints: Record<string, { path: string; key: string }> = {
-    status: { path: '/task/status/', key: 'status' },
-    priority: { path: '/task/priority/', key: 'priority' },
-    userId: { path: '/task/assignee/', key: 'userId' },
-    dueDate: { path: '/task/due-date/', key: 'dueDate' },
-    title: { path: '/task/title/', key: 'title' },
-    description: { path: '/task/description/', key: 'description' },
-  }
-  const endpoint = endpoints[field]
-  if (endpoint === undefined) throw new Error(`Unknown field: ${field}`)
-  return kaneoFetch(
-    config,
-    'PUT',
-    `${endpoint.path}${taskId}`,
-    { [endpoint.key]: value },
-    undefined,
-    TaskWithProjectIdSchema,
-  )
+type FullUpdateBody = {
+  title: string
+  description: string
+  status: string
+  priority: string
+  projectId: string
+  position: number
+  dueDate?: string
+  userId?: string
 }
 
 /**
- * Perform updates on a task, handling multiple field updates sequentially
+ * Build the JSON body for `PUT /task/:id` from an existing task plus a patch.
+ * Mirrors the official @kaneo/mcp `buildFullTaskUpdateBody` helper:
+ * the Kaneo API requires the full task payload on update, so we merge
+ * unchanged fields from the existing task.
+ */
+function requireString(value: string | undefined | null, field: string): string {
+  if (value === undefined || value === null || value === '') {
+    throw new Error(`Cannot update task: missing ${field}.`)
+  }
+  return value
+}
+
+function buildFullTaskUpdateBody(existing: CreateTaskResponse, patch: TaskUpdateParams): FullUpdateBody {
+  const position = existing.position
+  if (position === null || !Number.isFinite(position)) {
+    throw new Error('Cannot update task: missing numeric `position` on existing task.')
+  }
+
+  const body: FullUpdateBody = {
+    title: requireString(patch.title ?? existing.title, 'title'),
+    description: patch.description ?? existing.description ?? '',
+    status: requireString(patch.status ?? existing.status, 'status'),
+    priority: requireString(patch.priority ?? existing.priority, 'priority'),
+    projectId: requireString(patch.projectId ?? existing.projectId, 'projectId'),
+    position,
+  }
+
+  const existingDueDate = typeof existing.dueDate === 'string' ? existing.dueDate : undefined
+  const dueDate = patch.dueDate ?? existingDueDate
+  if (dueDate !== undefined) {
+    body.dueDate = dueDate
+  }
+
+  const userId = patch.userId ?? existing.userId ?? undefined
+  if (userId !== undefined) {
+    body.userId = userId
+  }
+
+  return body
+}
+
+/**
+ * Fetch the existing task, merge the patch, and PUT the full body to `/task/:id`.
+ *
+ * This matches the upstream @kaneo/mcp flow — the Kaneo API does not accept
+ * partial updates on the main task endpoint, it requires the full payload.
  */
 export async function performUpdate(
   config: KaneoConfig,
   taskId: string,
   params: TaskUpdateParams,
   statusDeps?: TaskStatusDeps,
-): Promise<z.infer<typeof TaskWithProjectIdSchema>> {
-  // Use single-field endpoints for each field being updated
-  // (The full /task/:id endpoint doesn't actually update fields)
-  const setFields = Object.entries(params).filter(([, v]) => v !== undefined)
+): Promise<CreateTaskResponse> {
+  log.debug({ taskId, fields: Object.keys(params) }, 'performUpdate called')
 
-  // Apply updates sequentially using reduce to chain promises
-  // This avoids await-in-loop while maintaining sequential execution
-  const result = await setFields.reduce<Promise<z.infer<typeof TaskWithProjectIdSchema> | undefined>>(
-    async (previousPromise, [field, value]) => {
-      await previousPromise
-      return singleFieldUpdate(config, taskId, field, value)
-    },
-    Promise.resolve(undefined),
-  )
+  const existing = await kaneoFetch(config, 'GET', `/task/${taskId}`, undefined, undefined, TaskSchema)
 
-  // Return the result, or fetch current if no updates
-  if (result !== undefined) {
-    // Denormalize status from column ID to slug
-    if (result.projectId !== undefined) {
-      result.status = await denormalizeStatus(config, result.projectId, result.status, statusDeps)
-    }
-    return result
+  const patch: TaskUpdateParams = { ...params }
+  if (patch.status !== undefined) {
+    patch.status = await validateStatus(config, existing.projectId, patch.status, statusDeps)
   }
 
-  // If no fields to update, just return current task
-  const task = await kaneoFetch(config, 'GET', `/task/${taskId}`, undefined, undefined, FullTaskSchema)
-  // Denormalize status from column ID to slug
-  if (task.projectId !== undefined) {
-    task.status = await denormalizeStatus(config, task.projectId, task.status, statusDeps)
-  }
-  return task
+  const body = buildFullTaskUpdateBody(existing, patch)
+  const updated = await kaneoFetch(config, 'PUT', `/task/${taskId}`, body, undefined, TaskSchema)
+
+  updated.status = await denormalizeStatus(config, updated.projectId, updated.status, statusDeps)
+  log.info({ taskId, number: updated.number }, 'Task updated')
+  return updated
 }

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -59,6 +59,23 @@ export type Task = {
   relations?: TaskRelation[]
 }
 
+/**
+ * Optional filters for `listTasks`. Mirrors the query params accepted by the
+ * upstream @kaneo/mcp `list_tasks` tool. Providers that don't support a given
+ * filter may ignore it.
+ */
+export type ListTasksParams = {
+  status?: string
+  priority?: 'no-priority' | 'low' | 'medium' | 'high' | 'urgent'
+  assigneeId?: string
+  page?: number
+  limit?: number
+  sortBy?: 'createdAt' | 'priority' | 'dueDate' | 'position' | 'title' | 'number'
+  sortOrder?: 'asc' | 'desc'
+  dueBefore?: string
+  dueAfter?: string
+}
+
 /** Minimal task representation for list results. */
 export type TaskListItem = {
   id: string
@@ -174,7 +191,7 @@ export interface TaskProvider {
     },
   ): Promise<Task>
 
-  listTasks(projectId: string): Promise<TaskListItem[]>
+  listTasks(projectId: string, params?: ListTasksParams): Promise<TaskListItem[]>
 
   searchTasks(params: { query: string; projectId?: string; limit?: number }): Promise<TaskSearchResult[]>
 

--- a/src/providers/youtrack/index.ts
+++ b/src/providers/youtrack/index.ts
@@ -1,6 +1,15 @@
 import type { AppError } from '../../errors.js'
 import { logger } from '../../logger.js'
-import type { Comment, Label, Project, Task, TaskListItem, TaskProvider, TaskSearchResult } from '../types.js'
+import type {
+  Comment,
+  Label,
+  ListTasksParams,
+  Project,
+  Task,
+  TaskListItem,
+  TaskProvider,
+  TaskSearchResult,
+} from '../types.js'
 import { classifyYouTrackError } from './classify-error.js'
 import { type YouTrackConfig } from './client.js'
 import { CONFIG_REQUIREMENTS, YOUTRACK_CAPABILITIES } from './constants.js'
@@ -76,7 +85,9 @@ export class YouTrackProvider implements TaskProvider {
     return updateYouTrackTask(this.config, taskId, params)
   }
 
-  listTasks(projectId: string): Promise<TaskListItem[]> {
+  listTasks(projectId: string, _params?: ListTasksParams): Promise<TaskListItem[]> {
+    // YouTrack provider doesn't yet translate ListTasksParams to YouTrack query syntax;
+    // filters are accepted for API parity with Kaneo but currently ignored.
     return listYouTrackTasks(this.config, projectId)
   }
 

--- a/src/tools/list-tasks.ts
+++ b/src/tools/list-tasks.ts
@@ -4,21 +4,35 @@ import { z } from 'zod'
 
 import { getConfig } from '../config.js'
 import { logger } from '../logger.js'
-import type { TaskProvider } from '../providers/types.js'
+import type { ListTasksParams, TaskProvider } from '../providers/types.js'
 import { utcToLocal } from '../utils/datetime.js'
 
 const log = logger.child({ scope: 'tool:list-tasks' })
 
 export function makeListTasksTool(provider: TaskProvider, userId?: string): ToolSet[string] {
   return tool({
-    description: 'List all tasks in a project. Use this to see all tasks in a specific project.',
+    description:
+      'List tasks in a project. Optional filters match the upstream @kaneo/mcp list_tasks tool (status, priority, assignee, pagination, sort, due-date range).',
     inputSchema: z.object({
       projectId: z.string().describe('Project ID to list tasks from'),
+      status: z.string().optional().describe('Filter by status column slug'),
+      priority: z.enum(['no-priority', 'low', 'medium', 'high', 'urgent']).optional().describe('Filter by priority'),
+      assigneeId: z.string().optional().describe('Filter by assignee user ID'),
+      page: z.number().int().positive().optional().describe('Page number (1-based)'),
+      limit: z.number().int().positive().optional().describe('Max tasks per page'),
+      sortBy: z
+        .enum(['createdAt', 'priority', 'dueDate', 'position', 'title', 'number'])
+        .optional()
+        .describe('Field to sort by'),
+      sortOrder: z.enum(['asc', 'desc']).optional().describe('Sort direction'),
+      dueBefore: z.iso.datetime({ offset: true }).optional().describe('Only tasks due before this ISO date'),
+      dueAfter: z.iso.datetime({ offset: true }).optional().describe('Only tasks due after this ISO date'),
     }),
-    execute: async ({ projectId }) => {
+    execute: async ({ projectId, ...rest }) => {
+      const params: ListTasksParams = rest
       try {
-        const tasks = await provider.listTasks(projectId)
-        log.info({ projectId, taskCount: tasks.length }, 'Tasks listed via tool')
+        const tasks = await provider.listTasks(projectId, params)
+        log.info({ projectId, taskCount: tasks.length, filters: rest }, 'Tasks listed via tool')
         const timezone = userId === undefined ? 'UTC' : (getConfig(userId, 'timezone') ?? 'UTC')
         return tasks.map((task) => ({ ...task, dueDate: utcToLocal(task.dueDate, timezone) }))
       } catch (error) {

--- a/tests/providers/kaneo/task-resource.test.ts
+++ b/tests/providers/kaneo/task-resource.test.ts
@@ -315,243 +315,98 @@ describe('TaskResource', () => {
   })
 
   describe('update', () => {
-    describe('single field updates', () => {
-      test('uses status endpoint for status update', async () => {
-        let requestUrl = ''
-        setMockFetch((url: string, _options: RequestInit) => {
-          requestUrl = url
-          return Promise.resolve(
-            new Response(
-              JSON.stringify(
-                createMockTask({
-                  id: 'task-1',
-                  title: 'Test',
-                  number: 1,
-                  status: 'done',
-                  description: '',
-                }),
-              ),
-              { status: 200 },
+    function mockGetThenPut(responseOverrides: Parameters<typeof createMockTask>[0] = {}): Array<{
+      url: string
+      method: string
+      body?: unknown
+    }> {
+      const requests: Array<{ url: string; method: string; body?: unknown }> = []
+      setMockFetch((url: string, options: RequestInit) => {
+        const parsedBody: unknown = typeof options.body === 'string' ? (JSON.parse(options.body) as unknown) : undefined
+        requests.push({ url, method: options.method ?? 'GET', body: parsedBody })
+        return Promise.resolve(
+          new Response(
+            JSON.stringify(
+              createMockTask({
+                id: 'task-1',
+                projectId: 'proj-1',
+                position: 3,
+                number: 1,
+                title: 'Test',
+                description: '',
+                status: 'col-1',
+                priority: 'no-priority',
+                ...responseOverrides,
+              }),
             ),
-          )
-        })
-
-        const resource = new TaskResource(mockConfig, statusDeps)
-        await resource.update('task-1', { status: 'done' })
-
-        expect(requestUrl).toContain('/task/status/task-1')
+            { status: 200 },
+          ),
+        )
       })
+      return requests
+    }
 
-      test('uses priority endpoint for priority update', async () => {
-        let requestUrl = ''
-        setMockFetch((url: string, _options: RequestInit) => {
-          requestUrl = url
-          return Promise.resolve(
-            new Response(
-              JSON.stringify(
-                createMockTask({
-                  id: 'task-1',
-                  title: 'Test',
-                  number: 1,
-                  priority: 'high',
-                  description: '',
-                }),
-              ),
-              { status: 200 },
-            ),
-          )
-        })
+    test('PUTs full merged body to /task/:id (single field)', async () => {
+      const requests = mockGetThenPut({ status: 'done' })
 
-        const resource = new TaskResource(mockConfig, statusDeps)
-        await resource.update('task-1', { priority: 'high' })
+      const resource = new TaskResource(mockConfig, statusDeps)
+      await resource.update('task-1', { status: 'done' })
 
-        expect(requestUrl).toContain('/task/priority/task-1')
-      })
-
-      test('uses assign endpoint for userId update', async () => {
-        let requestUrl = ''
-        setMockFetch((url: string, _options: RequestInit) => {
-          requestUrl = url
-          return Promise.resolve(
-            new Response(
-              JSON.stringify(
-                createMockTask({
-                  id: 'task-1',
-                  title: 'Test',
-                  number: 1,
-                  description: '',
-                  userId: 'user-123',
-                }),
-              ),
-              { status: 200 },
-            ),
-          )
-        })
-
-        const resource = new TaskResource(mockConfig, statusDeps)
-        await resource.update('task-1', { userId: 'user-123' })
-
-        expect(requestUrl).toContain('/task/assignee/task-1')
-      })
-
-      test('uses dueDate endpoint for dueDate update', async () => {
-        let requestUrl = ''
-        setMockFetch((url: string, _options: RequestInit) => {
-          requestUrl = url
-          return Promise.resolve(
-            new Response(
-              JSON.stringify(
-                createMockTask({
-                  id: 'task-1',
-                  title: 'Test',
-                  number: 1,
-                  description: '',
-                  dueDate: '2026-12-31',
-                }),
-              ),
-              { status: 200 },
-            ),
-          )
-        })
-
-        const resource = new TaskResource(mockConfig, statusDeps)
-        await resource.update('task-1', { dueDate: '2026-12-31' })
-
-        expect(requestUrl).toContain('/task/due-date/task-1')
-      })
-
-      test('uses title endpoint for title update', async () => {
-        let requestUrl = ''
-        setMockFetch((url: string, _options: RequestInit) => {
-          requestUrl = url
-          return Promise.resolve(
-            new Response(
-              JSON.stringify(
-                createMockTask({
-                  id: 'task-1',
-                  title: 'Updated Title',
-                  number: 1,
-                  description: '',
-                }),
-              ),
-              { status: 200 },
-            ),
-          )
-        })
-
-        const resource = new TaskResource(mockConfig, statusDeps)
-        await resource.update('task-1', { title: 'Updated Title' })
-
-        expect(requestUrl).toContain('/task/title/task-1')
-      })
-
-      test('uses description endpoint for description update', async () => {
-        let requestUrl = ''
-        setMockFetch((url: string, _options: RequestInit) => {
-          requestUrl = url
-          return Promise.resolve(
-            new Response(
-              JSON.stringify(
-                createMockTask({
-                  id: 'task-1',
-                  title: 'Test',
-                  number: 1,
-                  description: 'Updated description',
-                }),
-              ),
-              { status: 200 },
-            ),
-          )
-        })
-
-        const resource = new TaskResource(mockConfig, statusDeps)
-        await resource.update('task-1', { description: 'Updated description' })
-
-        expect(requestUrl).toContain('/task/description/task-1')
+      expect(requests).toHaveLength(2)
+      expect(requests[0]?.method).toBe('GET')
+      expect(requests[0]?.url).toContain('/task/task-1')
+      expect(requests[1]?.method).toBe('PUT')
+      expect(requests[1]?.url).toContain('/task/task-1')
+      expect(requests[1]?.body).toMatchObject({
+        title: 'Test',
+        description: '',
+        status: 'done',
+        priority: 'no-priority',
+        projectId: 'proj-1',
+        position: 3,
       })
     })
 
-    describe('multi-field updates', () => {
-      test('calls single-field endpoints for each field', async () => {
-        const requests: Array<{ url: string; method: string; body?: unknown }> = []
+    test('PUTs full merged body to /task/:id (multiple fields)', async () => {
+      const requests = mockGetThenPut({ title: 'New Title', priority: 'high', description: 'New desc' })
 
-        setMockFetch((url: string, options: RequestInit) => {
-          const parsedBody: unknown = typeof options.body === 'string' ? JSON.parse(options.body) : undefined
-          requests.push({ url, method: options.method ?? 'GET', body: parsedBody })
-
-          // Return success for any single-field endpoint
-          return Promise.resolve(
-            new Response(
-              JSON.stringify(
-                createMockTask({
-                  id: 'task-1',
-                  title: 'New Title',
-                  number: 1,
-                  status: 'done',
-                  priority: 'high',
-                  description: 'New desc',
-                }),
-              ),
-              { status: 200 },
-            ),
-          )
-        })
-
-        const resource = new TaskResource(mockConfig, statusDeps)
-        await resource.update('task-1', {
-          title: 'New Title',
-          status: 'done',
-          priority: 'high',
-          description: 'New desc',
-        })
-
-        // Should make 5 requests - one GET for validation + one for each field
-        expect(requests.length).toBe(5)
-        // GET request for projectId lookup
-        expect(requests[0]?.url).toContain('/task/task-1')
-        expect(requests[1]?.url).toContain('/task/title/task-1')
-        expect(requests[2]?.url).toContain('/task/status/task-1')
-        expect(requests[3]?.url).toContain('/task/priority/task-1')
-        expect(requests[4]?.url).toContain('/task/description/task-1')
+      const resource = new TaskResource(mockConfig, statusDeps)
+      await resource.update('task-1', {
+        title: 'New Title',
+        priority: 'high',
+        description: 'New desc',
       })
 
-      test('uses correct endpoints for each field type', async () => {
-        const requests: Array<{ url: string; body?: unknown }> = []
+      expect(requests).toHaveLength(2)
+      expect(requests[0]?.method).toBe('GET')
+      expect(requests[1]?.method).toBe('PUT')
+      expect(requests[1]?.body).toMatchObject({
+        title: 'New Title',
+        description: 'New desc',
+        priority: 'high',
+        projectId: 'proj-1',
+        position: 3,
+      })
+    })
 
-        setMockFetch((url: string, options: RequestInit) => {
-          const parsedBody: unknown = typeof options.body === 'string' ? JSON.parse(options.body) : undefined
-          requests.push({ url, body: parsedBody })
+    test('preserves unchanged fields from the existing task', async () => {
+      const requests = mockGetThenPut({
+        title: 'Existing',
+        description: 'Existing desc',
+        priority: 'medium',
+        status: 'col-2',
+      })
 
-          return Promise.resolve(
-            new Response(
-              JSON.stringify(
-                createMockTask({
-                  id: 'task-1',
-                  title: 'New',
-                  number: 1,
-                  status: 'done',
-                  priority: 'high',
-                  description: 'New',
-                }),
-              ),
-              { status: 200 },
-            ),
-          )
-        })
+      const resource = new TaskResource(mockConfig, statusDeps)
+      await resource.update('task-1', { title: 'Only title changed' })
 
-        const resource = new TaskResource(mockConfig, statusDeps)
-        await resource.update('task-1', {
-          title: 'New',
-          status: 'done',
-        })
-
-        expect(requests.length).toBe(3)
-        // GET request for projectId lookup
-        expect(requests[0]?.url).toContain('/task/task-1')
-        expect(requests[1]?.url).toContain('/task/title/task-1')
-        expect(requests[1]?.body).toMatchObject({ title: 'New' })
-        expect(requests[2]?.url).toContain('/task/status/task-1')
-        expect(requests[2]?.body).toMatchObject({ status: 'done' })
+      expect(requests[1]?.body).toMatchObject({
+        title: 'Only title changed',
+        description: 'Existing desc',
+        priority: 'medium',
+        status: 'col-2',
+        projectId: 'proj-1',
+        position: 3,
       })
     })
   })

--- a/tests/providers/kaneo/task-update-helpers.test.ts
+++ b/tests/providers/kaneo/task-update-helpers.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import type { KaneoConfig } from '../../../src/providers/kaneo/client.js'
+import type { TaskStatusDeps } from '../../../src/providers/kaneo/task-status.js'
+import { performUpdate } from '../../../src/providers/kaneo/task-update-helpers.js'
+import { createMockColumn, createMockTask, mockLogger, restoreFetch, setMockFetch } from '../../utils/test-helpers.js'
+
+describe('task-update-helpers', () => {
+  const config: KaneoConfig = { apiKey: 'test-key', baseUrl: 'https://api.test.com' }
+
+  let statusDeps: TaskStatusDeps
+
+  beforeEach(() => {
+    mockLogger()
+    statusDeps = {
+      listColumns: (): Promise<Array<{ id: string; name: string }>> =>
+        Promise.resolve([
+          createMockColumn({ id: 'col-1', name: 'To Do' }),
+          createMockColumn({ id: 'col-2', name: 'In Progress' }),
+          createMockColumn({ id: 'col-3', name: 'Done', isFinal: true }),
+        ]),
+    }
+  })
+
+  afterEach(() => {
+    restoreFetch()
+  })
+
+  describe('performUpdate', () => {
+    test('fetches existing task then PUTs merged full body', async () => {
+      const requests: Array<{ url: string; method: string; body?: unknown }> = []
+      setMockFetch((url: string, options: RequestInit) => {
+        const parsedBody: unknown = typeof options.body === 'string' ? (JSON.parse(options.body) as unknown) : undefined
+        requests.push({ url, method: options.method ?? 'GET', body: parsedBody })
+        if ((options.method ?? 'GET') === 'GET') {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify(
+                createMockTask({
+                  id: 'task-1',
+                  projectId: 'proj-1',
+                  position: 5,
+                  title: 'Existing Title',
+                  description: 'Existing description',
+                  status: 'col-1',
+                  priority: 'low',
+                }),
+              ),
+              { status: 200 },
+            ),
+          )
+        }
+        return Promise.resolve(
+          new Response(
+            JSON.stringify(
+              createMockTask({
+                id: 'task-1',
+                projectId: 'proj-1',
+                position: 5,
+                title: 'New Title',
+                description: 'Existing description',
+                status: 'col-1',
+                priority: 'high',
+              }),
+            ),
+            { status: 200 },
+          ),
+        )
+      })
+
+      const result = await performUpdate(config, 'task-1', { title: 'New Title', priority: 'high' }, statusDeps)
+
+      expect(requests).toHaveLength(2)
+      expect(requests[0]?.method).toBe('GET')
+      expect(requests[0]?.url).toContain('/task/task-1')
+      expect(requests[1]?.method).toBe('PUT')
+      expect(requests[1]?.url).toContain('/task/task-1')
+      expect(requests[1]?.body).toMatchObject({
+        title: 'New Title',
+        description: 'Existing description',
+        status: 'col-1',
+        priority: 'high',
+        projectId: 'proj-1',
+        position: 5,
+      })
+      expect(result.title).toBe('New Title')
+    })
+
+    test('validates and normalizes status through statusDeps', async () => {
+      const requests: Array<{ url: string; method: string; body?: unknown }> = []
+      setMockFetch((url: string, options: RequestInit) => {
+        const parsedBody: unknown = typeof options.body === 'string' ? (JSON.parse(options.body) as unknown) : undefined
+        requests.push({ url, method: options.method ?? 'GET', body: parsedBody })
+        if ((options.method ?? 'GET') === 'GET') {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify(
+                createMockTask({
+                  id: 'task-1',
+                  projectId: 'proj-1',
+                  position: 0,
+                  status: 'col-1',
+                }),
+              ),
+              { status: 200 },
+            ),
+          )
+        }
+        return Promise.resolve(
+          new Response(
+            JSON.stringify(
+              createMockTask({
+                id: 'task-1',
+                projectId: 'proj-1',
+                position: 0,
+                status: 'col-3',
+              }),
+            ),
+            { status: 200 },
+          ),
+        )
+      })
+
+      await performUpdate(config, 'task-1', { status: 'done' }, statusDeps)
+
+      // validateStatus normalizes status to a slug that matches a column
+      expect(requests[1]?.body).toMatchObject({ status: 'done' })
+    })
+
+    test('throws when existing task is missing position', async () => {
+      setMockFetch(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify(
+              createMockTask({
+                id: 'task-1',
+                projectId: 'proj-1',
+                // position explicitly null
+                position: null,
+              }),
+            ),
+            { status: 200 },
+          ),
+        ),
+      )
+
+      await expect(performUpdate(config, 'task-1', { title: 'x' }, statusDeps)).rejects.toThrow()
+    })
+  })
+})

--- a/tests/system-prompt.test.ts
+++ b/tests/system-prompt.test.ts
@@ -2,14 +2,15 @@ import { beforeEach, describe, expect, test, mock } from 'bun:test'
 
 import { buildSystemPrompt } from '../src/system-prompt.js'
 import { createMockProvider } from './tools/mock-provider.js'
-import { mockLogger } from './utils/test-helpers.js'
+import { mockLogger, setupTestDb } from './utils/test-helpers.js'
 
 describe('buildSystemPrompt', () => {
   const provider = createMockProvider()
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mockLogger()
     mock.restore()
+    await setupTestDb()
   })
 
   test('does not include current date and time in prompt (to preserve KV cache)', () => {

--- a/tests/tools/get-current-time.test.ts
+++ b/tests/tools/get-current-time.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test, beforeEach, mock } from 'bun:test'
 
 import { setCachedConfig } from '../../src/cache.js'
 import { makeGetCurrentTimeTool } from '../../src/tools/get-current-time.js'
-import { mockLogger } from '../utils/test-helpers.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
 
 interface TimeResult {
   datetime: string
@@ -24,9 +24,10 @@ function isTimeResult(val: unknown): val is TimeResult {
 }
 
 describe('makeGetCurrentTimeTool', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     mockLogger()
     mock.restore()
+    await setupTestDb()
     setCachedConfig('user-1', 'timezone', 'Asia/Karachi')
   })
 

--- a/tests/tools/task-tools.test.ts
+++ b/tests/tools/task-tools.test.ts
@@ -534,7 +534,7 @@ describe('Task Tools', () => {
     test('returns tool with correct structure', () => {
       const provider = createMockProvider()
       const tool = makeListTasksTool(provider)
-      expect(tool.description).toContain('List all tasks')
+      expect(tool.description).toContain('List tasks')
     })
 
     test('lists tasks for project', async () => {


### PR DESCRIPTION
The upstream @kaneo/mcp package (usekaneo/kaneo#1160) updates tasks
via a single `GET /task/:id` → merge → `PUT /task/:id` with the full
payload. Our previous implementation called a chain of single-field
endpoints (`/task/status/:id`, `/task/priority/:id`, etc.), which is
no longer the blessed path and required N+1 requests for multi-field
updates.

`performUpdate` now mirrors `buildFullTaskUpdateBody` from upstream,
collapsing multi-field updates to one PUT and removing the redundant
pre-validation fetch previously in `TaskResource.update`.

https://claude.ai/code/session_01RXCG3E9XZ7mNVKS8ZPShrF