### PR TITLE
feat: add Discord ChatProvider adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Chat provider: telegram or mattermost
+# Chat provider: telegram, mattermost, or discord
 CHAT_PROVIDER=telegram
 
 # Task provider: kaneo or youtrack (determines which task tracker to use)
@@ -62,3 +62,8 @@ KANEO_DISABLE_REGISTRATION=true
 #   /set main_model gpt-4o
 #   /set small_model gpt-4o-mini   # optional: model used to extract and summarise memory facts
 # Values are persisted in papai.db (SQLite). Use /config to view current settings.
+
+# --- Discord-specific (required when CHAT_PROVIDER=discord) ---
+# Bot Token from https://discord.com/developers/applications → your app → Bot → Reset Token.
+# The bot must have the MESSAGE CONTENT INTENT enabled in the Developer Portal → Bot page.
+# DISCORD_BOT_TOKEN=

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@opencode-ai/plugin": "1.4.1"
+    "@opencode-ai/plugin": "1.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-papai is a chat bot that manages tasks via LLM tool-calling. A user sends natural language messages through a configurable chat platform (Telegram or Mattermost), the bot invokes a configurable OpenAI-compatible LLM (via Vercel AI SDK) which autonomously selects and executes task tracker operations, then replies with the result. The chat platform, task tracker provider (Kaneo, YouTrack, or any future provider), LLM provider, base URL, and model are all runtime-configurable.
+papai is a chat bot that manages tasks via LLM tool-calling. A user sends natural language messages through a configurable chat platform (Telegram, Mattermost, or Discord), the bot invokes a configurable OpenAI-compatible LLM (via Vercel AI SDK) which autonomously selects and executes task tracker operations, then replies with the result. The chat platform, task tracker provider (Kaneo, YouTrack, or any future provider), LLM provider, base URL, and model are all runtime-configurable.
 
 ## Commands
 
@@ -183,6 +183,8 @@ Copy `.env.example` to `.env`. Required at startup (validated in `src/index.ts`)
 
 **Mattermost-specific:** `MATTERMOST_URL`, `MATTERMOST_BOT_TOKEN`
 
+**Discord-specific (when CHAT_PROVIDER=discord):** `DISCORD_BOT_TOKEN`
+
 **Kaneo-specific (when TASK_PROVIDER=kaneo):** `KANEO_CLIENT_URL`
 
 **YouTrack-specific (when TASK_PROVIDER=youtrack):** `YOUTRACK_URL`
@@ -211,9 +213,10 @@ User (Telegram/Mattermost) ─→ ChatProvider (chat/registry.ts) ─→ bot.ts 
 - **`src/index.ts`** — entry point; validates env vars, runs migrations, creates `ChatProvider`, calls `setupBot`, starts the provider.
 - **`src/bot.ts`** — platform-agnostic wiring; registers all command handlers and the message handler via `setupBot(chat, adminUserId)`.
 - **`src/chat/types.ts`** — `ChatProvider` interface, `ReplyFn`, `IncomingMessage`, `ChatUser`, `ChatFile`, `ThreadCapabilities` types.
-- **`src/chat/registry.ts`** — provider factory registry; `createChatProvider(name)` instantiates the named provider. Built-in: `telegram`, `mattermost`.
+- **`src/chat/registry.ts`** — provider factory registry; `createChatProvider(name)` instantiates the named provider. Built-in: `telegram`, `mattermost`, `discord`.
 - **`src/chat/telegram/`** — Grammy-based Telegram adapter (`TelegramChatProvider`). `format.ts` converts LLM markdown to Telegram `MessageEntity[]`. Supports forum topics (threads) for group chats.
 - **`src/chat/mattermost/`** — Mattermost REST+WebSocket adapter (`MattermostChatProvider`).
+- **`src/chat/discord/`** — discord.js v14 adapter (`DiscordChatProvider`). Supports DMs and guild-channel @mentions with chunked replies, button interactions, and guild-scoped `resolveUserId`. Outgoing file attachments are deferred.
 - **`src/config.ts`** — SQLite-backed **per-user** runtime config store; exposes `getConfig(userId, key)`, `setConfig(userId, key, value)`, `getAllConfig(userId)`.
 - **`src/users.ts`** — SQLite-backed user authorization store; `addUser`, `removeUser`, `isAuthorized`, `isAuthorizedByUsername`, `resolveUserByUsername`, `listUsers`.
 
@@ -482,7 +485,7 @@ someFunction(deps)
 - Runtime: **Bun** (not Node)
 - Validation: **Zod v4** for all schemas
 - LLM integration: **Vercel AI SDK** (`ai` package) with `@ai-sdk/openai`
-- Chat platforms: **Grammy** (Telegram adapter), Mattermost REST+WebSocket
+- Chat platforms: **Grammy** (Telegram adapter), Mattermost REST+WebSocket, **discord.js** v14 (Discord adapter)
 - Linting/formatting: **oxlint / oxfmt** (not ESLint/Prettier)
 - Strict TypeScript (`tsconfig.json` has strict mode + all safety flags)
 - Logging: **pino** with structured JSON output

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "ai": "^6.0.154",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
+        "discord.js": "^14.25.1",
         "drizzle-orm": "^0.45.2",
         "fuse.js": "^7.3.0",
         "grammy": "^1.42.0",
