### PR TITLE
feat(audit): implement keyword-batched behavior audit pipeline

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,6 @@
         "@gramio/format": "^0.6.0",
         "ai": "^6.0.154",
         "ai-tokenizer": "^1.0.6",
-        "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "defuddle": "^0.16.0",
         "discord.js": "^14.25.1",

--- a/docs/superpowers/plans/2026-04-20-behavior-audit-keyword-batching-implementation.md
+++ b/docs/superpowers/plans/2026-04-20-behavior-audit-keyword-batching-implementation.md
@@ -94,7 +94,14 @@ test('runPhase1 stores canonical keywords after extraction and vocabulary resolu
     MAX_RETRIES: 3,
     RETRY_BACKOFF_MS: [0, 0, 0] as const,
     MAX_STEPS: 20,
-    EXCLUDED_PREFIXES: ['tests/e2e/', 'tests/client/', 'tests/helpers/', 'tests/scripts/', 'tests/review-loop/', 'tests/types/'] as const,
+    EXCLUDED_PREFIXES: [
+      'tests/e2e/',
+      'tests/client/',
+      'tests/helpers/',
+      'tests/scripts/',
+      'tests/review-loop/',
+      'tests/types/',
+    ] as const,
   }))
 
   void mock.module('../../scripts/behavior-audit/extract-agent.js', () => ({
@@ -496,14 +503,15 @@ export async function recordKeywordUsage(keywords: readonly string[]): Promise<v
   const keywordSet = new Set(keywords)
   const now = new Date().toISOString()
   const updated = existing.map((entry) =>
-    keywordSet.has(entry.slug)
-      ? { ...entry, timesUsed: entry.timesUsed + 1, updatedAt: now }
-      : entry,
+    keywordSet.has(entry.slug) ? { ...entry, timesUsed: entry.timesUsed + 1, updatedAt: now } : entry,
   )
   await saveKeywordVocabulary(updated)
 }
 
-export function findExactKeyword(entries: readonly KeywordVocabularyEntry[], slug: string): KeywordVocabularyEntry | null {
+export function findExactKeyword(
+  entries: readonly KeywordVocabularyEntry[],
+  slug: string,
+): KeywordVocabularyEntry | null {
   return entries.find((entry) => entry.slug === slug) ?? null
 }
 ```
@@ -609,12 +617,12 @@ export interface ExtractedBehavior {
 And update `writeBehaviorFile`:
 
 ```typescript
-  for (const b of behaviors) {
-    lines.push(`## Test: "${b.fullPath}"\n`)
-    lines.push(`**Behavior:** ${b.behavior}`)
-    lines.push(`**Context:** ${b.context}`)
-    lines.push(`**Keywords:** ${b.keywords.join(', ')}\n`)
-  }
+for (const b of behaviors) {
+  lines.push(`## Test: "${b.fullPath}"\n`)
+  lines.push(`**Behavior:** ${b.behavior}`)
+  lines.push(`**Context:** ${b.context}`)
+  lines.push(`**Keywords:** ${b.keywords.join(', ')}\n`)
+}
 ```
 
 - [ ] **Step 4: Reset stale Phase 1 extracted behavior during migration**
@@ -634,13 +642,13 @@ const ExtractedBehaviorSchema = z.object({
 And in `migrateV1toV2`, reset Phase 1 extracted progress:
 
 ```typescript
-  return ProgressV2Schema.parse({
-    version: 2,
-    startedAt,
-    phase1: emptyPhase1(),
-    phase2: emptyPhase2(),
-    phase3: emptyPhase3(),
-  })
+return ProgressV2Schema.parse({
+  version: 2,
+  startedAt,
+  phase1: emptyPhase1(),
+  phase2: emptyPhase2(),
+  phase3: emptyPhase3(),
+})
 ```
 
 - [ ] **Step 5: Run the focused test to verify it passes**
@@ -757,7 +765,9 @@ test('runPhase1 persists vocabulary updates before marking a test done', async (
 
   const savedVocabulary = JSON.parse(await Bun.file(vocabularyPath).text()) as readonly { readonly slug: string }[]
   expect(savedVocabulary[0]?.slug).toBe('group-targeting')
-  expect(progress.phase1.completedTests['tests/tools/sample.test.ts']?.['tests/tools/sample.test.ts::suite > case']).toBe('done')
+  expect(
+    progress.phase1.completedTests['tests/tools/sample.test.ts']?.['tests/tools/sample.test.ts::suite > case'],
+  ).toBe('done')
 })
 ```
 
@@ -806,34 +816,31 @@ function buildResolverPrompt(candidateKeywords: readonly string[], vocabularyTex
 And in `processSingleTestCase`, replace the extraction block with:
 
 ```typescript
-  const extracted = await extractWithRetry(buildExtractionPrompt(testCase, testFilePath), 0)
-  if (extracted === null) {
-    markTestFailed(progress, testKey, 'extraction failed')
-    return null
-  }
+const extracted = await extractWithRetry(buildExtractionPrompt(testCase, testFilePath), 0)
+if (extracted === null) {
+  markTestFailed(progress, testKey, 'extraction failed')
+  return null
+}
 
-  const existingVocabulary = (await loadKeywordVocabulary()) ?? []
-  const vocabularyText = existingVocabulary.length === 0 ? '(empty)' : JSON.stringify(existingVocabulary, null, 2)
-  const resolved = await resolveKeywordsWithRetry(
-    buildResolverPrompt(extracted.candidateKeywords, vocabularyText),
-    0,
-  )
-  if (resolved === null) {
-    markTestFailed(progress, testKey, 'keyword resolution failed')
-    return null
-  }
+const existingVocabulary = (await loadKeywordVocabulary()) ?? []
+const vocabularyText = existingVocabulary.length === 0 ? '(empty)' : JSON.stringify(existingVocabulary, null, 2)
+const resolved = await resolveKeywordsWithRetry(buildResolverPrompt(extracted.candidateKeywords, vocabularyText), 0)
+if (resolved === null) {
+  markTestFailed(progress, testKey, 'keyword resolution failed')
+  return null
+}
 
-  const nextVocabulary = [...existingVocabulary, ...resolved.appendedEntries]
-  await saveKeywordVocabulary(nextVocabulary)
-  await recordKeywordUsage(resolved.keywords)
+const nextVocabulary = [...existingVocabulary, ...resolved.appendedEntries]
+await saveKeywordVocabulary(nextVocabulary)
+await recordKeywordUsage(resolved.keywords)
 
-  const behavior: ExtractedBehavior = {
-    testName: testCase.name,
-    fullPath: testCase.fullPath,
-    behavior: extracted.behavior,
-    context: extracted.context,
-    keywords: resolved.keywords,
-  }
+const behavior: ExtractedBehavior = {
+  testName: testCase.name,
+  fullPath: testCase.fullPath,
+  behavior: extracted.behavior,
+  context: extracted.context,
+  keywords: resolved.keywords,
+}
 ```
 
 - [ ] **Step 4: Run the focused test to verify it passes**
@@ -938,13 +945,13 @@ Update the Zod schema to match those new fields.
 Edit the `buildPhase2Fingerprint` call in `scripts/behavior-audit/extract-incremental.ts`:
 
 ```typescript
-  const phase2Fingerprint = buildPhase2Fingerprint({
-    testKey,
-    behavior: extractedBehavior.behavior,
-    context: extractedBehavior.context,
-    keywords: extractedBehavior.keywords,
-    phaseVersion: manifest.phaseVersions.phase2,
-  })
+const phase2Fingerprint = buildPhase2Fingerprint({
+  testKey,
+  behavior: extractedBehavior.behavior,
+  context: extractedBehavior.context,
+  keywords: extractedBehavior.keywords,
+  phaseVersion: manifest.phaseVersions.phase2,
+})
 ```
 
 - [ ] **Step 5: Run the focused incremental test to verify it passes**
@@ -1153,7 +1160,9 @@ function getPrimaryKeyword(keywords: readonly string[], cardinality: ReadonlyMap
   })[0]!
 }
 
-function groupByPrimaryKeyword(extractedBehaviors: Readonly<Record<string, ExtractedBehavior>>): readonly KeywordBatch[] {
+function groupByPrimaryKeyword(
+  extractedBehaviors: Readonly<Record<string, ExtractedBehavior>>,
+): readonly KeywordBatch[] {
   const keywordCounts = new Map<string, number>()
   for (const behavior of Object.values(extractedBehaviors)) {
     for (const keyword of behavior.keywords) {
@@ -1258,18 +1267,18 @@ Expected: FAIL because the current provenance storage and evaluation traversal s
 Edit `scripts/behavior-audit/consolidate.ts` when building `updatedEntries`:
 
 ```typescript
-      updatedEntries[cb.id] = {
-        consolidatedId: cb.id,
-        domain: cb.domain,
-        featureName: cb.featureName,
-        sourceTestKeys: cb.sourceTestKeys,
-        isUserFacing: cb.isUserFacing,
-        primaryKeyword: group.primaryKeyword,
-        keywords: [...new Set(group.inputs.flatMap((input) => input.keywords))].toSorted(),
-        sourceDomains: [...new Set(group.inputs.map((input) => input.domain))].toSorted(),
-        phase2Fingerprint: fingerprint,
-        lastConsolidatedAt: new Date().toISOString(),
-      }
+updatedEntries[cb.id] = {
+  consolidatedId: cb.id,
+  domain: cb.domain,
+  featureName: cb.featureName,
+  sourceTestKeys: cb.sourceTestKeys,
+  isUserFacing: cb.isUserFacing,
+  primaryKeyword: group.primaryKeyword,
+  keywords: [...new Set(group.inputs.flatMap((input) => input.keywords))].toSorted(),
+  sourceDomains: [...new Set(group.inputs.map((input) => input.domain))].toSorted(),
+  phase2Fingerprint: fingerprint,
+  lastConsolidatedAt: new Date().toISOString(),
+}
 ```
 
 - [ ] **Step 4: Adapt `evaluate.ts` to traverse consolidated entries from the manifest rather than `completedDomains`**
@@ -1279,7 +1288,9 @@ Edit `scripts/behavior-audit/evaluate.ts` so `runPhase3` derives its readable co
 Use this helper shape:
 
 ```typescript
-function getDomainsFromManifestEntries(entries: Readonly<Record<string, import('./incremental.js').ConsolidatedManifestEntry>>): readonly string[] {
+function getDomainsFromManifestEntries(
+  entries: Readonly<Record<string, import('./incremental.js').ConsolidatedManifestEntry>>,
+): readonly string[] {
   return [...new Set(Object.values(entries).map((entry) => entry.domain))].toSorted()
 }
 ```
@@ -1301,7 +1312,11 @@ function getDomainsFromManifestEntries(
   return [...new Set(Object.values(entries).map((entry) => entry.domain))].toSorted()
 }
 
-export async function runPhase3({ progress, selectedConsolidatedIds, consolidatedManifest }: Phase3RunInput): Promise<void> {
+export async function runPhase3({
+  progress,
+  selectedConsolidatedIds,
+  consolidatedManifest,
+}: Phase3RunInput): Promise<void> {
   console.log('\n[Phase 3] Reading consolidated behavior files...')
   const domains = consolidatedManifest === null ? [] : getDomainsFromManifestEntries(consolidatedManifest.entries)
   const allBehaviors = await parseConsolidatedFiles(domains)
@@ -1391,15 +1406,18 @@ test('behavior-audit-reset phase2 clears downstream state without deleting keywo
   const root = makeTempDir()
   const reportsDir = path.join(root, 'reports')
 
-  await Bun.write(path.join(reportsDir, 'keyword-vocabulary.json'), JSON.stringify([
-    {
-      slug: 'group-targeting',
-      description: 'Targeting work at a group context.',
-      createdAt: '2026-04-20T12:00:00.000Z',
-      updatedAt: '2026-04-20T12:00:00.000Z',
-      timesUsed: 1,
-    },
-  ]))
+  await Bun.write(
+    path.join(reportsDir, 'keyword-vocabulary.json'),
+    JSON.stringify([
+      {
+        slug: 'group-targeting',
+        description: 'Targeting work at a group context.',
+        createdAt: '2026-04-20T12:00:00.000Z',
+        updatedAt: '2026-04-20T12:00:00.000Z',
+        timesUsed: 1,
+      },
+    ]),
+  )
   await Bun.write(path.join(reportsDir, 'consolidated', 'tools.md'), '# consolidated')
   await Bun.write(path.join(reportsDir, 'stories', 'tools.md'), '# stories')
 
@@ -1464,11 +1482,11 @@ async function runPhase3IfNeeded(
 And in `main()` replace the Phase 3 call site with:
 
 ```typescript
-  const phase2Version = updatedManifest.phaseVersions.phase2
-  const consolidatedManifest = await runPhase2IfNeeded(progress, phase2Version)
-  await saveConsolidatedManifest(consolidatedManifest)
+const phase2Version = updatedManifest.phaseVersions.phase2
+const consolidatedManifest = await runPhase2IfNeeded(progress, phase2Version)
+await saveConsolidatedManifest(consolidatedManifest)
 
-  await runPhase3IfNeeded(progress, new Set(selection.phase3SelectedConsolidatedIds), consolidatedManifest)
+await runPhase3IfNeeded(progress, new Set(selection.phase3SelectedConsolidatedIds), consolidatedManifest)
 ```
 
 - [ ] **Step 4: Create `scripts/behavior-audit-reset.ts`**

--- a/scripts/behavior-audit-reset.ts
+++ b/scripts/behavior-audit-reset.ts
@@ -1,0 +1,43 @@
+import { rm } from 'node:fs/promises'
+
+import { CONSOLIDATED_DIR, CONSOLIDATED_MANIFEST_PATH, REPORTS_DIR, STORIES_DIR } from './behavior-audit/config.js'
+import { loadProgress, resetPhase2AndPhase3, resetPhase3, saveProgress } from './behavior-audit/progress.js'
+
+export type ResetTarget = 'phase2' | 'phase3' | 'all'
+
+export async function resetBehaviorAudit(target: ResetTarget): Promise<void> {
+  if (target === 'all') {
+    await rm(REPORTS_DIR, { recursive: true, force: true })
+    return
+  }
+
+  if (target === 'phase2') {
+    await rm(CONSOLIDATED_DIR, { recursive: true, force: true })
+    await rm(STORIES_DIR, { recursive: true, force: true })
+    await rm(CONSOLIDATED_MANIFEST_PATH, { force: true })
+
+    const progress = await loadProgress()
+    if (progress !== null) {
+      resetPhase2AndPhase3(progress)
+      await saveProgress(progress)
+    }
+    return
+  }
+
+  await rm(STORIES_DIR, { recursive: true, force: true })
+
+  const progress = await loadProgress()
+  if (progress !== null) {
+    resetPhase3(progress)
+    await saveProgress(progress)
+  }
+}
+
+const target = process.argv[2]
+
+if (target === 'phase2' || target === 'phase3' || target === 'all') {
+  await resetBehaviorAudit(target)
+} else if (target !== undefined) {
+  console.error('Usage: bun scripts/behavior-audit-reset.ts <phase2|phase3|all>')
+  process.exit(1)
+}

--- a/scripts/behavior-audit.ts
+++ b/scripts/behavior-audit.ts
@@ -103,12 +103,16 @@ async function runPhase2IfNeeded(
   return runPhase2(progress, consolidatedManifest, phase2Version)
 }
 
-async function runPhase3IfNeeded(progress: Progress, selectedConsolidatedIds: ReadonlySet<string>): Promise<void> {
+async function runPhase3IfNeeded(
+  progress: Progress,
+  selectedConsolidatedIds: ReadonlySet<string>,
+  consolidatedManifest: import('./behavior-audit/incremental.js').ConsolidatedManifest | null,
+): Promise<void> {
   if (progress.phase3.status === 'done') {
     console.log('[Phase 3] Already complete.\n')
     return
   }
-  await runPhase3({ progress, selectedConsolidatedIds })
+  await runPhase3({ progress, selectedConsolidatedIds, consolidatedManifest })
 }
 
 async function resolveHeadCommit(): Promise<string> {
@@ -175,7 +179,7 @@ async function main(): Promise<void> {
   const consolidatedManifest = await runPhase2IfNeeded(progress, phase2Version)
   await saveConsolidatedManifest(consolidatedManifest)
 
-  await runPhase3IfNeeded(progress, new Set(selection.phase3SelectedConsolidatedIds))
+  await runPhase3IfNeeded(progress, new Set(selection.phase3SelectedConsolidatedIds), consolidatedManifest)
 
   console.log('\nBehavior audit complete.')
 }

--- a/scripts/behavior-audit.ts
+++ b/scripts/behavior-audit.ts
@@ -169,14 +169,9 @@ async function main(): Promise<void> {
     return
   }
 
-  if (progress.phase1.status === 'not-started' || progress.phase1.status === 'in-progress') {
-    await runPhase1IfNeeded(parsedFiles, progress, new Set(selection.phase1SelectedTestKeys), updatedManifest)
-  } else {
-    console.log('[Phase 1] Already complete, skipping.\n')
-  }
+  await runPhase1IfNeeded(parsedFiles, progress, new Set(selection.phase1SelectedTestKeys), updatedManifest)
 
-  const phase2Version = updatedManifest.phaseVersions.phase2
-  const consolidatedManifest = await runPhase2IfNeeded(progress, phase2Version)
+  const consolidatedManifest = await runPhase2IfNeeded(progress, updatedManifest.phaseVersions.phase2)
   await saveConsolidatedManifest(consolidatedManifest)
 
   await runPhase3IfNeeded(progress, new Set(selection.phase3SelectedConsolidatedIds), consolidatedManifest)

--- a/scripts/behavior-audit/config.ts
+++ b/scripts/behavior-audit/config.ts
@@ -12,6 +12,7 @@ export const STORIES_DIR = resolve(REPORTS_DIR, 'stories')
 export const PROGRESS_PATH = resolve(REPORTS_DIR, 'progress.json')
 export const INCREMENTAL_MANIFEST_PATH = resolve(REPORTS_DIR, 'incremental-manifest.json')
 export const CONSOLIDATED_MANIFEST_PATH = resolve(REPORTS_DIR, 'consolidated-manifest.json')
+export const KEYWORD_VOCABULARY_PATH = resolve(REPORTS_DIR, 'keyword-vocabulary.json')
 
 export const PHASE1_TIMEOUT_MS = 1_200_000
 export const PHASE2_TIMEOUT_MS = 300_000

--- a/scripts/behavior-audit/consolidate-agent.ts
+++ b/scripts/behavior-audit/consolidate-agent.ts
@@ -15,25 +15,19 @@ const apiKey = getEnvOrFallback('OPENAI_API_KEY', 'no-key')
 const provider = createOpenAICompatible({ name: 'behavior-audit-consolidate', apiKey, baseURL: BASE_URL })
 const model = provider(MODEL)
 
-const SYSTEM_PROMPT = `You are a senior software analyst reviewing extracted test behaviors from a Telegram/Discord/Mattermost chat bot called "papai". Your job is to consolidate per-test behaviors into feature-level descriptions.
+const SYSTEM_PROMPT = `You are a senior software analyst reviewing extracted test behaviors from a Telegram/Discord/Mattermost chat bot called "papai".
 
-For the list of behaviors you receive (all from the same domain), you must:
+The batch you receive is a candidate pool formed for context-size control and candidate similarity. It is not guaranteed to describe only one feature.
 
-1. CLASSIFY each behavior as either:
-   - "user_facing": the behavior describes something a user can discover, trigger, or observe as a real product feature
-   - "internal": the behavior describes implementation details, internal routing, string parsing edge cases, data format correctness, or pure utility function behavior
+You must:
+1. classify each consolidation as user-facing or internal
+2. merge only behaviors that describe the same user-facing capability
+3. never force one output per batch or one output per keyword
+4. emit multiple consolidated outputs when the batch contains multiple distinct features
+5. generate user stories only for user-facing consolidated features
+6. keep internal-only consolidations separate and use userStory: null for them
 
-2. CONSOLIDATE related behaviors. Multiple tests that cover the same feature from different angles (happy path, error cases, edge cases, boundary conditions) should be merged into a single feature-level entry. A single consolidated entry can reference many source tests.
-
-3. For each consolidated behavior, produce:
-   - featureName: a short (3-6 word) name for the feature
-   - isUserFacing: true or false
-   - behavior: a single plain-language description starting with "When..." that covers the full feature (not just one test case)
-   - userStory: "As a [user type], I want [action] so that [benefit]." — required only when isUserFacing=true, null otherwise
-   - context: one paragraph describing the implementation chain (relevant functions, DB tables, key logic)
-   - sourceTestKeys: array of original test keys that were merged into this entry (pass through exactly as provided)
-
-You have tools to read source files, search the codebase, find files, and list directories. Use them to understand the implementation if needed.`
+Every user story must be feature-level, user-observable, complete in actor/action/benefit, and free of test names, function names, and implementation jargon.`
 
 const ConsolidationItemSchema = z.object({
   featureName: z.string(),
@@ -54,13 +48,19 @@ export interface ConsolidateBehaviorInput {
   readonly testKey: string
   readonly behavior: string
   readonly context: string
+  readonly keywords: readonly string[]
+  readonly primaryKeyword: string
+  readonly domain: string
 }
 
-function buildPrompt(domain: string, behaviors: readonly ConsolidateBehaviorInput[]): string {
+function buildPrompt(primaryKeyword: string, behaviors: readonly ConsolidateBehaviorInput[]): string {
   const behaviorList = behaviors
-    .map((b, i) => `${i + 1}. TestKey: "${b.testKey}"\n   Behavior: ${b.behavior}\n   Context: ${b.context}`)
+    .map(
+      (b, i) =>
+        `${i + 1}. TestKey: "${b.testKey}"\n   Domain: ${b.domain}\n   Primary keyword: ${b.primaryKeyword}\n   Keywords: ${b.keywords.join(', ')}\n   Behavior: ${b.behavior}\n   Context: ${b.context}`,
+    )
     .join('\n\n')
-  return `Domain: ${domain}\n\nExtracted behaviors:\n\n${behaviorList}`
+  return `Primary keyword: ${primaryKeyword}\n\nCandidate behavior pool:\n\n${behaviorList}`
 }
 
 function sleep(ms: number): Promise<void> {
@@ -106,7 +106,7 @@ function slugify(name: string): string {
 
 async function attemptConsolidation(
   prompt: string,
-  domain: string,
+  primaryKeyword: string,
   attempt: number,
   remaining: number,
 ): Promise<readonly { readonly id: string; readonly item: ConsolidationResult['consolidations'][number] }[] | null> {
@@ -121,20 +121,20 @@ async function attemptConsolidation(
   const result = await consolidateSingle(prompt, attempt)
   if (result !== null) {
     return result.consolidations.map((item) => ({
-      id: `${domain}::${slugify(item.featureName)}`,
+      id: `${primaryKeyword}::${slugify(item.featureName)}`,
       item,
     }))
   }
 
-  return attemptConsolidation(prompt, domain, attempt + 1, remaining - 1)
+  return attemptConsolidation(prompt, primaryKeyword, attempt + 1, remaining - 1)
 }
 
 export function consolidateWithRetry(
-  domain: string,
+  primaryKeyword: string,
   behaviors: readonly ConsolidateBehaviorInput[],
   attemptOffset: number,
 ): Promise<readonly { readonly id: string; readonly item: ConsolidationResult['consolidations'][number] }[] | null> {
-  const prompt = buildPrompt(domain, behaviors)
+  const prompt = buildPrompt(primaryKeyword, behaviors)
   const remaining = MAX_RETRIES - attemptOffset
-  return attemptConsolidation(prompt, domain, attemptOffset, remaining)
+  return attemptConsolidation(prompt, primaryKeyword, attemptOffset, remaining)
 }

--- a/scripts/behavior-audit/consolidate.ts
+++ b/scripts/behavior-audit/consolidate.ts
@@ -8,76 +8,102 @@ import type { ConsolidatedManifest } from './incremental.js'
 import { buildPhase2ConsolidationFingerprint } from './incremental.js'
 import type { Progress } from './progress.js'
 import {
-  getFailedDomainAttempts,
-  isDomainCompleted,
-  markDomainDone,
-  markDomainFailed,
+  getFailedBatchAttempts,
+  isBatchCompleted,
+  markBatchDone,
+  markBatchFailed,
   resetPhase3,
   saveProgress,
 } from './progress.js'
 import type { ConsolidatedBehavior, ExtractedBehavior } from './report-writer.js'
 import { writeConsolidatedFile } from './report-writer.js'
 
-interface DomainGroup {
-  readonly domain: string
+interface KeywordBatch {
+  readonly batchKey: string
+  readonly primaryKeyword: string
   readonly inputs: readonly ConsolidateBehaviorInput[]
 }
 
-function groupByDomain(extractedBehaviors: Readonly<Record<string, ExtractedBehavior>>): readonly DomainGroup[] {
-  const map = new Map<string, ConsolidateBehaviorInput[]>()
-  for (const [testKey, behavior] of Object.entries(extractedBehaviors)) {
-    const domain = getDomain(behavior.fullPath)
-    let group = map.get(domain)
-    if (group === undefined) {
-      group = []
-      map.set(domain, group)
-    }
-    group.push({ testKey, behavior: behavior.behavior, context: behavior.context })
-  }
-  return [...map.entries()].map(([domain, inputs]) => ({ domain, inputs }))
+function getPrimaryKeyword(keywords: readonly string[], cardinality: ReadonlyMap<string, number>): string {
+  return [...keywords].toSorted((a, b) => {
+    const countA = cardinality.get(a) ?? Number.MAX_SAFE_INTEGER
+    const countB = cardinality.get(b) ?? Number.MAX_SAFE_INTEGER
+    return countA === countB ? a.localeCompare(b) : countA - countB
+  })[0]!
 }
 
-async function consolidateDomain(
-  group: DomainGroup,
+function groupByPrimaryKeyword(
+  extractedBehaviors: Readonly<Record<string, ExtractedBehavior>>,
+): readonly KeywordBatch[] {
+  const keywordCounts = new Map<string, number>()
+  for (const behavior of Object.values(extractedBehaviors)) {
+    for (const keyword of behavior.keywords) {
+      keywordCounts.set(keyword, (keywordCounts.get(keyword) ?? 0) + 1)
+    }
+  }
+
+  const grouped = new Map<string, ConsolidateBehaviorInput[]>()
+  for (const [testKey, behavior] of Object.entries(extractedBehaviors)) {
+    const primaryKeyword = getPrimaryKeyword(behavior.keywords, keywordCounts)
+    const existing = grouped.get(primaryKeyword) ?? []
+    grouped.set(primaryKeyword, [
+      ...existing,
+      {
+        testKey,
+        behavior: behavior.behavior,
+        context: behavior.context,
+        keywords: behavior.keywords,
+        primaryKeyword,
+        domain: getDomain(behavior.fullPath),
+      },
+    ])
+  }
+
+  return [...grouped.entries()].map(([batchKey, inputs]) => ({ batchKey, primaryKeyword: batchKey, inputs }))
+}
+
+async function consolidateBatch(
+  group: KeywordBatch,
   idx: number,
   total: number,
   progress: Progress,
   consolidatedManifest: ConsolidatedManifest,
   phase2Version: string,
 ): Promise<ConsolidatedManifest> {
-  const { domain, inputs } = group
+  const { batchKey, primaryKeyword, inputs } = group
 
-  if (isDomainCompleted(progress, domain)) {
-    console.log(`[Phase 2] [${idx}/${total}] ${domain} — skipped (already done)`)
+  if (isBatchCompleted(progress, batchKey)) {
+    console.log(`[Phase 2] [${idx}/${total}] ${batchKey} — skipped (already done)`)
     return consolidatedManifest
   }
 
-  const failedAttempts = getFailedDomainAttempts(progress, domain)
+  const failedAttempts = getFailedBatchAttempts(progress, batchKey)
   if (failedAttempts >= MAX_RETRIES) {
-    console.log(`[Phase 2] [${idx}/${total}] ${domain} — skipped (max retries exceeded)`)
+    console.log(`[Phase 2] [${idx}/${total}] ${batchKey} — skipped (max retries exceeded)`)
     return consolidatedManifest
   }
 
-  console.log(`[Phase 2] [${idx}/${total}] ${domain} (${inputs.length} behaviors)...`)
+  console.log(`[Phase 2] [${idx}/${total}] ${batchKey} (${inputs.length} behaviors)...`)
 
-  const result = await consolidateWithRetry(domain, inputs, failedAttempts)
+  const result = await consolidateWithRetry(primaryKeyword, inputs, failedAttempts)
 
   if (result === null) {
-    markDomainFailed(progress, domain, 'consolidation failed after retries', failedAttempts + 1)
+    markBatchFailed(progress, batchKey, 'consolidation failed after retries', failedAttempts + 1)
     await saveProgress(progress)
     return consolidatedManifest
   }
 
-  const behaviors: string[] = inputs.map((i) => i.behavior)
   const fingerprint = buildPhase2ConsolidationFingerprint({
     sourceTestKeys: inputs.map((i) => i.testKey),
-    behaviors,
+    behaviors: inputs.map((i) => i.behavior),
     phaseVersion: phase2Version,
   })
 
+  const sourceDomains = [...new Set(inputs.map((i) => i.domain))].toSorted()
+
   const consolidations: ConsolidatedBehavior[] = result.map(({ id, item }) => ({
     id,
-    domain,
+    domain: primaryKeyword,
     featureName: item.featureName,
     isUserFacing: item.isUserFacing,
     behavior: item.behavior,
@@ -86,8 +112,8 @@ async function consolidateDomain(
     sourceTestKeys: item.sourceTestKeys,
   }))
 
-  await writeConsolidatedFile(domain, consolidations)
-  markDomainDone(progress, domain, consolidations)
+  await writeConsolidatedFile(primaryKeyword, consolidations)
+  markBatchDone(progress, batchKey, consolidations)
 
   const updatedEntries = { ...consolidatedManifest.entries }
   for (const cb of consolidations) {
@@ -97,6 +123,9 @@ async function consolidateDomain(
       featureName: cb.featureName,
       sourceTestKeys: cb.sourceTestKeys,
       isUserFacing: cb.isUserFacing,
+      primaryKeyword,
+      keywords: [...new Set(inputs.flatMap((input) => input.keywords))].toSorted(),
+      sourceDomains,
       phase2Fingerprint: fingerprint,
       lastConsolidatedAt: new Date().toISOString(),
     }
@@ -104,7 +133,7 @@ async function consolidateDomain(
 
   const userFacingCount = consolidations.filter((b) => b.isUserFacing).length
   console.log(
-    `[Phase 2] [${idx}/${total}] ${domain} — done (${consolidations.length} consolidated, ${userFacingCount} user-facing)`,
+    `[Phase 2] [${idx}/${total}] ${batchKey} — done (${consolidations.length} consolidated, ${userFacingCount} user-facing)`,
   )
 
   return { ...consolidatedManifest, entries: updatedEntries }
@@ -115,22 +144,22 @@ export async function runPhase2(
   consolidatedManifest: ConsolidatedManifest,
   phase2Version: string,
 ): Promise<ConsolidatedManifest> {
-  console.log('\n[Phase 2] Grouping extracted behaviors by domain...')
-  const groups = groupByDomain(progress.phase1.extractedBehaviors)
+  console.log('\n[Phase 2] Grouping extracted behaviors by primary keyword...')
+  const groups = groupByPrimaryKeyword(progress.phase1.extractedBehaviors)
   progress.phase2.status = 'in-progress'
-  progress.phase2.stats.domainsTotal = groups.length
+  progress.phase2.stats.batchesTotal = groups.length
 
   resetPhase3(progress)
   await saveProgress(progress)
 
-  console.log(`[Phase 2] Consolidating ${groups.length} domains...\n`)
+  console.log(`[Phase 2] Consolidating ${groups.length} keyword batches...\n`)
 
   const limit = pLimit(1)
   let currentManifest = consolidatedManifest
   await Promise.all(
     groups.map((group, i) =>
       limit(async () => {
-        currentManifest = await consolidateDomain(group, i + 1, groups.length, progress, currentManifest, phase2Version)
+        currentManifest = await consolidateBatch(group, i + 1, groups.length, progress, currentManifest, phase2Version)
       }),
     ),
   )
@@ -138,7 +167,7 @@ export async function runPhase2(
   progress.phase2.status = 'done'
   await saveProgress(progress)
   console.log(
-    `\n[Phase 2 complete] ${progress.phase2.stats.domainsDone} domains consolidated, ${progress.phase2.stats.domainsFailed} failed`,
+    `\n[Phase 2 complete] ${progress.phase2.stats.batchesDone} batches consolidated, ${progress.phase2.stats.batchesFailed} failed`,
   )
   return currentManifest
 }

--- a/scripts/behavior-audit/consolidate.ts
+++ b/scripts/behavior-audit/consolidate.ts
@@ -62,46 +62,11 @@ function groupByPrimaryKeyword(
   return [...grouped.entries()].map(([batchKey, inputs]) => ({ batchKey, primaryKeyword: batchKey, inputs }))
 }
 
-async function consolidateBatch(
-  group: KeywordBatch,
-  idx: number,
-  total: number,
-  progress: Progress,
-  consolidatedManifest: ConsolidatedManifest,
-  phase2Version: string,
-): Promise<ConsolidatedManifest> {
-  const { batchKey, primaryKeyword, inputs } = group
-
-  if (isBatchCompleted(progress, batchKey)) {
-    console.log(`[Phase 2] [${idx}/${total}] ${batchKey} — skipped (already done)`)
-    return consolidatedManifest
-  }
-
-  const failedAttempts = getFailedBatchAttempts(progress, batchKey)
-  if (failedAttempts >= MAX_RETRIES) {
-    console.log(`[Phase 2] [${idx}/${total}] ${batchKey} — skipped (max retries exceeded)`)
-    return consolidatedManifest
-  }
-
-  console.log(`[Phase 2] [${idx}/${total}] ${batchKey} (${inputs.length} behaviors)...`)
-
-  const result = await consolidateWithRetry(primaryKeyword, inputs, failedAttempts)
-
-  if (result === null) {
-    markBatchFailed(progress, batchKey, 'consolidation failed after retries', failedAttempts + 1)
-    await saveProgress(progress)
-    return consolidatedManifest
-  }
-
-  const fingerprint = buildPhase2ConsolidationFingerprint({
-    sourceTestKeys: inputs.map((i) => i.testKey),
-    behaviors: inputs.map((i) => i.behavior),
-    phaseVersion: phase2Version,
-  })
-
-  const sourceDomains = [...new Set(inputs.map((i) => i.domain))].toSorted()
-
-  const consolidations: ConsolidatedBehavior[] = result.map(({ id, item }) => ({
+function buildConsolidations(
+  result: Awaited<ReturnType<typeof consolidateWithRetry>>,
+  primaryKeyword: string,
+): ConsolidatedBehavior[] {
+  return result!.map(({ id, item }) => ({
     id,
     domain: primaryKeyword,
     featureName: item.featureName,
@@ -111,11 +76,17 @@ async function consolidateBatch(
     context: item.context,
     sourceTestKeys: item.sourceTestKeys,
   }))
+}
 
-  await writeConsolidatedFile(primaryKeyword, consolidations)
-  markBatchDone(progress, batchKey, consolidations)
-
-  const updatedEntries = { ...consolidatedManifest.entries }
+function applyConsolidationsToManifest(
+  consolidations: ConsolidatedBehavior[],
+  inputs: readonly ConsolidateBehaviorInput[],
+  primaryKeyword: string,
+  sourceDomains: readonly string[],
+  fingerprint: string,
+  currentEntries: ConsolidatedManifest['entries'],
+): ConsolidatedManifest['entries'] {
+  const updatedEntries = { ...currentEntries }
   for (const cb of consolidations) {
     updatedEntries[cb.id] = {
       consolidatedId: cb.id,
@@ -130,12 +101,55 @@ async function consolidateBatch(
       lastConsolidatedAt: new Date().toISOString(),
     }
   }
+  return updatedEntries
+}
 
+async function consolidateBatch(
+  group: KeywordBatch,
+  idx: number,
+  total: number,
+  progress: Progress,
+  consolidatedManifest: ConsolidatedManifest,
+  phase2Version: string,
+): Promise<ConsolidatedManifest> {
+  const { batchKey, primaryKeyword, inputs } = group
+  if (isBatchCompleted(progress, batchKey)) {
+    console.log(`[Phase 2] [${idx}/${total}] ${batchKey} — skipped (already done)`)
+    return consolidatedManifest
+  }
+  const failedAttempts = getFailedBatchAttempts(progress, batchKey)
+  if (failedAttempts >= MAX_RETRIES) {
+    console.log(`[Phase 2] [${idx}/${total}] ${batchKey} — skipped (max retries exceeded)`)
+    return consolidatedManifest
+  }
+  console.log(`[Phase 2] [${idx}/${total}] ${batchKey} (${inputs.length} behaviors)...`)
+  const result = await consolidateWithRetry(primaryKeyword, inputs, failedAttempts)
+  if (result === null) {
+    markBatchFailed(progress, batchKey, 'consolidation failed after retries', failedAttempts + 1)
+    await saveProgress(progress)
+    return consolidatedManifest
+  }
+  const fingerprint = buildPhase2ConsolidationFingerprint({
+    sourceTestKeys: inputs.map((i) => i.testKey),
+    behaviors: inputs.map((i) => i.behavior),
+    phaseVersion: phase2Version,
+  })
+  const sourceDomains = [...new Set(inputs.map((i) => i.domain))].toSorted()
+  const consolidations = buildConsolidations(result, primaryKeyword)
+  await writeConsolidatedFile(primaryKeyword, consolidations)
+  markBatchDone(progress, batchKey, consolidations)
+  const updatedEntries = applyConsolidationsToManifest(
+    consolidations,
+    inputs,
+    primaryKeyword,
+    sourceDomains,
+    fingerprint,
+    consolidatedManifest.entries,
+  )
   const userFacingCount = consolidations.filter((b) => b.isUserFacing).length
   console.log(
     `[Phase 2] [${idx}/${total}] ${batchKey} — done (${consolidations.length} consolidated, ${userFacingCount} user-facing)`,
   )
-
   return { ...consolidatedManifest, entries: updatedEntries }
 }
 

--- a/scripts/behavior-audit/evaluate.ts
+++ b/scripts/behavior-audit/evaluate.ts
@@ -3,6 +3,7 @@ import pLimit from 'p-limit'
 import { MAX_RETRIES } from './config.js'
 import { evaluateWithRetry } from './evaluate-agent.js'
 import { recordEval, recordStoredEvaluation, writeReports } from './evaluate-reporting.js'
+import type { ConsolidatedManifest } from './incremental.js'
 import { ALL_PERSONAS } from './personas.js'
 import type { Progress } from './progress.js'
 import {
@@ -18,6 +19,13 @@ import { readConsolidatedFile } from './report-writer.js'
 interface Phase3RunInput {
   readonly progress: Progress
   readonly selectedConsolidatedIds: ReadonlySet<string>
+  readonly consolidatedManifest: ConsolidatedManifest | null
+}
+
+function getDomainsFromManifestEntries(
+  entries: Readonly<Record<string, import('./incremental.js').ConsolidatedManifestEntry>>,
+): readonly string[] {
+  return [...new Set(Object.values(entries).map((entry) => entry.domain))].toSorted()
 }
 
 interface ParsedConsolidatedBehavior {
@@ -175,9 +183,13 @@ function processSingleBehavior(
   })
 }
 
-export async function runPhase3({ progress, selectedConsolidatedIds }: Phase3RunInput): Promise<void> {
+export async function runPhase3({
+  progress,
+  selectedConsolidatedIds,
+  consolidatedManifest,
+}: Phase3RunInput): Promise<void> {
   console.log('\n[Phase 3] Reading consolidated behavior files...')
-  const domains = Object.keys(progress.phase2.completedDomains)
+  const domains = consolidatedManifest === null ? [] : getDomainsFromManifestEntries(consolidatedManifest.entries)
   const allBehaviors = await parseConsolidatedFiles(domains)
   progress.phase3.status = 'in-progress'
   progress.phase3.stats.behaviorsTotal = allBehaviors.length

--- a/scripts/behavior-audit/evaluate.ts
+++ b/scripts/behavior-audit/evaluate.ts
@@ -38,9 +38,9 @@ interface ParsedConsolidatedBehavior {
 }
 
 async function parseConsolidatedFiles(domains: readonly string[]): Promise<readonly ParsedConsolidatedBehavior[]> {
+  const results = await Promise.all(domains.map((domain) => readConsolidatedFile(domain)))
   const behaviors: ParsedConsolidatedBehavior[] = []
-  for (const domain of domains) {
-    const consolidated = await readConsolidatedFile(domain)
+  for (const consolidated of results) {
     if (consolidated === null) continue
     for (const item of consolidated) {
       if (!item.isUserFacing || item.userStory === null) continue

--- a/scripts/behavior-audit/extract-agent.ts
+++ b/scripts/behavior-audit/extract-agent.ts
@@ -14,8 +14,7 @@ const ExtractionResultSchema = z.object({
 export type ExtractionResult = z.infer<typeof ExtractionResultSchema>
 
 function getEnvOrFallback(name: string, fallback: string): string {
-  const value = process.env[name]
-  return value === undefined ? fallback : value
+  return process.env[name] ?? fallback
 }
 
 const apiKey = getEnvOrFallback('OPENAI_API_KEY', 'no-key')
@@ -55,14 +54,13 @@ async function extractSingle(prompt: string, attempt: number): Promise<Extractio
   }
 }
 
-export async function extractWithRetry(prompt: string, attemptOffset: number): Promise<ExtractionResult | null> {
-  for (let attempt = attemptOffset; attempt < MAX_RETRIES; attempt++) {
-    if (attempt > attemptOffset) {
-      const backoff = RETRY_BACKOFF_MS[Math.min(attempt - 1, RETRY_BACKOFF_MS.length - 1)]!
-      await sleep(backoff)
-    }
-    const result = await extractSingle(prompt, attempt)
-    if (result !== null) return result
+export async function extractWithRetry(prompt: string, attempt: number): Promise<ExtractionResult | null> {
+  if (attempt > 0) {
+    const backoff = RETRY_BACKOFF_MS[Math.min(attempt - 1, RETRY_BACKOFF_MS.length - 1)]!
+    await sleep(backoff)
   }
-  return null
+  const result = await extractSingle(prompt, attempt)
+  if (result !== null) return result
+  if (attempt >= MAX_RETRIES - 1) return null
+  return extractWithRetry(prompt, attempt + 1)
 }

--- a/scripts/behavior-audit/extract-agent.ts
+++ b/scripts/behavior-audit/extract-agent.ts
@@ -1,0 +1,68 @@
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import { generateText, Output, stepCountIs } from 'ai'
+import { z } from 'zod'
+
+import { BASE_URL, MAX_RETRIES, MAX_STEPS, MODEL, PHASE1_TIMEOUT_MS, RETRY_BACKOFF_MS } from './config.js'
+import { makeAuditTools } from './tools.js'
+
+const ExtractionResultSchema = z.object({
+  behavior: z.string(),
+  context: z.string(),
+  candidateKeywords: z.array(z.string()).min(8).max(16),
+})
+
+export type ExtractionResult = z.infer<typeof ExtractionResultSchema>
+
+function getEnvOrFallback(name: string, fallback: string): string {
+  const value = process.env[name]
+  return value === undefined ? fallback : value
+}
+
+const apiKey = getEnvOrFallback('OPENAI_API_KEY', 'no-key')
+const provider = createOpenAICompatible({ name: 'behavior-audit-extract', apiKey, baseURL: BASE_URL })
+const model = provider(MODEL)
+
+const SYSTEM_PROMPT = `You are a senior software analyst examining a unit test from a Telegram/Discord/Mattermost chat bot called "papai" that manages tasks via LLM tool-calling.
+
+Return structured output with:
+- behavior: plain-language feature description beginning with "When..."
+- context: technical implementation summary for developers
+- candidateKeywords: 8-16 canonical lowercase slug keywords describing the behavior
+
+Keywords must be short canonical slugs like group-targeting or identity-resolution.`
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+async function extractSingle(prompt: string, attempt: number): Promise<ExtractionResult | null> {
+  const timeout = attempt > 0 ? PHASE1_TIMEOUT_MS * 2 : PHASE1_TIMEOUT_MS
+  try {
+    const result = await generateText({
+      model,
+      system: SYSTEM_PROMPT,
+      prompt,
+      tools: makeAuditTools(),
+      output: Output.object({ schema: ExtractionResultSchema }),
+      stopWhen: stepCountIs(MAX_STEPS + 1),
+      abortSignal: AbortSignal.timeout(timeout),
+    })
+    return result.output
+  } catch {
+    return null
+  }
+}
+
+export async function extractWithRetry(prompt: string, attemptOffset: number): Promise<ExtractionResult | null> {
+  for (let attempt = attemptOffset; attempt < MAX_RETRIES; attempt++) {
+    if (attempt > attemptOffset) {
+      const backoff = RETRY_BACKOFF_MS[Math.min(attempt - 1, RETRY_BACKOFF_MS.length - 1)]!
+      await sleep(backoff)
+    }
+    const result = await extractSingle(prompt, attempt)
+    if (result !== null) return result
+  }
+  return null
+}

--- a/scripts/behavior-audit/extract-incremental.ts
+++ b/scripts/behavior-audit/extract-incremental.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import { PROJECT_ROOT } from './config.js'
 import { getDomain } from './domain-map.js'
 import type { IncrementalManifest } from './incremental.js'
-import { buildPhase1Fingerprint, hashText } from './incremental.js'
+import { buildPhase1Fingerprint, buildPhase2Fingerprint, hashText } from './incremental.js'
 import type { ExtractedBehavior } from './report-writer.js'
 import type { ParsedTestFile, TestCase } from './test-parser.js'
 
@@ -30,6 +30,43 @@ async function loadMirroredSourceHash(testFilePath: string): Promise<string | nu
   return hashText(await Bun.file(absoluteMirroredPath).text())
 }
 
+function buildManifestEntry(input: {
+  readonly testKey: string
+  readonly testFile: ParsedTestFile
+  readonly testCase: TestCase
+  readonly dependencyPaths: readonly string[]
+  readonly extractedBehaviorPath: string
+  readonly phase1Fingerprint: string
+  readonly phase2Fingerprint: string
+  readonly lastPhase2CompletedAt: string | null
+}): IncrementalManifest['tests'][string] {
+  return {
+    testFile: input.testFile.filePath,
+    testName: input.testCase.fullPath,
+    dependencyPaths: input.dependencyPaths,
+    phase1Fingerprint: input.phase1Fingerprint,
+    phase2Fingerprint: input.phase2Fingerprint,
+    extractedBehaviorPath: input.extractedBehaviorPath,
+    domain: getDomain(input.testFile.filePath),
+    lastPhase1CompletedAt: new Date().toISOString(),
+    lastPhase2CompletedAt: input.lastPhase2CompletedAt,
+  }
+}
+
+async function loadFileDependencies(testFile: ParsedTestFile): Promise<{
+  readonly testFileHash: string
+  readonly mirroredSourceHash: string | null
+  readonly dependencyPaths: readonly string[]
+  readonly extractedBehaviorPath: string
+}> {
+  const testFileHash = hashText(await Bun.file(join(PROJECT_ROOT, testFile.filePath)).text())
+  const mirroredPath = deriveImplPath(testFile.filePath)
+  const mirroredSourceHash = await loadMirroredSourceHash(testFile.filePath)
+  const dependencyPaths = mirroredSourceHash === null ? [testFile.filePath] : [testFile.filePath, mirroredPath]
+  const extractedBehaviorPath = `reports/behaviors/${getDomain(testFile.filePath)}/${testFile.filePath.split('/').pop()!.replace('.test.ts', '.test.behaviors.md')}`
+  return { testFileHash, mirroredSourceHash, dependencyPaths, extractedBehaviorPath }
+}
+
 export async function updateManifestForExtractedTest(input: {
   readonly manifest: IncrementalManifest
   readonly testFile: ParsedTestFile
@@ -37,40 +74,40 @@ export async function updateManifestForExtractedTest(input: {
   readonly extractedBehavior: ExtractedBehavior
 }): Promise<{ readonly manifest: IncrementalManifest; readonly phase1Changed: boolean }> {
   const testKey = `${input.testFile.filePath}::${input.testCase.fullPath}`
-  const testFileHash = hashText(await Bun.file(join(PROJECT_ROOT, input.testFile.filePath)).text())
-  const mirroredPath = deriveImplPath(input.testFile.filePath)
-  const mirroredSourceHash = await loadMirroredSourceHash(input.testFile.filePath)
-  const dependencyPaths =
-    mirroredSourceHash === null ? [input.testFile.filePath] : [input.testFile.filePath, mirroredPath]
-  const extractedBehaviorPath = `reports/behaviors/${getDomain(input.testFile.filePath)}/${input.testFile.filePath.split('/').pop()!.replace('.test.ts', '.test.behaviors.md')}`
+  const deps = await loadFileDependencies(input.testFile)
   const previousEntry = input.manifest.tests[testKey]
   const phase1Fingerprint = buildPhase1Fingerprint({
     testKey,
-    testFileHash,
+    testFileHash: deps.testFileHash,
     testSource: input.testCase.source,
-    mirroredSourceHash,
+    mirroredSourceHash: deps.mirroredSourceHash,
     phaseVersion: input.manifest.phaseVersions.phase1,
   })
   const phase1Changed = previousEntry === undefined || previousEntry.phase1Fingerprint !== phase1Fingerprint
-  const phase2Fingerprint = phase1Changed ? null : previousEntry.phase2Fingerprint
-  const lastPhase2CompletedAt = phase2Fingerprint === null ? null : previousEntry!.lastPhase2CompletedAt
-
+  const phase2Fingerprint = buildPhase2Fingerprint({
+    testKey,
+    behavior: input.extractedBehavior.behavior,
+    context: input.extractedBehavior.context,
+    keywords: input.extractedBehavior.keywords,
+    phaseVersion: input.manifest.phaseVersions.phase2,
+  })
+  const phase2FingerprintChanged = previousEntry === undefined || previousEntry.phase2Fingerprint !== phase2Fingerprint
+  const lastPhase2CompletedAt = phase2FingerprintChanged ? null : previousEntry.lastPhase2CompletedAt
   return {
     manifest: {
       ...input.manifest,
       tests: {
         ...input.manifest.tests,
-        [testKey]: {
-          testFile: input.testFile.filePath,
-          testName: input.testCase.fullPath,
-          dependencyPaths,
+        [testKey]: buildManifestEntry({
+          testKey,
+          testFile: input.testFile,
+          testCase: input.testCase,
+          dependencyPaths: deps.dependencyPaths,
+          extractedBehaviorPath: deps.extractedBehaviorPath,
           phase1Fingerprint,
           phase2Fingerprint,
-          extractedBehaviorPath,
-          domain: getDomain(input.testFile.filePath),
-          lastPhase1CompletedAt: new Date().toISOString(),
           lastPhase2CompletedAt,
-        },
+        }),
       },
     },
     phase1Changed,

--- a/scripts/behavior-audit/extract.ts
+++ b/scripts/behavior-audit/extract.ts
@@ -1,11 +1,12 @@
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
-import { generateText, stepCountIs } from 'ai'
 import pLimit from 'p-limit'
 
-import { BASE_URL, MAX_RETRIES, MAX_STEPS, MODEL, PHASE1_TIMEOUT_MS, RETRY_BACKOFF_MS } from './config.js'
+import { MAX_RETRIES } from './config.js'
+import { extractWithRetry } from './extract-agent.js'
 import { updateManifestForExtractedTest } from './extract-incremental.js'
 import type { IncrementalManifest } from './incremental.js'
 import { saveManifest } from './incremental.js'
+import { resolveKeywordsWithRetry } from './keyword-resolver-agent.js'
+import { loadKeywordVocabulary, recordKeywordUsage, saveKeywordVocabulary } from './keyword-vocabulary.js'
 import type { Progress } from './progress.js'
 import {
   getFailedTestAttempts,
@@ -18,7 +19,6 @@ import {
 import type { ExtractedBehavior } from './report-writer.js'
 import { writeBehaviorFile } from './report-writer.js'
 import type { ParsedTestFile, TestCase } from './test-parser.js'
-import { makeAuditTools } from './tools.js'
 
 interface Phase1RunInput {
   readonly testFiles: readonly ParsedTestFile[]
@@ -27,151 +27,76 @@ interface Phase1RunInput {
   readonly manifest: IncrementalManifest
 }
 
-function getEnvOrFallback(name: string, fallback: string): string {
-  const value = process.env[name]
-  if (value === undefined) return fallback
-  return value
-}
-
-interface GenerationStep {
-  readonly toolCalls: readonly unknown[] | undefined
-}
-
-function getToolCallsForStep(step: GenerationStep): number {
-  return step.toolCalls === undefined ? 0 : step.toolCalls.length
-}
-
-const apiKey = getEnvOrFallback('OPENAI_API_KEY', 'no-key')
-const provider = createOpenAICompatible({ name: 'behavior-audit', apiKey, baseURL: BASE_URL })
-const model = provider(MODEL)
-
-const SYSTEM_PROMPT = `You are a senior software analyst examining a unit test from a Telegram/Discord/Mattermost chat bot called "papai" that manages tasks via LLM tool-calling. Your job is to understand what real-world behavior this test verifies and describe it in plain language that a non-programmer could understand.
-
-You have tools to read source files, search the codebase, find files, and list directories. Use them to understand the implementation behind the test — follow imports, read the functions being tested, understand the full chain from user input to bot response.
-
-Respond with ONLY a JSON object:
-{
-  "behavior": "Plain-language description of what the bot does in this scenario, written as if explaining to someone who has never seen code. Start with 'When...' to describe the trigger, then describe what happens.",
-  "context": "Technical context about HOW this works internally — what functions are called, what the data flow looks like. This is for developers reviewing the audit."
-}`
-
-interface ExtractionResult {
-  readonly behavior: string
-  readonly context: string
-}
-
-function isValidExtraction(raw: unknown): raw is Record<'behavior' | 'context', string> {
-  return (
-    typeof raw === 'object' &&
-    raw !== null &&
-    'behavior' in raw &&
-    typeof raw.behavior === 'string' &&
-    'context' in raw &&
-    typeof raw.context === 'string'
-  )
-}
-
-function parseJsonResponse(text: string): ExtractionResult | null {
-  try {
-    const jsonMatch = text.match(/\{[\s\S]*\}/)
-    if (jsonMatch === null) return null
-    const raw: unknown = JSON.parse(jsonMatch[0])
-    if (isValidExtraction(raw)) return { behavior: raw.behavior, context: raw.context }
-    return null
-  } catch {
-    return null
-  }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms)
-  })
-}
-
 function deriveImplPath(testPath: string): string {
   return testPath.replace(/^tests\//, 'src/').replace(/\.test\.ts$/, '.ts')
 }
 
-function buildUserMessage(testCase: TestCase, testFilePath: string): string {
+function buildExtractionPrompt(testCase: TestCase, testFilePath: string): string {
   const implPath = deriveImplPath(testFilePath)
   return `**Test file:** ${testFilePath}\n**Test name:** ${testCase.fullPath}\n**Likely implementation file:** ${implPath}\n\n\`\`\`typescript\n${testCase.source}\n\`\`\``
 }
 
-async function extractSingleTest(
-  testCase: TestCase,
-  testFilePath: string,
-  attempt: number,
-): Promise<ExtractionResult | null> {
-  const timeout = attempt > 0 ? PHASE1_TIMEOUT_MS * 2 : PHASE1_TIMEOUT_MS
-  const tools = makeAuditTools()
-  const start = Date.now()
-  try {
-    const result = await generateText({
-      model,
-      system: SYSTEM_PROMPT,
-      prompt: buildUserMessage(testCase, testFilePath),
-      tools,
-      stopWhen: stepCountIs(MAX_STEPS),
-      abortSignal: AbortSignal.timeout(timeout),
-    })
-    const elapsed = ((Date.now() - start) / 1000).toFixed(1)
-    const toolCallCount = result.steps.reduce((sum, step) => sum + getToolCallsForStep(step), 0)
-    const parsed = parseJsonResponse(result.text)
-    if (parsed === null) {
-      console.log(`    ✗ malformed JSON (${elapsed}s)`)
-      return null
-    }
-    console.log(`    ✓ (${elapsed}s, ${toolCallCount} tool calls)`)
-    return parsed
-  } catch (error) {
-    const elapsed = ((Date.now() - start) / 1000).toFixed(1)
-    console.log(`    ✗ ${error instanceof Error ? error.message : String(error)} (${elapsed}s)`)
+function buildResolverPrompt(candidateKeywords: readonly string[], vocabularyText: string): string {
+  return [
+    'Resolve the candidate keywords against the existing vocabulary.',
+    'Reuse existing slugs when semantically appropriate.',
+    'Append new entries only when no vocabulary slug adequately fits.',
+    '',
+    `Candidate keywords: ${candidateKeywords.join(', ')}`,
+    '',
+    'Existing vocabulary:',
+    vocabularyText,
+  ].join('\n')
+}
+
+async function resolveKeywords(
+  candidateKeywords: readonly string[],
+  testKey: string,
+  progress: Progress,
+): Promise<readonly string[] | null> {
+  const existingVocabulary = (await loadKeywordVocabulary()) ?? []
+  const vocabularyText = existingVocabulary.length === 0 ? '(empty)' : JSON.stringify(existingVocabulary, null, 2)
+  const resolved = await resolveKeywordsWithRetry(buildResolverPrompt(candidateKeywords, vocabularyText), 0)
+  if (resolved === null) {
+    markTestFailed(progress, testKey, 'keyword resolution failed')
     return null
   }
+  const nextVocabulary = [...existingVocabulary, ...resolved.appendedEntries]
+  await saveKeywordVocabulary(nextVocabulary)
+  await recordKeywordUsage(resolved.keywords)
+  return resolved.keywords
 }
 
-function retryExtraction(testCase: TestCase, testFilePath: string, attempt: number): Promise<ExtractionResult | null> {
-  return extractSingleTest(testCase, testFilePath, attempt).then((result) => {
-    if (result !== null || attempt >= MAX_RETRIES - 1) return result
-    const backoff = RETRY_BACKOFF_MS[Math.min(attempt, RETRY_BACKOFF_MS.length - 1)]!
-    return sleep(backoff).then(() => retryExtraction(testCase, testFilePath, attempt + 1))
-  })
-}
+type SingleTestResult = {
+  readonly behavior: ExtractedBehavior
+  readonly manifest: IncrementalManifest
+  readonly phase1Changed: boolean
+} | null
 
-async function processSingleTestCase(
+async function extractAndSave(
   testCase: TestCase,
   testFile: ParsedTestFile,
   testFilePath: string,
+  testKey: string,
   displayIndex: number,
   totalTests: number,
   progress: Progress,
   manifest: IncrementalManifest,
-): Promise<{
-  readonly behavior: ExtractedBehavior
-  readonly manifest: IncrementalManifest
-  readonly phase1Changed: boolean
-} | null> {
-  const testKey = `${testFilePath}::${testCase.fullPath}`
-  const existing = progress.phase1.extractedBehaviors[testKey]
-  if (existing !== undefined) {
-    return { behavior: existing, manifest, phase1Changed: false }
-  }
-  if (getFailedTestAttempts(progress, testKey) >= MAX_RETRIES) {
-    console.log(`  [${displayIndex}/${totalTests}] "${testCase.name}" (skipped, max retries reached)`)
-    return null
-  }
+): Promise<SingleTestResult> {
   process.stdout.write(`  [${displayIndex}/${totalTests}] "${testCase.name}" `)
-  const extracted = await retryExtraction(testCase, testFilePath, 0)
+  const extracted = await extractWithRetry(buildExtractionPrompt(testCase, testFilePath), 0)
   if (extracted === null) {
     markTestFailed(progress, testKey, 'extraction failed')
     return null
   }
+  const keywords = await resolveKeywords(extracted.candidateKeywords, testKey, progress)
+  if (keywords === null) return null
   const behavior: ExtractedBehavior = {
     testName: testCase.name,
     fullPath: testCase.fullPath,
     behavior: extracted.behavior,
     context: extracted.context,
+    keywords,
   }
   markTestDone(progress, testFilePath, testKey, behavior)
   const { manifest: updatedManifest, phase1Changed } = await updateManifestForExtractedTest({
@@ -181,7 +106,29 @@ async function processSingleTestCase(
     extractedBehavior: behavior,
   })
   await saveManifest(updatedManifest)
+  console.log(`    ✓`)
   return { behavior, manifest: updatedManifest, phase1Changed }
+}
+
+function processSingleTestCase(
+  testCase: TestCase,
+  testFile: ParsedTestFile,
+  testFilePath: string,
+  displayIndex: number,
+  totalTests: number,
+  progress: Progress,
+  manifest: IncrementalManifest,
+): Promise<SingleTestResult> {
+  const testKey = `${testFilePath}::${testCase.fullPath}`
+  const existing = progress.phase1.extractedBehaviors[testKey]
+  if (existing !== undefined) {
+    return Promise.resolve({ behavior: existing, manifest, phase1Changed: false })
+  }
+  if (getFailedTestAttempts(progress, testKey) >= MAX_RETRIES) {
+    console.log(`  [${displayIndex}/${totalTests}] "${testCase.name}" (skipped, max retries reached)`)
+    return Promise.resolve(null)
+  }
+  return extractAndSave(testCase, testFile, testFilePath, testKey, displayIndex, totalTests, progress, manifest)
 }
 
 async function runSelectedExtractions(input: {
@@ -237,12 +184,13 @@ function collectValidBehaviors(
 ): readonly ExtractedBehavior[] {
   return results
     .filter(
-      (result): result is {
+      (
+        result,
+      ): result is {
         readonly behavior: ExtractedBehavior
         readonly manifest: IncrementalManifest
         readonly phase1Changed: boolean
-      } =>
-        result !== null,
+      } => result !== null,
     )
     .map((result) => result.behavior)
 }

--- a/scripts/behavior-audit/incremental-selection.ts
+++ b/scripts/behavior-audit/incremental-selection.ts
@@ -1,0 +1,92 @@
+import type { ConsolidatedManifest, IncrementalManifest, IncrementalSelection } from './incremental.js'
+
+export interface SelectIncrementalWorkInput {
+  readonly changedFiles: readonly string[]
+  readonly previousManifest: IncrementalManifest
+  readonly currentPhaseVersions: IncrementalManifest['phaseVersions']
+  readonly discoveredTestKeys: readonly string[]
+  readonly previousConsolidatedManifest: ConsolidatedManifest | null
+}
+
+function toSortedUnique(values: readonly string[]): readonly string[] {
+  return [...new Set(values)].toSorted()
+}
+
+function computePhase1And2Keys(
+  input: SelectIncrementalWorkInput,
+  discoveredSet: ReadonlySet<string>,
+  changedFilesSet: ReadonlySet<string>,
+  previousPhaseVersions: IncrementalManifest['phaseVersions'],
+): {
+  readonly phase1Keys: readonly string[]
+  readonly phase2Keys: readonly string[]
+  readonly phase2VersionChanged: boolean
+} {
+  const entries = Object.entries(input.previousManifest.tests).filter(([k]) => discoveredSet.has(k))
+  const depKeys = entries.filter(([, e]) => e.dependencyPaths.some((p) => changedFilesSet.has(p))).map(([k]) => k)
+  const newKeys = input.discoveredTestKeys.filter((k) => input.previousManifest.tests[k] === undefined)
+  const phase1Keys = toSortedUnique([...depKeys, ...newKeys])
+  const phase2VersionChanged = previousPhaseVersions.phase2 !== input.currentPhaseVersions.phase2
+  const phase2VersionKeys = phase2VersionChanged
+    ? entries.filter(([, e]) => e.extractedBehaviorPath !== null).map(([k]) => k)
+    : []
+  return { phase1Keys, phase2Keys: toSortedUnique([...phase1Keys, ...phase2VersionKeys]), phase2VersionChanged }
+}
+
+function computePhase3Ids(
+  phase1Keys: readonly string[],
+  phase2Changed: boolean,
+  manifest: ConsolidatedManifest | null,
+): readonly string[] {
+  const ids: string[] = []
+  if (phase1Keys.length > 0 && manifest !== null) {
+    const phase1Set = new Set(phase1Keys)
+    for (const [id, entry] of Object.entries(manifest.entries)) {
+      if (entry.sourceTestKeys.some((k) => phase1Set.has(k))) ids.push(id)
+    }
+  }
+  if (phase2Changed && manifest !== null) {
+    for (const [id] of Object.entries(manifest.entries)) {
+      if (!ids.includes(id)) ids.push(id)
+    }
+  }
+  return ids
+}
+
+export function selectIncrementalWork(input: SelectIncrementalWorkInput): IncrementalSelection {
+  const discoveredSet = new Set(input.discoveredTestKeys)
+  const changedFilesSet = new Set(input.changedFiles)
+  const previousPhaseVersions = input.previousManifest.phaseVersions
+  const phase1VersionChanged = previousPhaseVersions.phase1 !== input.currentPhaseVersions.phase1
+  if (phase1VersionChanged) {
+    const all = toSortedUnique(input.discoveredTestKeys)
+    return {
+      phase1SelectedTestKeys: all,
+      phase2SelectedTestKeys: all,
+      phase3SelectedConsolidatedIds: [],
+      reportRebuildOnly: false,
+    }
+  }
+  const { phase1Keys, phase2Keys, phase2VersionChanged } = computePhase1And2Keys(
+    input,
+    discoveredSet,
+    changedFilesSet,
+    previousPhaseVersions,
+  )
+  const phase3SelectedConsolidatedIds = computePhase3Ids(
+    phase1Keys,
+    phase2VersionChanged,
+    input.previousConsolidatedManifest,
+  )
+  const reportVersionChanged = previousPhaseVersions.reports !== input.currentPhaseVersions.reports
+  return {
+    phase1SelectedTestKeys: phase1Keys,
+    phase2SelectedTestKeys: phase2Keys,
+    phase3SelectedConsolidatedIds,
+    reportRebuildOnly:
+      reportVersionChanged &&
+      phase1Keys.length === 0 &&
+      phase2Keys.length === 0 &&
+      phase3SelectedConsolidatedIds.length === 0,
+  }
+}

--- a/scripts/behavior-audit/incremental.ts
+++ b/scripts/behavior-audit/incremental.ts
@@ -52,6 +52,9 @@ export interface ConsolidatedManifestEntry {
   readonly featureName: string
   readonly sourceTestKeys: readonly string[]
   readonly isUserFacing: boolean
+  readonly primaryKeyword: string | null
+  readonly keywords: readonly string[]
+  readonly sourceDomains: readonly string[]
   readonly phase2Fingerprint: string | null
   readonly lastConsolidatedAt: string | null
 }
@@ -73,6 +76,7 @@ interface Phase2FingerprintInput {
   readonly testKey: string
   readonly behavior: string
   readonly context: string
+  readonly keywords: readonly string[]
   readonly phaseVersion: string
 }
 
@@ -109,6 +113,9 @@ const ConsolidatedManifestEntrySchema = z.object({
   featureName: z.string(),
   sourceTestKeys: z.array(z.string()),
   isUserFacing: z.boolean(),
+  primaryKeyword: z.string().nullable().default(null),
+  keywords: z.array(z.string()).default([]),
+  sourceDomains: z.array(z.string()).default([]),
   phase2Fingerprint: z.string().nullable(),
   lastConsolidatedAt: z.string().nullable(),
 })

--- a/scripts/behavior-audit/incremental.ts
+++ b/scripts/behavior-audit/incremental.ts
@@ -38,13 +38,8 @@ export interface IncrementalSelection {
   readonly reportRebuildOnly: boolean
 }
 
-interface SelectIncrementalWorkInput {
-  readonly changedFiles: readonly string[]
-  readonly previousManifest: IncrementalManifest
-  readonly currentPhaseVersions: IncrementalManifest['phaseVersions']
-  readonly discoveredTestKeys: readonly string[]
-  readonly previousConsolidatedManifest: ConsolidatedManifest | null
-}
+export type { SelectIncrementalWorkInput } from './incremental-selection.js'
+export { selectIncrementalWork } from './incremental-selection.js'
 
 export interface ConsolidatedManifestEntry {
   readonly consolidatedId: string
@@ -174,79 +169,6 @@ export function buildPhase2Fingerprint(input: Phase2FingerprintInput): string {
   return sha256Json(input)
 }
 
-function toSortedUnique(values: readonly string[]): readonly string[] {
-  return [...new Set(values)].toSorted()
-}
-
-export function selectIncrementalWork(input: SelectIncrementalWorkInput): IncrementalSelection {
-  const discoveredSet = new Set(input.discoveredTestKeys)
-  const changedFilesSet = new Set(input.changedFiles)
-  const previousPhaseVersions = input.previousManifest.phaseVersions
-
-  const phase1VersionChanged = previousPhaseVersions.phase1 !== input.currentPhaseVersions.phase1
-  if (phase1VersionChanged) {
-    const allDiscoveredTestKeys = toSortedUnique(input.discoveredTestKeys)
-    return {
-      phase1SelectedTestKeys: allDiscoveredTestKeys,
-      phase2SelectedTestKeys: allDiscoveredTestKeys,
-      phase3SelectedConsolidatedIds: [],
-      reportRebuildOnly: false,
-    }
-  }
-
-  const discoveredManifestEntries = Object.entries(input.previousManifest.tests).filter(([testKey]) =>
-    discoveredSet.has(testKey),
-  )
-
-  const dependencySelectedTestKeys = discoveredManifestEntries
-    .filter(([, entry]) => entry.dependencyPaths.some((dependencyPath) => changedFilesSet.has(dependencyPath)))
-    .map(([testKey]) => testKey)
-
-  const newTestKeys = input.discoveredTestKeys.filter((testKey) => input.previousManifest.tests[testKey] === undefined)
-
-  const phase1SelectedTestKeys = toSortedUnique([...dependencySelectedTestKeys, ...newTestKeys])
-
-  const phase2VersionChanged = previousPhaseVersions.phase2 !== input.currentPhaseVersions.phase2
-  const phase2VersionSelectedTestKeys = phase2VersionChanged
-    ? discoveredManifestEntries.filter(([, entry]) => entry.extractedBehaviorPath !== null).map(([testKey]) => testKey)
-    : []
-
-  const phase2SelectedTestKeys = toSortedUnique([...phase1SelectedTestKeys, ...phase2VersionSelectedTestKeys])
-
-  const reportVersionChanged = previousPhaseVersions.reports !== input.currentPhaseVersions.reports
-
-  const consolidatedManifest = input.previousConsolidatedManifest
-  const phase3SelectedConsolidatedIds: string[] = []
-
-  if (phase1SelectedTestKeys.length > 0 && consolidatedManifest !== null) {
-    const phase1Set = new Set(phase1SelectedTestKeys)
-    for (const [id, entry] of Object.entries(consolidatedManifest.entries)) {
-      if (entry.sourceTestKeys.some((tk) => phase1Set.has(tk))) {
-        phase3SelectedConsolidatedIds.push(id)
-      }
-    }
-  }
-
-  if (phase2VersionChanged && consolidatedManifest !== null) {
-    for (const [id] of Object.entries(consolidatedManifest.entries)) {
-      if (!phase3SelectedConsolidatedIds.includes(id)) {
-        phase3SelectedConsolidatedIds.push(id)
-      }
-    }
-  }
-
-  return {
-    phase1SelectedTestKeys,
-    phase2SelectedTestKeys,
-    phase3SelectedConsolidatedIds,
-    reportRebuildOnly:
-      reportVersionChanged &&
-      phase1SelectedTestKeys.length === 0 &&
-      phase2SelectedTestKeys.length === 0 &&
-      phase3SelectedConsolidatedIds.length === 0,
-  }
-}
-
 function splitGitPathOutput(output: Uint8Array): readonly string[] {
   const decodedOutput = new TextDecoder().decode(output)
   return decodedOutput.split('\u0000').filter((line) => line.length > 0)
@@ -293,12 +215,8 @@ export async function collectChangedFiles(previousLastStartCommit: string | null
 
 export async function loadManifest(): Promise<IncrementalManifest | null> {
   const manifestFile = Bun.file(INCREMENTAL_MANIFEST_PATH)
-  if (!(await manifestFile.exists())) {
-    return null
-  }
-
-  const text = await manifestFile.text()
-  return IncrementalManifestSchema.parse(JSON.parse(text))
+  if (!(await manifestFile.exists())) return null
+  return IncrementalManifestSchema.parse(JSON.parse(await manifestFile.text()))
 }
 
 export async function saveManifest(manifest: IncrementalManifest): Promise<void> {

--- a/scripts/behavior-audit/keyword-resolver-agent.ts
+++ b/scripts/behavior-audit/keyword-resolver-agent.ts
@@ -1,0 +1,63 @@
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import { generateText, Output, stepCountIs } from 'ai'
+import { z } from 'zod'
+
+import { BASE_URL, MAX_RETRIES, MAX_STEPS, MODEL, PHASE1_TIMEOUT_MS, RETRY_BACKOFF_MS } from './config.js'
+
+const VocabularyEntrySchema = z.object({
+  slug: z.string(),
+  description: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  timesUsed: z.number(),
+})
+
+const ResolverResultSchema = z.object({
+  keywords: z.array(z.string()).min(1),
+  appendedEntries: z.array(VocabularyEntrySchema),
+})
+
+export type ResolverResult = z.infer<typeof ResolverResultSchema>
+
+function getEnvOrFallback(name: string, fallback: string): string {
+  const value = process.env[name]
+  return value === undefined ? fallback : value
+}
+
+const apiKey = getEnvOrFallback('OPENAI_API_KEY', 'no-key')
+const provider = createOpenAICompatible({ name: 'behavior-audit-keyword-resolver', apiKey, baseURL: BASE_URL })
+const model = provider(MODEL)
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+async function resolveSingle(prompt: string, attempt: number): Promise<ResolverResult | null> {
+  const timeout = attempt > 0 ? PHASE1_TIMEOUT_MS * 2 : PHASE1_TIMEOUT_MS
+  try {
+    const result = await generateText({
+      model,
+      prompt,
+      output: Output.object({ schema: ResolverResultSchema }),
+      stopWhen: stepCountIs(MAX_STEPS + 1),
+      abortSignal: AbortSignal.timeout(timeout),
+    })
+    return result.output
+  } catch {
+    return null
+  }
+}
+
+export async function resolveKeywordsWithRetry(prompt: string, attemptOffset: number): Promise<ResolverResult | null> {
+  for (let attempt = attemptOffset; attempt < MAX_RETRIES; attempt++) {
+    if (attempt > attemptOffset) {
+      const backoff = RETRY_BACKOFF_MS[Math.min(attempt - 1, RETRY_BACKOFF_MS.length - 1)]!
+      await sleep(backoff)
+    }
+    const result = await resolveSingle(prompt, attempt)
+    if (result !== null) return result
+  }
+  return null
+}

--- a/scripts/behavior-audit/keyword-resolver-agent.ts
+++ b/scripts/behavior-audit/keyword-resolver-agent.ts
@@ -20,8 +20,7 @@ const ResolverResultSchema = z.object({
 export type ResolverResult = z.infer<typeof ResolverResultSchema>
 
 function getEnvOrFallback(name: string, fallback: string): string {
-  const value = process.env[name]
-  return value === undefined ? fallback : value
+  return process.env[name] ?? fallback
 }
 
 const apiKey = getEnvOrFallback('OPENAI_API_KEY', 'no-key')
@@ -50,14 +49,13 @@ async function resolveSingle(prompt: string, attempt: number): Promise<ResolverR
   }
 }
 
-export async function resolveKeywordsWithRetry(prompt: string, attemptOffset: number): Promise<ResolverResult | null> {
-  for (let attempt = attemptOffset; attempt < MAX_RETRIES; attempt++) {
-    if (attempt > attemptOffset) {
-      const backoff = RETRY_BACKOFF_MS[Math.min(attempt - 1, RETRY_BACKOFF_MS.length - 1)]!
-      await sleep(backoff)
-    }
-    const result = await resolveSingle(prompt, attempt)
-    if (result !== null) return result
+export async function resolveKeywordsWithRetry(prompt: string, attempt: number): Promise<ResolverResult | null> {
+  if (attempt > 0) {
+    const backoff = RETRY_BACKOFF_MS[Math.min(attempt - 1, RETRY_BACKOFF_MS.length - 1)]!
+    await sleep(backoff)
   }
-  return null
+  const result = await resolveSingle(prompt, attempt)
+  if (result !== null) return result
+  if (attempt >= MAX_RETRIES - 1) return null
+  return resolveKeywordsWithRetry(prompt, attempt + 1)
 }

--- a/scripts/behavior-audit/keyword-vocabulary.ts
+++ b/scripts/behavior-audit/keyword-vocabulary.ts
@@ -1,0 +1,51 @@
+import { mkdir, rename } from 'node:fs/promises'
+import { basename, dirname, join } from 'node:path'
+
+import { z } from 'zod'
+
+import { KEYWORD_VOCABULARY_PATH } from './config.js'
+
+const KeywordVocabularyEntrySchema = z.object({
+  slug: z.string(),
+  description: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  timesUsed: z.number(),
+})
+
+const KeywordVocabularySchema = z.array(KeywordVocabularyEntrySchema)
+
+export type KeywordVocabularyEntry = z.infer<typeof KeywordVocabularyEntrySchema>
+
+export async function loadKeywordVocabulary(): Promise<readonly KeywordVocabularyEntry[] | null> {
+  const file = Bun.file(KEYWORD_VOCABULARY_PATH)
+  if (!(await file.exists())) return null
+  const text = await file.text()
+  return KeywordVocabularySchema.parse(JSON.parse(text))
+}
+
+export async function saveKeywordVocabulary(entries: readonly KeywordVocabularyEntry[]): Promise<void> {
+  const parsed = KeywordVocabularySchema.parse(entries)
+  const dir = dirname(KEYWORD_VOCABULARY_PATH)
+  const tempPath = join(dir, `.${basename(KEYWORD_VOCABULARY_PATH)}.${process.pid}.${crypto.randomUUID()}.tmp`)
+  await mkdir(dir, { recursive: true })
+  await Bun.write(tempPath, JSON.stringify(parsed, null, 2) + '\n')
+  await rename(tempPath, KEYWORD_VOCABULARY_PATH)
+}
+
+export async function recordKeywordUsage(keywords: readonly string[]): Promise<void> {
+  const existing = (await loadKeywordVocabulary()) ?? []
+  const keywordSet = new Set(keywords)
+  const now = new Date().toISOString()
+  const updated = existing.map((entry) =>
+    keywordSet.has(entry.slug) ? { ...entry, timesUsed: entry.timesUsed + 1, updatedAt: now } : entry,
+  )
+  await saveKeywordVocabulary(updated)
+}
+
+export function findExactKeyword(
+  entries: readonly KeywordVocabularyEntry[],
+  slug: string,
+): KeywordVocabularyEntry | null {
+  return entries.find((entry) => entry.slug === slug) ?? null
+}

--- a/scripts/behavior-audit/progress-migrate.ts
+++ b/scripts/behavior-audit/progress-migrate.ts
@@ -7,6 +7,7 @@ const ExtractedBehaviorSchema = z.object({
   fullPath: z.string(),
   behavior: z.string(),
   context: z.string(),
+  keywords: z.array(z.string()).readonly(),
 })
 
 const PersonaScoreSchema = z.object({
@@ -62,13 +63,13 @@ const Phase1ProgressSchema = z.object({
 
 const Phase2ProgressSchema = z.object({
   status: z.enum(['not-started', 'in-progress', 'done']),
-  completedDomains: z.record(z.string(), z.literal('done')),
+  completedBatches: z.record(z.string(), z.literal('done')),
   consolidations: z.record(z.string(), ConsolidatedBehaviorArraySchema),
-  failedDomains: z.record(z.string(), FailedEntrySchema),
+  failedBatches: z.record(z.string(), FailedEntrySchema),
   stats: z.object({
-    domainsTotal: z.number(),
-    domainsDone: z.number(),
-    domainsFailed: z.number(),
+    batchesTotal: z.number(),
+    batchesDone: z.number(),
+    batchesFailed: z.number(),
     behaviorsConsolidated: z.number(),
   }),
 })
@@ -93,20 +94,6 @@ const ProgressV2Schema = z.object({
   phase3: Phase3ProgressSchema,
 })
 
-const LegacyPhase2AsPhase3Schema = z.object({
-  status: z.enum(['not-started', 'in-progress', 'done']).default('not-started'),
-  completedBehaviors: z.record(z.string(), z.literal('done')).default({}),
-  evaluations: z.record(z.string(), EvaluatedBehaviorSchema).default({}),
-  failedBehaviors: z.record(z.string(), FailedEntrySchema).default({}),
-  stats: z
-    .object({
-      behaviorsTotal: z.number(),
-      behaviorsDone: z.number(),
-      behaviorsFailed: z.number(),
-    })
-    .default({ behaviorsTotal: 0, behaviorsDone: 0, behaviorsFailed: 0 }),
-})
-
 function emptyPhase3(): Phase3Progress {
   return Phase3ProgressSchema.parse({
     status: 'not-started',
@@ -117,22 +104,13 @@ function emptyPhase3(): Phase3Progress {
   })
 }
 
-function migratePhase3FromLegacy(obj: Record<string, unknown>): Phase3Progress {
-  const legacyPhase2 = obj['phase2']
-  if (typeof legacyPhase2 === 'object' && legacyPhase2 !== null && 'evaluations' in legacyPhase2) {
-    const parsed = LegacyPhase2AsPhase3Schema.safeParse(legacyPhase2)
-    if (parsed.success) return Phase3ProgressSchema.parse(parsed.data)
-  }
-  return emptyPhase3()
-}
-
 function emptyPhase2(): Phase2Progress {
   return Phase2ProgressSchema.parse({
     status: 'not-started',
-    completedDomains: {},
+    completedBatches: {},
     consolidations: {},
-    failedDomains: {},
-    stats: { domainsTotal: 0, domainsDone: 0, domainsFailed: 0, behaviorsConsolidated: 0 },
+    failedBatches: {},
+    stats: { batchesTotal: 0, batchesDone: 0, batchesFailed: 0, behaviorsConsolidated: 0 },
   })
 }
 
@@ -145,10 +123,6 @@ function emptyPhase1(): Progress['phase1'] {
     completedFiles: [],
     stats: { filesTotal: 0, filesDone: 0, testsExtracted: 0, testsFailed: 0 },
   })
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
 }
 
 const LegacyPhase1Schema = z.looseObject({
@@ -173,25 +147,13 @@ const V1ProgressSchema = z.looseObject({
 
 function migrateV1toV2(raw: unknown): Progress {
   const parsed = V1ProgressSchema.safeParse(raw)
-  if (!parsed.success) {
-    return ProgressV2Schema.parse({
-      version: 2,
-      startedAt: new Date().toISOString(),
-      phase1: emptyPhase1(),
-      phase2: emptyPhase2(),
-      phase3: emptyPhase3(),
-    })
-  }
-  const { startedAt, phase1 } = parsed.data
-  const extractedBehaviors = isRecord(phase1.extractedBehaviors) ? phase1.extractedBehaviors : {}
-  const migratedPhase1 = Phase1ProgressSchema.parse({ ...phase1, extractedBehaviors })
-  const migratedPhase3 = isRecord(raw) ? migratePhase3FromLegacy(raw) : emptyPhase3()
+  const startedAt = parsed.success ? parsed.data.startedAt : new Date().toISOString()
   return ProgressV2Schema.parse({
     version: 2,
     startedAt,
-    phase1: migratedPhase1,
+    phase1: emptyPhase1(),
     phase2: emptyPhase2(),
-    phase3: migratedPhase3,
+    phase3: emptyPhase3(),
   })
 }
 

--- a/scripts/behavior-audit/progress.ts
+++ b/scripts/behavior-audit/progress.ts
@@ -26,10 +26,10 @@ interface Phase1Progress {
 
 export interface Phase2Progress {
   status: PhaseStatus
-  completedDomains: Record<string, 'done'>
+  completedBatches: Record<string, 'done'>
   consolidations: Record<string, readonly ConsolidatedBehavior[]>
-  failedDomains: Record<string, FailedEntry>
-  stats: { domainsTotal: number; domainsDone: number; domainsFailed: number; behaviorsConsolidated: number }
+  failedBatches: Record<string, FailedEntry>
+  stats: { batchesTotal: number; batchesDone: number; batchesFailed: number; behaviorsConsolidated: number }
 }
 
 export interface Phase3Progress {
@@ -51,10 +51,10 @@ export interface Progress {
 function emptyPhase2(): Phase2Progress {
   return {
     status: 'not-started',
-    completedDomains: {},
+    completedBatches: {},
     consolidations: {},
-    failedDomains: {},
-    stats: { domainsTotal: 0, domainsDone: 0, domainsFailed: 0, behaviorsConsolidated: 0 },
+    failedBatches: {},
+    stats: { batchesTotal: 0, batchesDone: 0, batchesFailed: 0, behaviorsConsolidated: 0 },
   }
 }
 
@@ -140,29 +140,29 @@ export function getFailedTestAttempts(progress: Progress, testKey: string): numb
   return progress.phase1.failedTests[testKey]?.attempts ?? 0
 }
 
-export function isDomainCompleted(progress: Progress, domain: string): boolean {
-  return progress.phase2.completedDomains[domain] === 'done'
+export function isBatchCompleted(progress: Progress, batchKey: string): boolean {
+  return progress.phase2.completedBatches[batchKey] === 'done'
 }
 
-export function markDomainDone(
+export function markBatchDone(
   progress: Progress,
-  domain: string,
+  batchKey: string,
   consolidations: readonly ConsolidatedBehavior[],
 ): void {
-  if (progress.phase2.completedDomains[domain] === 'done') return
-  progress.phase2.completedDomains[domain] = 'done'
-  progress.phase2.consolidations[domain] = consolidations
-  progress.phase2.stats.domainsDone++
+  if (progress.phase2.completedBatches[batchKey] === 'done') return
+  progress.phase2.completedBatches[batchKey] = 'done'
+  progress.phase2.consolidations[batchKey] = consolidations
+  progress.phase2.stats.batchesDone++
   progress.phase2.stats.behaviorsConsolidated += consolidations.length
 }
 
-export function markDomainFailed(progress: Progress, domain: string, error: string, attempts: number): void {
-  progress.phase2.failedDomains[domain] = { error, attempts, lastAttempt: new Date().toISOString() }
-  progress.phase2.stats.domainsFailed++
+export function markBatchFailed(progress: Progress, batchKey: string, error: string, attempts: number): void {
+  progress.phase2.failedBatches[batchKey] = { error, attempts, lastAttempt: new Date().toISOString() }
+  progress.phase2.stats.batchesFailed++
 }
 
-export function getFailedDomainAttempts(progress: Progress, domain: string): number {
-  return progress.phase2.failedDomains[domain]?.attempts ?? 0
+export function getFailedBatchAttempts(progress: Progress, batchKey: string): number {
+  return progress.phase2.failedBatches[batchKey]?.attempts ?? 0
 }
 
 export function isBehaviorCompleted(progress: Progress, key: string): boolean {

--- a/scripts/behavior-audit/report-index-helpers.ts
+++ b/scripts/behavior-audit/report-index-helpers.ts
@@ -1,0 +1,54 @@
+export interface DomainSummary {
+  readonly domain: string
+  readonly count: number
+  readonly avgDiscover: number
+  readonly avgUse: number
+  readonly avgRetain: number
+  readonly worstPersona: string
+}
+
+export interface FailedItem {
+  readonly testFile: string
+  readonly testName: string
+  readonly error: string
+  readonly attempts: number
+}
+
+export function buildSummaryHeader(
+  summaries: readonly DomainSummary[],
+  totalProcessed: number,
+  totalFailed: number,
+): readonly string[] {
+  const lines: string[] = [
+    '# Behavior Audit Summary\n',
+    `**Generated:** ${new Date().toISOString()}`,
+    `**Tests processed:** ${totalProcessed}`,
+    `**Behaviors failed:** ${totalFailed}\n`,
+    '| Domain | Behaviors | Avg Discover | Avg Use | Avg Retain | Worst Persona |',
+    '|--------|-----------|-------------|---------|------------|---------------|',
+  ]
+  for (const s of summaries) {
+    lines.push(
+      `| ${s.domain} | ${s.count} | ${s.avgDiscover.toFixed(1)} | ${s.avgUse.toFixed(1)} | ${s.avgRetain.toFixed(1)} | ${s.worstPersona} |`,
+    )
+  }
+  lines.push('')
+  return lines
+}
+
+export function buildTopItemsSection(title: string, items: ReadonlyMap<string, number>): readonly string[] {
+  const sorted = [...items.entries()].toSorted((a, b) => b[1] - a[1]).slice(0, 10)
+  if (sorted.length === 0) return []
+  return [`## ${title}\n`, ...sorted.map(([item, count], i) => `${i + 1}. "${item}" (${count})`), '']
+}
+
+export function buildFailedSection(failedItems: readonly FailedItem[]): readonly string[] {
+  if (failedItems.length === 0) return []
+  return [
+    '## Failed Extractions\n',
+    '| Test File | Test Name | Error | Attempts |',
+    '|-----------|-----------|-------|----------|',
+    ...failedItems.map((f) => `| ${f.testFile} | ${f.testName} | ${f.error} | ${f.attempts} |`),
+    '',
+  ]
+}

--- a/scripts/behavior-audit/report-writer.ts
+++ b/scripts/behavior-audit/report-writer.ts
@@ -12,6 +12,7 @@ export interface ExtractedBehavior {
   readonly fullPath: string
   readonly behavior: string
   readonly context: string
+  readonly keywords: readonly string[]
 }
 
 export interface EvaluatedBehavior {
@@ -82,7 +83,8 @@ export async function writeBehaviorFile(testFilePath: string, behaviors: readonl
   for (const b of behaviors) {
     lines.push(`## Test: "${b.fullPath}"\n`)
     lines.push(`**Behavior:** ${b.behavior}`)
-    lines.push(`**Context:** ${b.context}\n`)
+    lines.push(`**Context:** ${b.context}`)
+    lines.push(`**Keywords:** ${b.keywords.join(', ')}\n`)
   }
 
   await Bun.write(outPath, lines.join('\n'))

--- a/scripts/behavior-audit/report-writer.ts
+++ b/scripts/behavior-audit/report-writer.ts
@@ -6,6 +6,14 @@ import { z } from 'zod'
 import { BEHAVIORS_DIR, CONSOLIDATED_DIR, STORIES_DIR } from './config.js'
 import { getDomain } from './domain-map.js'
 import type { IncrementalManifest } from './incremental.js'
+import {
+  buildFailedSection,
+  buildSummaryHeader,
+  buildTopItemsSection,
+  type DomainSummary,
+  type FailedItem,
+} from './report-index-helpers.js'
+export type { DomainSummary, FailedItem } from './report-index-helpers.js'
 
 export interface ExtractedBehavior {
   readonly testName: string
@@ -49,22 +57,6 @@ const ConsolidatedBehaviorSchema = z.object({
 })
 
 const ConsolidatedBehaviorArraySchema = z.array(ConsolidatedBehaviorSchema).readonly()
-
-interface DomainSummary {
-  readonly domain: string
-  readonly count: number
-  readonly avgDiscover: number
-  readonly avgUse: number
-  readonly avgRetain: number
-  readonly worstPersona: string
-}
-
-interface FailedItem {
-  readonly testFile: string
-  readonly testName: string
-  readonly error: string
-  readonly attempts: number
-}
 
 interface RebuildReportsInput {
   readonly manifest: IncrementalManifest
@@ -153,17 +145,7 @@ export async function writeStoryFile(domain: string, evaluations: readonly Evalu
   await Bun.write(outPath, lines.join('\n'))
 }
 
-function buildSummary(
-  domain: string,
-  evals: readonly EvaluatedBehavior[],
-): {
-  readonly domain: string
-  readonly count: number
-  readonly avgDiscover: number
-  readonly avgUse: number
-  readonly avgRetain: number
-  readonly worstPersona: string
-} {
+function buildSummary(domain: string, evals: readonly EvaluatedBehavior[]): DomainSummary {
   const avg = (fn: (e: EvaluatedBehavior) => number): number => evals.reduce((s, e) => s + fn(e), 0) / evals.length
   const pAvg = (p: 'maria' | 'dani' | 'viktor'): number => avg((e) => (e[p].discover + e[p].use + e[p].retain) / 3)
   const personaScores: ReadonlyArray<readonly [string, number]> = [
@@ -182,96 +164,34 @@ function buildSummary(
   }
 }
 
-function buildSummaryHeader(
-  summaries: readonly DomainSummary[],
-  totalProcessed: number,
-  totalFailed: number,
-): readonly string[] {
-  const lines: string[] = [
-    '# Behavior Audit Summary\n',
-    `**Generated:** ${new Date().toISOString()}`,
-    `**Tests processed:** ${totalProcessed}`,
-    `**Behaviors failed:** ${totalFailed}\n`,
-    '| Domain | Behaviors | Avg Discover | Avg Use | Avg Retain | Worst Persona |',
-    '|--------|-----------|-------------|---------|------------|---------------|',
-  ]
-  for (const s of summaries) {
-    lines.push(
-      `| ${s.domain} | ${s.count} | ${s.avgDiscover.toFixed(1)} | ${s.avgUse.toFixed(1)} | ${s.avgRetain.toFixed(1)} | ${s.worstPersona} |`,
-    )
-  }
-  lines.push('')
-  return lines
-}
-
-function buildTopItemsSection(title: string, items: ReadonlyMap<string, number>): readonly string[] {
-  const sorted = [...items.entries()].toSorted((a, b) => b[1] - a[1]).slice(0, 10)
-  if (sorted.length === 0) return []
-  return [`## ${title}\n`, ...sorted.map(([item, count], i) => `${i + 1}. "${item}" (${count})`), '']
-}
-
-function buildFailedSection(failedItems: readonly FailedItem[]): readonly string[] {
-  if (failedItems.length === 0) return []
-  return [
-    '## Failed Extractions\n',
-    '| Test File | Test Name | Error | Attempts |',
-    '|-----------|-----------|-------|----------|',
-    ...failedItems.map((f) => `| ${f.testFile} | ${f.testName} | ${f.error} | ${f.attempts} |`),
-    '',
-  ]
+function countFrequency(items: readonly string[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const item of items) counts.set(item, (counts.get(item) ?? 0) + 1)
+  return counts
 }
 
 function groupExtractedBehaviorsByFile(
   manifest: IncrementalManifest,
   extractedBehaviorsByKey: Readonly<Record<string, ExtractedBehavior>>,
 ): Readonly<Record<string, readonly ExtractedBehavior[]>> {
-  const extractedByFile: Record<string, ExtractedBehavior[]> = {}
+  const result: Record<string, ExtractedBehavior[]> = {}
   for (const [testKey, entry] of Object.entries(manifest.tests)) {
-    const extractedBehavior = extractedBehaviorsByKey[testKey]
-    if (extractedBehavior === undefined) {
-      continue
-    }
-    const existing = extractedByFile[entry.testFile]
-    if (existing === undefined) {
-      extractedByFile[entry.testFile] = [extractedBehavior]
-      continue
-    }
-    existing.push(extractedBehavior)
+    const behavior = extractedBehaviorsByKey[testKey]
+    if (behavior !== undefined) (result[entry.testFile] ??= []).push(behavior)
   }
-  return extractedByFile
+  return result
 }
 
 function groupEvaluationsByDomain(
   manifest: IncrementalManifest,
   evaluationsByKey: Readonly<Record<string, EvaluatedBehavior>>,
 ): Readonly<Record<string, readonly EvaluatedBehavior[]>> {
-  const evaluationsByDomain: Record<string, EvaluatedBehavior[]> = {}
+  const result: Record<string, EvaluatedBehavior[]> = {}
   for (const [testKey, entry] of Object.entries(manifest.tests)) {
     const evaluation = evaluationsByKey[testKey]
-    if (evaluation === undefined) {
-      continue
-    }
-    const existing = evaluationsByDomain[entry.domain]
-    if (existing === undefined) {
-      evaluationsByDomain[entry.domain] = [evaluation]
-      continue
-    }
-    existing.push(evaluation)
+    if (evaluation !== undefined) (result[entry.domain] ??= []).push(evaluation)
   }
-  return evaluationsByDomain
-}
-
-function countFrequency(items: readonly string[]): Map<string, number> {
-  const counts = new Map<string, number>()
-  for (const item of items) {
-    const existing = counts.get(item)
-    if (existing === undefined) {
-      counts.set(item, 1)
-      continue
-    }
-    counts.set(item, existing + 1)
-  }
-  return counts
+  return result
 }
 
 async function writeRebuiltBehaviorFiles(
@@ -331,22 +251,14 @@ export async function rebuildReportsFromStoredResults({
   await writeRebuiltBehaviorFiles(extractedByFile)
 
   const evaluationsByDomain: Record<string, EvaluatedBehavior[]> = {}
-
-  if (consolidatedManifest !== null) {
-    for (const [consolidatedId, entry] of Object.entries(consolidatedManifest.entries)) {
-      const evaluation = evaluationsByKey[consolidatedId]
-      if (evaluation === undefined) continue
-      const existing = evaluationsByDomain[entry.domain]
-      if (existing === undefined) {
-        evaluationsByDomain[entry.domain] = [evaluation]
-      } else {
-        existing.push(evaluation)
-      }
+  if (consolidatedManifest === null) {
+    for (const [domain, evals] of Object.entries(groupEvaluationsByDomain(manifest, evaluationsByKey))) {
+      evaluationsByDomain[domain] = [...evals]
     }
   } else {
-    const legacyGrouped = groupEvaluationsByDomain(manifest, evaluationsByKey)
-    for (const [domain, evals] of Object.entries(legacyGrouped)) {
-      evaluationsByDomain[domain] = [...evals]
+    for (const [consolidatedId, entry] of Object.entries(consolidatedManifest.entries)) {
+      const evaluation = evaluationsByKey[consolidatedId]
+      if (evaluation !== undefined) (evaluationsByDomain[entry.domain] ??= []).push(evaluation)
     }
   }
 

--- a/tests/scripts/behavior-audit-incremental.test.ts
+++ b/tests/scripts/behavior-audit-incremental.test.ts
@@ -191,7 +191,7 @@ describe('behavior-audit incremental manifest', () => {
       runPhase3: async (): Promise<void> => {},
     }))
     void mock.module('../../scripts/behavior-audit/consolidate.js', () => ({
-      runPhase2: async (): Promise<IncrementalModule.ConsolidatedManifest> => ({ version: 1, entries: {} }),
+      runPhase2: (): Promise<IncrementalModule.ConsolidatedManifest> => Promise.resolve({ version: 1, entries: {} }),
     }))
   })
 

--- a/tests/scripts/behavior-audit-incremental.test.ts
+++ b/tests/scripts/behavior-audit-incremental.test.ts
@@ -389,12 +389,14 @@ describe('behavior-audit incremental manifest', () => {
       testKey: 'tests/tools/a.test.ts::suite > case',
       behavior: 'When the user creates a task, the bot saves it.',
       context: 'Calls createTask and persists provider output.',
+      keywords: ['task-create'],
       phaseVersion: 'v1',
     })
     const b = incremental.buildPhase2Fingerprint({
       testKey: 'tests/tools/a.test.ts::suite > case',
       behavior: 'When the user creates a task, the bot saves it.',
       context: 'Calls createTask, enriches metadata, and persists provider output.',
+      keywords: ['task-create'],
       phaseVersion: 'v1',
     })
 
@@ -641,5 +643,26 @@ describe('behavior-audit incremental manifest', () => {
 
     consoleErrorSpy.mockRestore()
     processExitSpy.mockRestore()
+  })
+
+  test('buildPhase2Fingerprint changes when canonical keywords change', async () => {
+    const incremental = await loadIncrementalModule()
+
+    const a = incremental.buildPhase2Fingerprint({
+      testKey: 'tests/tools/a.test.ts::suite > case',
+      behavior: 'When the user creates a task, the bot saves it.',
+      context: 'Calls createTask and persists provider output.',
+      keywords: ['task-create', 'task-save'],
+      phaseVersion: 'v1',
+    })
+    const b = incremental.buildPhase2Fingerprint({
+      testKey: 'tests/tools/a.test.ts::suite > case',
+      behavior: 'When the user creates a task, the bot saves it.',
+      context: 'Calls createTask and persists provider output.',
+      keywords: ['task-create', 'task-persist'],
+      phaseVersion: 'v1',
+    })
+
+    expect(a).not.toBe(b)
   })
 })

--- a/tests/scripts/behavior-audit-integration.test.ts
+++ b/tests/scripts/behavior-audit-integration.test.ts
@@ -3,12 +3,16 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
+import type * as ResetModule from '../../scripts/behavior-audit-reset.js'
+import type * as ConsolidateModule from '../../scripts/behavior-audit/consolidate.js'
 import type * as EvaluateModule from '../../scripts/behavior-audit/evaluate.js'
 import type * as ExtractModule from '../../scripts/behavior-audit/extract.js'
 import type { IncrementalManifest, IncrementalSelection } from '../../scripts/behavior-audit/incremental.js'
 import type * as IncrementalModule from '../../scripts/behavior-audit/incremental.js'
+import type * as KeywordVocabularyModule from '../../scripts/behavior-audit/keyword-vocabulary.js'
 import type { Progress } from '../../scripts/behavior-audit/progress.js'
 import type * as ProgressModule from '../../scripts/behavior-audit/progress.js'
+import type * as ReportWriterModule from '../../scripts/behavior-audit/report-writer.js'
 import { parseTestFile } from '../../scripts/behavior-audit/test-parser.js'
 import type { ParsedTestFile } from '../../scripts/behavior-audit/test-parser.js'
 
@@ -19,6 +23,10 @@ type IncrementalModuleShape = typeof IncrementalModule
 type ProgressModuleShape = typeof ProgressModule
 type ExtractModuleShape = typeof ExtractModule
 type EvaluateModuleShape = typeof EvaluateModule
+type ConsolidateModuleShape = typeof ConsolidateModule
+type KeywordVocabularyModuleShape = typeof KeywordVocabularyModule
+type ReportWriterModuleShape = typeof ReportWriterModule
+type ResetModuleShape = typeof ResetModule
 type SelectIncrementalWorkInput = Parameters<IncrementalModuleShape['selectIncrementalWork']>[0]
 type CaptureRunStartResult = ReturnType<IncrementalModuleShape['captureRunStart']>
 type ManifestTestEntry = IncrementalManifest['tests'][string]
@@ -111,10 +119,10 @@ function createEmptyProgress(filesTotal: number): Progress {
     },
     phase2: {
       status: 'not-started',
-      completedDomains: {},
+      completedBatches: {},
       consolidations: {},
-      failedDomains: {},
-      stats: { domainsTotal: 0, domainsDone: 0, domainsFailed: 0, behaviorsConsolidated: 0 },
+      failedBatches: {},
+      stats: { batchesTotal: 0, batchesDone: 0, batchesFailed: 0, behaviorsConsolidated: 0 },
     },
     phase3: {
       status: 'not-started',
@@ -328,7 +336,10 @@ function isPhase2Input(value: unknown): value is {
   readonly selectedConsolidatedIds: ReadonlySet<string>
 } {
   return (
-    isObject(value) && 'selectedConsolidatedIds' in value && value['selectedConsolidatedIds'] instanceof Set && 'progress' in value
+    isObject(value) &&
+    'selectedConsolidatedIds' in value &&
+    value['selectedConsolidatedIds'] instanceof Set &&
+    'progress' in value
   )
 }
 
@@ -395,6 +406,59 @@ function loadEvaluateModule(tag: string): Promise<EvaluateModuleShape> {
     `../../scripts/behavior-audit/evaluate.js?test=${tag}`,
     isEvaluateModule,
     'Unexpected evaluate module shape',
+  )
+}
+
+function isConsolidateModule(value: unknown): value is ConsolidateModuleShape {
+  return isObject(value) && hasFunctionProperty(value, 'runPhase2')
+}
+
+function isKeywordVocabularyModule(value: unknown): value is KeywordVocabularyModuleShape {
+  return (
+    isObject(value) &&
+    hasFunctionProperty(value, 'loadKeywordVocabulary') &&
+    hasFunctionProperty(value, 'saveKeywordVocabulary') &&
+    hasFunctionProperty(value, 'recordKeywordUsage')
+  )
+}
+
+function isReportWriterModule(value: unknown): value is ReportWriterModuleShape {
+  return isObject(value) && hasFunctionProperty(value, 'writeBehaviorFile')
+}
+
+function isResetModule(value: unknown): value is ResetModuleShape {
+  return isObject(value) && hasFunctionProperty(value, 'resetBehaviorAudit')
+}
+
+function loadConsolidateModule(tag: string): Promise<ConsolidateModuleShape> {
+  return importWithGuard(
+    `../../scripts/behavior-audit/consolidate.js?test=${tag}`,
+    isConsolidateModule,
+    'Unexpected consolidate module shape',
+  )
+}
+
+function loadKeywordVocabularyModule(tag: string): Promise<KeywordVocabularyModuleShape> {
+  return importWithGuard(
+    `../../scripts/behavior-audit/keyword-vocabulary.js?test=${tag}`,
+    isKeywordVocabularyModule,
+    'Unexpected keyword vocabulary module shape',
+  )
+}
+
+function loadReportWriterModule(tag: string): Promise<ReportWriterModuleShape> {
+  return importWithGuard(
+    `../../scripts/behavior-audit/report-writer.js?test=${tag}`,
+    isReportWriterModule,
+    'Unexpected report writer module shape',
+  )
+}
+
+function loadResetModule(tag: string): Promise<ResetModuleShape> {
+  return importWithGuard(
+    `../../scripts/behavior-audit-reset.js?test=${tag}`,
+    isResetModule,
+    'Unexpected reset module shape',
   )
 }
 
@@ -496,6 +560,7 @@ describe('behavior-audit entrypoint incremental selection', () => {
       PROGRESS_PATH: progressPath,
       INCREMENTAL_MANIFEST_PATH: manifestPath,
       CONSOLIDATED_MANIFEST_PATH: consolidatedManifestPath,
+      KEYWORD_VOCABULARY_PATH: path.join(reportsDir, 'keyword-vocabulary.json'),
       PHASE1_TIMEOUT_MS: 1_200_000,
       PHASE2_TIMEOUT_MS: 300_000,
       PHASE3_TIMEOUT_MS: 600_000,
@@ -517,7 +582,8 @@ describe('behavior-audit entrypoint incremental selection', () => {
       createEmptyManifest,
       createEmptyConsolidatedManifest: (): IncrementalModule.ConsolidatedManifest => ({ version: 1, entries: {} }),
       loadManifest: (): Promise<IncrementalManifest | null> => loadManifestImpl(),
-      loadConsolidatedManifest: (): Promise<IncrementalModule.ConsolidatedManifest | null> => loadConsolidatedManifestImpl(),
+      loadConsolidatedManifest: (): Promise<IncrementalModule.ConsolidatedManifest | null> =>
+        loadConsolidatedManifestImpl(),
       captureRunStart: (manifest: IncrementalManifest, currentHead: string, startedAt: string): CaptureRunStartResult =>
         captureRunStartImpl(manifest, currentHead, startedAt),
       saveManifest: (manifest: IncrementalManifest): Promise<void> => {
@@ -656,6 +722,7 @@ describe('behavior-audit entrypoint incremental selection', () => {
       fullPath: 'suite > first case',
       behavior: 'When the user triggers the first case, the stored behavior is reused.',
       context: 'Stored extracted context for the first case.',
+      keywords: [],
     }
     progress.phase3.evaluations[selectedKey] = {
       testName: 'suite > first case',
@@ -702,14 +769,12 @@ describe('behavior-audit phase 1 incremental selection', () => {
   let reportsDir: string
   let manifestPath: string
   let progressPath: string
-  let generateTextCalls: number
 
   beforeEach(async () => {
     root = makeTempDir()
     reportsDir = path.join(root, 'reports')
     manifestPath = path.join(reportsDir, 'incremental-manifest.json')
     progressPath = path.join(reportsDir, 'progress.json')
-    generateTextCalls = 0
 
     const testsDir = path.join(root, 'tests', 'tools')
     const srcDir = path.join(root, 'src', 'tools')
@@ -741,6 +806,8 @@ describe('behavior-audit phase 1 incremental selection', () => {
       STORIES_DIR: path.join(reportsDir, 'stories'),
       PROGRESS_PATH: progressPath,
       INCREMENTAL_MANIFEST_PATH: manifestPath,
+      CONSOLIDATED_MANIFEST_PATH: path.join(reportsDir, 'consolidated-manifest.json'),
+      KEYWORD_VOCABULARY_PATH: path.join(reportsDir, 'keyword-vocabulary.json'),
       PHASE1_TIMEOUT_MS: 1_200_000,
       PHASE2_TIMEOUT_MS: 600_000,
       MAX_RETRIES: 3,
@@ -760,24 +827,33 @@ describe('behavior-audit phase 1 incremental selection', () => {
     const realProgressModule = await loadProgressModule(`real=${crypto.randomUUID()}`)
     void mock.module('../../scripts/behavior-audit/incremental.js', () => ({ ...realIncrementalModule }))
     void mock.module('../../scripts/behavior-audit/progress.js', () => ({ ...realProgressModule }))
-    void mock.module('@ai-sdk/openai-compatible', () => ({
-      createOpenAICompatible: (): (() => { readonly mocked: true }) => (): { readonly mocked: true } => ({
-        mocked: true,
-      }),
+    void mock.module('../../scripts/behavior-audit/extract-agent.js', () => ({
+      extractWithRetry: (): Promise<{
+        readonly behavior: string
+        readonly context: string
+        readonly candidateKeywords: readonly string[]
+      }> =>
+        Promise.resolve({
+          behavior: 'When the selected test runs, the bot returns the extracted behavior.',
+          context: 'Calls the extractor and records the result for the selected test only.',
+          candidateKeywords: ['test-extraction', 'behavior-verification'],
+        }),
     }))
-    void mock.module('ai', () => ({
-      generateText: (): Promise<MockGenerateTextResult> => {
-        generateTextCalls += 1
-        const result: MockGenerateTextResult = {
-          text: JSON.stringify({
-            behavior: 'When the selected test runs, the bot returns the extracted behavior.',
-            context: 'Calls the extractor and records the result for the selected test only.',
-          }),
-          steps: [],
-        }
-        return Promise.resolve(result)
-      },
-      stepCountIs: (): symbol => Symbol('stepCountIs'),
+    void mock.module('../../scripts/behavior-audit/keyword-resolver-agent.js', () => ({
+      resolveKeywordsWithRetry: (): Promise<{
+        readonly keywords: readonly string[]
+        readonly appendedEntries: readonly {
+          readonly slug: string
+          readonly description: string
+          readonly createdAt: string
+          readonly updatedAt: string
+          readonly timesUsed: number
+        }[]
+      }> =>
+        Promise.resolve({
+          keywords: ['test-extraction', 'behavior-verification'],
+          appendedEntries: [],
+        }),
     }))
     void mock.module('../../scripts/behavior-audit/tools.js', () => ({
       makeAuditTools: (): Record<string, never> => ({}),
@@ -815,14 +891,13 @@ describe('behavior-audit phase 1 incremental selection', () => {
       manifest,
     })
 
-    expect(generateTextCalls).toBe(1)
     expect(Object.keys(progress.phase1.extractedBehaviors)).toEqual([selectedKey])
     expect(progress.phase1.completedTests[testFilePath]).toEqual({ [selectedKey]: 'done' })
 
     const savedManifest = await readSavedManifest(manifestPath)
     const savedEntry = getManifestEntry(savedManifest, selectedKey)
     expect(savedEntry.phase1Fingerprint).toBeTruthy()
-    expect(savedEntry.phase2Fingerprint).toBeNull()
+    expect(savedEntry.phase2Fingerprint).toBeTruthy()
     expect(savedEntry.lastPhase2CompletedAt).toBeNull()
     expect(savedEntry.dependencyPaths).toEqual(['tests/tools/sample.test.ts', 'src/tools/sample.ts'])
     expect(savedEntry.domain).toBe('tools')
@@ -932,7 +1007,7 @@ describe('behavior-audit phase 3 incremental selection', () => {
     const unselectedKey = 'tools::unselected-case'
     const progress = createEmptyProgress(1)
 
-    progress.phase2.completedDomains['tools'] = 'done'
+    progress.phase2.completedBatches['tools'] = 'done'
     progress.phase3.evaluations[unselectedKey] = {
       testName: 'suite > unselected case',
       behavior: 'When the unselected behavior runs, the bot keeps prior results.',
@@ -948,6 +1023,35 @@ describe('behavior-audit phase 3 incremental selection', () => {
     await evaluate.runPhase3({
       progress,
       selectedConsolidatedIds: new Set([selectedKey]),
+      consolidatedManifest: {
+        version: 1,
+        entries: {
+          [selectedKey]: {
+            consolidatedId: selectedKey,
+            domain: 'tools',
+            featureName: 'selected case',
+            sourceTestKeys: ['tests/tools/sample.test.ts::suite > selected case'],
+            isUserFacing: true,
+            primaryKeyword: null,
+            keywords: [],
+            sourceDomains: ['tools'],
+            phase2Fingerprint: null,
+            lastConsolidatedAt: null,
+          },
+          [unselectedKey]: {
+            consolidatedId: unselectedKey,
+            domain: 'tools',
+            featureName: 'unselected case',
+            sourceTestKeys: ['tests/tools/sample.test.ts::suite > unselected case'],
+            isUserFacing: true,
+            primaryKeyword: null,
+            keywords: [],
+            sourceDomains: ['tools'],
+            phase2Fingerprint: null,
+            lastConsolidatedAt: null,
+          },
+        },
+      },
     })
 
     const selectedEvaluation = progress.phase3.evaluations[selectedKey]
@@ -972,11 +1076,28 @@ describe('behavior-audit phase 3 incremental selection', () => {
     const evaluate = await loadEvaluateModule(crypto.randomUUID())
     const selectedKey = 'tools::selected-case'
     const progress = createEmptyProgress(1)
-    progress.phase2.completedDomains['tools'] = 'done'
+    progress.phase2.completedBatches['tools'] = 'done'
 
     await evaluate.runPhase3({
       progress,
       selectedConsolidatedIds: new Set([selectedKey]),
+      consolidatedManifest: {
+        version: 1,
+        entries: {
+          [selectedKey]: {
+            consolidatedId: selectedKey,
+            domain: 'tools',
+            featureName: 'selected case',
+            sourceTestKeys: ['tests/tools/sample.test.ts::suite > selected case'],
+            isUserFacing: true,
+            primaryKeyword: null,
+            keywords: [],
+            sourceDomains: ['tools'],
+            phase2Fingerprint: null,
+            lastConsolidatedAt: null,
+          },
+        },
+      },
     })
 
     const progressText = await Bun.file(progressPath).text()
@@ -1027,6 +1148,9 @@ describe('behavior-audit interrupted-run baseline', () => {
       REPORTS_DIR: reportsDir,
       BEHAVIORS_DIR: path.join(reportsDir, 'behaviors'),
       STORIES_DIR: path.join(reportsDir, 'stories'),
+      CONSOLIDATED_DIR: path.join(reportsDir, 'consolidated'),
+      CONSOLIDATED_MANIFEST_PATH: path.join(reportsDir, 'consolidated-manifest.json'),
+      KEYWORD_VOCABULARY_PATH: path.join(reportsDir, 'keyword-vocabulary.json'),
       PROGRESS_PATH: progressPath,
       INCREMENTAL_MANIFEST_PATH: manifestPath,
       PHASE1_TIMEOUT_MS: 1_200_000,
@@ -1099,7 +1223,9 @@ describe('behavior-audit interrupted-run baseline', () => {
       },
     }))
     void mock.module('../../scripts/behavior-audit/consolidate.js', () => ({
-      runPhase2: (): Promise<IncrementalModuleShape['createEmptyConsolidatedManifest'] extends () => infer TResult ? TResult : never> => {
+      runPhase2: (): Promise<
+        IncrementalModuleShape['createEmptyConsolidatedManifest'] extends () => infer TResult ? TResult : never
+      > => {
         if (shouldInterruptPhase2) {
           throw new Error('simulated interruption after run start')
         }
@@ -1140,4 +1266,564 @@ describe('behavior-audit interrupted-run baseline', () => {
     ])
     expect(getArrayItem(runPhase1Calls, 1).selectedTestKeys).toEqual(['tests/tools/sample.test.ts::suite > case'])
   })
+})
+
+test('runPhase1 stores canonical keywords after extraction and vocabulary resolution', async () => {
+  const root = makeTempDir()
+  const reportsDir = path.join(root, 'reports')
+  const progressPath = path.join(reportsDir, 'progress.json')
+  const manifestPath = path.join(reportsDir, 'incremental-manifest.json')
+  const vocabularyPath = path.join(reportsDir, 'keyword-vocabulary.json')
+
+  void mock.module('../../scripts/behavior-audit/config.js', () => ({
+    MODEL: 'qwen3-30b-a3b',
+    BASE_URL: 'http://localhost:1234/v1',
+    PROJECT_ROOT: root,
+    REPORTS_DIR: reportsDir,
+    BEHAVIORS_DIR: path.join(reportsDir, 'behaviors'),
+    CONSOLIDATED_DIR: path.join(reportsDir, 'consolidated'),
+    STORIES_DIR: path.join(reportsDir, 'stories'),
+    PROGRESS_PATH: progressPath,
+    INCREMENTAL_MANIFEST_PATH: manifestPath,
+    CONSOLIDATED_MANIFEST_PATH: path.join(reportsDir, 'consolidated-manifest.json'),
+    KEYWORD_VOCABULARY_PATH: vocabularyPath,
+    PHASE1_TIMEOUT_MS: 1_200_000,
+    PHASE2_TIMEOUT_MS: 300_000,
+    PHASE3_TIMEOUT_MS: 600_000,
+    MAX_RETRIES: 3,
+    RETRY_BACKOFF_MS: [0, 0, 0] as const,
+    MAX_STEPS: 20,
+    EXCLUDED_PREFIXES: [
+      'tests/e2e/',
+      'tests/client/',
+      'tests/helpers/',
+      'tests/scripts/',
+      'tests/review-loop/',
+      'tests/types/',
+    ] as const,
+  }))
+
+  void mock.module('../../scripts/behavior-audit/extract-agent.js', () => ({
+    extractWithRetry: (): Promise<{
+      readonly behavior: string
+      readonly context: string
+      readonly candidateKeywords: readonly string[]
+    }> =>
+      Promise.resolve({
+        behavior: 'When a user targets a group, the bot routes the request correctly.',
+        context: 'Resolves target context and forwards execution through the group routing path.',
+        candidateKeywords: ['group-routing', 'group-targeting', 'request-routing'],
+      }),
+  }))
+
+  void mock.module('../../scripts/behavior-audit/keyword-resolver-agent.js', () => ({
+    resolveKeywordsWithRetry: (): Promise<{
+      readonly keywords: readonly string[]
+      readonly appendedEntries: readonly {
+        readonly slug: string
+        readonly description: string
+        readonly createdAt: string
+        readonly updatedAt: string
+        readonly timesUsed: number
+      }[]
+    }> =>
+      Promise.resolve({
+        keywords: ['group-targeting', 'group-routing'],
+        appendedEntries: [],
+      }),
+  }))
+
+  const testFileContent = "describe('suite', () => { test('case', () => {}) })"
+  mkdirSync(path.join(root, 'tests', 'tools'), { recursive: true })
+  writeFileSync(path.join(root, 'tests', 'tools', 'sample.test.ts'), testFileContent)
+
+  const tag = crypto.randomUUID()
+  const extract = await loadExtractModule(`phase1-keywords-${tag}`)
+  const progressModule = await loadProgressModule(`phase1-keywords-${tag}`)
+  const incremental = await loadIncrementalModule(`phase1-keywords-${tag}`)
+
+  const progress = progressModule.createEmptyProgress(1)
+  const manifest = incremental.createEmptyManifest()
+  const parsed = parseTestFile('tests/tools/sample.test.ts', testFileContent)
+
+  await extract.runPhase1({
+    testFiles: [parsed],
+    progress,
+    selectedTestKeys: new Set(['tests/tools/sample.test.ts::suite > case']),
+    manifest,
+  })
+
+  const stored = progress.phase1.extractedBehaviors['tests/tools/sample.test.ts::suite > case']
+  expect(stored?.keywords).toEqual(['group-targeting', 'group-routing'])
+})
+
+test('extract-agent returns behavior, context, and candidateKeywords', async () => {
+  const mod: unknown = await import(`../../scripts/behavior-audit/extract-agent.js?test=shape-${crypto.randomUUID()}`)
+  expect(typeof mod).toBe('object')
+  expect(mod).toHaveProperty('extractWithRetry')
+})
+
+test('keyword-resolver-agent returns canonical keywords and appended entries', async () => {
+  const mod: unknown = await import(
+    `../../scripts/behavior-audit/keyword-resolver-agent.js?test=shape-${crypto.randomUUID()}`
+  )
+  expect(typeof mod).toBe('object')
+  expect(mod).toHaveProperty('resolveKeywordsWithRetry')
+})
+
+test('keyword-vocabulary persists entries and updates usage counts', async () => {
+  const root = makeTempDir()
+  const reportsDir = path.join(root, 'reports')
+  const vocabularyPath = path.join(reportsDir, 'keyword-vocabulary.json')
+
+  void mock.module('../../scripts/behavior-audit/config.js', () => ({
+    MODEL: 'qwen3-30b-a3b',
+    BASE_URL: 'http://localhost:1234/v1',
+    PROJECT_ROOT: root,
+    REPORTS_DIR: reportsDir,
+    BEHAVIORS_DIR: path.join(reportsDir, 'behaviors'),
+    CONSOLIDATED_DIR: path.join(reportsDir, 'consolidated'),
+    STORIES_DIR: path.join(reportsDir, 'stories'),
+    PROGRESS_PATH: path.join(reportsDir, 'progress.json'),
+    INCREMENTAL_MANIFEST_PATH: path.join(reportsDir, 'incremental-manifest.json'),
+    CONSOLIDATED_MANIFEST_PATH: path.join(reportsDir, 'consolidated-manifest.json'),
+    KEYWORD_VOCABULARY_PATH: vocabularyPath,
+    PHASE1_TIMEOUT_MS: 1_200_000,
+    PHASE2_TIMEOUT_MS: 300_000,
+    PHASE3_TIMEOUT_MS: 600_000,
+    MAX_RETRIES: 3,
+    RETRY_BACKOFF_MS: [0, 0, 0] as const,
+    MAX_STEPS: 20,
+    EXCLUDED_PREFIXES: [] as const,
+  }))
+
+  const typedVocab = await loadKeywordVocabularyModule(`vocab-${crypto.randomUUID()}`)
+  await typedVocab.saveKeywordVocabulary([
+    {
+      slug: 'group-targeting',
+      description: 'Targeting work at a group context.',
+      createdAt: '2026-04-20T12:00:00.000Z',
+      updatedAt: '2026-04-20T12:00:00.000Z',
+      timesUsed: 1,
+    },
+  ])
+
+  await typedVocab.recordKeywordUsage(['group-targeting'])
+
+  const saved = await typedVocab.loadKeywordVocabulary()
+  expect(saved).not.toBeNull()
+  expect(saved?.[0]?.timesUsed).toBe(2)
+})
+
+test('writeBehaviorFile renders canonical keywords for each extracted behavior', async () => {
+  const root = makeTempDir()
+  const reportsDir = path.join(root, 'reports')
+
+  void mock.module('../../scripts/behavior-audit/config.js', () => ({
+    MODEL: 'qwen3-30b-a3b',
+    BASE_URL: 'http://localhost:1234/v1',
+    PROJECT_ROOT: root,
+    REPORTS_DIR: reportsDir,
+    BEHAVIORS_DIR: path.join(reportsDir, 'behaviors'),
+    CONSOLIDATED_DIR: path.join(reportsDir, 'consolidated'),
+    STORIES_DIR: path.join(reportsDir, 'stories'),
+    PROGRESS_PATH: path.join(reportsDir, 'progress.json'),
+    INCREMENTAL_MANIFEST_PATH: path.join(reportsDir, 'incremental-manifest.json'),
+    CONSOLIDATED_MANIFEST_PATH: path.join(reportsDir, 'consolidated-manifest.json'),
+    KEYWORD_VOCABULARY_PATH: path.join(reportsDir, 'keyword-vocabulary.json'),
+    PHASE1_TIMEOUT_MS: 1_200_000,
+    PHASE2_TIMEOUT_MS: 300_000,
+    PHASE3_TIMEOUT_MS: 600_000,
+    MAX_RETRIES: 3,
+    RETRY_BACKOFF_MS: [0, 0, 0] as const,
+    MAX_STEPS: 20,
+    EXCLUDED_PREFIXES: [] as const,
+  }))
+
+  const typedWriter = await loadReportWriterModule(`keywords-${crypto.randomUUID()}`)
+  await typedWriter.writeBehaviorFile('tests/tools/sample.test.ts', [
+    {
+      testName: 'case',
+      fullPath: 'suite > case',
+      behavior: 'When a user targets a group, the bot routes the request correctly.',
+      context: 'Routes through group context selection.',
+      keywords: ['group-targeting', 'group-routing'],
+    },
+  ])
+
+  const fileText = await Bun.file(path.join(reportsDir, 'behaviors', 'tools', 'sample.test.behaviors.md')).text()
+  expect(fileText).toContain('**Keywords:** group-targeting, group-routing')
+})
+
+test('runPhase1 persists vocabulary updates before marking a test done', async () => {
+  const root = makeTempDir()
+  const reportsDir = path.join(root, 'reports')
+  const progressPath = path.join(reportsDir, 'progress.json')
+  const manifestPath = path.join(reportsDir, 'incremental-manifest.json')
+  const vocabularyPath = path.join(reportsDir, 'keyword-vocabulary.json')
+
+  void mock.module('../../scripts/behavior-audit/config.js', () => ({
+    MODEL: 'qwen3-30b-a3b',
+    BASE_URL: 'http://localhost:1234/v1',
+    PROJECT_ROOT: root,
+    REPORTS_DIR: reportsDir,
+    BEHAVIORS_DIR: path.join(reportsDir, 'behaviors'),
+    CONSOLIDATED_DIR: path.join(reportsDir, 'consolidated'),
+    STORIES_DIR: path.join(reportsDir, 'stories'),
+    PROGRESS_PATH: progressPath,
+    INCREMENTAL_MANIFEST_PATH: manifestPath,
+    CONSOLIDATED_MANIFEST_PATH: path.join(reportsDir, 'consolidated-manifest.json'),
+    KEYWORD_VOCABULARY_PATH: vocabularyPath,
+    PHASE1_TIMEOUT_MS: 1_200_000,
+    PHASE2_TIMEOUT_MS: 300_000,
+    PHASE3_TIMEOUT_MS: 600_000,
+    MAX_RETRIES: 3,
+    RETRY_BACKOFF_MS: [0, 0, 0] as const,
+    MAX_STEPS: 20,
+    EXCLUDED_PREFIXES: [] as const,
+  }))
+
+  void mock.module('../../scripts/behavior-audit/extract-agent.js', () => ({
+    extractWithRetry: (): Promise<{
+      readonly behavior: string
+      readonly context: string
+      readonly candidateKeywords: readonly string[]
+    }> =>
+      Promise.resolve({
+        behavior: 'When a user targets a group, the bot routes the request correctly.',
+        context: 'Routes through group context selection.',
+        candidateKeywords: ['group-targeting'],
+      }),
+  }))
+
+  void mock.module('../../scripts/behavior-audit/keyword-resolver-agent.js', () => ({
+    resolveKeywordsWithRetry: (): Promise<{
+      readonly keywords: readonly string[]
+      readonly appendedEntries: readonly {
+        readonly slug: string
+        readonly description: string
+        readonly createdAt: string
+        readonly updatedAt: string
+        readonly timesUsed: number
+      }[]
+    }> =>
+      Promise.resolve({
+        keywords: ['group-targeting'],
+        appendedEntries: [
+          {
+            slug: 'group-targeting',
+            description: 'Targeting work at a group context.',
+            createdAt: '2026-04-20T12:00:00.000Z',
+            updatedAt: '2026-04-20T12:00:00.000Z',
+            timesUsed: 1,
+          },
+        ],
+      }),
+  }))
+
+  const testFileContent = "describe('suite', () => { test('case', () => {}) })"
+  mkdirSync(path.join(root, 'tests', 'tools'), { recursive: true })
+  writeFileSync(path.join(root, 'tests', 'tools', 'sample.test.ts'), testFileContent)
+
+  const tag = crypto.randomUUID()
+  const extract = await loadExtractModule(`phase1-atomic-${tag}`)
+  const progressModule = await loadProgressModule(`phase1-atomic-${tag}`)
+  const incremental = await loadIncrementalModule(`phase1-atomic-${tag}`)
+
+  const progress = progressModule.createEmptyProgress(1)
+  const parsed = parseTestFile('tests/tools/sample.test.ts', testFileContent)
+
+  await extract.runPhase1({
+    testFiles: [parsed],
+    progress,
+    selectedTestKeys: new Set(['tests/tools/sample.test.ts::suite > case']),
+    manifest: incremental.createEmptyManifest(),
+  })
+
+  const savedVocabText = await Bun.file(vocabularyPath).text()
+  expect(savedVocabText).toContain('"group-targeting"')
+  expect(
+    progress.phase1.completedTests['tests/tools/sample.test.ts']?.['tests/tools/sample.test.ts::suite > case'],
+  ).toBe('done')
+})
+
+test('consolidate-agent prompt contract treats a keyword batch as a candidate pool rather than one feature', async () => {
+  const source = await Bun.file(path.join(process.cwd(), 'scripts/behavior-audit/consolidate-agent.ts')).text()
+  expect(source).toContain('candidate pool')
+  expect(source).toContain('never force one output per batch or one output per keyword')
+})
+
+test('runPhase2 groups cross-domain behaviors by primary keyword and preserves provenance', async () => {
+  void mock.module('../../scripts/behavior-audit/consolidate-agent.js', () => ({
+    consolidateWithRetry: (
+      primaryKeyword: string,
+      inputs: readonly { readonly testKey: string }[],
+    ): Promise<
+      | readonly {
+          readonly id: string
+          readonly item: {
+            readonly featureName: string
+            readonly isUserFacing: boolean
+            readonly behavior: string
+            readonly userStory: string | null
+            readonly context: string
+            readonly sourceTestKeys: readonly string[]
+          }
+        }[]
+      | null
+    > =>
+      Promise.resolve(
+        inputs.map((input) => ({
+          id: `${primaryKeyword}::${input.testKey.replace(/[^a-z0-9]/g, '-')}`,
+          item: {
+            featureName: `Feature from ${input.testKey}`,
+            isUserFacing: true,
+            behavior: 'When a user acts, something happens.',
+            userStory: 'As a user, I can do something.',
+            context: 'Implementation context.',
+            sourceTestKeys: [input.testKey],
+          },
+        })),
+      ),
+  }))
+
+  const consolidate = await loadConsolidateModule(`keyword-batches-${crypto.randomUUID()}`)
+  const progress = createEmptyProgress(2)
+
+  progress.phase1.extractedBehaviors['tests/tools/a.test.ts::suite > case'] = {
+    testName: 'case',
+    fullPath: 'suite > case',
+    behavior: 'When a user targets a group, the bot routes the request correctly.',
+    context: 'Routes through group context selection.',
+    keywords: ['group-targeting', 'group-routing'],
+  }
+  progress.phase1.extractedBehaviors['tests/commands/b.test.ts::suite > case'] = {
+    testName: 'case',
+    fullPath: 'suite > case',
+    behavior: 'When a user configures a group action, the bot applies the group target.',
+    context: 'Resolves group target before command execution.',
+    keywords: ['group-targeting', 'command-routing'],
+  }
+
+  const manifest = { version: 1 as const, entries: {} }
+  const result = await consolidate.runPhase2(progress, manifest, 'phase2-v1')
+
+  expect(Object.keys(result.entries).length).toBeGreaterThan(0)
+})
+
+test('phase2 can emit multiple feature-level stories from one keyword-owned batch', async () => {
+  void mock.module('../../scripts/behavior-audit/consolidate-agent.js', () => ({
+    consolidateWithRetry: (
+      primaryKeyword: string,
+      inputs: readonly { readonly testKey: string }[],
+    ): Promise<
+      | readonly {
+          readonly id: string
+          readonly item: {
+            readonly featureName: string
+            readonly isUserFacing: boolean
+            readonly behavior: string
+            readonly userStory: string | null
+            readonly context: string
+            readonly sourceTestKeys: readonly string[]
+          }
+        }[]
+      | null
+    > =>
+      Promise.resolve(
+        inputs.map((input, idx) => ({
+          id: `${primaryKeyword}::feature-${idx}`,
+          item: {
+            featureName: `Feature ${idx}`,
+            isUserFacing: true,
+            behavior: 'When a user acts, something happens.',
+            userStory: `As a user, I can do feature ${idx}.`,
+            context: 'Implementation context.',
+            sourceTestKeys: [input.testKey],
+          },
+        })),
+      ),
+  }))
+
+  const consolidate2 = await loadConsolidateModule(`multi-story-${crypto.randomUUID()}`)
+  const progress = createEmptyProgress(2)
+
+  progress.phase1.extractedBehaviors['tests/tools/a.test.ts::suite > one'] = {
+    testName: 'one',
+    fullPath: 'suite > one',
+    behavior: 'When a user targets a group, the bot routes the request correctly.',
+    context: 'Routes through group context selection.',
+    keywords: ['group-targeting', 'group-routing'],
+  }
+  progress.phase1.extractedBehaviors['tests/tools/a.test.ts::suite > two'] = {
+    testName: 'two',
+    fullPath: 'suite > two',
+    behavior: 'When a user manages group access, the bot shows authorization state.',
+    context: 'Reads group authorization records and formats output.',
+    keywords: ['group-targeting', 'group-authorization'],
+  }
+
+  const manifest = { version: 1 as const, entries: {} }
+  const result = await consolidate2.runPhase2(progress, manifest, 'phase2-v1')
+  expect(Object.keys(result.entries).length).toBeGreaterThan(1)
+})
+
+describe('behavior-audit entrypoint phase3 manifest passthrough', () => {
+  let root: string
+  let reportsDir: string
+  let manifestPath: string
+  let progressPath: string
+
+  beforeEach(async () => {
+    root = makeTempDir()
+    reportsDir = path.join(root, 'reports')
+    manifestPath = path.join(reportsDir, 'incremental-manifest.json')
+    progressPath = path.join(reportsDir, 'progress.json')
+
+    const testsDir = path.join(root, 'tests', 'tools')
+    mkdirSync(testsDir, { recursive: true })
+    writeFileSync(
+      path.join(testsDir, 'sample.test.ts'),
+      ["describe('suite', () => {", "  test('first case', () => {})", '})', ''].join('\n'),
+    )
+
+    void mock.module('../../scripts/behavior-audit/config.js', () => ({
+      MODEL: 'qwen3-30b-a3b',
+      BASE_URL: 'http://localhost:1234/v1',
+      PROJECT_ROOT: root,
+      REPORTS_DIR: reportsDir,
+      BEHAVIORS_DIR: path.join(reportsDir, 'behaviors'),
+      CONSOLIDATED_DIR: path.join(reportsDir, 'consolidated'),
+      STORIES_DIR: path.join(reportsDir, 'stories'),
+      PROGRESS_PATH: progressPath,
+      INCREMENTAL_MANIFEST_PATH: manifestPath,
+      CONSOLIDATED_MANIFEST_PATH: path.join(reportsDir, 'consolidated-manifest.json'),
+      KEYWORD_VOCABULARY_PATH: path.join(reportsDir, 'keyword-vocabulary.json'),
+      PHASE1_TIMEOUT_MS: 1_200_000,
+      PHASE2_TIMEOUT_MS: 300_000,
+      PHASE3_TIMEOUT_MS: 600_000,
+      MAX_RETRIES: 3,
+      RETRY_BACKOFF_MS: [0, 0, 0] as const,
+      MAX_STEPS: 20,
+      EXCLUDED_PREFIXES: [
+        'tests/e2e/',
+        'tests/client/',
+        'tests/helpers/',
+        'tests/scripts/',
+        'tests/review-loop/',
+        'tests/types/',
+      ] as const,
+    }))
+
+    const realIncrementalModule = await loadIncrementalModule(`passthrough=${crypto.randomUUID()}`)
+    const realProgressModule = await loadProgressModule(`passthrough=${crypto.randomUUID()}`)
+
+    void mock.module('../../scripts/behavior-audit/incremental.js', () => ({
+      ...realIncrementalModule,
+      collectChangedFiles: (): Promise<readonly string[]> => Promise.resolve([]),
+      selectIncrementalWork: (input: SelectIncrementalWorkInput): IncrementalSelection => ({
+        phase1SelectedTestKeys: [...input.discoveredTestKeys],
+        phase2SelectedTestKeys: [...input.discoveredTestKeys],
+        phase3SelectedConsolidatedIds: [],
+        reportRebuildOnly: false,
+      }),
+    }))
+    void mock.module('../../scripts/behavior-audit/progress.js', () => ({ ...realProgressModule }))
+    void mock.module('../../scripts/behavior-audit/extract.js', () => ({
+      runPhase1: (): Promise<void> => Promise.resolve(),
+    }))
+  })
+
+  test('main passes the consolidated manifest through to phase3 after phase2 completes', async () => {
+    await initializeGitRepo(root)
+
+    const consolidatedManifest = {
+      version: 1 as const,
+      entries: {
+        'tools::selected-case': {
+          consolidatedId: 'tools::selected-case',
+          domain: 'tools',
+          featureName: 'Selected case',
+          sourceTestKeys: ['tests/tools/sample.test.ts::suite > first case'],
+          isUserFacing: true,
+          primaryKeyword: 'group-targeting' as string | null,
+          keywords: ['group-targeting'] as readonly string[],
+          sourceDomains: ['tools'] as readonly string[],
+          phase2Fingerprint: 'phase2-fp' as string | null,
+          lastConsolidatedAt: '2026-04-20T12:00:00.000Z' as string | null,
+        },
+      },
+    }
+
+    let phase3ManifestArg: typeof consolidatedManifest | null = null
+
+    void mock.module('../../scripts/behavior-audit/consolidate.js', () => ({
+      runPhase2: (): Promise<typeof consolidatedManifest> => Promise.resolve(consolidatedManifest),
+    }))
+    void mock.module('../../scripts/behavior-audit/evaluate.js', () => ({
+      runPhase3: (input: {
+        readonly progress: Progress
+        readonly selectedConsolidatedIds: ReadonlySet<string>
+        readonly consolidatedManifest: typeof consolidatedManifest
+      }): Promise<void> => {
+        phase3ManifestArg = input.consolidatedManifest
+        return Promise.resolve()
+      },
+    }))
+
+    await loadBehaviorAuditEntryPoint(crypto.randomUUID())
+
+    expect(phase3ManifestArg).not.toBeNull()
+    expect(phase3ManifestArg).toMatchObject(consolidatedManifest)
+  })
+})
+
+test('behavior-audit-reset phase2 clears downstream state without deleting keyword vocabulary', async () => {
+  const root = makeTempDir()
+  const reportsDir = path.join(root, 'reports')
+
+  mkdirSync(path.join(reportsDir, 'consolidated'), { recursive: true })
+  mkdirSync(path.join(reportsDir, 'stories'), { recursive: true })
+  await Bun.write(
+    path.join(reportsDir, 'keyword-vocabulary.json'),
+    JSON.stringify([
+      {
+        slug: 'group-targeting',
+        description: 'Targeting work at a group context.',
+        createdAt: '2026-04-20T12:00:00.000Z',
+        updatedAt: '2026-04-20T12:00:00.000Z',
+        timesUsed: 1,
+      },
+    ]),
+  )
+  await Bun.write(path.join(reportsDir, 'consolidated', 'tools.md'), '# consolidated')
+  await Bun.write(path.join(reportsDir, 'stories', 'tools.md'), '# stories')
+
+  void mock.module('../../scripts/behavior-audit/config.js', () => ({
+    MODEL: 'qwen3-30b-a3b',
+    BASE_URL: 'http://localhost:1234/v1',
+    PROJECT_ROOT: root,
+    REPORTS_DIR: reportsDir,
+    BEHAVIORS_DIR: path.join(reportsDir, 'behaviors'),
+    CONSOLIDATED_DIR: path.join(reportsDir, 'consolidated'),
+    STORIES_DIR: path.join(reportsDir, 'stories'),
+    PROGRESS_PATH: path.join(reportsDir, 'progress.json'),
+    INCREMENTAL_MANIFEST_PATH: path.join(reportsDir, 'incremental-manifest.json'),
+    CONSOLIDATED_MANIFEST_PATH: path.join(reportsDir, 'consolidated-manifest.json'),
+    KEYWORD_VOCABULARY_PATH: path.join(reportsDir, 'keyword-vocabulary.json'),
+    PHASE1_TIMEOUT_MS: 1_200_000,
+    PHASE2_TIMEOUT_MS: 300_000,
+    PHASE3_TIMEOUT_MS: 600_000,
+    MAX_RETRIES: 3,
+    RETRY_BACKOFF_MS: [0, 0, 0] as const,
+    MAX_STEPS: 20,
+    EXCLUDED_PREFIXES: [] as const,
+  }))
+
+  const reset = await loadResetModule(`phase2-reset-${crypto.randomUUID()}`)
+  await reset.resetBehaviorAudit('phase2')
+
+  expect(await Bun.file(path.join(reportsDir, 'keyword-vocabulary.json')).exists()).toBe(true)
+  expect(await Bun.file(path.join(reportsDir, 'consolidated', 'tools.md')).exists()).toBe(false)
+  expect(await Bun.file(path.join(reportsDir, 'stories', 'tools.md')).exists()).toBe(false)
 })

--- a/tests/scripts/behavior-audit-integration.test.ts
+++ b/tests/scripts/behavior-audit-integration.test.ts
@@ -30,10 +30,6 @@ type ResetModuleShape = typeof ResetModule
 type SelectIncrementalWorkInput = Parameters<IncrementalModuleShape['selectIncrementalWork']>[0]
 type CaptureRunStartResult = ReturnType<IncrementalModuleShape['captureRunStart']>
 type ManifestTestEntry = IncrementalManifest['tests'][string]
-type MockGenerateTextResult = {
-  readonly text: string
-  readonly steps: readonly { readonly toolCalls: readonly unknown[] }[]
-}
 type MockEvaluationResult = Awaited<
   ReturnType<(typeof import('../../scripts/behavior-audit/evaluate-agent.js'))['evaluateWithRetry']>
 >
@@ -622,7 +618,7 @@ describe('behavior-audit entrypoint incremental selection', () => {
       },
     }))
     void mock.module('../../scripts/behavior-audit/consolidate.js', () => ({
-      runPhase2: async (): Promise<IncrementalModule.ConsolidatedManifest> => ({ version: 1, entries: {} }),
+      runPhase2: (): Promise<IncrementalModule.ConsolidatedManifest> => Promise.resolve({ version: 1, entries: {} }),
     }))
   })
 


### PR DESCRIPTION
Replaces per-test Phase 2 consolidation with keyword-batch grouping: behaviors are now grouped by their lowest-cardinality keyword and consolidated together, with a persistent keyword vocabulary for canonical slug reuse across runs.

https://claude.ai/code/session_018PWuRqa7E3vXn87CLcHxeC