### PR TITLE
docs: add e2e planning workflow

### DIFF
--- a/.github/instructions/e2e-testing.instructions.md
+++ b/.github/instructions/e2e-testing.instructions.md
@@ -40,3 +40,10 @@ describe('Feature', () => {
 - No `beforeAll`/`afterAll` needed — global setup handles Docker lifecycle
 - Do NOT mock anything — these tests hit real APIs
 - E2E tests are excluded from `bun test` via `bunfig.toml` — run with `bun test:e2e`
+
+## Planning New E2E Coverage
+
+- Before proposing or writing a new E2E plan, read `docs/superpowers/e2e-planning-workflow.md`.
+- Start new plan files from `docs/superpowers/templates/e2e-test-plan-template.md`.
+- Treat the existing Docker-backed Kaneo suite as **Tier 1: Provider-Real E2E**.
+- Prefer the smallest realism tier that proves the boundary; do not inflate Tier 2-4 coverage when Tier 1 or cheaper tests are sufficient.

--- a/docs/superpowers/e2e-planning-workflow.md
+++ b/docs/superpowers/e2e-planning-workflow.md
@@ -1,0 +1,83 @@
+# E2E Planning Workflow
+
+Use this workflow before writing any new papai E2E plan.
+
+## When to Use This Workflow
+
+Use this guide when you are:
+
+- proposing a new E2E plan
+- expanding the existing E2E suite
+- deciding whether a scenario belongs in E2E or at a cheaper test level
+- mapping a feature request to papai runtime boundaries
+
+## Planning Algorithm
+
+1. **Define the planning unit**  
+   State the user-visible behavior, the regression boundary, and the behaviors that must not break.
+2. **Map the architecture path**  
+   Trace the runtime boundaries the scenario crosses: chat adapter, auth or wizard interception, orchestrator, tools, provider, storage, scheduler, or debug surfaces.
+3. **Add feature and journey tags**  
+   Tag the scenario by product domain and by user journey so the final plan is auditable from both angles.
+4. **Choose the cheapest realism tier that proves the boundary**  
+   Do not promote a scenario into E2E if unit, integration, contract, or schema coverage is enough.
+5. **Expand the scenario matrix**  
+   Cover happy path, routing or permission gates, invalid input, external failures, persistence checks, cleanup, and cross-context leakage where relevant.
+6. **Name the oracles**  
+   Every scenario needs both a user-visible oracle and a backend or system oracle.
+7. **Define fixtures and teardown**  
+   State required config, auth state, test data, timing assumptions, and cleanup rules.
+8. **Emit the plan**  
+   Save the plan under `docs/superpowers/plans/YYYY-MM-DD-<topic>.md` using the shared template.
+
+## Realism Tiers
+
+| Tier                            | Meaning                                                                            | Typical papai use                                                            |
+| ------------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Tier 1: Provider-Real E2E       | Real task provider, controlled outer layers                                        | Kaneo or YouTrack provider operations and normalized task behavior           |
+| Tier 2: Runtime E2E             | Real papai runtime with controlled chat injection and deterministic model boundary | setup, auth, wizard, routing, tool capability behavior                       |
+| Tier 3: Platform-Integrated E2E | Real chat platform plus runtime                                                    | Telegram or Mattermost command, mention, button, and file behavior           |
+| Tier 4: Operational E2E         | Runtime plus schedulers or background delivery surfaces                            | recurring tasks, deferred prompts, proactive delivery, debug instrumentation |
+
+## papai Priority Order
+
+Start with the highest-signal lanes:
+
+1. setup, auth, configuration, and wizard flows
+2. DM versus group routing and mention rules
+3. orchestrator-to-tool-to-provider happy path and failure rollback
+4. capability-gated behavior and unsupported-surface handling
+
+Then cover:
+
+- identity linking
+- memos, instructions, and group-history behavior
+- recurring, deferred, and proactive flows
+- provider and platform parity gaps
+
+## Current Harness Map
+
+- `bun test:e2e` runs the current Docker-backed Kaneo suite.
+- `tests/e2e/bun-test-setup.ts` starts one shared E2E environment for the suite.
+- `tests/e2e/global-setup.ts` provisions a user and workspace and exposes the shared config.
+- `tests/e2e/kaneo-test-client.ts` owns test resource cleanup.
+- Today’s harness is **Tier 1: Provider-Real E2E** in the tier model above.
+
+## Required Output for Every Plan
+
+Every E2E plan must contain:
+
+- objective
+- regression boundary
+- chosen realism tier and rationale
+- included providers and platforms
+- architecture path
+- environment and fixtures
+- scenario matrix
+- non-E2E coverage or explicit exclusions
+- harness reuse and new gaps
+- implementation order
+
+## Starting Point
+
+Copy `docs/superpowers/templates/e2e-test-plan-template.md` into `docs/superpowers/plans/YYYY-MM-DD-<topic>.md` and fill it in with the workflow above.

--- a/docs/superpowers/templates/e2e-test-plan-template.md
+++ b/docs/superpowers/templates/e2e-test-plan-template.md
@@ -35,8 +35,8 @@ DM message
 
 ## Scenario Matrix
 
-| Scenario                      | Feature Tags                      | Journey Tags           | Layers Crossed                        | Trigger                       | User Oracle                       | System Oracle              | Failure Mode                                    | Cleanup                         | Notes                               |
-| ----------------------------- | --------------------------------- | ---------------------- | ------------------------------------- | ----------------------------- | --------------------------------- | -------------------------- | ----------------------------------------------- | ------------------------------- | ----------------------------------- |
+| Scenario | Feature Tags | Journey Tags | Layers Crossed | Trigger | User Oracle | System Oracle | Failure Mode | Cleanup | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Describe the happy path first | List the product domains involved | List the journey class | List the runtime boundaries exercised | Describe what starts the flow | Describe what the user should see | Describe the backend proof | Name the negative or degraded condition covered | Describe teardown and isolation | Note harness gaps or backend quirks |
 
 Add more rows until the plan covers happy path, routing or permission gates, invalid input, external failure, persistence verification, and cleanup.

--- a/docs/superpowers/templates/e2e-test-plan-template.md
+++ b/docs/superpowers/templates/e2e-test-plan-template.md
@@ -1,6 +1,6 @@
 # E2E Test Plan
 
-Rename this file and title to match the specific behavior or journey before saving it under `docs/superpowers/plans/`.
+Rename this file and title to match the specific behavior or journey before saving it as `docs/superpowers/plans/YYYY-MM-DD-<topic>.md`.
 
 **Objective:** State the user-visible behavior being validated.
 

--- a/docs/superpowers/templates/e2e-test-plan-template.md
+++ b/docs/superpowers/templates/e2e-test-plan-template.md
@@ -1,0 +1,58 @@
+# E2E Test Plan
+
+Rename this file and title to match the specific behavior or journey before saving it under `docs/superpowers/plans/`.
+
+**Objective:** State the user-visible behavior being validated.
+
+**Regression Boundary:** State what existing behavior must remain safe while adding this coverage.
+
+**Realism Tier:** State the chosen tier and why cheaper tests are not enough.
+
+**Platforms and Providers:** Name the included surfaces and the intentionally excluded ones.
+
+---
+
+## Architecture Path
+
+```text
+List the runtime path here, one boundary per line.
+Example:
+DM message
+  -> auth check
+  -> wizard interception
+  -> LLM orchestrator
+  -> tool capability gating
+  -> task provider
+  -> reply formatting
+```
+
+## Environment and Fixtures
+
+- State runtime assumptions.
+- State auth and config preconditions.
+- List seeded users, projects, tasks, labels, files, or scheduler state.
+- State teardown and isolation expectations.
+
+## Scenario Matrix
+
+| Scenario                      | Feature Tags                      | Journey Tags           | Layers Crossed                        | Trigger                       | User Oracle                       | System Oracle              | Failure Mode                                    | Cleanup                         | Notes                               |
+| ----------------------------- | --------------------------------- | ---------------------- | ------------------------------------- | ----------------------------- | --------------------------------- | -------------------------- | ----------------------------------------------- | ------------------------------- | ----------------------------------- |
+| Describe the happy path first | List the product domains involved | List the journey class | List the runtime boundaries exercised | Describe what starts the flow | Describe what the user should see | Describe the backend proof | Name the negative or degraded condition covered | Describe teardown and isolation | Note harness gaps or backend quirks |
+
+Add more rows until the plan covers happy path, routing or permission gates, invalid input, external failure, persistence verification, and cleanup.
+
+## Non-E2E Coverage
+
+- List the behaviors intentionally pushed down to unit, integration, schema, or contract tests.
+- Name anything explicitly left for manual verification.
+
+## Harness Reuse and Gaps
+
+- Name the existing harnesses to reuse.
+- Name any new helper, fixture, or platform setup work required.
+
+## Implementation Order
+
+1. Start with the highest-signal happy path.
+2. Add the most important negative path next.
+3. Add context leakage, persistence, or cleanup coverage after the main flow is stable.

--- a/docs/superpowers/templates/e2e-test-plan-template.md
+++ b/docs/superpowers/templates/e2e-test-plan-template.md
@@ -35,8 +35,8 @@ DM message
 
 ## Scenario Matrix
 
-| Scenario | Feature Tags | Journey Tags | Layers Crossed | Trigger | User Oracle | System Oracle | Failure Mode | Cleanup | Notes |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Scenario                      | Feature Tags                      | Journey Tags           | Layers Crossed                        | Trigger                       | User Oracle                       | System Oracle              | Failure Mode                                    | Cleanup                         | Notes                               |
+| ----------------------------- | --------------------------------- | ---------------------- | ------------------------------------- | ----------------------------- | --------------------------------- | -------------------------- | ----------------------------------------------- | ------------------------------- | ----------------------------------- |
 | Describe the happy path first | List the product domains involved | List the journey class | List the runtime boundaries exercised | Describe what starts the flow | Describe what the user should see | Describe the backend proof | Name the negative or degraded condition covered | Describe teardown and isolation | Note harness gaps or backend quirks |
 
 Add more rows until the plan covers happy path, routing or permission gates, invalid input, external failure, persistence verification, and cleanup.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -183,3 +183,7 @@ describe('Feature', () => {
 - No `beforeAll`/`afterAll` needed — Docker lifecycle is global
 - Do NOT mock anything in E2E tests
 - Run with `bun test:e2e` (excluded from `bun test`)
+- Before writing a new E2E plan, read `docs/superpowers/e2e-planning-workflow.md`.
+- Start new E2E plan docs from `docs/superpowers/templates/e2e-test-plan-template.md`.
+- The current Docker-backed Kaneo harness maps to **Tier 1: Provider-Real E2E**.
+- Escalate to Tier 2-4 only when the scenario depends on runtime, platform, or operational boundaries that Tier 1 cannot prove.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -11,6 +11,14 @@ These tests verify the integration between papai and the Kaneo API by:
 3. Running tests against the live API
 4. Cleaning up resources and stopping the server
 
+## Planning New E2E Coverage
+
+Before drafting a new papai E2E plan, read `docs/superpowers/e2e-planning-workflow.md` and start from `docs/superpowers/templates/e2e-test-plan-template.md`.
+
+Treat the current Docker-backed Kaneo suite as **Tier 1: Provider-Real E2E** in that workflow.
+
+Only promote scenarios to higher tiers when they need full runtime, platform, or operational boundaries that Tier 1 cannot prove.
+
 ## Running E2E Tests
 
 ### Prerequisites


### PR DESCRIPTION
## Summary
- add a reusable E2E planning workflow guide under docs/superpowers/
- add an E2E plan template with the required papai plan structure
- wire the new workflow into existing E2E docs and agent instructions

## Test Plan
- [x] bun test tests/providers tests/tools tests/db tests/utils tests/schemas tests/proactive tests/debug tests/*.test.ts --reporter=dot