### PR TITLE
feat: add readable group and user labels to /group and /groups commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@gramio/format": "^0.6.0",
     "ai": "^6.0.154",
     "ai-tokenizer": "^1.0.6",
-    "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "defuddle": "^0.16.0",
     "discord.js": "^14.25.1",

--- a/src/chat/discord/client-factory.ts
+++ b/src/chat/discord/client-factory.ts
@@ -4,11 +4,12 @@ import type { DiscordMessageLike } from './map-message.js'
 import type { SendableChannel } from './reply-helpers.js'
 
 export type DispatchableMessage = DiscordMessageLike & {
-  channel: SendableChannel & {
-    messages?: {
-      fetch: (id: string) => Promise<{ id: string; author: { id: string; username: string }; content: string }>
-    }
-  }
+  channel: SendableChannel &
+    Partial<{
+      messages: {
+        fetch: (id: string) => Promise<{ id: string; author: { id: string; username: string }; content: string }>
+      }
+    }>
 }
 
 type EventListener = (...args: unknown[]) => void
@@ -16,18 +17,38 @@ type EventListener = (...args: unknown[]) => void
 /** Structural type covering the discord.js Client API surface we use. */
 export type DiscordClientLike = {
   destroy: () => Promise<void>
-  users?: {
-    fetch: (id: string) => Promise<{
-      createDM: () => Promise<{ send: (arg: { content: string }) => Promise<unknown> }>
-    }>
+} & Partial<{
+  users: {
+    fetch: (id: string) => Promise<
+      {
+        createDM: () => Promise<{ send: (arg: { content: string }) => Promise<unknown> }>
+      } & Partial<{
+        username: string
+        displayName: string
+        globalName: string | null
+      }>
+    >
   }
-  channels?: { cache: { get(id: string): unknown } }
-  guilds?: { cache: { get(id: string): unknown } }
-}
+  channels: {
+    cache: { get(id: string): unknown }
+  } & Partial<{
+    fetch: (id: string) => Promise<unknown>
+  }>
+  guilds: { cache: { get(id: string): unknown } }
+}>
 
-/** Narrowed guild shape returned by cache.get — used in resolveUserId. */
+/** Narrowed guild shape returned by cache.get — used in resolveUserId and resolveUserLabel. */
 export type GuildLike = {
-  members: { search: (arg: { query: string; limit: number }) => Promise<Map<string, { id: string }>> }
+  members: {
+    search: (arg: { query: string; limit: number }) => Promise<Map<string, { id: string }>>
+  } & Partial<{
+    fetch: (id: string) => Promise<{
+      displayName: string | undefined
+      user:
+        | { username: string | undefined; displayName: string | undefined; globalName: string | null | undefined }
+        | undefined
+    }>
+  }>
 }
 
 /** Payload type for Discord ready event. */

