### PR TITLE
feat: implement deferred prompt delivery targets

### DIFF
--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -1,6 +1,7 @@
 import packageJson from '../package.json' with { type: 'json' }
 import { readChangelogFile as defaultReadChangelogFile } from './changelog-reader.js'
 import type { ChatProvider } from './chat/types.js'
+import { dmTarget } from './chat/types.js'
 import { getDrizzleDb } from './db/drizzle.js'
 import { versionAnnouncements } from './db/schema.js'
 import { logger } from './logger.js'
@@ -31,7 +32,7 @@ function markVersionAnnounced(version: string): boolean {
 
 async function sendAnnouncementToAdmin(adminUserId: string, markdown: string, chat: ChatProvider): Promise<boolean> {
   try {
-    await chat.sendMessage(adminUserId, markdown)
+    await chat.sendMessage(dmTarget(adminUserId), markdown)
     log.debug({ version: VERSION }, 'Announcement sent to admin')
     return true
   } catch (error) {

--- a/src/chat/deferred-target.ts
+++ b/src/chat/deferred-target.ts
@@ -1,0 +1,25 @@
+type ContextType = 'dm' | 'group'
+
+export type DeferredAudience = 'personal' | 'shared'
+
+export type DeferredDeliveryTarget = {
+  contextId: string
+  contextType: ContextType
+  threadId: string | null
+  audience: DeferredAudience
+  mentionUserIds: string[]
+  createdByUserId: string
+  createdByUsername: string | null
+}
+
+export function dmTarget(userId: string): DeferredDeliveryTarget {
+  return {
+    contextId: userId,
+    contextType: 'dm',
+    threadId: null,
+    audience: 'personal',
+    mentionUserIds: [],
+    createdByUserId: userId,
+    createdByUsername: null,
+  }
+}

--- a/src/chat/discord/client-factory.ts
+++ b/src/chat/discord/client-factory.ts
@@ -21,7 +21,7 @@ export type DiscordClientLike = {
       createDM: () => Promise<{ send: (arg: { content: string }) => Promise<unknown> }>
     }>
   }
-  channels?: { cache: { get(id: string): unknown } }
+  channels?: { cache: { get(id: string): unknown }; fetch?: (id: string) => Promise<unknown> }
   guilds?: { cache: { get(id: string): unknown } }
 }
 

--- a/src/chat/discord/index.ts
+++ b/src/chat/discord/index.ts
@@ -37,14 +37,14 @@ export type { DiscordClientFactory, DiscordClientLike, DispatchableMessage }
 export { defaultClientFactory }
 const log = logger.child({ scope: 'chat:discord' })
 type OnMessageHandler = (msg: IncomingMessage, reply: ReplyFn) => Promise<void>
-type SendableChannel = { send: (opts: { content: string }) => Promise<unknown> }
+type SendableChannel = { send: (opts: { content: string }) => Promise<unknown>; isSendable?: () => boolean }
+
 function isSendableChannel(val: unknown): val is SendableChannel {
-  return (
-    typeof val === 'object' &&
-    val !== null &&
-    'send' in val &&
-    typeof (val as Record<string, unknown>)['send'] === 'function'
-  )
+  if (typeof val !== 'object' || val === null) return false
+  const candidate = val as Partial<SendableChannel>
+  if (typeof candidate.send !== 'function') return false
+  if (candidate.isSendable === undefined) return true
+  return candidate.isSendable()
 }
 
 export class DiscordChatProvider implements ChatProvider {
@@ -81,7 +81,6 @@ export class DiscordChatProvider implements ChatProvider {
   onMessage(handler: OnMessageHandler): void {
     this.messageHandler = handler
   }
-
   onInteraction(handler: (interaction: IncomingInteraction, reply: ReplyFn) => Promise<void>): void {
     this.interactionHandler = handler
   }
@@ -110,7 +109,7 @@ export class DiscordChatProvider implements ChatProvider {
     const channel = fetchChannel ? await fetchChannel.call(this.client.channels, target.contextId) : undefined
     if (!isSendableChannel(channel)) {
       log.warn({ channelId: target.contextId }, 'Discord channel not sendable')
-      return
+      throw new Error('Discord channel not sendable')
     }
     const chunks = chunkForDiscord(content, discordTraits.maxMessageLength!)
     await chunks.reduce<Promise<unknown>>(

--- a/src/chat/discord/index.ts
+++ b/src/chat/discord/index.ts
@@ -6,6 +6,7 @@ import type {
   CommandHandler,
   ContextRendered,
   ContextSnapshot,
+  DeferredDeliveryTarget,
   IncomingInteraction,
   IncomingMessage,
   ReplyFn,
@@ -36,6 +37,15 @@ export type { DiscordClientFactory, DiscordClientLike, DispatchableMessage }
 export { defaultClientFactory }
 const log = logger.child({ scope: 'chat:discord' })
 type OnMessageHandler = (msg: IncomingMessage, reply: ReplyFn) => Promise<void>
+type SendableChannel = { send: (opts: { content: string }) => Promise<unknown> }
+function isSendableChannel(val: unknown): val is SendableChannel {
+  return (
+    typeof val === 'object' &&
+    val !== null &&
+    'send' in val &&
+    typeof (val as Record<string, unknown>)['send'] === 'function'
+  )
+}
 
 export class DiscordChatProvider implements ChatProvider {
   readonly name = 'discord'
@@ -76,18 +86,38 @@ export class DiscordChatProvider implements ChatProvider {
     this.interactionHandler = handler
   }
 
-  async sendMessage(userId: string, markdown: string): Promise<void> {
+  async sendMessage(target: DeferredDeliveryTarget, markdown: string): Promise<void> {
     if (this.client === null || this.client.users === undefined) {
       throw new Error('DiscordChatProvider.sendMessage called before start()')
     }
-    const user = await this.client.users.fetch(userId)
-    const dm = await user.createDM()
-    const chunks = chunkForDiscord(markdown, discordTraits.maxMessageLength!)
+    if (target.contextType === 'dm') {
+      const user = await this.client.users.fetch(target.contextId)
+      const dm = await user.createDM()
+      const chunks = chunkForDiscord(markdown, discordTraits.maxMessageLength!)
+      await chunks.reduce<Promise<unknown>>(
+        (prev, chunk) => prev.then(() => dm.send({ content: chunk })),
+        Promise.resolve(null),
+      )
+      log.info({ userId: target.contextId }, 'Discord DM sent')
+      return
+    }
+    let content = markdown
+    if (target.audience === 'personal' && target.mentionUserIds.length > 0) {
+      const mentions = target.mentionUserIds.map((id) => `<@${id}>`).join(' ')
+      content = `${mentions} ${markdown}`
+    }
+    const fetchChannel = this.client.channels?.fetch
+    const channel = fetchChannel ? await fetchChannel.call(this.client.channels, target.contextId) : undefined
+    if (!isSendableChannel(channel)) {
+      log.warn({ channelId: target.contextId }, 'Discord channel not sendable')
+      return
+    }
+    const chunks = chunkForDiscord(content, discordTraits.maxMessageLength!)
     await chunks.reduce<Promise<unknown>>(
-      (prev, chunk) => prev.then(() => dm.send({ content: chunk })),
+      (prev, chunk) => prev.then(() => channel.send({ content: chunk })),
       Promise.resolve(null),
     )
-    log.info({ userId }, 'Discord DM sent')
+    log.info({ channelId: target.contextId }, 'Discord channel message sent')
   }
 
   async resolveUserId(username: string, context: ResolveUserContext): Promise<string | null> {

--- a/src/chat/mattermost/file-helpers.ts
+++ b/src/chat/mattermost/file-helpers.ts
@@ -26,6 +26,35 @@ export async function resolveMattermostUserId(username: string, apiFetch: Matter
   }
 }
 
+export async function buildMattermostMentionPrefix(
+  mentionUserIds: readonly string[],
+  createdByUsername: string | null,
+  apiFetch: MattermostApiFetch,
+): Promise<string> {
+  const usernames = await Promise.all(
+    mentionUserIds.map(async (userId): Promise<string | null> => {
+      try {
+        const data = await apiFetch('GET', `/api/v4/users/${encodeURIComponent(userId)}`, undefined)
+        const parsed = UserMeSchema.safeParse(data)
+        return parsed.success && parsed.data.username !== undefined ? parsed.data.username : null
+      } catch {
+        return null
+      }
+    }),
+  )
+
+  const mentions = usernames.flatMap((username) => (username === null ? [] : [`@${username}`]))
+  if (mentions.length > 0) {
+    return `${mentions.join(' ')} `
+  }
+
+  if (createdByUsername === null) {
+    return ''
+  }
+
+  return `@${createdByUsername} `
+}
+
 export async function fetchMattermostFiles(
   fileIds: string[],
   apiFetch: (method: string, path: string, body: unknown) => Promise<unknown>,

--- a/src/chat/mattermost/index.ts
+++ b/src/chat/mattermost/index.ts
@@ -17,6 +17,7 @@ import { checkChannelAdmin } from './channel-helpers.js'
 import { fetchMattermostChannelInfo, fetchMattermostTeamInfo, type MattermostChannelInfo } from './context-metadata.js'
 import { renderMattermostContext } from './context-renderer.js'
 import {
+  buildMattermostMentionPrefix,
   cacheIncomingPost,
   downloadMattermostFile,
   fetchMattermostFiles,
@@ -80,7 +81,9 @@ export class MattermostChatProvider implements ChatProvider {
       return
     }
     const mention =
-      target.audience === 'personal' && target.createdByUsername !== null ? `@${target.createdByUsername} ` : ''
+      target.audience === 'personal'
+        ? await buildMattermostMentionPrefix(target.mentionUserIds, target.createdByUsername, this.apiFetch.bind(this))
+        : ''
     const post = {
       channel_id: target.contextId,
       message: `${mention}${markdown}`,

--- a/src/chat/mattermost/index.ts
+++ b/src/chat/mattermost/index.ts
@@ -7,6 +7,7 @@ import type {
   ContextRendered,
   ContextSnapshot,
   ContextType,
+  DeferredDeliveryTarget,
   IncomingFile,
   IncomingMessage,
   ReplyFn,
@@ -70,9 +71,22 @@ export class MattermostChatProvider implements ChatProvider {
     this.messageHandler = handler
   }
 
-  async sendMessage(userId: string, markdown: string): Promise<void> {
-    const channelId = await this.getOrCreateDmChannel(userId)
-    await this.apiFetch('POST', '/api/v4/posts', { channel_id: channelId, message: markdown })
+  async sendMessage(target: DeferredDeliveryTarget, markdown: string): Promise<void> {
+    if (target.contextType === 'dm') {
+      if (this.botUserId === null) throw new Error('Bot not started')
+      const dmData = await this.apiFetch('POST', '/api/v4/channels/direct', [this.botUserId, target.contextId])
+      const channelId = ChannelSchema.parse(dmData).id
+      await this.apiFetch('POST', '/api/v4/posts', { channel_id: channelId, message: markdown })
+      return
+    }
+    const mention =
+      target.audience === 'personal' && target.createdByUsername !== null ? `@${target.createdByUsername} ` : ''
+    const post = {
+      channel_id: target.contextId,
+      message: `${mention}${markdown}`,
+      ...(target.threadId === null ? {} : { root_id: target.threadId }),
+    }
+    await this.apiFetch('POST', '/api/v4/posts', post)
   }
 
   async start(): Promise<void> {
@@ -219,8 +233,7 @@ export class MattermostChatProvider implements ChatProvider {
   }
 
   private isBotMentioned(message: string): boolean {
-    if (this.botUsername === null) return false
-    return message.includes(`@${this.botUsername}`)
+    return this.botUsername !== null && message.includes(`@${this.botUsername}`)
   }
 
   private determineThreadId(
@@ -229,12 +242,8 @@ export class MattermostChatProvider implements ChatProvider {
     contextType: ContextType,
     replyToMessageId: string | undefined,
   ): string | undefined {
-    if (post.root_id !== undefined && post.root_id !== '') {
-      return post.root_id
-    }
-    if (isMentioned && contextType === 'group') {
-      return post.id
-    }
+    if (post.root_id !== undefined && post.root_id !== '') return post.root_id
+    if (isMentioned && contextType === 'group') return post.id
     return replyToMessageId
   }
 
@@ -264,20 +273,12 @@ export class MattermostChatProvider implements ChatProvider {
     })
   }
 
-  private async getOrCreateDmChannel(userId: string): Promise<string> {
-    if (this.botUserId === null) throw new Error('Bot not started')
-    const data = await this.apiFetch('POST', '/api/v4/channels/direct', [this.botUserId, userId])
-    return ChannelSchema.parse(data).id
-  }
-
   resolveUserId(username: string, _context: ResolveUserContext): Promise<string | null> {
     return resolveMattermostUserId(username, this.apiFetch.bind(this))
   }
 
   private wsSend(data: unknown): void {
-    if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify(data))
-    }
+    if (this.ws?.readyState === WebSocket.OPEN) this.ws.send(JSON.stringify(data))
   }
 
   private async apiFetch(method: string, path: string, body: unknown): Promise<unknown> {
@@ -287,8 +288,7 @@ export class MattermostChatProvider implements ChatProvider {
       body: body === undefined ? undefined : JSON.stringify(body),
     })
     if (!res.ok) throw new Error(`Mattermost API ${method} ${path} failed: ${res.status}`)
-    const data: unknown = await res.json()
-    return data
+    return res.json() as Promise<unknown>
   }
 
   renderContext(snapshot: ContextSnapshot): ContextRendered {

--- a/src/chat/telegram/index.ts
+++ b/src/chat/telegram/index.ts
@@ -30,6 +30,7 @@ import {
 } from './message-extraction.js'
 import { telegramCapabilities, telegramConfigRequirements, telegramTraits } from './metadata.js'
 import {
+  buildTelegramMentionPrefix,
   checkTelegramAdminStatus,
   createReplyParamsBuilder,
   getTelegramUsername,
@@ -39,10 +40,10 @@ import {
   sendReplacementButtonReply,
   sendReplacementTextReply,
   sendTextReply,
+  shiftTelegramEntity,
   telegramIsBotMentioned,
 } from './reply-helpers.js'
 export { extractReplyContext } from './message-extraction.js'
-
 const log = logger.child({ scope: 'chat:telegram' })
 const ignoreTelegramTypingError = (): null => null
 
@@ -110,16 +111,18 @@ export class TelegramChatProvider implements ChatProvider {
   }
   async sendMessage(target: DeferredDeliveryTarget, markdown: string): Promise<void> {
     const chatId = parseInt(target.contextId, 10)
-    let content = markdown
-    if (target.contextType === 'group' && target.audience === 'personal' && target.createdByUsername !== null) {
-      content = `@${target.createdByUsername} ${markdown}`
+    const mentionPrefix = buildTelegramMentionPrefix(target)
+    const formatted = formatLlmOutput(markdown)
+    const options: Parameters<typeof this.bot.api.sendMessage>[2] = {
+      entities: [
+        ...mentionPrefix.entities,
+        ...formatted.entities.map((entity) => shiftTelegramEntity(entity, mentionPrefix.text.length)),
+      ],
     }
-    const formatted = formatLlmOutput(content)
-    const options: Parameters<typeof this.bot.api.sendMessage>[2] = { entities: formatted.entities }
     if (target.contextType === 'group' && target.threadId !== null) {
       options.message_thread_id = parseInt(target.threadId, 10)
     }
-    await this.bot.api.sendMessage(chatId, formatted.text, options)
+    await this.bot.api.sendMessage(chatId, `${mentionPrefix.text}${formatted.text}`, options)
   }
   start(): Promise<void> {
     this.bot.on('callback_query:data', (ctx) => this.dispatchCallbackQuery(ctx))

--- a/src/chat/telegram/index.ts
+++ b/src/chat/telegram/index.ts
@@ -8,6 +8,7 @@ import type {
   CommandHandler,
   ContextRendered,
   ContextSnapshot,
+  DeferredDeliveryTarget,
   IncomingFile,
   IncomingInteraction,
   IncomingMessage,
@@ -107,9 +108,18 @@ export class TelegramChatProvider implements ChatProvider {
   onInteraction(handler: (interaction: IncomingInteraction, reply: ReplyFn) => Promise<void>): void {
     this.interactionHandler = handler
   }
-  async sendMessage(userId: string, markdown: string): Promise<void> {
-    const formatted = formatLlmOutput(markdown)
-    await this.bot.api.sendMessage(parseInt(userId, 10), formatted.text, { entities: formatted.entities })
+  async sendMessage(target: DeferredDeliveryTarget, markdown: string): Promise<void> {
+    const chatId = parseInt(target.contextId, 10)
+    let content = markdown
+    if (target.contextType === 'group' && target.audience === 'personal' && target.createdByUsername !== null) {
+      content = `@${target.createdByUsername} ${markdown}`
+    }
+    const formatted = formatLlmOutput(content)
+    const options: Parameters<typeof this.bot.api.sendMessage>[2] = { entities: formatted.entities }
+    if (target.contextType === 'group' && target.threadId !== null) {
+      options.message_thread_id = parseInt(target.threadId, 10)
+    }
+    await this.bot.api.sendMessage(chatId, formatted.text, options)
   }
   start(): Promise<void> {
     this.bot.on('callback_query:data', (ctx) => this.dispatchCallbackQuery(ctx))

--- a/src/chat/telegram/reply-helpers.ts
+++ b/src/chat/telegram/reply-helpers.ts
@@ -2,7 +2,7 @@ import type { MessageEntity } from '@grammyjs/types/message.js'
 import type { Context } from 'grammy'
 import { InlineKeyboard } from 'grammy'
 
-import type { ButtonReplyOptions, ReplyOptions } from '../types.js'
+import type { ButtonReplyOptions, DeferredDeliveryTarget, ReplyOptions } from '../types.js'
 import { formatLlmOutput } from './format.js'
 
 type TelegramReplyParameters = { message_id: number } & Partial<{ message_thread_id: number }>
@@ -18,6 +18,94 @@ type ReplacementCallOptions = Partial<{
   entities: ReturnType<typeof formatLlmOutput>['entities']
   reply_markup: InlineKeyboard
 }>
+
+type TelegramEntity = ReturnType<typeof formatLlmOutput>['entities'][number]
+
+type TelegramMentionPrefix = {
+  text: string
+  entities: readonly TelegramEntity[]
+}
+
+type TelegramMentionTarget = {
+  userId: number
+  label: string
+  firstName: string
+}
+
+const parseTelegramUserId = (value: string): number | null => {
+  if (!/^\d+$/.test(value)) {
+    return null
+  }
+
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+const getMentionLabel = (target: DeferredDeliveryTarget, mentionedUserId: string): string => {
+  if (mentionedUserId === target.createdByUserId) {
+    if (target.createdByUsername !== null) {
+      return `@${target.createdByUsername}`
+    }
+    return 'you'
+  }
+
+  return 'user'
+}
+
+const normalizeMentionFirstName = (label: string): string => (label.startsWith('@') ? label.slice(1) : label)
+
+export function buildTelegramMentionPrefix(target: DeferredDeliveryTarget): TelegramMentionPrefix {
+  if (target.contextType !== 'group' || target.audience !== 'personal') {
+    return { text: '', entities: [] }
+  }
+
+  const mentionTargets = target.mentionUserIds.flatMap<TelegramMentionTarget>((mentionedUserId) => {
+    const userId = parseTelegramUserId(mentionedUserId)
+    if (userId === null) {
+      return []
+    }
+
+    const label = getMentionLabel(target, mentionedUserId)
+    return [{ userId, label, firstName: normalizeMentionFirstName(label) }]
+  })
+
+  if (mentionTargets.length === 0) {
+    return { text: '', entities: [] }
+  }
+
+  const text = `${mentionTargets.map((mention) => mention.label).join(' ')} `
+  const mentionData = mentionTargets.reduce<{
+    offset: number
+    entities: readonly TelegramEntity[]
+  }>(
+    (acc, mention) => {
+      const entity: TelegramEntity = {
+        offset: acc.offset,
+        length: mention.label.length,
+        type: 'text_mention',
+        user: {
+          id: mention.userId,
+          is_bot: false,
+          first_name: mention.firstName,
+        },
+      }
+      return {
+        offset: acc.offset + mention.label.length + 1,
+        entities: [...acc.entities, entity],
+      }
+    },
+    { offset: 0, entities: [] },
+  )
+
+  return { text, entities: mentionData.entities }
+}
+
+export function shiftTelegramEntity(entity: TelegramEntity, offset: number): TelegramEntity {
+  return {
+    ...entity,
+    offset: entity.offset + offset,
+  }
+}
 
 const getTelegramMentionEntities = (entities: MessageEntity[] | undefined): MessageEntity[] => {
   if (entities === undefined) {

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -9,6 +9,10 @@ export type ChatUser = {
 /** Context type for messages - DM or group chat. */
 export type ContextType = 'dm' | 'group'
 
+import type { DeferredDeliveryTarget } from './deferred-target.js'
+export type { DeferredAudience, DeferredDeliveryTarget } from './deferred-target.js'
+export { dmTarget } from './deferred-target.js'
+
 /** Context passed to resolveUserId so adapters can scope searches. */
 export type ResolveUserContext = {
   /** Storage key of the conversation where the lookup originated (userId in DMs, channel/group ID in groups). */
@@ -272,8 +276,8 @@ export type ChatProvider = {
   /** Register the catch-all handler for non-command messages. */
   onMessage(handler: (msg: IncomingMessage, reply: ReplyFn) => Promise<void>): void
 
-  /** Send a formatted markdown message to a user by ID (for announcements). */
-  sendMessage(userId: string, markdown: string): Promise<void>
+  /** Send a formatted markdown message to a delivery target (for proactive/announcement sends). */
+  sendMessage(target: DeferredDeliveryTarget, markdown: string): Promise<void>
   /** Render a context snapshot into a platform-native representation. */
   renderContext(snapshot: ContextSnapshot): ContextRendered
 

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -1,6 +1,7 @@
 import pLimit from 'p-limit'
 
 import type { ChatProvider, CommandHandler, IncomingMessage, ReplyFn } from '../chat/types.js'
+import { dmTarget } from '../chat/types.js'
 import { logger } from '../logger.js'
 import {
   provisionAndConfigure as defaultProvisionAndConfigure,
@@ -208,7 +209,7 @@ async function handleAnnounce(chat: ChatProvider, reply: ReplyFn, msg: IncomingM
   const results = await Promise.allSettled(
     users.map((user) =>
       limit(async () => {
-        await chat.sendMessage(user.platform_user_id, message)
+        await chat.sendMessage(dmTarget(user.platform_user_id), message)
         return user.platform_user_id
       }),
     ),

--- a/src/db/deferred-schema.ts
+++ b/src/db/deferred-schema.ts
@@ -1,0 +1,77 @@
+import { sql } from 'drizzle-orm'
+import { index, integer, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+export const scheduledPrompts = sqliteTable(
+  'scheduled_prompts',
+  {
+    id: text('id').primaryKey(),
+    createdByUserId: text('created_by_user_id').notNull(),
+    createdByUsername: text('created_by_username'),
+    deliveryContextId: text('delivery_context_id'),
+    deliveryContextType: text('delivery_context_type'),
+    deliveryThreadId: text('delivery_thread_id'),
+    audience: text('audience').notNull().default('personal'),
+    mentionUserIds: text('mention_user_ids').notNull().default('[]'),
+    prompt: text('prompt').notNull(),
+    fireAt: text('fire_at').notNull(),
+    cronExpression: text('cron_expression'),
+    status: text('status').notNull().default('active'),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    lastExecutedAt: text('last_executed_at'),
+    executionMetadata: text('execution_metadata').notNull().default('{}'),
+  },
+  (table) => [
+    index('idx_scheduled_prompts_creator').on(table.createdByUserId),
+    index('idx_scheduled_prompts_status_fire').on(table.status, table.fireAt),
+  ],
+)
+
+export const alertPrompts = sqliteTable(
+  'alert_prompts',
+  {
+    id: text('id').primaryKey(),
+    createdByUserId: text('created_by_user_id').notNull(),
+    createdByUsername: text('created_by_username'),
+    deliveryContextId: text('delivery_context_id'),
+    deliveryContextType: text('delivery_context_type'),
+    deliveryThreadId: text('delivery_thread_id'),
+    audience: text('audience').notNull().default('personal'),
+    mentionUserIds: text('mention_user_ids').notNull().default('[]'),
+    prompt: text('prompt').notNull(),
+    condition: text('condition').notNull(),
+    status: text('status').notNull().default('active'),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    lastTriggeredAt: text('last_triggered_at'),
+    cooldownMinutes: integer('cooldown_minutes').notNull().default(60),
+    executionMetadata: text('execution_metadata').notNull().default('{}'),
+  },
+  (table) => [
+    index('idx_alert_prompts_creator').on(table.createdByUserId),
+    index('idx_alert_prompts_status').on(table.status),
+  ],
+)
+
+export const taskSnapshots = sqliteTable(
+  'task_snapshots',
+  {
+    userId: text('user_id').notNull(),
+    taskId: text('task_id').notNull(),
+    field: text('field').notNull(),
+    value: text('value').notNull(),
+    capturedAt: text('captured_at')
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.taskId, table.field] }),
+    index('idx_task_snapshots_user').on(table.userId),
+  ],
+)
+
+export type ScheduledPromptRow = typeof scheduledPrompts.$inferSelect
+export type AlertPromptRow = typeof alertPrompts.$inferSelect
+export type TaskSnapshotRow = typeof taskSnapshots.$inferSelect

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -30,6 +30,7 @@ import { migration021WebFetch } from './migrations/021_web_fetch.js'
 import { migration022DropUnusedLastSeenIndex } from './migrations/022_drop_unused_last_seen_index.js'
 import { migration023AddForeignKeys } from './migrations/023_add_foreign_keys.js'
 import { migration024AuthorizedGroups } from './migrations/024_authorized_groups.js'
+import { migration025DeferredPromptDeliveryTargets } from './migrations/025_deferred_prompt_delivery_targets.js'
 
 const getDbPath = (): string => {
   const dbPath = process.env['DB_PATH']
@@ -89,6 +90,7 @@ export const MIGRATIONS: readonly Migration[] = [
   migration022DropUnusedLastSeenIndex,
   migration023AddForeignKeys,
   migration024AuthorizedGroups,
+  migration025DeferredPromptDeliveryTargets,
 ]
 
 export const initDb = (): void => {

--- a/src/db/migrations/025_deferred_prompt_delivery_targets.ts
+++ b/src/db/migrations/025_deferred_prompt_delivery_targets.ts
@@ -1,0 +1,30 @@
+import type { Database } from 'bun:sqlite'
+
+import type { Migration } from '../migrate.js'
+
+export const migration025DeferredPromptDeliveryTargets: Migration = {
+  id: '025_deferred_prompt_delivery_targets',
+  up(db: Database): void {
+    // Rename user_id → created_by_user_id and add delivery columns for scheduled_prompts
+    db.run('ALTER TABLE scheduled_prompts RENAME COLUMN user_id TO created_by_user_id')
+    db.run('ALTER TABLE scheduled_prompts ADD COLUMN created_by_username TEXT')
+    db.run('ALTER TABLE scheduled_prompts ADD COLUMN delivery_context_id TEXT')
+    db.run('ALTER TABLE scheduled_prompts ADD COLUMN delivery_context_type TEXT')
+    db.run('ALTER TABLE scheduled_prompts ADD COLUMN delivery_thread_id TEXT')
+    db.run("ALTER TABLE scheduled_prompts ADD COLUMN audience TEXT NOT NULL DEFAULT 'personal'")
+    db.run("ALTER TABLE scheduled_prompts ADD COLUMN mention_user_ids TEXT NOT NULL DEFAULT '[]'")
+    db.run('DROP INDEX IF EXISTS idx_scheduled_prompts_user')
+    db.run('CREATE INDEX idx_scheduled_prompts_creator ON scheduled_prompts(created_by_user_id)')
+
+    // Same for alert_prompts
+    db.run('ALTER TABLE alert_prompts RENAME COLUMN user_id TO created_by_user_id')
+    db.run('ALTER TABLE alert_prompts ADD COLUMN created_by_username TEXT')
+    db.run('ALTER TABLE alert_prompts ADD COLUMN delivery_context_id TEXT')
+    db.run('ALTER TABLE alert_prompts ADD COLUMN delivery_context_type TEXT')
+    db.run('ALTER TABLE alert_prompts ADD COLUMN delivery_thread_id TEXT')
+    db.run("ALTER TABLE alert_prompts ADD COLUMN audience TEXT NOT NULL DEFAULT 'personal'")
+    db.run("ALTER TABLE alert_prompts ADD COLUMN mention_user_ids TEXT NOT NULL DEFAULT '[]'")
+    db.run('DROP INDEX IF EXISTS idx_alert_prompts_user')
+    db.run('CREATE INDEX idx_alert_prompts_creator ON alert_prompts(created_by_user_id)')
+  },
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -124,65 +124,10 @@ export const recurringTaskOccurrences = sqliteTable(
     index('idx_recurring_occurrences_task').on(table.taskId),
   ],
 )
-export const scheduledPrompts = sqliteTable(
-  'scheduled_prompts',
-  {
-    id: text('id').primaryKey(),
-    userId: text('user_id').notNull(),
-    prompt: text('prompt').notNull(),
-    fireAt: text('fire_at').notNull(),
-    cronExpression: text('cron_expression'),
-    status: text('status').notNull().default('active'),
-    createdAt: text('created_at')
-      .notNull()
-      .default(sql`(datetime('now'))`),
-    lastExecutedAt: text('last_executed_at'),
-    executionMetadata: text('execution_metadata').notNull().default('{}'),
-  },
-  (table) => [
-    index('idx_scheduled_prompts_user').on(table.userId),
-    index('idx_scheduled_prompts_status_fire').on(table.status, table.fireAt),
-  ],
-)
-export const alertPrompts = sqliteTable(
-  'alert_prompts',
-  {
-    id: text('id').primaryKey(),
-    userId: text('user_id').notNull(),
-    prompt: text('prompt').notNull(),
-    condition: text('condition').notNull(),
-    status: text('status').notNull().default('active'),
-    createdAt: text('created_at')
-      .notNull()
-      .default(sql`(datetime('now'))`),
-    lastTriggeredAt: text('last_triggered_at'),
-    cooldownMinutes: integer('cooldown_minutes').notNull().default(60),
-    executionMetadata: text('execution_metadata').notNull().default('{}'),
-  },
-  (table) => [index('idx_alert_prompts_user').on(table.userId), index('idx_alert_prompts_status').on(table.status)],
-)
-export const taskSnapshots = sqliteTable(
-  'task_snapshots',
-  {
-    userId: text('user_id').notNull(),
-    taskId: text('task_id').notNull(),
-    field: text('field').notNull(),
-    value: text('value').notNull(),
-    capturedAt: text('captured_at')
-      .notNull()
-      .default(sql`(datetime('now'))`),
-  },
-  (table) => [
-    primaryKey({ columns: [table.userId, table.taskId, table.field] }),
-    index('idx_task_snapshots_user').on(table.userId),
-  ],
-)
-
 export type RecurringTask = typeof recurringTasks.$inferSelect
 export type RecurringTaskOccurrence = typeof recurringTaskOccurrences.$inferSelect
-export type ScheduledPromptRow = typeof scheduledPrompts.$inferSelect
-export type AlertPromptRow = typeof alertPrompts.$inferSelect
-export type TaskSnapshotRow = typeof taskSnapshots.$inferSelect
+export { scheduledPrompts, alertPrompts, taskSnapshots } from './deferred-schema.js'
+export type { ScheduledPromptRow, AlertPromptRow, TaskSnapshotRow } from './deferred-schema.js'
 export const userInstructions = sqliteTable(
   'user_instructions',
   {

--- a/src/debug/server.ts
+++ b/src/debug/server.ts
@@ -99,9 +99,9 @@ function handleDashboardFile(pathname: string): Response {
   return new Response('Not found', { status: 404 })
 }
 
-export function startDebugServer(adminUserId: string): void {
+export function startDebugServer(adminUserId: string, logLevel = getLogLevel()): void {
   init(adminUserId)
-  logMultistream.add({ stream: logBufferStream, level: getLogLevel() })
+  logMultistream.add({ stream: logBufferStream, level: logLevel })
 
   const port = getPort()
   const hostname = getHostname()
@@ -147,6 +147,14 @@ export function stopDebugServer(): void {
   if (server !== null) {
     void server.stop()
     server = null
+    const streams: unknown = Reflect.get(logMultistream, 'streams')
+    if (Array.isArray(streams)) {
+      const idx = streams.findIndex(
+        (entry: unknown) =>
+          typeof entry === 'object' && entry !== null && Reflect.get(entry, 'stream') === logBufferStream,
+      )
+      if (idx !== -1) streams.splice(idx, 1)
+    }
     log.info('Debug server stopped')
   }
 }

--- a/src/deferred-prompts/alerts.ts
+++ b/src/deferred-prompts/alerts.ts
@@ -1,17 +1,18 @@
 import { and, eq } from 'drizzle-orm'
 
+import { dmTarget } from '../chat/types.js'
 import { getDrizzleDb } from '../db/drizzle.js'
 import { alertPrompts, type AlertPromptRow } from '../db/schema.js'
 import { logger } from '../logger.js'
-import type { Task } from '../providers/types.js'
 import {
   alertConditionSchema,
   DEFAULT_EXECUTION_METADATA,
   parseExecutionMetadata,
   type AlertCondition,
   type AlertPrompt,
+  type DeferredPromptDelivery,
+  type DeferredPromptDeliveryInput,
   type ExecutionMetadata,
-  type LeafCondition,
 } from './types.js'
 
 const log = logger.child({ scope: 'deferred:alerts' })
@@ -20,10 +21,39 @@ const log = logger.child({ scope: 'deferred:alerts' })
 
 const parseStatus = (raw: string): AlertPrompt['status'] => (raw === 'cancelled' ? 'cancelled' : 'active')
 
+function rowToDeliveryTarget(row: AlertPromptRow): DeferredPromptDelivery {
+  if (row.deliveryContextId !== null) {
+    const contextType = row.deliveryContextType === 'group' ? 'group' : 'dm'
+    const audience = row.audience === 'shared' ? 'shared' : 'personal'
+    let mentionUserIds: string[] = []
+    try {
+      const parsed: unknown = JSON.parse(row.mentionUserIds)
+      if (Array.isArray(parsed)) mentionUserIds = parsed.filter((x): x is string => typeof x === 'string')
+    } catch {
+      mentionUserIds = []
+    }
+    return {
+      contextId: row.deliveryContextId,
+      contextType,
+      threadId: row.deliveryThreadId,
+      audience,
+      mentionUserIds,
+      createdByUserId: row.createdByUserId,
+      createdByUsername: row.createdByUsername,
+    }
+  }
+  return {
+    ...dmTarget(row.createdByUserId),
+    createdByUsername: row.createdByUsername,
+  }
+}
+
 const toAlertPrompt = (row: AlertPromptRow): AlertPrompt => ({
   type: 'alert',
   id: row.id,
-  userId: row.userId,
+  createdByUserId: row.createdByUserId,
+  createdByUsername: row.createdByUsername,
+  deliveryTarget: rowToDeliveryTarget(row),
   prompt: row.prompt,
   condition: alertConditionSchema.parse(JSON.parse(row.condition)),
   status: parseStatus(row.status),
@@ -41,15 +71,24 @@ export const createAlertPrompt = (
   condition: AlertCondition,
   cooldownMinutes?: number,
   executionMetadata?: ExecutionMetadata,
+  delivery?: DeferredPromptDeliveryInput,
 ): AlertPrompt => {
   log.debug({ userId, cooldownMinutes }, 'createAlertPrompt called')
   const id = crypto.randomUUID()
   const db = getDrizzleDb()
 
+  const target = delivery ?? dmTarget(userId)
+
   db.insert(alertPrompts)
     .values({
       id,
-      userId,
+      createdByUserId: target.createdByUserId,
+      createdByUsername: target.createdByUsername,
+      deliveryContextId: target.contextType === 'group' ? target.contextId : null,
+      deliveryContextType: target.contextType === 'group' ? 'group' : null,
+      deliveryThreadId: target.threadId,
+      audience: target.audience,
+      mentionUserIds: JSON.stringify(target.mentionUserIds),
       prompt,
       condition: JSON.stringify(condition),
       status: 'active',
@@ -67,7 +106,7 @@ export const createAlertPrompt = (
 export const listAlertPrompts = (userId: string, status?: string): AlertPrompt[] => {
   log.debug({ userId, status }, 'listAlertPrompts called')
   const db = getDrizzleDb()
-  const conditions = [eq(alertPrompts.userId, userId)]
+  const conditions = [eq(alertPrompts.createdByUserId, userId)]
   if (status !== undefined) conditions.push(eq(alertPrompts.status, status))
 
   const rows = db
@@ -85,7 +124,7 @@ export const getAlertPrompt = (id: string, userId: string): AlertPrompt | null =
   const row = db
     .select()
     .from(alertPrompts)
-    .where(and(eq(alertPrompts.id, id), eq(alertPrompts.userId, userId)))
+    .where(and(eq(alertPrompts.id, id), eq(alertPrompts.createdByUserId, userId)))
     .get()
 
   if (row === undefined) {
@@ -110,7 +149,7 @@ export const updateAlertPrompt = (
   const existing = db
     .select()
     .from(alertPrompts)
-    .where(and(eq(alertPrompts.id, id), eq(alertPrompts.userId, userId)))
+    .where(and(eq(alertPrompts.id, id), eq(alertPrompts.createdByUserId, userId)))
     .get()
 
   if (existing === undefined) {
@@ -129,7 +168,7 @@ export const updateAlertPrompt = (
 
   db.update(alertPrompts)
     .set(set)
-    .where(and(eq(alertPrompts.id, id), eq(alertPrompts.userId, userId)))
+    .where(and(eq(alertPrompts.id, id), eq(alertPrompts.createdByUserId, userId)))
     .run()
   log.info({ id, userId }, 'Alert prompt updated')
   return getAlertPrompt(id, userId)
@@ -141,7 +180,7 @@ export const cancelAlertPrompt = (id: string, userId: string): AlertPrompt | nul
   const existing = db
     .select()
     .from(alertPrompts)
-    .where(and(eq(alertPrompts.id, id), eq(alertPrompts.userId, userId)))
+    .where(and(eq(alertPrompts.id, id), eq(alertPrompts.createdByUserId, userId)))
     .get()
 
   if (existing === undefined) {
@@ -151,7 +190,7 @@ export const cancelAlertPrompt = (id: string, userId: string): AlertPrompt | nul
 
   db.update(alertPrompts)
     .set({ status: 'cancelled' })
-    .where(and(eq(alertPrompts.id, id), eq(alertPrompts.userId, userId)))
+    .where(and(eq(alertPrompts.id, id), eq(alertPrompts.createdByUserId, userId)))
     .run()
   log.info({ id, userId }, 'Alert prompt cancelled')
   return getAlertPrompt(id, userId)
@@ -162,7 +201,7 @@ export const updateAlertTriggerTime = (id: string, userId: string, lastTriggered
   const db = getDrizzleDb()
   db.update(alertPrompts)
     .set({ lastTriggeredAt })
-    .where(and(eq(alertPrompts.id, id), eq(alertPrompts.userId, userId)))
+    .where(and(eq(alertPrompts.id, id), eq(alertPrompts.createdByUserId, userId)))
     .run()
   log.info({ id, userId }, 'Alert trigger time updated')
 }
@@ -189,86 +228,4 @@ export const getEligibleAlertPrompts = (): AlertPrompt[] => {
   return eligible.map(toAlertPrompt)
 }
 
-// --- Condition evaluation ---
-
-const getFieldValue = (task: Task, field: string): string | string[] | null | undefined => {
-  switch (field) {
-    case 'task.status':
-      return task.status ?? null
-    case 'task.priority':
-      return task.priority ?? null
-    case 'task.assignee':
-      return task.assignee ?? null
-    case 'task.dueDate':
-      return task.dueDate ?? null
-    case 'task.project':
-      return task.projectId ?? null
-    case 'task.labels':
-      return (task.labels ?? []).map((l) => l.name)
-    default:
-      return undefined
-  }
-}
-
-const evaluateLeaf = (leaf: LeafCondition, task: Task, snapshots: Map<string, string>, now: Date): boolean => {
-  const { field, op, value } = leaf
-  const fieldValue = getFieldValue(task, field)
-
-  switch (op) {
-    case 'eq':
-      return fieldValue === String(value)
-    case 'neq':
-      return fieldValue !== String(value)
-    case 'changed_to': {
-      const prev = snapshots.get(`${task.id}:${field.replace('task.', '')}`)
-      if (prev === undefined) return false
-      return prev !== String(value) && fieldValue === String(value)
-    }
-    case 'overdue': {
-      if (typeof fieldValue !== 'string' || fieldValue === '') return false
-      return new Date(fieldValue) < now
-    }
-    case 'gt': {
-      if (typeof fieldValue !== 'string' || fieldValue === '') return false
-      return new Date(fieldValue) > new Date(String(value))
-    }
-    case 'lt': {
-      if (typeof fieldValue !== 'string' || fieldValue === '') return false
-      return new Date(fieldValue) < new Date(String(value))
-    }
-    case 'contains':
-      return Array.isArray(fieldValue) && fieldValue.includes(String(value))
-    case 'not_contains':
-      return Array.isArray(fieldValue) && !fieldValue.includes(String(value))
-    default:
-      log.warn({ op, field }, 'Unknown operator')
-      return false
-  }
-}
-
-export const evaluateCondition = (
-  condition: AlertCondition,
-  task: Task,
-  snapshots: Map<string, string>,
-  now: Date = new Date(),
-): boolean => {
-  if ('and' in condition) return condition.and.every((c) => evaluateCondition(c, task, snapshots, now))
-  if ('or' in condition) return condition.or.some((c) => evaluateCondition(c, task, snapshots, now))
-  return evaluateLeaf(condition, task, snapshots, now)
-}
-
-// --- Human-readable description ---
-
-/** Sanitize a condition value for safe inclusion in LLM prompts. */
-const sanitizeValue = (value: string | number): string => {
-  const str = String(value)
-  const clean = str.replaceAll(/[\n\r]/g, ' ').slice(0, 200)
-  return `"${clean}"`
-}
-
-export const describeCondition = (condition: AlertCondition): string => {
-  if ('and' in condition) return `(${condition.and.map(describeCondition).join(' AND ')})`
-  if ('or' in condition) return `(${condition.or.map(describeCondition).join(' OR ')})`
-  const { field, op, value } = condition
-  return value === undefined ? `${field} ${op}` : `${field} ${op} ${sanitizeValue(value)}`
-}
+export { evaluateCondition, describeCondition } from './condition-eval.js'

--- a/src/deferred-prompts/condition-eval.ts
+++ b/src/deferred-prompts/condition-eval.ts
@@ -1,0 +1,84 @@
+import { logger } from '../logger.js'
+import type { Task } from '../providers/types.js'
+import type { AlertCondition, LeafCondition } from './types.js'
+
+const log = logger.child({ scope: 'deferred:condition-eval' })
+
+const getFieldValue = (task: Task, field: string): string | string[] | null | undefined => {
+  switch (field) {
+    case 'task.status':
+      return task.status ?? null
+    case 'task.priority':
+      return task.priority ?? null
+    case 'task.assignee':
+      return task.assignee ?? null
+    case 'task.dueDate':
+      return task.dueDate ?? null
+    case 'task.project':
+      return task.projectId ?? null
+    case 'task.labels':
+      return (task.labels ?? []).map((l) => l.name)
+    default:
+      return undefined
+  }
+}
+
+const evaluateLeaf = (leaf: LeafCondition, task: Task, snapshots: Map<string, string>, now: Date): boolean => {
+  const { field, op, value } = leaf
+  const fieldValue = getFieldValue(task, field)
+
+  switch (op) {
+    case 'eq':
+      return fieldValue === String(value)
+    case 'neq':
+      return fieldValue !== String(value)
+    case 'changed_to': {
+      const prev = snapshots.get(`${task.id}:${field.replace('task.', '')}`)
+      if (prev === undefined) return false
+      return prev !== String(value) && fieldValue === String(value)
+    }
+    case 'overdue': {
+      if (typeof fieldValue !== 'string' || fieldValue === '') return false
+      return new Date(fieldValue) < now
+    }
+    case 'gt': {
+      if (typeof fieldValue !== 'string' || fieldValue === '') return false
+      return new Date(fieldValue) > new Date(String(value))
+    }
+    case 'lt': {
+      if (typeof fieldValue !== 'string' || fieldValue === '') return false
+      return new Date(fieldValue) < new Date(String(value))
+    }
+    case 'contains':
+      return Array.isArray(fieldValue) && fieldValue.includes(String(value))
+    case 'not_contains':
+      return Array.isArray(fieldValue) && !fieldValue.includes(String(value))
+    default:
+      log.warn({ op, field }, 'Unknown operator')
+      return false
+  }
+}
+
+export const evaluateCondition = (
+  condition: AlertCondition,
+  task: Task,
+  snapshots: Map<string, string>,
+  now: Date = new Date(),
+): boolean => {
+  if ('and' in condition) return condition.and.every((c) => evaluateCondition(c, task, snapshots, now))
+  if ('or' in condition) return condition.or.some((c) => evaluateCondition(c, task, snapshots, now))
+  return evaluateLeaf(condition, task, snapshots, now)
+}
+
+const sanitizeValue = (value: string | number): string => {
+  const str = String(value)
+  const clean = str.replaceAll(/[\n\r]/g, ' ').slice(0, 200)
+  return `"${clean}"`
+}
+
+export const describeCondition = (condition: AlertCondition): string => {
+  if ('and' in condition) return `(${condition.and.map(describeCondition).join(' AND ')})`
+  if ('or' in condition) return `(${condition.or.map(describeCondition).join(' OR ')})`
+  const { field, op, value } = condition
+  return value === undefined ? `${field} ${op}` : `${field} ${op} ${sanitizeValue(value)}`
+}

--- a/src/deferred-prompts/poller-scheduled.ts
+++ b/src/deferred-prompts/poller-scheduled.ts
@@ -30,7 +30,7 @@ export function mergeExecutionMetadata(prompts: ScheduledPrompt[]): ExecutionMet
 function finalizeRecurring(prompt: ScheduledPrompt, now: string, timezone: string): void {
   const parsed = parseCron(prompt.cronExpression!)
   if (parsed === null) {
-    completeScheduledPrompt(prompt.id, prompt.userId, now)
+    completeScheduledPrompt(prompt.id, prompt.createdByUserId, now)
     log.warn(
       { id: prompt.id, cronExpression: prompt.cronExpression },
       'Invalid cron expression on recurring prompt, completing',
@@ -40,14 +40,17 @@ function finalizeRecurring(prompt: ScheduledPrompt, now: string, timezone: strin
 
   const next = nextCronOccurrence(parsed, new Date(), timezone)
   if (next === null) {
-    completeScheduledPrompt(prompt.id, prompt.userId, now)
-    log.warn({ id: prompt.id, userId: prompt.userId }, 'Could not compute next cron occurrence, completing prompt')
+    completeScheduledPrompt(prompt.id, prompt.createdByUserId, now)
+    log.warn(
+      { id: prompt.id, userId: prompt.createdByUserId },
+      'Could not compute next cron occurrence, completing prompt',
+    )
     return
   }
 
-  advanceScheduledPrompt(prompt.id, prompt.userId, next.toISOString(), now)
+  advanceScheduledPrompt(prompt.id, prompt.createdByUserId, next.toISOString(), now)
   log.info(
-    { id: prompt.id, userId: prompt.userId, nextFireAt: next.toISOString() },
+    { id: prompt.id, userId: prompt.createdByUserId, nextFireAt: next.toISOString() },
     'Recurring scheduled prompt advanced',
   )
 }
@@ -55,8 +58,8 @@ function finalizeRecurring(prompt: ScheduledPrompt, now: string, timezone: strin
 export function finalizeAllPrompts(prompts: ScheduledPrompt[], now: string, timezone: string): void {
   for (const prompt of prompts) {
     if (prompt.cronExpression === null) {
-      completeScheduledPrompt(prompt.id, prompt.userId, now)
-      log.info({ id: prompt.id, userId: prompt.userId }, 'One-shot scheduled prompt completed')
+      completeScheduledPrompt(prompt.id, prompt.createdByUserId, now)
+      log.info({ id: prompt.id, userId: prompt.createdByUserId }, 'One-shot scheduled prompt completed')
       continue
     }
 

--- a/src/deferred-prompts/poller.ts
+++ b/src/deferred-prompts/poller.ts
@@ -36,7 +36,15 @@ function logSettledErrors(results: PromiseSettledResult<void>[], context: string
 
 function deliveryGroupKey(prompt: ScheduledPrompt): string {
   const t = prompt.deliveryTarget
-  return `${prompt.createdByUserId}|${t.contextId}|${t.contextType}|${t.threadId ?? ''}`
+  return [
+    prompt.createdByUserId,
+    t.contextId,
+    t.contextType,
+    t.threadId ?? '',
+    t.audience,
+    t.createdByUsername ?? '',
+    [...t.mentionUserIds].sort().join(','),
+  ].join('|')
 }
 
 function promptToExecCtx(prompt: ScheduledPrompt): DeferredExecutionContext {

--- a/src/deferred-prompts/poller.ts
+++ b/src/deferred-prompts/poller.ts
@@ -1,6 +1,6 @@
 import pLimit from 'p-limit'
 
-import type { ChatProvider } from '../chat/types.js'
+import type { ChatProvider, DeferredDeliveryTarget } from '../chat/types.js'
 import { getConfig } from '../config.js'
 import { emit } from '../debug/event-bus.js'
 import { logger } from '../logger.js'
@@ -9,10 +9,10 @@ import { scheduler } from '../scheduler-instance.js'
 import { describeCondition, evaluateCondition, getEligibleAlertPrompts, updateAlertTriggerTime } from './alerts.js'
 import { alertsNeedFullTasks, enrichTasks, fetchAllTasks } from './fetch-tasks.js'
 import { finalizeAllPrompts, mergeExecutionMetadata } from './poller-scheduled.js'
-import { dispatchExecution, type BuildProviderFn } from './proactive-llm.js'
+import { dispatchExecution, type BuildProviderFn, type DeferredExecutionContext } from './proactive-llm.js'
 import { getScheduledPromptsDue } from './scheduled.js'
 import { getSnapshotsForUser, updateSnapshots } from './snapshots.js'
-import type { ScheduledPrompt } from './types.js'
+import type { AlertPrompt, ScheduledPrompt } from './types.js'
 
 const log = logger.child({ scope: 'deferred:poller' })
 const SCHEDULED_POLL_MS = 60_000
@@ -33,28 +33,52 @@ function logSettledErrors(results: PromiseSettledResult<void>[], context: string
     if (r.status === 'rejected') log.error({ error: String(r.reason) }, context)
   }
 }
-async function executeScheduledPromptsForUser(
-  userId: string,
+
+function deliveryGroupKey(prompt: ScheduledPrompt): string {
+  const t = prompt.deliveryTarget
+  return `${prompt.createdByUserId}|${t.contextId}|${t.contextType}|${t.threadId ?? ''}`
+}
+
+function promptToExecCtx(prompt: ScheduledPrompt): DeferredExecutionContext {
+  return {
+    createdByUserId: prompt.createdByUserId,
+    deliveryTarget: prompt.deliveryTarget,
+  }
+}
+
+function alertToExecCtx(alert: AlertPrompt): DeferredExecutionContext {
+  return {
+    createdByUserId: alert.createdByUserId,
+    deliveryTarget: alert.deliveryTarget,
+  }
+}
+
+async function executeScheduledPromptsForGroup(
+  execCtx: DeferredExecutionContext,
   prompts: ScheduledPrompt[],
   chat: ChatProvider,
   buildProviderFn: BuildProviderFn,
 ): Promise<void> {
-  const timezone = getConfig(userId, 'timezone') ?? 'UTC'
+  const { createdByUserId } = execCtx
+  const timezone = getConfig(createdByUserId, 'timezone') ?? 'UTC'
   const metadata = mergeExecutionMetadata(prompts)
   const mergedPrompt =
     prompts.length === 1 ? prompts[0]!.prompt : prompts.map((p, i) => `${String(i + 1)}. "${p.prompt}"`).join('\n')
   const promptIds = prompts.map((p) => p.id)
 
-  log.debug({ userId, promptCount: prompts.length, promptIds, mode: metadata.mode }, 'Executing scheduled prompts')
+  log.debug(
+    { userId: createdByUserId, promptCount: prompts.length, promptIds, mode: metadata.mode },
+    'Executing scheduled prompts',
+  )
   let response: string
   try {
-    response = await dispatchExecution(userId, 'scheduled', mergedPrompt, metadata, buildProviderFn)
-    await chat.sendMessage(userId, response)
+    response = await dispatchExecution(execCtx, 'scheduled', mergedPrompt, metadata, buildProviderFn)
+    await chat.sendMessage(execCtx.deliveryTarget, response)
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error)
-    log.error({ userId, promptIds, error: errMsg }, 'Scheduled prompt LLM invocation failed')
+    log.error({ userId: createdByUserId, promptIds, error: errMsg }, 'Scheduled prompt LLM invocation failed')
     response = `Failed: ${errMsg}`
-    await chat.sendMessage(userId, `I ran into an error while working on that: ${errMsg}`)
+    await chat.sendMessage(execCtx.deliveryTarget, `I ran into an error while working on that: ${errMsg}`)
   }
 
   finalizeAllPrompts(prompts, new Date().toISOString(), timezone)
@@ -69,12 +93,13 @@ export async function pollScheduledOnce(chat: ChatProvider, buildProviderFn: Bui
 
   if (duePrompts.length === 0) return
 
-  const byUser = new Map<string, ScheduledPrompt[]>()
+  const byGroup = new Map<string, ScheduledPrompt[]>()
   for (const prompt of duePrompts) {
     inFlightPrompts.add(prompt.id)
-    const existing = byUser.get(prompt.userId)
+    const key = deliveryGroupKey(prompt)
+    const existing = byGroup.get(key)
     if (existing === undefined) {
-      byUser.set(prompt.userId, [prompt])
+      byGroup.set(key, [prompt])
     } else {
       existing.push(prompt)
     }
@@ -83,9 +108,10 @@ export async function pollScheduledOnce(chat: ChatProvider, buildProviderFn: Bui
   const limit = pLimit(MAX_CONCURRENT_LLM_CALLS)
   try {
     const results = await Promise.allSettled(
-      [...byUser.entries()].map(([userId, prompts]) =>
-        limit((): Promise<void> => executeScheduledPromptsForUser(userId, prompts, chat, buildProviderFn)),
-      ),
+      [...byGroup.values()].map((prompts) => {
+        const execCtx = promptToExecCtx(prompts[0]!)
+        return limit((): Promise<void> => executeScheduledPromptsForGroup(execCtx, prompts, chat, buildProviderFn))
+      }),
     )
     logSettledErrors(results, 'Error executing scheduled prompts for user')
   } finally {
@@ -96,8 +122,7 @@ export async function pollScheduledOnce(chat: ChatProvider, buildProviderFn: Bui
 }
 
 async function executeSingleAlert(
-  alert: ReturnType<typeof getEligibleAlertPrompts>[number],
-  userId: string,
+  alert: AlertPrompt,
   tasks: Task[],
   snapshots: Map<string, string>,
   chat: ChatProvider,
@@ -111,32 +136,33 @@ async function executeSingleAlert(
   const taskList = matchedTasks.map((t) => `- [${t.title}](${t.url})${formatTaskStatus(t.status)}`).join('\n')
   const matchedTasksSummary = `Alert condition: ${conditionDesc}\n${taskList}`
 
+  const execCtx = alertToExecCtx(alert)
   let response: string
   try {
     response = await dispatchExecution(
-      userId,
+      execCtx,
       'alert',
       alert.prompt,
       alert.executionMetadata,
       buildProviderFn,
       matchedTasksSummary,
     )
-    await chat.sendMessage(userId, response)
+    await chat.sendMessage(alert.deliveryTarget, response)
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error)
-    log.error({ id: alert.id, userId, error: errMsg }, 'Alert prompt LLM invocation failed')
+    log.error({ id: alert.id, userId: alert.createdByUserId, error: errMsg }, 'Alert prompt LLM invocation failed')
     response = `Failed: ${errMsg}`
-    await chat.sendMessage(userId, `Sorry, something went wrong while preparing this update: ${errMsg}`)
+    await chat.sendMessage(alert.deliveryTarget, `Sorry, something went wrong while preparing this update: ${errMsg}`)
   }
 
   const now = new Date().toISOString()
-  updateAlertTriggerTime(alert.id, userId, now)
-  log.info({ id: alert.id, userId, matchedCount: matchedTasks.length }, 'Alert triggered')
+  updateAlertTriggerTime(alert.id, alert.createdByUserId, now)
+  log.info({ id: alert.id, userId: alert.createdByUserId, matchedCount: matchedTasks.length }, 'Alert triggered')
 }
 
 async function executeAlertsForUser(
   userId: string,
-  alerts: ReturnType<typeof getEligibleAlertPrompts>,
+  alerts: AlertPrompt[],
   chat: ChatProvider,
   buildProviderFn: BuildProviderFn,
   evalNow: Date,
@@ -158,9 +184,7 @@ async function executeAlertsForUser(
   const alertLimit = pLimit(MAX_CONCURRENT_LLM_CALLS)
   const alertResults = await Promise.allSettled(
     alerts.map((alert) =>
-      alertLimit(
-        (): Promise<void> => executeSingleAlert(alert, userId, tasks, snapshots, chat, buildProviderFn, evalNow),
-      ),
+      alertLimit((): Promise<void> => executeSingleAlert(alert, tasks, snapshots, chat, buildProviderFn, evalNow)),
     ),
   )
   logSettledErrors(alertResults, 'Error evaluating alert')
@@ -178,11 +202,11 @@ export async function pollAlertsOnce(chat: ChatProvider, buildProviderFn: BuildP
 
   const now = new Date()
 
-  const byUser = new Map<string, typeof eligibleAlerts>()
+  const byUser = new Map<string, AlertPrompt[]>()
   for (const alert of eligibleAlerts) {
-    const existing = byUser.get(alert.userId)
+    const existing = byUser.get(alert.createdByUserId)
     if (existing === undefined) {
-      byUser.set(alert.userId, [alert])
+      byUser.set(alert.createdByUserId, [alert])
     } else {
       existing.push(alert)
     }
@@ -256,3 +280,5 @@ export function getPollerSnapshot(): PollerSnapshot {
     maxConcurrentUsers: MAX_CONCURRENT_USERS,
   }
 }
+
+export type { DeferredDeliveryTarget }

--- a/src/deferred-prompts/poller.ts
+++ b/src/deferred-prompts/poller.ts
@@ -34,6 +34,7 @@ function logSettledErrors(results: PromiseSettledResult<void>[], context: string
 
 function deliveryGroupKey(prompt: ScheduledPrompt): string {
   const t = prompt.deliveryTarget
+  const mentionKey = t.audience === 'shared' ? '' : [...t.mentionUserIds].sort().join(',')
   return [
     prompt.createdByUserId,
     t.contextId,
@@ -41,7 +42,7 @@ function deliveryGroupKey(prompt: ScheduledPrompt): string {
     t.threadId ?? '',
     t.audience,
     t.createdByUsername ?? '',
-    [...t.mentionUserIds].sort().join(','),
+    mentionKey,
   ].join('|')
 }
 

--- a/src/deferred-prompts/poller.ts
+++ b/src/deferred-prompts/poller.ts
@@ -1,6 +1,6 @@
 import pLimit from 'p-limit'
 
-import type { ChatProvider, DeferredDeliveryTarget } from '../chat/types.js'
+import type { ChatProvider } from '../chat/types.js'
 import { getConfig } from '../config.js'
 import { emit } from '../debug/event-bus.js'
 import { logger } from '../logger.js'
@@ -23,10 +23,8 @@ let isRunning = false
 
 // In-flight prompt tracking to prevent multiple executions if poller interval is short or task is slow
 const inFlightPrompts = new Set<string>()
-
 function formatTaskStatus(status: string | undefined): string {
-  if (status === undefined) return ''
-  return ` (${status})`
+  return status === undefined ? '' : ` (${status})`
 }
 function logSettledErrors(results: PromiseSettledResult<void>[], context: string): void {
   for (const r of results) {
@@ -81,14 +79,18 @@ async function executeScheduledPromptsForGroup(
   let response: string
   try {
     response = await dispatchExecution(execCtx, 'scheduled', mergedPrompt, metadata, buildProviderFn)
-    await chat.sendMessage(execCtx.deliveryTarget, response)
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error)
-    log.error({ userId: createdByUserId, promptIds, error: errMsg }, 'Scheduled prompt LLM invocation failed')
-    response = `Failed: ${errMsg}`
+    log.error(
+      { userId: createdByUserId, promptIds, error: errMsg },
+      'Scheduled prompt execution failed before delivery',
+    )
     await chat.sendMessage(execCtx.deliveryTarget, `I ran into an error while working on that: ${errMsg}`)
+    finalizeAllPrompts(prompts, new Date().toISOString(), timezone)
+    return
   }
 
+  await chat.sendMessage(execCtx.deliveryTarget, response)
   finalizeAllPrompts(prompts, new Date().toISOString(), timezone)
 }
 
@@ -155,14 +157,20 @@ async function executeSingleAlert(
       buildProviderFn,
       matchedTasksSummary,
     )
-    await chat.sendMessage(alert.deliveryTarget, response)
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error)
-    log.error({ id: alert.id, userId: alert.createdByUserId, error: errMsg }, 'Alert prompt LLM invocation failed')
-    response = `Failed: ${errMsg}`
+    log.error(
+      { id: alert.id, userId: alert.createdByUserId, error: errMsg },
+      'Alert prompt execution failed before delivery',
+    )
     await chat.sendMessage(alert.deliveryTarget, `Sorry, something went wrong while preparing this update: ${errMsg}`)
+    const now = new Date().toISOString()
+    updateAlertTriggerTime(alert.id, alert.createdByUserId, now)
+    log.info({ id: alert.id, userId: alert.createdByUserId, matchedCount: matchedTasks.length }, 'Alert triggered')
+    return
   }
 
+  await chat.sendMessage(alert.deliveryTarget, response)
   const now = new Date().toISOString()
   updateAlertTriggerTime(alert.id, alert.createdByUserId, now)
   log.info({ id: alert.id, userId: alert.createdByUserId, matchedCount: matchedTasks.length }, 'Alert triggered')
@@ -288,5 +296,3 @@ export function getPollerSnapshot(): PollerSnapshot {
     maxConcurrentUsers: MAX_CONCURRENT_USERS,
   }
 }
-
-export type { DeferredDeliveryTarget }

--- a/src/deferred-prompts/proactive-llm.ts
+++ b/src/deferred-prompts/proactive-llm.ts
@@ -2,6 +2,7 @@ import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { generateText, stepCountIs, type ModelMessage, type ToolSet } from 'ai'
 
 import { getCachedHistory } from '../cache.js'
+import type { DeferredDeliveryTarget } from '../chat/types.js'
 import { getConfig } from '../config.js'
 import { buildMessagesWithMemory, runTrimInBackground, shouldTriggerTrim } from '../conversation.js'
 import { appendHistory } from '../history.js'
@@ -16,12 +17,15 @@ import type { ExecutionMetadata } from './types.js'
 
 const log = logger.child({ scope: 'deferred:proactive-llm' })
 
-// Minimal toolset for lightweight/context modes - just get_current_time
-function makeMinimalTools(userId: string): { get_current_time: ReturnType<typeof makeGetCurrentTimeTool> } {
-  return {
-    get_current_time: makeGetCurrentTimeTool(userId),
-  }
+/** Execution context for a deferred prompt: who created it and where to deliver. */
+export type DeferredExecutionContext = {
+  createdByUserId: string
+  deliveryTarget: DeferredDeliveryTarget
 }
+
+const makeMinimalTools = (userId: string): { get_current_time: ReturnType<typeof makeGetCurrentTimeTool> } => ({
+  get_current_time: makeGetCurrentTimeTool(userId),
+})
 
 export interface ProactiveLlmDeps {
   generateText: typeof generateText
@@ -56,21 +60,31 @@ function getLlmConfig(userId: string): LlmConfig | string {
   return { apiKey, baseURL, mainModel }
 }
 
+const getStorageContextId = (target: DeferredDeliveryTarget): string =>
+  target.contextType === 'group' && target.threadId !== null
+    ? `${target.contextId}:${target.threadId}`
+    : target.contextId
+
 type LlmResult = Awaited<ReturnType<typeof generateText>>
 
-function persistProactiveResults(userId: string, result: LlmResult, history: readonly ModelMessage[]): void {
+function persistProactiveResults(
+  creatorId: string,
+  storageContextId: string,
+  result: LlmResult,
+  history: readonly ModelMessage[],
+): void {
   const newFacts = extractFactsFromSdkResults(result.toolCalls, result.toolResults)
-  for (const fact of newFacts) upsertFact(userId, fact)
+  for (const fact of newFacts) upsertFact(creatorId, fact)
   if (newFacts.length > 0)
-    log.info({ userId, factsExtracted: newFacts.length }, 'Facts persisted from proactive results')
+    log.info({ userId: creatorId, factsExtracted: newFacts.length }, 'Facts persisted from proactive results')
 
   const msgs = result.response.messages
   if (msgs.length > 0) {
-    appendHistory(userId, msgs)
+    appendHistory(storageContextId, msgs)
     const updated = [...history, ...msgs]
-    if (shouldTriggerTrim(updated)) void runTrimInBackground(userId, updated)
+    if (shouldTriggerTrim(updated)) void runTrimInBackground(storageContextId, updated)
   }
-  log.debug({ userId, toolCalls: result.toolCalls?.length }, 'Proactive LLM response received')
+  log.debug({ userId: creatorId, toolCalls: result.toolCalls?.length }, 'Proactive LLM response received')
 }
 
 // --- Minimal system prompt (shared by lightweight and context modes) ---
@@ -100,99 +114,111 @@ const wrapPrompt = (prompt: string): string => `===DEFERRED_TASK===\n${prompt}\n
 // --- Three execution functions ---
 
 async function invokeLightweight(
-  userId: string,
+  execCtx: DeferredExecutionContext,
   type: 'scheduled' | 'alert',
   prompt: string,
   metadata: ExecutionMetadata,
   deps: ProactiveLlmDeps,
 ): Promise<string> {
-  log.debug({ userId, mode: 'lightweight' }, 'invokeLightweight called')
-  const config = getLlmConfig(userId)
+  const { createdByUserId } = execCtx
+  log.debug({ userId: createdByUserId, mode: 'lightweight' }, 'invokeLightweight called')
+  const config = getLlmConfig(createdByUserId)
   if (typeof config === 'string') return config
 
-  const smallModel = getConfig(userId, 'small_model')
+  const smallModel = getConfig(createdByUserId, 'small_model')
   const modelId = smallModel ?? config.mainModel
   const model = deps.buildModel(config, modelId)
   const messages: ModelMessage[] = [...buildMetadataMessages(metadata), { role: 'user', content: wrapPrompt(prompt) }]
 
-  log.debug({ userId, modelId, mode: 'lightweight' }, 'Calling generateText')
+  log.debug({ userId: createdByUserId, modelId, mode: 'lightweight' }, 'Calling generateText')
   const result = await deps.generateText({
     model,
     system: buildMinimalSystemPrompt(type),
     messages,
-    tools: makeMinimalTools(userId),
+    tools: makeMinimalTools(createdByUserId),
     timeout: 1_200_000,
   })
 
   const assistantMessages = result.response.messages
   if (assistantMessages.length > 0) {
-    const history = getCachedHistory(userId)
-    appendHistory(userId, assistantMessages)
-    log.debug({ userId, count: assistantMessages.length }, 'Lightweight response appended to history')
+    const history = getCachedHistory(createdByUserId)
+    appendHistory(createdByUserId, assistantMessages)
+    log.debug({ userId: createdByUserId, count: assistantMessages.length }, 'Lightweight response appended to history')
     const updatedHistory = [...history, ...assistantMessages]
-    if (shouldTriggerTrim(updatedHistory)) void runTrimInBackground(userId, updatedHistory)
+    if (shouldTriggerTrim(updatedHistory)) void runTrimInBackground(createdByUserId, updatedHistory)
   }
   return result.text ?? 'Done.'
 }
 
 async function invokeWithContext(
-  userId: string,
+  execCtx: DeferredExecutionContext,
   type: 'scheduled' | 'alert',
   prompt: string,
   metadata: ExecutionMetadata,
   deps: ProactiveLlmDeps,
 ): Promise<string> {
-  log.debug({ userId, mode: 'context' }, 'invokeWithContext called')
-  const config = getLlmConfig(userId)
+  const { createdByUserId, deliveryTarget } = execCtx
+  const storageContextId = getStorageContextId(deliveryTarget)
+  log.debug({ userId: createdByUserId, mode: 'context' }, 'invokeWithContext called')
+  const config = getLlmConfig(createdByUserId)
   if (typeof config === 'string') return config
 
   const model = deps.buildModel(config, config.mainModel)
-  const history = getCachedHistory(userId)
-  const { messages: messagesWithMemory } = buildMessagesWithMemory(userId, history)
+  const history = getCachedHistory(storageContextId)
+  const { messages: messagesWithMemory } = buildMessagesWithMemory(storageContextId, history)
   const messages: ModelMessage[] = [
     ...messagesWithMemory,
     ...buildMetadataMessages(metadata),
     { role: 'user', content: wrapPrompt(prompt) },
   ]
 
-  log.debug({ userId, mainModel: config.mainModel, historyLength: history.length, mode: 'context' }, 'generateText')
+  log.debug(
+    { userId: createdByUserId, mainModel: config.mainModel, historyLength: history.length, mode: 'context' },
+    'generateText',
+  )
   const result = await deps.generateText({
     model,
     system: buildMinimalSystemPrompt(type),
     messages,
-    tools: makeMinimalTools(userId),
+    tools: makeMinimalTools(createdByUserId),
     timeout: 1_200_000,
   })
 
   const assistantMessages = result.response.messages
   if (assistantMessages.length > 0) {
-    appendHistory(userId, assistantMessages)
+    appendHistory(storageContextId, assistantMessages)
     const updatedHistory = [...history, ...assistantMessages]
-    if (shouldTriggerTrim(updatedHistory)) void runTrimInBackground(userId, updatedHistory)
+    if (shouldTriggerTrim(updatedHistory)) void runTrimInBackground(storageContextId, updatedHistory)
   }
   return result.text ?? 'Done.'
 }
 
-function buildFullToolSet(provider: TaskProvider, userId: string): ToolSet {
+function buildFullToolSet(
+  provider: TaskProvider,
+  createdByUserId: string,
+  storageContextId: string,
+  contextType: 'dm' | 'group',
+): ToolSet {
   return makeTools(provider, {
-    storageContextId: userId,
-    chatUserId: userId,
+    storageContextId,
+    chatUserId: createdByUserId,
     mode: 'proactive',
-    contextType: 'dm',
+    contextType,
   })
 }
 
 function buildFullMessages(
-  userId: string,
+  createdByUserId: string,
+  storageContextId: string,
   type: 'scheduled' | 'alert',
   prompt: string,
   matchedTasksSummary: string | undefined,
   metadata: ExecutionMetadata,
 ): { messages: ModelMessage[]; systemPrompt: string } {
-  const timezone = getConfig(userId, 'timezone') ?? 'UTC'
+  const timezone = getConfig(createdByUserId, 'timezone') ?? 'UTC'
   const trigger = buildProactiveTrigger(type, prompt, timezone, matchedTasksSummary)
-  const history = getCachedHistory(userId)
-  const { messages: messagesWithMemory } = buildMessagesWithMemory(userId, history)
+  const history = getCachedHistory(storageContextId)
+  const { messages: messagesWithMemory } = buildMessagesWithMemory(storageContextId, history)
   return {
     messages: [
       ...messagesWithMemory,
@@ -205,7 +231,7 @@ function buildFullMessages(
 }
 
 async function invokeFull(
-  userId: string,
+  execCtx: DeferredExecutionContext,
   type: 'scheduled' | 'alert',
   prompt: string,
   metadata: ExecutionMetadata,
@@ -213,22 +239,27 @@ async function invokeFull(
   matchedTasksSummary: string | undefined,
   deps: ProactiveLlmDeps,
 ): Promise<string> {
-  log.debug({ userId, mode: 'full' }, 'invokeFull called')
-  const config = getLlmConfig(userId)
+  const { createdByUserId, deliveryTarget } = execCtx
+  const storageContextId = getStorageContextId(deliveryTarget)
+  log.debug({ userId: createdByUserId, mode: 'full' }, 'invokeFull called')
+  const config = getLlmConfig(createdByUserId)
   if (typeof config === 'string') return config
 
-  const provider = buildProviderFn(userId)
+  const provider = buildProviderFn(createdByUserId)
   if (provider === null) {
-    log.warn({ userId }, 'Could not build task provider for deferred prompt')
+    log.warn({ userId: createdByUserId }, 'Could not build task provider for deferred prompt')
     return 'Deferred prompt skipped: task provider not configured.'
   }
 
   const model = deps.buildModel(config, config.mainModel)
-  const tools = buildFullToolSet(provider, userId)
-  const systemPrompt = buildSystemPrompt(provider, userId)
-  const { messages } = buildFullMessages(userId, type, prompt, matchedTasksSummary, metadata)
+  const tools = buildFullToolSet(provider, createdByUserId, storageContextId, deliveryTarget.contextType)
+  const systemPrompt = buildSystemPrompt(provider, createdByUserId)
+  const { messages } = buildFullMessages(createdByUserId, storageContextId, type, prompt, matchedTasksSummary, metadata)
 
-  log.debug({ userId, mainModel: config.mainModel, historyLength: messages.length, mode: 'full' }, 'generateText')
+  log.debug(
+    { userId: createdByUserId, mainModel: config.mainModel, historyLength: messages.length, mode: 'full' },
+    'generateText',
+  )
   const result = await deps.generateText({
     model,
     system: systemPrompt,
@@ -237,14 +268,14 @@ async function invokeFull(
     stopWhen: deps.stepCountIs(25),
     timeout: 1_200_000,
   })
-  persistProactiveResults(userId, result, getCachedHistory(userId))
+  persistProactiveResults(createdByUserId, storageContextId, result, getCachedHistory(storageContextId))
   return result.text ?? 'Done.'
 }
 
 // --- Dispatcher ---
 
 export function dispatchExecution(
-  userId: string,
+  execCtx: DeferredExecutionContext,
   type: 'scheduled' | 'alert',
   prompt: string,
   metadata: ExecutionMetadata,
@@ -252,15 +283,16 @@ export function dispatchExecution(
   matchedTasksSummary?: string,
   deps: ProactiveLlmDeps = defaultProactiveLlmDeps,
 ): Promise<string> {
-  log.debug({ userId, mode: metadata.mode }, 'dispatchExecution called')
+  const { createdByUserId } = execCtx
+  log.debug({ userId: createdByUserId, mode: metadata.mode }, 'dispatchExecution called')
   switch (metadata.mode) {
     case 'lightweight':
-      return invokeLightweight(userId, type, prompt, metadata, deps)
+      return invokeLightweight(execCtx, type, prompt, metadata, deps)
     case 'context':
-      return invokeWithContext(userId, type, prompt, metadata, deps)
+      return invokeWithContext(execCtx, type, prompt, metadata, deps)
     case 'full':
-      return invokeFull(userId, type, prompt, metadata, buildProviderFn, matchedTasksSummary, deps)
+      return invokeFull(execCtx, type, prompt, metadata, buildProviderFn, matchedTasksSummary, deps)
     default:
-      return invokeFull(userId, type, prompt, metadata, buildProviderFn, matchedTasksSummary, deps)
+      return invokeFull(execCtx, type, prompt, metadata, buildProviderFn, matchedTasksSummary, deps)
   }
 }

--- a/src/deferred-prompts/proactive-llm.ts
+++ b/src/deferred-prompts/proactive-llm.ts
@@ -74,9 +74,12 @@ function persistProactiveResults(
   history: readonly ModelMessage[],
 ): void {
   const newFacts = extractFactsFromSdkResults(result.toolCalls, result.toolResults)
-  for (const fact of newFacts) upsertFact(creatorId, fact)
+  for (const fact of newFacts) upsertFact(storageContextId, fact)
   if (newFacts.length > 0)
-    log.info({ userId: creatorId, factsExtracted: newFacts.length }, 'Facts persisted from proactive results')
+    log.info(
+      { userId: creatorId, storageContextId, factsExtracted: newFacts.length },
+      'Facts persisted from proactive results',
+    )
 
   const msgs = result.response.messages
   if (msgs.length > 0) {
@@ -86,8 +89,6 @@ function persistProactiveResults(
   }
   log.debug({ userId: creatorId, toolCalls: result.toolCalls?.length }, 'Proactive LLM response received')
 }
-
-// --- Minimal system prompt (shared by lightweight and context modes) ---
 
 function buildMinimalSystemPrompt(type: 'scheduled' | 'alert'): string {
   return [
@@ -100,8 +101,6 @@ function buildMinimalSystemPrompt(type: 'scheduled' | 'alert'): string {
   ].join('\n')
 }
 
-// --- Message construction helpers ---
-
 function buildMetadataMessages(m: ExecutionMetadata): ModelMessage[] {
   const msgs: ModelMessage[] = [{ role: 'system', content: `[DELIVERY BRIEF]\n${m.delivery_brief}` }]
   if (m.context_snapshot !== null)
@@ -111,8 +110,6 @@ function buildMetadataMessages(m: ExecutionMetadata): ModelMessage[] {
 
 const wrapPrompt = (prompt: string): string => `===DEFERRED_TASK===\n${prompt}\n===END_DEFERRED_TASK===`
 
-// --- Three execution functions ---
-
 async function invokeLightweight(
   execCtx: DeferredExecutionContext,
   type: 'scheduled' | 'alert',
@@ -120,7 +117,8 @@ async function invokeLightweight(
   metadata: ExecutionMetadata,
   deps: ProactiveLlmDeps,
 ): Promise<string> {
-  const { createdByUserId } = execCtx
+  const { createdByUserId, deliveryTarget } = execCtx
+  const storageContextId = getStorageContextId(deliveryTarget)
   log.debug({ userId: createdByUserId, mode: 'lightweight' }, 'invokeLightweight called')
   const config = getLlmConfig(createdByUserId)
   if (typeof config === 'string') return config
@@ -141,11 +139,14 @@ async function invokeLightweight(
 
   const assistantMessages = result.response.messages
   if (assistantMessages.length > 0) {
-    const history = getCachedHistory(createdByUserId)
-    appendHistory(createdByUserId, assistantMessages)
-    log.debug({ userId: createdByUserId, count: assistantMessages.length }, 'Lightweight response appended to history')
+    const history = getCachedHistory(storageContextId)
+    appendHistory(storageContextId, assistantMessages)
+    log.debug(
+      { userId: createdByUserId, storageContextId, count: assistantMessages.length },
+      'Lightweight response appended to history',
+    )
     const updatedHistory = [...history, ...assistantMessages]
-    if (shouldTriggerTrim(updatedHistory)) void runTrimInBackground(createdByUserId, updatedHistory)
+    if (shouldTriggerTrim(updatedHistory)) void runTrimInBackground(storageContextId, updatedHistory)
   }
   return result.text ?? 'Done.'
 }
@@ -271,8 +272,6 @@ async function invokeFull(
   persistProactiveResults(createdByUserId, storageContextId, result, getCachedHistory(storageContextId))
   return result.text ?? 'Done.'
 }
-
-// --- Dispatcher ---
 
 export function dispatchExecution(
   execCtx: DeferredExecutionContext,

--- a/src/deferred-prompts/scheduled.ts
+++ b/src/deferred-prompts/scheduled.ts
@@ -1,5 +1,6 @@
 import { and, asc, eq, lte } from 'drizzle-orm'
 
+import { dmTarget } from '../chat/types.js'
 import { getDrizzleDb } from '../db/drizzle.js'
 import { scheduledPrompts } from '../db/schema.js'
 import type { ScheduledPromptRow } from '../db/schema.js'
@@ -7,6 +8,8 @@ import { logger } from '../logger.js'
 import {
   DEFAULT_EXECUTION_METADATA,
   parseExecutionMetadata,
+  type DeferredPromptDelivery,
+  type DeferredPromptDeliveryInput,
   type ExecutionMetadata,
   type ScheduledPrompt,
 } from './types.js'
@@ -21,11 +24,40 @@ function toStatus(value: string): ScheduledPrompt['status'] {
   return isValidStatus(value) ? value : 'active'
 }
 
+function rowToDeliveryTarget(row: ScheduledPromptRow): DeferredPromptDelivery {
+  if (row.deliveryContextId !== null) {
+    const contextType = row.deliveryContextType === 'group' ? 'group' : 'dm'
+    const audience = row.audience === 'shared' ? 'shared' : 'personal'
+    let mentionUserIds: string[] = []
+    try {
+      const parsed: unknown = JSON.parse(row.mentionUserIds)
+      if (Array.isArray(parsed)) mentionUserIds = parsed.filter((x): x is string => typeof x === 'string')
+    } catch {
+      mentionUserIds = []
+    }
+    return {
+      contextId: row.deliveryContextId,
+      contextType,
+      threadId: row.deliveryThreadId,
+      audience,
+      mentionUserIds,
+      createdByUserId: row.createdByUserId,
+      createdByUsername: row.createdByUsername,
+    }
+  }
+  return {
+    ...dmTarget(row.createdByUserId),
+    createdByUsername: row.createdByUsername,
+  }
+}
+
 function toScheduledPrompt(row: ScheduledPromptRow): ScheduledPrompt {
   return {
     type: 'scheduled',
     id: row.id,
-    userId: row.userId,
+    createdByUserId: row.createdByUserId,
+    createdByUsername: row.createdByUsername,
+    deliveryTarget: rowToDeliveryTarget(row),
     prompt: row.prompt,
     fireAt: row.fireAt,
     cronExpression: row.cronExpression,
@@ -41,6 +73,7 @@ export function createScheduledPrompt(
   prompt: string,
   schedule: { fireAt: string; cronExpression?: string },
   executionMetadata?: ExecutionMetadata,
+  delivery?: DeferredPromptDeliveryInput,
 ): ScheduledPrompt {
   log.debug({ userId, hasCron: schedule.cronExpression !== undefined }, 'createScheduledPrompt called')
 
@@ -48,10 +81,18 @@ export function createScheduledPrompt(
   const id = crypto.randomUUID()
   const fireAt = new Date(schedule.fireAt).toISOString()
 
+  const target = delivery ?? dmTarget(userId)
+
   db.insert(scheduledPrompts)
     .values({
       id,
-      userId,
+      createdByUserId: target.createdByUserId,
+      createdByUsername: target.createdByUsername,
+      deliveryContextId: target.contextType === 'group' ? target.contextId : null,
+      deliveryContextType: target.contextType === 'group' ? 'group' : null,
+      deliveryThreadId: target.threadId,
+      audience: target.audience,
+      mentionUserIds: JSON.stringify(target.mentionUserIds),
       prompt,
       fireAt,
       cronExpression: schedule.cronExpression ?? null,
@@ -71,7 +112,7 @@ export function listScheduledPrompts(userId: string, status?: string): Scheduled
 
   const db = getDrizzleDb()
 
-  const conditions = [eq(scheduledPrompts.userId, userId)]
+  const conditions = [eq(scheduledPrompts.createdByUserId, userId)]
   if (status !== undefined) {
     conditions.push(eq(scheduledPrompts.status, status))
   }
@@ -93,7 +134,7 @@ export function getScheduledPrompt(id: string, userId: string): ScheduledPrompt 
   const row = db
     .select()
     .from(scheduledPrompts)
-    .where(and(eq(scheduledPrompts.id, id), eq(scheduledPrompts.userId, userId)))
+    .where(and(eq(scheduledPrompts.id, id), eq(scheduledPrompts.createdByUserId, userId)))
     .get()
 
   if (row === undefined) {
@@ -125,7 +166,7 @@ export function updateScheduledPrompt(
   log.debug({ id, userId }, 'updateScheduledPrompt called')
 
   const db = getDrizzleDb()
-  const ownerFilter = and(eq(scheduledPrompts.id, id), eq(scheduledPrompts.userId, userId))
+  const ownerFilter = and(eq(scheduledPrompts.id, id), eq(scheduledPrompts.createdByUserId, userId))
 
   const existing = db.select().from(scheduledPrompts).where(ownerFilter).get()
   if (existing === undefined) return null
@@ -148,7 +189,7 @@ export function cancelScheduledPrompt(id: string, userId: string): ScheduledProm
   const existing = db
     .select()
     .from(scheduledPrompts)
-    .where(and(eq(scheduledPrompts.id, id), eq(scheduledPrompts.userId, userId)))
+    .where(and(eq(scheduledPrompts.id, id), eq(scheduledPrompts.createdByUserId, userId)))
     .get()
 
   if (existing === undefined) {
@@ -157,7 +198,7 @@ export function cancelScheduledPrompt(id: string, userId: string): ScheduledProm
 
   db.update(scheduledPrompts)
     .set({ status: 'cancelled' })
-    .where(and(eq(scheduledPrompts.id, id), eq(scheduledPrompts.userId, userId)))
+    .where(and(eq(scheduledPrompts.id, id), eq(scheduledPrompts.createdByUserId, userId)))
     .run()
 
   const row = db.select().from(scheduledPrompts).where(eq(scheduledPrompts.id, id)).get()
@@ -193,7 +234,7 @@ export function advanceScheduledPrompt(id: string, userId: string, nextFireAt: s
       fireAt: new Date(nextFireAt).toISOString(),
       lastExecutedAt: new Date(lastExecutedAt).toISOString(),
     })
-    .where(and(eq(scheduledPrompts.id, id), eq(scheduledPrompts.userId, userId)))
+    .where(and(eq(scheduledPrompts.id, id), eq(scheduledPrompts.createdByUserId, userId)))
     .run()
 
   log.info({ id, userId }, 'Scheduled prompt advanced')
@@ -209,7 +250,7 @@ export function completeScheduledPrompt(id: string, userId: string, lastExecuted
       status: 'completed',
       lastExecutedAt: new Date(lastExecutedAt).toISOString(),
     })
-    .where(and(eq(scheduledPrompts.id, id), eq(scheduledPrompts.userId, userId)))
+    .where(and(eq(scheduledPrompts.id, id), eq(scheduledPrompts.createdByUserId, userId)))
     .run()
 
   log.info({ id, userId }, 'Scheduled prompt completed')

--- a/src/deferred-prompts/tool-handlers.ts
+++ b/src/deferred-prompts/tool-handlers.ts
@@ -1,3 +1,5 @@
+import type { ContextType } from '../chat/types.js'
+import { dmTarget } from '../chat/types.js'
 import { getConfig } from '../config.js'
 import { nextCronOccurrence, parseCron } from '../cron.js'
 import { logger } from '../logger.js'
@@ -17,6 +19,7 @@ import {
   type AlertCondition,
   type CancelResult,
   type CreateResult,
+  type DeferredPromptDeliveryInput,
   type ExecutionMetadata,
   type GetResult,
   type ListResult,
@@ -28,12 +31,43 @@ const log = logger.child({ scope: 'deferred:tools' })
 
 // --- Input types ---
 
+export type CreateDeliveryContext = {
+  userId: string
+  storageContextId: string
+  contextType: ContextType
+  username?: string | null
+}
+
 export type CreateInput = {
   prompt: string
   schedule?: ScheduleInput
   condition?: AlertCondition
   cooldown_minutes?: number
   execution?: { mode: 'lightweight' | 'context' | 'full'; delivery_brief: string; context_snapshot?: string }
+  delivery?: { audience?: 'personal' | 'shared'; mention_user_ids?: string[] }
+}
+
+function buildDeliveryInput(
+  ctx: CreateDeliveryContext,
+  policy?: { audience?: 'personal' | 'shared'; mention_user_ids?: string[] },
+): DeferredPromptDeliveryInput {
+  if (ctx.contextType === 'dm') {
+    return { ...dmTarget(ctx.userId), createdByUsername: ctx.username ?? null }
+  }
+  const colonIdx = ctx.storageContextId.indexOf(':')
+  const contextId = colonIdx >= 0 ? ctx.storageContextId.slice(0, colonIdx) : ctx.storageContextId
+  const threadId = colonIdx >= 0 ? ctx.storageContextId.slice(colonIdx + 1) : null
+  const audience = policy?.audience === 'shared' ? 'shared' : 'personal'
+  const mentionUserIds = policy?.mention_user_ids ?? (audience === 'personal' ? [ctx.userId] : [])
+  return {
+    contextId,
+    contextType: 'group',
+    threadId,
+    audience,
+    mentionUserIds,
+    createdByUserId: ctx.userId,
+    createdByUsername: ctx.username ?? null,
+  }
 }
 
 export type UpdateInput = {
@@ -54,6 +88,7 @@ function createScheduled(
   prompt: string,
   schedule: ScheduleInput,
   executionMetadata: ExecutionMetadata,
+  delivery?: DeferredPromptDeliveryInput,
 ): CreateResult {
   const hasFireAt = schedule.fire_at !== undefined
   const hasCron = schedule.cron !== undefined && schedule.cron !== ''
@@ -84,7 +119,7 @@ function createScheduled(
     return { error: 'Schedule must include either fire_at or cron.' }
   }
 
-  const result = createScheduledPrompt(userId, prompt, { fireAt, cronExpression }, executionMetadata)
+  const result = createScheduledPrompt(userId, prompt, { fireAt, cronExpression }, executionMetadata, delivery)
   log.info({ id: result.id, userId, type: 'scheduled' }, 'Deferred prompt created')
   return {
     status: 'created',
@@ -101,11 +136,12 @@ function createAlert(
   condition: unknown,
   cooldownMinutes: number | undefined,
   executionMetadata: ExecutionMetadata,
+  delivery?: DeferredPromptDeliveryInput,
 ): CreateResult {
   const parseResult = alertConditionSchema.safeParse(condition)
   if (!parseResult.success) return { error: `Invalid condition: ${parseResult.error.message}` }
 
-  const result = createAlertPrompt(userId, prompt, parseResult.data, cooldownMinutes, executionMetadata)
+  const result = createAlertPrompt(userId, prompt, parseResult.data, cooldownMinutes, executionMetadata, delivery)
   log.info({ id: result.id, userId, type: 'alert' }, 'Deferred prompt created')
   return { status: 'created', type: 'alert', id: result.id, cooldownMinutes: result.cooldownMinutes }
 }
@@ -120,7 +156,7 @@ function parseExecution(
   return DEFAULT_EXECUTION_METADATA
 }
 
-export function executeCreate(userId: string, input: CreateInput): CreateResult {
+export function executeCreate(userId: string, input: CreateInput, deliveryCtx?: CreateDeliveryContext): CreateResult {
   const hasSchedule = input.schedule !== undefined
   const hasCondition = input.condition !== undefined
   log.debug({ userId, hasSchedule, hasCondition }, 'create_deferred_prompt called')
@@ -130,9 +166,10 @@ export function executeCreate(userId: string, input: CreateInput): CreateResult 
   }
 
   const executionMetadata = parseExecution(input.execution)
+  const delivery = deliveryCtx === undefined ? undefined : buildDeliveryInput(deliveryCtx, input.delivery)
 
-  if (hasSchedule) return createScheduled(userId, input.prompt, input.schedule!, executionMetadata)
-  return createAlert(userId, input.prompt, input.condition, input.cooldown_minutes, executionMetadata)
+  if (hasSchedule) return createScheduled(userId, input.prompt, input.schedule!, executionMetadata, delivery)
+  return createAlert(userId, input.prompt, input.condition, input.cooldown_minutes, executionMetadata, delivery)
 }
 
 export function executeList(

--- a/src/deferred-prompts/tool-handlers.ts
+++ b/src/deferred-prompts/tool-handlers.ts
@@ -58,7 +58,7 @@ function buildDeliveryInput(
   const contextId = colonIdx >= 0 ? ctx.storageContextId.slice(0, colonIdx) : ctx.storageContextId
   const threadId = colonIdx >= 0 ? ctx.storageContextId.slice(colonIdx + 1) : null
   const audience = policy?.audience === 'shared' ? 'shared' : 'personal'
-  const mentionUserIds = policy?.mention_user_ids ?? (audience === 'personal' ? [ctx.userId] : [])
+  const mentionUserIds = audience === 'shared' ? [] : (policy?.mention_user_ids ?? [ctx.userId])
   return {
     contextId,
     contextType: 'group',

--- a/src/deferred-prompts/types.ts
+++ b/src/deferred-prompts/types.ts
@@ -1,5 +1,34 @@
 import { z } from 'zod'
 
+import type { ContextType, DeferredAudience } from '../chat/types.js'
+
+// --- Delivery domain types ---
+
+/** Domain-layer delivery spec stored with each prompt (mirrors DeferredDeliveryTarget). */
+export type DeferredPromptDelivery = {
+  contextId: string
+  contextType: ContextType
+  threadId: string | null
+  audience: DeferredAudience
+  mentionUserIds: string[]
+  createdByUserId: string
+  createdByUsername: string | null
+}
+
+/** Input shape for delivery spec at creation time (same fields as DeferredPromptDelivery). */
+export type DeferredPromptDeliveryInput = DeferredPromptDelivery
+
+/** Tool-level delivery policy schema (audience + mention targets chosen by the LLM). */
+export const deliveryPolicySchema = z
+  .object({
+    audience: z.enum(['personal', 'shared']).describe("'personal' to @mention the creator, 'shared' for no mention"),
+    mention_user_ids: z
+      .array(z.string())
+      .describe('User IDs to @mention in the delivery message (personal audience only)'),
+  })
+  .optional()
+  .describe('Delivery policy for group contexts. Omit for DM prompts.')
+
 // --- Condition fields and operators ---
 
 export const CONDITION_FIELDS = [
@@ -145,7 +174,9 @@ export const executionInputSchema = z
 export type ScheduledPrompt = {
   type: 'scheduled'
   id: string
-  userId: string
+  createdByUserId: string
+  createdByUsername: string | null
+  deliveryTarget: DeferredPromptDelivery
   prompt: string
   fireAt: string
   cronExpression: string | null
@@ -158,7 +189,9 @@ export type ScheduledPrompt = {
 export type AlertPrompt = {
   type: 'alert'
   id: string
-  userId: string
+  createdByUserId: string
+  createdByUsername: string | null
+  deliveryTarget: DeferredPromptDelivery
   prompt: string
   condition: AlertCondition
   status: 'active' | 'cancelled'

--- a/src/llm-orchestrator.ts
+++ b/src/llm-orchestrator.ts
@@ -57,19 +57,20 @@ const isToolSet = (value: unknown): value is ToolSet =>
 const getOrCreateTools = (
   contextId: string,
   chatUserId: string,
+  username: string | null,
   provider: TaskProvider,
   contextType: 'dm' | 'group' | undefined,
 ): ToolSet => {
   // Security fix: In group chats, tools embed chatUserId-specific closures for "me" resolution.
   // The cache key must include chatUserId to prevent cross-user contamination.
-  const cacheKey = contextType === 'group' ? `${contextId}:${chatUserId}` : contextId
+  const cacheKey = contextType === 'group' ? `${contextId}:${chatUserId}:${username ?? ''}` : contextId
   const cachedTools = getCachedTools(cacheKey)
   if (cachedTools !== undefined && cachedTools !== null && isToolSet(cachedTools)) {
-    log.debug({ contextId, chatUserId }, 'Using cached tools')
+    log.debug({ contextId, chatUserId, hasUsername: username !== null }, 'Using cached tools')
     return cachedTools
   }
-  log.debug({ contextId, chatUserId }, 'Building tools (cache miss)')
-  const tools = makeTools(provider, { storageContextId: contextId, chatUserId, contextType })
+  log.debug({ contextId, chatUserId, hasUsername: username !== null }, 'Building tools (cache miss)')
+  const tools = makeTools(provider, { storageContextId: contextId, chatUserId, username, contextType })
   setCachedTools(cacheKey, tools)
   return tools
 }
@@ -191,7 +192,7 @@ const callLlm = async (
   const model = deps.buildOpenAI(llmApiKey, llmBaseUrl)(mainModel)
   const provider = deps.buildProviderForUser(configId)
   await maybeAutoLinkIdentity(chatUserId, username, provider)
-  const tools = getOrCreateTools(contextId, chatUserId, provider, contextType)
+  const tools = getOrCreateTools(contextId, chatUserId, username, provider, contextType)
   const timezone = resolveTimezone(configId)
   const { messages: messagesWithMemory, memoryMsg } = buildMessagesWithMemory(contextId, history)
   const validatedMessages = validateToolResults(messagesWithMemory)

--- a/src/scheduler-recurring.ts
+++ b/src/scheduler-recurring.ts
@@ -1,4 +1,5 @@
 import type { ChatProvider } from './chat/types.js'
+import { dmTarget } from './chat/types.js'
 import { emit } from './debug/event-bus.js'
 import { logger } from './logger.js'
 import type { Task, TaskProvider } from './providers/types.js'
@@ -50,7 +51,7 @@ export const notifyUser = async (
   if (chatProviderRef === null) return
 
   try {
-    await chatProviderRef.sendMessage(userId, `Recurring task created: **${created.title}** in project.`)
+    await chatProviderRef.sendMessage(dmTarget(userId), `Recurring task created: **${created.title}** in project.`)
   } catch (notifyError) {
     log.warn(
       { userId, error: notifyError instanceof Error ? notifyError.message : String(notifyError) },

--- a/src/tools/create-deferred-prompt.ts
+++ b/src/tools/create-deferred-prompt.ts
@@ -2,10 +2,12 @@ import { tool } from 'ai'
 import type { ToolSet } from 'ai'
 import { z } from 'zod'
 
+import type { ContextType } from '../chat/types.js'
 import { executeCreate, type CreateInput } from '../deferred-prompts/tool-handlers.js'
 import {
   alertConditionSchema,
   cooldownSchema,
+  deliveryPolicySchema,
   executionInputSchema,
   scheduleSchema,
 } from '../deferred-prompts/types.js'
@@ -13,7 +15,12 @@ import { logger } from '../logger.js'
 
 const log = logger.child({ scope: 'tool:create-deferred-prompt' })
 
-export function makeCreateDeferredPromptTool(userId: string): ToolSet[string] {
+export function makeCreateDeferredPromptTool(
+  userId: string,
+  storageContextId: string,
+  contextType: ContextType,
+  username?: string | null,
+): ToolSet[string] {
   return tool({
     description:
       'Create a scheduled task or monitoring alert. Provide either a schedule (for time-based) or a condition (for event-based), not both. Always classify the execution mode based on what the prompt needs at fire time.',
@@ -23,10 +30,11 @@ export function makeCreateDeferredPromptTool(userId: string): ToolSet[string] {
       condition: alertConditionSchema.optional().describe('Event-based trigger condition'),
       cooldown_minutes: cooldownSchema,
       execution: executionInputSchema,
+      delivery: deliveryPolicySchema,
     }),
     execute: (input: CreateInput) => {
       try {
-        return executeCreate(userId, input)
+        return executeCreate(userId, input, { userId, storageContextId, contextType, username })
       } catch (error) {
         log.error(
           { error: error instanceof Error ? error.message : String(error), tool: 'create_deferred_prompt' },

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -31,10 +31,11 @@ function wrapToolSet(tools: ToolSet): ToolSet {
 export function makeTools(provider: TaskProvider, options?: MakeToolsOptions): ToolSet {
   const storageContextId = options?.storageContextId
   const chatUserId = options?.chatUserId
+  const username = options?.username
   const contextId = storageContextId
   const mode = options?.mode ?? 'normal'
   const contextType = options?.contextType
 
-  const tools = buildTools(provider, chatUserId, contextId, mode, contextType)
+  const tools = buildTools(provider, chatUserId, contextId, mode, contextType, username)
   return wrapToolSet(tools)
 }

--- a/src/tools/tools-builder.ts
+++ b/src/tools/tools-builder.ts
@@ -262,6 +262,7 @@ export function buildTools(
   contextId: string | undefined,
   mode: ToolMode,
   contextType?: ContextType,
+  username?: string | null,
 ): ToolSet {
   const tools = makeCoreTools(provider, chatUserId, contextId)
   maybeAddProjectTools(tools, provider)
@@ -286,7 +287,7 @@ export function buildTools(
   if (mode === 'normal' && chatUserId !== undefined) {
     const ctxId = contextId ?? chatUserId
     const ctxType = contextType ?? 'dm'
-    tools['create_deferred_prompt'] = makeCreateDeferredPromptTool(chatUserId, ctxId, ctxType)
+    tools['create_deferred_prompt'] = makeCreateDeferredPromptTool(chatUserId, ctxId, ctxType, username)
     tools['list_deferred_prompts'] = makeListDeferredPromptsTool(chatUserId)
     tools['get_deferred_prompt'] = makeGetDeferredPromptTool(chatUserId)
     tools['update_deferred_prompt'] = makeUpdateDeferredPromptTool(chatUserId)

--- a/src/tools/tools-builder.ts
+++ b/src/tools/tools-builder.ts
@@ -237,15 +237,6 @@ function addRecurringTools(tools: ToolSet, userId: string | undefined): void {
   tools['delete_recurring_task'] = makeDeleteRecurringTaskTool()
 }
 
-function addDeferredPromptTools(tools: ToolSet, userId: string | undefined): void {
-  if (userId === undefined) return
-  tools['create_deferred_prompt'] = makeCreateDeferredPromptTool(userId)
-  tools['list_deferred_prompts'] = makeListDeferredPromptsTool(userId)
-  tools['get_deferred_prompt'] = makeGetDeferredPromptTool(userId)
-  tools['update_deferred_prompt'] = makeUpdateDeferredPromptTool(userId)
-  tools['cancel_deferred_prompt'] = makeCancelDeferredPromptTool(userId)
-}
-
 function addLookupGroupHistoryTool(tools: ToolSet, userId: string | undefined, contextId: string | undefined): void {
   if (userId === undefined || contextId === undefined) return
   if (!contextId.includes(':')) return
@@ -292,6 +283,14 @@ export function buildTools(
   addLookupGroupHistoryTool(tools, chatUserId, contextId)
   addWebFetchTool(tools, contextId, chatUserId)
   maybeAddIdentityTools(tools, provider, chatUserId, contextType)
-  if (mode === 'normal') addDeferredPromptTools(tools, chatUserId)
+  if (mode === 'normal' && chatUserId !== undefined) {
+    const ctxId = contextId ?? chatUserId
+    const ctxType = contextType ?? 'dm'
+    tools['create_deferred_prompt'] = makeCreateDeferredPromptTool(chatUserId, ctxId, ctxType)
+    tools['list_deferred_prompts'] = makeListDeferredPromptsTool(chatUserId)
+    tools['get_deferred_prompt'] = makeGetDeferredPromptTool(chatUserId)
+    tools['update_deferred_prompt'] = makeUpdateDeferredPromptTool(chatUserId)
+    tools['cancel_deferred_prompt'] = makeCancelDeferredPromptTool(chatUserId)
+  }
   return tools
 }

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -24,6 +24,11 @@ export type MakeToolsOptions = {
    */
   chatUserId: string
   /**
+   * The chat username for the current actor when the platform provides one.
+   * Used by tools that persist delivery metadata for later platform-native mentions.
+   */
+  username?: string | null
+  /**
    * Tool mode: 'normal' (default) includes deferred prompt tools,
    * 'proactive' excludes them for proactive delivery contexts.
    */

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -10,6 +10,7 @@ import type {
   CommandHandler,
   ContextRendered,
   ContextSnapshot,
+  DeferredDeliveryTarget,
   IncomingFile,
   IncomingInteraction,
   IncomingMessage,
@@ -794,7 +795,7 @@ describe('Bot Authorization Gate (setupBot)', () => {
 
       onMessage(_handler: (msg: IncomingMessage, reply: ReplyFn) => Promise<void>): void {}
 
-      sendMessage(_userId: string, _text: string): Promise<void> {
+      sendMessage(_target: DeferredDeliveryTarget, _text: string): Promise<void> {
         return Promise.resolve()
       }
 

--- a/tests/chat/discord/index.test.ts
+++ b/tests/chat/discord/index.test.ts
@@ -185,6 +185,78 @@ describe('DiscordChatProvider', () => {
     expect(sends[0]!.content).toBe('hello discord')
   })
 
+  test('sendMessage throws when a group channel is not sendable', async () => {
+    const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+    const provider = new DiscordChatProvider()
+
+    provider.testSetClient({
+      destroy: (): Promise<void> => Promise.resolve(),
+      users: {
+        fetch: (
+          _id: string,
+        ): Promise<{ createDM: () => Promise<{ send: (arg: { content: string }) => Promise<unknown> }> }> =>
+          Promise.reject(new Error('not used')),
+      },
+      channels: {
+        cache: new Map<string, unknown>(),
+        fetch: (_id: string): Promise<unknown> => Promise.resolve(null),
+      },
+    })
+
+    await expect(
+      provider.sendMessage(
+        {
+          contextId: 'chan-404',
+          contextType: 'group',
+          threadId: null,
+          audience: 'shared',
+          mentionUserIds: [],
+          createdByUserId: 'user-1',
+          createdByUsername: null,
+        },
+        'hello group',
+      ),
+    ).rejects.toThrow('Discord channel not sendable')
+  })
+
+  test('sendMessage throws when a fetched group channel reports isSendable() false', async () => {
+    const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+    const provider = new DiscordChatProvider()
+
+    provider.testSetClient({
+      destroy: (): Promise<void> => Promise.resolve(),
+      users: {
+        fetch: (
+          _id: string,
+        ): Promise<{ createDM: () => Promise<{ send: (arg: { content: string }) => Promise<unknown> }> }> =>
+          Promise.reject(new Error('not used')),
+      },
+      channels: {
+        cache: new Map<string, unknown>(),
+        fetch: (_id: string): Promise<unknown> =>
+          Promise.resolve({
+            send: (_arg: { content: string }): Promise<unknown> => Promise.resolve(undefined),
+            isSendable: (): boolean => false,
+          }),
+      },
+    })
+
+    await expect(
+      provider.sendMessage(
+        {
+          contextId: 'chan-stage',
+          contextType: 'group',
+          threadId: null,
+          audience: 'shared',
+          mentionUserIds: [],
+          createdByUserId: 'user-1',
+          createdByUsername: null,
+        },
+        'hello group',
+      ),
+    ).rejects.toThrow('Discord channel not sendable')
+  })
+
   test('resolveUserId returns snowflake as-is when the input is numeric', async () => {
     const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
     const provider = new DiscordChatProvider()

--- a/tests/chat/discord/index.test.ts
+++ b/tests/chat/discord/index.test.ts
@@ -4,6 +4,7 @@ import { addAuthorizedGroup } from '../../../src/authorized-groups.js'
 import type { ButtonInteractionLike } from '../../../src/chat/discord/buttons.js'
 import type { DiscordClientFactory } from '../../../src/chat/discord/index.js'
 import type { ContextSnapshot, IncomingMessage } from '../../../src/chat/types.js'
+import { dmTarget } from '../../../src/chat/types.js'
 import { setConfig } from '../../../src/config.js'
 import { upsertGroupAdminObservation, upsertKnownGroupContext } from '../../../src/group-settings/registry.js'
 import { startGroupSettingsSelection } from '../../../src/group-settings/selector.js'
@@ -179,7 +180,7 @@ describe('DiscordChatProvider', () => {
     }
     provider.testSetClient(fakeClient)
 
-    await provider.sendMessage('user-42', 'hello discord')
+    await provider.sendMessage(dmTarget('user-42'), 'hello discord')
     expect(sends).toHaveLength(1)
     expect(sends[0]!.content).toBe('hello discord')
   })

--- a/tests/chat/mattermost/index.test.ts
+++ b/tests/chat/mattermost/index.test.ts
@@ -112,6 +112,124 @@ describe('MattermostChatProvider', () => {
     })
   })
 
+  describe('sendMessage', () => {
+    test('mentions stored target usernames for personal group delivery', async () => {
+      const requests: Array<{ readonly path: string; readonly body: unknown }> = []
+
+      provider = new MattermostChatProvider()
+      Reflect.set(provider, 'apiFetch', (method: string, path: string, body: unknown) => {
+        requests.push({ path, body })
+
+        if (method === 'GET' && path === '/api/v4/users/user-2') {
+          return Promise.resolve({ id: 'user-2', username: 'alex' })
+        }
+
+        if (method === 'POST' && path === '/api/v4/posts') {
+          return Promise.resolve({ id: 'post-1' })
+        }
+
+        return Promise.resolve({})
+      })
+
+      await provider.sendMessage(
+        {
+          contextId: 'chan-1',
+          contextType: 'group',
+          threadId: null,
+          audience: 'personal',
+          mentionUserIds: ['user-2'],
+          createdByUserId: 'user-1',
+          createdByUsername: 'creator',
+        },
+        'hello',
+      )
+
+      expect(requests).toContainEqual({
+        path: '/api/v4/posts',
+        body: {
+          channel_id: 'chan-1',
+          message: '@alex hello',
+        },
+      })
+    })
+
+    test('falls back to creator username for legacy personal group delivery without mention targets', async () => {
+      const requests: Array<{ readonly path: string; readonly body: unknown }> = []
+
+      provider = new MattermostChatProvider()
+      Reflect.set(provider, 'apiFetch', (method: string, path: string, body: unknown) => {
+        requests.push({ path, body })
+
+        if (method === 'POST' && path === '/api/v4/posts') {
+          return Promise.resolve({ id: 'post-1' })
+        }
+
+        return Promise.resolve({})
+      })
+
+      await provider.sendMessage(
+        {
+          contextId: 'chan-1',
+          contextType: 'group',
+          threadId: null,
+          audience: 'personal',
+          mentionUserIds: [],
+          createdByUserId: 'user-1',
+          createdByUsername: 'creator',
+        },
+        'hello',
+      )
+
+      expect(requests).toContainEqual({
+        path: '/api/v4/posts',
+        body: {
+          channel_id: 'chan-1',
+          message: '@creator hello',
+        },
+      })
+    })
+
+    test('mentions stored targets even when createdByUsername is null', async () => {
+      const requests: Array<{ readonly path: string; readonly body: unknown }> = []
+
+      provider = new MattermostChatProvider()
+      Reflect.set(provider, 'apiFetch', (method: string, path: string, body: unknown) => {
+        requests.push({ path, body })
+
+        if (method === 'GET' && path === '/api/v4/users/user-2') {
+          return Promise.resolve({ id: 'user-2', username: 'alex' })
+        }
+
+        if (method === 'POST' && path === '/api/v4/posts') {
+          return Promise.resolve({ id: 'post-1' })
+        }
+
+        return Promise.resolve({})
+      })
+
+      await provider.sendMessage(
+        {
+          contextId: 'chan-1',
+          contextType: 'group',
+          threadId: null,
+          audience: 'personal',
+          mentionUserIds: ['user-2'],
+          createdByUserId: 'user-1',
+          createdByUsername: null,
+        },
+        'hello',
+      )
+
+      expect(requests).toContainEqual({
+        path: '/api/v4/posts',
+        body: {
+          channel_id: 'chan-1',
+          message: '@alex hello',
+        },
+      })
+    })
+  })
+
   test('buildPostedMessage includes channel and team names', async () => {
     const { reply } = createMockReply()
 

--- a/tests/chat/proactive-send-contract.test.ts
+++ b/tests/chat/proactive-send-contract.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { DeferredAudience, DeferredDeliveryTarget } from '../../src/chat/types.js'
+
+describe('Deferred proactive send types', () => {
+  test('supports group target with personal audience and mentions', () => {
+    const audience: DeferredAudience = 'personal'
+    const target: DeferredDeliveryTarget = {
+      contextId: '-1001234567890',
+      contextType: 'group',
+      threadId: '42',
+      audience,
+      mentionUserIds: ['12345678'],
+      createdByUserId: '12345678',
+      createdByUsername: 'ki',
+    }
+
+    expect(target.contextType).toBe('group')
+    expect(target.audience).toBe('personal')
+    expect(target.mentionUserIds).toEqual(['12345678'])
+  })
+
+  test('supports dm target with personal audience and no mentions', () => {
+    const target: DeferredDeliveryTarget = {
+      contextId: '12345678',
+      contextType: 'dm',
+      threadId: null,
+      audience: 'personal',
+      mentionUserIds: [],
+      createdByUserId: '12345678',
+      createdByUsername: null,
+    }
+
+    expect(target.contextType).toBe('dm')
+    expect(target.threadId).toBeNull()
+    expect(target.mentionUserIds).toHaveLength(0)
+  })
+
+  test('supports shared audience for group context', () => {
+    const target: DeferredDeliveryTarget = {
+      contextId: 'chan-1',
+      contextType: 'group',
+      threadId: null,
+      audience: 'shared',
+      mentionUserIds: [],
+      createdByUserId: 'u1',
+      createdByUsername: 'ki',
+    }
+
+    expect(target.audience).toBe('shared')
+    expect(target.mentionUserIds).toEqual([])
+  })
+})

--- a/tests/chat/proactive-send.test.ts
+++ b/tests/chat/proactive-send.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { DeferredDeliveryTarget } from '../../src/chat/types.js'
+
+describe('proactive send contract', () => {
+  test('telegram group personal target can carry mention metadata', () => {
+    const target: DeferredDeliveryTarget = {
+      contextId: '-1001',
+      contextType: 'group',
+      threadId: '42',
+      audience: 'personal',
+      mentionUserIds: ['12345'],
+      createdByUserId: '12345',
+      createdByUsername: 'ki',
+    }
+
+    expect(target.threadId).toBe('42')
+    expect(target.mentionUserIds).toEqual(['12345'])
+  })
+
+  test('mattermost shared group target carries no mention ids', () => {
+    const target: DeferredDeliveryTarget = {
+      contextId: 'chan-1',
+      contextType: 'group',
+      threadId: 'root-1',
+      audience: 'shared',
+      mentionUserIds: [],
+      createdByUserId: 'u1',
+      createdByUsername: 'ki',
+    }
+
+    expect(target.audience).toBe('shared')
+    expect(target.mentionUserIds).toEqual([])
+  })
+
+  test('discord personal group target keeps explicit mention ids', () => {
+    const target: DeferredDeliveryTarget = {
+      contextId: '123456789012345678',
+      contextType: 'group',
+      threadId: null,
+      audience: 'personal',
+      mentionUserIds: ['998877665544332211'],
+      createdByUserId: '998877665544332211',
+      createdByUsername: 'ki',
+    }
+
+    expect(target.mentionUserIds).toEqual(['998877665544332211'])
+  })
+
+  test('dm target has no thread and no mentions', () => {
+    const target: DeferredDeliveryTarget = {
+      contextId: 'user-123',
+      contextType: 'dm',
+      threadId: null,
+      audience: 'personal',
+      mentionUserIds: [],
+      createdByUserId: 'user-123',
+      createdByUsername: null,
+    }
+
+    expect(target.contextType).toBe('dm')
+    expect(target.threadId).toBeNull()
+    expect(target.mentionUserIds).toHaveLength(0)
+  })
+})

--- a/tests/chat/telegram/index.test.ts
+++ b/tests/chat/telegram/index.test.ts
@@ -14,10 +14,15 @@ import {
   type CacheContext,
   type MinimalContext,
 } from '../../../src/chat/telegram/message-extraction.js'
-import type { IncomingMessage, ReplyFn } from '../../../src/chat/types.js'
+import type { DeferredDeliveryTarget, IncomingMessage, ReplyFn } from '../../../src/chat/types.js'
 import { mockLogger } from '../../utils/test-helpers.js'
 
 type EditMessageCall = [text: string, options: Partial<{ reply_markup: unknown }> | undefined]
+type SendMessageCall = [
+  chatId: number,
+  text: string,
+  options: Partial<{ entities: unknown[]; message_thread_id: number }> | undefined,
+]
 
 const isBotMentionedFalse = (): boolean => false
 const includesTestBotMention = (text: string): boolean => text.includes('@testbot')
@@ -44,6 +49,22 @@ function isIncomingMessage(value: unknown): value is IncomingMessage {
 
 function isReplyFn(value: unknown): value is ReplyFn {
   return typeof value === 'object' && value !== null && 'text' in value && 'buttons' in value && 'formatted' in value
+}
+
+function isBotWithSendMessage(
+  value: unknown,
+): value is { api: { sendMessage: (...args: SendMessageCall) => Promise<unknown> } } {
+  return typeof value === 'object' && value !== null && 'api' in value
+}
+
+function getProviderBot(provider: TelegramChatProvider): {
+  api: { sendMessage: (...args: SendMessageCall) => Promise<unknown> }
+} {
+  const value = Reflect.get(provider as object, 'bot') as unknown
+  if (!isBotWithSendMessage(value)) {
+    throw new TypeError('Expected provider bot to expose api.sendMessage')
+  }
+  return value
 }
 
 // Mock the auth module to provide getThreadScopedStorageContextId
@@ -76,6 +97,186 @@ describe('TelegramChatProvider', () => {
       expect(provider.threadCapabilities.supportsThreads).toBe(true)
       expect(provider.threadCapabilities.canCreateThreads).toBe(true)
       expect(provider.threadCapabilities.threadScope).toBe('message')
+      delete process.env['TELEGRAM_BOT_TOKEN']
+    })
+  })
+
+  describe('sendMessage', () => {
+    test('uses an ID-based text mention with username label for personal group delivery', async () => {
+      process.env['TELEGRAM_BOT_TOKEN'] = 'test-token'
+      const provider = new TelegramChatProvider()
+      const bot = getProviderBot(provider)
+
+      const calls: SendMessageCall[] = []
+      bot.api.sendMessage = (...args: SendMessageCall): Promise<unknown> => {
+        calls.push(args)
+        return Promise.resolve(undefined)
+      }
+
+      const target: DeferredDeliveryTarget = {
+        contextId: '99',
+        contextType: 'group',
+        threadId: '123',
+        audience: 'personal',
+        mentionUserIds: ['42'],
+        createdByUserId: '42',
+        createdByUsername: 'alice',
+      }
+
+      await provider.sendMessage(target, 'hello')
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0]).toEqual([
+        99,
+        '@alice hello',
+        {
+          entities: [
+            {
+              offset: 0,
+              length: 6,
+              type: 'text_mention',
+              user: { id: 42, is_bot: false, first_name: 'alice' },
+            },
+          ],
+          message_thread_id: 123,
+        },
+      ])
+
+      delete process.env['TELEGRAM_BOT_TOKEN']
+    })
+
+    test('falls back to a generic ID-based mention and shifts markdown entities', async () => {
+      process.env['TELEGRAM_BOT_TOKEN'] = 'test-token'
+      const provider = new TelegramChatProvider()
+      const bot = getProviderBot(provider)
+
+      const calls: SendMessageCall[] = []
+      bot.api.sendMessage = (...args: SendMessageCall): Promise<unknown> => {
+        calls.push(args)
+        return Promise.resolve(undefined)
+      }
+
+      const target: DeferredDeliveryTarget = {
+        contextId: '99',
+        contextType: 'group',
+        threadId: null,
+        audience: 'personal',
+        mentionUserIds: ['42'],
+        createdByUserId: '42',
+        createdByUsername: null,
+      }
+
+      await provider.sendMessage(target, '**hi**')
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0]).toEqual([
+        99,
+        'you hi',
+        {
+          entities: [
+            {
+              offset: 0,
+              length: 3,
+              type: 'text_mention',
+              user: { id: 42, is_bot: false, first_name: 'you' },
+            },
+            {
+              offset: 4,
+              length: 2,
+              type: 'bold',
+            },
+          ],
+        },
+      ])
+
+      delete process.env['TELEGRAM_BOT_TOKEN']
+    })
+
+    test('does not fall back to username text when mentionUserIds are invalid', async () => {
+      process.env['TELEGRAM_BOT_TOKEN'] = 'test-token'
+      const provider = new TelegramChatProvider()
+      const bot = getProviderBot(provider)
+
+      const calls: SendMessageCall[] = []
+      bot.api.sendMessage = (...args: SendMessageCall): Promise<unknown> => {
+        calls.push(args)
+        return Promise.resolve(undefined)
+      }
+
+      const target: DeferredDeliveryTarget = {
+        contextId: '99',
+        contextType: 'group',
+        threadId: null,
+        audience: 'personal',
+        mentionUserIds: ['not-a-number'],
+        createdByUserId: '42',
+        createdByUsername: 'alice',
+      }
+
+      await provider.sendMessage(target, 'hello')
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0]).toEqual([
+        99,
+        'hello',
+        {
+          entities: [],
+        },
+      ])
+
+      delete process.env['TELEGRAM_BOT_TOKEN']
+    })
+
+    test('creates text mentions for multiple IDs and shifts following entities', async () => {
+      process.env['TELEGRAM_BOT_TOKEN'] = 'test-token'
+      const provider = new TelegramChatProvider()
+      const bot = getProviderBot(provider)
+
+      const calls: SendMessageCall[] = []
+      bot.api.sendMessage = (...args: SendMessageCall): Promise<unknown> => {
+        calls.push(args)
+        return Promise.resolve(undefined)
+      }
+
+      const target: DeferredDeliveryTarget = {
+        contextId: '99',
+        contextType: 'group',
+        threadId: null,
+        audience: 'personal',
+        mentionUserIds: ['42', '7'],
+        createdByUserId: '42',
+        createdByUsername: 'alice',
+      }
+
+      await provider.sendMessage(target, '**hi**')
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0]).toEqual([
+        99,
+        '@alice user hi',
+        {
+          entities: [
+            {
+              offset: 0,
+              length: 6,
+              type: 'text_mention',
+              user: { id: 42, is_bot: false, first_name: 'alice' },
+            },
+            {
+              offset: 7,
+              length: 4,
+              type: 'text_mention',
+              user: { id: 7, is_bot: false, first_name: 'user' },
+            },
+            {
+              offset: 12,
+              length: 2,
+              type: 'bold',
+            },
+          ],
+        },
+      ])
+
       delete process.env['TELEGRAM_BOT_TOKEN']
     })
   })

--- a/tests/db/deferred-prompt-delivery-migration.test.ts
+++ b/tests/db/deferred-prompt-delivery-migration.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { eq } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { alertPrompts, scheduledPrompts } from '../../src/db/schema.js'
+import { setupTestDb } from '../utils/test-helpers.js'
+
+describe('migration 025: deferred prompt delivery targets', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('scheduled_prompts stores explicit creator and delivery fields', () => {
+    const db = getDrizzleDb()
+    db.insert(scheduledPrompts)
+      .values({
+        id: 'sp1',
+        createdByUserId: 'u1',
+        createdByUsername: 'ki',
+        deliveryContextId: '-1001',
+        deliveryContextType: 'group',
+        deliveryThreadId: '42',
+        audience: 'personal',
+        mentionUserIds: '["u1"]',
+        prompt: 'remind me',
+        fireAt: '2027-01-01T00:00:00.000Z',
+      })
+      .run()
+
+    const row = db.select().from(scheduledPrompts).where(eq(scheduledPrompts.id, 'sp1')).get()
+    expect(row).not.toBeUndefined()
+    expect(row!.createdByUserId).toBe('u1')
+    expect(row!.deliveryContextId).toBe('-1001')
+    expect(row!.audience).toBe('personal')
+  })
+
+  test('alert_prompts stores explicit creator and delivery fields', () => {
+    const db = getDrizzleDb()
+    db.insert(alertPrompts)
+      .values({
+        id: 'ap1',
+        createdByUserId: 'u2',
+        createdByUsername: 'alex',
+        deliveryContextId: 'chan-1',
+        deliveryContextType: 'group',
+        deliveryThreadId: 'root-1',
+        audience: 'shared',
+        mentionUserIds: '[]',
+        prompt: 'notify channel',
+        condition: '{"field":"task.status","op":"eq","value":"done"}',
+      })
+      .run()
+
+    const row = db.select().from(alertPrompts).where(eq(alertPrompts.id, 'ap1')).get()
+    expect(row).not.toBeUndefined()
+    expect(row!.createdByUserId).toBe('u2')
+    expect(row!.deliveryContextId).toBe('chan-1')
+    expect(row!.audience).toBe('shared')
+  })
+})

--- a/tests/debug/server.test.ts
+++ b/tests/debug/server.test.ts
@@ -52,9 +52,9 @@ describe('debug-server', () => {
     ensurePublicBuilt()
     restoreFetch()
     process.env['DEBUG_PORT'] = String(TEST_PORT)
-    // Capture the log level that will be used for the stream
+    // Capture the log level and pass it explicitly to avoid mock-binding interference
     capturedLogLevel = getLogLevel()
-    startDebugServer('test-admin')
+    startDebugServer('test-admin', capturedLogLevel)
     seedLogBuffer()
   })
 

--- a/tests/deferred-prompts/alerts.test.ts
+++ b/tests/deferred-prompts/alerts.test.ts
@@ -32,7 +32,7 @@ describe('alert prompt CRUD', () => {
 
     expect(result.type).toBe('alert')
     expect(result.id).toBeTruthy()
-    expect(result.userId).toBe('user1')
+    expect(result.createdByUserId).toBe('user1')
     expect(result.prompt).toBe('Notify when done')
     expect(result.condition).toEqual(condition)
     expect(result.status).toBe('active')
@@ -212,6 +212,67 @@ describe('alert prompt CRUD', () => {
     const eligible = getEligibleAlertPrompts()
     expect(eligible).toHaveLength(1)
     expect(eligible[0]!.prompt).toBe('Past cooldown alert')
+  })
+})
+
+describe('alerts delivery target', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('creates alert prompt with explicit creator and delivery target', () => {
+    const alert = createAlertPrompt(
+      'user-1',
+      'notify channel',
+      { field: 'task.status', op: 'eq', value: 'done' },
+      60,
+      undefined,
+      {
+        contextId: 'chan-1',
+        contextType: 'group',
+        threadId: 'root-1',
+        audience: 'shared',
+        mentionUserIds: [],
+        createdByUserId: 'user-1',
+        createdByUsername: 'ki',
+      },
+    )
+
+    expect(alert.createdByUserId).toBe('user-1')
+    expect(alert.deliveryTarget.contextId).toBe('chan-1')
+    expect(alert.deliveryTarget.audience).toBe('shared')
+  })
+
+  test('lists alerts by creator identity after schema rename', () => {
+    createAlertPrompt('user-1', 'mine', { field: 'task.status', op: 'eq', value: 'done' }, 60, undefined, {
+      contextId: 'chan-1',
+      contextType: 'group',
+      threadId: null,
+      audience: 'shared',
+      mentionUserIds: [],
+      createdByUserId: 'user-1',
+      createdByUsername: null,
+    })
+    createAlertPrompt('user-2', 'not mine', { field: 'task.status', op: 'eq', value: 'done' }, 60, undefined, {
+      contextId: 'chan-1',
+      contextType: 'group',
+      threadId: null,
+      audience: 'shared',
+      mentionUserIds: [],
+      createdByUserId: 'user-2',
+      createdByUsername: null,
+    })
+
+    expect(listAlertPrompts('user-1')).toHaveLength(1)
+  })
+
+  test('defaults to dm delivery when no delivery provided', () => {
+    const condition: AlertCondition = { field: 'task.status', op: 'eq', value: 'done' }
+    const alert = createAlertPrompt('user1', 'Default delivery', condition)
+
+    expect(alert.deliveryTarget.contextType).toBe('dm')
+    expect(alert.deliveryTarget.contextId).toBe('user1')
+    expect(alert.deliveryTarget.audience).toBe('personal')
   })
 })
 

--- a/tests/deferred-prompts/deferred-delivery-types.test.ts
+++ b/tests/deferred-prompts/deferred-delivery-types.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { DeferredAudience } from '../../src/chat/types.js'
+import type { DeferredPromptDelivery } from '../../src/deferred-prompts/types.js'
+
+describe('deferred delivery domain types', () => {
+  test('supports personal delivery with mention targets', () => {
+    const audience: DeferredAudience = 'personal'
+    const delivery: DeferredPromptDelivery = {
+      contextId: '-1001',
+      contextType: 'group',
+      threadId: '42',
+      audience,
+      mentionUserIds: ['u1'],
+      createdByUserId: 'u1',
+      createdByUsername: 'ki',
+    }
+
+    expect(delivery.audience).toBe('personal')
+    expect(delivery.mentionUserIds).toEqual(['u1'])
+  })
+
+  test('supports shared delivery with no mention targets', () => {
+    const delivery: DeferredPromptDelivery = {
+      contextId: '-1001',
+      contextType: 'group',
+      threadId: null,
+      audience: 'shared',
+      mentionUserIds: [],
+      createdByUserId: 'u1',
+      createdByUsername: null,
+    }
+
+    expect(delivery.audience).toBe('shared')
+    expect(delivery.threadId).toBeNull()
+  })
+
+  test('supports dm delivery', () => {
+    const delivery: DeferredPromptDelivery = {
+      contextId: 'user-1',
+      contextType: 'dm',
+      threadId: null,
+      audience: 'personal',
+      mentionUserIds: [],
+      createdByUserId: 'user-1',
+      createdByUsername: null,
+    }
+
+    expect(delivery.contextType).toBe('dm')
+  })
+})

--- a/tests/deferred-prompts/poller.test.ts
+++ b/tests/deferred-prompts/poller.test.ts
@@ -513,4 +513,38 @@ describe('delivery target routing', () => {
 
     expect(callCount).toBe(2)
   })
+
+  test('same creator and thread but different delivery semantics do not merge into one scheduled execution batch', async () => {
+    let callCount = 0
+    generateTextImpl = (): Promise<GenerateTextResult> => {
+      callCount++
+      return Promise.resolve({ text: 'Done.', toolCalls: [], toolResults: [], response: { messages: [] } })
+    }
+
+    const pastTime = new Date(Date.now() - 60_000).toISOString()
+    createScheduledPrompt(USER_ID, 'Personal reminder', { fireAt: pastTime }, undefined, {
+      contextId: '-1001',
+      contextType: 'group',
+      threadId: '42',
+      audience: 'personal',
+      mentionUserIds: [USER_ID],
+      createdByUserId: USER_ID,
+      createdByUsername: 'alice',
+    })
+    createScheduledPrompt(USER_ID, 'Shared reminder', { fireAt: pastTime }, undefined, {
+      contextId: '-1001',
+      contextType: 'group',
+      threadId: '42',
+      audience: 'shared',
+      mentionUserIds: [],
+      createdByUserId: USER_ID,
+      createdByUsername: 'alice',
+    })
+
+    await pollScheduledOnce(chat, () => provider)
+
+    expect(callCount).toBe(2)
+    expect(sentMessages).toHaveLength(2)
+    expect(sentMessages.map((message) => message.target.audience).sort()).toEqual(['personal', 'shared'])
+  })
 })

--- a/tests/deferred-prompts/poller.test.ts
+++ b/tests/deferred-prompts/poller.test.ts
@@ -602,4 +602,38 @@ describe('delivery target routing', () => {
     expect(sentMessages).toHaveLength(2)
     expect(sentMessages.map((message) => message.target.audience).sort()).toEqual(['personal', 'shared'])
   })
+
+  test('shared scheduled prompts still batch together when one stored target has stale mention ids', async () => {
+    let callCount = 0
+    generateTextImpl = (): Promise<GenerateTextResult> => {
+      callCount++
+      return Promise.resolve({ text: 'Done.', toolCalls: [], toolResults: [], response: { messages: [] } })
+    }
+
+    const pastTime = new Date(Date.now() - 60_000).toISOString()
+    createScheduledPrompt(USER_ID, 'Shared reminder one', { fireAt: pastTime }, undefined, {
+      contextId: '-1001',
+      contextType: 'group',
+      threadId: '42',
+      audience: 'shared',
+      mentionUserIds: ['stale-user-id'],
+      createdByUserId: USER_ID,
+      createdByUsername: 'alice',
+    })
+    createScheduledPrompt(USER_ID, 'Shared reminder two', { fireAt: pastTime }, undefined, {
+      contextId: '-1001',
+      contextType: 'group',
+      threadId: '42',
+      audience: 'shared',
+      mentionUserIds: [],
+      createdByUserId: USER_ID,
+      createdByUsername: 'alice',
+    })
+
+    await pollScheduledOnce(chat, () => provider)
+
+    expect(callCount).toBe(1)
+    expect(sentMessages).toHaveLength(1)
+    expect(sentMessages[0]!.target.audience).toBe('shared')
+  })
 })

--- a/tests/deferred-prompts/poller.test.ts
+++ b/tests/deferred-prompts/poller.test.ts
@@ -2,7 +2,7 @@ import { mock, beforeEach, describe, expect, test } from 'bun:test'
 
 import type { ModelMessage } from 'ai'
 
-import type { ChatProvider } from '../../src/chat/types.js'
+import type { ChatProvider, DeferredDeliveryTarget } from '../../src/chat/types.js'
 import { setConfig } from '../../src/config.js'
 import { createAlertPrompt } from '../../src/deferred-prompts/alerts.js'
 import { pollAlertsOnce, pollScheduledOnce } from '../../src/deferred-prompts/poller.js'
@@ -35,7 +35,7 @@ type GenerateTextResult = {
 // --- Tests ---
 
 describe('pollScheduledOnce', () => {
-  let sentMessages: Array<{ userId: string; text: string }>
+  let sentMessages: Array<{ target: { contextId: string; contextType: string }; text: string }>
   let chat: ChatProvider
   let provider: TaskProvider
   let generateTextImpl = (): Promise<GenerateTextResult> =>
@@ -67,7 +67,7 @@ describe('pollScheduledOnce', () => {
 
     // Should have sent a message
     expect(sentMessages).toHaveLength(1)
-    expect(sentMessages[0]!.userId).toBe(USER_ID)
+    expect(sentMessages[0]!.target.contextId).toBe(USER_ID)
     expect(sentMessages[0]!.text).toBe('Task completed.')
 
     // Should be marked as completed
@@ -193,7 +193,7 @@ describe('pollScheduledOnce', () => {
 })
 
 describe('pollScheduledOnce — error handling', () => {
-  let sentMessages: Array<{ userId: string; text: string }>
+  let sentMessages: Array<{ target: { contextId: string; contextType: string }; text: string }>
   let chat: ChatProvider
   let generateTextImpl = (): Promise<GenerateTextResult> =>
     Promise.resolve({ text: 'Done.', toolCalls: [], toolResults: [], response: { messages: [] } })
@@ -224,7 +224,7 @@ describe('pollScheduledOnce — error handling', () => {
 
     await pollScheduledOnce(chat, () => createMockProvider())
 
-    expect(sentMessages.some((m: { userId: string; text: string }) => m.userId === userId)).toBe(true)
+    expect(sentMessages.some((m) => m.target.contextId === userId)).toBe(true)
   })
 
   test('completes one-shot prompt even when LLM fails', async () => {
@@ -261,7 +261,7 @@ describe('pollScheduledOnce — error handling', () => {
 })
 
 describe('pollAlertsOnce', () => {
-  let sentMessages: Array<{ userId: string; text: string }>
+  let sentMessages: Array<{ target: { contextId: string; contextType: string }; text: string }>
   let chat: ChatProvider
   let generateTextImpl = (): Promise<GenerateTextResult> =>
     Promise.resolve({ text: 'Done.', toolCalls: [], toolResults: [], response: { messages: [] } })
@@ -320,7 +320,7 @@ describe('pollAlertsOnce', () => {
     await pollAlertsOnce(chat, () => provider)
 
     expect(sentMessages).toHaveLength(1)
-    expect(sentMessages[0]!.userId).toBe(USER_ID)
+    expect(sentMessages[0]!.target.contextId).toBe(USER_ID)
     expect(sentMessages[0]!.text).toBe('Alert triggered.')
   })
 
@@ -355,7 +355,7 @@ describe('pollAlertsOnce', () => {
 })
 
 describe('pollScheduledOnce Race Condition', () => {
-  let sentMessages: Array<{ userId: string; text: string }>
+  let sentMessages: Array<{ target: { contextId: string; contextType: string }; text: string }>
   let chat: ChatProvider
   let provider: TaskProvider
   let resolveLlm: (result: GenerateTextResult) => void
@@ -410,5 +410,107 @@ describe('pollScheduledOnce Race Condition', () => {
 
     // With the fix, only one message should be sent even with overlapping polls
     expect(sentMessages).toHaveLength(1)
+  })
+})
+
+describe('delivery target routing', () => {
+  let sentMessages: Array<{ target: DeferredDeliveryTarget; text: string }>
+  let chat: ChatProvider
+  let provider: TaskProvider
+  let generateTextImpl = (): Promise<GenerateTextResult> =>
+    Promise.resolve({ text: 'Done.', toolCalls: [], toolResults: [], response: { messages: [] } })
+
+  beforeEach(async () => {
+    generateTextImpl = (): Promise<GenerateTextResult> =>
+      Promise.resolve({ text: 'Done.', toolCalls: [], toolResults: [], response: { messages: [] } })
+    void mock.module('ai', () => ({
+      generateText: (..._args: unknown[]): Promise<GenerateTextResult> => generateTextImpl(),
+      stepCountIs: (_n: number): unknown => undefined,
+    }))
+    void mock.module('@ai-sdk/openai-compatible', () => ({
+      createOpenAICompatible: (): (() => string) => (): string => 'mock-model',
+    }))
+    await setupTestDb()
+    const result = createMockChatWithSentMessages()
+    chat = result.provider
+    sentMessages = result.sentMessages
+    provider = createMockProvider()
+    setupUserConfig(USER_ID)
+  })
+
+  test('scheduled prompt created in group fires to stored group target, not DM', async () => {
+    const pastTime = new Date(Date.now() - 60_000).toISOString()
+    createScheduledPrompt(USER_ID, 'Check my overdue tasks', { fireAt: pastTime }, undefined, {
+      contextId: '-1001',
+      contextType: 'group',
+      threadId: '42',
+      audience: 'personal',
+      mentionUserIds: [USER_ID],
+      createdByUserId: USER_ID,
+      createdByUsername: null,
+    })
+
+    await pollScheduledOnce(chat, () => provider)
+
+    expect(sentMessages).toHaveLength(1)
+    expect(sentMessages[0]!.target.contextId).toBe('-1001')
+    expect(sentMessages[0]!.target.threadId).toBe('42')
+    expect(sentMessages[0]!.target.audience).toBe('personal')
+  })
+
+  test('alert created in group fires to stored group target, not DM', async () => {
+    createAlertPrompt(
+      USER_ID,
+      'Notify this channel',
+      { field: 'task.status', op: 'eq', value: 'done' },
+      60,
+      undefined,
+      {
+        contextId: 'chan-1',
+        contextType: 'group',
+        threadId: 'root-1',
+        audience: 'shared',
+        mentionUserIds: [],
+        createdByUserId: USER_ID,
+        createdByUsername: null,
+      },
+    )
+
+    const matchingProvider = createMockProvider({
+      listProjects: mock(() => Promise.resolve([{ id: 'proj-1', name: 'Test', url: 'http://test/proj/1' }])),
+      listTasks: mock(() =>
+        Promise.resolve([{ id: 'task-1', title: 'Completed Task', status: 'done', url: 'http://test/1' }]),
+      ),
+    })
+
+    await pollAlertsOnce(chat, () => matchingProvider)
+
+    expect(sentMessages.length).toBeGreaterThan(0)
+    expect(sentMessages[0]!.target.contextId).toBe('chan-1')
+    expect(sentMessages[0]!.target.audience).toBe('shared')
+  })
+
+  test('same creator but different delivery targets do not merge into one scheduled execution batch', async () => {
+    let callCount = 0
+    generateTextImpl = (): Promise<GenerateTextResult> => {
+      callCount++
+      return Promise.resolve({ text: 'Done.', toolCalls: [], toolResults: [], response: { messages: [] } })
+    }
+
+    const pastTime = new Date(Date.now() - 60_000).toISOString()
+    createScheduledPrompt(USER_ID, 'DM task', { fireAt: pastTime })
+    createScheduledPrompt(USER_ID, 'Group task', { fireAt: pastTime }, undefined, {
+      contextId: '-1001',
+      contextType: 'group',
+      threadId: null,
+      audience: 'shared',
+      mentionUserIds: [],
+      createdByUserId: USER_ID,
+      createdByUsername: null,
+    })
+
+    await pollScheduledOnce(chat, () => provider)
+
+    expect(callCount).toBe(2)
   })
 })

--- a/tests/deferred-prompts/poller.test.ts
+++ b/tests/deferred-prompts/poller.test.ts
@@ -4,7 +4,7 @@ import type { ModelMessage } from 'ai'
 
 import type { ChatProvider, DeferredDeliveryTarget } from '../../src/chat/types.js'
 import { setConfig } from '../../src/config.js'
-import { createAlertPrompt } from '../../src/deferred-prompts/alerts.js'
+import { createAlertPrompt, getAlertPrompt } from '../../src/deferred-prompts/alerts.js'
 import { pollAlertsOnce, pollScheduledOnce } from '../../src/deferred-prompts/poller.js'
 import { createScheduledPrompt, getScheduledPrompt } from '../../src/deferred-prompts/scheduled.js'
 import type { TaskProvider } from '../../src/providers/types.js'
@@ -258,6 +258,32 @@ describe('pollScheduledOnce — error handling', () => {
     expect(updated!.status).toBe('active')
     expect(new Date(updated!.fireAt).getTime()).toBeGreaterThan(Date.now())
   })
+
+  test('keeps one-shot prompt active when delivery fails after LLM succeeds', async () => {
+    const userId = 'delivery-fail-user'
+    setupUserConfig(userId)
+    const pastTime = new Date(Date.now() - 60_000).toISOString()
+    const created = createScheduledPrompt(userId, 'one-time task', { fireAt: pastTime })
+    let sendCount = 0
+
+    chat = {
+      ...chat,
+      sendMessage: (_target: DeferredDeliveryTarget, text: string): Promise<void> => {
+        sendCount += 1
+        if (sendCount === 1) return Promise.reject(new Error('delivery failed'))
+        sentMessages.push({ target: _target, text })
+        return Promise.resolve()
+      },
+    }
+
+    await pollScheduledOnce(chat, () => createMockProvider())
+
+    const updated = getScheduledPrompt(created.id, userId)
+    expect(updated).not.toBeNull()
+    expect(updated!.status).toBe('active')
+    expect(updated!.lastExecutedAt).toBeNull()
+    expect(sentMessages).toHaveLength(0)
+  })
 })
 
 describe('pollAlertsOnce', () => {
@@ -351,6 +377,35 @@ describe('pollAlertsOnce', () => {
 
     expect(sentMessages).toHaveLength(1)
     expect(sentMessages[0]!.text).toBe('Alert triggered.')
+  })
+
+  test('does not update alert trigger time when delivery fails', async () => {
+    const created = createAlertPrompt(USER_ID, 'Notify on done', { field: 'task.status', op: 'eq', value: 'done' })
+    let sendCount = 0
+
+    chat = {
+      ...chat,
+      sendMessage: (_target: DeferredDeliveryTarget, text: string): Promise<void> => {
+        sendCount += 1
+        if (sendCount === 1) return Promise.reject(new Error('delivery failed'))
+        sentMessages.push({ target: _target, text })
+        return Promise.resolve()
+      },
+    }
+
+    const provider = createMockProvider({
+      listProjects: mock(() => Promise.resolve([{ id: 'proj-1', name: 'Test', url: 'http://test/proj/1' }])),
+      listTasks: mock(() =>
+        Promise.resolve([{ id: 'task-1', title: 'Completed Task', status: 'done', url: 'http://test/1' }]),
+      ),
+    })
+
+    await pollAlertsOnce(chat, () => provider)
+
+    const updated = getAlertPrompt(created.id, USER_ID)
+    expect(updated).not.toBeNull()
+    expect(updated!.lastTriggeredAt).toBeNull()
+    expect(sentMessages).toHaveLength(0)
   })
 })
 

--- a/tests/deferred-prompts/proactive-llm.test.ts
+++ b/tests/deferred-prompts/proactive-llm.test.ts
@@ -11,6 +11,8 @@ import { dispatchExecution } from '../../src/deferred-prompts/proactive-llm.js'
 import type { DeferredExecutionContext } from '../../src/deferred-prompts/proactive-llm.js'
 import type { ExecutionMetadata } from '../../src/deferred-prompts/types.js'
 import { appendHistory } from '../../src/history.js'
+import { loadHistory } from '../../src/history.js'
+import { loadFacts } from '../../src/memory.js'
 import { createMockProvider } from '../tools/mock-provider.js'
 import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
 
@@ -34,6 +36,21 @@ function makeExecCtx(userId: string = USER_ID): DeferredExecutionContext {
       threadId: null,
       audience: 'personal',
       mentionUserIds: [],
+      createdByUserId: userId,
+      createdByUsername: null,
+    },
+  }
+}
+
+function makeGroupThreadExecCtx(userId: string = USER_ID): DeferredExecutionContext {
+  return {
+    createdByUserId: userId,
+    deliveryTarget: {
+      contextId: '-1001',
+      contextType: 'group',
+      threadId: '42',
+      audience: 'personal',
+      mentionUserIds: [userId],
       createdByUserId: userId,
       createdByUsername: null,
     },
@@ -166,6 +183,24 @@ describe('dispatchExecution', () => {
         messages.some((m) => typeof m.content === 'string' && m.content.includes('[CONTEXT FROM CREATION TIME]')),
       ).toBe(false)
     })
+
+    test('persists lightweight history to group thread delivery context instead of creator DM', async () => {
+      setupUserConfig()
+      generateTextImpl = (args: GenerateTextCall): Promise<GenerateTextResult> => {
+        generateTextCalls.push(args)
+        return Promise.resolve({
+          text: 'Thread reminder',
+          toolCalls: [],
+          toolResults: [],
+          response: { messages: [{ role: 'assistant', content: 'Thread reminder' }] },
+        })
+      }
+
+      await dispatchExecution(makeGroupThreadExecCtx(), 'scheduled', 'drink water', metadata, () => null)
+
+      expect(loadHistory('-1001:42')).toEqual([{ role: 'assistant', content: 'Thread reminder' }])
+      expect(loadHistory(USER_ID)).toEqual([])
+    })
   })
 
   describe('context mode', () => {
@@ -252,6 +287,27 @@ describe('dispatchExecution', () => {
       setupUserConfig()
       const result = await dispatchExecution(makeExecCtx(), 'scheduled', 'check overdue', metadata, () => null)
       expect(result).toContain('task provider not configured')
+    })
+
+    test('stores extracted facts in group thread delivery context instead of creator DM', async () => {
+      setupUserConfig()
+      const provider = createMockProvider()
+      generateTextImpl = (args: GenerateTextCall): Promise<GenerateTextResult> => {
+        generateTextCalls.push(args)
+        return Promise.resolve({
+          text: 'Created task',
+          toolCalls: [],
+          toolResults: [{ toolName: 'create_task', output: { id: 'task-1', title: 'Thread task', number: 17 } }],
+          response: { messages: [] },
+        })
+      }
+
+      await dispatchExecution(makeGroupThreadExecCtx(), 'scheduled', 'check overdue', metadata, () => provider)
+
+      expect(loadFacts('-1001:42')).toEqual([
+        expect.objectContaining({ identifier: '#17', title: 'Thread task', url: '' }),
+      ])
+      expect(loadFacts(USER_ID)).toEqual([])
     })
   })
 

--- a/tests/deferred-prompts/proactive-llm.test.ts
+++ b/tests/deferred-prompts/proactive-llm.test.ts
@@ -8,6 +8,7 @@ import type { ModelMessage } from 'ai'
 
 import { setConfig } from '../../src/config.js'
 import { dispatchExecution } from '../../src/deferred-prompts/proactive-llm.js'
+import type { DeferredExecutionContext } from '../../src/deferred-prompts/proactive-llm.js'
 import type { ExecutionMetadata } from '../../src/deferred-prompts/types.js'
 import { appendHistory } from '../../src/history.js'
 import { createMockProvider } from '../tools/mock-provider.js'
@@ -23,6 +24,21 @@ type GenerateTextResult = {
 type GenerateTextCall = { model: string; system: string; messages: ModelMessage[]; tools: unknown }
 
 const USER_ID = 'exec-mode-user'
+
+function makeExecCtx(userId: string = USER_ID): DeferredExecutionContext {
+  return {
+    createdByUserId: userId,
+    deliveryTarget: {
+      contextId: userId,
+      contextType: 'dm',
+      threadId: null,
+      audience: 'personal',
+      mentionUserIds: [],
+      createdByUserId: userId,
+      createdByUsername: null,
+    },
+  }
+}
 
 function setupUserConfig(opts?: { smallModel?: string }): void {
   setConfig(USER_ID, 'llm_apikey', 'test-key')
@@ -72,21 +88,21 @@ describe('dispatchExecution', () => {
 
     test('uses small_model when configured', async () => {
       setupUserConfig({ smallModel: 'small-model' })
-      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'drink water', metadata, () => null)
       expect(generateTextCalls).toHaveLength(1)
       expect(generateTextCalls[0]!.model).toContain('small-model')
     })
 
     test('falls back to main_model when small_model not set', async () => {
       setupUserConfig()
-      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'drink water', metadata, () => null)
       expect(generateTextCalls).toHaveLength(1)
       expect(generateTextCalls[0]!.model).toContain('main-model')
     })
 
     test('includes get_current_time tool only', async () => {
       setupUserConfig()
-      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'drink water', metadata, () => null)
       expect(generateTextCalls[0]!.tools).toBeDefined()
       expect(generateTextCalls[0]!.tools).toHaveProperty('get_current_time')
       // Should not have task-related tools in lightweight mode
@@ -95,7 +111,7 @@ describe('dispatchExecution', () => {
 
     test('uses minimal system prompt', async () => {
       setupUserConfig()
-      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'drink water', metadata, () => null)
       const system = generateTextCalls[0]!.system
       expect(system).toContain('[PROACTIVE EXECUTION]')
       expect(system).not.toContain('DEFERRED PROMPTS')
@@ -103,7 +119,7 @@ describe('dispatchExecution', () => {
 
     test('includes delivery brief in messages', async () => {
       setupUserConfig()
-      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'drink water', metadata, () => null)
       const messages = generateTextCalls[0]!.messages
       const systemMsgs = messages.filter((m) => m.role === 'system')
       expect(systemMsgs.some((m) => typeof m.content === 'string' && m.content.includes('[DELIVERY BRIEF]'))).toBe(true)
@@ -114,7 +130,7 @@ describe('dispatchExecution', () => {
 
     test('wraps prompt in deferred task delimiters', async () => {
       setupUserConfig()
-      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'drink water', metadata, () => null)
       const messages = generateTextCalls[0]!.messages
       const userMsgs = messages.filter((m) => m.role === 'user')
       expect(userMsgs.some((m) => typeof m.content === 'string' && m.content.includes('===DEFERRED_TASK==='))).toBe(
@@ -126,7 +142,7 @@ describe('dispatchExecution', () => {
     test('does not load conversation history', async () => {
       setupUserConfig()
       appendHistory(USER_ID, [{ role: 'user', content: 'old message' }])
-      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'drink water', metadata, () => null)
       const messages = generateTextCalls[0]!.messages
       expect(messages.some((m) => typeof m.content === 'string' && m.content.includes('old message'))).toBe(false)
     })
@@ -134,7 +150,7 @@ describe('dispatchExecution', () => {
     test('includes context snapshot when present', async () => {
       setupUserConfig()
       const withSnapshot: ExecutionMetadata = { ...metadata, context_snapshot: 'User discussed migration' }
-      await dispatchExecution(USER_ID, 'scheduled', 'remind about migration', withSnapshot, () => null)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'remind about migration', withSnapshot, () => null)
       const messages = generateTextCalls[0]!.messages
       const systemMsgs = messages.filter((m) => m.role === 'system')
       expect(
@@ -144,7 +160,7 @@ describe('dispatchExecution', () => {
 
     test('omits context snapshot message when null', async () => {
       setupUserConfig()
-      await dispatchExecution(USER_ID, 'scheduled', 'drink water', metadata, () => null)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'drink water', metadata, () => null)
       const messages = generateTextCalls[0]!.messages
       expect(
         messages.some((m) => typeof m.content === 'string' && m.content.includes('[CONTEXT FROM CREATION TIME]')),
@@ -161,21 +177,21 @@ describe('dispatchExecution', () => {
 
     test('uses main_model', async () => {
       setupUserConfig()
-      await dispatchExecution(USER_ID, 'scheduled', 'standup reminder', metadata, () => null)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'standup reminder', metadata, () => null)
       expect(generateTextCalls[0]!.model).toContain('main-model')
     })
 
     test('loads conversation history', async () => {
       setupUserConfig()
       appendHistory(USER_ID, [{ role: 'user', content: 'history message' }])
-      await dispatchExecution(USER_ID, 'scheduled', 'standup reminder', metadata, () => null)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'standup reminder', metadata, () => null)
       const messages = generateTextCalls[0]!.messages
       expect(messages.some((m) => typeof m.content === 'string' && m.content.includes('history message'))).toBe(true)
     })
 
     test('includes get_current_time tool only', async () => {
       setupUserConfig()
-      await dispatchExecution(USER_ID, 'scheduled', 'standup reminder', metadata, () => null)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'standup reminder', metadata, () => null)
       expect(generateTextCalls[0]!.tools).toBeDefined()
       expect(generateTextCalls[0]!.tools).toHaveProperty('get_current_time')
       // Should not have task-related tools in context mode
@@ -184,7 +200,7 @@ describe('dispatchExecution', () => {
 
     test('uses minimal system prompt', async () => {
       setupUserConfig()
-      await dispatchExecution(USER_ID, 'scheduled', 'standup reminder', metadata, () => null)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'standup reminder', metadata, () => null)
       const system = generateTextCalls[0]!.system
       expect(system).toContain('[PROACTIVE EXECUTION]')
     })
@@ -200,14 +216,14 @@ describe('dispatchExecution', () => {
     test('uses main_model', async () => {
       setupUserConfig()
       const provider = createMockProvider()
-      await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => provider)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'check overdue', metadata, () => provider)
       expect(generateTextCalls[0]!.model).toContain('main-model')
     })
 
     test('includes tools with proactive mode', async () => {
       setupUserConfig()
       const provider = createMockProvider()
-      await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => provider)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'check overdue', metadata, () => provider)
       expect(generateTextCalls[0]!.tools).toBeDefined()
       // Full mode with proactive delivery should exclude deferred prompt tools
       expect(generateTextCalls[0]!.tools).not.toHaveProperty('create_deferred_prompt')
@@ -217,7 +233,7 @@ describe('dispatchExecution', () => {
     test('uses full system prompt', async () => {
       setupUserConfig()
       const provider = createMockProvider()
-      await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => provider)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'check overdue', metadata, () => provider)
       const system = generateTextCalls[0]!.system
       // Full system prompt includes provider-specific content
       expect(system.length).toBeGreaterThan(200)
@@ -227,14 +243,14 @@ describe('dispatchExecution', () => {
       setupUserConfig()
       const provider = createMockProvider()
       appendHistory(USER_ID, [{ role: 'user', content: 'full mode history' }])
-      await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => provider)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'check overdue', metadata, () => provider)
       const messages = generateTextCalls[0]!.messages
       expect(messages.some((m) => typeof m.content === 'string' && m.content.includes('full mode history'))).toBe(true)
     })
 
     test('returns error when provider cannot be built', async () => {
       setupUserConfig()
-      const result = await dispatchExecution(USER_ID, 'scheduled', 'check overdue', metadata, () => null)
+      const result = await dispatchExecution(makeExecCtx(), 'scheduled', 'check overdue', metadata, () => null)
       expect(result).toContain('task provider not configured')
     })
   })
@@ -244,8 +260,43 @@ describe('dispatchExecution', () => {
       setupUserConfig()
       const emptyMetadata: ExecutionMetadata = { mode: 'full', delivery_brief: '', context_snapshot: null }
       const provider = createMockProvider()
-      await dispatchExecution(USER_ID, 'scheduled', 'test', emptyMetadata, () => provider)
+      await dispatchExecution(makeExecCtx(), 'scheduled', 'test', emptyMetadata, () => provider)
       expect(generateTextCalls[0]!.tools).toBeDefined()
+    })
+  })
+
+  describe('stored delivery context', () => {
+    const metadata: ExecutionMetadata = {
+      mode: 'full',
+      delivery_brief: 'Check overdue tasks grouped by project',
+      context_snapshot: null,
+    }
+
+    test('full mode uses stored delivery context for tools and history while reading config from creator', async () => {
+      setupUserConfig()
+      const provider = createMockProvider()
+
+      await dispatchExecution(
+        {
+          createdByUserId: USER_ID,
+          deliveryTarget: {
+            contextId: '-1001:42',
+            contextType: 'group',
+            threadId: '42',
+            audience: 'personal',
+            mentionUserIds: [USER_ID],
+            createdByUserId: USER_ID,
+            createdByUsername: null,
+          },
+        },
+        'scheduled',
+        'check overdue',
+        metadata,
+        () => provider,
+      )
+
+      expect(generateTextCalls).toHaveLength(1)
+      expect(generateTextCalls[0]!.tools).toHaveProperty('create_task')
     })
   })
 })

--- a/tests/deferred-prompts/scheduled.test.ts
+++ b/tests/deferred-prompts/scheduled.test.ts
@@ -30,7 +30,7 @@ describe('createScheduledPrompt', () => {
 
     expect(prompt.type).toBe('scheduled')
     expect(prompt.id).toBeDefined()
-    expect(prompt.userId).toBe(USER_ID)
+    expect(prompt.createdByUserId).toBe(USER_ID)
     expect(prompt.prompt).toBe('Remind me to check tasks')
     expect(prompt.fireAt).toBe(fireAt)
     expect(prompt.cronExpression).toBeNull()
@@ -65,7 +65,7 @@ describe('listScheduledPrompts', () => {
 
     const prompts = listScheduledPrompts(USER_ID)
     expect(prompts).toHaveLength(2)
-    expect(prompts.every((p) => p.userId === USER_ID)).toBe(true)
+    expect(prompts.every((p) => p.createdByUserId === USER_ID)).toBe(true)
   })
 
   test('filters by status', () => {
@@ -218,5 +218,66 @@ describe('completeScheduledPrompt', () => {
     expect(updated).not.toBeNull()
     expect(updated!.status).toBe('completed')
     expect(updated!.lastExecutedAt).toBe(executedAt)
+  })
+})
+
+describe('delivery target persistence', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('creates scheduled prompt with explicit creator and delivery target', () => {
+    const fireAt = new Date(Date.now() + 60_000).toISOString()
+    const prompt = createScheduledPrompt('user-1', 'remind me', { fireAt }, undefined, {
+      contextId: '-1001',
+      contextType: 'group',
+      threadId: '42',
+      audience: 'personal',
+      mentionUserIds: ['user-1'],
+      createdByUserId: 'user-1',
+      createdByUsername: 'ki',
+    })
+
+    expect(prompt.createdByUserId).toBe('user-1')
+    expect(prompt.createdByUsername).toBe('ki')
+    expect(prompt.deliveryTarget.contextId).toBe('-1001')
+    expect(prompt.deliveryTarget.threadId).toBe('42')
+    expect(prompt.deliveryTarget.audience).toBe('personal')
+    expect(prompt.deliveryTarget.mentionUserIds).toEqual(['user-1'])
+  })
+
+  test('lists scheduled prompts by creator identity after schema rename', () => {
+    const fireAt = new Date(Date.now() + 60_000).toISOString()
+    createScheduledPrompt('user-1', 'mine', { fireAt }, undefined, {
+      contextId: '-1001',
+      contextType: 'group',
+      threadId: null,
+      audience: 'shared',
+      mentionUserIds: [],
+      createdByUserId: 'user-1',
+      createdByUsername: null,
+    })
+    createScheduledPrompt('user-2', 'not mine', { fireAt }, undefined, {
+      contextId: '-1001',
+      contextType: 'group',
+      threadId: null,
+      audience: 'shared',
+      mentionUserIds: [],
+      createdByUserId: 'user-2',
+      createdByUsername: null,
+    })
+
+    const prompts = listScheduledPrompts('user-1')
+    expect(prompts).toHaveLength(1)
+    expect(prompts[0]!.createdByUserId).toBe('user-1')
+  })
+
+  test('defaults to dm delivery when no delivery provided', () => {
+    const fireAt = new Date(Date.now() + 60_000).toISOString()
+    const prompt = createScheduledPrompt(USER_ID, 'default delivery', { fireAt })
+
+    expect(prompt.deliveryTarget.contextType).toBe('dm')
+    expect(prompt.deliveryTarget.contextId).toBe(USER_ID)
+    expect(prompt.deliveryTarget.audience).toBe('personal')
   })
 })

--- a/tests/deferred-prompts/tools.test.ts
+++ b/tests/deferred-prompts/tools.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, test } from 'bun:test'
 import type { ToolSet } from 'ai'
 
 import { setConfig } from '../../src/config.js'
+import { getAlertPrompt } from '../../src/deferred-prompts/alerts.js'
+import { getScheduledPrompt } from '../../src/deferred-prompts/scheduled.js'
 import { makeCancelDeferredPromptTool } from '../../src/tools/cancel-deferred-prompt.js'
 import { makeCreateDeferredPromptTool } from '../../src/tools/create-deferred-prompt.js'
 import { makeGetDeferredPromptTool } from '../../src/tools/get-deferred-prompt.js'
@@ -15,7 +17,7 @@ const toolCtx = { toolCallId: 'tc1', messages: [] as never[], abortSignal: new A
 
 function getTools(): ToolSet {
   return {
-    create_deferred_prompt: makeCreateDeferredPromptTool(USER_ID),
+    create_deferred_prompt: makeCreateDeferredPromptTool(USER_ID, USER_ID, 'dm'),
     list_deferred_prompts: makeListDeferredPromptsTool(USER_ID),
     get_deferred_prompt: makeGetDeferredPromptTool(USER_ID),
     update_deferred_prompt: makeUpdateDeferredPromptTool(USER_ID),
@@ -446,5 +448,68 @@ describe('execution metadata', () => {
     const detail: unknown = await get.execute({ id }, toolCtx)
     expect(detail).toHaveProperty('executionMetadata.mode', 'lightweight')
     expect(detail).toHaveProperty('executionMetadata.delivery_brief', 'Updated brief')
+  })
+})
+
+describe('delivery classification persistence', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+    setConfig(USER_ID, 'timezone', 'UTC')
+  })
+
+  test('group scheduled prompt persists personal audience and mention target chosen at creation', async () => {
+    const tool = makeCreateDeferredPromptTool(USER_ID, '-1001:42', 'group')
+    if (!tool.execute) throw new Error('Tool execute is undefined')
+
+    const result: unknown = await tool.execute(
+      {
+        prompt: 'Remind me to send the report',
+        schedule: { fire_at: futureFireAt() },
+        delivery: {
+          audience: 'personal',
+          mention_user_ids: [USER_ID],
+        },
+        execution: {
+          mode: 'context',
+          delivery_brief: 'Personal reminder in the same group thread',
+          context_snapshot: 'Discussed weekly reporting in this thread.',
+        },
+      },
+      toolCtx,
+    )
+
+    const created = getScheduledPrompt(extractId(result), USER_ID)
+    expect(created).not.toBeNull()
+    expect(created!.deliveryTarget.contextId).toBe('-1001')
+    expect(created!.deliveryTarget.audience).toBe('personal')
+    expect(created!.deliveryTarget.mentionUserIds).toEqual([USER_ID])
+  })
+
+  test('group alert persists shared audience and no mention targets chosen at creation', async () => {
+    const tool = makeCreateDeferredPromptTool(USER_ID, 'chan-1', 'group')
+    if (!tool.execute) throw new Error('Tool execute is undefined')
+
+    const result: unknown = await tool.execute(
+      {
+        prompt: 'Notify this channel when a task becomes overdue',
+        condition: { field: 'task.dueDate', op: 'overdue' },
+        delivery: {
+          audience: 'shared',
+          mention_user_ids: [],
+        },
+        execution: {
+          mode: 'full',
+          delivery_brief: 'Shared group alert for the whole channel',
+          context_snapshot: 'Group operations alert for overdue work.',
+        },
+      },
+      toolCtx,
+    )
+
+    const created = getAlertPrompt(extractId(result), USER_ID)
+    expect(created).not.toBeNull()
+    expect(created!.deliveryTarget.contextId).toBe('chan-1')
+    expect(created!.deliveryTarget.audience).toBe('shared')
+    expect(created!.deliveryTarget.mentionUserIds).toEqual([])
   })
 })

--- a/tests/deferred-prompts/tools.test.ts
+++ b/tests/deferred-prompts/tools.test.ts
@@ -512,4 +512,31 @@ describe('delivery classification persistence', () => {
     expect(created!.deliveryTarget.audience).toBe('shared')
     expect(created!.deliveryTarget.mentionUserIds).toEqual([])
   })
+
+  test('group shared delivery drops stale mention targets chosen by the model', async () => {
+    const tool = makeCreateDeferredPromptTool(USER_ID, 'chan-1', 'group')
+    if (!tool.execute) throw new Error('Tool execute is undefined')
+
+    const result: unknown = await tool.execute(
+      {
+        prompt: 'Notify this channel when a task becomes overdue',
+        condition: { field: 'task.dueDate', op: 'overdue' },
+        delivery: {
+          audience: 'shared',
+          mention_user_ids: [USER_ID, 'stale-user-id'],
+        },
+        execution: {
+          mode: 'full',
+          delivery_brief: 'Shared group alert for the whole channel',
+          context_snapshot: 'Group operations alert for overdue work.',
+        },
+      },
+      toolCtx,
+    )
+
+    const created = getAlertPrompt(extractId(result), USER_ID)
+    expect(created).not.toBeNull()
+    expect(created!.deliveryTarget.audience).toBe('shared')
+    expect(created!.deliveryTarget.mentionUserIds).toEqual([])
+  })
 })

--- a/tests/scripts/behavior-audit-incremental.test.ts
+++ b/tests/scripts/behavior-audit-incremental.test.ts
@@ -76,6 +76,8 @@ async function initializeGitRepo(root: string): Promise<void> {
       'user.name=Test User',
       '-c',
       'user.email=test@example.com',
+      '-c',
+      'commit.gpgsign=false',
       'commit',
       '--allow-empty',
       '-m',
@@ -89,7 +91,19 @@ async function initializeGitRepo(root: string): Promise<void> {
 async function commitAll(root: string, message: string): Promise<void> {
   await runCommand(['git', 'add', '.'], root)
   await runCommand(
-    ['git', '-c', 'user.name=Test User', '-c', 'user.email=test@example.com', 'commit', '-m', message, '-q'],
+    [
+      'git',
+      '-c',
+      'user.name=Test User',
+      '-c',
+      'user.email=test@example.com',
+      '-c',
+      'commit.gpgsign=false',
+      'commit',
+      '-m',
+      message,
+      '-q',
+    ],
     root,
   )
 }

--- a/tests/scripts/behavior-audit-integration.test.ts
+++ b/tests/scripts/behavior-audit-integration.test.ts
@@ -65,6 +65,8 @@ async function initializeGitRepo(root: string): Promise<void> {
       'user.name=Test User',
       '-c',
       'user.email=test@example.com',
+      '-c',
+      'commit.gpgsign=false',
       'commit',
       '--allow-empty',
       '-m',
@@ -78,7 +80,19 @@ async function initializeGitRepo(root: string): Promise<void> {
 async function commitAll(root: string, message: string): Promise<void> {
   await runCommand(['git', 'add', '.'], root)
   await runCommand(
-    ['git', '-c', 'user.name=Test User', '-c', 'user.email=test@example.com', 'commit', '-m', message, '-q'],
+    [
+      'git',
+      '-c',
+      'user.name=Test User',
+      '-c',
+      'user.email=test@example.com',
+      '-c',
+      'commit.gpgsign=false',
+      'commit',
+      '-m',
+      message,
+      '-q',
+    ],
     root,
   )
 }

--- a/tests/tools/index.test.ts
+++ b/tests/tools/index.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it, test, mock, beforeEach } from 'bun:test'
 
+import { setConfig } from '../../src/config.js'
+import { getScheduledPrompt } from '../../src/deferred-prompts/scheduled.js'
 import { makeTools, type MakeToolsOptions } from '../../src/tools/index.js'
-import { mockLogger } from '../utils/test-helpers.js'
+import { getToolExecutor, mockLogger, setupTestDb } from '../utils/test-helpers.js'
 import { createMockProvider } from './mock-provider.js'
 
 describe('makeTools', () => {
   beforeEach(() => {
     mockLogger()
     mock.restore()
+  })
+
+  beforeEach(async () => {
+    await setupTestDb()
+    setConfig('user-1', 'timezone', 'UTC')
   })
 
   const provider = createMockProvider()
@@ -126,6 +133,40 @@ describe('makeTools', () => {
     expect(tools).toHaveProperty('list_deferred_prompts')
     expect(tools).toHaveProperty('cancel_deferred_prompt')
     expect(tools).toHaveProperty('get_deferred_prompt')
+  })
+
+  test('group deferred prompts created via makeTools preserve creator username for personal delivery', async () => {
+    const tools = makeTools(provider, {
+      storageContextId: '-1001:42',
+      chatUserId: 'user-1',
+      contextType: 'group',
+      username: 'ki',
+    })
+    const execute = getToolExecutor(tools['create_deferred_prompt'])
+
+    const future = new Date(Date.now() + 3_600_000)
+    const date = future.toISOString().slice(0, 10)
+    const time = future.toISOString().slice(11, 16)
+
+    const result = await execute(
+      {
+        prompt: 'Ping me later',
+        schedule: { fire_at: { date, time } },
+        delivery: { audience: 'personal' },
+        execution: { mode: 'context', delivery_brief: 'Personal reminder in thread' },
+      },
+      { toolCallId: 'tc1', messages: [], abortSignal: new AbortController().signal },
+    )
+
+    if (typeof result !== 'object' || result === null || !('id' in result)) {
+      throw new Error('Expected create_deferred_prompt result with id')
+    }
+    const id = result['id']
+    if (typeof id !== 'string') throw new Error('Expected id to be string')
+
+    const created = getScheduledPrompt(id, 'user-1')
+    expect(created).not.toBeNull()
+    expect(created?.deliveryTarget.createdByUsername).toBe('ki')
   })
 
   test('proactive mode excludes deferred prompt tools', () => {

--- a/tests/utils/test-helpers.ts
+++ b/tests/utils/test-helpers.ts
@@ -13,6 +13,7 @@ import type {
   CommandHandler,
   ContextRendered,
   ContextSnapshot,
+  DeferredDeliveryTarget,
   EmbedOptions,
   IncomingInteraction,
   IncomingMessage,
@@ -296,7 +297,7 @@ type CreateAuthOptions = Partial<
 type CreateMockChatOptions = Partial<
   Readonly<{
     commandHandlers: Map<string, CommandHandler>
-    sendMessage: (userId: string, text: string) => Promise<void>
+    sendMessage: (target: DeferredDeliveryTarget, text: string) => Promise<void>
     onMessageHandler: (handler: (msg: IncomingMessage, reply: ReplyFn) => Promise<void>) => void
     resolveUserId: (username: string, context: ResolveUserContext) => Promise<string | null>
     onInteractionHandler: (handler: (interaction: IncomingInteraction, reply: ReplyFn) => Promise<void>) => void
@@ -310,7 +311,8 @@ type CreateMockChatOptions = Partial<
 const EMPTY_CREATE_AUTH_OPTIONS: CreateAuthOptions = {}
 const EMPTY_CREATE_MOCK_CHAT_OPTIONS: CreateMockChatOptions = {}
 const DEFAULT_MOCK_CHAT_TRAITS: ChatProviderTraits = { observedGroupMessages: 'all' }
-const DEFAULT_SEND_MESSAGE: (userId: string, text: string) => Promise<void> = (_userId, _text) => Promise.resolve()
+const DEFAULT_SEND_MESSAGE: (target: DeferredDeliveryTarget, text: string) => Promise<void> = (_target, _text) =>
+  Promise.resolve()
 const DEFAULT_SET_COMMANDS: (adminUserId: string) => Promise<void> = (_adminUserId) => Promise.resolve()
 const DEFAULT_RESOLVE_USER_ID = (username: string, _context: ResolveUserContext): Promise<string | null> => {
   const clean = username.startsWith('@') ? username.slice(1) : username
@@ -420,7 +422,7 @@ export function createMockChat(...args: [] | [options: CreateMockChatOptions]): 
   const resolveUserId = options.resolveUserId
   const setCommands = options.setCommands
 
-  let sendMessageImpl: (userId: string, text: string) => Promise<void> = DEFAULT_SEND_MESSAGE
+  let sendMessageImpl: (target: DeferredDeliveryTarget, text: string) => Promise<void> = DEFAULT_SEND_MESSAGE
   if (sendMessage !== undefined) {
     sendMessageImpl = sendMessage
   }
@@ -494,6 +496,8 @@ export function createMockChatWithCommandHandlers(...args: [] | [options: Create
 
 /**
  * Create a mock chat provider with custom sendMessage behavior and command handler capture.
+ * The callback receives contextId (string) for backward compatibility with callers that
+ * pre-date the DeferredDeliveryTarget interface.
  */
 export function createMockChatWithHandler(sendMessageImpl: (userId: string, markdown: string) => Promise<void>): {
   mockChat: ChatProvider
@@ -502,7 +506,8 @@ export function createMockChatWithHandler(sendMessageImpl: (userId: string, mark
   const handlers = new Map<string, CommandHandler>()
   const mockChat = createMockChat({
     commandHandlers: handlers,
-    sendMessage: sendMessageImpl,
+    sendMessage: (target: DeferredDeliveryTarget, text: string): Promise<void> =>
+      sendMessageImpl(target.contextId, text),
   })
   return { mockChat, handlers }
 }
@@ -541,13 +546,13 @@ export function createMockChatForBot(): {
  */
 export function createMockChatWithSentMessages(): {
   provider: ChatProvider
-  sentMessages: Array<{ userId: string; text: string }>
+  sentMessages: Array<{ target: DeferredDeliveryTarget; text: string }>
 } {
-  const sentMessages: Array<{ userId: string; text: string }> = []
+  const sentMessages: Array<{ target: DeferredDeliveryTarget; text: string }> = []
 
   const provider = createMockChat({
-    sendMessage: (userId: string, text: string): Promise<void> => {
-      sentMessages.push({ userId, text })
+    sendMessage: (target: DeferredDeliveryTarget, text: string): Promise<void> => {
+      sentMessages.push({ target, text })
       return Promise.resolve()
     },
   })


### PR DESCRIPTION
Replace the DM-only deferred prompt flow with an explicit delivery
contract so scheduled prompts and alerts fire into the same
DM/group/thread context where they were created, with personal vs
shared audience behavior and provider-specific mention rendering.

Key changes:
- Add DeferredDeliveryTarget / DeferredAudience to chat/types.ts
  (extracted to chat/deferred-target.ts); update sendMessage signature
  across all three adapters (Telegram, Mattermost, Discord)
- DB migration 025: rename user_id → created_by_user_id, add 6
  delivery columns to scheduled_prompts and alert_prompts
  (schema extracted to db/deferred-schema.ts)
- deliveryPolicySchema + DeferredPromptDelivery domain types in
  deferred-prompts/types.ts
- buildDeliveryInput() in tool-handlers.ts reconstructs delivery spec
  from creation context (DM vs group, thread, audience, mentions)
- getStorageContextId() + deliveryGroupKey() in poller.ts / proactive-llm.ts
  for correct context routing and prompt batching by delivery target
- Condition evaluation extracted to condition-eval.ts from alerts.ts
- Telegram/Mattermost/Discord adapters handle group @mention and
  thread routing from the delivery target

https://claude.ai/code/session_01AjCHBGbRVmQwkP4WpcVzTb