### PR TITLE
fix(/context): apply tool routing to reflect actual exposed surface

### DIFF
--- a/src/commands/context-collector.ts
+++ b/src/commands/context-collector.ts
@@ -4,14 +4,22 @@
 // See LICENSE in the project root for details.
 
 import type { ModelMessage } from 'ai'
-import type { Tokenizer as TokenizerType } from 'ai-tokenizer'
 
 import type { ContextSection, ContextSnapshot } from '../chat/types.js'
 import { logger } from '../logger.js'
+import type { ToolRoutingIntent } from '../tools/tool-router.js'
+
+export { defaultCountTokens, prepareDefaultCountTokens, type EncodingName } from './context-tokenizer.js'
 
 const log = logger.child({ scope: 'commands:context-collector' })
 
 type Fact = { identifier: string; title: string; url: string; last_seen: string }
+
+export type ToolRoutingInfo = {
+  intent: ToolRoutingIntent
+  fullToolCount: number
+  exposedToolCount: number
+}
 
 export interface ContextCollectorDeps {
   getMainModel: () => string | null
@@ -24,6 +32,7 @@ export interface ContextCollectorDeps {
   getFacts: () => readonly Fact[]
   getActiveToolDefinitions: () => Record<string, unknown>
   getProviderName: () => string
+  getToolRoutingInfo?: () => ToolRoutingInfo | undefined
   countTokens: (text: string) => number
 }
 
@@ -205,11 +214,19 @@ const buildToolsSection = (deps: ContextCollectorDeps, counter: SafeCounter): Co
   const count = Object.keys(tools).length
   const providerName = deps.getProviderName()
   const tokens = counter.count(serializeTools(tools))
+  const routing = deps.getToolRoutingInfo?.()
   return {
     label: 'Tools',
     tokens,
-    detail: `${String(count)} active, gated by ${providerName}`,
+    detail: buildToolsDetail(count, providerName, routing),
   }
+}
+
+const buildToolsDetail = (exposedCount: number, providerName: string, routing: ToolRoutingInfo | undefined): string => {
+  if (routing === undefined) {
+    return `${String(exposedCount)} active, gated by ${providerName}`
+  }
+  return `${String(routing.exposedToolCount)} of ${String(routing.fullToolCount)} active, gated by ${providerName} · routed for ${routing.intent}`
 }
 
 export const collectContext = (contextId: string, deps: ContextCollectorDeps): ContextSnapshot => {
@@ -240,42 +257,4 @@ export const collectContext = (contextId: string, deps: ContextCollectorDeps): C
   )
 
   return { modelName, sections, totalTokens, maxTokens, approximate: counter.approximate }
-}
-
-type EncodingName = 'o200k_base' | 'cl100k_base'
-
-const tokenizerCache = new Map<EncodingName, TokenizerType>()
-
-const loadTokenizer = async (encoding: EncodingName): Promise<TokenizerType> => {
-  const cached = tokenizerCache.get(encoding)
-  if (cached !== undefined) return cached
-  const { Tokenizer } = await import('ai-tokenizer')
-  const encodingModule =
-    encoding === 'o200k_base'
-      ? await import('ai-tokenizer/encoding/o200k_base')
-      : await import('ai-tokenizer/encoding/cl100k_base')
-  const tokenizer = new Tokenizer(encodingModule)
-  tokenizerCache.set(encoding, tokenizer)
-  return tokenizer
-}
-
-/**
- * Synchronous wrapper used by the collector. On first call per encoding,
- * throws with a special marker so the caller can lazy-load via `prepareDefaultCountTokens`.
- */
-export const defaultCountTokens = (text: string, encoding: EncodingName): number => {
-  if (text.length === 0) return 0
-  const tokenizer = tokenizerCache.get(encoding)
-  if (tokenizer === undefined) {
-    throw new Error(`tokenizer not loaded: ${encoding}`)
-  }
-  return tokenizer.count(text)
-}
-
-/**
- * Preload a tokenizer for the given encoding. Must be called before `collectContext`
- * uses the synchronous `defaultCountTokens`.
- */
-export const prepareDefaultCountTokens = async (encoding: EncodingName): Promise<void> => {
-  await loadTokenizer(encoding)
 }