--- a/src/chat/discord/client-factory.ts
+++ b/src/chat/discord/client-factory.ts
@@ -44,6 +44,7 @@ export type GuildLike = {
   } & Partial<{
     fetch: (id: string) => Promise<{
       displayName: string | undefined
+      nickname: string | null | undefined
       user:
         | { username: string | undefined; displayName: string | undefined; globalName: string | null | undefined }
         | undefined

--- a/src/chat/discord/index.ts
+++ b/src/chat/discord/index.ts
@@ -27,12 +27,12 @@ import {
 import { renderDiscordContext } from './context-renderer.js'
 import { chunkForDiscord } from './format-chunking.js'
 import { handleDiscordGroupSettingsSelection } from './group-settings.js'
-import { resolveDiscordGroupLabel, resolveDiscordUserLabel } from './label-helpers.js'
+import { resolveDiscordGroupLabel, resolveDiscordGuildFromContext, resolveDiscordUserLabel } from './label-helpers.js'
 import { mapDiscordMessage } from './map-message.js'
 import { discordCapabilities, discordConfigRequirements, discordTraits } from './metadata.js'
 import { buildDiscordReplyContext } from './reply-context.js'
 import { createDiscordReplyFn } from './reply-helpers.js'
-import { isDispatchableMessage, isGuildLike, isReadyPayload } from './type-guards.js'
+import { isDispatchableMessage, isReadyPayload } from './type-guards.js'
 export type { DiscordClientFactory, DiscordClientLike, DispatchableMessage }
 export { defaultClientFactory }
 const log = logger.child({ scope: 'chat:discord' })
@@ -97,23 +97,22 @@ export class DiscordChatProvider implements ChatProvider {
     if (context.contextType !== 'group') return null
     if (this.client === null) return null
 
-    if (this.client.channels === undefined || this.client.guilds === undefined) return null
-    const raw = this.client.channels.cache.get(context.contextId)
-    if (typeof raw !== 'object' || raw === null || !('guildId' in raw)) return null
-    const guildId = raw.guildId
-    if (typeof guildId !== 'string') return null
-    const rawGuild = this.client.guilds.cache.get(guildId)
-    if (!isGuildLike(rawGuild)) return null
+    const resolvedGuild = await resolveDiscordGuildFromContext(this.client, context.contextId)
+    if (resolvedGuild === null) return null
 
     try {
-      const members = await rawGuild.members.search({ query: clean, limit: 1 })
+      const members = await resolvedGuild.guild.members.search({ query: clean, limit: 1 })
       for (const m of members.values()) {
         return m.id
       }
       return null
     } catch (error) {
       log.warn(
-        { username: clean, guildId, error: error instanceof Error ? error.message : String(error) },
+        {
+          username: clean,
+          guildId: resolvedGuild.guildId,
+          error: error instanceof Error ? error.message : String(error),
+        },
         'Discord member search failed',
       )
       return null

--- a/src/chat/discord/index.ts
+++ b/src/chat/discord/index.ts
@@ -27,6 +27,7 @@ import {
 import { renderDiscordContext } from './context-renderer.js'
 import { chunkForDiscord } from './format-chunking.js'
 import { handleDiscordGroupSettingsSelection } from './group-settings.js'
+import { resolveDiscordGroupLabel, resolveDiscordUserLabel } from './label-helpers.js'
 import { mapDiscordMessage } from './map-message.js'
 import { discordCapabilities, discordConfigRequirements, discordTraits } from './metadata.js'
 import { buildDiscordReplyContext } from './reply-context.js'
@@ -51,16 +52,16 @@ export class DiscordChatProvider implements ChatProvider {
   private readonly clientFactory: DiscordClientFactory
   private readonly commands = new Map<string, CommandHandler>()
   private messageHandler: OnMessageHandler | null = null
-  private interactionHandler?: (interaction: IncomingInteraction, reply: ReplyFn) => Promise<void>
+  private interactionHandler: ((interaction: IncomingInteraction, reply: ReplyFn) => Promise<void>) | null = null
   private client: DiscordClientLike | null = null
 
-  constructor(clientFactory?: DiscordClientFactory) {
+  constructor(clientFactory: DiscordClientFactory | undefined) {
     const token = process.env['DISCORD_BOT_TOKEN']
     if (token === undefined || token.trim() === '') {
       throw new Error('DISCORD_BOT_TOKEN environment variable is required')
     }
     this.token = token
-    this.clientFactory = clientFactory ?? defaultClientFactory
+    this.clientFactory = typeof clientFactory === 'function' ? clientFactory : defaultClientFactory
     log.debug({ tokenLength: this.token.length }, 'DiscordChatProvider constructed')
   }
 
@@ -119,14 +120,24 @@ export class DiscordChatProvider implements ChatProvider {
     }
   }
 
+  resolveGroupLabel(groupId: string): Promise<string | null> {
+    if (this.client === null) return Promise.resolve(null)
+    return resolveDiscordGroupLabel(this.client, groupId)
+  }
+
+  resolveUserLabel(userId: string, context: ResolveUserContext | undefined): Promise<string | null> {
+    if (this.client === null) return Promise.resolve(null)
+    return resolveDiscordUserLabel(this.client, userId, context)
+  }
+
   start(): Promise<void> {
-    const adminUserId = process.env['ADMIN_USER_ID'] ?? ''
+    const adminUserId = typeof process.env['ADMIN_USER_ID'] === 'string' ? process.env['ADMIN_USER_ID'] : ''
     const client = this.clientFactory()
     this.client = client
 
     client.on('messageCreate', (rawMsg) => {
       if (!isDispatchableMessage(rawMsg)) return
-      this.dispatchMessage(rawMsg, client.user?.id ?? '', adminUserId).catch((error: unknown) => {
+      this.dispatchMessage(rawMsg, client.user === null ? '' : client.user.id, adminUserId).catch((error: unknown) => {
         log.error({ error: error instanceof Error ? error.message : String(error) }, 'messageCreate dispatch failed')
       })
     })
@@ -190,7 +201,7 @@ export class DiscordChatProvider implements ChatProvider {
     // Handle group-settings selector callbacks before standard routing
     if (await handleDiscordGroupSettingsSelection(interaction, incoming.user.id, result.reply)) return
 
-    if (this.interactionHandler === undefined) {
+    if (this.interactionHandler === null) {
       const auth = checkAuthorizationExtended(
         incoming.user.id,
         incoming.user.username,

--- a/src/chat/discord/label-helpers.ts
+++ b/src/chat/discord/label-helpers.ts
@@ -1,0 +1,99 @@
+import { logger } from '../../logger.js'
+import type { ResolveUserContext } from '../types.js'
+import type { DiscordClientLike } from './client-factory.js'
+import { isGuildLike } from './type-guards.js'
+
+const log = logger.child({ scope: 'chat:discord:labels' })
+
+export function formatDiscordUserLabel(displayName: string | null, username: string | null): string | null {
+  if (displayName !== null && username !== null && displayName !== username) {
+    return `${displayName} (@${username})`
+  }
+  if (displayName !== null) return displayName
+  if (username !== null) return `@${username}`
+  return null
+}
+
+export function getDiscordUserDisplayName(
+  user: Partial<{
+    displayName: string
+    globalName: string | null
+    username: string
+  }>,
+): string | null {
+  if (user.displayName !== undefined && user.displayName !== '') return user.displayName
+  if (user.globalName !== undefined && user.globalName !== null && user.globalName !== '') return user.globalName
+  return null
+}
+
+export async function resolveDiscordGroupLabel(client: DiscordClientLike, groupId: string): Promise<string | null> {
+  if (client.channels === undefined) return null
+  const cached = client.channels.cache.get(groupId)
+  if (typeof cached === 'object' && cached !== null && 'name' in cached && typeof cached.name === 'string') {
+    return cached.name
+  }
+  if (client.channels.fetch === undefined) return null
+  try {
+    const ch = await client.channels.fetch(groupId)
+    if (typeof ch !== 'object' || ch === null) return null
+    if ('name' in ch && typeof ch.name === 'string') return ch.name.length > 0 ? ch.name : null
+    return null
+  } catch (e) {
+    log.warn({ groupId, error: e instanceof Error ? e.message : String(e) }, 'Discord group label lookup failed')
+    return null
+  }
+}
+
+async function tryGuildMemberLabel(
+  client: DiscordClientLike,
+  userId: string,
+  contextId: string,
+): Promise<string | null> {
+  if (client.channels === undefined || client.guilds === undefined) return null
+  const rawChannel = client.channels.cache.get(contextId)
+  if (
+    typeof rawChannel !== 'object' ||
+    rawChannel === null ||
+    !('guildId' in rawChannel) ||
+    typeof rawChannel.guildId !== 'string'
+  ) {
+    return null
+  }
+  const rawGuild = client.guilds.cache.get(rawChannel.guildId)
+  if (!isGuildLike(rawGuild) || rawGuild.members.fetch === undefined) return null
+  try {
+    const member = await rawGuild.members.fetch(userId)
+    const displayName = member.displayName !== undefined && member.displayName !== '' ? member.displayName : null
+    const userNode = member.user
+    const username =
+      userNode !== undefined && userNode.username !== undefined && userNode.username !== '' ? userNode.username : null
+    return formatDiscordUserLabel(displayName, username)
+  } catch (e) {
+    log.warn(
+      { userId, contextId, error: e instanceof Error ? e.message : String(e) },
+      'Discord guild member label lookup failed',
+    )
+    return null
+  }
+}
+
+export async function resolveDiscordUserLabel(
+  client: DiscordClientLike,
+  userId: string,
+  context: ResolveUserContext | undefined,
+): Promise<string | null> {
+  if (context !== undefined && context.contextType === 'group') {
+    const guildLabel = await tryGuildMemberLabel(client, userId, context.contextId)
+    if (guildLabel !== null) return guildLabel
+  }
+  if (client.users === undefined) return null
+  try {
+    const user = await client.users.fetch(userId)
+    const displayName = getDiscordUserDisplayName(user)
+    const username = user.username !== undefined && user.username !== '' ? user.username : null
+    return formatDiscordUserLabel(displayName, username)
+  } catch (e) {
+    log.warn({ userId, error: e instanceof Error ? e.message : String(e) }, 'Discord user label lookup failed')
+    return null
+  }
+}

--- a/src/chat/discord/label-helpers.ts
+++ b/src/chat/discord/label-helpers.ts
@@ -21,8 +21,32 @@ export function getDiscordUserDisplayName(
     username: string
   }>,
 ): string | null {
-  if (user.displayName !== undefined && user.displayName !== '') return user.displayName
   if (user.globalName !== undefined && user.globalName !== null && user.globalName !== '') return user.globalName
+  return null
+}
+
+export function getDiscordMemberDisplayName(
+  member: Partial<{
+    displayName: string
+    nickname: string | null
+    user:
+      | Partial<{
+          displayName: string
+          globalName: string | null
+          username: string
+        }>
+      | undefined
+  }>,
+): string | null {
+  if (member.nickname !== undefined && member.nickname !== null && member.nickname !== '') return member.nickname
+  if (
+    member.user !== undefined &&
+    member.user.globalName !== undefined &&
+    member.user.globalName !== null &&
+    member.user.globalName !== ''
+  ) {
+    return member.user.globalName
+  }
   return null
 }
 
@@ -63,7 +87,7 @@ async function tryGuildMemberLabel(
   if (!isGuildLike(rawGuild) || rawGuild.members.fetch === undefined) return null
   try {
     const member = await rawGuild.members.fetch(userId)
-    const displayName = member.displayName !== undefined && member.displayName !== '' ? member.displayName : null
+    const displayName = getDiscordMemberDisplayName(member)
     const userNode = member.user
     const username =
       userNode !== undefined && userNode.username !== undefined && userNode.username !== '' ? userNode.username : null

--- a/src/chat/discord/label-helpers.ts
+++ b/src/chat/discord/label-helpers.ts
@@ -6,7 +6,7 @@ import { isGuildLike } from './type-guards.js'
 const log = logger.child({ scope: 'chat:discord:labels' })
 
 export function formatDiscordUserLabel(displayName: string | null, username: string | null): string | null {
-  if (displayName !== null && username !== null && displayName !== username) {
+  if (displayName !== null && username !== null) {
     return `${displayName} (@${username})`
   }
   if (displayName !== null) return displayName

--- a/src/chat/discord/label-helpers.ts
+++ b/src/chat/discord/label-helpers.ts
@@ -1,6 +1,6 @@
 import { logger } from '../../logger.js'
 import type { ResolveUserContext } from '../types.js'
-import type { DiscordClientLike } from './client-factory.js'
+import type { DiscordClientLike, GuildLike } from './client-factory.js'
 import { isGuildLike } from './type-guards.js'
 
 const log = logger.child({ scope: 'chat:discord:labels' })
@@ -68,25 +68,48 @@ export async function resolveDiscordGroupLabel(client: DiscordClientLike, groupI
   }
 }
 
+function getDiscordChannelGuildId(channel: unknown): string | null {
+  if (typeof channel !== 'object' || channel === null || !('guildId' in channel)) return null
+  return typeof channel.guildId === 'string' ? channel.guildId : null
+}
+
+export async function resolveDiscordGuildFromContext(
+  client: DiscordClientLike,
+  contextId: string,
+): Promise<Readonly<{ guild: GuildLike; guildId: string }> | null> {
+  if (client.channels === undefined || client.guilds === undefined) return null
+
+  const cachedGuildId = getDiscordChannelGuildId(client.channels.cache.get(contextId))
+  if (cachedGuildId !== null) {
+    const cachedGuild = client.guilds.cache.get(cachedGuildId)
+    return isGuildLike(cachedGuild) ? { guild: cachedGuild, guildId: cachedGuildId } : null
+  }
+
+  if (client.channels.fetch === undefined) return null
+
+  try {
+    const fetchedChannel = await client.channels.fetch(contextId)
+    const fetchedGuildId = getDiscordChannelGuildId(fetchedChannel)
+    if (fetchedGuildId === null) return null
+
+    const fetchedGuild = client.guilds.cache.get(fetchedGuildId)
+    return isGuildLike(fetchedGuild) ? { guild: fetchedGuild, guildId: fetchedGuildId } : null
+  } catch (e) {
+    log.warn({ contextId, error: e instanceof Error ? e.message : String(e) }, 'Discord channel lookup failed')
+    return null
+  }
+}
+
 async function tryGuildMemberLabel(
   client: DiscordClientLike,
   userId: string,
   contextId: string,
 ): Promise<string | null> {
-  if (client.channels === undefined || client.guilds === undefined) return null
-  const rawChannel = client.channels.cache.get(contextId)
-  if (
-    typeof rawChannel !== 'object' ||
-    rawChannel === null ||
-    !('guildId' in rawChannel) ||
-    typeof rawChannel.guildId !== 'string'
-  ) {
-    return null
-  }
-  const rawGuild = client.guilds.cache.get(rawChannel.guildId)
-  if (!isGuildLike(rawGuild) || rawGuild.members.fetch === undefined) return null
+  const resolvedGuild = await resolveDiscordGuildFromContext(client, contextId)
+  if (resolvedGuild === null || resolvedGuild.guild.members.fetch === undefined) return null
+
   try {
-    const member = await rawGuild.members.fetch(userId)
+    const member = await resolvedGuild.guild.members.fetch(userId)
     const displayName = getDiscordMemberDisplayName(member)
     const userNode = member.user
     const username =

--- a/src/chat/mattermost/index.ts
+++ b/src/chat/mattermost/index.ts
@@ -23,6 +23,7 @@ import {
   resolveMattermostUserId,
   uploadMattermostFile,
 } from './file-helpers.js'
+import { resolveMattermostGroupLabel, resolveMattermostUserLabel } from './label-helpers.js'
 import { mattermostCapabilities, mattermostConfigRequirements, mattermostTraits } from './metadata.js'
 import { buildMattermostReplyContext } from './reply-context.js'
 import { createMattermostReplyFn } from './reply-helpers.js'
@@ -76,16 +77,16 @@ export class MattermostChatProvider implements ChatProvider {
   }
 
   async start(): Promise<void> {
-    const data = await this.apiFetch('GET', '/api/v4/users/me', undefined)
+    const data = await this.apiFetch('GET', '/api/v4/users/me', void 0)
     const user = UserMeSchema.parse(data)
     this.botUserId = user.id
-    this.botUsername = user.username ?? null
+    this.botUsername = typeof user.username === 'string' ? user.username : null
     log.info({ botUserId: this.botUserId, botUsername: this.botUsername }, 'Mattermost bot started')
     this.connectWebSocket()
   }
 
   stop(): Promise<void> {
-    this.ws?.close()
+    if (this.ws !== null) this.ws.close()
     this.ws = null
     log.info('Mattermost bot stopped')
     return Promise.resolve()
@@ -131,7 +132,6 @@ export class MattermostChatProvider implements ChatProvider {
     if (parsed === null) return
     const { post, senderName } = parsed
     if (post.user_id === this.botUserId) return
-
     const replyToMessageId = extractReplyId(post.parent_id, post.root_id)
     cacheIncomingPost(post, replyToMessageId, senderName)
     const { msg, reply, command, isAdmin } = await this.buildPostedMessage(post, senderName, replyToMessageId)
@@ -139,7 +139,7 @@ export class MattermostChatProvider implements ChatProvider {
   }
 
   private fetchFilesForPost(post: MattermostPost): Promise<IncomingFile[] | undefined> {
-    if (post.file_ids === undefined || post.file_ids.length === 0) return Promise.resolve(undefined)
+    if (post.file_ids === undefined || post.file_ids.length === 0) return Promise.resolve(void 0)
     return fetchMattermostFiles(post.file_ids, this.apiFetch.bind(this), (fileId) =>
       downloadMattermostFile(this.baseUrl, this.token, fileId),
     )
@@ -156,28 +156,25 @@ export class MattermostChatProvider implements ChatProvider {
     command: { handler: CommandHandler; match: string } | null
     isAdmin: boolean
   }> {
+    const api = this.apiFetch.bind(this)
     const replyContext =
-      replyToMessageId === undefined
-        ? undefined
-        : await buildMattermostReplyContext(post, replyToMessageId, this.apiFetch.bind(this))
-    const channelInfo: MattermostChannelInfo = await fetchMattermostChannelInfo(
-      this.apiFetch.bind(this),
-      post.channel_id,
-    )
+      replyToMessageId === undefined ? undefined : await buildMattermostReplyContext(post, replyToMessageId, api)
+    const channelInfo: MattermostChannelInfo = await fetchMattermostChannelInfo(api, post.channel_id)
     const contextType: ContextType = channelInfo.type === 'D' ? 'dm' : 'group'
-    const teamInfo =
-      contextType === 'group' && channelInfo.team_id !== undefined
-        ? await fetchMattermostTeamInfo(this.apiFetch.bind(this), channelInfo.team_id)
-        : null
-    const isAdmin = await checkChannelAdmin(post.channel_id, post.user_id, this.apiFetch.bind(this))
+    const teamId = contextType === 'group' ? channelInfo.team_id : undefined
+    const teamInfo = teamId === undefined ? null : await fetchMattermostTeamInfo(api, teamId)
+    const isAdmin = await checkChannelAdmin(post.channel_id, post.user_id, api)
     const isMentioned = this.isBotMentioned(post.message)
     const threadId = this.determineThreadId(post, isMentioned, contextType, replyToMessageId)
     const reply = this.buildReplyFn(post.channel_id, post.id, threadId)
     const command = this.matchCommand(post.message)
-    const username = post.user_name ?? senderName ?? null
+    const uname = post.user_name
+    const username = typeof uname === 'string' ? uname : typeof senderName === 'string' ? senderName : null
+    const dispName = typeof channelInfo.display_name === 'string' ? channelInfo.display_name : channelInfo.name
     const contextName =
-      contextType === 'group' ? (channelInfo.display_name ?? channelInfo.name ?? post.channel_id) : undefined
-    const contextParentName = contextType === 'group' ? (teamInfo?.display_name ?? teamInfo?.name) : undefined
+      contextType === 'group' ? (typeof dispName === 'string' ? dispName : post.channel_id) : undefined
+    const pt = contextType === 'group' ? teamInfo : null
+    const contextParentName = pt === null ? undefined : typeof pt.display_name === 'string' ? pt.display_name : pt.name
     const files = await this.fetchFilesForPost(post)
     const msg: IncomingMessage = {
       user: { id: post.user_id, username, isAdmin },
@@ -187,7 +184,7 @@ export class MattermostChatProvider implements ChatProvider {
       contextParentName,
       isMentioned,
       text: post.message,
-      commandMatch: command?.match,
+      commandMatch: command === null ? undefined : command.match,
       messageId: post.id,
       replyToMessageId,
       replyContext,
@@ -218,10 +215,8 @@ export class MattermostChatProvider implements ChatProvider {
     }
   }
 
-  private isBotMentioned(message: string): boolean {
-    if (this.botUsername === null) return false
-    return message.includes(`@${this.botUsername}`)
-  }
+  private isBotMentioned = (message: string): boolean =>
+    this.botUsername !== null && message.includes(`@${this.botUsername}`)
 
   private determineThreadId(
     post: MattermostPost,
@@ -250,7 +245,7 @@ export class MattermostChatProvider implements ChatProvider {
     return null
   }
 
-  private buildReplyFn(channelId: string, postId?: string, threadId?: string): ReplyFn {
+  private buildReplyFn(channelId: string, postId: string | undefined, threadId: string | undefined): ReplyFn {
     return createMattermostReplyFn({
       channelId,
       postId,
@@ -270,12 +265,15 @@ export class MattermostChatProvider implements ChatProvider {
     return ChannelSchema.parse(data).id
   }
 
-  resolveUserId(username: string, _context: ResolveUserContext): Promise<string | null> {
-    return resolveMattermostUserId(username, this.apiFetch.bind(this))
-  }
+  resolveUserId = (username: string, _context: ResolveUserContext): Promise<string | null> =>
+    resolveMattermostUserId(username, this.apiFetch.bind(this))
+  resolveGroupLabel = (groupId: string): Promise<string | null> =>
+    resolveMattermostGroupLabel(this.apiFetch.bind(this), groupId)
+  resolveUserLabel = (userId: string): Promise<string | null> =>
+    resolveMattermostUserLabel(this.apiFetch.bind(this), userId)
 
   private wsSend(data: unknown): void {
-    if (this.ws?.readyState === WebSocket.OPEN) {
+    if (this.ws !== null && this.ws.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(data))
     }
   }

--- a/src/chat/mattermost/label-helpers.ts
+++ b/src/chat/mattermost/label-helpers.ts
@@ -1,0 +1,57 @@
+import { logger } from '../../logger.js'
+import { fetchMattermostChannelInfo } from './context-metadata.js'
+import { MattermostUserSchema } from './schema.js'
+
+const log = logger.child({ scope: 'chat:mattermost:labels' })
+
+type ApiFetchFn = (method: string, path: string, body: unknown) => Promise<unknown>
+
+export function formatMattermostUserLabel(
+  username: string,
+  firstName: string,
+  lastName: string,
+  nickname: string,
+): string | null {
+  const parts: string[] = []
+  if (firstName !== '') parts.push(firstName)
+  if (lastName !== '') parts.push(lastName)
+  const display = parts.join(' ')
+  const bestName = display.length > 0 ? display : nickname === '' ? null : nickname
+  const at = username === '' ? null : `@${username}`
+  if (bestName === null) return at
+  if (at === null) return bestName
+  return `${bestName} (${at})`
+}
+
+export async function resolveMattermostGroupLabel(apiFetch: ApiFetchFn, groupId: string): Promise<string | null> {
+  try {
+    const info = await fetchMattermostChannelInfo(apiFetch, groupId)
+    if (info.display_name !== undefined && info.display_name !== '') return info.display_name
+    if (info.name !== undefined && info.name !== '') return info.name
+    return null
+  } catch (e) {
+    log.warn({ groupId, error: e instanceof Error ? e.message : String(e) }, 'Mattermost group label lookup failed')
+    return null
+  }
+}
+
+export async function resolveMattermostUserLabel(apiFetch: ApiFetchFn, userId: string): Promise<string | null> {
+  try {
+    const data = await apiFetch('GET', `/api/v4/users/${encodeURIComponent(userId)}`, void 0)
+    const parsed = MattermostUserSchema.safeParse(data)
+    if (!parsed.success) {
+      log.warn({ userId, error: parsed.error }, 'Failed to parse Mattermost user label response')
+      return null
+    }
+    const u = parsed.data
+    return formatMattermostUserLabel(
+      typeof u.username === 'string' ? u.username : '',
+      typeof u.first_name === 'string' ? u.first_name : '',
+      typeof u.last_name === 'string' ? u.last_name : '',
+      typeof u.nickname === 'string' ? u.nickname : '',
+    )
+  } catch (e) {
+    log.warn({ userId, error: e instanceof Error ? e.message : String(e) }, 'Mattermost user label lookup failed')
+    return null
+  }
+}

--- a/src/chat/mattermost/schema.ts
+++ b/src/chat/mattermost/schema.ts
@@ -43,9 +43,17 @@ export const TeamInfoSchema = z.object({
 export const ChannelMemberSchema = z.object({ roles: z.string() })
 export const FileUploadSchema = z.object({ file_infos: z.array(z.object({ id: z.string() })) })
 
+export const MattermostUserSchema = z.object({
+  id: z.string(),
+  username: z.string().optional(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  nickname: z.string().optional(),
+})
+
 export type MattermostPost = z.infer<typeof MattermostPostSchema>
 
-export function extractReplyId(parentId?: string, rootId?: string): string | undefined {
+export function extractReplyId(parentId: string | undefined, rootId: string | undefined): string | undefined {
   if (parentId !== undefined && parentId !== '') return parentId
   if (rootId !== undefined && rootId !== '') return rootId
   return undefined

--- a/src/chat/registry.ts
+++ b/src/chat/registry.ts
@@ -19,7 +19,7 @@ const providers = new Map<string, ChatProviderFactory>()
 
 registerChatProvider('telegram', () => new TelegramChatProvider())
 registerChatProvider('mattermost', () => new MattermostChatProvider())
-registerChatProvider('discord', () => new DiscordChatProvider())
+registerChatProvider('discord', () => new DiscordChatProvider(undefined))
 
 function registerChatProvider(name: string, factory: ChatProviderFactory): void {
   providers.set(name, factory)

--- a/src/chat/telegram/index.ts
+++ b/src/chat/telegram/index.ts
@@ -19,6 +19,7 @@ import { renderTelegramContext } from './context-renderer.js'
 import { extractFilesFromContext, type TelegramFileFetcher } from './file-helpers.js'
 import { formatLlmOutput } from './format.js'
 import { buildTelegramInteraction } from './interaction-helpers.js'
+import { resolveTelegramGroupLabel, resolveTelegramUserLabel } from './label-helpers.js'
 import {
   cacheTelegramMessage,
   extractContextInfo,
@@ -136,6 +137,15 @@ export class TelegramChatProvider implements ChatProvider {
     const clean = username.startsWith('@') ? username.slice(1) : username
     return Promise.resolve(/^\d+$/.test(clean) ? clean : null)
   }
+
+  resolveGroupLabel(groupId: string): Promise<string | null> {
+    return resolveTelegramGroupLabel((chatId) => this.bot.api.getChat(chatId), groupId)
+  }
+
+  resolveUserLabel(userId: string, context: ResolveUserContext | undefined): Promise<string | null> {
+    return resolveTelegramUserLabel((chatId, uid) => this.bot.api.getChatMember(chatId, uid), userId, context)
+  }
+
   async setCommands(adminUserId: string): Promise<void> {
     const userCmds = [
       { command: 'help', description: 'Show available commands' },

--- a/src/chat/telegram/label-helpers.ts
+++ b/src/chat/telegram/label-helpers.ts
@@ -1,0 +1,69 @@
+import { logger } from '../../logger.js'
+import type { ResolveUserContext } from '../types.js'
+
+const log = logger.child({ scope: 'chat:telegram:labels' })
+
+type GetChatFn = (chatId: number) => Promise<unknown>
+type GetChatMemberFn = (chatId: number, userId: number) => Promise<unknown>
+
+export function formatTelegramUserLabel(
+  firstName: string,
+  lastName: string | undefined,
+  username: string | undefined,
+): string | null {
+  const parts: string[] = []
+  if (firstName !== '') parts.push(firstName)
+  if (lastName !== undefined && lastName !== '') parts.push(lastName)
+  const display = parts.join(' ')
+  const at = username !== undefined && username !== '' ? `@${username}` : null
+  if (display.length > 0) return at === null ? display : `${display} (${at})`
+  return at
+}
+
+export async function resolveTelegramGroupLabel(getChat: GetChatFn, groupId: string): Promise<string | null> {
+  const id = Number(groupId)
+  if (!Number.isInteger(id)) return null
+  try {
+    const chat = await getChat(id)
+    if (
+      typeof chat === 'object' &&
+      chat !== null &&
+      'title' in chat &&
+      typeof chat.title === 'string' &&
+      chat.title !== ''
+    ) {
+      return chat.title
+    }
+    return null
+  } catch (e) {
+    log.warn({ groupId, error: e instanceof Error ? e.message : String(e) }, 'Telegram group label lookup failed')
+    return null
+  }
+}
+
+export async function resolveTelegramUserLabel(
+  getChatMember: GetChatMemberFn,
+  userId: string,
+  context: ResolveUserContext | undefined,
+): Promise<string | null> {
+  const uid = Number(userId)
+  if (!Number.isInteger(uid) || context === undefined || context.contextType !== 'group') return null
+  const cid = Number(context.contextId)
+  if (!Number.isInteger(cid)) return null
+  try {
+    const member = await getChatMember(cid, uid)
+    if (typeof member !== 'object' || member === null || !('user' in member)) return null
+    const u = member.user
+    if (typeof u !== 'object' || u === null) return null
+    const firstName = 'first_name' in u && typeof u.first_name === 'string' ? u.first_name : ''
+    const lastName = 'last_name' in u && typeof u.last_name === 'string' && u.last_name !== '' ? u.last_name : undefined
+    const username = 'username' in u && typeof u.username === 'string' && u.username !== '' ? u.username : undefined
+    return formatTelegramUserLabel(firstName, lastName, username)
+  } catch (e) {
+    log.warn(
+      { userId, contextId: context.contextId, error: e instanceof Error ? e.message : String(e) },
+      'Telegram user label lookup failed',
+    )
+    return null
+  }
+}

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -286,6 +286,8 @@ export type ChatProvider = {
   /** Register the handler for button/callback interactions (optional). */
   onInteraction: (handler: (interaction: IncomingInteraction, reply: ReplyFn) => Promise<void>) => void
   resolveUserId: (username: string, context: ResolveUserContext) => Promise<string | null>
+  resolveUserLabel: (userId: string, context: ResolveUserContext | undefined) => Promise<string | null>
+  resolveGroupLabel: (groupId: string) => Promise<string | null>
   /** Register the bot's command list with the platform (for command menus). */
   setCommands: (adminUserId: string) => Promise<void>
 }>

--- a/src/commands/group.ts
+++ b/src/commands/group.ts
@@ -27,7 +27,8 @@ function resolveUserLabelCached(
   userId: string,
   cache: Map<string, Promise<string | null>>,
 ): Promise<string | null> {
-  const existing = cache.get(userId)
+  const cacheKey = `${resolverContext.contextType}:${resolverContext.contextId}:${userId}`
+  const existing = cache.get(cacheKey)
   if (existing !== undefined) {
     return existing
   }
@@ -38,7 +39,7 @@ function resolveUserLabelCached(
       ? Promise.resolve(null)
       : fn(userId, { contextId: resolverContext.contextId, contextType: resolverContext.contextType })
 
-  cache.set(userId, pending)
+  cache.set(cacheKey, pending)
   return pending
 }
 

--- a/src/commands/group.ts
+++ b/src/commands/group.ts
@@ -9,6 +9,55 @@ const log = logger.child({ scope: 'commands:group' })
 const GROUP_CHAT_USAGE = 'Usage: /group adduser <user-id|@username> | /group deluser <user-id|@username> | /group users'
 const DM_ADMIN_USAGE = 'Usage: /group add <group-id> | /group remove <group-id> | /groups'
 
+type LabelResolverContext = {
+  readonly chat: ChatProvider
+  readonly contextId: string
+  readonly contextType: 'dm' | 'group'
+}
+
+function makeDisplayLabel(label: string | null, fallback: string): string {
+  if (label !== null) {
+    return label
+  }
+  return fallback
+}
+
+function resolveUserLabelCached(
+  resolverContext: LabelResolverContext,
+  userId: string,
+  cache: Map<string, Promise<string | null>>,
+): Promise<string | null> {
+  const existing = cache.get(userId)
+  if (existing !== undefined) {
+    return existing
+  }
+
+  const fn = resolverContext.chat.resolveUserLabel
+  const pending =
+    fn === undefined
+      ? Promise.resolve(null)
+      : fn(userId, { contextId: resolverContext.contextId, contextType: resolverContext.contextType })
+
+  cache.set(userId, pending)
+  return pending
+}
+
+function resolveGroupLabelCached(
+  chat: ChatProvider,
+  groupId: string,
+  cache: Map<string, Promise<string | null>>,
+): Promise<string | null> {
+  const existing = cache.get(groupId)
+  if (existing !== undefined) {
+    return existing
+  }
+
+  const fn = chat.resolveGroupLabel
+  const pending = fn === undefined ? Promise.resolve(null) : fn(groupId)
+  cache.set(groupId, pending)
+  return pending
+}
+
 export function registerGroupCommand(chat: ChatProvider): void {
   chat.registerCommand('group', async (msg: IncomingMessage, reply: ReplyFn, auth: AuthorizationResult) => {
     if (msg.contextType === 'dm') {
@@ -36,7 +85,25 @@ export function registerGroupCommand(chat: ChatProvider): void {
       return
     }
 
-    const lines = groups.map((group) => `${group.group_id} (added by ${group.added_by})`)
+    const groupLabelCache = new Map<string, Promise<string | null>>()
+    const userLabelCache = new Map<string, Promise<string | null>>()
+
+    const lines = await Promise.all(
+      groups.map(async (group) => {
+        const [resolvedGroupLabel, resolvedUserLabel] = await Promise.all([
+          resolveGroupLabelCached(chat, group.group_id, groupLabelCache),
+          resolveUserLabelCached(
+            { chat, contextId: group.group_id, contextType: 'group' },
+            group.added_by,
+            userLabelCache,
+          ),
+        ])
+
+        const groupLabel = makeDisplayLabel(resolvedGroupLabel, group.group_id)
+        const userLabel = makeDisplayLabel(resolvedUserLabel, group.added_by)
+        return `${groupLabel} (added by ${userLabel})`
+      }),
+    )
     await reply.text(`Authorized groups:\n${lines.join('\n')}`)
   })
 }
@@ -59,7 +126,7 @@ async function handleGroupMemberCommand(chat: ChatProvider, msg: IncomingMessage
       await handleDelUser(chat, msg, reply, targetUser)
       break
     case 'users':
-      await handleListUsers(msg, reply)
+      await handleListUsers(chat, msg, reply)
       break
     case '':
     case undefined:
@@ -172,7 +239,7 @@ async function handleDelUser(
   log.info({ groupId: msg.contextId, userId }, 'Group member removed')
 }
 
-async function handleListUsers(msg: IncomingMessage, reply: ReplyFn): Promise<void> {
+async function handleListUsers(chat: ChatProvider, msg: IncomingMessage, reply: ReplyFn): Promise<void> {
   const members = listGroupMembers(msg.contextId)
 
   if (members.length === 0) {
@@ -180,8 +247,27 @@ async function handleListUsers(msg: IncomingMessage, reply: ReplyFn): Promise<vo
     return
   }
 
-  const memberList = members.map((m) => `- ${m.user_id} (added by ${m.added_by})`).join('\n')
-  await reply.text(`Group members:\n${memberList}`)
+  const userLabelCache = new Map<string, Promise<string | null>>()
+  const resolverContext: LabelResolverContext = {
+    chat,
+    contextId: msg.contextId,
+    contextType: msg.contextType,
+  }
+
+  const lines = await Promise.all(
+    members.map(async (member) => {
+      const [resolvedMemberLabel, resolvedAdderLabel] = await Promise.all([
+        resolveUserLabelCached(resolverContext, member.user_id, userLabelCache),
+        resolveUserLabelCached(resolverContext, member.added_by, userLabelCache),
+      ])
+
+      const memberLabel = makeDisplayLabel(resolvedMemberLabel, member.user_id)
+      const adderLabel = makeDisplayLabel(resolvedAdderLabel, member.added_by)
+      return `- ${memberLabel} (added by ${adderLabel})`
+    }),
+  )
+
+  await reply.text(`Group members:\n${lines.join('\n')}`)
 }
 
 async function extractUserId(

--- a/src/commands/group.ts
+++ b/src/commands/group.ts
@@ -16,10 +16,7 @@ type LabelResolverContext = {
 }
 
 function makeDisplayLabel(label: string | null, fallback: string): string {
-  if (label !== null) {
-    return label
-  }
-  return fallback
+  return label ?? fallback
 }
 
 function resolveUserLabelCached(
@@ -29,15 +26,26 @@ function resolveUserLabelCached(
 ): Promise<string | null> {
   const cacheKey = `${resolverContext.contextType}:${resolverContext.contextId}:${userId}`
   const existing = cache.get(cacheKey)
-  if (existing !== undefined) {
-    return existing
-  }
+  if (existing !== undefined) return existing
 
   const fn = resolverContext.chat.resolveUserLabel
   const pending =
     fn === undefined
       ? Promise.resolve(null)
-      : fn(userId, { contextId: resolverContext.contextId, contextType: resolverContext.contextType })
+      : fn(userId, { contextId: resolverContext.contextId, contextType: resolverContext.contextType }).catch(
+          (error: unknown): string | null => {
+            log.warn(
+              {
+                userId,
+                contextId: resolverContext.contextId,
+                contextType: resolverContext.contextType,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              'User label lookup failed in group command',
+            )
+            return null
+          },
+        )
 
   cache.set(cacheKey, pending)
   return pending
@@ -49,12 +57,19 @@ function resolveGroupLabelCached(
   cache: Map<string, Promise<string | null>>,
 ): Promise<string | null> {
   const existing = cache.get(groupId)
-  if (existing !== undefined) {
-    return existing
-  }
+  if (existing !== undefined) return existing
 
   const fn = chat.resolveGroupLabel
-  const pending = fn === undefined ? Promise.resolve(null) : fn(groupId)
+  const pending =
+    fn === undefined
+      ? Promise.resolve(null)
+      : fn(groupId).catch((error: unknown): string | null => {
+          log.warn(
+            { groupId, error: error instanceof Error ? error.message : String(error) },
+            'Group label lookup failed in group command',
+          )
+          return null
+        })
   cache.set(groupId, pending)
   return pending
 }
@@ -121,10 +136,10 @@ async function handleGroupMemberCommand(chat: ChatProvider, msg: IncomingMessage
 
   switch (subcommand) {
     case 'adduser':
-      await handleAddUser(chat, msg, reply, targetUser)
+      await handleGroupMemberUpdate(chat, msg, reply, targetUser, 'add')
       break
     case 'deluser':
-      await handleDelUser(chat, msg, reply, targetUser)
+      await handleGroupMemberUpdate(chat, msg, reply, targetUser, 'remove')
       break
     case 'users':
       await handleListUsers(chat, msg, reply)
@@ -178,19 +193,22 @@ async function handleAuthorizedGroupCommand(
   await reply.text(`Unknown subcommand. ${DM_ADMIN_USAGE}`)
 }
 
-async function handleAddUser(
+async function handleGroupMemberUpdate(
   chat: ChatProvider,
   msg: IncomingMessage,
   reply: ReplyFn,
   targetUser: string | undefined,
+  action: 'add' | 'remove',
 ): Promise<void> {
   if (!msg.user.isAdmin) {
-    await reply.text('Only group admins can add users.')
+    await reply.text(action === 'add' ? 'Only group admins can add users.' : 'Only group admins can remove users.')
     return
   }
 
   if (targetUser === undefined) {
-    await reply.text('Usage: /group adduser <user-id|@username>')
+    await reply.text(
+      action === 'add' ? 'Usage: /group adduser <user-id|@username>' : 'Usage: /group deluser <user-id|@username>',
+    )
     return
   }
 
@@ -204,37 +222,13 @@ async function handleAddUser(
   }
 
   const { userId } = result
-  addGroupMember(msg.contextId, userId, msg.user.id)
-  await reply.text(`User ${targetUser} added to this group.`)
-  log.info({ groupId: msg.contextId, userId }, 'Group member added')
-}
-
-async function handleDelUser(
-  chat: ChatProvider,
-  msg: IncomingMessage,
-  reply: ReplyFn,
-  targetUser: string | undefined,
-): Promise<void> {
-  if (!msg.user.isAdmin) {
-    await reply.text('Only group admins can remove users.')
+  if (action === 'add') {
+    addGroupMember(msg.contextId, userId, msg.user.id)
+    await reply.text(`User ${targetUser} added to this group.`)
+    log.info({ groupId: msg.contextId, userId }, 'Group member added')
     return
   }
 
-  if (targetUser === undefined) {
-    await reply.text('Usage: /group deluser <user-id|@username>')
-    return
-  }
-
-  const result = await extractUserId(chat, targetUser, {
-    contextId: msg.contextId,
-    contextType: msg.contextType,
-  })
-  if (result.kind === 'error') {
-    await reply.text(result.message)
-    return
-  }
-
-  const { userId } = result
   removeGroupMember(msg.contextId, userId)
   await reply.text(`User ${targetUser} removed from this group.`)
   log.info({ groupId: msg.contextId, userId }, 'Group member removed')

--- a/src/commands/group.ts
+++ b/src/commands/group.ts
@@ -1,3 +1,5 @@
+import pLimit from 'p-limit'
+
 import { addAuthorizedGroup, listAuthorizedGroups, removeAuthorizedGroup } from '../authorized-groups.js'
 import { supportsUserResolution } from '../chat/capabilities.js'
 import type { AuthorizationResult, ChatProvider, IncomingMessage, ReplyFn, ResolveUserContext } from '../chat/types.js'
@@ -8,6 +10,7 @@ const log = logger.child({ scope: 'commands:group' })
 
 const GROUP_CHAT_USAGE = 'Usage: /group adduser <user-id|@username> | /group deluser <user-id|@username> | /group users'
 const DM_ADMIN_USAGE = 'Usage: /group add <group-id> | /group remove <group-id> | /groups'
+const MAX_CONCURRENT_LABEL_LOOKUPS = 5
 
 type LabelResolverContext = {
   readonly chat: ChatProvider
@@ -15,36 +18,41 @@ type LabelResolverContext = {
   readonly contextType: 'dm' | 'group'
 }
 
+type ScheduleLookup = (lookup: () => Promise<string | null>) => Promise<string | null>
+
 function makeDisplayLabel(label: string | null, fallback: string): string {
-  return label ?? fallback
+  if (label === null) return fallback
+  return label
 }
 
 function resolveUserLabelCached(
   resolverContext: LabelResolverContext,
   userId: string,
   cache: Map<string, Promise<string | null>>,
+  scheduleLookup: ScheduleLookup,
 ): Promise<string | null> {
   const cacheKey = `${resolverContext.contextType}:${resolverContext.contextId}:${userId}`
   const existing = cache.get(cacheKey)
   if (existing !== undefined) return existing
-
   const fn = resolverContext.chat.resolveUserLabel
   const pending =
     fn === undefined
       ? Promise.resolve(null)
-      : fn(userId, { contextId: resolverContext.contextId, contextType: resolverContext.contextType }).catch(
-          (error: unknown): string | null => {
-            log.warn(
-              {
-                userId,
-                contextId: resolverContext.contextId,
-                contextType: resolverContext.contextType,
-                error: error instanceof Error ? error.message : String(error),
-              },
-              'User label lookup failed in group command',
-            )
-            return null
-          },
+      : scheduleLookup(() =>
+          fn(userId, { contextId: resolverContext.contextId, contextType: resolverContext.contextType }).catch(
+            (error: unknown): string | null => {
+              log.warn(
+                {
+                  userId,
+                  contextId: resolverContext.contextId,
+                  contextType: resolverContext.contextType,
+                  error: error instanceof Error ? error.message : String(error),
+                },
+                'User label lookup failed in group command',
+              )
+              return null
+            },
+          ),
         )
 
   cache.set(cacheKey, pending)
@@ -55,21 +63,23 @@ function resolveGroupLabelCached(
   chat: ChatProvider,
   groupId: string,
   cache: Map<string, Promise<string | null>>,
+  scheduleLookup: ScheduleLookup,
 ): Promise<string | null> {
   const existing = cache.get(groupId)
   if (existing !== undefined) return existing
-
   const fn = chat.resolveGroupLabel
   const pending =
     fn === undefined
       ? Promise.resolve(null)
-      : fn(groupId).catch((error: unknown): string | null => {
-          log.warn(
-            { groupId, error: error instanceof Error ? error.message : String(error) },
-            'Group label lookup failed in group command',
-          )
-          return null
-        })
+      : scheduleLookup(() =>
+          fn(groupId).catch((error: unknown): string | null => {
+            log.warn(
+              { groupId, error: error instanceof Error ? error.message : String(error) },
+              'Group label lookup failed in group command',
+            )
+            return null
+          }),
+        )
   cache.set(groupId, pending)
   return pending
 }
@@ -80,38 +90,34 @@ export function registerGroupCommand(chat: ChatProvider): void {
       await handleAuthorizedGroupCommand(msg, reply, auth)
       return
     }
-
     await handleGroupMemberCommand(chat, msg, reply)
   })
-
   chat.registerCommand('groups', async (msg: IncomingMessage, reply: ReplyFn, auth: AuthorizationResult) => {
     if (msg.contextType !== 'dm') {
       await reply.text('This command is only available in direct messages.')
       return
     }
-
     if (!auth.isBotAdmin) {
       await reply.text('Only bot admins can list authorized groups.')
       return
     }
-
     const groups = listAuthorizedGroups()
     if (groups.length === 0) {
       await reply.text('No authorized groups.')
       return
     }
-
     const groupLabelCache = new Map<string, Promise<string | null>>()
     const userLabelCache = new Map<string, Promise<string | null>>()
-
+    const limit = pLimit(MAX_CONCURRENT_LABEL_LOOKUPS)
     const lines = await Promise.all(
       groups.map(async (group) => {
         const [resolvedGroupLabel, resolvedUserLabel] = await Promise.all([
-          resolveGroupLabelCached(chat, group.group_id, groupLabelCache),
+          resolveGroupLabelCached(chat, group.group_id, groupLabelCache, limit),
           resolveUserLabelCached(
             { chat, contextId: group.group_id, contextType: 'group' },
             group.added_by,
             userLabelCache,
+            limit,
           ),
         ])
 
@@ -241,19 +247,18 @@ async function handleListUsers(chat: ChatProvider, msg: IncomingMessage, reply: 
     await reply.text('No members in this group yet.')
     return
   }
-
   const userLabelCache = new Map<string, Promise<string | null>>()
+  const limit = pLimit(MAX_CONCURRENT_LABEL_LOOKUPS)
   const resolverContext: LabelResolverContext = {
     chat,
     contextId: msg.contextId,
     contextType: msg.contextType,
   }
-
   const lines = await Promise.all(
     members.map(async (member) => {
       const [resolvedMemberLabel, resolvedAdderLabel] = await Promise.all([
-        resolveUserLabelCached(resolverContext, member.user_id, userLabelCache),
-        resolveUserLabelCached(resolverContext, member.added_by, userLabelCache),
+        resolveUserLabelCached(resolverContext, member.user_id, userLabelCache, limit),
+        resolveUserLabelCached(resolverContext, member.added_by, userLabelCache, limit),
       ])
 
       const memberLabel = makeDisplayLabel(resolvedMemberLabel, member.user_id)
@@ -261,7 +266,6 @@ async function handleListUsers(chat: ChatProvider, msg: IncomingMessage, reply: 
       return `- ${memberLabel} (added by ${adderLabel})`
     }),
   )
-
   await reply.text(`Group members:\n${lines.join('\n')}`)
 }
 

--- a/tests/chat/discord/index.test.ts
+++ b/tests/chat/discord/index.test.ts
@@ -35,24 +35,24 @@ describe('DiscordChatProvider', () => {
   test('constructor throws when DISCORD_BOT_TOKEN is missing', async () => {
     delete process.env['DISCORD_BOT_TOKEN']
     const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-    expect(() => new DiscordChatProvider()).toThrow('DISCORD_BOT_TOKEN environment variable is required')
+    expect(() => new DiscordChatProvider(undefined)).toThrow('DISCORD_BOT_TOKEN environment variable is required')
   })
 
   test('constructor throws when DISCORD_BOT_TOKEN is whitespace only', async () => {
     process.env['DISCORD_BOT_TOKEN'] = '   '
     const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-    expect(() => new DiscordChatProvider()).toThrow('DISCORD_BOT_TOKEN environment variable is required')
+    expect(() => new DiscordChatProvider(undefined)).toThrow('DISCORD_BOT_TOKEN environment variable is required')
   })
 
   test('constructor succeeds with a non-empty token and exposes name="discord"', async () => {
     const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-    const provider = new DiscordChatProvider()
+    const provider = new DiscordChatProvider(undefined)
     expect(provider.name).toBe('discord')
   })
 
   test('registerCommand routes a matching /help text through the command handler', async () => {
     const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-    const provider = new DiscordChatProvider()
+    const provider = new DiscordChatProvider(undefined)
 
     const captured: IncomingMessage[] = []
     provider.registerCommand('help', (msg): Promise<void> => {
@@ -83,7 +83,7 @@ describe('DiscordChatProvider', () => {
 
   test('onMessage receives non-command messages after mapping', async () => {
     const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-    const provider = new DiscordChatProvider()
+    const provider = new DiscordChatProvider(undefined)
 
     const seen: IncomingMessage[] = []
     provider.onMessage((msg): Promise<void> => {
@@ -114,7 +114,7 @@ describe('DiscordChatProvider', () => {
 
   test('bot-authored messages are ignored', async () => {
     const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-    const provider = new DiscordChatProvider()
+    const provider = new DiscordChatProvider(undefined)
     const seen: IncomingMessage[] = []
     provider.onMessage((msg): Promise<void> => {
       seen.push(msg)
@@ -141,7 +141,7 @@ describe('DiscordChatProvider', () => {
 
   test('stop() calls client.destroy when a client exists', async () => {
     const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-    const provider = new DiscordChatProvider()
+    const provider = new DiscordChatProvider(undefined)
     let destroyed = false
     provider.testSetClient({
       destroy: (): Promise<void> => {
@@ -155,7 +155,7 @@ describe('DiscordChatProvider', () => {
 
   test('sendMessage creates a DM channel and sends the markdown', async () => {
     const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-    const provider = new DiscordChatProvider()
+    const provider = new DiscordChatProvider(undefined)
 
     const sends: Array<Partial<{ content: string }>> = []
     const dmChannel = {
@@ -186,21 +186,21 @@ describe('DiscordChatProvider', () => {
 
   test('resolveUserId returns snowflake as-is when the input is numeric', async () => {
     const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-    const provider = new DiscordChatProvider()
+    const provider = new DiscordChatProvider(undefined)
     const result = await provider.resolveUserId('1234567890', { contextId: 'c1', contextType: 'group' })
     expect(result).toBe('1234567890')
   })
 
   test('resolveUserId returns null in DMs (no guild context)', async () => {
     const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-    const provider = new DiscordChatProvider()
+    const provider = new DiscordChatProvider(undefined)
     const result = await provider.resolveUserId('@alice', { contextId: 'u1', contextType: 'dm' })
     expect(result).toBeNull()
   })
 
   test('resolveUserId searches members in the channel guild for group context', async () => {
     const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-    const provider = new DiscordChatProvider()
+    const provider = new DiscordChatProvider(undefined)
 
     const fakeGuild = {
       members: {
@@ -229,7 +229,7 @@ describe('DiscordChatProvider', () => {
   describe('renderContext', () => {
     test('returns embed method result with context snapshot', async () => {
       const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-      const provider = new DiscordChatProvider()
+      const provider = new DiscordChatProvider(undefined)
 
       const snapshot: ContextSnapshot = {
         modelName: 'gpt-4o',
@@ -519,7 +519,7 @@ describe('DiscordChatProvider', () => {
   describe('testDispatchButtonInteraction', () => {
     test('calls deferUpdate and routes customId to message handler', async () => {
       const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-      const provider = new DiscordChatProvider()
+      const provider = new DiscordChatProvider(undefined)
 
       // Authorize the user
       addUser('u1', 'admin-id', 'alice')
@@ -558,7 +558,7 @@ describe('DiscordChatProvider', () => {
 
     test('builds interaction replies around the clicked editable message', async () => {
       const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-      const provider = new DiscordChatProvider()
+      const provider = new DiscordChatProvider(undefined)
 
       const sends: SendCapture[] = []
       const edits: SendCapture[] = []
@@ -618,7 +618,7 @@ describe('DiscordChatProvider', () => {
 
     test('falls back to new messages when the clicked message is not editable', async () => {
       const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-      const provider = new DiscordChatProvider()
+      const provider = new DiscordChatProvider(undefined)
 
       const sends: SendCapture[] = []
       const edits: SendCapture[] = []
@@ -678,7 +678,7 @@ describe('DiscordChatProvider', () => {
 
     test('routes slash-prefixed customId to registered command handler', async () => {
       const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-      const provider = new DiscordChatProvider()
+      const provider = new DiscordChatProvider(undefined)
 
       // Authorize the user
       addUser('u2', 'admin-id', 'bob')
@@ -712,7 +712,7 @@ describe('DiscordChatProvider', () => {
 
     test('uses user ID as contextId in DM channels (type=1)', async () => {
       const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-      const provider = new DiscordChatProvider()
+      const provider = new DiscordChatProvider(undefined)
 
       // Authorize the user
       addUser('user-77', 'admin-id', 'carol')
@@ -746,7 +746,7 @@ describe('DiscordChatProvider', () => {
 
     test('uses channelId as contextId in guild channels (type=0)', async () => {
       const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-      const provider = new DiscordChatProvider()
+      const provider = new DiscordChatProvider(undefined)
 
       // Authorize the user
       addAuthorizedGroup('guild-channel-99', 'admin-id')
@@ -781,7 +781,7 @@ describe('DiscordChatProvider', () => {
 
     test('skips dispatch when channel is null', async () => {
       const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-      const provider = new DiscordChatProvider()
+      const provider = new DiscordChatProvider(undefined)
 
       const seen: IncomingMessage[] = []
       provider.onMessage((msg): Promise<void> => {
@@ -806,7 +806,7 @@ describe('DiscordChatProvider', () => {
     test('handles cfg: callback when no active editor (no-op)', async () => {
       await setupTestDb()
       const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-      const provider = new DiscordChatProvider()
+      const provider = new DiscordChatProvider(undefined)
 
       let deferred = false
       const fakeInteraction: ButtonInteractionLike = {
@@ -835,7 +835,7 @@ describe('DiscordChatProvider', () => {
     test('handles wizard_ callback when no active wizard (no-op)', async () => {
       await setupTestDb()
       const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-      const provider = new DiscordChatProvider()
+      const provider = new DiscordChatProvider(undefined)
 
       let deferred = false
       const fakeInteraction: ButtonInteractionLike = {
@@ -863,7 +863,7 @@ describe('DiscordChatProvider', () => {
 
     test('Discord DM group-settings callback opens config for the selected group', async () => {
       const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-      const provider = new DiscordChatProvider()
+      const provider = new DiscordChatProvider(undefined)
       await setupTestDb()
 
       upsertKnownGroupContext({
@@ -910,7 +910,7 @@ describe('DiscordChatProvider', () => {
 
     test('Discord DM selector continues into setup when the selector command is setup', async () => {
       const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-      const provider = new DiscordChatProvider()
+      const provider = new DiscordChatProvider(undefined)
       await setupTestDb()
 
       upsertKnownGroupContext({
@@ -975,7 +975,7 @@ describe('DiscordChatProvider', () => {
 
     test('handles deferUpdate failure gracefully', async () => {
       const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
-      const provider = new DiscordChatProvider()
+      const provider = new DiscordChatProvider(undefined)
 
       // Authorize the user
       addUser('u-def', 'admin-id', 'defer-fail')
@@ -1060,6 +1060,85 @@ describe('DiscordChatProvider', () => {
         setTimeout(resolve, 0)
       })
       // No assertion needed: reaching here without an unhandled rejection is the proof
+    })
+
+    test('resolveGroupLabel returns the fetched channel name', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+      const provider = new DiscordChatProvider(undefined)
+
+      provider.testSetClient({
+        destroy: (): Promise<void> => Promise.resolve(),
+        channels: {
+          cache: new Map(),
+          fetch: (id: string): Promise<{ name: string }> => {
+            expect(id).toBe('chan-7')
+            return Promise.resolve({ name: 'engineering-chat' })
+          },
+        },
+      })
+
+      const label = await provider.resolveGroupLabel?.('chan-7')
+      expect(label).toBe('engineering-chat')
+    })
+
+    test('resolveUserLabel prefers guild member display name and username', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+      const provider = new DiscordChatProvider(undefined)
+
+      provider.testSetClient({
+        destroy: (): Promise<void> => Promise.resolve(),
+        channels: {
+          cache: new Map([['chan-7', { guildId: 'guild-3' }]]),
+        },
+        guilds: {
+          cache: new Map([
+            [
+              'guild-3',
+              {
+                members: {
+                  search: (): Promise<Map<string, { id: string }>> =>
+                    Promise.resolve(new Map<string, { id: string }>()),
+                  fetch: (id: string): Promise<{ displayName: string; user: { username: string } }> => {
+                    expect(id).toBe('user-9')
+                    return Promise.resolve({ displayName: 'John Johnson', user: { username: 'itsmike' } })
+                  },
+                },
+              },
+            ],
+          ]),
+        },
+      })
+
+      const label = await provider.resolveUserLabel?.('user-9', { contextId: 'chan-7', contextType: 'group' })
+      expect(label).toBe('John Johnson (@itsmike)')
+    })
+
+    test('resolveUserLabel falls back to global user fetch when guild context is unavailable', async () => {
+      const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+      const provider = new DiscordChatProvider(undefined)
+
+      provider.testSetClient({
+        destroy: (): Promise<void> => Promise.resolve(),
+        users: {
+          fetch: (
+            id: string,
+          ): Promise<{
+            displayName: string
+            username: string
+            createDM: () => Promise<{ send: (arg: { content: string }) => Promise<unknown> }>
+          }> => {
+            expect(id).toBe('user-12')
+            return Promise.resolve({
+              displayName: 'Jane Admin',
+              username: 'janeadmin',
+              createDM: () => Promise.resolve({ send: (): Promise<unknown> => Promise.resolve(null) }),
+            })
+          },
+        },
+      })
+
+      const label = await provider.resolveUserLabel?.('user-12', { contextId: 'dm-user', contextType: 'dm' })
+      expect(label).toBe('Jane Admin (@janeadmin)')
     })
 
     test('interactionCreate listener catches and does not rethrow when handleButtonInteraction rejects', async () => {

--- a/tests/chat/discord/index.test.ts
+++ b/tests/chat/discord/index.test.ts
@@ -226,6 +226,38 @@ describe('DiscordChatProvider', () => {
     expect(result).toBe('u-9')
   })
 
+  test('resolveUserId fetches an uncached channel before searching the guild', async () => {
+    const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')
+    const provider = new DiscordChatProvider(undefined)
+
+    const fakeGuild = {
+      members: {
+        search: (arg: { query: string; limit: number }): Promise<Map<string, { id: string }>> => {
+          expect(arg.query).toBe('alice')
+          expect(arg.limit).toBe(1)
+          return Promise.resolve(new Map([['u-10', { id: 'u-10' }]]))
+        },
+      },
+    }
+    const fakeClient = {
+      destroy: (): Promise<void> => Promise.resolve(),
+      channels: {
+        cache: new Map(),
+        fetch: (id: string): Promise<{ guildId: string }> => {
+          expect(id).toBe('chan-8')
+          return Promise.resolve({ guildId: 'guild-4' })
+        },
+      },
+      guilds: {
+        cache: new Map([['guild-4', fakeGuild]]),
+      },
+    }
+    provider.testSetClient(fakeClient)
+
+    const result = await provider.resolveUserId('@alice', { contextId: 'chan-8', contextType: 'group' })
+    expect(result).toBe('u-10')
+  })
+
   describe('renderContext', () => {
     test('returns embed method result with context snapshot', async () => {
       const { DiscordChatProvider } = await import('../../../src/chat/discord/index.js')

--- a/tests/chat/discord/index.test.ts
+++ b/tests/chat/discord/index.test.ts
@@ -1098,9 +1098,19 @@ describe('DiscordChatProvider', () => {
                 members: {
                   search: (): Promise<Map<string, { id: string }>> =>
                     Promise.resolve(new Map<string, { id: string }>()),
-                  fetch: (id: string): Promise<{ displayName: string; user: { username: string } }> => {
+                  fetch: (
+                    id: string,
+                  ): Promise<{
+                    displayName: string
+                    nickname: string
+                    user: { username: string; globalName: null; displayName: string }
+                  }> => {
                     expect(id).toBe('user-9')
-                    return Promise.resolve({ displayName: 'John Johnson', user: { username: 'itsmike' } })
+                    return Promise.resolve({
+                      displayName: 'John Johnson',
+                      nickname: 'John Johnson',
+                      user: { username: 'itsmike', globalName: null, displayName: 'itsmike' },
+                    })
                   },
                 },
               },
@@ -1124,12 +1134,14 @@ describe('DiscordChatProvider', () => {
             id: string,
           ): Promise<{
             displayName: string
+            globalName: string | null
             username: string
             createDM: () => Promise<{ send: (arg: { content: string }) => Promise<unknown> }>
           }> => {
             expect(id).toBe('user-12')
             return Promise.resolve({
               displayName: 'Jane Admin',
+              globalName: 'Jane Admin',
               username: 'janeadmin',
               createDM: () => Promise.resolve({ send: (): Promise<unknown> => Promise.resolve(null) }),
             })

--- a/tests/chat/discord/label-helpers.test.ts
+++ b/tests/chat/discord/label-helpers.test.ts
@@ -139,3 +139,48 @@ test('resolveDiscordUserLabel formats username-only guild members as @username',
 
   expect(label).toBe('@itsmike')
 })
+
+test('resolveDiscordUserLabel fetches an uncached channel to resolve guild nicknames', async () => {
+  const label = await resolveDiscordUserLabel(
+    {
+      destroy: (): Promise<void> => Promise.resolve(),
+      channels: {
+        cache: new Map(),
+        fetch: (id: string): Promise<{ guildId: string }> => {
+          expect(id).toBe('chan-8')
+          return Promise.resolve({ guildId: 'guild-3' })
+        },
+      },
+      guilds: {
+        cache: new Map([
+          [
+            'guild-3',
+            {
+              members: {
+                search: (): Promise<Map<string, { id: string }>> => Promise.resolve(new Map<string, { id: string }>()),
+                fetch: (
+                  id: string,
+                ): Promise<{
+                  displayName: string
+                  nickname: string
+                  user: { username: string; displayName: string; globalName: null }
+                }> => {
+                  expect(id).toBe('user-9')
+                  return Promise.resolve({
+                    displayName: 'John Johnson',
+                    nickname: 'Ops Mike',
+                    user: { username: 'itsmike', displayName: 'itsmike', globalName: null },
+                  })
+                },
+              },
+            },
+          ],
+        ]),
+      },
+    },
+    'user-9',
+    { contextId: 'chan-8', contextType: 'group' },
+  )
+
+  expect(label).toBe('Ops Mike (@itsmike)')
+})

--- a/tests/chat/discord/label-helpers.test.ts
+++ b/tests/chat/discord/label-helpers.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from 'bun:test'
 
-import { formatDiscordUserLabel, getDiscordUserDisplayName } from '../../../src/chat/discord/label-helpers.js'
+import {
+  formatDiscordUserLabel,
+  getDiscordMemberDisplayName,
+  getDiscordUserDisplayName,
+  resolveDiscordUserLabel,
+} from '../../../src/chat/discord/label-helpers.js'
 
 test('formatDiscordUserLabel formats display name with username when they differ', () => {
   expect(formatDiscordUserLabel('John Johnson', 'itsmike')).toBe('John Johnson (@itsmike)')
@@ -22,16 +27,115 @@ test('formatDiscordUserLabel returns just display name when it equals username',
   expect(formatDiscordUserLabel('itsmike', 'itsmike')).toBe('itsmike')
 })
 
-test('getDiscordUserDisplayName returns displayName when set', () => {
-  expect(getDiscordUserDisplayName({ displayName: 'John', globalName: null, username: 'john' })).toBe('John')
+test('getDiscordUserDisplayName returns globalName when set', () => {
+  expect(getDiscordUserDisplayName({ displayName: 'John', globalName: 'John Global', username: 'john' })).toBe(
+    'John Global',
+  )
 })
 
-test('getDiscordUserDisplayName falls back to globalName', () => {
-  expect(getDiscordUserDisplayName({ displayName: '', globalName: 'John Global', username: 'john' })).toBe(
+test('getDiscordUserDisplayName ignores displayName fallback and uses globalName only', () => {
+  expect(getDiscordUserDisplayName({ displayName: 'john', globalName: 'John Global', username: 'john' })).toBe(
     'John Global',
   )
 })
 
 test('getDiscordUserDisplayName returns null when both are empty', () => {
   expect(getDiscordUserDisplayName({ displayName: '', globalName: null, username: 'john' })).toBeNull()
+})
+
+test('getDiscordUserDisplayName returns null for username-only users', () => {
+  expect(getDiscordUserDisplayName({ displayName: 'itsmike', globalName: null, username: 'itsmike' })).toBeNull()
+})
+
+test('getDiscordMemberDisplayName prefers nickname over user globalName', () => {
+  expect(
+    getDiscordMemberDisplayName({
+      displayName: 'ignored display name fallback',
+      nickname: 'Ops Mike',
+      user: { username: 'itsmike', displayName: 'ignored', globalName: 'Michael' },
+    }),
+  ).toBe('Ops Mike')
+})
+
+test('getDiscordMemberDisplayName falls back to user globalName', () => {
+  expect(
+    getDiscordMemberDisplayName({
+      displayName: 'ignored display name fallback',
+      nickname: null,
+      user: { username: 'itsmike', displayName: 'ignored', globalName: 'Michael' },
+    }),
+  ).toBe('Michael')
+})
+
+test('getDiscordMemberDisplayName returns null for username-only guild members', () => {
+  expect(
+    getDiscordMemberDisplayName({
+      displayName: 'itsmike',
+      nickname: null,
+      user: { username: 'itsmike', displayName: 'itsmike', globalName: null },
+    }),
+  ).toBeNull()
+})
+
+test('resolveDiscordUserLabel formats username-only fetched users as @username', async () => {
+  const label = await resolveDiscordUserLabel(
+    {
+      destroy: (): Promise<void> => Promise.resolve(),
+      users: {
+        fetch: (): Promise<{
+          username: string
+          displayName: string
+          globalName: null
+          createDM: () => Promise<{ send: (arg: { content: string }) => Promise<unknown> }>
+        }> =>
+          Promise.resolve({
+            username: 'itsmike',
+            displayName: 'itsmike',
+            globalName: null,
+            createDM: () => Promise.resolve({ send: (): Promise<unknown> => Promise.resolve(null) }),
+          }),
+      },
+    },
+    'user-1',
+    { contextId: 'dm-user', contextType: 'dm' },
+  )
+
+  expect(label).toBe('@itsmike')
+})
+
+test('resolveDiscordUserLabel formats username-only guild members as @username', async () => {
+  const label = await resolveDiscordUserLabel(
+    {
+      destroy: (): Promise<void> => Promise.resolve(),
+      channels: {
+        cache: new Map([['chan-7', { guildId: 'guild-3' }]]),
+      },
+      guilds: {
+        cache: new Map([
+          [
+            'guild-3',
+            {
+              members: {
+                search: (): Promise<Map<string, { id: string }>> => Promise.resolve(new Map<string, { id: string }>()),
+                fetch: (): Promise<{
+                  displayName: string
+                  nickname: null
+                  user: { username: string; displayName: string; globalName: null }
+                }> =>
+                  Promise.resolve({
+                    displayName: 'itsmike',
+                    nickname: null,
+                    user: { username: 'itsmike', displayName: 'itsmike', globalName: null },
+                  }),
+              },
+            },
+          ],
+        ]),
+      },
+    },
+    'user-9',
+    { contextId: 'chan-7', contextType: 'group' },
+  )
+
+  expect(label).toBe('@itsmike')
 })

--- a/tests/chat/discord/label-helpers.test.ts
+++ b/tests/chat/discord/label-helpers.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from 'bun:test'
+
+import { formatDiscordUserLabel, getDiscordUserDisplayName } from '../../../src/chat/discord/label-helpers.js'
+
+test('formatDiscordUserLabel formats display name with username when they differ', () => {
+  expect(formatDiscordUserLabel('John Johnson', 'itsmike')).toBe('John Johnson (@itsmike)')
+})
+
+test('formatDiscordUserLabel returns display name when no username', () => {
+  expect(formatDiscordUserLabel('John Johnson', null)).toBe('John Johnson')
+})
+
+test('formatDiscordUserLabel returns @username when no display name', () => {
+  expect(formatDiscordUserLabel(null, 'itsmike')).toBe('@itsmike')
+})
+
+test('formatDiscordUserLabel returns null when both are null', () => {
+  expect(formatDiscordUserLabel(null, null)).toBeNull()
+})
+
+test('formatDiscordUserLabel returns just display name when it equals username', () => {
+  expect(formatDiscordUserLabel('itsmike', 'itsmike')).toBe('itsmike')
+})
+
+test('getDiscordUserDisplayName returns displayName when set', () => {
+  expect(getDiscordUserDisplayName({ displayName: 'John', globalName: null, username: 'john' })).toBe('John')
+})
+
+test('getDiscordUserDisplayName falls back to globalName', () => {
+  expect(getDiscordUserDisplayName({ displayName: '', globalName: 'John Global', username: 'john' })).toBe(
+    'John Global',
+  )
+})
+
+test('getDiscordUserDisplayName returns null when both are empty', () => {
+  expect(getDiscordUserDisplayName({ displayName: '', globalName: null, username: 'john' })).toBeNull()
+})

--- a/tests/chat/discord/label-helpers.test.ts
+++ b/tests/chat/discord/label-helpers.test.ts
@@ -23,8 +23,8 @@ test('formatDiscordUserLabel returns null when both are null', () => {
   expect(formatDiscordUserLabel(null, null)).toBeNull()
 })
 
-test('formatDiscordUserLabel returns just display name when it equals username', () => {
-  expect(formatDiscordUserLabel('itsmike', 'itsmike')).toBe('itsmike')
+test('formatDiscordUserLabel includes @username when display name equals username', () => {
+  expect(formatDiscordUserLabel('itsmike', 'itsmike')).toBe('itsmike (@itsmike)')
 })
 
 test('getDiscordUserDisplayName returns globalName when set', () => {

--- a/tests/chat/mattermost/index.test.ts
+++ b/tests/chat/mattermost/index.test.ts
@@ -622,3 +622,64 @@ describe('fetchMattermostFiles', () => {
     expect(result[0]?.fileId).toBe('f1')
   })
 })
+
+describe('MattermostChatProvider reverse label resolution', () => {
+  test('resolveGroupLabel returns channel display name', async () => {
+    setMockFetch((url: string) => {
+      if (url.includes('/api/v4/channels/chan-1')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ type: 'O', display_name: 'Operations', name: 'operations' }), { status: 200 }),
+        )
+      }
+      return Promise.resolve(new Response(null, { status: 404 }))
+    })
+
+    process.env['MATTERMOST_URL'] = 'http://localhost:8065'
+    process.env['MATTERMOST_BOT_TOKEN'] = 'test-token'
+    const provider = new MattermostChatProvider()
+    const label = await provider.resolveGroupLabel?.('chan-1')
+
+    expect(label).toBe('Operations')
+    restoreFetch()
+  })
+
+  test('resolveUserLabel returns display name and username', async () => {
+    setMockFetch((url: string) => {
+      if (url.includes('/api/v4/users/user-1')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              id: 'user-1',
+              username: 'itsmike',
+              first_name: 'John',
+              last_name: 'Johnson',
+              nickname: '',
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      return Promise.resolve(new Response(null, { status: 404 }))
+    })
+
+    process.env['MATTERMOST_URL'] = 'http://localhost:8065'
+    process.env['MATTERMOST_BOT_TOKEN'] = 'test-token'
+    const provider = new MattermostChatProvider()
+    const label = await provider.resolveUserLabel?.('user-1')
+
+    expect(label).toBe('John Johnson (@itsmike)')
+    restoreFetch()
+  })
+
+  test('resolveUserLabel returns null when user lookup fails', async () => {
+    setMockFetch(() => Promise.resolve(new Response(null, { status: 404 })))
+
+    process.env['MATTERMOST_URL'] = 'http://localhost:8065'
+    process.env['MATTERMOST_BOT_TOKEN'] = 'test-token'
+    const provider = new MattermostChatProvider()
+    const label = await provider.resolveUserLabel?.('missing-user')
+
+    expect(label).toBeNull()
+    restoreFetch()
+  })
+})

--- a/tests/chat/mattermost/label-helpers.test.ts
+++ b/tests/chat/mattermost/label-helpers.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'bun:test'
+
+import { formatMattermostUserLabel } from '../../../src/chat/mattermost/label-helpers.js'
+
+test('formatMattermostUserLabel formats first+last name with username', () => {
+  expect(formatMattermostUserLabel('itsmike', 'John', 'Johnson', '')).toBe('John Johnson (@itsmike)')
+})
+
+test('formatMattermostUserLabel uses nickname when no first/last name', () => {
+  expect(formatMattermostUserLabel('itsmike', '', '', 'JohnnyBoy')).toBe('JohnnyBoy (@itsmike)')
+})
+
+test('formatMattermostUserLabel returns only username when no display name', () => {
+  expect(formatMattermostUserLabel('itsmike', '', '', '')).toBe('@itsmike')
+})
+
+test('formatMattermostUserLabel returns null when all fields are empty', () => {
+  expect(formatMattermostUserLabel('', '', '', '')).toBeNull()
+})
+
+test('formatMattermostUserLabel returns display name without username when username is empty', () => {
+  expect(formatMattermostUserLabel('', 'John', 'Johnson', '')).toBe('John Johnson')
+})

--- a/tests/chat/telegram/index.test.ts
+++ b/tests/chat/telegram/index.test.ts
@@ -595,3 +595,58 @@ describe('extractFilesFromContext', () => {
     expect(first.filename).toBe('document')
   })
 })
+
+describe('TelegramChatProvider reverse label resolution', () => {
+  test('resolveGroupLabel returns chat title from getChat', async () => {
+    process.env['TELEGRAM_BOT_TOKEN'] = 'test-token'
+    const provider = new TelegramChatProvider()
+    Reflect.set(provider, 'bot', {
+      api: {
+        getChat: (chatId: number): Promise<{ title: string | undefined }> => {
+          expect(chatId).toBe(-1003768634358)
+          return Promise.resolve({ title: 'Engineering Chat' })
+        },
+      },
+    })
+
+    const label = await provider.resolveGroupLabel?.('-1003768634358')
+    expect(label).toBe('Engineering Chat')
+    delete process.env['TELEGRAM_BOT_TOKEN']
+  })
+
+  test('resolveUserLabel returns full name and username from getChatMember', async () => {
+    process.env['TELEGRAM_BOT_TOKEN'] = 'test-token'
+    const provider = new TelegramChatProvider()
+    Reflect.set(provider, 'bot', {
+      api: {
+        getChatMember: (
+          _chatId: number | string,
+          userId: number,
+        ): Promise<{
+          user:
+            | { first_name: string | undefined; last_name: string | undefined; username: string | undefined }
+            | undefined
+        }> => {
+          expect(userId).toBe(164696606)
+          return Promise.resolve({ user: { first_name: 'John', last_name: 'Johnson', username: 'itsmike' } })
+        },
+      },
+    })
+
+    const label = await provider.resolveUserLabel?.('164696606', { contextId: '-1003768634358', contextType: 'group' })
+    expect(label).toBe('John Johnson (@itsmike)')
+    delete process.env['TELEGRAM_BOT_TOKEN']
+  })
+
+  test('resolveUserLabel returns null for non-numeric Telegram user IDs', async () => {
+    process.env['TELEGRAM_BOT_TOKEN'] = 'test-token'
+    const provider = new TelegramChatProvider()
+
+    const label = await provider.resolveUserLabel?.('not-a-number', {
+      contextId: '-1003768634358',
+      contextType: 'group',
+    })
+    expect(label).toBeNull()
+    delete process.env['TELEGRAM_BOT_TOKEN']
+  })
+})

--- a/tests/chat/telegram/label-helpers.test.ts
+++ b/tests/chat/telegram/label-helpers.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from 'bun:test'
+
+import {
+  formatTelegramUserLabel,
+  resolveTelegramGroupLabel,
+  resolveTelegramUserLabel,
+} from '../../../src/chat/telegram/label-helpers.js'
+
+test('formatTelegramUserLabel formats full name with username', () => {
+  expect(formatTelegramUserLabel('John', 'Johnson', 'itsmike')).toBe('John Johnson (@itsmike)')
+})
+
+test('formatTelegramUserLabel formats first name only', () => {
+  expect(formatTelegramUserLabel('John', undefined, undefined)).toBe('John')
+})
+
+test('formatTelegramUserLabel formats username only when name is empty', () => {
+  expect(formatTelegramUserLabel('', undefined, 'itsmike')).toBe('@itsmike')
+})
+
+test('formatTelegramUserLabel returns null when all fields are empty', () => {
+  expect(formatTelegramUserLabel('', undefined, undefined)).toBeNull()
+})
+
+test('resolveTelegramGroupLabel returns title from chat', async () => {
+  const getChat = (_id: number): Promise<unknown> => Promise.resolve({ type: 'supergroup', title: 'Engineering Chat' })
+
+  const label = await resolveTelegramGroupLabel(getChat, '-1001234567890')
+  expect(label).toBe('Engineering Chat')
+})
+
+test('resolveTelegramGroupLabel returns null for non-numeric group ID', async () => {
+  const getChat = (_id: number): Promise<unknown> => Promise.resolve({})
+  const label = await resolveTelegramGroupLabel(getChat, 'not-a-number')
+  expect(label).toBeNull()
+})
+
+test('resolveTelegramGroupLabel returns null when chat has no title', async () => {
+  const getChat = (_id: number): Promise<unknown> => Promise.resolve({ type: 'private' })
+  const label = await resolveTelegramGroupLabel(getChat, '-1001234567890')
+  expect(label).toBeNull()
+})
+
+test('resolveTelegramUserLabel returns null for DM context', async () => {
+  const getChatMember = (_cid: number, _uid: number): Promise<unknown> => Promise.resolve({})
+  const label = await resolveTelegramUserLabel(getChatMember, '12345', {
+    contextId: '12345',
+    contextType: 'dm',
+  })
+  expect(label).toBeNull()
+})
+
+test('resolveTelegramUserLabel returns null for non-numeric user ID', async () => {
+  const getChatMember = (_cid: number, _uid: number): Promise<unknown> => Promise.resolve({})
+  const label = await resolveTelegramUserLabel(getChatMember, 'not-a-number', {
+    contextId: '-1001234567890',
+    contextType: 'group',
+  })
+  expect(label).toBeNull()
+})

--- a/tests/commands/group.test.ts
+++ b/tests/commands/group.test.ts
@@ -655,11 +655,53 @@ describe('group commands', () => {
       expect(textCalls[0]).toContain('group-123 (added by admin1)')
     })
 
+    test('falls back to raw IDs when /groups label resolution rejects', async () => {
+      const fallbackHandlers = new Map<string, CommandHandler>()
+      const fallbackChat = createMockChat({
+        commandHandlers: fallbackHandlers,
+        resolveGroupLabel: (_groupId: string): Promise<string | null> =>
+          Promise.reject(new Error('group lookup failed')),
+        resolveUserLabel: (_userId: string): Promise<string | null> => Promise.reject(new Error('user lookup failed')),
+      })
+      registerGroupCommand(fallbackChat)
+
+      const { addAuthorizedGroup } = await import('../../src/authorized-groups.js')
+      addAuthorizedGroup('group-123', 'admin1')
+
+      const handler = fallbackHandlers.get('groups')
+      expect(handler).toBeDefined()
+
+      const { reply, textCalls } = createMockReply()
+      await handler!(createDmMessage('admin1'), reply, createAuth('admin1', { isBotAdmin: true }))
+
+      expect(textCalls[0]).toContain('group-123 (added by admin1)')
+    })
+
     test('falls back to raw IDs when /group users label resolution returns null', async () => {
       const fallbackHandlers = new Map<string, CommandHandler>()
       const fallbackChat = createMockChat({
         commandHandlers: fallbackHandlers,
         resolveUserLabel: (_userId: string): Promise<string | null> => Promise.resolve(null),
+      })
+      registerGroupCommand(fallbackChat)
+
+      const { addGroupMember } = await import('../../src/groups.js')
+      addGroupMember('group1', 'user1', 'admin1')
+
+      const handler = fallbackHandlers.get('group')
+      expect(handler).toBeDefined()
+
+      const { reply, textCalls } = createMockReply()
+      await handler!(createGroupMessage('user1', 'users', false), reply, createAuth('user1'))
+
+      expect(textCalls[0]).toContain('- user1 (added by admin1)')
+    })
+
+    test('falls back to raw IDs when /group users label resolution rejects', async () => {
+      const fallbackHandlers = new Map<string, CommandHandler>()
+      const fallbackChat = createMockChat({
+        commandHandlers: fallbackHandlers,
+        resolveUserLabel: (_userId: string): Promise<string | null> => Promise.reject(new Error('user lookup failed')),
       })
       registerGroupCommand(fallbackChat)
 

--- a/tests/commands/group.test.ts
+++ b/tests/commands/group.test.ts
@@ -581,6 +581,34 @@ describe('group commands', () => {
       expect(textCalls[0]).not.toContain('group-123 (added by admin1)')
     })
 
+    test('resolves added-by labels separately for each authorized group context', async () => {
+      const labeledHandlers = new Map<string, CommandHandler>()
+      const labeledChat = createMockChat({
+        commandHandlers: labeledHandlers,
+        resolveGroupLabel: (groupId: string): Promise<string | null> => Promise.resolve(groupId),
+        resolveUserLabel: (userId: string, context?: ResolveUserContext): Promise<string | null> => {
+          if (userId !== 'admin1') return Promise.resolve(null)
+          if (context?.contextId === 'group-123') return Promise.resolve('Alice One (@admin1)')
+          if (context?.contextId === 'group-456') return Promise.resolve('Alice Two (@admin1)')
+          return Promise.resolve(null)
+        },
+      })
+      registerGroupCommand(labeledChat)
+
+      const { addAuthorizedGroup } = await import('../../src/authorized-groups.js')
+      addAuthorizedGroup('group-123', 'admin1')
+      addAuthorizedGroup('group-456', 'admin1')
+
+      const handler = labeledHandlers.get('groups')
+      expect(handler).toBeDefined()
+
+      const { reply, textCalls } = createMockReply()
+      await handler!(createDmMessage('admin1'), reply, createAuth('admin1', { isBotAdmin: true }))
+
+      expect(textCalls[0]).toContain('group-123 (added by Alice One (@admin1))')
+      expect(textCalls[0]).toContain('group-456 (added by Alice Two (@admin1))')
+    })
+
     test('lists group users with resolved member and adder labels', async () => {
       const labeledHandlers = new Map<string, CommandHandler>()
       const labeledChat = createMockChat({

--- a/tests/commands/group.test.ts
+++ b/tests/commands/group.test.ts
@@ -550,4 +550,101 @@ describe('group commands', () => {
       expect(textCalls[0]).toBe('User 12345 added to this group.')
     })
   })
+
+  describe('readable label resolution', () => {
+    test('lists authorized groups with resolved group and user labels', async () => {
+      const labeledHandlers = new Map<string, CommandHandler>()
+      const labeledChat = createMockChat({
+        commandHandlers: labeledHandlers,
+        resolveGroupLabel: (groupId: string): Promise<string | null> => {
+          if (groupId === 'group-123') return Promise.resolve('Engineering Chat')
+          return Promise.resolve(null)
+        },
+        resolveUserLabel: (userId: string): Promise<string | null> => {
+          if (userId === 'admin1') return Promise.resolve('John Johnson (@itsmike)')
+          return Promise.resolve(null)
+        },
+      })
+      registerGroupCommand(labeledChat)
+
+      const { addAuthorizedGroup } = await import('../../src/authorized-groups.js')
+      addAuthorizedGroup('group-123', 'admin1')
+
+      const handler = labeledHandlers.get('groups')
+      expect(handler).toBeDefined()
+
+      const { reply, textCalls } = createMockReply()
+      await handler!(createDmMessage('admin1'), reply, createAuth('admin1', { isBotAdmin: true }))
+
+      expect(textCalls[0]).toContain('Engineering Chat')
+      expect(textCalls[0]).toContain('John Johnson (@itsmike)')
+      expect(textCalls[0]).not.toContain('group-123 (added by admin1)')
+    })
+
+    test('lists group users with resolved member and adder labels', async () => {
+      const labeledHandlers = new Map<string, CommandHandler>()
+      const labeledChat = createMockChat({
+        commandHandlers: labeledHandlers,
+        resolveUserLabel: (userId: string): Promise<string | null> => {
+          if (userId === 'user1') return Promise.resolve('John Johnson (@itsmike)')
+          if (userId === 'admin1') return Promise.resolve('Jane Admin (@janeadmin)')
+          return Promise.resolve(null)
+        },
+      })
+      registerGroupCommand(labeledChat)
+
+      const { addGroupMember } = await import('../../src/groups.js')
+      addGroupMember('group1', 'user1', 'admin1')
+
+      const handler = labeledHandlers.get('group')
+      expect(handler).toBeDefined()
+
+      const { reply, textCalls } = createMockReply()
+      await handler!(createGroupMessage('user1', 'users', false), reply, createAuth('user1'))
+
+      expect(textCalls[0]).toContain('John Johnson (@itsmike)')
+      expect(textCalls[0]).toContain('added by Jane Admin (@janeadmin)')
+    })
+
+    test('falls back to raw IDs when /groups label resolution returns null', async () => {
+      const fallbackHandlers = new Map<string, CommandHandler>()
+      const fallbackChat = createMockChat({
+        commandHandlers: fallbackHandlers,
+        resolveGroupLabel: (_groupId: string): Promise<string | null> => Promise.resolve(null),
+        resolveUserLabel: (_userId: string): Promise<string | null> => Promise.resolve(null),
+      })
+      registerGroupCommand(fallbackChat)
+
+      const { addAuthorizedGroup } = await import('../../src/authorized-groups.js')
+      addAuthorizedGroup('group-123', 'admin1')
+
+      const handler = fallbackHandlers.get('groups')
+      expect(handler).toBeDefined()
+
+      const { reply, textCalls } = createMockReply()
+      await handler!(createDmMessage('admin1'), reply, createAuth('admin1', { isBotAdmin: true }))
+
+      expect(textCalls[0]).toContain('group-123 (added by admin1)')
+    })
+
+    test('falls back to raw IDs when /group users label resolution returns null', async () => {
+      const fallbackHandlers = new Map<string, CommandHandler>()
+      const fallbackChat = createMockChat({
+        commandHandlers: fallbackHandlers,
+        resolveUserLabel: (_userId: string): Promise<string | null> => Promise.resolve(null),
+      })
+      registerGroupCommand(fallbackChat)
+
+      const { addGroupMember } = await import('../../src/groups.js')
+      addGroupMember('group1', 'user1', 'admin1')
+
+      const handler = fallbackHandlers.get('group')
+      expect(handler).toBeDefined()
+
+      const { reply, textCalls } = createMockReply()
+      await handler!(createGroupMessage('user1', 'users', false), reply, createAuth('user1'))
+
+      expect(textCalls[0]).toContain('- user1 (added by admin1)')
+    })
+  })
 })

--- a/tests/commands/group.test.ts
+++ b/tests/commands/group.test.ts
@@ -21,6 +21,56 @@ const getFirstReply = (textCalls: readonly string[]): string | null => {
   return firstReply
 }
 
+const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+const createBlockingLabelLookup = (): {
+  readonly lookup: () => Promise<string | null>
+  readonly getMaxInFlight: () => number
+  readonly stopBlocking: () => void
+  readonly releaseAll: () => void
+} => {
+  let shouldBlock = true
+  let inFlight = 0
+  let maxInFlight = 0
+  let releases: Array<() => void> = []
+
+  return {
+    lookup: () => {
+      inFlight += 1
+      maxInFlight = Math.max(maxInFlight, inFlight)
+
+      if (!shouldBlock) {
+        inFlight -= 1
+        return Promise.resolve(null)
+      }
+
+      return new Promise((resolve) => {
+        releases = [
+          ...releases,
+          (): void => {
+            inFlight -= 1
+            resolve(null)
+          },
+        ]
+      })
+    },
+    getMaxInFlight: () => maxInFlight,
+    stopBlocking: () => {
+      shouldBlock = false
+    },
+    releaseAll: () => {
+      const currentReleases = releases
+      releases = []
+      currentReleases.forEach((release) => {
+        release()
+      })
+    },
+  }
+}
+
 describe('group commands', () => {
   let mockChat: ChatProvider
   let commandHandlers: Map<string, CommandHandler>
@@ -586,10 +636,10 @@ describe('group commands', () => {
       const labeledChat = createMockChat({
         commandHandlers: labeledHandlers,
         resolveGroupLabel: (groupId: string): Promise<string | null> => Promise.resolve(groupId),
-        resolveUserLabel: (userId: string, context?: ResolveUserContext): Promise<string | null> => {
+        resolveUserLabel: (userId: string, context: ResolveUserContext | undefined): Promise<string | null> => {
           if (userId !== 'admin1') return Promise.resolve(null)
-          if (context?.contextId === 'group-123') return Promise.resolve('Alice One (@admin1)')
-          if (context?.contextId === 'group-456') return Promise.resolve('Alice Two (@admin1)')
+          if (context !== undefined && context.contextId === 'group-123') return Promise.resolve('Alice One (@admin1)')
+          if (context !== undefined && context.contextId === 'group-456') return Promise.resolve('Alice Two (@admin1)')
           return Promise.resolve(null)
         },
       })
@@ -632,6 +682,65 @@ describe('group commands', () => {
 
       expect(textCalls[0]).toContain('John Johnson (@itsmike)')
       expect(textCalls[0]).toContain('added by Jane Admin (@janeadmin)')
+    })
+
+    test('bounds concurrent /groups label lookups', async () => {
+      const blockingLookup = createBlockingLabelLookup()
+      const labeledHandlers = new Map<string, CommandHandler>()
+      const labeledChat = createMockChat({
+        commandHandlers: labeledHandlers,
+        resolveGroupLabel: (): Promise<string | null> => blockingLookup.lookup(),
+        resolveUserLabel: (): Promise<string | null> => blockingLookup.lookup(),
+      })
+      registerGroupCommand(labeledChat)
+
+      const { addAuthorizedGroup } = await import('../../src/authorized-groups.js')
+      for (const index of [1, 2, 3, 4, 5, 6]) {
+        addAuthorizedGroup(`group-${index}`, `admin-${index}`)
+      }
+
+      const handler = labeledHandlers.get('groups')
+      expect(handler).toBeDefined()
+
+      const { reply } = createMockReply()
+      const handlerPromise = handler!(createDmMessage('admin1'), reply, createAuth('admin1', { isBotAdmin: true }))
+
+      await flushMicrotasks()
+
+      expect(blockingLookup.getMaxInFlight()).toBe(5)
+
+      blockingLookup.stopBlocking()
+      blockingLookup.releaseAll()
+      await handlerPromise
+    })
+
+    test('bounds concurrent /group users label lookups', async () => {
+      const blockingLookup = createBlockingLabelLookup()
+      const labeledHandlers = new Map<string, CommandHandler>()
+      const labeledChat = createMockChat({
+        commandHandlers: labeledHandlers,
+        resolveUserLabel: (): Promise<string | null> => blockingLookup.lookup(),
+      })
+      registerGroupCommand(labeledChat)
+
+      const { addGroupMember } = await import('../../src/groups.js')
+      for (const index of [1, 2, 3, 4, 5, 6]) {
+        addGroupMember('group1', `user-${index}`, `admin-${index}`)
+      }
+
+      const handler = labeledHandlers.get('group')
+      expect(handler).toBeDefined()
+
+      const { reply } = createMockReply()
+      const handlerPromise = handler!(createGroupMessage('user1', 'users', false), reply, createAuth('user1'))
+
+      await flushMicrotasks()
+
+      expect(blockingLookup.getMaxInFlight()).toBe(5)
+
+      blockingLookup.stopBlocking()
+      blockingLookup.releaseAll()
+      await handlerPromise
     })
 
     test('falls back to raw IDs when /groups label resolution returns null', async () => {

--- a/tests/utils/papai-policy-lint.test.ts
+++ b/tests/utils/papai-policy-lint.test.ts
@@ -4,7 +4,6 @@ import os from 'node:os'
 import path from 'node:path'
 
 const REPO_ROOT = path.resolve(import.meta.dir, '../..')
-const OXLINT_BIN = path.join(REPO_ROOT, 'node_modules/.bin/oxlint')
 const PLUGIN_PATH = path.join(REPO_ROOT, 'lint-plugins/papai-policy.js')
 
 const eslintDirective = ['eslint', 'disable'].join('-')
@@ -47,7 +46,7 @@ function runRule(ruleName: string, source: string): LintResult {
     )
     fs.writeFileSync(filePath, source)
 
-    const proc = Bun.spawnSync([OXLINT_BIN, '--config', configPath, filePath], {
+    const proc = Bun.spawnSync([process.execPath, 'x', 'oxlint', '--config', configPath, filePath], {
       cwd: REPO_ROOT,
       stdio: ['ignore', 'pipe', 'pipe'],
     })

--- a/tests/utils/test-helpers.ts
+++ b/tests/utils/test-helpers.ts
@@ -299,6 +299,8 @@ type CreateMockChatOptions = Partial<
     sendMessage: (userId: string, text: string) => Promise<void>
     onMessageHandler: (handler: (msg: IncomingMessage, reply: ReplyFn) => Promise<void>) => void
     resolveUserId: (username: string, context: ResolveUserContext) => Promise<string | null>
+    resolveUserLabel: (userId: string, context?: ResolveUserContext) => Promise<string | null>
+    resolveGroupLabel: (groupId: string) => Promise<string | null>
     onInteractionHandler: (handler: (interaction: IncomingInteraction, reply: ReplyFn) => Promise<void>) => void
     setCommands: (adminUserId: string) => Promise<void>
     capabilities: Set<ChatCapability>
@@ -316,6 +318,9 @@ const DEFAULT_RESOLVE_USER_ID = (username: string, _context: ResolveUserContext)
   const clean = username.startsWith('@') ? username.slice(1) : username
   return Promise.resolve(clean)
 }
+const DEFAULT_RESOLVE_USER_LABEL = (_userId: string, _context?: ResolveUserContext): Promise<string | null> =>
+  Promise.resolve(null)
+const DEFAULT_RESOLVE_GROUP_LABEL = (_groupId: string): Promise<string | null> => Promise.resolve(null)
 
 function hasAppError(error: Error): error is Error & { appError: AppError } {
   const appError: unknown = Reflect.get(error, 'appError')
@@ -418,6 +423,8 @@ export function createMockChat(...args: [] | [options: CreateMockChatOptions]): 
   const onInteractionHandler = options.onInteractionHandler
   const sendMessage = options.sendMessage
   const resolveUserId = options.resolveUserId
+  const resolveUserLabel = options.resolveUserLabel
+  const resolveGroupLabel = options.resolveGroupLabel
   const setCommands = options.setCommands
 
   let sendMessageImpl: (userId: string, text: string) => Promise<void> = DEFAULT_SEND_MESSAGE
@@ -428,6 +435,16 @@ export function createMockChat(...args: [] | [options: CreateMockChatOptions]): 
   let resolveUserIdImpl = DEFAULT_RESOLVE_USER_ID
   if (resolveUserId !== undefined) {
     resolveUserIdImpl = resolveUserId
+  }
+
+  let resolveUserLabelImpl = DEFAULT_RESOLVE_USER_LABEL
+  if (resolveUserLabel !== undefined) {
+    resolveUserLabelImpl = resolveUserLabel
+  }
+
+  let resolveGroupLabelImpl = DEFAULT_RESOLVE_GROUP_LABEL
+  if (resolveGroupLabel !== undefined) {
+    resolveGroupLabelImpl = resolveGroupLabel
   }
 
   let setCommandsImpl: (adminUserId: string) => Promise<void> = DEFAULT_SET_COMMANDS
@@ -466,6 +483,8 @@ export function createMockChat(...args: [] | [options: CreateMockChatOptions]): 
         })()),
     sendMessage: sendMessageImpl,
     resolveUserId: resolveUserIdImpl,
+    resolveUserLabel: resolveUserLabelImpl,
+    resolveGroupLabel: resolveGroupLabelImpl,
     setCommands: setCommandsImpl,
     renderContext: (snapshot: ContextSnapshot): ContextRendered => ({
       method: 'text',


### PR DESCRIPTION
Implements reverse label resolution for Mattermost, Discord, and Telegram
so that /group users and /groups display human-readable names instead of
raw platform IDs.

https://claude.ai/code/session_018iC2CD8JnL7cbiXPHmoXYa