@@ -116,6 +117,18 @@
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
+
+    "@discordjs/builders": ["@discordjs/builders@1.14.1", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.40", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ=="],
+
+    "@discordjs/collection": ["@discordjs/collection@1.5.3", "", {}, "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="],
+
+    "@discordjs/formatters": ["@discordjs/formatters@0.6.2", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ=="],
+
+    "@discordjs/rest": ["@discordjs/rest@2.6.1", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.2.0", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.5", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.40", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg=="],
+
+    "@discordjs/util": ["@discordjs/util@1.2.0", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg=="],
+
+    "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
@@ -425,6 +438,12 @@
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
+    "@sapphire/async-queue": ["@sapphire/async-queue@1.5.5", "", {}, "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg=="],
+
+    "@sapphire/shapeshift": ["@sapphire/shapeshift@4.0.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "lodash": "^4.17.21" } }, "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg=="],
+
+    "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
+
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
@@ -470,6 +489,8 @@
     "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260409.1", "", { "os": "win32", "cpu": "x64" }, "sha512-WRd+JpQipTsE15QgYr3w7J0f1NKvGcq2QEgmcq8hB0WZA1X2WhQopNu+MpPQ3tdDD42VjMhm8ZoB8HpuOoXK5w=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
+
+    "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.7", "", {}, "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
@@ -546,6 +567,10 @@
     "des.js": ["des.js@1.1.0", "", { "dependencies": { "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg=="],
 
     "diff-match-patch": ["diff-match-patch@1.0.5", "", {}, "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="],
+
+    "discord-api-types": ["discord-api-types@0.38.45", "", {}, "sha512-DiI01i00FPv6n+hXcFkFxK8Y/rFRpKs6U6aP32N4T73nTbj37Eua3H/95TBpLktLWB6xnLXhYDGvyLq6zzYY2w=="],
+
+    "discord.js": ["discord.js@14.26.2", "", { "dependencies": { "@discordjs/builders": "^1.14.1", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.1", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.40", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-feShi+gULJ6R2MAA4/KkCFnkJcuVrROJrKk4czplzq8gE1oqhqgOy9K0Scu44B8oGeWKe04egquzf+ia6VtXAw=="],
 
     "doctypes": ["doctypes@1.1.0", "", {}, "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ=="],
 
@@ -697,9 +722,15 @@
 
     "knip": ["knip@6.3.1", "", { "dependencies": { "@nodelib/fs.walk": "^1.2.3", "fast-glob": "^3.3.3", "formatly": "^0.3.0", "get-tsconfig": "4.13.7", "jiti": "^2.6.0", "minimist": "^1.2.8", "oxc-parser": "^0.121.0", "oxc-resolver": "^11.19.1", "picocolors": "^1.1.1", "picomatch": "^4.0.1", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "unbash": "^2.2.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-22kLJloVcOVOAudCxlFOC0ICAMme7dKsS7pVTEnrmyKGpswb8ieznvAiSKUeFVDJhb01ect6dkDc1Ha1g1sPpg=="],
 
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
+
     "lodash.groupby": ["lodash.groupby@4.6.0", "", {}, "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw=="],
 
+    "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
+
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "magic-bytes.js": ["magic-bytes.js@1.13.0", "", {}, "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="],
 
     "markdown-table": ["markdown-table@2.0.0", "", { "dependencies": { "repeat-string": "^1.0.0" } }, "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A=="],
 
@@ -891,6 +922,8 @@
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
+    "ts-mixer": ["ts-mixer@6.0.4", "", {}, "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
@@ -906,6 +939,8 @@
     "unbash": ["unbash@2.2.0", "", {}, "sha512-X2wH19RAPZE3+ldGicOkoj/SIA83OIxcJ6Cuaw23hf8Xc6fQpvZXY0SftE2JgS0QhYLUG4uwodSI3R53keyh7w=="],
 
     "underscore": ["underscore@1.13.8", "", {}, "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="],
+
+    "undici": ["undici@6.24.1", "", {}, "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -950,6 +985,12 @@
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@discordjs/rest/@sapphire/snowflake": ["@sapphire/snowflake@3.5.5", "", {}, "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ=="],
+
+    "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 

--- a/docs/cleanup/discord-thread-capabilities-doc-task.md
+++ b/docs/cleanup/discord-thread-capabilities-doc-task.md
@@ -1,0 +1,86 @@
+# Discord Thread Capabilities Documentation Task
+
+## Task ID
+
+CLEANUP-2026-04-11
+
+## Summary
+
+Add inline code comment to document that Discord's `threadCapabilities.supportsThreads: false` is a deliberate deferral per the design specification, not an oversight.
+
+## Context
+
+### Issue Location
+
+File: `src/chat/discord/index.ts` (lines 55-59)
+
+### Current State
+
+```typescript
+readonly threadCapabilities: ThreadCapabilities = {
+  supportsThreads: false,
+  canCreateThreads: false,
+  threadScope: 'message',
+}
+```
+
+### Design Reference
+
+Per §14 of `docs/discord-chat-design.md` (Non-goals section):
+
+> "Message reactions, **threads**, voice, and stage channels... are not listened for. **Threads are treated as a non-supported channel type and ignored.**"
+
+### Why This Is Correct
+
+- Discord guild channels **do** support threads natively
+- Thread support was **explicitly excluded** from Phase 1 scope
+- The `supportsThreads: false` setting accurately reflects the approved design
+- This is consistent with other non-goals: slash commands, reactions, voice, file attachments (Phase 1)
+
+## Task Requirements
+
+- [x] Add inline comment explaining the deliberate deferral
+- [ ] Optional: Add similar note to `CLAUDE.md` Discord section
+- [ ] Optional: Consider adding to future Discord Phase 2 planning document
+
+## Implementation
+
+### Change Made
+
+```typescript
+readonly threadCapabilities: ThreadCapabilities = {
+  // Out of scope per §14 of discord-chat-design.md (Phase 1). Threads are treated as non-supported.
+  supportsThreads: false,
+  canCreateThreads: false,
+  threadScope: 'message',
+}
+```
+
+### Verification
+
+- [x] Comment references the correct design document section
+- [x] Comment explains this is Phase 1 scope limitation
+- [x] No functional changes - pure documentation
+
+## Related Documents
+
+- `docs/discord-chat-design.md` §14 - Non-goals section
+- `src/chat/discord/index.ts` - Discord chat provider implementation
+- `src/chat/types.ts` - ThreadCapabilities type definition
+
+## Future Work
+
+This documentation supports potential Phase 2 implementation where Discord thread support may be added. When that work begins:
+
+1. Review §14 of the design doc to assess thread support scope
+2. Update `threadCapabilities` to reflect actual Discord thread capabilities
+3. Discord threads are message-scoped (similar to Telegram), not post-scoped
+4. Thread creation likely requires `canCreateThreads: true` and Gateway intent adjustments
+
+## Status
+
+**COMPLETED** - Documentation comment added to `src/chat/discord/index.ts`
+
+## Notes
+
+This task was created in response to code review feedback noting that `threadCapabilities` was "hardcoded" to `supportsThreads: false`. The review correctly identified this as a deliberate deferral consistent with the approved design, but flagged it for documentation to prevent future confusion.

--- a/docs/superpowers/plans/2026-04-10-e2e-planning-workflow.md
+++ b/docs/superpowers/plans/2026-04-10-e2e-planning-workflow.md
@@ -1,0 +1,379 @@
+# E2E Planning Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Operationalize the approved E2E planning workflow so maintainers and AI agents can consistently write architecture-aware papai E2E plans from a shared guide, reusable template, and linked testing instructions.
+
+**Architecture:** This is a docs-first rollout, not a runtime change. Create one day-to-day workflow guide distilled from the approved spec, create one reusable plan template that matches the required output contract, then wire both artifacts into the existing E2E testing docs and AI instruction files where future planners already look for guidance.
+
+**Tech Stack:** Markdown, repository docs under `docs/`, `tests/CLAUDE.md`, `.github/instructions/e2e-testing.instructions.md`, `rg`, `git`
+
+---
+
+## File Structure
+
+This stays as a **single plan** because every change supports one bounded outcome: making the new E2E planning workflow discoverable and reusable. Splitting guide, template, and doc wiring into separate plans would force the implementer to rediscover the same terminology, tier model, and output contract multiple times.
+
+| Path                                                   | Responsibility                                                                                       |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `docs/superpowers/e2e-planning-workflow.md`            | Maintainer-facing operator guide that distills the approved spec into a practical planning algorithm |
+| `docs/superpowers/templates/e2e-test-plan-template.md` | Copyable template for new E2E plan documents with the required papai structure                       |
+| `tests/e2e/README.md`                                  | Human-facing description of how the current Kaneo harness fits into the broader tier model           |
+| `tests/CLAUDE.md`                                      | Agent-facing testing guidance for future E2E planners working in `tests/`                            |
+| `.github/instructions/e2e-testing.instructions.md`     | Copilot instruction snippet so future E2E plan work automatically follows the workflow               |
+
+---
+
+### Task 1: Publish the day-to-day E2E planning guide
+
+**Files:**
+
+- Create: `docs/superpowers/e2e-planning-workflow.md`
+
+- [ ] **Step 1: Verify the guide does not already exist**
+
+Run:
+
+```bash
+test ! -f docs/superpowers/e2e-planning-workflow.md && echo "missing"
+```
+
+Expected: `missing`
+
+- [ ] **Step 2: Create the guide with the approved workflow**
+
+Create `docs/superpowers/e2e-planning-workflow.md` with this content:
+
+```markdown
+# E2E Planning Workflow
+
+Use this workflow before writing any new papai E2E plan.
+
+## When to Use This Workflow
+
+Use this guide when you are:
+
+- proposing a new E2E plan
+- expanding the existing E2E suite
+- deciding whether a scenario belongs in E2E or at a cheaper test level
+- mapping a feature request to papai runtime boundaries
+
+## Planning Algorithm
+
+1. **Define the planning unit**  
+   State the user-visible behavior, the regression boundary, and the behaviors that must not break.
+2. **Map the architecture path**  
+   Trace the runtime boundaries the scenario crosses: chat adapter, auth or wizard interception, orchestrator, tools, provider, storage, scheduler, or debug surfaces.
+3. **Add feature and journey tags**  
+   Tag the scenario by product domain and by user journey so the final plan is auditable from both angles.
+4. **Choose the cheapest realism tier that proves the boundary**  
+   Do not promote a scenario into E2E if unit, integration, contract, or schema coverage is enough.
+5. **Expand the scenario matrix**  
+   Cover happy path, routing or permission gates, invalid input, external failures, persistence checks, cleanup, and cross-context leakage where relevant.
+6. **Name the oracles**  
+   Every scenario needs both a user-visible oracle and a backend or system oracle.
+7. **Define fixtures and teardown**  
+   State required config, auth state, test data, timing assumptions, and cleanup rules.
+8. **Emit the plan**  
+   Save the plan under `docs/superpowers/plans/YYYY-MM-DD-<topic>.md` using the shared template.
+
+## Realism Tiers
+
+| Tier                            | Meaning                                                                            | Typical papai use                                                            |
+| ------------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Tier 1: Provider-Real E2E       | Real task provider, controlled outer layers                                        | Kaneo or YouTrack provider operations and normalized task behavior           |
+| Tier 2: Runtime E2E             | Real papai runtime with controlled chat injection and deterministic model boundary | setup, auth, wizard, routing, tool capability behavior                       |
+| Tier 3: Platform-Integrated E2E | Real chat platform plus runtime                                                    | Telegram or Mattermost command, mention, button, and file behavior           |
+| Tier 4: Operational E2E         | Runtime plus schedulers or background delivery surfaces                            | recurring tasks, deferred prompts, proactive delivery, debug instrumentation |
+
+## papai Priority Order
+
+Start with the highest-signal lanes:
+
+1. setup, auth, configuration, and wizard flows
+2. DM versus group routing and mention rules
+3. orchestrator-to-tool-to-provider happy path and failure rollback
+4. capability-gated behavior and unsupported-surface handling
+
+Then cover:
+
+- identity linking
+- memos, instructions, and group-history behavior
+- recurring, deferred, and proactive flows
+- provider and platform parity gaps
+
+## Current Harness Map
+
+- `bun test:e2e` runs the current Docker-backed Kaneo suite.
+- `tests/e2e/bun-test-setup.ts` starts one shared E2E environment for the suite.
+- `tests/e2e/global-setup.ts` provisions a user and workspace and exposes the shared config.
+- `tests/e2e/kaneo-test-client.ts` owns test resource cleanup.
+- Today’s harness is **Tier 1: Provider-Real E2E** in the tier model above.
+
+## Required Output for Every Plan
+
+Every E2E plan must contain:
+
+- objective
+- regression boundary
+- chosen realism tier and rationale
+- included providers and platforms
+- architecture path
+- environment and fixtures
+- scenario matrix
+- non-E2E coverage or explicit exclusions
+- harness reuse and new gaps
+- implementation order
+
+## Starting Point
+
+Copy `docs/superpowers/templates/e2e-test-plan-template.md` into `docs/superpowers/plans/YYYY-MM-DD-<topic>.md` and fill it in with the workflow above.
+```
+
+- [ ] **Step 3: Verify the guide has the required sections**
+
+Run:
+
+```bash
+rg "^## " docs/superpowers/e2e-planning-workflow.md
+```
+
+Expected output contains these headings:
+
+- `## When to Use This Workflow`
+- `## Planning Algorithm`
+- `## Realism Tiers`
+- `## papai Priority Order`
+- `## Current Harness Map`
+- `## Required Output for Every Plan`
+- `## Starting Point`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/e2e-planning-workflow.md
+git commit -m "docs: add e2e planning workflow guide"
+```
+
+### Task 2: Create the reusable E2E plan template
+
+**Files:**
+
+- Create: `docs/superpowers/templates/e2e-test-plan-template.md`
+
+- [ ] **Step 1: Verify the template does not already exist**
+
+Run:
+
+```bash
+test ! -f docs/superpowers/templates/e2e-test-plan-template.md && echo "missing"
+```
+
+Expected: `missing`
+
+- [ ] **Step 2: Create the template file**
+
+Create `docs/superpowers/templates/e2e-test-plan-template.md` with this content:
+
+````markdown
+# E2E Test Plan
+
+Rename this file and title to match the specific behavior or journey before saving it under `docs/superpowers/plans/`.
+
+**Objective:** State the user-visible behavior being validated.
+
+**Regression Boundary:** State what existing behavior must remain safe while adding this coverage.
+
+**Realism Tier:** State the chosen tier and why cheaper tests are not enough.
+
+**Platforms and Providers:** Name the included surfaces and the intentionally excluded ones.
+
+---
+
+## Architecture Path
+
+```text
+List the runtime path here, one boundary per line.
+Example:
+DM message
+  -> auth check
+  -> wizard interception
+  -> LLM orchestrator
+  -> tool capability gating
+  -> task provider
+  -> reply formatting
+```
+````
+
+## Environment and Fixtures
+
+- State runtime assumptions.
+- State auth and config preconditions.
+- List seeded users, projects, tasks, labels, files, or scheduler state.
+- State teardown and isolation expectations.
+
+## Scenario Matrix
+
+| Scenario                      | Feature Tags                      | Journey Tags           | Layers Crossed                        | Trigger                       | User Oracle                       | System Oracle              | Failure Mode                                    | Cleanup                         | Notes                               |
+| ----------------------------- | --------------------------------- | ---------------------- | ------------------------------------- | ----------------------------- | --------------------------------- | -------------------------- | ----------------------------------------------- | ------------------------------- | ----------------------------------- |
+| Describe the happy path first | List the product domains involved | List the journey class | List the runtime boundaries exercised | Describe what starts the flow | Describe what the user should see | Describe the backend proof | Name the negative or degraded condition covered | Describe teardown and isolation | Note harness gaps or backend quirks |
+
+Add more rows until the plan covers happy path, routing or permission gates, invalid input, external failure, persistence verification, and cleanup.
+
+## Non-E2E Coverage
+
+- List the behaviors intentionally pushed down to unit, integration, schema, or contract tests.
+- Name anything explicitly left for manual verification.
+
+## Harness Reuse and Gaps
+
+- Name the existing harnesses to reuse.
+- Name any new helper, fixture, or platform setup work required.
+
+## Implementation Order
+
+1. Start with the highest-signal happy path.
+2. Add the most important negative path next.
+3. Add context leakage, persistence, or cleanup coverage after the main flow is stable.
+
+````
+
+- [ ] **Step 3: Verify the template exposes the required structure**
+
+Run:
+
+```bash
+rg "^## " docs/superpowers/templates/e2e-test-plan-template.md
+````
+
+Expected output contains these headings:
+
+- `## Architecture Path`
+- `## Environment and Fixtures`
+- `## Scenario Matrix`
+- `## Non-E2E Coverage`
+- `## Harness Reuse and Gaps`
+- `## Implementation Order`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/templates/e2e-test-plan-template.md
+git commit -m "docs: add e2e test plan template"
+```
+
+### Task 3: Wire the workflow into existing E2E docs and agent instructions
+
+**Files:**
+
+- Modify: `tests/e2e/README.md`
+- Modify: `tests/CLAUDE.md`
+- Modify: `.github/instructions/e2e-testing.instructions.md`
+
+- [ ] **Step 1: Verify the current docs do not already reference the workflow**
+
+Run:
+
+```bash
+rg "e2e-planning-workflow|e2e-test-plan-template" tests/e2e/README.md tests/CLAUDE.md .github/instructions/e2e-testing.instructions.md
+```
+
+Expected: no matches
+
+- [ ] **Step 2: Add the workflow references**
+
+Update `tests/e2e/README.md` by adding this section after `## Overview`:
+
+```markdown
+## Planning New E2E Coverage
+
+Before drafting a new papai E2E plan, read `docs/superpowers/e2e-planning-workflow.md` and start from `docs/superpowers/templates/e2e-test-plan-template.md`.
+
+Treat the current Docker-backed Kaneo suite as **Tier 1: Provider-Real E2E** in that workflow.
+
+Only promote scenarios to higher tiers when they need full runtime, platform, or operational boundaries that Tier 1 cannot prove.
+```
+
+Update `tests/CLAUDE.md` by extending the `## E2E Testing` section with these bullets:
+
+```markdown
+- Before writing a new E2E plan, read `docs/superpowers/e2e-planning-workflow.md`.
+- Start new E2E plan docs from `docs/superpowers/templates/e2e-test-plan-template.md`.
+- The current Docker-backed Kaneo harness maps to **Tier 1: Provider-Real E2E**.
+- Escalate to Tier 2-4 only when the scenario depends on runtime, platform, or operational boundaries that Tier 1 cannot prove.
+```
+
+Update `.github/instructions/e2e-testing.instructions.md` by adding this section after `## Rules`:
+
+```markdown
+## Planning New E2E Coverage
+
+- Before proposing or writing a new E2E plan, read `docs/superpowers/e2e-planning-workflow.md`.
+- Start new plan files from `docs/superpowers/templates/e2e-test-plan-template.md`.
+- Treat the existing Docker-backed Kaneo suite as **Tier 1: Provider-Real E2E**.
+- Prefer the smallest realism tier that proves the boundary; do not inflate Tier 2-4 coverage when Tier 1 or cheaper tests are sufficient.
+```
+
+- [ ] **Step 3: Verify all three docs now point to the workflow**
+
+Run:
+
+```bash
+rg "docs/superpowers/e2e-planning-workflow.md|docs/superpowers/templates/e2e-test-plan-template.md|Tier 1: Provider-Real E2E" tests/e2e/README.md tests/CLAUDE.md .github/instructions/e2e-testing.instructions.md
+```
+
+Expected: matches in all three files
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/README.md tests/CLAUDE.md .github/instructions/e2e-testing.instructions.md
+git commit -m "docs: link e2e planning workflow"
+```
+
+### Task 4: Final verification pass
+
+**Files:**
+
+- Modify: `docs/superpowers/e2e-planning-workflow.md`
+- Modify: `docs/superpowers/templates/e2e-test-plan-template.md`
+- Modify: `tests/e2e/README.md`
+- Modify: `tests/CLAUDE.md`
+- Modify: `.github/instructions/e2e-testing.instructions.md`
+
+- [ ] **Step 1: Review cross-links and terminology**
+
+Run:
+
+```bash
+rg "Tier 1: Provider-Real E2E|docs/superpowers/e2e-planning-workflow.md|docs/superpowers/templates/e2e-test-plan-template.md" docs/superpowers/e2e-planning-workflow.md docs/superpowers/templates/e2e-test-plan-template.md tests/e2e/README.md tests/CLAUDE.md .github/instructions/e2e-testing.instructions.md
+```
+
+Expected: the tier name and both file paths are used consistently everywhere
+
+- [ ] **Step 2: Trim any duplicated or conflicting wording**
+
+If any file drifts from the approved terminology, normalize it so these exact phrases remain stable:
+
+```markdown
+Tier 1: Provider-Real E2E
+docs/superpowers/e2e-planning-workflow.md
+docs/superpowers/templates/e2e-test-plan-template.md
+```
+
+- [ ] **Step 3: Inspect the final diff**
+
+Run:
+
+```bash
+git --no-pager diff -- docs/superpowers/e2e-planning-workflow.md docs/superpowers/templates/e2e-test-plan-template.md tests/e2e/README.md tests/CLAUDE.md .github/instructions/e2e-testing.instructions.md
+```
+
+Expected: only the planned workflow, template, and reference changes are present
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/e2e-planning-workflow.md docs/superpowers/templates/e2e-test-plan-template.md tests/e2e/README.md tests/CLAUDE.md .github/instructions/e2e-testing.instructions.md
+git commit -m "docs: finish e2e planning workflow rollout"
+```

--- a/docs/superpowers/plans/2026-04-11-context-command-redesign.md
+++ b/docs/superpowers/plans/2026-04-11-context-command-redesign.md
@@ -1,0 +1,2617 @@
+# /context Command Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the admin-only file-export `/context` command with a visual context window display available to all authorized users. Shows a proportional emoji grid of token usage by category plus platform-specific detail (Telegram monospace block, Discord embed, Mattermost markdown table).
+
+**Architecture:** Add a platform-agnostic `ContextCollector` that gathers system prompt, memory, history, and tool definitions, tokenizes each with `ai-tokenizer`, and produces a `ContextSnapshot`. Each `ChatProvider` grows a `renderContext(snapshot)` method that produces platform-native output via a shared grid builder. Add an optional `reply.embed()` method so Discord can emit native embeds.
+
+**Tech Stack:** Bun, TypeScript, Bun test, Vercel AI SDK, `ai-tokenizer`, discord.js v14, grammy, pino
+
+---
+
+## Scope Notes
+
+This is a single plan: one new dependency, one new command flow, one interface extension. Everything shares the `ContextSnapshot` type that must be defined before any renderer or handler can consume it.
+
+The existing `/context` file export is **replaced**, not extended — the `adminUserId` parameter on `registerContextCommand` goes away, the file-upload code is deleted, and any test that asserts admin-only behavior is rewritten.
+
+## File Structure
+
+| Path                                             | Responsibility                                                                                                                                                                 |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/chat/types.ts`                              | Add `ContextSection`, `ContextSnapshot`, `ContextRendered`, `EmbedField`, `EmbedOptions`; extend `ChatProvider` with `renderContext()`; extend `ReplyFn` with optional `embed` |
+| `src/commands/context-collector.ts`              | Gather context data, tokenize sections, produce `ContextSnapshot`                                                                                                              |
+| `src/commands/context-grid.ts`                   | Shared grid builder (proportional emoji grid from a snapshot)                                                                                                                  |
+| `src/commands/context.ts`                        | Command handler (rewritten) — calls collector, delegates rendering to provider                                                                                                 |
+| `src/commands/index.ts`                          | No API change; verify re-export still works                                                                                                                                    |
+| `src/bot.ts`                                     | Remove `adminUserId` argument from `registerContextCommand` call                                                                                                               |
+| `src/chat/telegram/context-renderer.ts`          | Telegram renderer: inline emoji grid + monospace detail                                                                                                                        |
+| `src/chat/telegram/index.ts`                     | Add `renderContext()` method delegating to the renderer                                                                                                                        |
+| `src/chat/discord/context-renderer.ts`           | Discord renderer: emoji grid description + embed fields                                                                                                                        |
+| `src/chat/discord/reply-helpers.ts`              | Add `embed()` method to `createDiscordReplyFn`                                                                                                                                 |
+| `src/chat/discord/index.ts`                      | Add `renderContext()` method delegating to the renderer                                                                                                                        |
+| `src/chat/mattermost/context-renderer.ts`        | Mattermost renderer: emoji grid + markdown table                                                                                                                               |
+| `src/chat/mattermost/index.ts`                   | Add `renderContext()` method delegating to the renderer                                                                                                                        |
+| `tests/utils/test-helpers.ts`                    | Update `createMockReply()` and `createMockChat()` to include new members                                                                                                       |
+| `tests/commands/context-collector.test.ts`       | Unit tests for the collector (DI-driven)                                                                                                                                       |
+| `tests/commands/context-grid.test.ts`            | Unit tests for the grid builder                                                                                                                                                |
+| `tests/commands/context.test.ts`                 | New unit tests for the command handler                                                                                                                                         |
+| `tests/chat/telegram/context-renderer.test.ts`   | Unit tests for the Telegram renderer                                                                                                                                           |
+| `tests/chat/discord/context-renderer.test.ts`    | Unit tests for the Discord renderer                                                                                                                                            |
+| `tests/chat/discord/reply-helpers.test.ts`       | Add assertions for the new `embed()` method                                                                                                                                    |
+| `tests/chat/mattermost/context-renderer.test.ts` | Unit tests for the Mattermost renderer                                                                                                                                         |
+| `package.json`                                   | Add `ai-tokenizer` dependency                                                                                                                                                  |
+
+---
+
+### Task 1: Add the `ai-tokenizer` dependency
+
+**Files:**
+
+- Modify: `package.json`
+
+- [ ] **Step 1: Install the dependency**
+
+Run:
+
+```bash
+bun add ai-tokenizer
+```
+
+Expected: installs `ai-tokenizer` as a runtime dependency and updates `package.json` + `bun.lock`.
+
+- [ ] **Step 2: Verify the install worked**
+
+Run:
+
+```bash
+bun pm ls | grep ai-tokenizer
+```
+
+Expected: one line showing `ai-tokenizer` with a version.
+
+- [ ] **Step 3: Smoke-test the import path we will use**
+
+Run:
+
+```bash
+bun -e "import('ai-tokenizer/encoding/cl100k_base').then(m => console.log(Object.keys(m).slice(0,5))).catch(e => { console.error(e); process.exit(1) })"
+```
+
+Expected: prints an array (the encoding module's exports). If the import path differs, adjust subsequent tasks to use whatever path actually works — `ai-tokenizer` exposes each encoding at `ai-tokenizer/encoding/<name>` per its README.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json bun.lock
+git commit -m "chore: add ai-tokenizer dependency for /context token counts"
+```
+
+---
+
+### Task 2: Extend chat types with `ContextSnapshot`, `ContextRendered`, and `EmbedOptions`
+
+**Files:**
+
+- Modify: `src/chat/types.ts`
+
+- [ ] **Step 1: Add the new types near the existing reply types**
+
+Open `src/chat/types.ts` and add the following block **before** the existing `type ReplyFn = ...` definition (around line 122, right after the `ButtonReplyOptions` interface):
+
+```typescript
+/** One section of the LLM context window, with an optional nested breakdown. */
+export type ContextSection = {
+  label: string
+  tokens: number
+  detail?: string
+  children?: ContextSection[]
+}
+
+/** Snapshot of the LLM context window for a given conversation. */
+export type ContextSnapshot = {
+  modelName: string
+  sections: ContextSection[]
+  totalTokens: number
+  /** Model's context window if known, null for unrecognized models. */
+  maxTokens: number | null
+  /** True when token counts came from a char/4 fallback because tokenization failed. */
+  approximate: boolean
+}
+
+/** One field inside a Discord-style embed. */
+export type EmbedField = {
+  name: string
+  value: string
+  inline?: boolean
+}
+
+/** Options for sending a structured embed (Discord-only today). */
+export type EmbedOptions = {
+  title: string
+  description: string
+  fields?: EmbedField[]
+  footer?: string
+  color?: number
+}
+
+/** Result of `ChatProvider.renderContext` — describes how the handler should send the output. */
+export type ContextRendered =
+  | { method: 'text'; content: string }
+  | { method: 'formatted'; content: string }
+  | { method: 'embed'; embed: EmbedOptions }
+```
+
+- [ ] **Step 2: Extend `ReplyFn` with the optional `embed` method**
+
+Still in `src/chat/types.ts`, replace the existing `ReplyFn` type (lines 124–131) with:
+
+```typescript
+/** Reply function injected into handlers — the only way to send messages back to the user. */
+export type ReplyFn = {
+  text: (content: string, options?: ReplyOptions) => Promise<void>
+  formatted: (markdown: string, options?: ReplyOptions) => Promise<void>
+  file: (file: ChatFile, options?: ReplyOptions) => Promise<void>
+  typing: () => void
+  redactMessage?: (replacementText: string) => Promise<void>
+  buttons: (content: string, options: ButtonReplyOptions) => Promise<void>
+  /** Optional: send a structured embed. Only Discord implements this today. */
+  embed?: (options: EmbedOptions) => Promise<void>
+}
+```
+
+- [ ] **Step 3: Extend `ChatProvider` with `renderContext`**
+
+In the same file, replace the existing `ChatProvider` interface (lines 134–156) with:
+
+```typescript
+/** The core interface every chat platform provider must implement. */
+export interface ChatProvider {
+  readonly name: string
+  /** Thread support capabilities */
+  readonly threadCapabilities: ThreadCapabilities
+
+  /** Register a slash command handler (e.g., 'help' for /help). */
+  registerCommand(name: string, handler: CommandHandler): void
+
+  /** Register the catch-all handler for non-command messages. */
+  onMessage(handler: (msg: IncomingMessage, reply: ReplyFn) => Promise<void>): void
+
+  /** Send a formatted markdown message to a user by ID (for announcements). */
+  sendMessage(userId: string, markdown: string): Promise<void>
+
+  /** Resolve a username to a user ID. Returns null if not found. `context` allows adapters like Discord to scope the lookup to the caller's guild. */
+  resolveUserId(username: string, context: ResolveUserContext): Promise<string | null>
+
+  /** Render a context snapshot into a platform-native representation. */
+  renderContext(snapshot: ContextSnapshot): ContextRendered
+
+  /** Start the bot event loop. */
+  start(): Promise<void>
+
+  /** Graceful shutdown. */
+  stop(): Promise<void>
+}
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run:
+
+```bash
+bun typecheck
+```
+
+Expected: many new errors pointing at `TelegramChatProvider`, `DiscordChatProvider`, `MattermostChatProvider`, `createMockChat`, `createMockReply`, and any tests that construct a `ChatProvider` by hand — they now miss `renderContext`. That is expected — subsequent tasks implement these methods. Do **not** try to make typecheck green yet. Keep the failures as a worklist.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/chat/types.ts
+git commit -m "feat(chat): add ContextSnapshot, ContextRendered, EmbedOptions types"
+```
+
+---
+
+### Task 3: Update `createMockReply` and `createMockChat` helpers
+
+**Files:**
+
+- Modify: `tests/utils/test-helpers.ts`
+
+These helpers are used throughout the test suite. They must implement the new interface shape before any downstream test can compile.
+
+- [ ] **Step 1: Write a failing assertion for the new `embed` stub**
+
+Open `tests/utils/test-helpers.ts`. We are going to modify the helpers themselves; their own tests live implicitly across the suite. As a sanity check, add this ad-hoc verification temporarily to the bottom of `tests/commands/context.test.ts` (create the file if it does not exist yet, stubbing with just `import { test } from 'bun:test'`):
+
+```typescript
+import { test, expect } from 'bun:test'
+import { createMockReply, createMockChat } from '../utils/test-helpers.js'
+
+test('createMockReply exposes an embed stub', () => {
+  const { reply } = createMockReply()
+  expect(typeof reply.embed).toBe('function')
+})
+
+test('createMockChat implements renderContext', () => {
+  const chat = createMockChat()
+  expect(typeof chat.renderContext).toBe('function')
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+
+```bash
+bun test tests/commands/context.test.ts
+```
+
+Expected: FAIL — either because `reply.embed` is undefined or because `chat.renderContext` is not a function.
+
+- [ ] **Step 3: Update `createMockReply` to include `embed` and expose an embed log**
+
+In `tests/utils/test-helpers.ts`, locate `MockReplyResult` (declared around line 190 — find it by searching for `MockReplyResult`) and the `createMockReply` function (line 204). Update both:
+
+```typescript
+export interface MockReplyResult {
+  reply: ReplyFn
+  textCalls: string[]
+  redactCalls: string[]
+  embedCalls: EmbedOptions[]
+  getReplies: () => string[]
+  getRedactions: () => string[]
+  getEmbeds: () => EmbedOptions[]
+}
+
+export function createMockReply(): MockReplyResult {
+  const textCalls: string[] = []
+  const redactCalls: string[] = []
+  const embedCalls: EmbedOptions[] = []
+  const reply: ReplyFn = {
+    text: (content: string): Promise<void> => {
+      textCalls.push(content)
+      return Promise.resolve()
+    },
+    formatted: (content: string): Promise<void> => {
+      textCalls.push(content)
+      return Promise.resolve()
+    },
+    file: (): Promise<void> => Promise.resolve(),
+    typing: (): void => {},
+    redactMessage: (replacementText: string): Promise<void> => {
+      redactCalls.push(replacementText)
+      return Promise.resolve()
+    },
+    buttons: (content: string): Promise<void> => {
+      textCalls.push(content)
+      return Promise.resolve()
+    },
+    embed: (options: EmbedOptions): Promise<void> => {
+      embedCalls.push(options)
+      return Promise.resolve()
+    },
+  }
+  return {
+    reply,
+    textCalls,
+    redactCalls,
+    embedCalls,
+    getReplies: () => textCalls,
+    getRedactions: () => redactCalls,
+    getEmbeds: () => embedCalls,
+  }
+}
+```
+
+Note that `formatted` now pushes into `textCalls` — the existing `createMockReply` returned `Promise.resolve()` without recording. Our new command handler dispatches to `formatted`, so tests need to see what was sent. If any existing test asserted that `textCalls` contained only `text` calls, fix it in place when we find it.
+
+- [ ] **Step 4: Import `EmbedOptions` in the helpers file**
+
+At the top of `tests/utils/test-helpers.ts`, update the chat types import. Find the existing line:
+
+```typescript
+import type {
+  AuthorizationResult,
+  ChatProvider,
+  CommandHandler,
+  IncomingMessage,
+  ReplyFn,
+  ResolveUserContext,
+} from '../../src/chat/types.js'
+```
+
+Replace with:
+
+```typescript
+import type {
+  AuthorizationResult,
+  ChatProvider,
+  CommandHandler,
+  ContextRendered,
+  ContextSnapshot,
+  EmbedOptions,
+  IncomingMessage,
+  ReplyFn,
+  ResolveUserContext,
+} from '../../src/chat/types.js'
+```
+
+- [ ] **Step 5: Update `createMockChat` to implement `renderContext`**
+
+In the same file, update `createMockChat` (line 309). Find the `return { ... }` block and add a `renderContext` entry alongside `start`/`stop`:
+
+```typescript
+    renderContext: (snapshot: ContextSnapshot): ContextRendered => ({
+      method: 'text',
+      content: `mock renderContext: ${snapshot.modelName} total=${String(snapshot.totalTokens)}`,
+    }),
+```
+
+The full return block should read:
+
+```typescript
+return {
+  name: 'mock',
+  threadCapabilities: {
+    supportsThreads: true,
+    canCreateThreads: false,
+    threadScope: 'message',
+  },
+  registerCommand: (name: string, handler: CommandHandler): void => {
+    options.commandHandlers?.set(name, handler)
+  },
+  onMessage: (handler): void => {
+    options.onMessageHandler?.(handler)
+  },
+  sendMessage: options.sendMessage ?? ((): Promise<void> => Promise.resolve()),
+  resolveUserId:
+    options.resolveUserId ??
+    ((username: string, _context: ResolveUserContext): Promise<string | null> => {
+      const clean = username.startsWith('@') ? username.slice(1) : username
+      return Promise.resolve(clean)
+    }),
+  renderContext: (snapshot: ContextSnapshot): ContextRendered => ({
+    method: 'text',
+    content: `mock renderContext: ${snapshot.modelName} total=${String(snapshot.totalTokens)}`,
+  }),
+  start: (): Promise<void> => Promise.resolve(),
+  stop: (): Promise<void> => Promise.resolve(),
+}
+```
+
+- [ ] **Step 6: Update any other mock chat factories in the file**
+
+Search `tests/utils/test-helpers.ts` for other `createMockChat*` functions (`createMockChatWithCommandHandlers`, `createMockChatWithHandler`, `createMockChatForBot`, `createMockChatWithSentMessages` — found via grep at lines 349, 361, 377, 399). Each returns an object literal of type `ChatProvider`. Add the same `renderContext` implementation to each of them. If the factory spreads `createMockChat(...)` already, no change is needed — verify by reading each function body.
+
+- [ ] **Step 7: Run the sanity tests from Step 1**
+
+Run:
+
+```bash
+bun test tests/commands/context.test.ts
+```
+
+Expected: PASS on both `createMockReply exposes an embed stub` and `createMockChat implements renderContext`.
+
+- [ ] **Step 8: Run the full test suite to find fallout**
+
+Run:
+
+```bash
+bun test
+```
+
+Expected: the suite still has many failures from unimplemented `renderContext` on the real providers (Telegram/Discord/Mattermost class instances). That is expected. Any test that constructed a `ChatProvider`-typed literal inline will also fail — fix those in the same commit by adding a `renderContext` stub that throws `new Error('not used in this test')`. Search with:
+
+```bash
+grep -rn "ChatProvider = {" tests/ || true
+grep -rn ": ChatProvider = {" tests/ || true
+```
+
+Add stubs inline where needed. Do not rewrite tests semantically; just add the missing method.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tests/utils/test-helpers.ts tests/commands/context.test.ts tests/
+git commit -m "test(helpers): add renderContext and embed to mock chat and reply helpers"
+```
+
+---
+
+### Task 4: Build the context grid utility
+
+**Files:**
+
+- Create: `src/commands/context-grid.ts`
+- Create: `tests/commands/context-grid.test.ts`
+
+The grid takes a `ContextSnapshot` and produces a fixed-size emoji grid that can be dropped into any renderer.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/commands/context-grid.test.ts`:
+
+```typescript
+import { describe, expect, test } from 'bun:test'
+
+import type { ContextSnapshot } from '../../src/chat/types.js'
+import { buildContextGrid, GRID_COLS, GRID_ROWS } from '../../src/commands/context-grid.js'
+
+const baseSnapshot = (overrides: Partial<ContextSnapshot> = {}): ContextSnapshot => ({
+  modelName: 'gpt-4o',
+  totalTokens: 0,
+  maxTokens: 128_000,
+  approximate: false,
+  sections: [],
+  ...overrides,
+})
+
+describe('buildContextGrid', () => {
+  test('returns a string with GRID_ROWS lines of GRID_COLS cells when maxTokens is known', () => {
+    const snapshot = baseSnapshot({
+      totalTokens: 1_000,
+      sections: [{ label: 'System prompt', tokens: 1_000 }],
+    })
+    const grid = buildContextGrid(snapshot)
+    const lines = grid.split('\n')
+    expect(lines).toHaveLength(GRID_ROWS)
+    for (const line of lines) {
+      // Each cell is a single emoji (using Array.from for unicode-safe counting)
+      expect(Array.from(line)).toHaveLength(GRID_COLS)
+    }
+  })
+
+  test('assigns one cell per section when tokens are tiny', () => {
+    const snapshot = baseSnapshot({
+      totalTokens: 4,
+      maxTokens: 128_000,
+      sections: [
+        { label: 'System prompt', tokens: 1 },
+        { label: 'Memory context', tokens: 1 },
+        { label: 'Conversation history', tokens: 1 },
+        { label: 'Tools', tokens: 1 },
+      ],
+    })
+    const grid = buildContextGrid(snapshot)
+    expect(grid).toContain('🟦')
+    expect(grid).toContain('🟩')
+    expect(grid).toContain('🟨')
+    expect(grid).toContain('🟪')
+    expect(grid).toContain('⬜') // free space still dominates
+  })
+
+  test('fills the grid proportionally when usage is substantial', () => {
+    const snapshot = baseSnapshot({
+      totalTokens: 64_000, // 50% of 128_000
+      sections: [{ label: 'System prompt', tokens: 64_000 }],
+    })
+    const grid = buildContextGrid(snapshot)
+    const usedCells = Array.from(grid).filter((c) => c === '🟦').length
+    expect(usedCells).toBeGreaterThanOrEqual(99)
+    expect(usedCells).toBeLessThanOrEqual(101)
+  })
+
+  test('renders a single 20-cell row when maxTokens is null', () => {
+    const snapshot = baseSnapshot({
+      maxTokens: null,
+      totalTokens: 400,
+      sections: [
+        { label: 'System prompt', tokens: 200 },
+        { label: 'Tools', tokens: 200 },
+      ],
+    })
+    const grid = buildContextGrid(snapshot)
+    expect(grid.split('\n')).toHaveLength(1)
+    expect(Array.from(grid)).toHaveLength(GRID_COLS)
+    expect(grid).not.toContain('⬜') // no free-space cells without a known limit
+  })
+
+  test('produces an all-free grid when there are no sections', () => {
+    const snapshot = baseSnapshot({
+      totalTokens: 0,
+      sections: [],
+    })
+    const grid = buildContextGrid(snapshot)
+    const cells = Array.from(grid.replace(/\n/g, ''))
+    expect(cells.every((c) => c === '⬜')).toBe(true)
+  })
+
+  test('caps oversized usage at full grid', () => {
+    const snapshot = baseSnapshot({
+      totalTokens: 200_000,
+      sections: [{ label: 'System prompt', tokens: 200_000 }],
+    })
+    const grid = buildContextGrid(snapshot)
+    const cells = Array.from(grid.replace(/\n/g, ''))
+    expect(cells.every((c) => c === '🟦')).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+
+```bash
+bun test tests/commands/context-grid.test.ts
+```
+
+Expected: FAIL — cannot find module `../../src/commands/context-grid.js`.
+
+- [ ] **Step 3: Implement the grid builder**
+
+Create `src/commands/context-grid.ts`:
+
+```typescript
+import type { ContextSection, ContextSnapshot } from '../chat/types.js'
+
+export const GRID_COLS = 20
+export const GRID_ROWS = 10
+const TOTAL_CELLS = GRID_COLS * GRID_ROWS
+
+const FREE_CELL = '⬜'
+
+const SECTION_EMOJIS: Record<string, string> = {
+  'System prompt': '🟦',
+  'Memory context': '🟩',
+  'Conversation history': '🟨',
+  Tools: '🟪',
+}
+
+const FALLBACK_EMOJI = '🟫'
+
+function emojiForLabel(label: string): string {
+  return SECTION_EMOJIS[label] ?? FALLBACK_EMOJI
+}
+
+type Allocation = { emoji: string; cells: number }
+
+function allocateCells(sections: readonly ContextSection[], cellBudget: number, tokensPerCell: number): Allocation[] {
+  if (tokensPerCell <= 0) return []
+
+  const allocations: Allocation[] = []
+  let assigned = 0
+  for (const section of sections) {
+    if (section.tokens <= 0) continue
+    const rawCells = section.tokens / tokensPerCell
+    const cells = Math.max(1, Math.round(rawCells))
+    allocations.push({ emoji: emojiForLabel(section.label), cells })
+    assigned += cells
+  }
+
+  // Trim from the largest allocation until we fit the budget (keep every section >= 1).
+  while (assigned > cellBudget) {
+    let largestIndex = -1
+    let largestCells = 1
+    for (let i = 0; i < allocations.length; i++) {
+      const entry = allocations[i]!
+      if (entry.cells > largestCells) {
+        largestCells = entry.cells
+        largestIndex = i
+      }
+    }
+    if (largestIndex === -1) break
+    allocations[largestIndex]!.cells -= 1
+    assigned -= 1
+  }
+
+  return allocations
+}
+
+function assembleCells(allocations: readonly Allocation[], totalCells: number, fillFree: boolean): string[] {
+  const cells: string[] = []
+  for (const entry of allocations) {
+    for (let i = 0; i < entry.cells; i++) cells.push(entry.emoji)
+  }
+  if (fillFree) {
+    while (cells.length < totalCells) cells.push(FREE_CELL)
+  }
+  return cells.slice(0, totalCells)
+}
+
+function gridToString(cells: readonly string[], cols: number): string {
+  const rows: string[] = []
+  for (let i = 0; i < cells.length; i += cols) {
+    rows.push(cells.slice(i, i + cols).join(''))
+  }
+  return rows.join('\n')
+}
+
+export function buildContextGrid(snapshot: ContextSnapshot): string {
+  if (snapshot.maxTokens === null) {
+    // Single-row bar: allocate only used cells, no free space.
+    const used = Math.max(snapshot.totalTokens, 1)
+    const tokensPerCell = used / GRID_COLS
+    const allocations = allocateCells(snapshot.sections, GRID_COLS, tokensPerCell)
+    const cells = assembleCells(allocations, GRID_COLS, false)
+    // Pad with the fallback emoji only if allocations under-filled (defensive).
+    while (cells.length < GRID_COLS) cells.push(FALLBACK_EMOJI)
+    return gridToString(cells, GRID_COLS)
+  }
+
+  const tokensPerCell = snapshot.maxTokens / TOTAL_CELLS
+  const usedCells = Math.min(TOTAL_CELLS, Math.round(snapshot.totalTokens / tokensPerCell))
+  const allocations = allocateCells(snapshot.sections, usedCells, tokensPerCell)
+  const cells = assembleCells(allocations, TOTAL_CELLS, true)
+  return gridToString(cells, GRID_COLS)
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run:
+
+```bash
+bun test tests/commands/context-grid.test.ts
+```
+
+Expected: PASS on all six tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/context-grid.ts tests/commands/context-grid.test.ts
+git commit -m "feat(commands): add context grid builder for /context output"
+```
+
+---
+
+### Task 5: Build the context collector
+
+**Files:**
+
+- Create: `src/commands/context-collector.ts`
+- Create: `tests/commands/context-collector.test.ts`
+
+The collector is the platform-agnostic core that assembles a `ContextSnapshot` from the user's live context. We use DI so tests can supply canned inputs and a fake tokenizer.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/commands/context-collector.test.ts`:
+
+```typescript
+import { describe, expect, test, beforeEach } from 'bun:test'
+import type { ModelMessage } from 'ai'
+
+import type { ContextCollectorDeps } from '../../src/commands/context-collector.js'
+import { collectContext, resolveEncodingName, resolveMaxTokens } from '../../src/commands/context-collector.js'
+import { mockLogger } from '../utils/test-helpers.js'
+
+const makeDeps = (overrides: Partial<ContextCollectorDeps> = {}): ContextCollectorDeps => ({
+  getMainModel: () => 'gpt-4o',
+  buildSystemPrompt: () => 'BASE PROMPT BODY',
+  buildInstructionsBlock: () => '',
+  getProviderAddendum: () => '',
+  getHistory: () => [] as readonly ModelMessage[],
+  getMemoryMessage: () => null,
+  getSummary: () => null,
+  getFacts: () => [],
+  getActiveToolDefinitions: () => ({}),
+  getProviderName: () => 'kaneo',
+  countTokens: (text: string) => Math.ceil(text.length / 4),
+  ...overrides,
+})
+
+describe('collectContext', () => {
+  beforeEach(() => {
+    mockLogger()
+  })
+
+  test('returns the resolved model name', async () => {
+    const deps = makeDeps({ getMainModel: () => 'gpt-4.1-mini' })
+    const snapshot = await collectContext('user1', deps)
+    expect(snapshot.modelName).toBe('gpt-4.1-mini')
+  })
+
+  test('sums section tokens into totalTokens', async () => {
+    const deps = makeDeps({
+      countTokens: (text: string) => text.length, // deterministic
+      buildSystemPrompt: () => 'AAAA', // 4 tokens
+      getHistory: () => [{ role: 'user', content: 'BB' }], // 2 tokens (plus serialization framing, see below)
+      getActiveToolDefinitions: () => ({ search_tasks: { description: 'C' } }),
+    })
+    const snapshot = await collectContext('user1', deps)
+    expect(snapshot.totalTokens).toBe(snapshot.sections.reduce((acc, s) => acc + s.tokens, 0))
+    expect(snapshot.totalTokens).toBeGreaterThan(0)
+  })
+
+  test('produces sections in the expected order with the expected labels', async () => {
+    const snapshot = await collectContext('user1', makeDeps())
+    expect(snapshot.sections.map((s) => s.label)).toEqual([
+      'System prompt',
+      'Memory context',
+      'Conversation history',
+      'Tools',
+    ])
+  })
+
+  test('memory section has Summary and Known entities children', async () => {
+    const deps = makeDeps({
+      getSummary: () => 'brief summary',
+      getFacts: () => [
+        { identifier: '#1', title: 'A', url: '', last_seen: '2026-04-11' },
+        { identifier: '#2', title: 'B', url: '', last_seen: '2026-04-11' },
+      ],
+      getMemoryMessage: () => 'Memory block',
+    })
+    const snapshot = await collectContext('user1', deps)
+    const memory = snapshot.sections.find((s) => s.label === 'Memory context')!
+    expect(memory.children?.map((c) => c.label)).toEqual(['Summary', 'Known entities'])
+    expect(memory.children?.[1]?.detail).toBe('2 facts')
+  })
+
+  test('system prompt section has Base / Custom / Addendum children when non-empty', async () => {
+    const deps = makeDeps({
+      buildInstructionsBlock: () => '=== Custom instructions ===\n- use short words\n',
+      getProviderAddendum: () => 'kaneo addendum',
+    })
+    const snapshot = await collectContext('user1', deps)
+    const sysPrompt = snapshot.sections.find((s) => s.label === 'System prompt')!
+    const labels = sysPrompt.children?.map((c) => c.label) ?? []
+    expect(labels).toContain('Base instructions')
+    expect(labels).toContain('Custom instructions')
+    expect(labels).toContain('Provider addendum')
+  })
+
+  test('Conversation history detail shows message count', async () => {
+    const deps = makeDeps({
+      getHistory: () => [
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'hello' },
+        { role: 'user', content: 'how are you' },
+      ],
+    })
+    const snapshot = await collectContext('user1', deps)
+    const convo = snapshot.sections.find((s) => s.label === 'Conversation history')!
+    expect(convo.detail).toBe('3 messages')
+  })
+
+  test('Tools detail shows count and provider name', async () => {
+    const deps = makeDeps({
+      getActiveToolDefinitions: () => ({ a: {}, b: {}, c: {} }),
+      getProviderName: () => 'kaneo',
+    })
+    const snapshot = await collectContext('user1', deps)
+    const tools = snapshot.sections.find((s) => s.label === 'Tools')!
+    expect(tools.detail).toBe('3 active, gated by kaneo')
+  })
+
+  test('returns maxTokens=null for unknown model', async () => {
+    const deps = makeDeps({ getMainModel: () => 'some-random-new-model' })
+    const snapshot = await collectContext('user1', deps)
+    expect(snapshot.maxTokens).toBeNull()
+  })
+
+  test('returns maxTokens for known model prefix', async () => {
+    const deps = makeDeps({ getMainModel: () => 'gpt-4o-2024-08-06' })
+    const snapshot = await collectContext('user1', deps)
+    expect(snapshot.maxTokens).toBe(128_000)
+  })
+
+  test('sets approximate=true when tokenizer throws', async () => {
+    const deps = makeDeps({
+      countTokens: () => {
+        throw new Error('encoding failed')
+      },
+    })
+    const snapshot = await collectContext('user1', deps)
+    expect(snapshot.approximate).toBe(true)
+    // Falls back to char/4 — must still produce non-zero counts for non-empty sections
+    expect(snapshot.totalTokens).toBeGreaterThan(0)
+  })
+
+  test('handles completely empty state', async () => {
+    const snapshot = await collectContext('user1', makeDeps())
+    expect(snapshot.sections.find((s) => s.label === 'Memory context')?.tokens).toBe(0)
+    expect(snapshot.sections.find((s) => s.label === 'Conversation history')?.tokens).toBe(0)
+  })
+})
+
+describe('resolveEncodingName', () => {
+  test('picks o200k_base for GPT-4o family', () => {
+    expect(resolveEncodingName('gpt-4o')).toBe('o200k_base')
+    expect(resolveEncodingName('gpt-4o-mini')).toBe('o200k_base')
+    expect(resolveEncodingName('gpt-4.1')).toBe('o200k_base')
+    expect(resolveEncodingName('o1-preview')).toBe('o200k_base')
+    expect(resolveEncodingName('o3-mini')).toBe('o200k_base')
+  })
+
+  test('falls back to cl100k_base', () => {
+    expect(resolveEncodingName('gpt-4-turbo')).toBe('cl100k_base')
+    expect(resolveEncodingName('claude-sonnet-4-20250514')).toBe('cl100k_base')
+    expect(resolveEncodingName('some-random-thing')).toBe('cl100k_base')
+  })
+})
+
+describe('resolveMaxTokens', () => {
+  test('matches exact known models', () => {
+    expect(resolveMaxTokens('gpt-4o')).toBe(128_000)
+    expect(resolveMaxTokens('gpt-4.1')).toBe(1_048_576)
+  })
+
+  test('matches by longest prefix', () => {
+    expect(resolveMaxTokens('gpt-4o-2024-08-06')).toBe(128_000)
+    expect(resolveMaxTokens('gpt-4.1-mini-preview')).toBe(1_048_576)
+  })
+
+  test('returns null for unknown', () => {
+    expect(resolveMaxTokens('weird-model-name')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+
+```bash
+bun test tests/commands/context-collector.test.ts
+```
+
+Expected: FAIL — cannot find module `../../src/commands/context-collector.js`.
+
+- [ ] **Step 3: Implement the collector**
+
+Create `src/commands/context-collector.ts`:
+
+```typescript
+import type { ModelMessage } from 'ai'
+
+import type { ContextSection, ContextSnapshot } from '../chat/types.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ scope: 'commands:context-collector' })
+
+type Fact = { identifier: string; title: string; url: string; last_seen: string }
+
+export interface ContextCollectorDeps {
+  /** Get the user's configured model name, or null if unset. */
+  getMainModel: () => string | null
+  /** Full system prompt the LLM would see. */
+  buildSystemPrompt: () => string
+  /** Custom instructions block (empty string when none). */
+  buildInstructionsBlock: () => string
+  /** Provider-specific prompt addendum (empty string when none). */
+  getProviderAddendum: () => string
+  /** Conversation history as the LLM would see it. */
+  getHistory: () => readonly ModelMessage[]
+  /** Assembled memory context message (null when none). */
+  getMemoryMessage: () => string | null
+  /** Raw summary string (null when none). */
+  getSummary: () => string | null
+  /** Known entities (facts). */
+  getFacts: () => readonly Fact[]
+  /** Active tool definitions the LLM would see (Vercel AI SDK ToolSet). */
+  getActiveToolDefinitions: () => Record<string, unknown>
+  /** Task provider name for the "gated by" detail line. */
+  getProviderName: () => string
+  /** Token counter. May throw on encoding load failure — caller handles the fallback. */
+  countTokens: (text: string) => number
+}
+
+const FALLBACK_MODEL = 'unknown'
+
+const MODEL_CONTEXT_WINDOWS: ReadonlyArray<readonly [prefix: string, tokens: number]> = [
+  // Sorted so longer prefixes match first.
+  ['gpt-4.1-nano', 1_048_576],
+  ['gpt-4.1-mini', 1_048_576],
+  ['gpt-4.1', 1_048_576],
+  ['gpt-4o-mini', 128_000],
+  ['gpt-4o', 128_000],
+  ['gpt-4-turbo', 128_000],
+  ['o4-mini', 200_000],
+  ['o3-mini', 200_000],
+  ['o1-preview', 128_000],
+  ['o1-mini', 128_000],
+  ['o1', 200_000],
+  ['claude-haiku-4-5', 200_000],
+  ['claude-sonnet-4', 200_000],
+  ['claude-opus-4', 200_000],
+]
+
+export function resolveEncodingName(modelName: string): 'o200k_base' | 'cl100k_base' {
+  if (/gpt-4o|gpt-4\.1|^o1|^o3|^o4/.test(modelName)) return 'o200k_base'
+  return 'cl100k_base'
+}
+
+export function resolveMaxTokens(modelName: string): number | null {
+  for (const [prefix, tokens] of MODEL_CONTEXT_WINDOWS) {
+    if (modelName.startsWith(prefix)) return tokens
+  }
+  return null
+}
+
+function serializeMessage(message: ModelMessage): string {
+  const content = typeof message.content === 'string' ? message.content : JSON.stringify(message.content)
+  return `${message.role}: ${content}`
+}
+
+function serializeHistory(history: readonly ModelMessage[]): string {
+  return history.map(serializeMessage).join('\n')
+}
+
+function serializeTools(tools: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(tools)
+  } catch (error) {
+    log.warn({ error: error instanceof Error ? error.message : String(error) }, 'Failed to serialize tools')
+    return Object.keys(tools).join(',')
+  }
+}
+
+type SafeCounter = { count: (text: string) => number; approximate: boolean }
+
+function makeSafeCounter(raw: (text: string) => number): SafeCounter {
+  let approximate = false
+  return {
+    count: (text: string): number => {
+      if (text.length === 0) return 0
+      if (approximate) return Math.ceil(text.length / 4)
+      try {
+        return raw(text)
+      } catch (error) {
+        approximate = true
+        log.warn(
+          { error: error instanceof Error ? error.message : String(error) },
+          'Tokenizer threw, falling back to char/4 estimate',
+        )
+        return Math.ceil(text.length / 4)
+      }
+    },
+    get approximate(): boolean {
+      return approximate
+    },
+  }
+}
+
+function buildSystemPromptSection(deps: ContextCollectorDeps, counter: SafeCounter): ContextSection {
+  const fullPrompt = deps.buildSystemPrompt()
+  const customInstructions = deps.buildInstructionsBlock()
+  const addendum = deps.getProviderAddendum()
+  // Base instructions = the body after stripping custom instructions and addendum.
+  // buildSystemPrompt composes as `${customInstructions}${BASE_PROMPT}${addendum}`,
+  // so base-instructions tokens ≈ full - custom - addendum.
+  const totalTokens = counter.count(fullPrompt)
+  const customTokens = counter.count(customInstructions)
+  const addendumTokens = counter.count(addendum)
+  const baseTokens = Math.max(0, totalTokens - customTokens - addendumTokens)
+
+  const children: ContextSection[] = [{ label: 'Base instructions', tokens: baseTokens }]
+  if (customTokens > 0) children.push({ label: 'Custom instructions', tokens: customTokens })
+  if (addendumTokens > 0) children.push({ label: 'Provider addendum', tokens: addendumTokens })
+
+  return { label: 'System prompt', tokens: totalTokens, children }
+}
+
+function buildMemorySection(deps: ContextCollectorDeps, counter: SafeCounter): ContextSection {
+  const memoryMessage = deps.getMemoryMessage()
+  const summary = deps.getSummary() ?? ''
+  const facts = deps.getFacts()
+  const factText = facts.map((f) => `${f.identifier}: ${f.title}`).join('\n')
+
+  const totalTokens =
+    memoryMessage === null ? counter.count(summary) + counter.count(factText) : counter.count(memoryMessage)
+  const summaryTokens = counter.count(summary)
+  const factsTokens = counter.count(factText)
+
+  const children: ContextSection[] = [{ label: 'Summary', tokens: summaryTokens }]
+  const factsChild: ContextSection = {
+    label: 'Known entities',
+    tokens: factsTokens,
+    detail: `${String(facts.length)} fact${facts.length === 1 ? '' : 's'}`,
+  }
+  children.push(factsChild)
+
+  return { label: 'Memory context', tokens: totalTokens, children }
+}
+
+function buildHistorySection(deps: ContextCollectorDeps, counter: SafeCounter): ContextSection {
+  const history = deps.getHistory()
+  const tokens = counter.count(serializeHistory(history))
+  return {
+    label: 'Conversation history',
+    tokens,
+    detail: `${String(history.length)} message${history.length === 1 ? '' : 's'}`,
+  }
+}
+
+function buildToolsSection(deps: ContextCollectorDeps, counter: SafeCounter): ContextSection {
+  const tools = deps.getActiveToolDefinitions()
+  const count = Object.keys(tools).length
+  const providerName = deps.getProviderName()
+  const tokens = counter.count(serializeTools(tools))
+  return {
+    label: 'Tools',
+    tokens,
+    detail: `${String(count)} active, gated by ${providerName}`,
+  }
+}
+
+export async function collectContext(contextId: string, deps: ContextCollectorDeps): Promise<ContextSnapshot> {
+  log.debug({ contextId }, 'collectContext called')
+  const modelName = deps.getMainModel() ?? FALLBACK_MODEL
+  const counter = makeSafeCounter(deps.countTokens)
+
+  const sections: ContextSection[] = [
+    buildSystemPromptSection(deps, counter),
+    buildMemorySection(deps, counter),
+    buildHistorySection(deps, counter),
+    buildToolsSection(deps, counter),
+  ]
+
+  const totalTokens = sections.reduce((acc, s) => acc + s.tokens, 0)
+  const maxTokens = resolveMaxTokens(modelName)
+
+  log.info(
+    {
+      contextId,
+      modelName,
+      totalTokens,
+      maxTokens,
+      approximate: counter.approximate,
+      sectionTokens: sections.map((s) => ({ label: s.label, tokens: s.tokens })),
+    },
+    'Context collected',
+  )
+
+  return { modelName, sections, totalTokens, maxTokens, approximate: counter.approximate }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run:
+
+```bash
+bun test tests/commands/context-collector.test.ts
+```
+
+Expected: PASS on all tests. If any test fails because of how `buildSystemPromptSection` splits tokens, inspect the calculation — base tokens are derived as `total − custom − addendum`, which depends on `countTokens` being additive (which it is for the test's `length`-based stub).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/context-collector.ts tests/commands/context-collector.test.ts
+git commit -m "feat(commands): add context collector with DI-driven token counting"
+```
+
+---
+
+### Task 6: Wire the collector's `countTokens` to `ai-tokenizer`
+
+**Files:**
+
+- Modify: `src/commands/context-collector.ts`
+- Modify: `tests/commands/context-collector.test.ts` (smoke test for the real tokenizer)
+
+The collector accepts `countTokens` via DI for easy testing, but production needs a real implementation backed by `ai-tokenizer`. We expose it as `defaultCountTokens` and let callers pass it in.
+
+- [ ] **Step 1: Write the failing smoke test**
+
+Append to `tests/commands/context-collector.test.ts`:
+
+```typescript
+import { defaultCountTokens } from '../../src/commands/context-collector.js'
+
+describe('defaultCountTokens', () => {
+  test('returns a positive integer for non-empty text', () => {
+    const n = defaultCountTokens('hello world', 'cl100k_base')
+    expect(Number.isInteger(n)).toBe(true)
+    expect(n).toBeGreaterThan(0)
+  })
+
+  test('returns 0 for empty text', () => {
+    expect(defaultCountTokens('', 'cl100k_base')).toBe(0)
+  })
+
+  test('o200k_base encoding works', () => {
+    const n = defaultCountTokens('hello world', 'o200k_base')
+    expect(n).toBeGreaterThan(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+
+```bash
+bun test tests/commands/context-collector.test.ts
+```
+
+Expected: FAIL on the three new tests — `defaultCountTokens` is not exported.
+
+- [ ] **Step 3: Add `defaultCountTokens` to the collector**
+
+At the top of `src/commands/context-collector.ts`, below the existing imports, add:
+
+```typescript
+import type { Tokenizer } from 'ai-tokenizer'
+```
+
+Then add these two helpers below `resolveMaxTokens` (but above `serializeMessage`):
+
+```typescript
+type EncodingName = 'o200k_base' | 'cl100k_base'
+
+const tokenizerCache = new Map<EncodingName, Tokenizer>()
+
+async function loadTokenizer(encoding: EncodingName): Promise<Tokenizer> {
+  const cached = tokenizerCache.get(encoding)
+  if (cached !== undefined) return cached
+  const { Tokenizer: TokenizerCtor } = await import('ai-tokenizer')
+  const encodingModule =
+    encoding === 'o200k_base'
+      ? ((await import('ai-tokenizer/encoding/o200k_base')) as { default: unknown })
+      : ((await import('ai-tokenizer/encoding/cl100k_base')) as { default: unknown })
+  const tokenizer = new TokenizerCtor(encodingModule.default)
+  tokenizerCache.set(encoding, tokenizer)
+  return tokenizer
+}
+
+/**
+ * Synchronous wrapper used by the collector. On first call per encoding,
+ * throws with a special marker so the caller can lazy-load via `prepareDefaultCountTokens`.
+ */
+export function defaultCountTokens(text: string, encoding: EncodingName): number {
+  if (text.length === 0) return 0
+  const tokenizer = tokenizerCache.get(encoding)
+  if (tokenizer === undefined) {
+    throw new Error(`tokenizer not loaded: ${encoding}`)
+  }
+  return tokenizer.count(text)
+}
+
+/**
+ * Preload a tokenizer for the given encoding. Must be called before `collectContext`
+ * uses the synchronous `defaultCountTokens`.
+ */
+export async function prepareDefaultCountTokens(encoding: EncodingName): Promise<void> {
+  await loadTokenizer(encoding)
+}
+```
+
+The reason for splitting prepare and count: `collectContext` is `async`, so we can `await prepareDefaultCountTokens` first, then hand `(text) => defaultCountTokens(text, encoding)` as the synchronous DI callback. If the `ai-tokenizer` import shape turns out to differ (see Task 1 Step 3), adjust `loadTokenizer` to match its real public API — but keep the same public shape (`defaultCountTokens(text, encoding)` / `prepareDefaultCountTokens(encoding)`).
+
+- [ ] **Step 4: Run the smoke test**
+
+Run:
+
+```bash
+bun test tests/commands/context-collector.test.ts
+```
+
+Expected: the three `defaultCountTokens` tests FAIL with `tokenizer not loaded` because we never called `prepareDefaultCountTokens`. Update the test to preload first:
+
+```typescript
+describe('defaultCountTokens', () => {
+  beforeEach(async () => {
+    await prepareDefaultCountTokens('cl100k_base')
+    await prepareDefaultCountTokens('o200k_base')
+  })
+
+  test('returns a positive integer for non-empty text', () => {
+    const n = defaultCountTokens('hello world', 'cl100k_base')
+    expect(Number.isInteger(n)).toBe(true)
+    expect(n).toBeGreaterThan(0)
+  })
+
+  test('returns 0 for empty text', () => {
+    expect(defaultCountTokens('', 'cl100k_base')).toBe(0)
+  })
+
+  test('o200k_base encoding works', () => {
+    const n = defaultCountTokens('hello world', 'o200k_base')
+    expect(n).toBeGreaterThan(0)
+  })
+})
+```
+
+Also add `prepareDefaultCountTokens` to the existing import line near the top of the test file.
+
+Run again:
+
+```bash
+bun test tests/commands/context-collector.test.ts
+```
+
+Expected: PASS on all tests.
+
+If the tokenizer tests still fail because of an unexpected `ai-tokenizer` API shape, consult the package's README and fix `loadTokenizer`. The signature `tokenizer.count(text)` is from the project's public docs; if the real method is `tokenizer.countTokens(text)` or `encode(text).length`, adjust `defaultCountTokens` accordingly and do **not** change its public signature.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/context-collector.ts tests/commands/context-collector.test.ts
+git commit -m "feat(commands): wire ai-tokenizer into context collector as default counter"
+```
+
+---
+
+### Task 7: Rewrite the `/context` command handler
+
+**Files:**
+
+- Modify: `src/commands/context.ts`
+- Modify: `src/bot.ts`
+- Create: `tests/commands/context.test.ts` (expand the stub from Task 3)
+
+The new handler:
+
+1. Loads user config for `main_model`, active tools, and history via the production modules.
+2. Builds a `ContextCollectorDeps` that plugs in the real helpers.
+3. Calls `collectContext` and `chat.renderContext`.
+4. Dispatches the rendered result via `reply.embed`, `reply.formatted`, or `reply.text`.
+
+- [ ] **Step 1: Replace the stub test file**
+
+Overwrite `tests/commands/context.test.ts` with:
+
+```typescript
+import { describe, expect, test, beforeEach } from 'bun:test'
+
+import type { ChatProvider, ContextSnapshot, CommandHandler } from '../../src/chat/types.js'
+import { registerContextCommand } from '../../src/commands/context.js'
+import { createAuth, createDmMessage, createMockChat, createMockReply, mockLogger } from '../utils/test-helpers.js'
+
+function captureCommand(chat: ChatProvider, commands: Map<string, CommandHandler>): CommandHandler {
+  const handler = commands.get('context')
+  if (handler === undefined) {
+    throw new Error('context command not registered')
+  }
+  return handler
+}
+
+const snapshotDeps = (
+  overrides?: Partial<import('../../src/commands/context.js').ContextCommandDeps>,
+): import('../../src/commands/context.js').ContextCommandDeps => ({
+  collectContext: async (): Promise<ContextSnapshot> => ({
+    modelName: 'gpt-4o',
+    sections: [
+      { label: 'System prompt', tokens: 1000 },
+      { label: 'Memory context', tokens: 500 },
+      { label: 'Conversation history', tokens: 2000 },
+      { label: 'Tools', tokens: 3000 },
+    ],
+    totalTokens: 6500,
+    maxTokens: 128_000,
+    approximate: false,
+  }),
+  ...overrides,
+})
+
+describe('registerContextCommand', () => {
+  beforeEach(() => {
+    mockLogger()
+  })
+
+  test('available to non-admin users', async () => {
+    const commands = new Map<string, CommandHandler>()
+    const chat = createMockChat({ commandHandlers: commands })
+    registerContextCommand(chat, snapshotDeps())
+
+    const handler = captureCommand(chat, commands)
+    const { reply, textCalls } = createMockReply()
+    const msg = createDmMessage('some-regular-user')
+    const auth = createAuth('some-regular-user', { isBotAdmin: false })
+
+    await handler(msg, reply, auth)
+
+    expect(textCalls.length).toBeGreaterThan(0)
+  })
+
+  test('does not reject unauthorized users before the bot dispatcher (auth gate is upstream)', async () => {
+    const commands = new Map<string, CommandHandler>()
+    const chat = createMockChat({ commandHandlers: commands })
+    registerContextCommand(chat, snapshotDeps())
+
+    const handler = captureCommand(chat, commands)
+    const { reply, textCalls } = createMockReply()
+    const msg = createDmMessage('user1')
+    const auth = createAuth('user1', { allowed: false })
+
+    await handler(msg, reply, auth)
+
+    // Handler itself must return early on !auth.allowed without sending anything.
+    expect(textCalls.length).toBe(0)
+  })
+
+  test('dispatches text output via reply.text', async () => {
+    const commands = new Map<string, CommandHandler>()
+    const chat: ChatProvider = {
+      ...createMockChat({ commandHandlers: commands }),
+      renderContext: () => ({ method: 'text', content: 'RAW TEXT PAYLOAD' }),
+    }
+    registerContextCommand(chat, snapshotDeps())
+    const handler = captureCommand(chat, commands)
+
+    const { reply, textCalls } = createMockReply()
+    await handler(createDmMessage('user1'), reply, createAuth('user1'))
+
+    expect(textCalls).toContain('RAW TEXT PAYLOAD')
+  })
+
+  test('dispatches formatted output via reply.formatted', async () => {
+    const commands = new Map<string, CommandHandler>()
+    const chat: ChatProvider = {
+      ...createMockChat({ commandHandlers: commands }),
+      renderContext: () => ({ method: 'formatted', content: '**markdown**' }),
+    }
+    registerContextCommand(chat, snapshotDeps())
+    const handler = captureCommand(chat, commands)
+
+    const { reply, textCalls } = createMockReply()
+    await handler(createDmMessage('user1'), reply, createAuth('user1'))
+
+    // Our updated createMockReply records formatted calls in textCalls.
+    expect(textCalls).toContain('**markdown**')
+  })
+
+  test('dispatches embed output via reply.embed when available', async () => {
+    const commands = new Map<string, CommandHandler>()
+    const chat: ChatProvider = {
+      ...createMockChat({ commandHandlers: commands }),
+      renderContext: () => ({
+        method: 'embed',
+        embed: {
+          title: 'Context · gpt-4o',
+          description: '🟦🟦⬜',
+          footer: '6,500 / 128,000 tokens',
+          color: 0x2ecc71,
+        },
+      }),
+    }
+    registerContextCommand(chat, snapshotDeps())
+    const handler = captureCommand(chat, commands)
+
+    const { reply, embedCalls } = createMockReply()
+    await handler(createDmMessage('user1'), reply, createAuth('user1'))
+
+    expect(embedCalls).toHaveLength(1)
+    expect(embedCalls[0]?.title).toBe('Context · gpt-4o')
+  })
+
+  test('falls back to reply.formatted when embed is requested but reply.embed is undefined', async () => {
+    const commands = new Map<string, CommandHandler>()
+    const chat: ChatProvider = {
+      ...createMockChat({ commandHandlers: commands }),
+      renderContext: () => ({
+        method: 'embed',
+        embed: {
+          title: 'Context · gpt-4o',
+          description: '🟦🟦⬜',
+          footer: '6,500 / 128,000 tokens',
+        },
+      }),
+    }
+    registerContextCommand(chat, snapshotDeps())
+    const handler = captureCommand(chat, commands)
+
+    const { reply, textCalls } = createMockReply()
+    delete (reply as { embed?: unknown }).embed
+    await handler(createDmMessage('user1'), reply, createAuth('user1'))
+
+    // Fallback should render something containing the title and description
+    expect(textCalls.some((t) => t.includes('Context · gpt-4o'))).toBe(true)
+    expect(textCalls.some((t) => t.includes('🟦🟦⬜'))).toBe(true)
+  })
+
+  test('reports collector errors with a friendly text message', async () => {
+    const commands = new Map<string, CommandHandler>()
+    const chat = createMockChat({ commandHandlers: commands })
+    registerContextCommand(
+      chat,
+      snapshotDeps({
+        collectContext: async () => {
+          throw new Error('boom')
+        },
+      }),
+    )
+    const handler = captureCommand(chat, commands)
+
+    const { reply, textCalls } = createMockReply()
+    await handler(createDmMessage('user1'), reply, createAuth('user1'))
+
+    expect(textCalls.length).toBe(1)
+    expect(textCalls[0]).toMatch(/could not build context view/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+
+```bash
+bun test tests/commands/context.test.ts
+```
+
+Expected: FAIL — `registerContextCommand` still has the two-arg `(chat, adminUserId)` signature and imports from the old implementation.
+
+- [ ] **Step 3: Replace `src/commands/context.ts` with the new implementation**
+
+Overwrite the whole file with:
+
+```typescript
+import type { ModelMessage } from 'ai'
+
+import { getCachedTools } from '../cache.js'
+import type { ChatProvider, ContextRendered, ContextSnapshot } from '../chat/types.js'
+import { getConfig } from '../config.js'
+import { buildMessagesWithMemory } from '../conversation.js'
+import { loadHistory } from '../history.js'
+import { buildInstructionsBlock } from '../instructions.js'
+import { logger } from '../logger.js'
+import { loadFacts, loadSummary } from '../memory.js'
+import { buildProviderForUser } from '../providers/factory.js'
+import type { TaskProvider } from '../providers/types.js'
+import { buildSystemPrompt } from '../system-prompt.js'
+import { makeTools } from '../tools/index.js'
+
+import {
+  collectContext as defaultCollectContext,
+  defaultCountTokens,
+  prepareDefaultCountTokens,
+  resolveEncodingName,
+  type ContextCollectorDeps,
+} from './context-collector.js'
+
+const log = logger.child({ scope: 'commands:context' })
+
+export interface ContextCommandDeps {
+  /** The collector entry point — swap for tests. */
+  collectContext: (contextId: string, collectorDeps: ContextCollectorDeps) => Promise<ContextSnapshot>
+}
+
+const defaultDeps: ContextCommandDeps = {
+  collectContext: defaultCollectContext,
+}
+
+function safeBuildProvider(contextId: string): TaskProvider | null {
+  try {
+    return buildProviderForUser(contextId, false)
+  } catch (error) {
+    log.warn(
+      { contextId, error: error instanceof Error ? error.message : String(error) },
+      'Provider unavailable while building context view',
+    )
+    return null
+  }
+}
+
+function buildMemoryMessageText(contextId: string, history: readonly ModelMessage[]): string | null {
+  const { memoryMsg } = buildMessagesWithMemory(contextId, history)
+  return memoryMsg === null ? null : memoryMsg.content
+}
+
+function buildCollectorDeps(contextId: string, provider: TaskProvider | null): ContextCollectorDeps {
+  const modelName = getConfig(contextId, 'main_model')
+  const encoding = resolveEncodingName(modelName ?? 'unknown')
+
+  return {
+    getMainModel: () => modelName,
+    buildSystemPrompt: () =>
+      provider === null ? buildInstructionsBlock(contextId) : buildSystemPrompt(provider, contextId),
+    buildInstructionsBlock: () => buildInstructionsBlock(contextId),
+    getProviderAddendum: () => (provider === null ? '' : provider.getPromptAddendum()),
+    getHistory: () => loadHistory(contextId),
+    getMemoryMessage: () => buildMemoryMessageText(contextId, loadHistory(contextId)),
+    getSummary: () => loadSummary(contextId),
+    getFacts: () => loadFacts(contextId),
+    getActiveToolDefinitions: () => {
+      const cached = getCachedTools(contextId)
+      if (cached !== undefined && cached !== null) return cached as Record<string, unknown>
+      if (provider === null) return {}
+      return makeTools(provider, contextId, 'normal', contextId) as Record<string, unknown>
+    },
+    getProviderName: () => provider?.name ?? 'none',
+    countTokens: (text: string): number => defaultCountTokens(text, encoding),
+  }
+}
+
+function renderFallback(rendered: ContextRendered & { method: 'embed' }): string {
+  const lines: string[] = []
+  lines.push(rendered.embed.title)
+  lines.push('')
+  lines.push(rendered.embed.description)
+  if (rendered.embed.fields !== undefined) {
+    lines.push('')
+    for (const field of rendered.embed.fields) {
+      lines.push(`${field.name}: ${field.value}`)
+    }
+  }
+  if (rendered.embed.footer !== undefined) {
+    lines.push('')
+    lines.push(rendered.embed.footer)
+  }
+  return lines.join('\n')
+}
+
+export function registerContextCommand(chat: ChatProvider, deps: ContextCommandDeps = defaultDeps): void {
+  chat.registerCommand('context', async (msg, reply, auth) => {
+    if (!auth.allowed) return
+
+    log.debug({ userId: msg.user.id, storageContextId: auth.storageContextId }, '/context command called')
+
+    let snapshot: ContextSnapshot
+    try {
+      const modelName = getConfig(auth.storageContextId, 'main_model')
+      if (modelName !== null) {
+        await prepareDefaultCountTokens(resolveEncodingName(modelName))
+      } else {
+        await prepareDefaultCountTokens('cl100k_base')
+      }
+      const provider = safeBuildProvider(auth.storageContextId)
+      const collectorDeps = buildCollectorDeps(auth.storageContextId, provider)
+      snapshot = await deps.collectContext(auth.storageContextId, collectorDeps)
+    } catch (error) {
+      log.warn(
+        {
+          userId: msg.user.id,
+          storageContextId: auth.storageContextId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        '/context collector failed',
+      )
+      await reply.text('Sorry — could not build context view right now.')
+      return
+    }
+
+    const rendered = chat.renderContext(snapshot)
+
+    if (rendered.method === 'embed') {
+      if (reply.embed !== undefined) {
+        await reply.embed(rendered.embed)
+      } else {
+        await reply.formatted(renderFallback(rendered))
+      }
+    } else if (rendered.method === 'formatted') {
+      await reply.formatted(rendered.content)
+    } else {
+      await reply.text(rendered.content)
+    }
+
+    log.info(
+      {
+        userId: msg.user.id,
+        storageContextId: auth.storageContextId,
+        totalTokens: snapshot.totalTokens,
+        maxTokens: snapshot.maxTokens,
+        method: rendered.method,
+        approximate: snapshot.approximate,
+      },
+      '/context command executed',
+    )
+  })
+}
+```
+
+- [ ] **Step 4: Update `bot.ts` to drop `adminUserId`**
+
+In `src/bot.ts`, find line 51:
+
+```typescript
+registerContextCommand(chat, adminUserId)
+```
+
+Replace with:
+
+```typescript
+registerContextCommand(chat)
+```
+
+`adminUserId` is still used by the other calls (`registerClearCommand`, `registerAdminCommands`) so don't remove the parameter from `registerCommands` itself.
+
+- [ ] **Step 5: Run the command tests**
+
+Run:
+
+```bash
+bun test tests/commands/context.test.ts
+```
+
+Expected: PASS on all seven tests.
+
+Note: the two sanity tests from Task 3 (`createMockReply exposes an embed stub` and `createMockChat implements renderContext`) should either be removed or left alone if you want to keep them. Either is fine.
+
+- [ ] **Step 6: Run typecheck**
+
+Run:
+
+```bash
+bun typecheck
+```
+
+Expected: the only remaining type errors are on `TelegramChatProvider`, `DiscordChatProvider`, and `MattermostChatProvider` missing `renderContext`. All other `ChatProvider` consumers should now compile.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/commands/context.ts src/bot.ts tests/commands/context.test.ts
+git commit -m "feat(commands): rewrite /context as visual snapshot dispatcher"
+```
+
+---
+
+### Task 8: Telegram context renderer
+
+**Files:**
+
+- Create: `src/chat/telegram/context-renderer.ts`
+- Create: `tests/chat/telegram/context-renderer.test.ts`
+- Modify: `src/chat/telegram/index.ts`
+
+Telegram output: one message. Header line (plain text), blank line, emoji grid (inline), blank line, monospace code block with the detail breakdown.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/chat/telegram/context-renderer.test.ts`:
+
+````typescript
+import { describe, expect, test } from 'bun:test'
+
+import type { ContextSnapshot } from '../../../src/chat/types.js'
+import { renderTelegramContext } from '../../../src/chat/telegram/context-renderer.js'
+
+const snapshot: ContextSnapshot = {
+  modelName: 'gpt-4o',
+  totalTokens: 6_770,
+  maxTokens: 128_000,
+  approximate: false,
+  sections: [
+    {
+      label: 'System prompt',
+      tokens: 820,
+      children: [
+        { label: 'Base instructions', tokens: 650 },
+        { label: 'Custom instructions', tokens: 120 },
+        { label: 'Provider addendum', tokens: 50 },
+      ],
+    },
+    {
+      label: 'Memory context',
+      tokens: 350,
+      children: [
+        { label: 'Summary', tokens: 180 },
+        { label: 'Known entities', tokens: 170, detail: '12 facts' },
+      ],
+    },
+    { label: 'Conversation history', tokens: 2_400, detail: '34 messages' },
+    { label: 'Tools', tokens: 3_200, detail: '18 active, gated by kaneo' },
+  ],
+}
+
+describe('renderTelegramContext', () => {
+  test('returns a text method result', () => {
+    const result = renderTelegramContext(snapshot)
+    expect(result.method).toBe('text')
+  })
+
+  test('contains header with model and usage', () => {
+    const result = renderTelegramContext(snapshot)
+    if (result.method !== 'text') throw new Error('expected text')
+    expect(result.content).toContain('gpt-4o')
+    expect(result.content).toContain('6,770')
+    expect(result.content).toContain('128,000')
+    expect(result.content).toMatch(/5\.\d%/)
+  })
+
+  test('contains the emoji grid', () => {
+    const result = renderTelegramContext(snapshot)
+    if (result.method !== 'text') throw new Error('expected text')
+    expect(result.content).toContain('🟦')
+    expect(result.content).toContain('⬜')
+  })
+
+  test('wraps detail section in a code block', () => {
+    const result = renderTelegramContext(snapshot)
+    if (result.method !== 'text') throw new Error('expected text')
+    expect(result.content).toContain('```')
+    expect(result.content).toContain('System prompt')
+    expect(result.content).toContain('820')
+    expect(result.content).toContain('Conversation history')
+    expect(result.content).toContain('34 messages')
+  })
+
+  test('omits percentage when maxTokens is null', () => {
+    const result = renderTelegramContext({ ...snapshot, maxTokens: null })
+    if (result.method !== 'text') throw new Error('expected text')
+    expect(result.content).not.toMatch(/%/)
+    expect(result.content).toContain('6,770 tokens')
+  })
+
+  test('notes approximate counts when applicable', () => {
+    const result = renderTelegramContext({ ...snapshot, approximate: true })
+    if (result.method !== 'text') throw new Error('expected text')
+    expect(result.content).toMatch(/approximate/i)
+  })
+})
+````
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+
+```bash
+bun test tests/chat/telegram/context-renderer.test.ts
+```
+
+Expected: FAIL — cannot find module `../../../src/chat/telegram/context-renderer.js`.
+
+- [ ] **Step 3: Implement the Telegram renderer**
+
+Create `src/chat/telegram/context-renderer.ts`:
+
+```typescript
+import type { ContextRendered, ContextSection, ContextSnapshot } from '../types.js'
+import { buildContextGrid } from '../../commands/context-grid.js'
+
+function formatNumber(n: number): string {
+  return n.toLocaleString('en-US')
+}
+
+function buildHeader(snapshot: ContextSnapshot): string {
+  const total = formatNumber(snapshot.totalTokens)
+  if (snapshot.maxTokens === null) {
+    return `Context · ${snapshot.modelName} · ${total} tokens`
+  }
+  const max = formatNumber(snapshot.maxTokens)
+  const pct = ((snapshot.totalTokens / snapshot.maxTokens) * 100).toFixed(1)
+  return `Context · ${snapshot.modelName} · ${total} / ${max} tokens (${pct}%)`
+}
+
+function formatSectionLine(section: ContextSection, indent: number): string {
+  const pad = ' '.repeat(indent)
+  const tokens = `${formatNumber(section.tokens)} tk`
+  return `${pad}${section.label.padEnd(24 - indent)} ${tokens.padStart(10)}`
+}
+
+function buildDetail(snapshot: ContextSnapshot): string {
+  const lines: string[] = []
+  for (const section of snapshot.sections) {
+    lines.push(formatSectionLine(section, 0))
+    if (section.children !== undefined) {
+      for (const child of section.children) {
+        lines.push(formatSectionLine(child, 2))
+      }
+    }
+    if (section.detail !== undefined) {
+      lines.push(`  ${section.detail}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+export function renderTelegramContext(snapshot: ContextSnapshot): ContextRendered {
+  const header = buildHeader(snapshot)
+  const grid = buildContextGrid(snapshot)
+  const detail = buildDetail(snapshot)
+  const footer = snapshot.approximate ? '\n\n_token counts are approximate_' : ''
+  const content = `${header}\n\n${grid}\n\n\`\`\`\n${detail}\n\`\`\`${footer}`
+  return { method: 'text', content }
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run:
+
+```bash
+bun test tests/chat/telegram/context-renderer.test.ts
+```
+
+Expected: PASS on all tests.
+
+- [ ] **Step 5: Wire the renderer into `TelegramChatProvider`**
+
+Open `src/chat/telegram/index.ts`. Add the import alongside the existing ones:
+
+```typescript
+import { renderTelegramContext } from './context-renderer.js'
+```
+
+Then, in the class body (after `threadCapabilities` and before other members is fine), add:
+
+```typescript
+  renderContext(snapshot: ContextSnapshot): ContextRendered {
+    return renderTelegramContext(snapshot)
+  }
+```
+
+Also add the types to the existing `import type { ... } from '../types.js'` block at the top so the return type is known:
+
+```typescript
+import type {
+  AuthorizationResult,
+  ChatProvider,
+  CommandHandler,
+  ContextRendered,
+  ContextSnapshot,
+  ContextType,
+  IncomingFile,
+  IncomingMessage,
+  ReplyFn,
+  ReplyOptions,
+  ResolveUserContext,
+} from '../types.js'
+```
+
+- [ ] **Step 6: Typecheck Telegram**
+
+Run:
+
+```bash
+bun typecheck
+```
+
+Expected: Telegram errors are gone. Discord and Mattermost still error on missing `renderContext`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/chat/telegram/context-renderer.ts src/chat/telegram/index.ts tests/chat/telegram/context-renderer.test.ts
+git commit -m "feat(chat/telegram): implement renderContext with inline grid and monospace detail"
+```
+
+---
+
+### Task 9: Mattermost context renderer
+
+**Files:**
+
+- Create: `src/chat/mattermost/context-renderer.ts`
+- Create: `tests/chat/mattermost/context-renderer.test.ts`
+- Modify: `src/chat/mattermost/index.ts`
+
+Mattermost output: one formatted markdown message with bold header, emoji grid, then a markdown table for the detail.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/chat/mattermost/context-renderer.test.ts`:
+
+```typescript
+import { describe, expect, test } from 'bun:test'
+
+import type { ContextSnapshot } from '../../../src/chat/types.js'
+import { renderMattermostContext } from '../../../src/chat/mattermost/context-renderer.js'
+
+const snapshot: ContextSnapshot = {
+  modelName: 'gpt-4o',
+  totalTokens: 6_770,
+  maxTokens: 128_000,
+  approximate: false,
+  sections: [
+    {
+      label: 'System prompt',
+      tokens: 820,
+      children: [
+        { label: 'Base instructions', tokens: 650 },
+        { label: 'Custom instructions', tokens: 120 },
+        { label: 'Provider addendum', tokens: 50 },
+      ],
+    },
+    {
+      label: 'Memory context',
+      tokens: 350,
+      children: [
+        { label: 'Summary', tokens: 180 },
+        { label: 'Known entities', tokens: 170, detail: '12 facts' },
+      ],
+    },
+    { label: 'Conversation history', tokens: 2_400, detail: '34 messages' },
+    { label: 'Tools', tokens: 3_200, detail: '18 active, gated by kaneo' },
+  ],
+}
+
+describe('renderMattermostContext', () => {
+  test('returns a formatted method result', () => {
+    const result = renderMattermostContext(snapshot)
+    expect(result.method).toBe('formatted')
+  })
+
+  test('contains bold header with model and usage', () => {
+    const result = renderMattermostContext(snapshot)
+    if (result.method !== 'formatted') throw new Error('expected formatted')
+    expect(result.content).toContain('**Context**')
+    expect(result.content).toContain('gpt-4o')
+    expect(result.content).toContain('6,770')
+    expect(result.content).toContain('128,000')
+  })
+
+  test('contains a markdown table', () => {
+    const result = renderMattermostContext(snapshot)
+    if (result.method !== 'formatted') throw new Error('expected formatted')
+    expect(result.content).toContain('| Section')
+    expect(result.content).toContain('| ------ | ------')
+  })
+
+  test('table rows use section emojis', () => {
+    const result = renderMattermostContext(snapshot)
+    if (result.method !== 'formatted') throw new Error('expected formatted')
+    expect(result.content).toContain('| 🟦 **System prompt**')
+    expect(result.content).toContain('| 🟩 **Memory context**')
+    expect(result.content).toContain('| 🟨 **Conversation history**')
+    expect(result.content).toContain('| 🟪 **Tools**')
+  })
+
+  test('contains the emoji grid', () => {
+    const result = renderMattermostContext(snapshot)
+    if (result.method !== 'formatted') throw new Error('expected formatted')
+    expect(result.content).toContain('🟦')
+    expect(result.content).toContain('⬜')
+  })
+
+  test('notes approximate counts when applicable', () => {
+    const result = renderMattermostContext({ ...snapshot, approximate: true })
+    if (result.method !== 'formatted') throw new Error('expected formatted')
+    expect(result.content).toMatch(/_token counts are approximate_/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+
+```bash
+bun test tests/chat/mattermost/context-renderer.test.ts
+```
+
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Implement the Mattermost renderer**
+
+Create `src/chat/mattermost/context-renderer.ts`:
+
+```typescript
+import type { ContextRendered, ContextSection, ContextSnapshot } from '../types.js'
+import { buildContextGrid } from '../../commands/context-grid.js'
+
+const SECTION_EMOJI: Record<string, string> = {
+  'System prompt': '🟦',
+  'Memory context': '🟩',
+  'Conversation history': '🟨',
+  Tools: '🟪',
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString('en-US')
+}
+
+function buildHeader(snapshot: ContextSnapshot): string {
+  const total = formatNumber(snapshot.totalTokens)
+  if (snapshot.maxTokens === null) {
+    return `**Context** · ${snapshot.modelName} · ${total} tokens`
+  }
+  const max = formatNumber(snapshot.maxTokens)
+  const pct = ((snapshot.totalTokens / snapshot.maxTokens) * 100).toFixed(1)
+  return `**Context** · ${snapshot.modelName} · ${total} / ${max} tokens (${pct}%)`
+}
+
+function emojiFor(label: string): string {
+  return SECTION_EMOJI[label] ?? ' '
+}
+
+function topRow(section: ContextSection): string {
+  return `| ${emojiFor(section.label)} **${section.label}** | ${formatNumber(section.tokens)} |`
+}
+
+function childRow(child: ContextSection): string {
+  const label = child.detail === undefined ? child.label : `${child.label} (${child.detail})`
+  return `| ↳ ${label} | ${formatNumber(child.tokens)} |`
+}
+
+function detailRow(detail: string): string {
+  return `| ↳ ${detail} |  |`
+}
+
+function buildTable(snapshot: ContextSnapshot): string {
+  const lines = ['| Section | Tokens |', '| ------ | ------:|']
+  for (const section of snapshot.sections) {
+    lines.push(topRow(section))
+    if (section.children !== undefined) {
+      for (const child of section.children) lines.push(childRow(child))
+    }
+    if (section.detail !== undefined) lines.push(detailRow(section.detail))
+  }
+  return lines.join('\n')
+}
+
+export function renderMattermostContext(snapshot: ContextSnapshot): ContextRendered {
+  const header = buildHeader(snapshot)
+  const grid = buildContextGrid(snapshot)
+  const table = buildTable(snapshot)
+  const footer = snapshot.approximate ? '\n\n_token counts are approximate_' : ''
+  return { method: 'formatted', content: `${header}\n\n${grid}\n\n${table}${footer}` }
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run:
+
+```bash
+bun test tests/chat/mattermost/context-renderer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Wire the renderer into `MattermostChatProvider`**
+
+Open `src/chat/mattermost/index.ts`. Update the imports:
+
+```typescript
+import type {
+  AuthorizationResult,
+  ChatProvider,
+  CommandHandler,
+  ContextRendered,
+  ContextSnapshot,
+  ContextType,
+  IncomingMessage,
+  ReplyFn,
+  ResolveUserContext,
+} from '../types.js'
+```
+
+Then add the import:
+
+```typescript
+import { renderMattermostContext } from './context-renderer.js'
+```
+
+Add the method to the class body:
+
+```typescript
+  renderContext(snapshot: ContextSnapshot): ContextRendered {
+    return renderMattermostContext(snapshot)
+  }
+```
+
+- [ ] **Step 6: Typecheck**
+
+Run:
+
+```bash
+bun typecheck
+```
+
+Expected: Telegram and Mattermost gone from the error list; only Discord remains.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/chat/mattermost/context-renderer.ts src/chat/mattermost/index.ts tests/chat/mattermost/context-renderer.test.ts
+git commit -m "feat(chat/mattermost): implement renderContext with grid and markdown table"
+```
+
+---
+
+### Task 10: Discord `reply.embed` implementation
+
+**Files:**
+
+- Modify: `src/chat/discord/reply-helpers.ts`
+- Modify: `tests/chat/discord/reply-helpers.test.ts`
+
+Before the Discord renderer can be used, `reply.embed` must exist. Add it as a new method on `createDiscordReplyFn`'s returned object using discord.js v14's `EmbedBuilder`.
+
+- [ ] **Step 1: Write the failing test**
+
+Open `tests/chat/discord/reply-helpers.test.ts`. Add a new `describe` block at the bottom:
+
+```typescript
+describe('createDiscordReplyFn().embed', () => {
+  test('sends an embed via channel.send', async () => {
+    const sent: unknown[] = []
+    const channel = {
+      id: 'chan-1',
+      send: async (arg: unknown): Promise<{ id: string; edit: () => Promise<unknown> }> => {
+        sent.push(arg)
+        return { id: 'msg-1', edit: () => Promise.resolve(undefined) }
+      },
+      sendTyping: () => Promise.resolve(undefined),
+    }
+    const { createDiscordReplyFn } = await import('../../../src/chat/discord/reply-helpers.js')
+    const reply = createDiscordReplyFn({ channel, replyToMessageId: undefined })
+
+    expect(reply.embed).toBeDefined()
+    await reply.embed!({
+      title: 'Context · gpt-4o',
+      description: '🟦🟦⬜',
+      fields: [{ name: 'System prompt', value: '820 tk' }],
+      footer: '6,770 / 128,000 tokens',
+      color: 0x2ecc71,
+    })
+
+    expect(sent).toHaveLength(1)
+    const payload = sent[0] as { embeds?: unknown[] }
+    expect(Array.isArray(payload.embeds)).toBe(true)
+    expect(payload.embeds).toHaveLength(1)
+  })
+
+  test('handles embeds without optional fields', async () => {
+    const sent: unknown[] = []
+    const channel = {
+      id: 'chan-1',
+      send: async (arg: unknown): Promise<{ id: string; edit: () => Promise<unknown> }> => {
+        sent.push(arg)
+        return { id: 'msg-1', edit: () => Promise.resolve(undefined) }
+      },
+      sendTyping: () => Promise.resolve(undefined),
+    }
+    const { createDiscordReplyFn } = await import('../../../src/chat/discord/reply-helpers.js')
+    const reply = createDiscordReplyFn({ channel, replyToMessageId: undefined })
+
+    await reply.embed!({
+      title: 'Minimal',
+      description: 'Just the basics',
+    })
+    expect(sent).toHaveLength(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+
+```bash
+bun test tests/chat/discord/reply-helpers.test.ts
+```
+
+Expected: FAIL — `reply.embed` is undefined.
+
+- [ ] **Step 3: Implement `embed` on `createDiscordReplyFn`**
+
+Open `src/chat/discord/reply-helpers.ts`. Update the imports to add `EmbedBuilder`:
+
+```typescript
+import { EmbedBuilder } from 'discord.js'
+
+import { logger } from '../../logger.js'
+import type { ButtonReplyOptions, ChatFile, EmbedOptions, ReplyFn, ReplyOptions } from '../types.js'
+import { toActionRows } from './buttons.js'
+import { chunkForDiscord } from './format-chunking.js'
+import { formatLlmOutput } from './format.js'
+```
+
+Also update `SendableChannel.send` to accept an `embeds` array:
+
+```typescript
+export type SendableChannel = {
+  id: string
+  send: (arg: {
+    content?: string
+    components?: unknown[]
+    embeds?: unknown[]
+    reply?: { messageReference: string; failIfNotExists: boolean }
+  }) => Promise<{ id: string; edit: (arg: { content?: string; components?: unknown[] }) => Promise<unknown> }>
+  sendTyping: () => Promise<void>
+}
+```
+
+Then add the `embed` method inside the returned object (alongside `buttons`):
+
+```typescript
+    embed: async (options: EmbedOptions): Promise<void> => {
+      const builder = new EmbedBuilder().setTitle(options.title).setDescription(options.description)
+      if (options.fields !== undefined) {
+        builder.addFields(options.fields.map((f) => ({ name: f.name, value: f.value, inline: f.inline ?? false })))
+      }
+      if (options.footer !== undefined) {
+        builder.setFooter({ text: options.footer })
+      }
+      if (options.color !== undefined) {
+        builder.setColor(options.color)
+      }
+      const sent = await channel.send({ embeds: [builder.toJSON()] })
+      lastBotMessage = sent
+    },
+```
+
+- [ ] **Step 4: Run the test**
+
+Run:
+
+```bash
+bun test tests/chat/discord/reply-helpers.test.ts
+```
+
+Expected: PASS on the two new embed tests, plus the existing tests still passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/chat/discord/reply-helpers.ts tests/chat/discord/reply-helpers.test.ts
+git commit -m "feat(chat/discord): add reply.embed method using discord.js EmbedBuilder"
+```
+
+---
+
+### Task 11: Discord context renderer
+
+**Files:**
+
+- Create: `src/chat/discord/context-renderer.ts`
+- Create: `tests/chat/discord/context-renderer.test.ts`
+- Modify: `src/chat/discord/index.ts`
+
+Discord output: an embed with title `Context · <model>`, description = emoji grid, fields for each section, footer = token usage, color based on utilization.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/chat/discord/context-renderer.test.ts`:
+
+```typescript
+import { describe, expect, test } from 'bun:test'
+
+import type { ContextSnapshot } from '../../../src/chat/types.js'
+import { renderDiscordContext } from '../../../src/chat/discord/context-renderer.js'
+
+const snapshot: ContextSnapshot = {
+  modelName: 'gpt-4o',
+  totalTokens: 6_770,
+  maxTokens: 128_000,
+  approximate: false,
+  sections: [
+    {
+      label: 'System prompt',
+      tokens: 820,
+      children: [
+        { label: 'Base instructions', tokens: 650 },
+        { label: 'Custom instructions', tokens: 120 },
+        { label: 'Provider addendum', tokens: 50 },
+      ],
+    },
+    {
+      label: 'Memory context',
+      tokens: 350,
+      children: [
+        { label: 'Summary', tokens: 180 },
+        { label: 'Known entities', tokens: 170, detail: '12 facts' },
+      ],
+    },
+    { label: 'Conversation history', tokens: 2_400, detail: '34 messages' },
+    { label: 'Tools', tokens: 3_200, detail: '18 active, gated by kaneo' },
+  ],
+}
+
+describe('renderDiscordContext', () => {
+  test('returns embed method with Context title', () => {
+    const result = renderDiscordContext(snapshot)
+    expect(result.method).toBe('embed')
+    if (result.method !== 'embed') throw new Error('expected embed')
+    expect(result.embed.title).toBe('Context · gpt-4o')
+  })
+
+  test('description contains the emoji grid', () => {
+    const result = renderDiscordContext(snapshot)
+    if (result.method !== 'embed') throw new Error('expected embed')
+    expect(result.embed.description).toContain('🟦')
+    expect(result.embed.description).toContain('⬜')
+  })
+
+  test('has one field per top-level section', () => {
+    const result = renderDiscordContext(snapshot)
+    if (result.method !== 'embed') throw new Error('expected embed')
+    expect(result.embed.fields?.map((f) => f.name)).toEqual([
+      '🟦 System prompt',
+      '🟩 Memory context',
+      '🟨 Conversation history',
+      '🟪 Tools',
+    ])
+  })
+
+  test('section fields list child tokens in their values', () => {
+    const result = renderDiscordContext(snapshot)
+    if (result.method !== 'embed') throw new Error('expected embed')
+    const systemField = result.embed.fields?.find((f) => f.name === '🟦 System prompt')
+    expect(systemField?.value).toContain('820')
+    expect(systemField?.value).toContain('Base instructions')
+    expect(systemField?.value).toContain('Custom instructions')
+    expect(systemField?.value).toContain('Provider addendum')
+  })
+
+  test('footer shows tokens + percentage', () => {
+    const result = renderDiscordContext(snapshot)
+    if (result.method !== 'embed') throw new Error('expected embed')
+    expect(result.embed.footer).toContain('6,770')
+    expect(result.embed.footer).toContain('128,000')
+    expect(result.embed.footer).toMatch(/5\.\d%/)
+  })
+
+  test('color is green below 50% usage', () => {
+    const result = renderDiscordContext(snapshot)
+    if (result.method !== 'embed') throw new Error('expected embed')
+    expect(result.embed.color).toBe(0x2ecc71)
+  })
+
+  test('color is yellow between 50% and 80% usage', () => {
+    const result = renderDiscordContext({ ...snapshot, totalTokens: 80_000 })
+    if (result.method !== 'embed') throw new Error('expected embed')
+    expect(result.embed.color).toBe(0xf1c40f)
+  })
+
+  test('color is red above 80% usage', () => {
+    const result = renderDiscordContext({ ...snapshot, totalTokens: 110_000 })
+    if (result.method !== 'embed') throw new Error('expected embed')
+    expect(result.embed.color).toBe(0xe74c3c)
+  })
+
+  test('footer omits percentage when maxTokens is null', () => {
+    const result = renderDiscordContext({ ...snapshot, maxTokens: null })
+    if (result.method !== 'embed') throw new Error('expected embed')
+    expect(result.embed.footer).not.toMatch(/%/)
+    expect(result.embed.footer).toContain('6,770 tokens')
+  })
+
+  test('notes approximate counts in footer when applicable', () => {
+    const result = renderDiscordContext({ ...snapshot, approximate: true })
+    if (result.method !== 'embed') throw new Error('expected embed')
+    expect(result.embed.footer).toMatch(/approximate/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+
+```bash
+bun test tests/chat/discord/context-renderer.test.ts
+```
+
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Implement the Discord renderer**
+
+Create `src/chat/discord/context-renderer.ts`:
+
+```typescript
+import type { ContextRendered, ContextSection, ContextSnapshot, EmbedField } from '../types.js'
+import { buildContextGrid } from '../../commands/context-grid.js'
+
+const COLOR_GREEN = 0x2ecc71
+const COLOR_YELLOW = 0xf1c40f
+const COLOR_RED = 0xe74c3c
+
+const SECTION_EMOJI: Record<string, string> = {
+  'System prompt': '🟦',
+  'Memory context': '🟩',
+  'Conversation history': '🟨',
+  Tools: '🟪',
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString('en-US')
+}
+
+function pickColor(snapshot: ContextSnapshot): number | undefined {
+  if (snapshot.maxTokens === null) return undefined
+  const ratio = snapshot.totalTokens / snapshot.maxTokens
+  if (ratio < 0.5) return COLOR_GREEN
+  if (ratio < 0.8) return COLOR_YELLOW
+  return COLOR_RED
+}
+
+function buildFooter(snapshot: ContextSnapshot): string {
+  const total = formatNumber(snapshot.totalTokens)
+  const approximate = snapshot.approximate ? ' (approximate)' : ''
+  if (snapshot.maxTokens === null) {
+    return `${total} tokens${approximate}`
+  }
+  const max = formatNumber(snapshot.maxTokens)
+  const pct = ((snapshot.totalTokens / snapshot.maxTokens) * 100).toFixed(1)
+  return `${total} / ${max} tokens (${pct}%)${approximate}`
+}
+
+function emojiFor(label: string): string {
+  return SECTION_EMOJI[label] ?? ' '
+}
+
+function buildFieldValue(section: ContextSection): string {
+  const lines: string[] = [`${formatNumber(section.tokens)} tokens`]
+  if (section.children !== undefined) {
+    for (const child of section.children) {
+      const suffix = child.detail === undefined ? '' : ` (${child.detail})`
+      lines.push(`↳ ${child.label}${suffix}: ${formatNumber(child.tokens)}`)
+    }
+  }
+  if (section.detail !== undefined) {
+    lines.push(section.detail)
+  }
+  return lines.join('\n')
+}
+
+function buildFields(snapshot: ContextSnapshot): EmbedField[] {
+  return snapshot.sections.map((section) => ({
+    name: `${emojiFor(section.label)} ${section.label}`,
+    value: buildFieldValue(section),
+    inline: false,
+  }))
+}
+
+export function renderDiscordContext(snapshot: ContextSnapshot): ContextRendered {
+  const embed = {
+    title: `Context · ${snapshot.modelName}`,
+    description: buildContextGrid(snapshot),
+    fields: buildFields(snapshot),
+    footer: buildFooter(snapshot),
+    ...(pickColor(snapshot) !== undefined ? { color: pickColor(snapshot)! } : {}),
+  }
+  return { method: 'embed', embed }
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run:
+
+```bash
+bun test tests/chat/discord/context-renderer.test.ts
+```
+
+Expected: PASS on all ten tests.
+
+- [ ] **Step 5: Wire the renderer into `DiscordChatProvider`**
+
+Open `src/chat/discord/index.ts`. Update the imports:
+
+```typescript
+import type {
+  AuthorizationResult,
+  ChatProvider,
+  CommandHandler,
+  ContextRendered,
+  ContextSnapshot,
+  IncomingMessage,
+  ReplyFn,
+  ResolveUserContext,
+  ThreadCapabilities,
+} from '../types.js'
+```
+
+Add the renderer import:
+
+```typescript
+import { renderDiscordContext } from './context-renderer.js'
+```
+
+Add the method to the class body:
+
+```typescript
+  renderContext(snapshot: ContextSnapshot): ContextRendered {
+    return renderDiscordContext(snapshot)
+  }
+```
+
+- [ ] **Step 6: Typecheck**
+
+Run:
+
+```bash
+bun typecheck
+```
+
+Expected: PASS — no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/chat/discord/context-renderer.ts src/chat/discord/index.ts tests/chat/discord/context-renderer.test.ts
+git commit -m "feat(chat/discord): implement renderContext with embed fields and color coding"
+```
+
+---
+
+### Task 12: Full suite verification and final polish
+
+**Files:**
+
+- Run commands only (no source changes unless fixes are needed)
+
+- [ ] **Step 1: Run lint**
+
+Run:
+
+```bash
+bun lint
+```
+
+Expected: PASS. Fix any oxlint errors in the new files — common ones are `no-unused-vars` on imports and `strict-boolean-expressions` on nullable checks. Remember: never add lint-disable comments.
+
+- [ ] **Step 2: Run format**
+
+Run:
+
+```bash
+bun format
+```
+
+Then:
+
+```bash
+bun format:check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run:
+
+```bash
+bun test
+```
+
+Expected: PASS. The most likely failure mode is old tests constructing inline `ChatProvider` literals without `renderContext`. Grep for `name: 'mock'` and fix any that still have an incomplete object literal. Also grep for direct uses of `createMockReply().reply.formatted` in tests that expected it to not be captured (now it populates `textCalls`).
+
+- [ ] **Step 4: Run knip**
+
+Run:
+
+```bash
+bun knip
+```
+
+Expected: PASS. If knip flags unused exports in `src/commands/context-collector.ts` (e.g., `resolveEncodingName` or `resolveMaxTokens`), confirm they are consumed by `context.ts` or a test. Both functions are tested directly and one is used inside the handler, so knip should accept them.
+
+- [ ] **Step 5: Manual smoke test**
+
+Start the bot against a test user and run `/context` on each platform that is configured in your local env. Confirm:
+
+- Telegram: receives one message with header, inline emoji grid, and a monospace code block.
+- Discord: receives a single embed with colored sidebar, description grid, and per-section fields.
+- Mattermost: receives one formatted message with bold header, inline emoji grid, and markdown table.
+
+(If you can only test one platform locally, skip the others — CI + unit tests cover the logic.)
+
+- [ ] **Step 6: Final commit**
+
+If any fixes landed in Steps 1-4, commit them:
+
+```bash
+git add -A
+git commit -m "chore: lint, format, and test fallout from /context redesign"
+```
+
+If nothing changed, skip this commit.
+
+---
+
+## Self-Review Results
+
+**Spec coverage:**
+
+- Data Model (ContextSection, ContextSnapshot, ContextRendered) → Task 2 ✓
+- Token counting via `ai-tokenizer` with encoding resolution → Tasks 1, 5, 6 ✓
+- `MODEL_CONTEXT_WINDOWS` lookup with prefix matching → Task 5 ✓
+- Fallback to `chars/4` when tokenizer throws → Task 5 ✓
+- Visual grid builder (20×10, min-1-cell, single-row fallback) → Task 4 ✓
+- Telegram renderer (inline grid + monospace detail) → Task 8 ✓
+- Discord renderer (embed with fields, color coding) → Task 11 ✓
+- Mattermost renderer (grid + markdown table) → Task 9 ✓
+- `ChatProvider.renderContext` interface extension → Task 2 + 8/9/11 wiring ✓
+- `ReplyFn.embed?` optional method → Task 2 + Task 10 implementation ✓
+- Command handler dispatches via method kind with embed fallback → Task 7 ✓
+- Rewritten handler is available to all authorized users (not admin-only) → Task 7 ✓
+- `registerContextCommand(chat)` (no `adminUserId`) → Task 7 Step 4 ✓
+- File structure matches spec → all task file paths align ✓
+- Testing: collector, grid, command, three renderers, Discord embed method → Tasks 4, 5, 7, 8, 9, 10, 11 ✓
+
+**Placeholder scan:** No TBD, TODO, or "implement later" text. All code blocks are complete. One contingency noted (ai-tokenizer API shape) — Task 6 instructs the implementer to adjust `loadTokenizer` and `defaultCountTokens` wiring without changing public signatures if the real API differs.
+
+**Type consistency:**
+
+- `ContextSnapshot` has `approximate: boolean` — used by Telegram, Discord, Mattermost renderers and test fixtures (all include it).
+- `ContextRendered` is a discriminated union on `method`; every `method === 'embed'` branch accesses `.embed`, every `'text'`/`'formatted'` branch accesses `.content` — consistent across handler and renderers.
+- `EmbedOptions` fields (`title`, `description`, `fields?`, `footer?`, `color?`) used consistently in Task 2 definition, Task 10 Discord `reply.embed`, and Task 11 Discord renderer.
+- `ContextCollectorDeps` fields used in Task 5 implementation match the ones referenced in Task 7 `buildCollectorDeps` (`getMainModel`, `buildSystemPrompt`, `buildInstructionsBlock`, `getProviderAddendum`, `getHistory`, `getMemoryMessage`, `getSummary`, `getFacts`, `getActiveToolDefinitions`, `getProviderName`, `countTokens`).
+- `registerContextCommand` signature change from `(chat, adminUserId)` to `(chat, deps?)` — caller in `bot.ts` updated in Task 7 Step 4.
+
+No gaps found.

--- a/docs/superpowers/specs/2026-04-10-e2e-planning-workflow-design.md
+++ b/docs/superpowers/specs/2026-04-10-e2e-planning-workflow-design.md
@@ -1,0 +1,400 @@
+# E2E Planning Workflow Design
+
+**Date:** 2026-04-10  
+**Topic:** Reusable Workflow for Writing Full-Product E2E Test Plans  
+**Status:** Approved
+
+---
+
+## 1. Problem Statement
+
+papai now spans multiple architectural layers and product surfaces:
+
+- chat adapters for Telegram and Mattermost
+- authorization, setup, group routing, wizard interception, and config editing in the bot layer
+- LLM orchestration with capability-gated tool calling
+- provider adapters for Kaneo and YouTrack
+- persistent state for config, history, memory, instructions, memos, and scheduling
+- proactive and operational flows such as recurring tasks, deferred prompts, and debug instrumentation
+
+The current E2E suite exercises only part of that system. It is strong at the **Kaneo provider integration** layer, but it is not a reusable planning method for future end-to-end coverage across the full product.
+
+The missing piece is not just more tests. It is a **repeatable planning workflow** that helps maintainers and AI agents decide:
+
+1. what actually deserves E2E coverage
+2. which system boundaries a scenario crosses
+3. which dependencies must be real versus controlled
+4. what artifacts a complete E2E plan must contain
+
+Without that workflow, future plans will drift toward either narrow provider-only checks or vague top-level journey lists that miss important architectural seams.
+
+---
+
+## 2. Goals
+
+1. Define a reusable workflow for writing future E2E test plans in papai.
+2. Make planning **layer-first**, with feature and journey overlays.
+3. Tier candidate scenarios by **realism and cost** so E2E scope stays intentional.
+4. Standardize the output shape of E2E plans for both maintainers and AI agents.
+5. Ground planning in the current repo architecture, current harnesses, and known coverage gaps.
+
+## 3. Non-Goals
+
+- Writing the implementation plan for this workflow.
+- Designing the exact test cases for every papai feature in this document.
+- Replacing unit, schema, or integration testing with E2E testing.
+- Redesigning the current E2E harness before a concrete plan calls for it.
+- Restricting future E2E work to Kaneo only; Kaneo is the current baseline, not the permanent boundary.
+
+---
+
+## 4. Current Project Context
+
+### 4.1 Runtime Architecture
+
+For E2E planning, papai should be modeled as this delivery chain:
+
+```text
+Chat platform
+  -> chat adapter
+  -> bot authorization / command routing / wizard + config interception
+  -> LLM orchestrator
+  -> capability-gated tools
+  -> task provider adapter
+  -> external task system
+  -> reply path back to chat
+```
+
+Important stateful subsystems sit beside that path:
+
+- per-user runtime config
+- authorization and group membership state
+- conversation history and cache
+- fact memory
+- memos
+- recurring tasks
+- deferred prompts
+- custom instructions
+- identity mappings
+- debug event emission and dashboard state
+
+This matters because a user-visible behavior in papai often spans multiple seams at once. A useful E2E plan must therefore treat features as **cross-layer workflows**, not isolated module checks.
+
+### 4.2 Available Feature Surface
+
+The planning workflow must recognize the full product surface, not only the existing E2E suite.
+
+| Area                         | Current Surface                                                                                            |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Core task flow               | create, update, search, list, get, current time                                                            |
+| Provider-gated task flow     | delete, count, relations, watchers, votes, visibility                                                      |
+| Provider-gated domains       | comments, labels, projects and team, statuses, attachments, work items                                     |
+| User-scoped product features | memos, recurring tasks, deferred prompts, instructions                                                     |
+| Contextual features          | identity linking, group-history lookup                                                                     |
+| Operational and UX flows     | `/setup`, `/config`, `/clear`, admin and group commands, auto-start wizard, config editor, debug dashboard |
+| Platform surfaces            | Telegram and Mattermost adapters, formatting, file handling, reply behavior                                |
+
+### 4.3 Current E2E Baseline
+
+The repository already has a solid **provider-real** E2E harness:
+
+- Docker-managed Kaneo environment
+- global setup that provisions a real user and workspace
+- cleanup client for projects, tasks, and labels
+- E2E coverage for tasks, search, comments, relations, labels, projects, statuses/columns, error handling, and several workflow-style provider tests
+
+That baseline is valuable, but it is still concentrated on **provider adapter behavior**. It does not yet provide a planning system for:
+
+- chat adapter behavior
+- DM versus group routing
+- auth and setup flows
+- wizard interception and config editing
+- LLM orchestration decisions
+- memory, instructions, recurring, deferred, and proactive flows
+- provider parity across Kaneo and YouTrack
+- platform-specific interaction differences
+
+---
+
+## 5. Design Principles
+
+### 5.1 Layer-First Planning
+
+Planning begins with the architectural layers a behavior crosses, not with a flat feature list. This keeps E2E work tied to real integration seams.
+
+### 5.2 Feature and Journey Overlays
+
+Feature tags and user-journey tags are still required, but they augment the layer model instead of replacing it.
+
+### 5.3 Realism Must Be Earned
+
+Every candidate scenario must justify its E2E cost. If a behavior can be proven at a cheaper level without losing confidence in the important boundary, it should not be promoted into the E2E plan.
+
+### 5.4 Explicit Oracles
+
+A plan is incomplete unless it states how success is proven:
+
+- user-visible reply
+- provider-side state
+- database or cache state
+- scheduled artifact
+- emitted debug or operational signal
+
+### 5.5 Isolation and Cleanup Are Part of Planning
+
+Fixtures, teardown, time control, seeded identities, and cross-test isolation are not implementation details. They belong in the planning workflow itself.
+
+---
+
+## 6. Workflow Pipeline
+
+Future E2E plans should be written with the following pipeline.
+
+### Step 1: Define the Planning Unit
+
+Start with one bounded change or behavior at a time.
+
+Required output:
+
+- the user-visible outcome
+- the regression boundary
+- the “must not break” behaviors
+
+Examples:
+
+- “First-time user completes setup and can issue a natural-language task request”
+- “Group mention flow respects authorization and thread-scoped storage”
+- “Deferred prompt fires later and replies into the correct context”
+
+### Step 2: Map the Architecture Path
+
+Trace which layers the behavior crosses.
+
+Possible layers:
+
+- chat adapter
+- bot authorization and routing
+- wizard or config interception
+- LLM orchestrator
+- tool assembly and capability gating
+- provider adapter
+- external task system
+- persistence and cache
+- scheduler and proactive delivery
+- debug and observability surfaces
+
+This step is mandatory. If the path is unclear, the plan is not ready.
+
+### Step 3: Overlay Feature and Journey Context
+
+Tag the planning unit with:
+
+1. **feature domains**  
+   such as tasks, labels, memos, recurring tasks, instructions, identity, or attachments
+2. **journey domains**  
+   such as first-time setup, DM usage, group usage, admin flow, proactive flow, or failure recovery
+
+These overlays make the final plan auditable by product capability and user journey while still remaining architecture-aware.
+
+### Step 4: Select the Realism Tier
+
+Choose the cheapest tier that still validates the meaningful boundary.
+
+If the scenario does not require a real cross-boundary interaction, remove it from the E2E plan and push it down to a cheaper test level.
+
+### Step 5: Expand Scenario Classes
+
+For each approved E2E candidate, the plan must consider:
+
+- happy path
+- permission or routing gates
+- invalid input or unsupported capability behavior
+- external provider or platform failure
+- persistence and refresh verification
+- cleanup and isolation
+- cross-context leakage checks when context is part of the behavior
+- eventual consistency or retry behavior when the backend is known to be asynchronous
+
+This is where a single product behavior becomes a scenario matrix instead of a single optimistic test.
+
+### Step 6: Define Oracles and Observability
+
+Each scenario must name both:
+
+1. the **user-visible oracle**
+2. the **system oracle**
+
+Examples:
+
+| Scenario Type     | User-Visible Oracle                           | System Oracle                                        |
+| ----------------- | --------------------------------------------- | ---------------------------------------------------- |
+| Chat flow         | expected text, button state, or file response | message routing, stored context, emitted reply event |
+| Provider workflow | expected confirmation message                 | created or updated provider entity                   |
+| Scheduler flow    | notification arrives at the right time        | scheduled entry consumed or state transitioned       |
+| Wizard flow       | next prompt or validation error               | config state updated, wizard state advanced          |
+
+### Step 7: Define Fixtures, Controls, and Teardown
+
+The plan must specify:
+
+- provider and chat platform assumptions
+- required capabilities
+- config and auth state
+- seed users, tasks, projects, labels, or files
+- timing controls and clock assumptions
+- cleanup rules
+- shared harness reuse versus new harness requirements
+
+### Step 8: Emit the Plan Artifact
+
+The resulting E2E plan should be concise but structured, with a stable schema described in Section 8.
+
+---
+
+## 7. Realism Tiers
+
+The planning workflow uses realism tiers to keep cost proportional to confidence.
+
+| Tier                            | Purpose                                                                                   | Real Dependencies                                                              | Typical papai Uses                                                                           |
+| ------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| Tier 1: Provider-Real E2E       | Validate provider adapters and normalized domain behavior                                 | real task provider, controlled outer layers                                    | Kaneo or YouTrack task operations, relations, comments, labels, statuses                     |
+| Tier 2: Runtime E2E             | Validate papai runtime behavior across bot, orchestration, storage, and provider boundary | real papai runtime, controlled chat injection and deterministic model boundary | setup flow, auth gating, wizard progression, context routing, tool capability behavior       |
+| Tier 3: Platform-Integrated E2E | Validate adapter-specific behavior and platform interaction semantics                     | real chat platform integration plus runtime                                    | Telegram or Mattermost command handling, mentions, buttons, file behavior, formatting limits |
+| Tier 4: Operational E2E         | Validate scheduled, proactive, or operational flows over time                             | runtime plus schedulers, background services, and relevant external systems    | recurring tasks, deferred prompts, proactive delivery, debug instrumentation visibility      |
+
+### Tiering Rule
+
+A scenario belongs in an E2E plan only if it depends on at least one meaningful real boundary **and** at least one user-visible oracle.
+
+If not, the workflow should explicitly mark it as:
+
+- unit
+- integration
+- schema
+- contract
+- or manual verification
+
+instead of forcing it into E2E scope.
+
+---
+
+## 8. Standard Output for Every E2E Plan
+
+Every future E2E plan written with this workflow should contain the same sections.
+
+### 8.1 Plan Header
+
+- objective
+- regression boundary
+- owners or audience
+- chosen realism tier
+- included platforms and providers
+- excluded scope
+
+### 8.2 Architecture Path
+
+List the exact layers crossed by the planned behavior.
+
+Example:
+
+```text
+Telegram group mention
+  -> auth check
+  -> thread-scoped storage resolution
+  -> wizard interception
+  -> LLM orchestrator
+  -> tool capability gating
+  -> Kaneo provider
+  -> reply formatting back to Telegram
+```
+
+### 8.3 Environment and Fixture Model
+
+Document:
+
+- runtime assumptions
+- seeded users and credentials
+- required projects, tasks, labels, or files
+- scheduler or time controls
+- teardown strategy
+
+### 8.4 Scenario Matrix
+
+Each row in the plan should contain:
+
+| Field          | Meaning                                     |
+| -------------- | ------------------------------------------- |
+| Scenario       | Short scenario name                         |
+| Feature Tags   | Product domains involved                    |
+| Journey Tags   | User journey class                          |
+| Layers Crossed | Architectural boundaries exercised          |
+| Trigger        | What starts the behavior                    |
+| User Oracle    | What the user should observe                |
+| System Oracle  | What the system state must show             |
+| Failure Mode   | Negative or degraded condition covered      |
+| Cleanup        | How isolation is restored                   |
+| Notes          | Harness gaps, backend quirks, or exclusions |
+
+### 8.5 Implementation Notes
+
+Each plan should also include:
+
+- existing harnesses to reuse
+- new harness work required
+- known backend quirks
+- order of implementation
+
+This ensures the plan is immediately actionable without mixing implementation details into the scenario matrix itself.
+
+---
+
+## 9. papai Default Priority Lanes
+
+When multiple E2E plans compete for attention, papai should bias toward these lanes.
+
+### 9.1 High Priority
+
+- setup, auth, and configuration flows
+- wizard interception and validation
+- DM versus group routing and mention rules
+- orchestrator-to-tool-to-provider happy path
+- orchestrator failure rollback and user-facing error behavior
+- provider capability-gated behavior and unsupported-surface handling
+
+These are the places where cross-layer regressions are most likely to damage core user trust.
+
+### 9.2 Medium Priority
+
+- identity linking and “me” resolution flows
+- memos, instructions, and group-history behavior
+- recurring tasks, deferred prompts, and scheduled execution
+- cross-context persistence and isolation guarantees
+
+These are important but often require more harness work or more deterministic time controls.
+
+### 9.3 Expansion Lanes
+
+- Telegram versus Mattermost parity and platform-specific interaction differences
+- YouTrack parity against Kaneo-covered behavior
+- attachments, work items, watchers, votes, visibility, and other provider-gated surfaces
+- debug dashboard and operational observability flows
+
+These are valuable targets once the highest-risk runtime journeys are planned and covered.
+
+---
+
+## 10. How Maintainers and AI Agents Should Use This
+
+When writing a new E2E plan:
+
+1. start with the bounded behavior
+2. map the architecture path
+3. tag features and journeys
+4. choose the realism tier
+5. expand the scenario matrix
+6. state the oracles, fixtures, and teardown
+7. call out what is intentionally excluded from E2E
+
+The result should read like a **planning algorithm applied to one behavior**, not like a backlog dump or a giant list of possible tests.
+
+That is the core purpose of this design: make future E2E plans consistent, architecture-aware, and cheap enough to maintain while still covering the product boundaries that matter.

--- a/docs/superpowers/specs/2026-04-11-context-command-redesign.md
+++ b/docs/superpowers/specs/2026-04-11-context-command-redesign.md
@@ -1,0 +1,345 @@
+# /context Command Redesign
+
+Replaces the admin-only file-export `/context` command with a visual context window display available to all authorized users. Inspired by Claude Code's `/context` — shows a proportional emoji grid of token usage by category, followed by platform-specific detail.
+
+## Goals
+
+- Make `/context` available to all authorized users (not admin-only)
+- Replace file upload with inline graphical representation
+- Show all four LLM context sources: system prompt, memory, conversation history, tools
+- Provide accurate token counts via real tokenization
+- Show context window utilization against known model limits
+- Render platform-adaptive detail below the shared grid
+
+## Architecture
+
+```
+/context handler (src/commands/context.ts)
+  --> ContextCollector (src/commands/context-collector.ts)
+        --> gathers system prompt, memory, history, tools
+        --> tokenizes each section via ai-tokenizer
+        --> resolves maxTokens from model name
+        --> returns ContextSnapshot
+  --> chat.renderContext(snapshot)
+        --> platform adapter renders grid + detail
+        --> returns ContextRendered { method, content, embedOptions? }
+  --> handler dispatches via reply.text / reply.formatted / reply.embed
+```
+
+## Data Model
+
+### ContextSection
+
+```typescript
+type ContextSection = {
+  label: string // "System prompt", "Conversation history", etc.
+  tokens: number // actual token count
+  detail?: string // e.g. "34 messages (trimmed from 48)"
+  children?: ContextSection[]
+}
+```
+
+### ContextSnapshot
+
+```typescript
+type ContextSnapshot = {
+  modelName: string
+  sections: ContextSection[]
+  totalTokens: number
+  maxTokens: number | null // null for unknown models
+}
+```
+
+### Sections tree
+
+```
+├── System prompt
+│   ├── Base instructions
+│   ├── Custom instructions (N)
+│   └── Provider addendum
+├── Memory context
+│   ├── Summary
+│   └── Known entities (N)
+├── Conversation history
+│   └── N messages (trimmed from M)
+└── Tools (N active)
+    └── Gated by: <provider> provider
+```
+
+### ContextRendered
+
+```typescript
+type ContextRendered = {
+  method: 'text' | 'formatted' | 'embed'
+  content: string
+  embedOptions?: EmbedOptions
+}
+```
+
+## Token Counting
+
+### Library
+
+`ai-tokenizer` — pure JS, no WASM, first-class Vercel AI SDK support, >=97% accuracy for major models, 5-7x faster than tiktoken.
+
+### Encoding selection
+
+```typescript
+function resolveEncoding(modelName: string): string {
+  if (modelName.match(/gpt-4o|gpt-4.1|o1|o3|o4/)) return 'o200k_base'
+  return 'cl100k_base' // safe default for Claude, GPT-4, unknowns
+}
+```
+
+Encoding is lazy-loaded on first use (2-8MB), cached in module scope.
+
+### Model context window map
+
+```typescript
+const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  'gpt-4o': 128_000,
+  'gpt-4.1': 1_048_576,
+  'gpt-4.1-mini': 1_048_576,
+  'gpt-4.1-nano': 1_048_576,
+  'gpt-4-turbo': 128_000,
+  'claude-sonnet-4-20250514': 200_000,
+  'claude-haiku-4-5-20251001': 200_000,
+  // extensible
+}
+```
+
+Prefix matching for model variants (e.g. `gpt-4o-2024-08-06` matches `gpt-4o`). Returns `null` for unrecognized models.
+
+### What gets tokenized
+
+Each section's text content is tokenized independently:
+
+- **System prompt:** full string from `buildSystemPrompt()`
+- **Custom instructions:** text from `buildInstructionsBlock()`
+- **Provider addendum:** string from `provider.getPromptAddendum()`
+- **Memory context:** assembled memory message from `buildMessagesWithMemory()`
+- **History:** each message serialized as role:content pairs (mirrors what the LLM receives)
+- **Tools:** JSON-serialized tool definitions from `getActiveTools()`
+
+### Fallback
+
+If tokenizer fails to load, falls back to `Math.ceil(chars / 4)` and appends a note: "Token counts are approximate."
+
+## Visual Grid
+
+A 20-column grid where each cell represents a proportional chunk of the context window. Uses colored square emoji (inherently colored, renders on all platforms without code blocks):
+
+| Symbol | Category             |
+| ------ | -------------------- |
+| `🟦`   | System prompt        |
+| `🟩`   | Memory context       |
+| `🟨`   | Conversation history |
+| `🟪`   | Tools                |
+| `⬜`   | Free space           |
+
+### Grid sizing
+
+- 20 columns, fixed at 10 rows = 200 cells total
+- Each cell = `maxTokens / 200` tokens
+- Minimum 1 cell per non-empty category (nothing disappears at small percentages)
+- When `maxTokens` is null (unknown model): single-row (20 cells) proportional bar showing only used categories, no free space cells
+
+### Example (6,770 / 128,000 tokens)
+
+```
+🟦🟦🟪🟪🟨🟨🟨🟩⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜
+⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜
+⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜
+...
+```
+
+## Platform Renderers
+
+Each `ChatProvider` implements a `renderContext(snapshot: ContextSnapshot): ContextRendered` method. The shared grid builder lives in `src/commands/context-grid.ts`.
+
+### ChatProvider interface addition
+
+```typescript
+// src/chat/types.ts
+interface ChatProvider {
+  // ... existing methods ...
+  renderContext(snapshot: ContextSnapshot): ContextRendered
+}
+```
+
+### Telegram
+
+Returns `{ method: 'text' }`. Grid as inline emoji, detail in a monospace code block:
+
+```
+Context · gpt-4o · 6,770 / 128,000 tokens (5.3%)
+
+🟦🟦🟪🟪🟨🟨🟨🟩⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜
+⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜
+...
+
+🟦 System prompt         820 tk
+   Base instructions     650 tk
+   Custom instructions    120 tk
+   Provider addendum       50 tk
+🟩 Memory context        350 tk
+   Summary               180 tk
+   Known entities (12)   170 tk
+🟨 Conversation        2,400 tk
+   34 messages
+🟪 Tools (18 active)   3,200 tk
+   Gated by: kaneo
+```
+
+Detail section wrapped in a code block for column alignment.
+
+### Discord
+
+Returns `{ method: 'embed', embedOptions: { ... } }`. Uses discord.js embed:
+
+- **Title:** Context · gpt-4o
+- **Description:** emoji grid
+- **Fields:** one per category with token count and children detail
+- **Footer:** `6,770 / 128,000 tokens (5.3%)`
+- **Color:** green (#2ecc71) at <50%, yellow (#f1c40f) at 50-80%, red (#e74c3c) at >80%
+
+### Mattermost
+
+Returns `{ method: 'formatted' }`. Grid as inline emoji, detail as a markdown table:
+
+```markdown
+**Context** · gpt-4o · 6,770 / 128,000 tokens (5.3%)
+
+🟦🟦🟪🟪🟨🟨🟨🟩⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜
+...
+
+| Section                   | Tokens |
+| :------------------------ | -----: |
+| 🟦 **System prompt**      |    820 |
+| ↳ Base instructions       |    650 |
+| ↳ Custom instructions (2) |    120 |
+| ↳ Provider addendum       |     50 |
+| 🟩 **Memory context**     |    350 |
+| ↳ Summary                 |    180 |
+| ↳ Known entities (12)     |    170 |
+| 🟨 **Conversation**       |  2,400 |
+| ↳ 34 messages             |        |
+| 🟪 **Tools (18 active)**  |  3,200 |
+| ↳ Gated by: kaneo         |        |
+```
+
+## ReplyFn Extension
+
+### EmbedOptions
+
+```typescript
+type EmbedField = {
+  name: string
+  value: string
+  inline?: boolean
+}
+
+type EmbedOptions = {
+  title: string
+  description: string
+  fields?: EmbedField[]
+  footer?: string
+  color?: number
+}
+```
+
+### ReplyFn addition
+
+```typescript
+type ReplyFn = {
+  // ... existing ...
+  embed?: (options: EmbedOptions) => Promise<void>
+}
+```
+
+Optional — only Discord implements it. Command handler checks existence before calling, falls back to `reply.formatted()`.
+
+## Command Handler
+
+### Location
+
+`src/commands/context.ts` — replaces current implementation entirely.
+
+### Registration
+
+`registerContextCommand(chat)` — no `adminUserId` parameter. Standard authorization check via `auth.isAuthorized`.
+
+### Flow
+
+1. Verify user is authorized (standard auth, not admin-only)
+2. Call `collectContext(storageContextId)`
+3. Call `chat.renderContext(snapshot)` to get platform-specific output
+4. Dispatch:
+   - `embed` + `reply.embed` exists: call `reply.embed(embedOptions)`
+   - `formatted`: call `reply.formatted(content)`
+   - `text` or fallback: call `reply.text(content)`
+
+### bot.ts change
+
+Remove `adminUserId` from `registerContextCommand()` call signature.
+
+## File Structure
+
+```
+src/commands/
+  context.ts                          -- handler (rewritten)
+  context-collector.ts                -- ContextCollector + types
+  context-grid.ts                     -- shared grid builder
+
+src/chat/types.ts                     -- ContextRendered, EmbedOptions, EmbedField types
+                                      -- ChatProvider.renderContext() method
+                                      -- ReplyFn.embed? addition
+
+src/chat/telegram/context-renderer.ts
+src/chat/discord/context-renderer.ts
+src/chat/mattermost/context-renderer.ts
+```
+
+## Dependency
+
+New: `ai-tokenizer` — pure JS tokenizer with Vercel AI SDK support.
+
+## Testing
+
+### context-collector.ts
+
+- Collects all sections with correct token counts (DI with fake deps)
+- Resolves encoding by model name (o200k for GPT-4o family, cl100k fallback)
+- Looks up maxTokens for known models, returns null for unknown
+- Handles empty state (no history, no summary, no facts, no instructions)
+- Falls back to char estimation when tokenizer fails
+
+### context-grid.ts
+
+- Produces correct grid dimensions (20 cols, rows scaled)
+- Minimum 1 cell per non-empty category
+- Proportional distribution matches token ratios
+- Unknown maxTokens produces single-row proportional bar
+- Empty context produces all-free grid
+
+### context-renderers (per platform)
+
+- Telegram: returns `{ method: 'text' }` with grid + monospace detail
+- Discord: returns `{ method: 'embed' }` with correct embed structure, color thresholds
+- Mattermost: returns `{ method: 'formatted' }` with grid + markdown table
+
+### context.ts (handler)
+
+- Available to all authorized users (not admin-gated)
+- Calls collector, passes snapshot to renderContext, dispatches by method
+- Falls back from embed to formatted when reply.embed undefined
+
+### reply.embed (Discord adapter)
+
+- Translates EmbedOptions to discord.js EmbedBuilder
+- Handles missing optional fields
+
+### Not tested
+
+- Actual tokenizer accuracy (ai-tokenizer's responsibility)
+- Emoji rendering fidelity (visual QA)

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -41,9 +41,7 @@
   "ignoreExportsUsedInFile": true,
 
   // Ignore migration files (executed at runtime, not imported)
-  // env-validation.ts is used by the entry point but cannot be statically imported
-  // without triggering side effects in tests
-  "ignore": ["src/db/migrations/**", "src/env-validation.ts"],
+  "ignore": ["src/db/migrations/**"],
 
   // Intentionally exported for future orchestrator integration (identity claim detection and auto-link)
   "ignoreIssues": {

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -41,7 +41,9 @@
   "ignoreExportsUsedInFile": true,
 
   // Ignore migration files (executed at runtime, not imported)
-  "ignore": ["src/db/migrations/**"],
+  // env-validation.ts is used by the entry point but cannot be statically imported
+  // without triggering side effects in tests
+  "ignore": ["src/db/migrations/**", "src/env-validation.ts"],
 
   // Intentionally exported for future orchestrator integration (identity claim detection and auto-link)
   "ignoreIssues": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ai": "^6.0.154",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
+    "discord.js": "^14.25.1",
     "drizzle-orm": "^0.45.2",
     "fuse.js": "^7.3.0",
     "grammy": "^1.42.0",

--- a/src/chat/discord/buttons.ts
+++ b/src/chat/discord/buttons.ts
@@ -1,0 +1,41 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js'
+
+import type { ChatButton } from '../types.js'
+
+export const DISCORD_CUSTOM_ID_MAX = 100
+export const DISCORD_BUTTONS_PER_ROW = 5
+export const DISCORD_ROWS_PER_MESSAGE = 5
+
+const styleMap: Record<NonNullable<ChatButton['style']>, ButtonStyle> = {
+  primary: ButtonStyle.Primary,
+  secondary: ButtonStyle.Secondary,
+  danger: ButtonStyle.Danger,
+}
+
+/** Convert papai ChatButtons to discord.js ActionRow components. */
+export function toActionRows(buttons: ChatButton[]): ActionRowBuilder<ButtonBuilder>[] {
+  const maxTotal = DISCORD_BUTTONS_PER_ROW * DISCORD_ROWS_PER_MESSAGE
+  if (buttons.length > maxTotal) {
+    throw new Error(
+      `too many buttons: got ${String(buttons.length)}, max ${String(maxTotal)} (${String(DISCORD_ROWS_PER_MESSAGE)} rows × ${String(DISCORD_BUTTONS_PER_ROW)} per row)`,
+    )
+  }
+
+  for (const btn of buttons) {
+    if (btn.callbackData.length > DISCORD_CUSTOM_ID_MAX) {
+      throw new Error(`custom_id exceeds ${String(DISCORD_CUSTOM_ID_MAX)} chars: "${btn.callbackData.slice(0, 20)}…"`)
+    }
+  }
+
+  const rows: ActionRowBuilder<ButtonBuilder>[] = []
+  for (let i = 0; i < buttons.length; i += DISCORD_BUTTONS_PER_ROW) {
+    const slice = buttons.slice(i, i + DISCORD_BUTTONS_PER_ROW)
+    const row = new ActionRowBuilder<ButtonBuilder>()
+    for (const btn of slice) {
+      const style = btn.style === undefined ? ButtonStyle.Secondary : styleMap[btn.style]
+      row.addComponents(new ButtonBuilder().setCustomId(btn.callbackData).setLabel(btn.text).setStyle(style))
+    }
+    rows.push(row)
+  }
+  return rows
+}

--- a/src/chat/discord/buttons.ts
+++ b/src/chat/discord/buttons.ts
@@ -1,10 +1,86 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js'
 
+import { logger } from '../../logger.js'
 import type { ChatButton } from '../types.js'
+
+const log = logger.child({ scope: 'chat:discord:buttons' })
 
 export const DISCORD_CUSTOM_ID_MAX = 100
 export const DISCORD_BUTTONS_PER_ROW = 5
 export const DISCORD_ROWS_PER_MESSAGE = 5
+
+/** Channel interface for button interactions. */
+export type ButtonChannelLike = {
+  id: string
+  type: number
+  send: (arg: {
+    content?: string
+    components?: unknown[]
+    reply?: { messageReference: string; failIfNotExists: boolean }
+  }) => Promise<{ id: string; edit: (arg: { content?: string; components?: unknown[] }) => Promise<unknown> }>
+  sendTyping: () => Promise<void>
+}
+
+/** Structural type for a Discord button interaction. */
+export type ButtonInteractionLike = {
+  user: { id: string; username: string }
+  customId: string
+  channelId: string
+  channel: ButtonChannelLike | null
+  message: { id: string }
+  deferUpdate(): Promise<void>
+}
+
+/** Handler callback type for button interactions. */
+export type ButtonCallbackHandler = (callbackData: string) => Promise<void>
+
+/**
+ * Dispatch a Discord button interaction to the appropriate handler.
+ * Routes cfg:-prefixed callbacks to config editor and wizard_-prefixed to wizard.
+ */
+export async function dispatchButtonInteraction(
+  interaction: ButtonInteractionLike,
+  onConfigEditor: ButtonCallbackHandler,
+  onWizard: ButtonCallbackHandler,
+): Promise<void> {
+  const data = interaction.customId
+
+  // Always attempt to defer the update first
+  try {
+    await interaction.deferUpdate()
+  } catch (error) {
+    log.warn(
+      { error: error instanceof Error ? error.message : String(error), customId: data },
+      'Failed to deferUpdate Discord button interaction',
+    )
+  }
+
+  // Route to config editor handler
+  if (data.startsWith('cfg:')) {
+    await onConfigEditor(data)
+    return
+  }
+
+  // Route to wizard handler
+  if (data.startsWith('wizard_')) {
+    await onWizard(data)
+    return
+  }
+
+  // Unrecognized callback - log but don't error
+  log.debug({ customId: data }, 'Unrecognized button custom_id, ignoring')
+}
+
+// discord.js enum values: InteractionType.MessageComponent = 3, ComponentType.Button = 2
+const INTERACTION_TYPE_MESSAGE_COMPONENT = 3
+const COMPONENT_TYPE_BUTTON = 2
+
+/** Runtime type guard for discord.js button interactions. */
+export function isButtonInteraction(i: unknown): i is ButtonInteractionLike {
+  if (typeof i !== 'object' || i === null) return false
+  if (!('type' in i) || !('componentType' in i)) return false
+  return i.type === INTERACTION_TYPE_MESSAGE_COMPONENT && i.componentType === COMPONENT_TYPE_BUTTON
+}
 
 const styleMap: Record<NonNullable<ChatButton['style']>, ButtonStyle> = {
   primary: ButtonStyle.Primary,

--- a/src/chat/discord/client-factory.ts
+++ b/src/chat/discord/client-factory.ts
@@ -1,0 +1,56 @@
+import { Client, GatewayIntentBits } from 'discord.js'
+
+import type { DiscordMessageLike } from './map-message.js'
+import type { SendableChannel } from './reply-helpers.js'
+
+export type DispatchableMessage = DiscordMessageLike & {
+  channel: SendableChannel & {
+    messages?: {
+      fetch: (id: string) => Promise<{ id: string; author: { id: string; username: string }; content: string }>
+    }
+  }
+}
+
+type EventListener = (...args: unknown[]) => void
+
+/** Structural type covering the discord.js Client API surface we use. */
+export type DiscordClientLike = {
+  destroy: () => Promise<void>
+  users?: {
+    fetch: (id: string) => Promise<{
+      createDM: () => Promise<{ send: (arg: { content: string }) => Promise<unknown> }>
+    }>
+  }
+  channels?: { cache: { get(id: string): unknown } }
+  guilds?: { cache: { get(id: string): unknown } }
+}
+
+/** Narrowed guild shape returned by cache.get — used in resolveUserId. */
+export type GuildLike = {
+  members: { search: (arg: { query: string; limit: number }) => Promise<Map<string, { id: string }>> }
+}
+
+/** Minimal event-emitter + login surface used inside start(). */
+export type LiveDiscordClient = DiscordClientLike & {
+  on(event: string, listener: EventListener): unknown
+  once(event: string, listener: EventListener): unknown
+  login(token: string): Promise<string>
+  user: { id: string; username: string } | null
+}
+
+/** Factory that produces a LiveDiscordClient. Overridable in tests via the constructor. */
+export type DiscordClientFactory = () => LiveDiscordClient
+
+/** Create a discord.js Client configured with the intents papai needs. */
+export function defaultClientFactory(): LiveDiscordClient {
+  // Client satisfies LiveDiscordClient structurally — the declared return
+  // type lets TypeScript verify the assignment without an unsafe assertion.
+  return new Client({
+    intents: [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.MessageContent,
+      GatewayIntentBits.DirectMessages,
+    ],
+  })
+}

--- a/src/chat/discord/format-chunking.ts
+++ b/src/chat/discord/format-chunking.ts
@@ -1,3 +1,9 @@
+// Length of fence markers for chunk budget calculations
+// FENCE_CLOSE_LEN represents the length of newline + three backticks
+const FENCE_CLOSE_LEN = 4
+// FENCE_OPEN_LEN represents the length of three backticks + newline
+const FENCE_OPEN_LEN = 4
+
 /**
  * Split a string into chunks no longer than `maxLen`, preferring to split
  * on paragraph breaks, then sentence breaks, then word breaks. If a fenced
@@ -12,7 +18,14 @@ export function chunkForDiscord(input: string, maxLen: number): string[] {
   let carriedOpenFence = false
 
   while (remainder.length > maxLen) {
-    const sliceEnd = findSplitPoint(remainder, maxLen)
+    // Reserve space for fence operations:
+    // - Opening fence from previous chunk (if carriedOpenFence)
+    // - Potential closing fence for this chunk (we must reserve for worst case)
+    let budget = maxLen - FENCE_CLOSE_LEN
+    if (carriedOpenFence) {
+      budget = budget - FENCE_OPEN_LEN
+    }
+    const sliceEnd = findSplitPoint(remainder, budget)
     let chunk = remainder.slice(0, sliceEnd)
     remainder = remainder.slice(sliceEnd)
 

--- a/src/chat/discord/format-chunking.ts
+++ b/src/chat/discord/format-chunking.ts
@@ -1,0 +1,62 @@
+/**
+ * Split a string into chunks no longer than `maxLen`, preferring to split
+ * on paragraph breaks, then sentence breaks, then word breaks. If a fenced
+ * code block would be split, emit a synthetic closing and reopening fence
+ * so each chunk remains syntactically balanced.
+ */
+export function chunkForDiscord(input: string, maxLen: number): string[] {
+  if (input.length <= maxLen) return [input]
+
+  const chunks: string[] = []
+  let remainder = input
+  let carriedOpenFence = false
+
+  while (remainder.length > maxLen) {
+    const sliceEnd = findSplitPoint(remainder, maxLen)
+    let chunk = remainder.slice(0, sliceEnd)
+    remainder = remainder.slice(sliceEnd)
+
+    if (carriedOpenFence) {
+      chunk = '```\n' + chunk
+      carriedOpenFence = false
+    }
+
+    const fenceCount = (chunk.match(/```/g) ?? []).length
+    if (fenceCount % 2 === 1) {
+      chunk = chunk + '\n```'
+      carriedOpenFence = true
+    }
+
+    chunks.push(chunk)
+  }
+
+  if (remainder.length > 0) {
+    let tail = remainder
+    if (carriedOpenFence) {
+      tail = '```\n' + tail
+    }
+    chunks.push(tail)
+  }
+
+  return chunks
+}
+
+function findSplitPoint(text: string, maxLen: number): number {
+  if (text.length <= maxLen) return text.length
+
+  const paragraph = text.lastIndexOf('\n\n', maxLen)
+  if (paragraph > 0) return paragraph + 2
+
+  const newline = text.lastIndexOf('\n', maxLen)
+  if (newline > 0) return newline + 1
+
+  for (let i = maxLen; i > maxLen / 2; i--) {
+    const ch = text[i]
+    if (ch === '.' || ch === '!' || ch === '?') return i + 1
+  }
+
+  const ws = text.lastIndexOf(' ', maxLen)
+  if (ws > 0) return ws + 1
+
+  return maxLen
+}

--- a/src/chat/discord/format.ts
+++ b/src/chat/discord/format.ts
@@ -1,0 +1,51 @@
+import { chunkForDiscord } from './format-chunking.js'
+
+const DISCORD_MAX_CONTENT_LEN = 2000
+
+/**
+ * Normalize LLM markdown for Discord's dialect and chunk the result.
+ * Discord's markdown is a near-superset of papai's LLM output, so most of
+ * the transformation is defensive: flatten tables (Discord does not render
+ * them), zero-width-escape @everyone / @here, and chunk at 2000 chars.
+ */
+export function formatLlmOutput(markdown: string): string[] {
+  const stepOne = flattenTables(markdown)
+  const stepTwo = escapeMassMentions(stepOne)
+  return chunkForDiscord(stepTwo, DISCORD_MAX_CONTENT_LEN)
+}
+
+function flattenTables(text: string): string {
+  const lines = text.split('\n')
+  const out: string[] = []
+  let i = 0
+  while (i < lines.length) {
+    const line = lines[i]!
+    const next = lines[i + 1]
+    if (line.trim().startsWith('|') && next !== undefined && /^\|[\s-:|]+\|\s*$/.test(next.trim())) {
+      const header = stripPipes(line)
+      out.push(header)
+      i += 2
+      while (i < lines.length && lines[i]!.trim().startsWith('|')) {
+        out.push(stripPipes(lines[i]!))
+        i++
+      }
+      continue
+    }
+    out.push(line)
+    i++
+  }
+  return out.join('\n')
+}
+
+function stripPipes(row: string): string {
+  return row
+    .trim()
+    .replace(/^\||\|$/g, '')
+    .split('|')
+    .map((cell) => cell.trim())
+    .join(' | ')
+}
+
+function escapeMassMentions(text: string): string {
+  return text.replace(/@everyone/g, '@\u200beveryone').replace(/@here/g, '@\u200bhere')
+}

--- a/src/chat/discord/handlers.ts
+++ b/src/chat/discord/handlers.ts
@@ -1,0 +1,141 @@
+/**
+ * Discord button interaction handlers for wizard and config editor callbacks.
+ */
+
+import { handleEditorCallback, hasActiveEditor } from '../../config-editor/index.js'
+import { logger } from '../../logger.js'
+import {
+  cancelWizard,
+  getNextPrompt,
+  getWizardSession,
+  hasActiveWizard,
+  processWizardMessage,
+  resetWizardSession,
+  validateAndSaveWizardConfig,
+} from '../../wizard/index.js'
+import type { ChatButton } from '../types.js'
+import type { ButtonChannelLike } from './buttons.js'
+import { createDiscordReplyFn } from './reply-helpers.js'
+
+const log = logger.child({ scope: 'chat:discord:handlers' })
+
+type WizardResult = { handled: boolean; response?: string; buttons?: Array<{ text: string; action: string }> }
+
+function makeReply(channel: ButtonChannelLike): ReturnType<typeof createDiscordReplyFn> {
+  return createDiscordReplyFn({ channel, replyToMessageId: undefined })
+}
+
+async function sendWizardResult(result: WizardResult, channel: ButtonChannelLike): Promise<void> {
+  if (!result.handled) return
+  const reply = makeReply(channel)
+  const buttons = result.buttons
+  if (buttons !== undefined && buttons.length > 0) {
+    const chatButtons: ChatButton[] = buttons.map((btn) => ({
+      text: btn.text,
+      callbackData: `wizard_${btn.action}`,
+      style: btn.action === 'cancel' ? 'danger' : ('primary' as const),
+    }))
+    await reply.buttons(result.response ?? '', { buttons: chatButtons })
+  } else {
+    await reply.text(result.response ?? '')
+  }
+}
+
+/**
+ * Handle config editor callbacks from Discord button interactions.
+ */
+export async function handleConfigEditorCallback(
+  userId: string,
+  contextId: string,
+  data: string,
+  channel: ButtonChannelLike,
+): Promise<void> {
+  if (!hasActiveEditor(userId, contextId)) return
+
+  const { parseCallbackData } = await import('../../config-editor/index.js')
+  const { action, key } = parseCallbackData(data)
+
+  if (action === null) {
+    log.warn({ data }, 'Unknown config editor callback data')
+    return
+  }
+
+  log.debug({ userId, contextId, action, key }, 'Handling Discord config editor callback')
+
+  const result = handleEditorCallback(userId, contextId, action, key ?? undefined)
+
+  if (!result.handled) {
+    log.warn({ action, key }, 'Config editor callback not handled')
+    return
+  }
+
+  const reply = makeReply(channel)
+  const buttons = result.buttons
+  if (buttons !== undefined && buttons.length > 0) {
+    const chatButtons: ChatButton[] = buttons.map((btn) => ({
+      text: btn.text,
+      callbackData:
+        btn.action === 'edit' && btn.key !== undefined
+          ? `cfg:edit:${btn.key}`
+          : btn.action === 'save' && btn.key !== undefined
+            ? `cfg:save:${btn.key}`
+            : `cfg:${btn.action}`,
+      style: btn.style ?? 'primary',
+    }))
+    await reply.buttons(result.response ?? '', { buttons: chatButtons })
+  } else {
+    await reply.text(result.response ?? '')
+  }
+}
+
+/**
+ * Handle wizard callbacks from Discord button interactions.
+ */
+export async function handleWizardCallback(
+  userId: string,
+  contextId: string,
+  data: string,
+  channel: ButtonChannelLike,
+): Promise<void> {
+  if (!hasActiveWizard(userId, contextId)) return
+
+  log.debug({ userId, contextId, data }, 'Handling Discord wizard callback')
+
+  switch (data) {
+    case 'wizard_confirm': {
+      const result = await validateAndSaveWizardConfig(userId, contextId)
+      await makeReply(channel).text(result.message)
+      return
+    }
+    case 'wizard_cancel': {
+      cancelWizard(userId, contextId)
+      await makeReply(channel).text('Wizard cancelled. Type /setup to restart.')
+      return
+    }
+    case 'wizard_restart': {
+      cancelWizard(userId, contextId)
+      await makeReply(channel).text('Restarting wizard... Type /setup to begin.')
+      return
+    }
+    case 'wizard_edit': {
+      const session = getWizardSession(userId, contextId)
+      if (session !== null) {
+        resetWizardSession(userId, contextId)
+        const prompt = getNextPrompt(userId, contextId)
+        await makeReply(channel).text(`Editing configuration from the beginning...\n\n${prompt}`)
+      }
+      return
+    }
+    case 'wizard_skip_small_model':
+    case 'wizard_skip_embedding': {
+      const skipValue = data === 'wizard_skip_small_model' ? 'same' : 'skip'
+      const result = await processWizardMessage(userId, contextId, skipValue)
+      await sendWizardResult(result, channel)
+      return
+    }
+    default: {
+      const result = await processWizardMessage(userId, contextId, data)
+      await sendWizardResult(result, channel)
+    }
+  }
+}

--- a/src/chat/discord/index.ts
+++ b/src/chat/discord/index.ts
@@ -7,8 +7,22 @@ import type {
   ResolveUserContext,
   ThreadCapabilities,
 } from '../types.js'
+import { type DiscordMessageLike, mapDiscordMessage } from './map-message.js'
+import { buildDiscordReplyContext } from './reply-context.js'
+import { type SendableChannel, createDiscordReplyFn } from './reply-helpers.js'
+import { withTypingIndicator } from './typing-indicator.js'
 
 const log = logger.child({ scope: 'chat:discord' })
+
+type OnMessageHandler = (msg: IncomingMessage, reply: ReplyFn) => Promise<void>
+
+type DispatchableMessage = DiscordMessageLike & {
+  channel: SendableChannel & {
+    messages?: {
+      fetch: (id: string) => Promise<{ id: string; author: { id: string; username: string }; content: string }>
+    }
+  }
+}
 
 export class DiscordChatProvider implements ChatProvider {
   readonly name = 'discord'
@@ -18,6 +32,9 @@ export class DiscordChatProvider implements ChatProvider {
     threadScope: 'message',
   }
   private readonly token: string
+  private readonly commands = new Map<string, CommandHandler>()
+  private messageHandler: OnMessageHandler | null = null
+  private client: { destroy: () => Promise<void> } | null = null
 
   constructor() {
     const token = process.env['DISCORD_BOT_TOKEN']
@@ -28,12 +45,13 @@ export class DiscordChatProvider implements ChatProvider {
     log.debug({ tokenLength: this.token.length }, 'DiscordChatProvider constructed')
   }
 
-  registerCommand(_name: string, _handler: CommandHandler): void {
-    throw new Error('DiscordChatProvider.registerCommand not implemented yet')
+  registerCommand(name: string, handler: CommandHandler): void {
+    this.commands.set(name, handler)
+    log.debug({ command: name }, 'Discord command registered')
   }
 
-  onMessage(_handler: (msg: IncomingMessage, reply: ReplyFn) => Promise<void>): void {
-    throw new Error('DiscordChatProvider.onMessage not implemented yet')
+  onMessage(handler: OnMessageHandler): void {
+    this.messageHandler = handler
   }
 
   sendMessage(_userId: string, _markdown: string): Promise<void> {
@@ -48,7 +66,63 @@ export class DiscordChatProvider implements ChatProvider {
     return Promise.reject(new Error('DiscordChatProvider.start not implemented yet'))
   }
 
-  stop(): Promise<void> {
-    return Promise.resolve()
+  async stop(): Promise<void> {
+    if (this.client === null) return
+    await this.client.destroy()
+    this.client = null
+  }
+
+  /** Test-only: inject a stub client for stop() testing. */
+  testSetClient(c: { destroy: () => Promise<void> }): void {
+    this.client = c
+  }
+
+  /** Test-only: simulate inbound messageCreate without a live Client. */
+  async testDispatchMessage(message: DispatchableMessage, botId: string, adminUserId: string): Promise<void> {
+    await this.dispatchMessage(message, botId, adminUserId)
+  }
+
+  private async dispatchMessage(message: DispatchableMessage, botId: string, adminUserId: string): Promise<void> {
+    const mapped = mapDiscordMessage(message, botId, adminUserId)
+    if (mapped === null) return
+
+    const reply = createDiscordReplyFn({
+      channel: message.channel,
+      replyToMessageId: mapped.messageId,
+    })
+
+    const command = this.matchCommand(mapped.text)
+    if (command !== null) {
+      mapped.commandMatch = command.match
+      await command.handler(mapped, reply, {
+        allowed: true,
+        isBotAdmin: mapped.user.isAdmin,
+        isGroupAdmin: mapped.user.isAdmin,
+        storageContextId: mapped.contextId,
+      })
+      return
+    }
+
+    if (this.messageHandler !== null) {
+      if (message.channel.messages !== undefined) {
+        mapped.replyContext = await buildDiscordReplyContext(
+          { reference: message.reference, channel: { id: message.channel.id, messages: message.channel.messages } },
+          mapped.contextId,
+        )
+      }
+      await withTypingIndicator(message.channel, () => this.messageHandler!(mapped, reply))
+    }
+  }
+
+  private matchCommand(text: string): { handler: CommandHandler; match: string } | null {
+    const trimmed = text.trim()
+    if (!trimmed.startsWith('/')) return null
+    for (const [name, handler] of this.commands) {
+      if (trimmed === `/${name}` || trimmed.startsWith(`/${name} `)) {
+        const match = trimmed.slice(name.length + 2).trim()
+        return { handler, match }
+      }
+    }
+    return null
   }
 }

--- a/src/chat/discord/index.ts
+++ b/src/chat/discord/index.ts
@@ -7,12 +7,14 @@ import type {
   ResolveUserContext,
   ThreadCapabilities,
 } from '../types.js'
+import { chunkForDiscord } from './format-chunking.js'
 import { type DiscordMessageLike, mapDiscordMessage } from './map-message.js'
 import { buildDiscordReplyContext } from './reply-context.js'
 import { type SendableChannel, createDiscordReplyFn } from './reply-helpers.js'
 import { withTypingIndicator } from './typing-indicator.js'
 
 const log = logger.child({ scope: 'chat:discord' })
+const DISCORD_MAX_CONTENT_LEN = 2000
 
 type OnMessageHandler = (msg: IncomingMessage, reply: ReplyFn) => Promise<void>
 
@@ -21,6 +23,27 @@ type DispatchableMessage = DiscordMessageLike & {
     messages?: {
       fetch: (id: string) => Promise<{ id: string; author: { id: string; username: string }; content: string }>
     }
+  }
+}
+
+/** Structural type covering the discord.js Client API surface we use. */
+export type DiscordClientLike = {
+  destroy: () => Promise<void>
+  users?: {
+    fetch: (id: string) => Promise<{
+      createDM: () => Promise<{ send: (arg: { content: string }) => Promise<unknown> }>
+    }>
+  }
+  channels?: { cache: Map<string, { guildId?: string }> }
+  guilds?: {
+    cache: Map<
+      string,
+      {
+        members: {
+          search: (arg: { query: string; limit: number }) => Promise<Map<string, { id: string }>>
+        }
+      }
+    >
   }
 }
 
@@ -34,7 +57,7 @@ export class DiscordChatProvider implements ChatProvider {
   private readonly token: string
   private readonly commands = new Map<string, CommandHandler>()
   private messageHandler: OnMessageHandler | null = null
-  private client: { destroy: () => Promise<void> } | null = null
+  private client: DiscordClientLike | null = null
 
   constructor() {
     const token = process.env['DISCORD_BOT_TOKEN']
@@ -54,12 +77,46 @@ export class DiscordChatProvider implements ChatProvider {
     this.messageHandler = handler
   }
 
-  sendMessage(_userId: string, _markdown: string): Promise<void> {
-    return Promise.reject(new Error('DiscordChatProvider.sendMessage not implemented yet'))
+  async sendMessage(userId: string, markdown: string): Promise<void> {
+    if (this.client === null || this.client.users === undefined) {
+      throw new Error('DiscordChatProvider.sendMessage called before start()')
+    }
+    const user = await this.client.users.fetch(userId)
+    const dm = await user.createDM()
+    const chunks = chunkForDiscord(markdown, DISCORD_MAX_CONTENT_LEN)
+    await chunks.reduce<Promise<unknown>>(
+      (prev, chunk) => prev.then(() => dm.send({ content: chunk })),
+      Promise.resolve(null),
+    )
+    log.info({ userId }, 'Discord DM sent')
   }
 
-  resolveUserId(_username: string, _context: ResolveUserContext): Promise<string | null> {
-    return Promise.resolve(null)
+  async resolveUserId(username: string, context: ResolveUserContext): Promise<string | null> {
+    const clean = username.startsWith('@') ? username.slice(1) : username
+    if (/^\d+$/.test(clean)) return clean
+    if (context.contextType !== 'group') return null
+    if (this.client === null) return null
+
+    if (this.client.channels === undefined || this.client.guilds === undefined) return null
+    const channel = this.client.channels.cache.get(context.contextId)
+    const guildId = channel?.guildId
+    if (guildId === undefined) return null
+    const guild = this.client.guilds.cache.get(guildId)
+    if (guild === undefined) return null
+
+    try {
+      const members = await guild.members.search({ query: clean, limit: 1 })
+      for (const m of members.values()) {
+        return m.id
+      }
+      return null
+    } catch (error) {
+      log.warn(
+        { username: clean, guildId, error: error instanceof Error ? error.message : String(error) },
+        'Discord member search failed',
+      )
+      return null
+    }
   }
 
   start(): Promise<void> {
@@ -72,8 +129,8 @@ export class DiscordChatProvider implements ChatProvider {
     this.client = null
   }
 
-  /** Test-only: inject a stub client for stop() testing. */
-  testSetClient(c: { destroy: () => Promise<void> }): void {
+  /** Test-only: inject a stub client. */
+  testSetClient(c: DiscordClientLike): void {
     this.client = c
   }
 

--- a/src/chat/discord/index.ts
+++ b/src/chat/discord/index.ts
@@ -1,0 +1,54 @@
+import { logger } from '../../logger.js'
+import type {
+  ChatProvider,
+  CommandHandler,
+  IncomingMessage,
+  ReplyFn,
+  ResolveUserContext,
+  ThreadCapabilities,
+} from '../types.js'
+
+const log = logger.child({ scope: 'chat:discord' })
+
+export class DiscordChatProvider implements ChatProvider {
+  readonly name = 'discord'
+  readonly threadCapabilities: ThreadCapabilities = {
+    supportsThreads: false,
+    canCreateThreads: false,
+    threadScope: 'message',
+  }
+  private readonly token: string
+
+  constructor() {
+    const token = process.env['DISCORD_BOT_TOKEN']
+    if (token === undefined || token.trim() === '') {
+      throw new Error('DISCORD_BOT_TOKEN environment variable is required')
+    }
+    this.token = token
+    log.debug({ tokenLength: this.token.length }, 'DiscordChatProvider constructed')
+  }
+
+  registerCommand(_name: string, _handler: CommandHandler): void {
+    throw new Error('DiscordChatProvider.registerCommand not implemented yet')
+  }
+
+  onMessage(_handler: (msg: IncomingMessage, reply: ReplyFn) => Promise<void>): void {
+    throw new Error('DiscordChatProvider.onMessage not implemented yet')
+  }
+
+  sendMessage(_userId: string, _markdown: string): Promise<void> {
+    return Promise.reject(new Error('DiscordChatProvider.sendMessage not implemented yet'))
+  }
+
+  resolveUserId(_username: string, _context: ResolveUserContext): Promise<string | null> {
+    return Promise.resolve(null)
+  }
+
+  start(): Promise<void> {
+    return Promise.reject(new Error('DiscordChatProvider.start not implemented yet'))
+  }
+
+  stop(): Promise<void> {
+    return Promise.resolve()
+  }
+}

--- a/src/chat/discord/index.ts
+++ b/src/chat/discord/index.ts
@@ -1,5 +1,6 @@
 import { logger } from '../../logger.js'
 import type {
+  AuthorizationResult,
   ChatProvider,
   CommandHandler,
   IncomingMessage,
@@ -7,44 +8,46 @@ import type {
   ResolveUserContext,
   ThreadCapabilities,
 } from '../types.js'
+import { type ButtonInteractionLike, dispatchButtonInteraction, isButtonInteraction } from './buttons.js'
+import {
+  type DiscordClientFactory,
+  type DiscordClientLike,
+  type DispatchableMessage,
+  type GuildLike,
+  defaultClientFactory,
+} from './client-factory.js'
 import { chunkForDiscord } from './format-chunking.js'
-import { type DiscordMessageLike, mapDiscordMessage } from './map-message.js'
+import { handleConfigEditorCallback, handleWizardCallback } from './handlers.js'
+import { mapDiscordMessage } from './map-message.js'
 import { buildDiscordReplyContext } from './reply-context.js'
-import { type SendableChannel, createDiscordReplyFn } from './reply-helpers.js'
+import { createDiscordReplyFn } from './reply-helpers.js'
 import { withTypingIndicator } from './typing-indicator.js'
+
+export type { DiscordClientFactory, DiscordClientLike, DispatchableMessage }
+export { defaultClientFactory }
 
 const log = logger.child({ scope: 'chat:discord' })
 const DISCORD_MAX_CONTENT_LEN = 2000
+const CHANNEL_TYPE_DM = 1
 
 type OnMessageHandler = (msg: IncomingMessage, reply: ReplyFn) => Promise<void>
 
-type DispatchableMessage = DiscordMessageLike & {
-  channel: SendableChannel & {
-    messages?: {
-      fetch: (id: string) => Promise<{ id: string; author: { id: string; username: string }; content: string }>
-    }
-  }
+type ReadyPayload = { user: { id: string; username: string } }
+
+function isDispatchableMessage(v: unknown): v is DispatchableMessage {
+  return typeof v === 'object' && v !== null && 'id' in v && 'author' in v && 'channel' in v
 }
 
-/** Structural type covering the discord.js Client API surface we use. */
-export type DiscordClientLike = {
-  destroy: () => Promise<void>
-  users?: {
-    fetch: (id: string) => Promise<{
-      createDM: () => Promise<{ send: (arg: { content: string }) => Promise<unknown> }>
-    }>
-  }
-  channels?: { cache: Map<string, { guildId?: string }> }
-  guilds?: {
-    cache: Map<
-      string,
-      {
-        members: {
-          search: (arg: { query: string; limit: number }) => Promise<Map<string, { id: string }>>
-        }
-      }
-    >
-  }
+function isGuildLike(v: unknown): v is GuildLike {
+  if (typeof v !== 'object' || v === null || !('members' in v)) return false
+  const m = v.members
+  return typeof m === 'object' && m !== null && 'search' in m && typeof m.search === 'function'
+}
+
+function isReadyPayload(v: unknown): v is ReadyPayload {
+  if (typeof v !== 'object' || v === null || !('user' in v)) return false
+  const u = v.user
+  return typeof u === 'object' && u !== null && 'id' in u && 'username' in u
 }
 
 export class DiscordChatProvider implements ChatProvider {
@@ -55,16 +58,18 @@ export class DiscordChatProvider implements ChatProvider {
     threadScope: 'message',
   }
   private readonly token: string
+  private readonly clientFactory: DiscordClientFactory
   private readonly commands = new Map<string, CommandHandler>()
   private messageHandler: OnMessageHandler | null = null
   private client: DiscordClientLike | null = null
 
-  constructor() {
+  constructor(clientFactory?: DiscordClientFactory) {
     const token = process.env['DISCORD_BOT_TOKEN']
     if (token === undefined || token.trim() === '') {
       throw new Error('DISCORD_BOT_TOKEN environment variable is required')
     }
     this.token = token
+    this.clientFactory = clientFactory ?? defaultClientFactory
     log.debug({ tokenLength: this.token.length }, 'DiscordChatProvider constructed')
   }
 
@@ -98,14 +103,15 @@ export class DiscordChatProvider implements ChatProvider {
     if (this.client === null) return null
 
     if (this.client.channels === undefined || this.client.guilds === undefined) return null
-    const channel = this.client.channels.cache.get(context.contextId)
-    const guildId = channel?.guildId
-    if (guildId === undefined) return null
-    const guild = this.client.guilds.cache.get(guildId)
-    if (guild === undefined) return null
+    const raw = this.client.channels.cache.get(context.contextId)
+    if (typeof raw !== 'object' || raw === null || !('guildId' in raw)) return null
+    const guildId = raw.guildId
+    if (typeof guildId !== 'string') return null
+    const rawGuild = this.client.guilds.cache.get(guildId)
+    if (!isGuildLike(rawGuild)) return null
 
     try {
-      const members = await guild.members.search({ query: clean, limit: 1 })
+      const members = await rawGuild.members.search({ query: clean, limit: 1 })
       for (const m of members.values()) {
         return m.id
       }
@@ -120,7 +126,33 @@ export class DiscordChatProvider implements ChatProvider {
   }
 
   start(): Promise<void> {
-    return Promise.reject(new Error('DiscordChatProvider.start not implemented yet'))
+    const adminUserId = process.env['ADMIN_USER_ID'] ?? ''
+    const client = this.clientFactory()
+    this.client = client
+
+    client.on('messageCreate', (rawMsg) => {
+      if (!isDispatchableMessage(rawMsg)) return
+      void this.dispatchMessage(rawMsg, client.user?.id ?? '', adminUserId)
+    })
+
+    client.on('interactionCreate', (rawInteraction) => {
+      if (!isButtonInteraction(rawInteraction)) return
+      void this.handleButtonInteraction(rawInteraction, adminUserId)
+    })
+
+    client.on('error', (rawError) => {
+      const msg = rawError instanceof Error ? rawError.message : String(rawError)
+      log.error({ error: msg }, 'Discord client error')
+    })
+
+    return new Promise<void>((resolve, reject) => {
+      client.once('ready', (readyClient) => {
+        if (!isReadyPayload(readyClient)) return
+        log.info({ botId: readyClient.user.id, botUsername: readyClient.user.username }, 'Discord bot is ready')
+        resolve()
+      })
+      client.login(this.token).catch(reject)
+    })
   }
 
   async stop(): Promise<void> {
@@ -137,6 +169,81 @@ export class DiscordChatProvider implements ChatProvider {
   /** Test-only: simulate inbound messageCreate without a live Client. */
   async testDispatchMessage(message: DispatchableMessage, botId: string, adminUserId: string): Promise<void> {
     await this.dispatchMessage(message, botId, adminUserId)
+  }
+
+  /** Test-only: simulate a button interaction without a live Client. */
+  async testDispatchButtonInteraction(
+    interaction: ButtonInteractionLike,
+    _botId: string,
+    adminUserId: string,
+  ): Promise<void> {
+    await this.handleButtonInteraction(interaction, adminUserId)
+  }
+
+  private async handleButtonInteraction(interaction: ButtonInteractionLike, adminUserId: string): Promise<void> {
+    const channel = interaction.channel
+    if (channel === null) {
+      log.warn({ channelId: interaction.channelId }, 'Button interaction: channel not available, skipping')
+      return
+    }
+
+    const contextType = channel.type === CHANNEL_TYPE_DM ? ('dm' as const) : ('group' as const)
+    const contextId = contextType === 'dm' ? interaction.user.id : interaction.channelId
+    const userId = interaction.user.id
+
+    const onCfg = async (data: string): Promise<void> => {
+      await handleConfigEditorCallback(userId, contextId, data, channel)
+    }
+    const onWizard = async (data: string): Promise<void> => {
+      await handleWizardCallback(userId, contextId, data, channel)
+    }
+
+    await dispatchButtonInteraction(interaction, onCfg, onWizard)
+
+    this.routeButtonFallback(interaction, channel, contextId, contextType, adminUserId)
+  }
+
+  private routeButtonFallback(
+    interaction: ButtonInteractionLike,
+    channel: NonNullable<ButtonInteractionLike['channel']>,
+    contextId: string,
+    contextType: 'dm' | 'group',
+    adminUserId: string,
+  ): void {
+    const data = interaction.customId
+    if (data.startsWith('cfg:') || data.startsWith('wizard_')) return
+
+    const mapped: IncomingMessage = {
+      user: {
+        id: interaction.user.id,
+        username: interaction.user.username.length > 0 ? interaction.user.username : null,
+        isAdmin: interaction.user.id === adminUserId,
+      },
+      contextId,
+      contextType,
+      isMentioned: true,
+      text: data,
+      messageId: interaction.message.id,
+    }
+
+    const reply = createDiscordReplyFn({ channel, replyToMessageId: undefined })
+
+    const command = this.matchCommand(mapped.text)
+    if (command !== null) {
+      mapped.commandMatch = command.match
+      const auth: AuthorizationResult = {
+        allowed: true,
+        isBotAdmin: mapped.user.isAdmin,
+        isGroupAdmin: mapped.user.isAdmin,
+        storageContextId: mapped.contextId,
+      }
+      void command.handler(mapped, reply, auth)
+      return
+    }
+
+    if (this.messageHandler !== null) {
+      void this.messageHandler(mapped, reply)
+    }
   }
 
   private async dispatchMessage(message: DispatchableMessage, botId: string, adminUserId: string): Promise<void> {

--- a/src/chat/discord/index.ts
+++ b/src/chat/discord/index.ts
@@ -53,6 +53,7 @@ function isReadyPayload(v: unknown): v is ReadyPayload {
 export class DiscordChatProvider implements ChatProvider {
   readonly name = 'discord'
   readonly threadCapabilities: ThreadCapabilities = {
+    // Out of scope per §14 of discord-chat-design.md (Phase 1). Threads are treated as non-supported.
     supportsThreads: false,
     canCreateThreads: false,
     threadScope: 'message',

--- a/src/chat/discord/index.ts
+++ b/src/chat/discord/index.ts
@@ -133,12 +133,19 @@ export class DiscordChatProvider implements ChatProvider {
 
     client.on('messageCreate', (rawMsg) => {
       if (!isDispatchableMessage(rawMsg)) return
-      void this.dispatchMessage(rawMsg, client.user?.id ?? '', adminUserId)
+      this.dispatchMessage(rawMsg, client.user?.id ?? '', adminUserId).catch((error: unknown) => {
+        log.error({ error: error instanceof Error ? error.message : String(error) }, 'messageCreate dispatch failed')
+      })
     })
 
     client.on('interactionCreate', (rawInteraction) => {
       if (!isButtonInteraction(rawInteraction)) return
-      void this.handleButtonInteraction(rawInteraction, adminUserId)
+      this.handleButtonInteraction(rawInteraction, adminUserId).catch((error: unknown) => {
+        log.error(
+          { error: error instanceof Error ? error.message : String(error) },
+          'interactionCreate dispatch failed',
+        )
+      })
     })
 
     client.on('error', (rawError) => {
@@ -201,16 +208,16 @@ export class DiscordChatProvider implements ChatProvider {
 
     await dispatchButtonInteraction(interaction, onCfg, onWizard)
 
-    this.routeButtonFallback(interaction, channel, contextId, contextType, adminUserId)
+    await this.routeButtonFallback(interaction, channel, contextId, contextType, adminUserId)
   }
 
-  private routeButtonFallback(
+  private async routeButtonFallback(
     interaction: ButtonInteractionLike,
     channel: NonNullable<ButtonInteractionLike['channel']>,
     contextId: string,
     contextType: 'dm' | 'group',
     adminUserId: string,
-  ): void {
+  ): Promise<void> {
     const data = interaction.customId
     if (data.startsWith('cfg:') || data.startsWith('wizard_')) return
 
@@ -238,12 +245,12 @@ export class DiscordChatProvider implements ChatProvider {
         isGroupAdmin: mapped.user.isAdmin,
         storageContextId: mapped.contextId,
       }
-      void command.handler(mapped, reply, auth)
+      await command.handler(mapped, reply, auth)
       return
     }
 
     if (this.messageHandler !== null) {
-      void this.messageHandler(mapped, reply)
+      await this.messageHandler(mapped, reply)
     }
   }
 

--- a/src/chat/discord/map-message.ts
+++ b/src/chat/discord/map-message.ts
@@ -1,0 +1,64 @@
+import { logger } from '../../logger.js'
+import type { ContextType, IncomingMessage } from '../types.js'
+import { isBotMentioned, stripBotMention } from './mention-helpers.js'
+
+const log = logger.child({ scope: 'chat:discord:map' })
+
+// Minimal structural type over discord.js Message to keep this module
+// runtime-free of discord.js. Production code will pass a real Message
+// object and the structural match will hold.
+export type DiscordMessageLike = {
+  id: string
+  author: { id: string; username: string; bot: boolean }
+  content: string
+  channel: { id: string; type: number }
+  mentions: { has: (id: string) => boolean }
+  reference: { messageId?: string } | null
+  type: number
+}
+
+// Discord.js ChannelType: DM = 1. Everything else maps to 'group'.
+const CHANNEL_TYPE_DM = 1
+
+// Discord.js MessageType values we accept. Default = 0, Reply = 19.
+const ACCEPTED_MESSAGE_TYPES = new Set<number>([0, 19])
+
+/** Map a Discord message to papai's IncomingMessage. Returns null if the message should be ignored. */
+export function mapDiscordMessage(
+  message: DiscordMessageLike,
+  botId: string,
+  adminUserId: string,
+): IncomingMessage | null {
+  if (message.author.bot) {
+    log.debug({ messageId: message.id, authorId: message.author.id }, 'Skipping bot-authored message')
+    return null
+  }
+  if (!ACCEPTED_MESSAGE_TYPES.has(message.type)) {
+    log.debug({ messageId: message.id, type: message.type }, 'Skipping unsupported message type')
+    return null
+  }
+
+  const contextType: ContextType = message.channel.type === CHANNEL_TYPE_DM ? 'dm' : 'group'
+  const contextId = contextType === 'dm' ? message.author.id : message.channel.id
+  const mentioned = isBotMentioned(message.content, botId, contextType)
+
+  if (contextType === 'group' && !mentioned) {
+    return null
+  }
+
+  const text = stripBotMention(message.content, botId)
+
+  return {
+    user: {
+      id: message.author.id,
+      username: message.author.username.length > 0 ? message.author.username : null,
+      isAdmin: message.author.id === adminUserId,
+    },
+    contextId,
+    contextType,
+    isMentioned: mentioned,
+    text,
+    messageId: message.id,
+    replyToMessageId: message.reference?.messageId,
+  }
+}

--- a/src/chat/discord/mention-helpers.ts
+++ b/src/chat/discord/mention-helpers.ts
@@ -2,7 +2,7 @@ import type { ContextType } from '../types.js'
 
 /** Strip the leading `<@botId>` or `<@!botId>` mention from a Discord message content and trim. */
 export function stripBotMention(content: string, botId: string): string {
-  const pattern = new RegExp(`^<@!?${botId}>\\s*`)
+  const pattern = new RegExp(`^<@!?${RegExp.escape(botId)}>\\s*`)
   return content.replace(pattern, '').trim()
 }
 

--- a/src/chat/discord/mention-helpers.ts
+++ b/src/chat/discord/mention-helpers.ts
@@ -1,0 +1,17 @@
+import type { ContextType } from '../types.js'
+
+/** Strip the leading `<@botId>` or `<@!botId>` mention from a Discord message content and trim. */
+export function stripBotMention(content: string, botId: string): string {
+  const pattern = new RegExp(`^<@!?${botId}>\\s*`)
+  return content.replace(pattern, '').trim()
+}
+
+/**
+ * Returns true if the Discord message should be treated as an @mention of the bot.
+ * DMs are always considered mentions (parity with Telegram/Mattermost DM semantics).
+ * Group channels match `<@botId>` or `<@!botId>` substrings.
+ */
+export function isBotMentioned(content: string, botId: string, contextType: ContextType): boolean {
+  if (contextType === 'dm') return true
+  return content.includes(`<@${botId}>`) || content.includes(`<@!${botId}>`)
+}

--- a/src/chat/discord/reply-context.ts
+++ b/src/chat/discord/reply-context.ts
@@ -1,0 +1,48 @@
+import { logger } from '../../logger.js'
+import { buildReplyContextChain } from '../../reply-context.js'
+import type { ReplyContext } from '../types.js'
+
+const log = logger.child({ scope: 'chat:discord:reply-context' })
+
+export type DiscordReplyMessageLike = {
+  reference: { messageId?: string } | null
+  channel: {
+    id: string
+    messages: {
+      fetch: (id: string) => Promise<{
+        id: string
+        author: { id: string; username: string }
+        content: string
+      }>
+    }
+  }
+}
+
+/** Build a ReplyContext from a Discord message's reference, using a REST fetch for the parent. */
+export async function buildDiscordReplyContext(
+  message: DiscordReplyMessageLike,
+  contextId: string,
+): Promise<ReplyContext | undefined> {
+  const refId = message.reference?.messageId
+  if (refId === undefined) return undefined
+
+  const { chain, chainSummary } = buildReplyContextChain(contextId, refId)
+
+  try {
+    const parent = await message.channel.messages.fetch(refId)
+    return {
+      messageId: refId,
+      authorId: parent.author.id,
+      authorUsername: parent.author.username,
+      text: parent.content,
+      chain,
+      chainSummary,
+    }
+  } catch (error) {
+    log.warn(
+      { refId, error: error instanceof Error ? error.message : String(error) },
+      'Failed to fetch Discord parent message',
+    )
+    return { messageId: refId, chain, chainSummary }
+  }
+}

--- a/src/chat/discord/reply-helpers.ts
+++ b/src/chat/discord/reply-helpers.ts
@@ -1,0 +1,87 @@
+import { logger } from '../../logger.js'
+import type { ButtonReplyOptions, ChatFile, ReplyFn, ReplyOptions } from '../types.js'
+import { toActionRows } from './buttons.js'
+import { chunkForDiscord } from './format-chunking.js'
+import { formatLlmOutput } from './format.js'
+
+const log = logger.child({ scope: 'chat:discord:reply' })
+const DISCORD_MAX_CONTENT_LEN = 2000
+
+export type SendableChannel = {
+  id: string
+  send: (arg: {
+    content?: string
+    components?: unknown[]
+    reply?: { messageReference: string; failIfNotExists: boolean }
+  }) => Promise<{ id: string; edit: (arg: { content?: string; components?: unknown[] }) => Promise<unknown> }>
+  sendTyping: () => Promise<void>
+}
+
+export type CreateDiscordReplyFnParams = {
+  channel: SendableChannel
+  replyToMessageId: string | undefined
+}
+
+type MessageRef = { messageReference: string; failIfNotExists: boolean } | undefined
+
+type BotMessage = {
+  id: string
+  edit: (arg: { content?: string; components?: unknown[] }) => Promise<unknown>
+}
+
+function buildReply(replyToMessageId: string | undefined, options?: ReplyOptions): MessageRef {
+  const target = options?.replyToMessageId ?? replyToMessageId
+  return target === undefined ? undefined : { messageReference: target, failIfNotExists: false }
+}
+
+function sendChunksSequentially(
+  channel: SendableChannel,
+  chunks: string[],
+  replyToMessageId: string | undefined,
+  options?: ReplyOptions,
+): Promise<BotMessage | null> {
+  // Chunks must be sent sequentially to preserve message ordering.
+  // Using reduce to chain promises instead of await-in-loop.
+  return chunks.reduce<Promise<BotMessage | null>>(
+    (prev, chunk) => prev.then(() => channel.send({ content: chunk, reply: buildReply(replyToMessageId, options) })),
+    Promise.resolve(null),
+  )
+}
+
+export function createDiscordReplyFn(params: CreateDiscordReplyFnParams): ReplyFn {
+  const { channel, replyToMessageId } = params
+  let lastBotMessage: BotMessage | null = null
+
+  return {
+    text: async (content: string, options?: ReplyOptions): Promise<void> => {
+      const chunks = chunkForDiscord(content, DISCORD_MAX_CONTENT_LEN)
+      lastBotMessage = await sendChunksSequentially(channel, chunks, replyToMessageId, options)
+    },
+    formatted: async (markdown: string, options?: ReplyOptions): Promise<void> => {
+      const chunks = formatLlmOutput(markdown)
+      lastBotMessage = await sendChunksSequentially(channel, chunks, replyToMessageId, options)
+    },
+    file: (_file: ChatFile, _options?: ReplyOptions): Promise<void> => {
+      return Promise.reject(new Error('Discord file send not implemented — deferred'))
+    },
+    typing: (): void => {
+      channel.sendTyping().catch(() => undefined)
+    },
+    redactMessage: async (replacementText: string): Promise<void> => {
+      if (lastBotMessage === null) return
+      try {
+        await lastBotMessage.edit({ content: replacementText, components: [] })
+      } catch (error) {
+        log.warn(
+          { channelId: channel.id, error: error instanceof Error ? error.message : String(error) },
+          'Failed to redact Discord message',
+        )
+      }
+    },
+    buttons: async (content: string, options: ButtonReplyOptions): Promise<void> => {
+      const rows = options.buttons === undefined ? [] : toActionRows(options.buttons)
+      const sent = await channel.send({ content, components: rows, reply: buildReply(replyToMessageId, options) })
+      lastBotMessage = sent
+    },
+  }
+}

--- a/src/chat/discord/typing-indicator.ts
+++ b/src/chat/discord/typing-indicator.ts
@@ -1,0 +1,24 @@
+// Under Discord's ~10s typing expiry
+const TYPING_INTERVAL_MS = 4500
+
+type TypingChannel = {
+  sendTyping: () => Promise<void>
+}
+
+/**
+ * Run `fn` while periodically triggering the Discord typing indicator on
+ * `channel`. Errors from `sendTyping` are swallowed; errors from `fn` are
+ * re-thrown.
+ */
+export async function withTypingIndicator<T>(channel: TypingChannel, fn: () => Promise<T>): Promise<T> {
+  const send = (): void => {
+    channel.sendTyping().catch(() => undefined)
+  }
+  send()
+  const interval = setInterval(send, TYPING_INTERVAL_MS)
+  try {
+    return await fn()
+  } finally {
+    clearInterval(interval)
+  }
+}

--- a/src/chat/mattermost/index.ts
+++ b/src/chat/mattermost/index.ts
@@ -6,6 +6,7 @@ import type {
   ContextType,
   IncomingMessage,
   ReplyFn,
+  ResolveUserContext,
 } from '../types.js'
 import {
   cacheIncomingPost,
@@ -262,7 +263,7 @@ export class MattermostChatProvider implements ChatProvider {
     return ChannelSchema.parse(data).id
   }
 
-  async resolveUserId(username: string): Promise<string | null> {
+  async resolveUserId(username: string, _context: ResolveUserContext): Promise<string | null> {
     const cleanUsername = username.startsWith('@') ? username.slice(1) : username
     try {
       const data = await this.apiFetch('GET', `/api/v4/users/username/${encodeURIComponent(cleanUsername)}`, undefined)

--- a/src/chat/registry.ts
+++ b/src/chat/registry.ts
@@ -1,4 +1,5 @@
 import { logger } from '../logger.js'
+import { DiscordChatProvider } from './discord/index.js'
 import { MattermostChatProvider } from './mattermost/index.js'
 import { TelegramChatProvider } from './telegram/index.js'
 import type { ChatProvider } from './types.js'
@@ -11,6 +12,7 @@ const providers = new Map<string, ChatProviderFactory>()
 
 registerChatProvider('telegram', () => new TelegramChatProvider())
 registerChatProvider('mattermost', () => new MattermostChatProvider())
+registerChatProvider('discord', () => new DiscordChatProvider())
 
 function registerChatProvider(name: string, factory: ChatProviderFactory): void {
   providers.set(name, factory)

--- a/src/chat/registry.ts
+++ b/src/chat/registry.ts
@@ -1,3 +1,4 @@
+import { validateChatProviderEnv } from '../env-validation.js'
 import { logger } from '../logger.js'
 import { DiscordChatProvider } from './discord/index.js'
 import { MattermostChatProvider } from './mattermost/index.js'
@@ -7,6 +8,12 @@ import type { ChatProvider } from './types.js'
 const log = logger.child({ scope: 'chat:registry' })
 
 type ChatProviderFactory = () => ChatProvider
+
+export interface RegistryDeps {
+  env: Record<string, string | undefined>
+}
+
+const defaultDeps: RegistryDeps = { env: process.env }
 
 const providers = new Map<string, ChatProviderFactory>()
 
@@ -18,12 +25,13 @@ function registerChatProvider(name: string, factory: ChatProviderFactory): void 
   providers.set(name, factory)
 }
 
-export function createChatProvider(name: string): ChatProvider {
-  const factory = providers.get(name)
-  if (factory === undefined) {
-    log.error({ name }, 'Unknown chat provider requested')
-    throw new Error(`Unknown chat provider: ${name}. Available: ${[...providers.keys()].join(', ')}`)
+export function createChatProvider(name: string, deps: RegistryDeps = defaultDeps): ChatProvider {
+  const validation = validateChatProviderEnv(name, deps.env)
+  if (!validation.ok) {
+    log.error({ reason: validation.reason, missing: validation.missing }, 'Invalid chat provider configuration')
+    throw new Error(validation.reason)
   }
+  const factory = providers.get(name)!
   log.debug({ name }, 'Creating chat provider instance')
   return factory()
 }

--- a/src/chat/telegram/index.ts
+++ b/src/chat/telegram/index.ts
@@ -13,6 +13,7 @@ import type {
   IncomingMessage,
   ReplyFn,
   ReplyOptions,
+  ResolveUserContext,
 } from '../types.js'
 import { handleConfigEditorCallback } from './config-editor-callbacks.js'
 import { extractFilesFromContext, type TelegramFileFetcher } from './file-helpers.js'
@@ -128,9 +129,8 @@ export class TelegramChatProvider implements ChatProvider {
     await this.bot.stop()
   }
 
-  resolveUserId(username: string): Promise<string | null> {
-    // Telegram Bot API cannot resolve usernames to user IDs
-    // Only numeric IDs can be used directly
+  resolveUserId(username: string, _context: ResolveUserContext): Promise<string | null> {
+    // Telegram Bot API cannot resolve usernames to user IDs; only numeric IDs work directly
     const cleanUsername = username.startsWith('@') ? username.slice(1) : username
     if (/^\d+$/.test(cleanUsername)) {
       return Promise.resolve(cleanUsername)

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -9,6 +9,14 @@ export type ChatUser = {
 /** Context type for messages - DM or group chat. */
 export type ContextType = 'dm' | 'group'
 
+/** Context passed to resolveUserId so adapters can scope searches. */
+export type ResolveUserContext = {
+  /** Storage key of the conversation where the lookup originated (userId in DMs, channel/group ID in groups). */
+  contextId: string
+  /** 'dm' or 'group' — adapters may use this to decide whether guild-scoped search is possible. */
+  contextType: ContextType
+}
+
 /** Thread support capabilities for a chat platform. */
 export type ThreadCapabilities = {
   /** Platform has thread/topic support */
@@ -137,8 +145,8 @@ export interface ChatProvider {
   /** Send a formatted markdown message to a user by ID (for announcements). */
   sendMessage(userId: string, markdown: string): Promise<void>
 
-  /** Resolve a username to a user ID. Returns null if not found. */
-  resolveUserId(username: string): Promise<string | null>
+  /** Resolve a username to a user ID. Returns null if not found. `context` allows adapters like Discord to scope the lookup to the caller's guild. */
+  resolveUserId(username: string, context: ResolveUserContext): Promise<string | null>
 
   /** Start the bot event loop. */
   start(): Promise<void>

--- a/src/commands/group.ts
+++ b/src/commands/group.ts
@@ -1,4 +1,4 @@
-import type { AuthorizationResult, ChatProvider, IncomingMessage, ReplyFn } from '../chat/types.js'
+import type { AuthorizationResult, ChatProvider, IncomingMessage, ReplyFn, ResolveUserContext } from '../chat/types.js'
 import { addGroupMember, listGroupMembers, removeGroupMember } from '../groups.js'
 import { logger } from '../logger.js'
 
@@ -58,7 +58,10 @@ async function handleAddUser(
     return
   }
 
-  const userId = await extractUserId(chat, targetUser)
+  const userId = await extractUserId(chat, targetUser, {
+    contextId: msg.contextId,
+    contextType: msg.contextType,
+  })
   if (userId === null) {
     await reply.text('Please provide a valid user mention or ID.')
     return
@@ -85,7 +88,10 @@ async function handleDelUser(
     return
   }
 
-  const userId = await extractUserId(chat, targetUser)
+  const userId = await extractUserId(chat, targetUser, {
+    contextId: msg.contextId,
+    contextType: msg.contextType,
+  })
   if (userId === null) {
     await reply.text('Please provide a valid user mention or ID.')
     return
@@ -108,10 +114,10 @@ async function handleListUsers(msg: IncomingMessage, reply: ReplyFn): Promise<vo
   await reply.text(`Group members:\n${memberList}`)
 }
 
-async function extractUserId(chat: ChatProvider, input: string): Promise<string | null> {
+async function extractUserId(chat: ChatProvider, input: string, context: ResolveUserContext): Promise<string | null> {
   if (input.startsWith('@')) {
     // Try to resolve username to user ID via chat provider
-    const resolved = await chat.resolveUserId(input)
+    const resolved = await chat.resolveUserId(input, context)
     // If resolution fails, fall back to using the raw username (for backward compatibility)
     return resolved ?? input.slice(1)
   }

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,4 +1,4 @@
-import type { ChatProvider, CommandHandler } from '../chat/types.js'
+import type { ChatProvider, CommandHandler, ContextType } from '../chat/types.js'
 import { logger } from '../logger.js'
 
 const log = logger.child({ scope: 'commands:help' })
@@ -57,15 +57,29 @@ function getGroupHelpText(isGroupAdmin: boolean): string {
   return text
 }
 
+export function buildHelpText(
+  providerName: string,
+  contextType: ContextType,
+  opts: { isBotAdmin: boolean; isGroupAdmin: boolean },
+): string {
+  let helpText = contextType === 'dm' ? getDmHelpText(opts.isBotAdmin) : getGroupHelpText(opts.isGroupAdmin)
+
+  if (providerName === 'discord' && opts.isBotAdmin) {
+    helpText += '\n\nNote: `/context` export is deferred on Discord.'
+  }
+
+  return helpText
+}
+
 export function registerHelpCommand(chat: ChatProvider): void {
   const handler: CommandHandler = async (msg, reply, auth) => {
     log.info({ userId: msg.user.id, contextType: msg.contextType }, '/help command executed')
 
-    if (msg.contextType === 'dm') {
-      await reply.text(getDmHelpText(auth.isBotAdmin))
-    } else {
-      await reply.text(getGroupHelpText(auth.isGroupAdmin))
-    }
+    const helpText = buildHelpText(chat.name, msg.contextType, {
+      isBotAdmin: auth.isBotAdmin,
+      isGroupAdmin: auth.isGroupAdmin,
+    })
+    await reply.text(helpText)
   }
 
   chat.registerCommand('help', handler)

--- a/src/env-validation.ts
+++ b/src/env-validation.ts
@@ -1,0 +1,24 @@
+export type ChatProviderValidationResult = { ok: true } | { ok: false; reason: string; missing?: string[] }
+
+export function validateChatProviderEnv(
+  chatProvider: string | undefined,
+  env: Record<string, string | undefined>,
+): ChatProviderValidationResult {
+  if (chatProvider !== 'telegram' && chatProvider !== 'mattermost' && chatProvider !== 'discord') {
+    return {
+      ok: false,
+      reason: 'CHAT_PROVIDER must be "telegram", "mattermost", or "discord"',
+    }
+  }
+  const requirements: Record<'telegram' | 'mattermost' | 'discord', readonly string[]> = {
+    telegram: ['TELEGRAM_BOT_TOKEN'],
+    mattermost: ['MATTERMOST_URL', 'MATTERMOST_BOT_TOKEN'],
+    discord: ['DISCORD_BOT_TOKEN'],
+  }
+  const required = requirements[chatProvider]
+  const missing = required.filter((key) => (env[key]?.trim() ?? '') === '')
+  if (missing.length > 0) {
+    return { ok: false, reason: `Missing ${chatProvider} env vars`, missing }
+  }
+  return { ok: true }
+}

--- a/src/llm-orchestrator.ts
+++ b/src/llm-orchestrator.ts
@@ -84,8 +84,10 @@ const sendLlmResponse = async (
   )
 }
 
-const invokeModel = async (args: InvokeModelArgs): ReturnType<LlmOrchestratorDeps['generateText']> => {
-  const { contextId, mainModel, model, provider, tools, messages, deps } = args
+const invokeModel = async (
+  args: InvokeModelArgs & { reply?: ReplyFn },
+): ReturnType<LlmOrchestratorDeps['generateText']> => {
+  const { contextId, mainModel, model, provider, tools, messages, deps, reply } = args
   const start = Date.now()
   emitLlmStart(contextId, mainModel, messages, tools)
   const result = await deps.generateText({
@@ -112,6 +114,13 @@ const invokeModel = async (args: InvokeModelArgs): ReturnType<LlmOrchestratorDep
         success: event.success,
         ...(event.success ? {} : { error: String(event.error) }),
       })
+      // Provide immediate user feedback for tool execution failures
+      if (!event.success && reply !== undefined) {
+        const toolName = event.toolCall.toolName
+        const errorMessage = event.error instanceof Error ? event.error.message : String(event.error)
+        log.warn({ contextId, toolName, error: errorMessage }, 'Tool execution failed')
+        void reply.text(`⚠️ Tool "${toolName}" failed: ${errorMessage}`)
+      }
     },
   })
   emitLlmEnd(contextId, mainModel, result, start, messages, tools)
@@ -152,6 +161,7 @@ const callLlm = async (
     tools,
     messages: messagesWithMemory,
     deps,
+    reply,
   })
   log.debug({ contextId, toolCalls: result.toolCalls?.length, usage: result.usage }, 'LLM response received')
   persistFactsFromResults(contextId, result.toolCalls, result.toolResults)

--- a/src/wizard/index.ts
+++ b/src/wizard/index.ts
@@ -1,4 +1,5 @@
-export { hasActiveWizard } from './state.js'
-export { processWizardMessage, createWizard } from './engine.js'
+export { hasActiveWizard, getWizardSession, resetWizardSession } from './state.js'
+export { processWizardMessage, createWizard, getNextPrompt, cancelWizard } from './engine.js'
 export type { WizardProcessResult } from './types.js'
 export { validateLlmApiKey, validateLlmBaseUrl, validateModelExists, type ValidationResult } from './validation.js'
+export { validateAndSaveWizardConfig } from './save.js'

--- a/tests/chat/discord/buttons.test.ts
+++ b/tests/chat/discord/buttons.test.ts
@@ -1,7 +1,26 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, test, beforeEach } from 'bun:test'
 
-import { DISCORD_CUSTOM_ID_MAX, toActionRows } from '../../../src/chat/discord/buttons.js'
+import {
+  DISCORD_CUSTOM_ID_MAX,
+  dispatchButtonInteraction,
+  toActionRows,
+  type ButtonChannelLike,
+  type ButtonInteractionLike,
+} from '../../../src/chat/discord/buttons.js'
 import type { ChatButton } from '../../../src/chat/types.js'
+import { mockLogger } from '../../utils/test-helpers.js'
+
+type EditFn = (arg: { content?: string; components?: unknown[] }) => Promise<unknown>
+type SendResult = { id: string; edit: EditFn }
+
+function fakeChannel(id = 'c'): ButtonChannelLike {
+  return {
+    id,
+    type: 0,
+    send: (): Promise<SendResult> => Promise.resolve({ id: 'x', edit: (): Promise<void> => Promise.resolve() }),
+    sendTyping: (): Promise<void> => Promise.resolve(),
+  }
+}
 
 describe('toActionRows', () => {
   test('builds a single row for up to 5 buttons', () => {
@@ -57,5 +76,178 @@ describe('toActionRows', () => {
     const styles = rows[0]!.components.map((c) => c.toJSON().style)
     // Primary=1, Secondary=2, Danger=4
     expect(styles).toEqual([1, 2, 4])
+  })
+})
+
+describe('dispatchButtonInteraction', () => {
+  beforeEach(() => {
+    mockLogger()
+  })
+
+  test('routes cfg:-prefixed interactions through config-editor handler', async () => {
+    const cfgCalls: string[] = []
+    const wizardCalls: string[] = []
+    const interaction: ButtonInteractionLike = {
+      customId: 'cfg:edit:llm_apikey',
+      deferUpdate: () => Promise.resolve(),
+      user: { id: 'user-1', username: 'testuser' },
+      message: { id: 'msg-1' },
+      channel: fakeChannel('chan-1'),
+      channelId: 'chan-1',
+    }
+
+    await dispatchButtonInteraction(
+      interaction,
+      (data: string): Promise<void> => {
+        cfgCalls.push(data)
+        return Promise.resolve()
+      },
+      (data: string): Promise<void> => {
+        wizardCalls.push(data)
+        return Promise.resolve()
+      },
+    )
+
+    expect(cfgCalls).toEqual(['cfg:edit:llm_apikey'])
+    expect(wizardCalls).toEqual([])
+  })
+
+  test('routes wizard_-prefixed interactions through wizard handler', async () => {
+    const cfgCalls: string[] = []
+    const wizardCalls: string[] = []
+    const interaction: ButtonInteractionLike = {
+      customId: 'wizard_confirm',
+      deferUpdate: () => Promise.resolve(),
+      user: { id: 'user-2', username: 'testuser2' },
+      message: { id: 'msg-2' },
+      channel: fakeChannel('chan-2'),
+      channelId: 'chan-2',
+    }
+
+    await dispatchButtonInteraction(
+      interaction,
+      (data: string): Promise<void> => {
+        cfgCalls.push(data)
+        return Promise.resolve()
+      },
+      (data: string): Promise<void> => {
+        wizardCalls.push(data)
+        return Promise.resolve()
+      },
+    )
+
+    expect(cfgCalls).toEqual([])
+    expect(wizardCalls).toEqual(['wizard_confirm'])
+  })
+
+  test('ignores unrecognized interactions', async () => {
+    const cfgCalls: string[] = []
+    const wizardCalls: string[] = []
+    const interaction: ButtonInteractionLike = {
+      customId: 'some_random_callback',
+      deferUpdate: () => Promise.resolve(),
+      user: { id: 'u', username: 'user' },
+      message: { id: 'm' },
+      channel: fakeChannel(),
+      channelId: 'c',
+    }
+
+    await dispatchButtonInteraction(
+      interaction,
+      (d: string): Promise<void> => {
+        cfgCalls.push(d)
+        return Promise.resolve()
+      },
+      (d: string): Promise<void> => {
+        wizardCalls.push(d)
+        return Promise.resolve()
+      },
+    )
+
+    expect(cfgCalls).toEqual([])
+    expect(wizardCalls).toEqual([])
+  })
+
+  test('handles deferUpdate failure gracefully', async () => {
+    const cfgCalls: string[] = []
+    const interaction: ButtonInteractionLike = {
+      customId: 'cfg:save:main_model',
+      deferUpdate: (): Promise<void> => Promise.reject(new Error('Network error')),
+      user: { id: 'u', username: 'user' },
+      message: { id: 'm' },
+      channel: fakeChannel(),
+      channelId: 'c',
+    }
+
+    await dispatchButtonInteraction(
+      interaction,
+      (d: string): Promise<void> => {
+        cfgCalls.push(d)
+        return Promise.resolve()
+      },
+      (): Promise<void> => Promise.resolve(),
+    )
+
+    // Handler should still be called despite deferUpdate failure
+    expect(cfgCalls).toEqual(['cfg:save:main_model'])
+  })
+})
+
+describe('isButtonInteraction', () => {
+  test('returns true for button interactions (type=3, componentType=2)', async () => {
+    const { isButtonInteraction } = await import('../../../src/chat/discord/buttons.js')
+    const obj = {
+      type: 3,
+      componentType: 2,
+      user: { id: 'u1', username: 'test' },
+      customId: 'x',
+      channelId: 'c1',
+      channel: null,
+      message: { id: 'm1' },
+      deferUpdate: (): Promise<void> => Promise.resolve(),
+    }
+    expect(isButtonInteraction(obj)).toBe(true)
+  })
+
+  test('returns false for non-button component types', async () => {
+    const { isButtonInteraction } = await import('../../../src/chat/discord/buttons.js')
+    expect(isButtonInteraction({ type: 3, componentType: 3 })).toBe(false)
+  })
+
+  test('returns false for non-component interaction types', async () => {
+    const { isButtonInteraction } = await import('../../../src/chat/discord/buttons.js')
+    expect(isButtonInteraction({ type: 2, componentType: 2 })).toBe(false)
+  })
+
+  test('returns false for non-objects', async () => {
+    const { isButtonInteraction } = await import('../../../src/chat/discord/buttons.js')
+    expect(isButtonInteraction(null)).toBe(false)
+    expect(isButtonInteraction('string')).toBe(false)
+    expect(isButtonInteraction(42)).toBe(false)
+  })
+
+  test('returns false for objects without type/componentType', async () => {
+    const { isButtonInteraction } = await import('../../../src/chat/discord/buttons.js')
+    expect(isButtonInteraction({})).toBe(false)
+    expect(isButtonInteraction({ type: 3 })).toBe(false)
+  })
+})
+
+describe('Button types', () => {
+  test('ButtonInteractionLike type accepts valid interaction objects', () => {
+    const validInteraction: ButtonInteractionLike = {
+      user: { id: 'u1', username: 'test' },
+      customId: 'test:action',
+      channelId: 'c1',
+      channel: fakeChannel('c1'),
+      message: { id: 'm1' },
+      deferUpdate: (): Promise<void> => Promise.resolve(),
+    }
+    expect(validInteraction.customId).toBe('test:action')
+  })
+
+  test('ButtonChannelLike type accepts valid channel objects', () => {
+    const validChannel: ButtonChannelLike = fakeChannel('c1')
+    expect(validChannel.id).toBe('c1')
   })
 })

--- a/tests/chat/discord/buttons.test.ts
+++ b/tests/chat/discord/buttons.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test'
+
+import { DISCORD_CUSTOM_ID_MAX, toActionRows } from '../../../src/chat/discord/buttons.js'
+import type { ChatButton } from '../../../src/chat/types.js'
+
+describe('toActionRows', () => {
+  test('builds a single row for up to 5 buttons', () => {
+    const buttons: ChatButton[] = [
+      { text: 'A', callbackData: 'cb:a', style: 'primary' },
+      { text: 'B', callbackData: 'cb:b', style: 'secondary' },
+    ]
+    const rows = toActionRows(buttons)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.components).toHaveLength(2)
+  })
+
+  test('splits into multiple rows of 5', () => {
+    const buttons: ChatButton[] = Array.from({ length: 12 }, (_, i) => ({
+      text: `btn${String(i)}`,
+      callbackData: `cb:${String(i)}`,
+    }))
+    const rows = toActionRows(buttons)
+    expect(rows).toHaveLength(3)
+    expect(rows[0]!.components).toHaveLength(5)
+    expect(rows[1]!.components).toHaveLength(5)
+    expect(rows[2]!.components).toHaveLength(2)
+  })
+
+  test('rejects more than 25 buttons (5 rows x 5)', () => {
+    const buttons: ChatButton[] = Array.from({ length: 26 }, (_, i) => ({
+      text: `b${String(i)}`,
+      callbackData: `cb:${String(i)}`,
+    }))
+    expect(() => toActionRows(buttons)).toThrow(/too many buttons/i)
+  })
+
+  test('rejects custom_id longer than 100 chars', () => {
+    const long = 'x'.repeat(DISCORD_CUSTOM_ID_MAX + 1)
+    expect(() => toActionRows([{ text: 'Go', callbackData: long }])).toThrow(/custom_id/)
+  })
+
+  test('defaults to secondary style when style is undefined', () => {
+    const rows = toActionRows([{ text: 'neutral', callbackData: 'cb:n' }])
+    // ButtonBuilder stores data internally; access via toJSON()
+    const json = rows[0]!.components[0]!.toJSON()
+    // Secondary = 2 in Discord ButtonStyle enum
+    expect(json.style).toBe(2)
+  })
+
+  test('maps primary/secondary/danger to ButtonStyle enum values', () => {
+    const buttons: ChatButton[] = [
+      { text: 'P', callbackData: 'cb:p', style: 'primary' },
+      { text: 'S', callbackData: 'cb:s', style: 'secondary' },
+      { text: 'D', callbackData: 'cb:d', style: 'danger' },
+    ]
+    const rows = toActionRows(buttons)
+    const styles = rows[0]!.components.map((c) => c.toJSON().style)
+    // Primary=1, Secondary=2, Danger=4
+    expect(styles).toEqual([1, 2, 4])
+  })
+})

--- a/tests/chat/discord/client-factory.test.ts
+++ b/tests/chat/discord/client-factory.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import type { GuildLike } from '../../../src/chat/discord/client-factory.js'
+import { mockLogger } from '../../utils/test-helpers.js'
+
+describe('client-factory', () => {
+  beforeEach(() => {
+    mockLogger()
+  })
+
+  test('defaultClientFactory creates a discord.js Client instance with the required interface', async () => {
+    const { defaultClientFactory } = await import('../../../src/chat/discord/client-factory.js')
+    const client = defaultClientFactory()
+    expect(typeof client.on).toBe('function')
+    expect(typeof client.once).toBe('function')
+    expect(typeof client.login).toBe('function')
+    expect(typeof client.destroy).toBe('function')
+    await client.destroy().catch(() => undefined)
+  })
+
+  test('GuildLike type accepts objects with a members.search method', () => {
+    const guild: GuildLike = {
+      members: {
+        search: (_arg: { query: string; limit: number }): Promise<Map<string, { id: string }>> =>
+          Promise.resolve(new Map<string, { id: string }>()),
+      },
+    }
+    expect(typeof guild.members.search).toBe('function')
+  })
+})

--- a/tests/chat/discord/format-chunking.test.ts
+++ b/tests/chat/discord/format-chunking.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test'
+
+import { chunkForDiscord } from '../../../src/chat/discord/format-chunking.js'
+
+describe('chunkForDiscord', () => {
+  test('returns a single chunk for input shorter than max', () => {
+    const result = chunkForDiscord('short text', 2000)
+    expect(result).toEqual(['short text'])
+  })
+
+  test('returns single-element array for empty input', () => {
+    expect(chunkForDiscord('', 2000)).toEqual([''])
+  })
+
+  test('splits on paragraph boundary preferentially', () => {
+    const first = 'a'.repeat(1500)
+    const second = 'b'.repeat(1500)
+    const input = `${first}\n\n${second}`
+    const chunks = chunkForDiscord(input, 2000)
+    expect(chunks).toHaveLength(2)
+    expect(chunks[0]!.trim()).toBe(first)
+    expect(chunks[1]!.trim()).toBe(second)
+  })
+
+  test('respects the max length boundary exactly', () => {
+    const input = 'x'.repeat(4000)
+    const chunks = chunkForDiscord(input, 2000)
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(2000)
+    }
+    expect(chunks.join('')).toBe(input)
+  })
+
+  test('preserves fenced code blocks across chunks by re-opening them', () => {
+    const codeBlock = '```\n' + 'code line\n'.repeat(300) + '```'
+    const chunks = chunkForDiscord(codeBlock, 2000)
+    for (const chunk of chunks) {
+      const openCount = (chunk.match(/```/g) ?? []).length
+      expect(openCount % 2).toBe(0)
+    }
+    expect(chunks.every((c) => c.length <= 2000)).toBe(true)
+  })
+
+  test('handles exactly-max-length input without splitting', () => {
+    const input = 'y'.repeat(2000)
+    expect(chunkForDiscord(input, 2000)).toEqual([input])
+  })
+
+  test('splits at sentence boundary when no paragraph break exists', () => {
+    const sentence1 = 'A'.repeat(1500) + '. '
+    const sentence2 = 'B'.repeat(400) + '.'
+    const chunks = chunkForDiscord(sentence1 + sentence2, 2000)
+    expect(chunks.length).toBeGreaterThanOrEqual(1)
+    expect(chunks.every((c) => c.length <= 2000)).toBe(true)
+    expect(chunks.join('').replace(/\s+/g, '')).toBe((sentence1 + sentence2).replace(/\s+/g, ''))
+  })
+})

--- a/tests/chat/discord/format-chunking.test.ts
+++ b/tests/chat/discord/format-chunking.test.ts
@@ -46,6 +46,20 @@ describe('chunkForDiscord', () => {
     expect(chunkForDiscord(input, 2000)).toEqual([input])
   })
 
+  test('does not exceed maxLen when fence healing adds characters', () => {
+    // Create a scenario where chunk ends exactly at maxLen with unbalanced fence
+    // Fence close adds 4 chars ('\n```'), which should not exceed maxLen
+    const fenceOpen = '```typescript\n'
+    // Leave room for one char
+    const codeContent = 'x'.repeat(100 - fenceOpen.length - 1)
+    const input = fenceOpen + codeContent + '\n```\nmore content here that will cause another split'
+    const chunks = chunkForDiscord(input, 100)
+
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(100)
+    }
+  })
+
   test('splits at sentence boundary when no paragraph break exists', () => {
     const sentence1 = 'A'.repeat(1500) + '. '
     const sentence2 = 'B'.repeat(400) + '.'

--- a/tests/chat/discord/format.test.ts
+++ b/tests/chat/discord/format.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+
+import { formatLlmOutput } from '../../../src/chat/discord/format.js'
+
+describe('formatLlmOutput (Discord)', () => {
+  test('returns plain text unchanged for simple input', () => {
+    const chunks = formatLlmOutput('hello world')
+    expect(chunks).toEqual(['hello world'])
+  })
+
+  test('preserves **bold**, *italic*, `code`, and fenced blocks', () => {
+    const input = '**strong** and *em* and `code` and\n```\nblock\n```'
+    const chunks = formatLlmOutput(input)
+    expect(chunks.length).toBe(1)
+    expect(chunks[0]).toContain('**strong**')
+    expect(chunks[0]).toContain('*em*')
+    expect(chunks[0]).toContain('`code`')
+    expect(chunks[0]).toContain('```\nblock\n```')
+  })
+
+  test('escapes @everyone and @here to prevent mass pings', () => {
+    const input = 'hey @everyone and @here look'
+    const chunks = formatLlmOutput(input)
+    expect(chunks[0]).not.toContain('@everyone')
+    expect(chunks[0]).not.toContain('@here')
+    expect(chunks[0]).toContain('@\u200beveryone')
+    expect(chunks[0]).toContain('@\u200bhere')
+  })
+
+  test('flattens a markdown table to pipe-separated rows', () => {
+    const input = '| col1 | col2 |\n| --- | --- |\n| a    | b    |\n| c    | d    |'
+    const chunks = formatLlmOutput(input)
+    expect(chunks[0]).toContain('col1 | col2')
+    expect(chunks[0]).toContain('a | b')
+    expect(chunks[0]).toContain('c | d')
+    expect(chunks[0]).not.toMatch(/^\|\s*-/m)
+  })
+
+  test('chunks output longer than 2000 chars into multiple strings', () => {
+    const input = 'paragraph one\n\n' + 'x'.repeat(3000)
+    const chunks = formatLlmOutput(input)
+    expect(chunks.length).toBeGreaterThan(1)
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(2000)
+    }
+  })
+})

--- a/tests/chat/discord/handlers.test.ts
+++ b/tests/chat/discord/handlers.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test, beforeEach } from 'bun:test'
+
+import { handleConfigEditorCallback, handleWizardCallback } from '../../../src/chat/discord/handlers.js'
+import { mockLogger, setupTestDb } from '../../utils/test-helpers.js'
+
+describe('discord handlers', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  describe('handleConfigEditorCallback', () => {
+    test('returns early when no active editor', async () => {
+      const channel = {
+        id: 'c1',
+        type: 0,
+        send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+          Promise.resolve({ id: 'm1', edit: (): Promise<void> => Promise.resolve() }),
+        sendTyping: (): Promise<void> => Promise.resolve(),
+      }
+
+      await handleConfigEditorCallback('user-1', 'ctx-1', 'cfg:edit:llm_apikey', channel)
+      expect(true).toBe(true)
+    })
+  })
+
+  describe('handleWizardCallback', () => {
+    test('returns early when no active wizard', async () => {
+      const channel = {
+        id: 'c1',
+        type: 0,
+        send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+          Promise.resolve({ id: 'm1', edit: (): Promise<void> => Promise.resolve() }),
+        sendTyping: (): Promise<void> => Promise.resolve(),
+      }
+
+      await handleWizardCallback('user-1', 'ctx-1', 'wizard_confirm', channel)
+      expect(true).toBe(true)
+    })
+  })
+})

--- a/tests/chat/discord/handlers.test.ts
+++ b/tests/chat/discord/handlers.test.ts
@@ -1,41 +1,65 @@
-import { describe, expect, test, beforeEach } from 'bun:test'
+import { beforeEach, describe, expect, test } from 'bun:test'
 
 import { handleConfigEditorCallback, handleWizardCallback } from '../../../src/chat/discord/handlers.js'
+import { deleteEditorSession } from '../../../src/config-editor/index.js'
+import { deleteWizardSession } from '../../../src/wizard/state.js'
 import { mockLogger, setupTestDb } from '../../utils/test-helpers.js'
 
 describe('discord handlers', () => {
+  const configUserId = 'discord-config-handler-user'
+  const configContextId = 'discord-config-handler-context'
+  const wizardUserId = 'discord-wizard-handler-user'
+  const wizardContextId = 'discord-wizard-handler-context'
+
   beforeEach(async () => {
     mockLogger()
     await setupTestDb()
+    deleteEditorSession(configUserId, configContextId)
+    deleteWizardSession(wizardUserId, wizardContextId)
   })
+
+  function makeChannel(): {
+    sends: string[]
+    channel: {
+      id: string
+      type: number
+      send: () => Promise<{ id: string; edit: () => Promise<void> }>
+      sendTyping: () => Promise<void>
+    }
+  } {
+    const sends: string[] = []
+
+    return {
+      sends,
+      channel: {
+        id: 'c1',
+        type: 0,
+        send: (): Promise<{ id: string; edit: () => Promise<void> }> => {
+          sends.push(`send-${String(sends.length + 1)}`)
+          return Promise.resolve({ id: 'm1', edit: (): Promise<void> => Promise.resolve() })
+        },
+        sendTyping: (): Promise<void> => Promise.resolve(),
+      },
+    }
+  }
 
   describe('handleConfigEditorCallback', () => {
     test('returns early when no active editor', async () => {
-      const channel = {
-        id: 'c1',
-        type: 0,
-        send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
-          Promise.resolve({ id: 'm1', edit: (): Promise<void> => Promise.resolve() }),
-        sendTyping: (): Promise<void> => Promise.resolve(),
-      }
+      const { channel, sends } = makeChannel()
 
-      await handleConfigEditorCallback('user-1', 'ctx-1', 'cfg:edit:llm_apikey', channel)
-      expect(true).toBe(true)
+      await handleConfigEditorCallback(configUserId, configContextId, 'cfg:edit:llm_apikey', channel)
+
+      expect(sends).toHaveLength(0)
     })
   })
 
   describe('handleWizardCallback', () => {
     test('returns early when no active wizard', async () => {
-      const channel = {
-        id: 'c1',
-        type: 0,
-        send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
-          Promise.resolve({ id: 'm1', edit: (): Promise<void> => Promise.resolve() }),
-        sendTyping: (): Promise<void> => Promise.resolve(),
-      }
+      const { channel, sends } = makeChannel()
 
-      await handleWizardCallback('user-1', 'ctx-1', 'wizard_confirm', channel)
-      expect(true).toBe(true)
+      await handleWizardCallback(wizardUserId, wizardContextId, 'wizard_confirm', channel)
+
+      expect(sends).toHaveLength(0)
     })
   })
 })

--- a/tests/chat/discord/index.test.ts
+++ b/tests/chat/discord/index.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
-import { mockLogger } from '../../utils/test-helpers.js'
+import type { IncomingMessage } from '../../../src/chat/types.js'
+import { mockLogger, mockMessageCache } from '../../utils/test-helpers.js'
 
 describe('DiscordChatProvider', () => {
   const originalToken = process.env['DISCORD_BOT_TOKEN']
 
   beforeEach(() => {
     mockLogger()
+    mockMessageCache()
+    process.env['DISCORD_BOT_TOKEN'] = 'fake-token-123'
   })
 
   afterEach(() => {
@@ -30,9 +33,111 @@ describe('DiscordChatProvider', () => {
   })
 
   test('constructor succeeds with a non-empty token and exposes name="discord"', async () => {
-    process.env['DISCORD_BOT_TOKEN'] = 'fake-token-123'
     const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
     const provider = new DiscordChatProvider()
     expect(provider.name).toBe('discord')
+  })
+
+  test('registerCommand routes a matching /help text through the command handler', async () => {
+    const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+    const provider = new DiscordChatProvider()
+
+    const captured: IncomingMessage[] = []
+    provider.registerCommand('help', (msg): Promise<void> => {
+      captured.push(msg)
+      return Promise.resolve()
+    })
+
+    const fakeMessage = {
+      id: 'm1',
+      author: { id: 'u1', username: 'alice', bot: false },
+      content: '<@bot_id> /help',
+      channel: {
+        id: 'c1',
+        type: 0,
+        send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+          Promise.resolve({ id: 'out1', edit: (): Promise<void> => Promise.resolve() }),
+        sendTyping: (): Promise<void> => Promise.resolve(),
+      },
+      mentions: { has: (id: string): boolean => id === 'bot_id' },
+      reference: null,
+      type: 0,
+    }
+    await provider.testDispatchMessage(fakeMessage, 'bot_id', 'admin_id')
+
+    expect(captured).toHaveLength(1)
+    expect(captured[0]!.text).toBe('/help')
+  })
+
+  test('onMessage receives non-command messages after mapping', async () => {
+    const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+    const provider = new DiscordChatProvider()
+
+    const seen: IncomingMessage[] = []
+    provider.onMessage((msg): Promise<void> => {
+      seen.push(msg)
+      return Promise.resolve()
+    })
+
+    const fakeMessage = {
+      id: 'm2',
+      author: { id: 'u2', username: 'bob', bot: false },
+      content: '<@bot_id> what is the weather',
+      channel: {
+        id: 'c2',
+        type: 0,
+        send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+          Promise.resolve({ id: 'out2', edit: (): Promise<void> => Promise.resolve() }),
+        sendTyping: (): Promise<void> => Promise.resolve(),
+      },
+      mentions: { has: (id: string): boolean => id === 'bot_id' },
+      reference: null,
+      type: 0,
+    }
+    await provider.testDispatchMessage(fakeMessage, 'bot_id', 'admin_id')
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0]!.text).toBe('what is the weather')
+  })
+
+  test('bot-authored messages are ignored', async () => {
+    const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+    const provider = new DiscordChatProvider()
+    const seen: IncomingMessage[] = []
+    provider.onMessage((msg): Promise<void> => {
+      seen.push(msg)
+      return Promise.resolve()
+    })
+    const fakeMessage = {
+      id: 'm3',
+      author: { id: 'bot_id', username: 'bot', bot: true },
+      content: '<@bot_id> nothing',
+      channel: {
+        id: 'c3',
+        type: 0,
+        send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+          Promise.resolve({ id: 'out3', edit: (): Promise<void> => Promise.resolve() }),
+        sendTyping: (): Promise<void> => Promise.resolve(),
+      },
+      mentions: { has: (): boolean => true },
+      reference: null,
+      type: 0,
+    }
+    await provider.testDispatchMessage(fakeMessage, 'bot_id', 'admin_id')
+    expect(seen).toHaveLength(0)
+  })
+
+  test('stop() calls client.destroy when a client exists', async () => {
+    const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+    const provider = new DiscordChatProvider()
+    let destroyed = false
+    provider.testSetClient({
+      destroy: (): Promise<void> => {
+        destroyed = true
+        return Promise.resolve()
+      },
+    })
+    await provider.stop()
+    expect(destroyed).toBe(true)
   })
 })

--- a/tests/chat/discord/index.test.ts
+++ b/tests/chat/discord/index.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
+import type { ButtonInteractionLike } from '../../../src/chat/discord/buttons.js'
+import type { DiscordClientFactory } from '../../../src/chat/discord/index.js'
 import type { IncomingMessage } from '../../../src/chat/types.js'
-import { mockLogger, mockMessageCache } from '../../utils/test-helpers.js'
+import { mockLogger, mockMessageCache, setupTestDb } from '../../utils/test-helpers.js'
 
 describe('DiscordChatProvider', () => {
   const originalToken = process.env['DISCORD_BOT_TOKEN']
@@ -212,5 +214,507 @@ describe('DiscordChatProvider', () => {
 
     const result = await provider.resolveUserId('@alice', { contextId: 'chan-7', contextType: 'group' })
     expect(result).toBe('u-9')
+  })
+
+  describe('defaultClientFactory', () => {
+    test('creates a discord.js Client instance with the required interface', async () => {
+      const { defaultClientFactory } = await import('../../../src/chat/discord/index.js')
+      const client = defaultClientFactory()
+      expect(typeof client.on).toBe('function')
+      expect(typeof client.once).toBe('function')
+      expect(typeof client.login).toBe('function')
+      expect(typeof client.destroy).toBe('function')
+      // Clean up the client to avoid open handles
+      await client.destroy().catch(() => undefined)
+    })
+  })
+
+  describe('start()', () => {
+    test('resolves when ClientReady fires after login', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+
+      const readyListeners: Array<(arg: { user: { id: string; username: string } }) => void> = []
+
+      const fakeClient = {
+        destroy: (): Promise<void> => Promise.resolve(),
+        user: null,
+        on: (_event: string, _listener: (...args: unknown[]) => void): void => undefined,
+        once: (event: string, listener: (...args: unknown[]) => void): void => {
+          if (event === 'ready') readyListeners.push(listener as (typeof readyListeners)[0])
+        },
+        login: (_token: string): Promise<string> => Promise.resolve('fake-token-123'),
+      }
+
+      const factory: DiscordClientFactory = () => fakeClient
+      const provider = new DiscordChatProvider(factory)
+      const startPromise = provider.start()
+
+      await Promise.resolve()
+      readyListeners[0]!({ user: { id: 'bot-42', username: 'testbot' } })
+
+      await startPromise
+    })
+
+    test('registers messageCreate, interactionCreate, and error listeners', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+
+      const registeredEvents: string[] = []
+      const readyListeners: Array<(arg: { user: { id: string; username: string } }) => void> = []
+
+      const fakeClient = {
+        destroy: (): Promise<void> => Promise.resolve(),
+        user: null,
+        on: (event: string, _listener: (...args: unknown[]) => void): void => {
+          registeredEvents.push(event)
+        },
+        once: (event: string, listener: (...args: unknown[]) => void): void => {
+          if (event === 'ready') readyListeners.push(listener as (typeof readyListeners)[0])
+        },
+        login: (_token: string): Promise<string> => Promise.resolve('fake-token-123'),
+      }
+
+      const factory: DiscordClientFactory = () => fakeClient
+      const provider = new DiscordChatProvider(factory)
+      const startPromise = provider.start()
+
+      await Promise.resolve()
+      readyListeners[0]!({ user: { id: 'bot-42', username: 'testbot' } })
+      await startPromise
+
+      expect(registeredEvents).toContain('messageCreate')
+      expect(registeredEvents).toContain('interactionCreate')
+      expect(registeredEvents).toContain('error')
+    })
+
+    test('dispatches incoming DM message via messageCreate listener', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+
+      const messageListeners: Array<(...args: unknown[]) => void> = []
+      const readyListeners: Array<(arg: { user: { id: string; username: string } }) => void> = []
+
+      const fakeClient = {
+        destroy: (): Promise<void> => Promise.resolve(),
+        user: { id: 'bot-42', username: 'testbot' },
+        on: (event: string, listener: (...args: unknown[]) => void): void => {
+          if (event === 'messageCreate') messageListeners.push(listener)
+        },
+        once: (event: string, listener: (...args: unknown[]) => void): void => {
+          if (event === 'ready') readyListeners.push(listener as (typeof readyListeners)[0])
+        },
+        login: (_token: string): Promise<string> => Promise.resolve('fake-token-123'),
+      }
+
+      const factory: DiscordClientFactory = () => fakeClient
+      const provider = new DiscordChatProvider(factory)
+
+      let resolveReceived!: (msg: IncomingMessage) => void
+      const received = new Promise<IncomingMessage>((res) => {
+        resolveReceived = res
+      })
+      provider.onMessage((msg): Promise<void> => {
+        resolveReceived(msg)
+        return Promise.resolve()
+      })
+
+      const startPromise = provider.start()
+      await Promise.resolve()
+      readyListeners[0]!({ user: { id: 'bot-42', username: 'testbot' } })
+      await startPromise
+
+      const fakeMessage = {
+        id: 'msg-dm-1',
+        author: { id: 'u1', username: 'alice', bot: false },
+        content: 'hello from dm',
+        channel: {
+          id: 'dm-chan-1',
+          type: 1,
+          send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+            Promise.resolve({ id: 'out1', edit: (): Promise<void> => Promise.resolve() }),
+          sendTyping: (): Promise<void> => Promise.resolve(),
+        },
+        mentions: { has: (_id: string): boolean => false },
+        reference: null,
+        type: 0,
+      }
+
+      messageListeners[0]!(fakeMessage)
+      const msg = await received
+
+      expect(msg.text).toBe('hello from dm')
+      expect(msg.contextType).toBe('dm')
+      expect(msg.user.id).toBe('u1')
+    })
+
+    test('error listener fires without throwing', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+
+      const errorListeners: Array<(...args: unknown[]) => void> = []
+      const readyListeners: Array<(arg: { user: { id: string; username: string } }) => void> = []
+
+      const fakeClient = {
+        destroy: (): Promise<void> => Promise.resolve(),
+        user: null,
+        on: (event: string, listener: (...args: unknown[]) => void): void => {
+          if (event === 'error') errorListeners.push(listener)
+        },
+        once: (event: string, listener: (...args: unknown[]) => void): void => {
+          if (event === 'ready') readyListeners.push(listener as (typeof readyListeners)[0])
+        },
+        login: (_token: string): Promise<string> => Promise.resolve('fake-token-123'),
+      }
+
+      const factory: DiscordClientFactory = () => fakeClient
+      const provider = new DiscordChatProvider(factory)
+      const startPromise = provider.start()
+      await Promise.resolve()
+      readyListeners[0]!({ user: { id: 'bot-42', username: 'testbot' } })
+      await startPromise
+
+      // Fire the error listener — should not throw
+      expect(() => errorListeners[0]!(new Error('test discord error'))).not.toThrow()
+      // Also exercise the non-Error path
+      expect(() => errorListeners[0]!('string error')).not.toThrow()
+    })
+
+    test('non-button interactionCreate is silently ignored', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+
+      const interactionListeners: Array<(...args: unknown[]) => void> = []
+      const readyListeners: Array<(arg: { user: { id: string; username: string } }) => void> = []
+
+      const fakeClient = {
+        destroy: (): Promise<void> => Promise.resolve(),
+        user: null,
+        on: (event: string, listener: (...args: unknown[]) => void): void => {
+          if (event === 'interactionCreate') interactionListeners.push(listener)
+        },
+        once: (event: string, listener: (...args: unknown[]) => void): void => {
+          if (event === 'ready') readyListeners.push(listener as (typeof readyListeners)[0])
+        },
+        login: (_token: string): Promise<string> => Promise.resolve('fake-token-123'),
+      }
+
+      const factory: DiscordClientFactory = () => fakeClient
+      const provider = new DiscordChatProvider(factory)
+
+      const seen: IncomingMessage[] = []
+      provider.onMessage((msg): Promise<void> => {
+        seen.push(msg)
+        return Promise.resolve()
+      })
+
+      const startPromise = provider.start()
+      await Promise.resolve()
+      readyListeners[0]!({ user: { id: 'bot-42', username: 'testbot' } })
+      await startPromise
+
+      interactionListeners[0]!({ type: 2, componentType: 2 })
+      await Promise.resolve()
+
+      expect(seen).toHaveLength(0)
+    })
+
+    test('button interactionCreate dispatches to message handler via start()', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+
+      const interactionListeners: Array<(...args: unknown[]) => void> = []
+      const readyListeners: Array<(arg: { user: { id: string; username: string } }) => void> = []
+
+      const fakeClient = {
+        destroy: (): Promise<void> => Promise.resolve(),
+        user: { id: 'bot-42', username: 'testbot' },
+        on: (event: string, listener: (...args: unknown[]) => void): void => {
+          if (event === 'interactionCreate') interactionListeners.push(listener)
+        },
+        once: (event: string, listener: (...args: unknown[]) => void): void => {
+          if (event === 'ready') readyListeners.push(listener as (typeof readyListeners)[0])
+        },
+        login: (_token: string): Promise<string> => Promise.resolve('fake-token-123'),
+      }
+
+      const factory: DiscordClientFactory = () => fakeClient
+      const provider = new DiscordChatProvider(factory)
+
+      let resolveReceived!: (msg: IncomingMessage) => void
+      const received = new Promise<IncomingMessage>((res) => {
+        resolveReceived = res
+      })
+      provider.onMessage((msg): Promise<void> => {
+        resolveReceived(msg)
+        return Promise.resolve()
+      })
+
+      const startPromise = provider.start()
+      await Promise.resolve()
+      readyListeners[0]!({ user: { id: 'bot-42', username: 'testbot' } })
+      await startPromise
+
+      const fakeButtonInteraction = {
+        type: 3,
+        componentType: 2,
+        user: { id: 'u5', username: 'eve' },
+        customId: 'test:btn',
+        channelId: 'u5',
+        channel: {
+          id: 'u5',
+          type: 1,
+          send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+            Promise.resolve({ id: 'm-btn', edit: (): Promise<void> => Promise.resolve() }),
+          sendTyping: (): Promise<void> => Promise.resolve(),
+        },
+        message: { id: 'msg-btn-1' },
+        deferUpdate: (): Promise<void> => Promise.resolve(),
+      }
+
+      interactionListeners[0]!(fakeButtonInteraction)
+      const msg = await received
+
+      expect(msg.text).toBe('test:btn')
+      expect(msg.user.id).toBe('u5')
+    })
+  })
+
+  describe('testDispatchButtonInteraction', () => {
+    test('calls deferUpdate and routes customId to message handler', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+      const provider = new DiscordChatProvider()
+
+      const seen: IncomingMessage[] = []
+      provider.onMessage((msg): Promise<void> => {
+        seen.push(msg)
+        return Promise.resolve()
+      })
+
+      let deferred = false
+      const fakeInteraction: ButtonInteractionLike = {
+        user: { id: 'u1', username: 'alice' },
+        customId: 'test:action',
+        channelId: 'u1',
+        channel: {
+          id: 'u1',
+          type: 1,
+          send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+            Promise.resolve({ id: 'msg-x', edit: (): Promise<void> => Promise.resolve() }),
+          sendTyping: (): Promise<void> => Promise.resolve(),
+        },
+        message: { id: 'original-msg-1' },
+        deferUpdate: (): Promise<void> => {
+          deferred = true
+          return Promise.resolve()
+        },
+      }
+
+      await provider.testDispatchButtonInteraction(fakeInteraction, 'bot-42', 'admin-id')
+
+      expect(deferred).toBe(true)
+      expect(seen).toHaveLength(1)
+      expect(seen[0]!.text).toBe('test:action')
+    })
+
+    test('routes slash-prefixed customId to registered command handler', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+      const provider = new DiscordChatProvider()
+
+      const captured: IncomingMessage[] = []
+      provider.registerCommand('help', (msg): Promise<void> => {
+        captured.push(msg)
+        return Promise.resolve()
+      })
+
+      const fakeInteraction: ButtonInteractionLike = {
+        user: { id: 'u2', username: 'bob' },
+        customId: '/help',
+        channelId: 'u2',
+        channel: {
+          id: 'u2',
+          type: 1,
+          send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+            Promise.resolve({ id: 'msg-y', edit: (): Promise<void> => Promise.resolve() }),
+          sendTyping: (): Promise<void> => Promise.resolve(),
+        },
+        message: { id: 'btn-msg-2' },
+        deferUpdate: (): Promise<void> => Promise.resolve(),
+      }
+
+      await provider.testDispatchButtonInteraction(fakeInteraction, 'bot-42', 'admin-id')
+
+      expect(captured).toHaveLength(1)
+      expect(captured[0]!.text).toBe('/help')
+    })
+
+    test('uses user ID as contextId in DM channels (type=1)', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+      const provider = new DiscordChatProvider()
+
+      const seen: IncomingMessage[] = []
+      provider.onMessage((msg): Promise<void> => {
+        seen.push(msg)
+        return Promise.resolve()
+      })
+
+      const fakeInteraction: ButtonInteractionLike = {
+        user: { id: 'user-77', username: 'carol' },
+        customId: 'some:action',
+        channelId: 'dm-channel-77',
+        channel: {
+          id: 'dm-channel-77',
+          type: 1,
+          send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+            Promise.resolve({ id: 'm1', edit: (): Promise<void> => Promise.resolve() }),
+          sendTyping: (): Promise<void> => Promise.resolve(),
+        },
+        message: { id: 'msg-3' },
+        deferUpdate: (): Promise<void> => Promise.resolve(),
+      }
+
+      await provider.testDispatchButtonInteraction(fakeInteraction, 'bot-42', 'admin-id')
+
+      expect(seen[0]!.contextId).toBe('user-77')
+      expect(seen[0]!.contextType).toBe('dm')
+    })
+
+    test('uses channelId as contextId in guild channels (type=0)', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+      const provider = new DiscordChatProvider()
+
+      const seen: IncomingMessage[] = []
+      provider.onMessage((msg): Promise<void> => {
+        seen.push(msg)
+        return Promise.resolve()
+      })
+
+      const fakeInteraction: ButtonInteractionLike = {
+        user: { id: 'user-88', username: 'dave' },
+        customId: 'some:action',
+        channelId: 'guild-channel-99',
+        channel: {
+          id: 'guild-channel-99',
+          type: 0,
+          send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+            Promise.resolve({ id: 'm2', edit: (): Promise<void> => Promise.resolve() }),
+          sendTyping: (): Promise<void> => Promise.resolve(),
+        },
+        message: { id: 'msg-4' },
+        deferUpdate: (): Promise<void> => Promise.resolve(),
+      }
+
+      await provider.testDispatchButtonInteraction(fakeInteraction, 'bot-42', 'admin-id')
+
+      expect(seen[0]!.contextId).toBe('guild-channel-99')
+      expect(seen[0]!.contextType).toBe('group')
+    })
+
+    test('skips dispatch when channel is null', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+      const provider = new DiscordChatProvider()
+
+      const seen: IncomingMessage[] = []
+      provider.onMessage((msg): Promise<void> => {
+        seen.push(msg)
+        return Promise.resolve()
+      })
+
+      const fakeInteraction: ButtonInteractionLike = {
+        user: { id: 'u3', username: 'eve' },
+        customId: 'some:action',
+        channelId: 'chan-x',
+        channel: null,
+        message: { id: 'msg-5' },
+        deferUpdate: (): Promise<void> => Promise.resolve(),
+      }
+
+      await provider.testDispatchButtonInteraction(fakeInteraction, 'bot-42', 'admin-id')
+
+      expect(seen).toHaveLength(0)
+    })
+
+    test('handles cfg: callback when no active editor (no-op)', async () => {
+      await setupTestDb()
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+      const provider = new DiscordChatProvider()
+
+      let deferred = false
+      const fakeInteraction: ButtonInteractionLike = {
+        user: { id: 'user-cfg', username: 'cfguser' },
+        customId: 'cfg:edit:llm_apikey',
+        channelId: 'user-cfg',
+        channel: {
+          id: 'user-cfg',
+          type: 1,
+          send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+            Promise.resolve({ id: 'msg-cfg', edit: (): Promise<void> => Promise.resolve() }),
+          sendTyping: (): Promise<void> => Promise.resolve(),
+        },
+        message: { id: 'msg-cfg-1' },
+        deferUpdate: (): Promise<void> => {
+          deferred = true
+          return Promise.resolve()
+        },
+      }
+
+      // No active editor, should defer and return without error
+      await provider.testDispatchButtonInteraction(fakeInteraction, 'bot-42', 'admin-id')
+      expect(deferred).toBe(true)
+    })
+
+    test('handles wizard_ callback when no active wizard (no-op)', async () => {
+      await setupTestDb()
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+      const provider = new DiscordChatProvider()
+
+      let deferred = false
+      const fakeInteraction: ButtonInteractionLike = {
+        user: { id: 'user-wiz', username: 'wizuser' },
+        customId: 'wizard_confirm',
+        channelId: 'user-wiz',
+        channel: {
+          id: 'user-wiz',
+          type: 1,
+          send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+            Promise.resolve({ id: 'msg-wiz', edit: (): Promise<void> => Promise.resolve() }),
+          sendTyping: (): Promise<void> => Promise.resolve(),
+        },
+        message: { id: 'msg-wiz-1' },
+        deferUpdate: (): Promise<void> => {
+          deferred = true
+          return Promise.resolve()
+        },
+      }
+
+      // No active wizard, should defer and return without error
+      await provider.testDispatchButtonInteraction(fakeInteraction, 'bot-42', 'admin-id')
+      expect(deferred).toBe(true)
+    })
+
+    test('handles deferUpdate failure gracefully', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+      const provider = new DiscordChatProvider()
+
+      const seen: IncomingMessage[] = []
+      provider.onMessage((msg): Promise<void> => {
+        seen.push(msg)
+        return Promise.resolve()
+      })
+
+      const fakeInteraction: ButtonInteractionLike = {
+        user: { id: 'u-def', username: 'defer-fail' },
+        customId: 'fallback:action',
+        channelId: 'u-def',
+        channel: {
+          id: 'u-def',
+          type: 1,
+          send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+            Promise.resolve({ id: 'msg-def', edit: (): Promise<void> => Promise.resolve() }),
+          sendTyping: (): Promise<void> => Promise.resolve(),
+        },
+        message: { id: 'msg-def-1' },
+        deferUpdate: (): Promise<void> => Promise.reject(new Error('Defer failed')),
+      }
+
+      // Should still route to message handler despite defer failure
+      await provider.testDispatchButtonInteraction(fakeInteraction, 'bot-42', 'admin-id')
+      expect(seen).toHaveLength(1)
+      expect(seen[0]!.text).toBe('fallback:action')
+    })
   })
 })

--- a/tests/chat/discord/index.test.ts
+++ b/tests/chat/discord/index.test.ts
@@ -140,4 +140,77 @@ describe('DiscordChatProvider', () => {
     await provider.stop()
     expect(destroyed).toBe(true)
   })
+
+  test('sendMessage creates a DM channel and sends the markdown', async () => {
+    const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+    const provider = new DiscordChatProvider()
+
+    const sends: { content?: string }[] = []
+    const dmChannel = {
+      id: 'dm-chan-1',
+      send: (arg: { content?: string }): Promise<{ id: string; edit: () => Promise<void> }> => {
+        sends.push(arg)
+        return Promise.resolve({ id: 'msg-x', edit: (): Promise<void> => Promise.resolve() })
+      },
+      sendTyping: (): Promise<void> => Promise.resolve(),
+    }
+    const fakeClient = {
+      destroy: (): Promise<void> => Promise.resolve(),
+      users: {
+        fetch: (id: string): Promise<{ createDM: () => Promise<typeof dmChannel> }> => {
+          expect(id).toBe('user-42')
+          return Promise.resolve({
+            createDM: (): Promise<typeof dmChannel> => Promise.resolve(dmChannel),
+          })
+        },
+      },
+    }
+    provider.testSetClient(fakeClient)
+
+    await provider.sendMessage('user-42', 'hello discord')
+    expect(sends).toHaveLength(1)
+    expect(sends[0]!.content).toBe('hello discord')
+  })
+
+  test('resolveUserId returns snowflake as-is when the input is numeric', async () => {
+    const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+    const provider = new DiscordChatProvider()
+    const result = await provider.resolveUserId('1234567890', { contextId: 'c1', contextType: 'group' })
+    expect(result).toBe('1234567890')
+  })
+
+  test('resolveUserId returns null in DMs (no guild context)', async () => {
+    const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+    const provider = new DiscordChatProvider()
+    const result = await provider.resolveUserId('@alice', { contextId: 'u1', contextType: 'dm' })
+    expect(result).toBeNull()
+  })
+
+  test('resolveUserId searches members in the channel guild for group context', async () => {
+    const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+    const provider = new DiscordChatProvider()
+
+    const fakeGuild = {
+      members: {
+        search: (arg: { query: string; limit: number }): Promise<Map<string, { id: string }>> => {
+          expect(arg.query).toBe('alice')
+          expect(arg.limit).toBe(1)
+          return Promise.resolve(new Map([['u-9', { id: 'u-9' }]]))
+        },
+      },
+    }
+    const fakeClient = {
+      destroy: (): Promise<void> => Promise.resolve(),
+      channels: {
+        cache: new Map([['chan-7', { guildId: 'guild-3' }]]),
+      },
+      guilds: {
+        cache: new Map([['guild-3', fakeGuild]]),
+      },
+    }
+    provider.testSetClient(fakeClient)
+
+    const result = await provider.resolveUserId('@alice', { contextId: 'chan-7', contextType: 'group' })
+    expect(result).toBe('u-9')
+  })
 })

--- a/tests/chat/discord/index.test.ts
+++ b/tests/chat/discord/index.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { mockLogger } from '../../utils/test-helpers.js'
+
+describe('DiscordChatProvider', () => {
+  const originalToken = process.env['DISCORD_BOT_TOKEN']
+
+  beforeEach(() => {
+    mockLogger()
+  })
+
+  afterEach(() => {
+    if (originalToken === undefined) {
+      delete process.env['DISCORD_BOT_TOKEN']
+    } else {
+      process.env['DISCORD_BOT_TOKEN'] = originalToken
+    }
+  })
+
+  test('constructor throws when DISCORD_BOT_TOKEN is missing', async () => {
+    delete process.env['DISCORD_BOT_TOKEN']
+    const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+    expect(() => new DiscordChatProvider()).toThrow('DISCORD_BOT_TOKEN environment variable is required')
+  })
+
+  test('constructor throws when DISCORD_BOT_TOKEN is whitespace only', async () => {
+    process.env['DISCORD_BOT_TOKEN'] = '   '
+    const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+    expect(() => new DiscordChatProvider()).toThrow('DISCORD_BOT_TOKEN environment variable is required')
+  })
+
+  test('constructor succeeds with a non-empty token and exposes name="discord"', async () => {
+    process.env['DISCORD_BOT_TOKEN'] = 'fake-token-123'
+    const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+    const provider = new DiscordChatProvider()
+    expect(provider.name).toBe('discord')
+  })
+})

--- a/tests/chat/discord/index.test.ts
+++ b/tests/chat/discord/index.test.ts
@@ -717,4 +717,111 @@ describe('DiscordChatProvider', () => {
       expect(seen[0]!.text).toBe('fallback:action')
     })
   })
+
+  describe('listener rejection handling', () => {
+    test('messageCreate listener catches and does not rethrow when dispatchMessage rejects', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+
+      const messageListeners: Array<(...args: unknown[]) => void> = []
+      const readyListeners: Array<(arg: { user: { id: string; username: string } }) => void> = []
+
+      const fakeClient = {
+        destroy: (): Promise<void> => Promise.resolve(),
+        user: { id: 'bot-42', username: 'testbot' },
+        on: (event: string, listener: (...args: unknown[]) => void): void => {
+          if (event === 'messageCreate') messageListeners.push(listener)
+        },
+        once: (event: string, listener: (...args: unknown[]) => void): void => {
+          if (event === 'ready') readyListeners.push(listener as (typeof readyListeners)[0])
+        },
+        login: (_token: string): Promise<string> => Promise.resolve('fake-token-123'),
+      }
+
+      const factory: DiscordClientFactory = () => fakeClient
+      const provider = new DiscordChatProvider(factory)
+
+      provider.onMessage((): Promise<void> => Promise.reject(new Error('handler boom')))
+
+      const startPromise = provider.start()
+      await Promise.resolve()
+      readyListeners[0]!({ user: { id: 'bot-42', username: 'testbot' } })
+      await startPromise
+
+      const fakeMessage = {
+        id: 'msg-rej-1',
+        author: { id: 'u1', username: 'alice', bot: false },
+        content: 'hello',
+        channel: {
+          id: 'dm-rej-1',
+          type: 1,
+          send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+            Promise.resolve({ id: 'out-rej', edit: (): Promise<void> => Promise.resolve() }),
+          sendTyping: (): Promise<void> => Promise.resolve(),
+        },
+        mentions: { has: (_id: string): boolean => false },
+        reference: null,
+        type: 0,
+      }
+
+      // Fire the listener — the rejection must be caught inside the listener, not propagated
+      messageListeners[0]!(fakeMessage)
+      // Flush microtasks to let the promise rejection propagate if unhandled
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0)
+      })
+      // No assertion needed: reaching here without an unhandled rejection is the proof
+    })
+
+    test('interactionCreate listener catches and does not rethrow when handleButtonInteraction rejects', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+
+      const interactionListeners: Array<(...args: unknown[]) => void> = []
+      const readyListeners: Array<(arg: { user: { id: string; username: string } }) => void> = []
+
+      const fakeClient = {
+        destroy: (): Promise<void> => Promise.resolve(),
+        user: { id: 'bot-42', username: 'testbot' },
+        on: (event: string, listener: (...args: unknown[]) => void): void => {
+          if (event === 'interactionCreate') interactionListeners.push(listener)
+        },
+        once: (event: string, listener: (...args: unknown[]) => void): void => {
+          if (event === 'ready') readyListeners.push(listener as (typeof readyListeners)[0])
+        },
+        login: (_token: string): Promise<string> => Promise.resolve('fake-token-123'),
+      }
+
+      const factory: DiscordClientFactory = () => fakeClient
+      const provider = new DiscordChatProvider(factory)
+
+      // message handler throws so the full dispatch path rejects
+      provider.onMessage((): Promise<void> => Promise.reject(new Error('interaction boom')))
+
+      const startPromise = provider.start()
+      await Promise.resolve()
+      readyListeners[0]!({ user: { id: 'bot-42', username: 'testbot' } })
+      await startPromise
+
+      const fakeInteraction = {
+        type: 3,
+        componentType: 2,
+        user: { id: 'u-rej', username: 'rej-user' },
+        customId: 'some:action',
+        channelId: 'u-rej',
+        channel: {
+          id: 'u-rej',
+          type: 1,
+          send: (): Promise<{ id: string; edit: () => Promise<void> }> =>
+            Promise.resolve({ id: 'm-rej', edit: (): Promise<void> => Promise.resolve() }),
+          sendTyping: (): Promise<void> => Promise.resolve(),
+        },
+        message: { id: 'msg-rej-btn' },
+        deferUpdate: (): Promise<void> => Promise.resolve(),
+      }
+
+      interactionListeners[0]!(fakeInteraction)
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0)
+      })
+    })
+  })
 })

--- a/tests/chat/discord/map-message.test.ts
+++ b/tests/chat/discord/map-message.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { type DiscordMessageLike, mapDiscordMessage } from '../../../src/chat/discord/map-message.js'
+import { mockLogger } from '../../utils/test-helpers.js'
+
+describe('mapDiscordMessage', () => {
+  beforeEach(() => {
+    mockLogger()
+  })
+
+  const botId = 'bot-snowflake'
+  const adminId = 'admin-snowflake'
+
+  function makeMsg(overrides: Partial<DiscordMessageLike> = {}): DiscordMessageLike {
+    return {
+      id: 'msg-1',
+      author: { id: 'user-1', username: 'alice', bot: false },
+      content: 'hello',
+      channel: { id: 'chan-1', type: 0 },
+      mentions: { has: (id) => id === botId },
+      reference: null,
+      type: 0,
+      ...overrides,
+    }
+  }
+
+  test('maps a guild message that @mentions the bot', () => {
+    const msg = makeMsg({ content: `<@${botId}> /help` })
+    const result = mapDiscordMessage(msg, botId, adminId)
+    expect(result).not.toBeNull()
+    expect(result!.user.id).toBe('user-1')
+    expect(result!.user.username).toBe('alice')
+    expect(result!.user.isAdmin).toBe(false)
+    expect(result!.contextType).toBe('group')
+    expect(result!.contextId).toBe('chan-1')
+    expect(result!.isMentioned).toBe(true)
+    expect(result!.text).toBe('/help')
+    expect(result!.messageId).toBe('msg-1')
+  })
+
+  test('maps a DM message', () => {
+    const msg = makeMsg({
+      channel: { id: 'dm-1', type: 1 },
+      content: 'what is the status?',
+      mentions: { has: () => false },
+    })
+    const result = mapDiscordMessage(msg, botId, adminId)
+    expect(result).not.toBeNull()
+    expect(result!.contextType).toBe('dm')
+    expect(result!.contextId).toBe('user-1')
+    expect(result!.isMentioned).toBe(true)
+    expect(result!.text).toBe('what is the status?')
+  })
+
+  test('marks admin users via ADMIN_USER_ID equality', () => {
+    const msg = makeMsg({
+      author: { id: adminId, username: 'admin', bot: false },
+      content: `<@${botId}> hello`,
+    })
+    const result = mapDiscordMessage(msg, botId, adminId)
+    expect(result).not.toBeNull()
+    expect(result!.user.isAdmin).toBe(true)
+  })
+
+  test('returns null for bot-authored messages', () => {
+    const msg = makeMsg({ author: { id: 'some-bot', username: 'other', bot: true } })
+    expect(mapDiscordMessage(msg, botId, adminId)).toBeNull()
+  })
+
+  test('returns null for unsupported MessageType variants', () => {
+    const msg = makeMsg({ type: 7 })
+    expect(mapDiscordMessage(msg, botId, adminId)).toBeNull()
+  })
+
+  test('returns null for guild message that does not mention the bot', () => {
+    const msg = makeMsg({ content: 'unrelated chatter', mentions: { has: () => false } })
+    expect(mapDiscordMessage(msg, botId, adminId)).toBeNull()
+  })
+
+  test('preserves replyToMessageId from message.reference', () => {
+    const msg = makeMsg({
+      content: `<@${botId}> yep`,
+      reference: { messageId: 'parent-msg-99' },
+      type: 19,
+    })
+    const result = mapDiscordMessage(msg, botId, adminId)
+    expect(result!.replyToMessageId).toBe('parent-msg-99')
+  })
+})

--- a/tests/chat/discord/mention-helpers.test.ts
+++ b/tests/chat/discord/mention-helpers.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test'
+
+import { isBotMentioned, stripBotMention } from '../../../src/chat/discord/mention-helpers.js'
+
+describe('stripBotMention', () => {
+  const botId = '1234567890123456'
+
+  test('strips leading <@botId> mention and trim', () => {
+    expect(stripBotMention(`<@${botId}> hello world`, botId)).toBe('hello world')
+  })
+
+  test('strips leading nickname-style <@!botId> mention', () => {
+    expect(stripBotMention(`<@!${botId}> /help`, botId)).toBe('/help')
+  })
+
+  test('leaves other user mentions intact', () => {
+    expect(stripBotMention(`<@${botId}> hello <@999>`, botId)).toBe('hello <@999>')
+  })
+
+  test('does not strip mid-string bot mentions', () => {
+    expect(stripBotMention(`thanks <@${botId}> for help`, botId)).toBe(`thanks <@${botId}> for help`)
+  })
+
+  test('returns text unchanged when no bot mention present', () => {
+    expect(stripBotMention('plain text', botId)).toBe('plain text')
+  })
+
+  test('handles empty string', () => {
+    expect(stripBotMention('', botId)).toBe('')
+  })
+
+  test('handles mention followed by multiple whitespace', () => {
+    expect(stripBotMention(`<@${botId}>    \t  hello`, botId)).toBe('hello')
+  })
+})
+
+describe('isBotMentioned', () => {
+  const botId = '1234567890123456'
+
+  test('returns true in DMs unconditionally', () => {
+    expect(isBotMentioned('hello there', botId, 'dm')).toBe(true)
+    expect(isBotMentioned('', botId, 'dm')).toBe(true)
+  })
+
+  test('returns true when <@botId> appears in group channel content', () => {
+    expect(isBotMentioned(`<@${botId}> do a thing`, botId, 'group')).toBe(true)
+  })
+
+  test('returns true when <@!botId> (nickname) appears in group content', () => {
+    expect(isBotMentioned(`<@!${botId}> hey`, botId, 'group')).toBe(true)
+  })
+
+  test('returns false in group content that does not mention the bot', () => {
+    expect(isBotMentioned('hello world', botId, 'group')).toBe(false)
+    expect(isBotMentioned('<@9999> hey', botId, 'group')).toBe(false)
+  })
+})

--- a/tests/chat/discord/reply-context.test.ts
+++ b/tests/chat/discord/reply-context.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { buildDiscordReplyContext, type DiscordReplyMessageLike } from '../../../src/chat/discord/reply-context.js'
+import { mockLogger, mockMessageCache } from '../../utils/test-helpers.js'
+
+describe('buildDiscordReplyContext', () => {
+  beforeEach(() => {
+    mockLogger()
+    mockMessageCache()
+  })
+
+  test('returns undefined when message has no reference', async () => {
+    const msg: DiscordReplyMessageLike = {
+      reference: null,
+      channel: { id: 'chan', messages: { fetch: () => Promise.reject(new Error('should not be called')) } },
+    }
+    const result = await buildDiscordReplyContext(msg, 'chan-1')
+    expect(result).toBeUndefined()
+  })
+
+  test('returns a populated ReplyContext when REST fetch succeeds', async () => {
+    const msg: DiscordReplyMessageLike = {
+      reference: { messageId: 'parent-1' },
+      channel: {
+        id: 'chan-1',
+        messages: {
+          fetch: (id) =>
+            id === 'parent-1'
+              ? Promise.resolve({
+                  id: 'parent-1',
+                  author: { id: 'user-9', username: 'bob' },
+                  content: 'the parent text',
+                })
+              : Promise.reject(new Error('404')),
+        },
+      },
+    }
+    const result = await buildDiscordReplyContext(msg, 'chan-1')
+    expect(result).toBeDefined()
+    expect(result!.messageId).toBe('parent-1')
+    expect(result!.authorId).toBe('user-9')
+    expect(result!.authorUsername).toBe('bob')
+    expect(result!.text).toBe('the parent text')
+  })
+
+  test('returns a skeleton ReplyContext when REST fetch throws', async () => {
+    const msg: DiscordReplyMessageLike = {
+      reference: { messageId: 'parent-1' },
+      channel: {
+        id: 'chan-1',
+        messages: { fetch: () => Promise.reject(new Error('404 Unknown Message')) },
+      },
+    }
+    const result = await buildDiscordReplyContext(msg, 'chan-1')
+    expect(result).toBeDefined()
+    expect(result!.messageId).toBe('parent-1')
+    expect(result!.authorId).toBeUndefined()
+    expect(result!.text).toBeUndefined()
+  })
+})

--- a/tests/chat/discord/reply-helpers.test.ts
+++ b/tests/chat/discord/reply-helpers.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { createDiscordReplyFn, type SendableChannel } from '../../../src/chat/discord/reply-helpers.js'
+import { mockLogger } from '../../utils/test-helpers.js'
+
+type SendArg = {
+  content?: string
+  components?: unknown[]
+  reply?: { messageReference: string; failIfNotExists: boolean }
+}
+
+describe('createDiscordReplyFn', () => {
+  beforeEach(() => {
+    mockLogger()
+  })
+
+  function makeChannel(): { sends: SendArg[]; typingCalls: number[]; channel: SendableChannel } {
+    const sends: SendArg[] = []
+    const typingCalls: number[] = []
+    return {
+      sends,
+      typingCalls,
+      channel: {
+        id: 'chan-1',
+        send: (arg: SendArg) => {
+          sends.push(arg)
+          return Promise.resolve({ id: `bot-msg-${String(sends.length)}`, edit: () => Promise.resolve() })
+        },
+        sendTyping: () => {
+          typingCalls.push(Date.now())
+          return Promise.resolve()
+        },
+      },
+    }
+  }
+
+  test('text() sends content via channel.send', async () => {
+    const { channel, sends } = makeChannel()
+    const reply = createDiscordReplyFn({ channel, replyToMessageId: undefined })
+    await reply.text('hello')
+    expect(sends).toHaveLength(1)
+    expect(sends[0]!.content).toBe('hello')
+  })
+
+  test('text() sets reply.messageReference when replyToMessageId is provided', async () => {
+    const { channel, sends } = makeChannel()
+    const reply = createDiscordReplyFn({ channel, replyToMessageId: 'parent-1' })
+    await reply.text('yo')
+    expect(sends[0]!.reply?.messageReference).toBe('parent-1')
+    expect(sends[0]!.reply?.failIfNotExists).toBe(false)
+  })
+
+  test('formatted() chunks long input into multiple sends', async () => {
+    const { channel, sends } = makeChannel()
+    const reply = createDiscordReplyFn({ channel, replyToMessageId: undefined })
+    await reply.formatted('x'.repeat(4500))
+    expect(sends.length).toBeGreaterThanOrEqual(3)
+    for (const s of sends) {
+      expect((s.content ?? '').length).toBeLessThanOrEqual(2000)
+    }
+  })
+
+  test('typing() calls channel.sendTyping', () => {
+    const { channel, typingCalls } = makeChannel()
+    const reply = createDiscordReplyFn({ channel, replyToMessageId: undefined })
+    reply.typing()
+    expect(typingCalls.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test('file() throws a clear deferral error', async () => {
+    const { channel } = makeChannel()
+    const reply = createDiscordReplyFn({ channel, replyToMessageId: undefined })
+    await expect(reply.file({ content: Buffer.from('data'), filename: 'x.txt' })).rejects.toThrow(
+      /Discord file send not implemented/,
+    )
+  })
+
+  test('redactMessage() edits the last bot-authored message', async () => {
+    const { channel } = makeChannel()
+    const reply = createDiscordReplyFn({ channel, replyToMessageId: undefined })
+    await reply.text('first reply')
+    await expect(reply.redactMessage!('[redacted]')).resolves.toBeUndefined()
+  })
+
+  test('buttons() builds action rows and sends', async () => {
+    const { channel, sends } = makeChannel()
+    const reply = createDiscordReplyFn({ channel, replyToMessageId: undefined })
+    await reply.buttons('choose', {
+      buttons: [
+        { text: 'Yes', callbackData: 'cb:y', style: 'primary' },
+        { text: 'No', callbackData: 'cb:n', style: 'danger' },
+      ],
+    })
+    expect(sends).toHaveLength(1)
+    expect(sends[0]!.content).toBe('choose')
+    expect(Array.isArray(sends[0]!.components)).toBe(true)
+    expect((sends[0]!.components ?? []).length).toBe(1)
+  })
+})

--- a/tests/chat/discord/typing-indicator.test.ts
+++ b/tests/chat/discord/typing-indicator.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { withTypingIndicator } from '../../../src/chat/discord/typing-indicator.js'
+import { mockLogger } from '../../utils/test-helpers.js'
+
+describe('withTypingIndicator', () => {
+  beforeEach(() => {
+    mockLogger()
+  })
+
+  test('calls sendTyping immediately and returns the fn result', async () => {
+    const calls: number[] = []
+    const channel = {
+      sendTyping: (): Promise<void> => {
+        calls.push(Date.now())
+        return Promise.resolve()
+      },
+    }
+    const result = await withTypingIndicator(channel, () => Promise.resolve('computed'))
+    expect(result).toBe('computed')
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test('propagates errors from the inner fn', async () => {
+    const channel = { sendTyping: (): Promise<void> => Promise.resolve() }
+    await expect(
+      withTypingIndicator(channel, () => {
+        throw new Error('inner failure')
+      }),
+    ).rejects.toThrow('inner failure')
+  })
+
+  test('swallows sendTyping errors', async () => {
+    const channel = {
+      sendTyping: (): Promise<void> => Promise.reject(new Error('403 Forbidden')),
+    }
+    const result = await withTypingIndicator(channel, () => Promise.resolve('ok'))
+    expect(result).toBe('ok')
+  })
+})

--- a/tests/chat/mattermost/index.test.ts
+++ b/tests/chat/mattermost/index.test.ts
@@ -23,7 +23,7 @@ describe('MattermostChatProvider', () => {
       })
 
       provider = new MattermostChatProvider()
-      const userId = await provider.resolveUserId('testuser')
+      const userId = await provider.resolveUserId('testuser', { contextId: 'c1', contextType: 'group' })
 
       expect(userId).toBe('user123')
       restoreFetch()
@@ -38,7 +38,7 @@ describe('MattermostChatProvider', () => {
       })
 
       provider = new MattermostChatProvider()
-      const userId = await provider.resolveUserId('@testuser')
+      const userId = await provider.resolveUserId('@testuser', { contextId: 'c1', contextType: 'group' })
 
       expect(userId).toBe('user123')
       restoreFetch()
@@ -50,7 +50,7 @@ describe('MattermostChatProvider', () => {
       })
 
       provider = new MattermostChatProvider()
-      const userId = await provider.resolveUserId('nonexistent')
+      const userId = await provider.resolveUserId('nonexistent', { contextId: 'c1', contextType: 'group' })
 
       expect(userId).toBeNull()
       restoreFetch()

--- a/tests/chat/registry.test.ts
+++ b/tests/chat/registry.test.ts
@@ -1,12 +1,29 @@
-import { beforeEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
 import { createChatProvider } from '../../src/chat/registry.js'
 import { mockLogger } from '../utils/test-helpers.js'
 
 describe('chat registry', () => {
+  const originalDiscordToken = process.env['DISCORD_BOT_TOKEN']
+  const originalTelegramToken = process.env['TELEGRAM_BOT_TOKEN']
+
   beforeEach(() => {
     mockLogger()
-    process.env['DISCORD_BOT_TOKEN'] = 'fake-token-123'
+    process.env['DISCORD_BOT_TOKEN'] = 'fake-discord-token'
+    process.env['TELEGRAM_BOT_TOKEN'] = 'fake-telegram-token'
+  })
+
+  afterEach(() => {
+    if (originalDiscordToken === undefined) {
+      delete process.env['DISCORD_BOT_TOKEN']
+    } else {
+      process.env['DISCORD_BOT_TOKEN'] = originalDiscordToken
+    }
+    if (originalTelegramToken === undefined) {
+      delete process.env['TELEGRAM_BOT_TOKEN']
+    } else {
+      process.env['TELEGRAM_BOT_TOKEN'] = originalTelegramToken
+    }
   })
 
   test('createChatProvider("discord") returns a DiscordChatProvider instance', () => {
@@ -14,7 +31,25 @@ describe('chat registry', () => {
     expect(provider.name).toBe('discord')
   })
 
-  test('createChatProvider("unknown") throws', () => {
-    expect(() => createChatProvider('unknown')).toThrow(/Unknown chat provider/)
+  test('createChatProvider("telegram") returns a TelegramChatProvider instance', () => {
+    const provider = createChatProvider('telegram')
+    expect(provider.name).toBe('telegram')
+  })
+
+  // Failure paths: pass { env: {} } so validation fires before the constructor reads process.env
+  test('createChatProvider throws for unknown provider', () => {
+    expect(() => createChatProvider('unknown', { env: {} })).toThrow(/CHAT_PROVIDER must be/)
+  })
+
+  test('createChatProvider("discord") throws when DISCORD_BOT_TOKEN is missing', () => {
+    expect(() => createChatProvider('discord', { env: {} })).toThrow(/Missing discord env vars/)
+  })
+
+  test('createChatProvider("telegram") throws when TELEGRAM_BOT_TOKEN is missing', () => {
+    expect(() => createChatProvider('telegram', { env: {} })).toThrow(/Missing telegram env vars/)
+  })
+
+  test('createChatProvider("mattermost") throws when required env vars are missing', () => {
+    expect(() => createChatProvider('mattermost', { env: {} })).toThrow(/Missing mattermost env vars/)
   })
 })

--- a/tests/chat/registry.test.ts
+++ b/tests/chat/registry.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { createChatProvider } from '../../src/chat/registry.js'
+import { mockLogger } from '../utils/test-helpers.js'
+
+describe('chat registry', () => {
+  beforeEach(() => {
+    mockLogger()
+    process.env['DISCORD_BOT_TOKEN'] = 'fake-token-123'
+  })
+
+  test('createChatProvider("discord") returns a DiscordChatProvider instance', () => {
+    const provider = createChatProvider('discord')
+    expect(provider.name).toBe('discord')
+  })
+
+  test('createChatProvider("unknown") throws', () => {
+    expect(() => createChatProvider('unknown')).toThrow(/Unknown chat provider/)
+  })
+})

--- a/tests/chat/telegram/index.test.ts
+++ b/tests/chat/telegram/index.test.ts
@@ -67,10 +67,12 @@ describe('TelegramChatProvider', () => {
   })
 
   describe('resolveUserId', () => {
+    const context = { contextId: 'c1', contextType: 'group' as const }
+
     test('returns numeric ID as-is', async () => {
       process.env['TELEGRAM_BOT_TOKEN'] = 'test-token'
       const provider = new TelegramChatProvider()
-      const result = await provider.resolveUserId('123456789')
+      const result = await provider.resolveUserId('123456789', context)
       expect(result).toBe('123456789')
       delete process.env['TELEGRAM_BOT_TOKEN']
     })
@@ -78,7 +80,7 @@ describe('TelegramChatProvider', () => {
     test('returns null for username (cannot resolve via Bot API)', async () => {
       process.env['TELEGRAM_BOT_TOKEN'] = 'test-token'
       const provider = new TelegramChatProvider()
-      const result = await provider.resolveUserId('@username')
+      const result = await provider.resolveUserId('@username', context)
       expect(result).toBeNull()
       delete process.env['TELEGRAM_BOT_TOKEN']
     })

--- a/tests/chat/types.test.ts
+++ b/tests/chat/types.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, test } from 'bun:test'
 
-import type { ChatProvider, ThreadCapabilities } from '../../src/chat/types.js'
+import type { ChatProvider, ContextType, ResolveUserContext, ThreadCapabilities } from '../../src/chat/types.js'
 
 describe('ThreadCapabilities', () => {
   it('should have correct structure', () => {
@@ -15,9 +15,25 @@ describe('ThreadCapabilities', () => {
   })
 })
 
+describe('ResolveUserContext', () => {
+  test('has contextId and contextType', () => {
+    const ctx: ResolveUserContext = { contextId: 'c1', contextType: 'group' }
+    expect(ctx.contextId).toBe('c1')
+    expect(ctx.contextType).toBe('group')
+  })
+
+  test('contextType accepts dm and group', () => {
+    const dm: ContextType = 'dm'
+    const group: ContextType = 'group'
+    const ctxDm: ResolveUserContext = { contextId: 'u1', contextType: dm }
+    const ctxGroup: ResolveUserContext = { contextId: 'g1', contextType: group }
+    expect(ctxDm.contextType).toBe('dm')
+    expect(ctxGroup.contextType).toBe('group')
+  })
+})
+
 describe('ChatProvider interface', () => {
-  test('resolveUserId method exists', async () => {
-    // Mock provider implementing the interface
+  test('resolveUserId accepts username and context', async () => {
     const mockProvider: ChatProvider = {
       name: 'mock',
       threadCapabilities: {
@@ -28,7 +44,7 @@ describe('ChatProvider interface', () => {
       registerCommand: (): void => {},
       onMessage: (): void => {},
       sendMessage: async (): Promise<void> => {},
-      resolveUserId: (username: string): Promise<string | null> => {
+      resolveUserId: (username: string, _context: ResolveUserContext): Promise<string | null> => {
         if (username === 'testuser') return Promise.resolve('user123')
         return Promise.resolve(null)
       },
@@ -36,10 +52,11 @@ describe('ChatProvider interface', () => {
       stop: async (): Promise<void> => {},
     }
 
-    const result = await mockProvider.resolveUserId('testuser')
+    const context: ResolveUserContext = { contextId: 'c1', contextType: 'group' }
+    const result = await mockProvider.resolveUserId('testuser', context)
     expect(result).toBe('user123')
 
-    const notFound = await mockProvider.resolveUserId('nonexistent')
+    const notFound = await mockProvider.resolveUserId('nonexistent', context)
     expect(notFound).toBeNull()
   })
 })

--- a/tests/commands/group.test.ts
+++ b/tests/commands/group.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
 
-import type { ChatProvider, CommandHandler, IncomingMessage } from '../../src/chat/types.js'
+import type { ChatProvider, CommandHandler, IncomingMessage, ResolveUserContext } from '../../src/chat/types.js'
 import { registerGroupCommand } from '../../src/commands/group.js'
 import {
   createAuth,
@@ -25,7 +25,7 @@ describe('group commands', () => {
     commandHandlers = new Map()
     mockChat = createMockChat({
       commandHandlers,
-      resolveUserId: (username: string): Promise<string | null> => {
+      resolveUserId: (username: string, _context): Promise<string | null> => {
         const clean = username.startsWith('@') ? username.slice(1) : username
         if (clean === 'user1') return Promise.resolve('user1_id')
         if (clean === 'user2') return Promise.resolve('user2_id')
@@ -158,6 +158,32 @@ describe('group commands', () => {
       const { listGroupMembers } = await import('../../src/groups.js')
       const members = listGroupMembers('group1')
       expect(members.some((m) => m.user_id === 'unknown_user')).toBe(true)
+    })
+
+    test('passes msg context into ChatProvider.resolveUserId', async () => {
+      let lastResolveContext: ResolveUserContext | null = null
+      const contextHandlers = new Map<string, CommandHandler>()
+      const contextChat = createMockChat({
+        commandHandlers: contextHandlers,
+        resolveUserId: (_username: string, context: ResolveUserContext): Promise<string | null> => {
+          lastResolveContext = context
+          return Promise.resolve('resolved-id')
+        },
+      })
+      registerGroupCommand(contextChat)
+      const handler = contextHandlers.get('group')
+      expect(handler).toBeDefined()
+
+      const { reply } = createMockReply()
+      await handler!(
+        createGroupMessage('admin1', 'adduser @alice', true, 'channel-42'),
+        reply,
+        createAuth('admin1', { isGroupAdmin: true }),
+      )
+
+      expect(lastResolveContext).not.toBeNull()
+      expect(lastResolveContext!.contextId).toBe('channel-42')
+      expect(lastResolveContext!.contextType).toBe('group')
     })
   })
 

--- a/tests/commands/help.test.ts
+++ b/tests/commands/help.test.ts
@@ -114,3 +114,25 @@ describe('help command', () => {
     expect(capturedText).toContain('Admin commands:')
   })
 })
+
+describe('buildHelpText', () => {
+  test('/help on Discord admin appends a /context deferral note', async () => {
+    const { buildHelpText } = await import('../../src/commands/help.js')
+    const discordHelp = buildHelpText('discord', 'dm', { isBotAdmin: true, isGroupAdmin: false })
+
+    expect(discordHelp).toContain('/context')
+    expect(discordHelp).toContain('deferred')
+  })
+
+  test('/help on Discord for non-admin does NOT mention /context', async () => {
+    const { buildHelpText } = await import('../../src/commands/help.js')
+    const discordHelp = buildHelpText('discord', 'dm', { isBotAdmin: false, isGroupAdmin: false })
+    expect(discordHelp).not.toContain('/context')
+  })
+
+  test('/help on telegram does not contain deferral note', async () => {
+    const { buildHelpText } = await import('../../src/commands/help.js')
+    const telegramHelp = buildHelpText('telegram', 'dm', { isBotAdmin: true, isGroupAdmin: false })
+    expect(telegramHelp).not.toContain('deferred')
+  })
+})

--- a/tests/env-validation.test.ts
+++ b/tests/env-validation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test'
+
+import { validateChatProviderEnv } from '../src/env-validation.js'
+
+describe('validateChatProviderEnv', () => {
+  test('accepts telegram with TELEGRAM_BOT_TOKEN', () => {
+    const result = validateChatProviderEnv('telegram', { TELEGRAM_BOT_TOKEN: 'tok' })
+    expect(result.ok).toBe(true)
+  })
+
+  test('accepts mattermost with MATTERMOST_URL and MATTERMOST_BOT_TOKEN', () => {
+    const result = validateChatProviderEnv('mattermost', {
+      MATTERMOST_URL: 'https://mm.example.com',
+      MATTERMOST_BOT_TOKEN: 'tok',
+    })
+    expect(result.ok).toBe(true)
+  })
+
+  test('accepts discord with DISCORD_BOT_TOKEN', () => {
+    const result = validateChatProviderEnv('discord', { DISCORD_BOT_TOKEN: 'tok' })
+    expect(result.ok).toBe(true)
+  })
+
+  test('rejects discord when DISCORD_BOT_TOKEN is missing', () => {
+    const result = validateChatProviderEnv('discord', {})
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.missing).toContain('DISCORD_BOT_TOKEN')
+  })
+
+  test('rejects unknown provider', () => {
+    const result = validateChatProviderEnv('unknown', {})
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toContain('CHAT_PROVIDER must be')
+  })
+})

--- a/tests/llm-orchestrator.test.ts
+++ b/tests/llm-orchestrator.test.ts
@@ -378,6 +378,105 @@ describe('processMessage', () => {
     })
   })
 
+  describe('tool execution failure', () => {
+    // Store callback captured by generateText for testing tool failure feedback
+    let capturedOnToolCallFinish:
+      | ((event: {
+          toolCall: { toolName: string; toolCallId: string; input: unknown }
+          durationMs: number
+          success: boolean
+          error?: unknown
+        }) => void)
+      | undefined
+
+    beforeEach(() => {
+      capturedOnToolCallFinish = undefined
+      // Override generateText to capture the onToolCallFinish callback
+      void mock.module('ai', () => ({
+        ...realAi,
+        generateText: (args: {
+          messages?: unknown[]
+          experimental_onToolCallFinish?: typeof capturedOnToolCallFinish
+        }): Promise<GenerateTextResult> => {
+          capturedOnToolCallFinish = args.experimental_onToolCallFinish
+          return generateTextImpl(args)
+        },
+        stepCountIs: (): (() => boolean) => () => false,
+      }))
+    })
+
+    test('sends immediate user feedback when tool execution fails', async () => {
+      seedConfigForContext('tool-fail-ctx')
+
+      generateTextImpl = (): Promise<GenerateTextResult> =>
+        Promise.resolve({
+          text: 'Done!',
+          toolCalls: [{ toolName: 'create_task', toolCallId: 'call-1', input: { title: 'Test' } }],
+          toolResults: [{ toolName: 'create_task', toolCallId: 'call-1', output: { error: 'failed' } }],
+          steps: [],
+          response: { messages: [{ role: 'assistant' as const, content: 'Done!' }] },
+          usage: {},
+          finishReason: 'stop',
+          warnings: undefined,
+          request: {},
+          providerMetadata: undefined,
+        })
+
+      const { reply, textCalls } = createMockReply()
+
+      await processMessage(reply, 'tool-fail-ctx', null, 'create a task')
+
+      // Simulate a tool failure by calling the captured callback
+      if (capturedOnToolCallFinish !== undefined) {
+        capturedOnToolCallFinish({
+          toolCall: { toolName: 'create_task', toolCallId: 'call-1', input: { title: 'Test' } },
+          durationMs: 100,
+          success: false,
+          error: new Error('Task creation failed'),
+        })
+      }
+
+      // Should have received immediate feedback about the tool failure
+      expect(textCalls.some((call) => call.includes('create_task') && call.includes('failed'))).toBe(true)
+    })
+
+    test('handles non-Error objects in tool failure callback', async () => {
+      seedConfigForContext('tool-fail-string-ctx')
+
+      generateTextImpl = (): Promise<GenerateTextResult> =>
+        Promise.resolve({
+          text: 'Done!',
+          toolCalls: [],
+          toolResults: [],
+          steps: [],
+          response: { messages: [{ role: 'assistant' as const, content: 'Done!' }] },
+          usage: {},
+          finishReason: 'stop',
+          warnings: undefined,
+          request: {},
+          providerMetadata: undefined,
+        })
+
+      const { reply, textCalls } = createMockReply()
+
+      await processMessage(reply, 'tool-fail-string-ctx', null, 'do something')
+
+      // Simulate a tool failure with a string error
+      if (capturedOnToolCallFinish !== undefined) {
+        capturedOnToolCallFinish({
+          toolCall: { toolName: 'search_tasks', toolCallId: 'call-2', input: { q: 'test' } },
+          durationMs: 50,
+          success: false,
+          error: 'String error message',
+        })
+      }
+
+      expect(textCalls.some((call) => call.includes('search_tasks') && call.includes('String error message'))).toBe(
+        true,
+      )
+    })
+  })
+
   describe('success path history', () => {
     test('on success, history is extended with assistant messages', async () => {
       generateTextImpl = (): Promise<GenerateTextResult> =>

--- a/tests/utils/test-helpers.ts
+++ b/tests/utils/test-helpers.ts
@@ -9,6 +9,7 @@ import type {
   CommandHandler,
   IncomingMessage,
   ReplyFn,
+  ResolveUserContext,
 } from '../../src/chat/types.js'
 import { _resetDrizzleDb, _setDrizzleDb } from '../../src/db/drizzle.js'
 import type { Migration } from '../../src/db/migrate.js'
@@ -314,7 +315,7 @@ export function createMockChat(
     /** Callback when a message handler is registered via onMessage */
     onMessageHandler?: (handler: (msg: IncomingMessage, reply: ReplyFn) => Promise<void>) => void
     /** Custom resolveUserId implementation */
-    resolveUserId?: (username: string) => Promise<string | null>
+    resolveUserId?: (username: string, context: ResolveUserContext) => Promise<string | null>
   } = {},
 ): ChatProvider {
   return {
@@ -333,7 +334,7 @@ export function createMockChat(
     sendMessage: options.sendMessage ?? ((): Promise<void> => Promise.resolve()),
     resolveUserId:
       options.resolveUserId ??
-      ((username: string): Promise<string | null> => {
+      ((username: string, _context: ResolveUserContext): Promise<string | null> => {
         const clean = username.startsWith('@') ? username.slice(1) : username
         return Promise.resolve(clean)
       }),

--- a/tests/wizard/index.test.ts
+++ b/tests/wizard/index.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  cancelWizard,
+  createWizard,
+  getNextPrompt,
+  getWizardSession,
+  hasActiveWizard,
+  processWizardMessage,
+  resetWizardSession,
+  validateAndSaveWizardConfig,
+  validateLlmApiKey,
+  validateLlmBaseUrl,
+  validateModelExists,
+} from '../../src/wizard/index.js'
+
+describe('wizard/index exports', () => {
+  test('exports all required functions', () => {
+    // State exports
+    expect(typeof hasActiveWizard).toBe('function')
+    expect(typeof getWizardSession).toBe('function')
+    expect(typeof resetWizardSession).toBe('function')
+
+    // Engine exports
+    expect(typeof processWizardMessage).toBe('function')
+    expect(typeof createWizard).toBe('function')
+    expect(typeof getNextPrompt).toBe('function')
+    expect(typeof cancelWizard).toBe('function')
+
+    // Save exports
+    expect(typeof validateAndSaveWizardConfig).toBe('function')
+
+    // Validation exports
+    expect(typeof validateLlmApiKey).toBe('function')
+    expect(typeof validateLlmBaseUrl).toBe('function')
+    expect(typeof validateModelExists).toBe('function')
+  })
+})


### PR DESCRIPTION
## Summary

- Add a third `ChatProvider` adapter (`discord`) using discord.js v14, supporting DMs and guild-channel @mentions with full `ReplyFn` parity (text, formatted, typing, redactMessage, buttons)
- Extend `ChatProvider.resolveUserId` with a `ResolveUserContext` parameter so Discord can scope member searches per guild while Telegram/Mattermost keep existing behavior
- Add 70+ new tests across 11 test files (2651 total pass, 0 fail)

### New files
- `src/chat/discord/` — 9 modules: provider, mention helpers, message mapper, reply-context, format/chunking, typing indicator, buttons, reply helpers
- `tests/chat/discord/` — 9 corresponding test files
- `src/env-validation.ts` — extracted chat provider env validation

### Modified files
- `src/chat/types.ts` — `ResolveUserContext` type, extended `resolveUserId` signature
- `src/chat/telegram/index.ts`, `src/chat/mattermost/index.ts` — absorb new signature (ignored)
- `src/chat/registry.ts` — register `discord` provider
- `src/commands/group.ts` — thread context through `extractUserId`
- `src/commands/help.ts` — extract `buildHelpText`, append Discord `/context` deferral note
- `CLAUDE.md`, `.env.example`, `knip.jsonc` — documentation and config updates

### Deferred (out of scope per design doc)
- `start()` with live `Client.login` + `Events.MessageCreate`/`InteractionCreate` wiring
- Outgoing file attachments (throws clear error)
- `/context` export on Discord
- Application (slash) commands, reactions, threads, voice, sharding

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — 0 errors
- [x] `bun format:check` — clean
- [x] `bun knip` — clean
- [x] `bun test` — 2651 pass, 0 fail
- [ ] Manual E2E against a real Discord application (requires bot token + test guild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)