--- a/src/commands/context-tokenizer.ts
+++ b/src/commands/context-tokenizer.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { Tokenizer as TokenizerType } from 'ai-tokenizer'
+
+export type EncodingName = 'o200k_base' | 'cl100k_base'
+
+const tokenizerCache = new Map<EncodingName, TokenizerType>()
+
+const loadTokenizer = async (encoding: EncodingName): Promise<TokenizerType> => {
+  const cached = tokenizerCache.get(encoding)
+  if (cached !== undefined) return cached
+  const { Tokenizer } = await import('ai-tokenizer')
+  const encodingModule =
+    encoding === 'o200k_base'
+      ? await import('ai-tokenizer/encoding/o200k_base')
+      : await import('ai-tokenizer/encoding/cl100k_base')
+  const tokenizer = new Tokenizer(encodingModule)
+  tokenizerCache.set(encoding, tokenizer)
+  return tokenizer
+}
+
+/**
+ * Synchronous wrapper used by the collector. On first call per encoding,
+ * throws with a special marker so the caller can lazy-load via `prepareDefaultCountTokens`.
+ */
+export const defaultCountTokens = (text: string, encoding: EncodingName): number => {
+  if (text.length === 0) return 0
+  const tokenizer = tokenizerCache.get(encoding)
+  if (tokenizer === undefined) {
+    throw new Error(`tokenizer not loaded: ${encoding}`)
+  }
+  return tokenizer.count(text)
+}
+
+/**
+ * Preload a tokenizer for the given encoding. Must be called before `collectContext`
+ * uses the synchronous `defaultCountTokens`.
+ */
+export const prepareDefaultCountTokens = async (encoding: EncodingName): Promise<void> => {
+  await loadTokenizer(encoding)
+}

--- a/src/commands/context-tool-resolution.ts
+++ b/src/commands/context-tool-resolution.ts
@@ -10,6 +10,7 @@ import { logger } from '../logger.js'
 import { buildProviderForUser } from '../providers/factory.js'
 import type { TaskProvider } from '../providers/types.js'
 import { makeTools } from '../tools/index.js'
+import { routeToolsForMessage, type ToolRoutingIntent } from '../tools/tool-router.js'
 
 const log = logger.child({ scope: 'commands:context-tool-resolution' })
 
@@ -20,8 +21,15 @@ export type BuildLiveToolSet = (
   provider: TaskProvider | null,
 ) => ToolSet | null
 
+export interface ResolvedToolSurfaceRouting {
+  intent: ToolRoutingIntent
+  fullToolCount: number
+  exposedToolCount: number
+}
+
 export interface ResolvedContextToolSurface {
   definitions: Record<string, unknown>
+  routing?: ResolvedToolSurfaceRouting
 }
 
 export function safeBuildProvider(contextId: string): TaskProvider | null {
@@ -62,11 +70,12 @@ export function resolveContextToolSurface(
   contextType: 'dm' | 'group',
   provider: TaskProvider | null,
   buildLiveToolSet: BuildLiveToolSet,
+  lastUserText?: string,
 ): ResolvedContextToolSurface {
   try {
     const liveTools = buildLiveToolSet(storageContextId, actorUserId, contextType, provider)
     if (liveTools !== null) {
-      return { definitions: toToolRecord(liveTools) }
+      return applyRoutingIfApplicable(liveTools, lastUserText)
     }
   } catch (error) {
     log.warn(
@@ -81,6 +90,21 @@ export function resolveContextToolSurface(
   }
 
   return buildDegradedToolSurface(storageContextId)
+}
+
+function applyRoutingIfApplicable(liveTools: ToolSet, lastUserText: string | undefined): ResolvedContextToolSurface {
+  if (lastUserText === undefined || lastUserText.trim().length === 0) {
+    return { definitions: toToolRecord(liveTools) }
+  }
+  const routed = routeToolsForMessage(lastUserText, liveTools)
+  return {
+    definitions: toToolRecord(routed.tools),
+    routing: {
+      intent: routed.decision.intent,
+      fullToolCount: routed.fullToolCount,
+      exposedToolCount: routed.exposedToolCount,
+    },
+  }
 }
 
 function toToolRecord(value: unknown): Record<string, unknown> {

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -20,6 +20,7 @@ import {
   defaultCountTokens,
   prepareDefaultCountTokens,
   resolveEncodingName,
+  type ToolRoutingInfo,
 } from './context-collector.js'
 import {
   buildInvocationToolSet,
@@ -43,6 +44,7 @@ export interface ContextCommandDeps {
     contextType: 'dm' | 'group',
     provider: TaskProvider | null,
     buildLiveToolSet: BuildLiveToolSet,
+    lastUserText?: string,
   ) => ResolvedContextToolSurface
 }
 
@@ -71,6 +73,29 @@ function buildMemoryMessageText(contextId: string, history: readonly ModelMessag
   return memoryMsg === null ? null : memoryMsg.content
 }
 
+function extractTextFromUserContent(content: ModelMessage['content']): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  const parts: string[] = []
+  for (const part of content) {
+    if (typeof part === 'object' && part !== null && 'type' in part && part.type === 'text' && 'text' in part) {
+      const text = (part as { text: unknown }).text
+      if (typeof text === 'string') parts.push(text)
+    }
+  }
+  return parts.join(' ')
+}
+
+export function getLastUserText(history: readonly ModelMessage[]): string | undefined {
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const message = history[i]
+    if (message === undefined || message.role !== 'user') continue
+    const text = extractTextFromUserContent(message.content).trim()
+    if (text.length > 0) return text
+  }
+  return undefined
+}
+
 async function buildCollectorDeps(
   storageContextId: string,
   provider: TaskProvider | null,
@@ -97,6 +122,7 @@ async function buildCollectorDeps(
     getFacts: () => loadFacts(storageContextId),
     getActiveToolDefinitions: (): Record<string, unknown> => deps.resolveActiveToolDefinitions(resolvedToolSurface),
     getProviderName: () => providerName,
+    getToolRoutingInfo: (): ToolRoutingInfo | undefined => resolvedToolSurface.routing,
     countTokens: (text: string): number => defaultCountTokens(text, resolvedEncoding),
   }
 }
@@ -167,12 +193,14 @@ async function handleContextCommand(
   log.debug({ userId: msg.user.id, storageContextId: auth.storageContextId }, '/context command called')
 
   const provider = deps.buildProvider(auth.storageContextId)
+  const lastUserText = getLastUserText(loadHistory(auth.storageContextId))
   const resolvedToolSurface = deps.resolveToolSurface(
     auth.storageContextId,
     msg.user.id,
     msg.contextType,
     provider,
     deps.buildLiveToolSet,
+    lastUserText,
   )
   let snapshot: ContextSnapshot
   try {

--- a/tests/commands/context-collector.test.ts
+++ b/tests/commands/context-collector.test.ts
@@ -138,6 +138,17 @@ describe('collectContext', () => {
     expect(tools.detail).toBe('3 active, gated by kaneo')
   })
 
+  test('Tools detail includes routing info when last user message routed to a subset', () => {
+    const deps = makeDeps({
+      getActiveToolDefinitions: () => ({ save_memo: {}, search_memos: {} }),
+      getProviderName: () => 'kaneo',
+      getToolRoutingInfo: () => ({ intent: 'memo', fullToolCount: 49, exposedToolCount: 2 }),
+    })
+    const snapshot = collectContext('user1', deps)
+    const tools = requireSection(snapshot.sections, 'Tools')
+    expect(tools.detail).toBe('2 of 49 active, gated by kaneo · routed for memo')
+  })
+
   test('returns maxTokens=null for unknown model', () => {
     const deps = makeDeps({ getMainModel: () => 'some-random-new-model' })
     const snapshot = collectContext('user1', deps)

--- a/tests/commands/context-tool-resolution.test.ts
+++ b/tests/commands/context-tool-resolution.test.ts
@@ -30,6 +30,49 @@ describe('context-tool-resolution', () => {
     expect(Object.keys(surface.definitions).length).toBeGreaterThan(0)
   })
 
+  test('resolveContextToolSurface returns the full set when no lastUserText is provided', () => {
+    const provider = createMockProvider()
+    const surface = resolveContextToolSurface('user-1', 'user-1', 'dm', provider, buildInvocationToolSet)
+
+    expect(surface.routing).toBeUndefined()
+  })
+
+  test('resolveContextToolSurface applies routing when lastUserText is provided', () => {
+    const provider = createMockProvider()
+    const full = resolveContextToolSurface('user-1', 'user-1', 'dm', provider, buildInvocationToolSet)
+    const routed = resolveContextToolSurface(
+      'user-1',
+      'user-1',
+      'dm',
+      provider,
+      buildInvocationToolSet,
+      'remember that I prefer morning standups',
+    )
+
+    expect(routed.routing).toBeDefined()
+    expect(routed.routing?.intent).toBe('memo')
+    expect(routed.routing?.fullToolCount).toBe(Object.keys(full.definitions).length)
+    expect(routed.routing?.exposedToolCount).toBe(Object.keys(routed.definitions).length)
+    expect(Object.keys(routed.definitions).length).toBeLessThan(Object.keys(full.definitions).length)
+    expect(routed.definitions).toHaveProperty('save_memo')
+    expect(routed.definitions).not.toHaveProperty('create_task')
+  })
+
+  test('resolveContextToolSurface returns full set when routing falls back to full intent', () => {
+    const provider = createMockProvider()
+    const routed = resolveContextToolSurface(
+      'user-1',
+      'user-1',
+      'dm',
+      provider,
+      buildInvocationToolSet,
+      'can you handle the thing we discussed',
+    )
+
+    expect(routed.routing?.intent).toBe('full')
+    expect(routed.routing?.exposedToolCount).toBe(routed.routing?.fullToolCount)
+  })
+
   test('buildInvocationToolSet returns null when provider is null', () => {
     const result = buildInvocationToolSet('user-1', 'user-1', 'dm', null)
     expect(result).toBeNull()


### PR DESCRIPTION
/context now runs routeToolsForMessage against the most recent user
message and reports the routed subset (e.g. "12 of 49 active, gated by
kaneo · routed for memo") instead of always showing the full max tool
surface. Previously the panel reported 49 tools / 72K tk regardless of
what the next LLM call would actually receive, making the routing
appear broken.

Also extracted tokenizer loading into context-tokenizer.ts to keep
context-collector.ts under the 300-line limit after the new helper.

https://claude.ai/code/session_01EhDxnM8KhP4qknSiRmDVZi