### PR TITLE
docs(billing): design initial migration from BYOK to central LLM + usage telemetry

### DIFF
--- a/docs/superpowers/plans/2026-05-19-central-llm-billing-roadmap.md
+++ b/docs/superpowers/plans/2026-05-19-central-llm-billing-roadmap.md
@@ -214,6 +214,166 @@ moves toward a metering vendor and the outbox path is needed.
 
 ---
 
+## Phase 5 — Anonymous DB-wide statistics
+
+### Goal
+Bot admin can see structural counts and sizes for every domain table in
+the bot's SQLite database, per billing subject and bot-wide, without
+exposing any content. The dataset answers questions the billing research
+flags as inputs to pricing: how heavy is the median user, what's the
+right cap on memos or recurring tasks per tier, which surfaces are
+amplifiers vs niche. Aligns with
+`docs/research/billing/06-papai-integration-notes.md` §3 (cost-amplifier
+surfaces) and `04-metering-and-telemetry.md` §1 (candidate billable
+units).
+
+### Anonymity contract
+Counts, sizes, timestamps, and enum distributions only. Never content,
+never usernames, never message text, never memo bodies, never
+attachment filenames. The only identifiers in the output are
+`storage_context_id` and `chat_user_id`, both already opaque platform
+ids — which the dashboard already exposes. A second "global stats" view
+suppresses even those, returning only aggregates and distributions
+suitable for screenshotting or sharing.
+
+### Scope
+
+#### Per-subject counts (extend the phase 3 subject detail)
+For each `storage_context_id`, count rows in:
+
+| Table | Metrics |
+| --- | --- |
+| `memos` | total, by `status` (active / archived / promoted), by `tags` cardinality, total `content` bytes, total `embedding` bytes, oldest / newest `created_at`, count with `embedding IS NOT NULL` |
+| `scheduled_prompts` | total, pending / fired / cancelled, distinct delivery targets (no target identifiers, just count) |
+| `recurring_tasks` | total, enabled / disabled, distinct `projectId` count, count with `nextRun` in the next 7d, distinct `rrule` patterns (hashed) |
+| `instructions` | total, total `content` bytes |
+| `attachments` | total, by `status`, by `sourceProvider`, total stored bytes (from manifest), count with `isActive=1`, count by `extension` bucket |
+| `message_metadata` | total, by `contextType` derived from id shape, count with `author_id=chat_user_id`, oldest / newest `timestamp`, total `text` bytes (size only) |
+| conversation history | turn count per subject, summary count, total summarized bytes |
+| `user_identity_mappings` | count per provider name |
+| `staged_files` | count, by `status`, total bytes |
+| `users` (for subjects that are users) | `addedAt`, `addedBy` presence, `kaneoWorkspaceId` presence |
+| `group_members` (for subjects that are groups) | member count, distinct `addedBy` count |
+| `group_user_observations` | observation count per group; **counts only**, never observation text |
+| `web_fetch_cache` | distinct hosts (hashed), total fetches per subject if join is feasible, bytes stored |
+| `llm_usage_events` | already in phase 3; included here for completeness |
+| tool-failures (already in dashboard) | count per subject, per `errorType` distribution |
+
+#### Bot-wide aggregates (new "Stats" tab)
+- Total subjects (DM users, groups), with growth chart over the last 30d
+  from `users.addedAt` and `authorized_groups.addedAt`.
+- Per-table totals + distribution percentiles (p50/p90/p99 per subject)
+  for memo count, recurring task count, message count, attachment bytes.
+- Active-subject counts at 1d / 7d / 30d windows derived from
+  `llm_usage_events.occurred_at` (phase 2) and
+  `message_metadata.timestamp`.
+- Storage footprint: SQLite `page_count * page_size`, plus S3 bucket
+  total bytes from the manifest tally.
+- Identity-provider mix: how many subjects have mapped to Kaneo vs
+  YouTrack identity.
+- Recurring vs deferred mix: how many subjects use each surface.
+- Web fetch volume by hashed host (top 20 by count, hosts hashed).
+- Tool usage mix: rolled up from `llm_usage_events.tool_call_count`,
+  refined if phase 4 ships the per-tool table.
+
+External tasks (Kaneo / YouTrack) are out of scope — the bot doesn't
+own that data. The closest local proxies are `users.kaneoWorkspaceId`
+presence and any task-id references stored in `message_metadata`; we
+report those without leaving the local DB.
+
+#### Optional time series — migration 037 (deferred decision)
+A `usage_snapshots(snapshot_at INTEGER, subject_id TEXT, metric TEXT,
+value INTEGER)` table written by a nightly job lets the dashboard chart
+growth. Recommendation: **defer to phase 5b**. The phase 5a slice
+queries live tables on demand. Add the snapshot table only once the
+queries are too slow to run on every dashboard open — typically when
+`memos` or `message_metadata` cross a few hundred thousand rows.
+
+#### Module sketch
+```
+src/stats/
+  index.ts           — public API: getSubjectStats(id), getGlobalStats()
+  per-table.ts       — one query function per source table
+  aggregate.ts       — distribution math (percentiles), bucketing helpers
+  hashing.ts         — keyed hash for rrule patterns + hostnames
+  types.ts           — SubjectStats, GlobalStats
+```
+
+Server routes (phase 5a):
+- `GET /stats/subject/:id` — per-subject stats blob.
+- `GET /stats/global` — bot-wide aggregates.
+
+Dashboard:
+- Subject detail in the Billing tab gains a "Stats" sub-panel.
+- New top-level "Stats" tab shows the bot-wide view.
+
+### Out of scope for this phase
+- No content, ever — even hashed. Hashing applies to rrule strings and
+  hostnames, both already non-PII-ish, only to dedupe for distribution
+  charts without exposing the raw value.
+- No mutation: this phase is read-only against the existing tables.
+- No external provider calls (no live Kaneo `count_tasks`); we count
+  what the bot stored locally and label external-task counts as
+  unknown.
+- No CSV / JSON export to disk in v1; the dashboard rendering is the
+  output. Export is straightforward to add later from the same API.
+- No time series; reconsider in 5b.
+
+### Risk profile
+Low. Read-only queries against existing tables, no schema change in
+5a. Main risk is query cost on large tables (`message_metadata`,
+`memos`) — mitigated by:
+- index check during planning; add missing indexes in 5a only if a
+  required query degrades.
+- caching the global view for 60s in-process; per-subject views are
+  fast enough to compute on click.
+
+### Acceptance
+- `/stats/global` returns shapes documented in `types.ts` and matches
+  hand-rolled SQL aggregates on a seeded fixture.
+- `/stats/subject/:id` returns counts that sum to the totals in the
+  global view, modulo the time window.
+- No raw text, filename, memo body, message body, observation text, or
+  username appears in the response payload for either route — covered
+  by a redaction-style test that diffs the response against a forbidden
+  substring list.
+- Global view renders with 1k seeded subjects + 100k seeded
+  `message_metadata` rows in under 500ms (in-process, on a dev laptop).
+
+### Rollback
+Remove routes and the new tab. No data to roll back; queries are
+read-only.
+
+### Estimated size
+~600 lines server code + tests (mostly tests, the queries are short),
+~700 lines client code + tests for the Stats tab and sub-panel.
+
+### Open questions to resolve before phase 5 starts
+- Anonymity contract — is hashing hostnames in the web-fetch breakdown
+  acceptable, or do we omit them entirely? Recommendation: keyed hash
+  with a per-deployment salt, so values are deterministic in a single
+  deployment but not portable across deployments.
+- Bot-wide view — show only when the deployment has more than N subjects
+  (to avoid trivial deanonymization in tiny deployments)? Recommendation:
+  hide the per-subject id from global view always; show distribution
+  shapes only.
+- Time series — phase 5a (live queries) or jump straight to 5b
+  (`usage_snapshots`)? Recommendation: 5a first; the snapshot table
+  earns its place once we see live-query latency, not before.
+- External task counts (Kaneo / YouTrack) — defer entirely, or call the
+  provider tool's `count_tasks` per subject lazily on dashboard open?
+  Recommendation: defer. Live provider calls turn a stats page into a
+  rate-limit risk surface.
+- Conversation history — currently stored as turns plus summaries; what
+  exactly do we count? Recommendation: turn count and summary count
+  only; ignore byte-size of historical text in 5a.
+
+### Trigger to start
+After phase 3 ships and the Billing tab is in operator hands long
+enough to know which secondary stats they keep asking SQL for.
+
+---
+
 ## Cross-phase concerns
 
 ### Branch strategy
@@ -221,6 +381,7 @@ One branch per phase, off `main`. Naming:
 - `claude/central-llm-phase-1-env-credentials`
 - `claude/central-llm-phase-2-usage-recorder`
 - `claude/central-llm-phase-3-billing-dashboard`
+- `claude/central-llm-phase-5-anonymous-stats` (phase 4 named when scoped)
 
 Each phase merges before the next opens. The design doc and this plan
 land first (current branch).
@@ -242,12 +403,23 @@ runtime check assumes 035's presence.
 - Phase 3: `tests/debug/server-billing.test.ts`,
   `tests/client/billing/*`. Manual smoke: dashboard walkthrough with two
   seeded subjects.
+- Phase 5: `tests/stats/*` from scratch — per-table query tests against
+  seeded fixtures, redaction test that scans the response payload for
+  any forbidden substring (memo bodies, usernames, message text,
+  filenames). Manual smoke: seed 1k subjects + 100k messages, open the
+  global Stats tab, confirm latency budget.
 
 ### Security review checkpoints
 - Phase 1: `bun security` after wizard changes (prompt injection surface
   for the new misconfigured-bot reply).
 - Phase 3: dedicated `/security-review` of the credentials form route.
   Token in the request body must be redacted from access logs.
+- Phase 5: dedicated `/security-review` of the anonymity contract.
+  Reviewer's checklist: every query returns counts/sizes/timestamps
+  only; every string field in the response is either an opaque id, an
+  enum, a keyed-hash, or a number-as-string; the forbidden-substring
+  test exists and passes. Treat any leak of content as a release-
+  blocking defect.
 
 ### Documentation updates
 - Phase 1: `CLAUDE.md` env-var section gains `LLM_API_KEY`,
@@ -256,6 +428,10 @@ runtime check assumes 035's presence.
   key list.
 - Phase 2: no doc change; module is internal.
 - Phase 3: dashboard guide (if one exists) gets a Billing section.
+- Phase 5: dashboard guide gets a Stats section, plus an "Anonymity
+  contract" subsection in `CLAUDE.md` (or a sibling `docs/stats.md`)
+  spelling out which fields are exposed and which are forbidden, so
+  future contributors don't widen the surface accidentally.
 
 ### Open questions to resolve before each phase starts
 Phase 1:
@@ -302,8 +478,16 @@ Phase 3:
                                                                           |
                                                                           v
                                                             Phase 4 (proposed)
-                                                                  ...
+                                                                  |
+                                                                  v
+                                                Phase 5 (anonymous DB stats)
+                                          |---------------------------------------|
+                                            brainstorm → design → plan → impl → review → ship
 ```
+
+Phase 5 does not depend on phase 4 — it can land directly after phase 3.
+The diagram shows it after 4 only because 4's tool-call rows would feed
+phase 5's tool-usage breakdown if available.
 
 No phase opens its plan stage until the prior phase has merged. Each
 phase brings the codebase to a shippable state on its own.

--- a/docs/superpowers/plans/2026-05-19-central-llm-billing-roadmap.md
+++ b/docs/superpowers/plans/2026-05-19-central-llm-billing-roadmap.md
@@ -1,0 +1,309 @@
+# Central LLM + Billing — Phased Rollout Plan
+
+**Date:** 2026-05-19
+**Status:** Draft
+**Design reference:** [`../specs/2026-05-19-central-llm-billing-design.md`](../specs/2026-05-19-central-llm-billing-design.md)
+**Branch baseline:** `claude/central-llm-billing-design-HTCaV`
+
+## Why phase this work
+
+The design doc covers three distinct concerns wired together: removing BYOK,
+recording usage, and surfacing it on the dashboard. They share a goal but
+not a blast radius:
+
+- The credential change is user-visible and touches the message hot path.
+- The telemetry change is silent and additive.
+- The dashboard change is admin-only and isolated.
+
+Shipping them as one branch couples three reviews and three release
+windows. Splitting them lets each phase land, soak, and unblock the next.
+
+Each phase runs through the same five-step workflow:
+
+1. **Brainstorm** — short open exploration; alternatives, trade-offs, open
+   questions. Output: a brainstorm note in `docs/superpowers/notes/`.
+2. **Design** — chosen approach with decisions and non-goals. Output: a
+   design doc in `docs/superpowers/specs/` (this rollout already has one
+   covering the whole scope; per-phase design docs refine it).
+3. **Planning** — sequenced implementation steps with file edits, tests,
+   migration ordering, rollback. Output: a plan in
+   `docs/superpowers/plans/`.
+4. **Implementation** — one feature branch per phase, merged when green.
+5. **Review** — security pass, manual smoke, dashboard walkthrough where
+   applicable. Output: review comments on the PR.
+
+## Phase 1 — Central LLM credentials, env-only
+
+### Goal
+New users can DM the bot and get a useful reply without entering an LLM API
+key. Bot admin sets credentials once via environment variables.
+
+### Scope
+- Migration 034: create `system_config` table.
+- Migration 036: delete the five LLM keys from `user_config`.
+- On startup, seed `system_config` from `LLM_API_KEY`, `LLM_BASE_URL`,
+  `MAIN_MODEL`, `SMALL_MODEL`, `EMBEDDING_MODEL` when rows are missing.
+- `src/llm-orchestrator-config.ts` reads LLM keys from `system_config`
+  instead of `user_config`.
+- `src/wizard/steps.ts`: remove the five LLM wizard steps.
+- `src/types/config.ts`: drop `LlmConfigKey` and the LLM entries in
+  `CONFIG_KEYS` / `ALL_CONFIG_KEYS`.
+- `src/config.ts`: drop `copyAdminLlmConfig`, `isMissingLlmConfig`,
+  `LLM_COPY_KEYS`, `llm_apikey` from `SENSITIVE_KEYS`.
+- `src/providers/kaneo/provision.ts`: drop `copyAdminLlmConfig` callsites.
+- Orchestrator emits a "bot misconfigured" reply when `system_config` is
+  empty, instead of "complete /setup".
+
+### Out of scope for this phase
+- No dashboard admin form. Credentials change requires env update + restart.
+- No usage telemetry table — phase 2.
+- No billing UI — phase 3.
+
+### Risk profile
+Highest of the three. Touches the hot path, deletes user data, removes a
+wizard branch. Needs careful staging.
+
+### Acceptance
+- Fresh-install bot with `LLM_API_KEY` env set answers a first message
+  with no `/setup` interaction beyond task provider + timezone.
+- Existing users keep working: migration drops their LLM rows; bot now
+  reads admin's env-seeded keys.
+- All existing tests pass; new tests cover the migration and the new
+  resolution path.
+
+### Rollback
+- Revert the orchestrator and wizard code changes; the `system_config`
+  rows can stay (harmless once unused).
+- Migration 036 (the destructive one) is one-way at the data level; a
+  rollback restores BYOK as a code surface but the per-user keys users
+  previously typed are gone. Mitigate by exporting `user_config` rows to
+  a backup file before migration 036 runs.
+
+### Estimated size
+~600 lines code + migrations, ~400 lines tests.
+
+---
+
+## Phase 2 — Usage telemetry recording
+
+### Goal
+Every `llm:end` event becomes a durable row in `llm_usage_events`. No UI
+yet. The bot collects pricing data silently so phase 3 has something to
+show.
+
+### Scope
+- Migration 035: create `llm_usage_events` table + indexes.
+- `src/db/schema.ts`: add Drizzle table.
+- `src/usage/` module:
+  - `recorder.ts` — `recordUsage(payload)` inserts one row.
+  - `index.ts` — `initUsageRecorder()` subscribes to the event bus.
+  - `query.ts` — read helpers (used by phase 3 but landed here so the
+    public surface is testable end-to-end).
+  - `types.ts` — `UsageEvent`, `SubjectSummary`, `RequestRow`.
+- `src/index.ts`: call `initUsageRecorder()` after DB init.
+- Cover both main-model and embedding callsites. `src/embeddings.ts:18`
+  and `src/web/distill.ts:88` are the embedding entry points; route them
+  through a thin wrapper that emits a recorder-shaped event (or extend
+  `emitLlmEnd` with a `modelRole` parameter — design call inside the
+  phase 2 brainstorm).
+- Idempotency: ULID per event, generated in-process. `event_id` is a
+  primary key — duplicate inserts fail loudly in tests, never silently.
+
+### Out of scope for this phase
+- No HTTP routes — phase 3.
+- No dashboard tab — phase 3.
+- No tool-call rows; per-request `tool_call_count` is enough.
+- No daily roll-ups; raw query works at this volume.
+
+### Risk profile
+Low. Additive table, additive module. Recorder failures must not break
+the event bus — wrapped in try/catch with log, no rethrow.
+
+### Acceptance
+- After a real LLM call, one row appears in `llm_usage_events` with
+  populated tokens, model, model role, turn id, both subject ids.
+- Failed `llm:end` (error path) still produces a row with `error` set.
+- A recorder exception is logged and dropped; other subscribers
+  (`state-collector`, telemetry) continue to fire.
+- New `tests/usage/*` suite exercises recorder + query in isolation
+  using DI; query results match raw SQL on a seeded fixture.
+
+### Rollback
+Drop the migration; remove the `initUsageRecorder()` call. Fully
+reversible.
+
+### Estimated size
+~400 lines code + migration, ~500 lines tests.
+
+---
+
+## Phase 3 — Billing dashboard tab + admin credentials form
+
+### Goal
+Bot admin opens the dashboard, sees subjects sorted by tokens, drills
+into one, and updates LLM credentials without restarting.
+
+### Scope
+- `src/debug/server.ts`: routes
+  - `GET /billing/subjects?window=30d`
+  - `GET /billing/subject/:id?window=30d`
+  - `GET /admin/llm`
+  - `POST /admin/llm`
+- `src/system-config.ts`: `setSystemConfig(key, value, adminId)` writes
+  to the table created in phase 1. Bot admin is authenticated by the
+  same `DEBUG_TOKEN` that gates the dashboard.
+- Subject display-name resolver: join to `users.username` for DMs, to
+  `authorized_groups` / `group_user_observations` for groups, fall back
+  to raw id.
+- `client/debug/dashboard-types.ts`: add `billingSubjects`,
+  `billingDetail` to `DashboardState`.
+- `client/debug/dashboard.svelte.ts`: new "Billing" tab.
+- New components:
+  - `client/debug/billing/SubjectsTable.svelte` — sortable list with
+    main / small / embedding columns.
+  - `client/debug/billing/SubjectDetail.svelte` — virtualized per-request
+    table, expandable rows.
+  - `client/debug/billing/CredentialsForm.svelte` — masked display +
+    edit-to-replace input per key.
+- Window selector: 24h / 7d / 30d / all.
+
+### Out of scope for this phase
+- No charts (explicitly "very basic").
+- No CSV export.
+- No DM `/admin` command — credentials still change via dashboard only.
+- No tool-call drill-down beyond the per-turn count.
+
+### Risk profile
+Medium. New UI surface; only visible to admin. The credentials form is
+the new sensitive surface and needs a security review.
+
+### Acceptance
+- Billing tab loads, lists subjects with totals matching a
+  hand-rolled SQL aggregate over `llm_usage_events`.
+- Clicking a subject shows its request rows; row expansion shows
+  per-request JSON.
+- Admin pastes a new API key into the form; bot's next LLM call uses it
+  without restart.
+- Form rejects unauthenticated requests with 401; admin route audit log
+  records the change with `updated_by`.
+
+### Rollback
+Remove the new routes and the Billing tab; data tables stay.
+
+### Estimated size
+~500 lines server code + tests, ~800 lines client code + tests.
+
+---
+
+## Phase 4 (proposed) — Tool-call rows + idempotency hardening
+
+Listed for visibility, not committed.
+
+### Possible scope
+- New `tool_call_events` table mirroring `llm_usage_events` shape, keyed
+  by `turn_id`.
+- Switch `event_id` to a deterministic hash of
+  `(responseId, occurredAt, modelRole)` so the recorder is safe outside
+  the in-process bus (queue, retry).
+- Cross-process outbox columns: `forwarded_at`, `forward_attempts`,
+  `forward_error`. No worker yet — just the schema slot.
+
+### Trigger to start
+Phase 3 data shows tool-call cost is material, or the billing research
+moves toward a metering vendor and the outbox path is needed.
+
+---
+
+## Cross-phase concerns
+
+### Branch strategy
+One branch per phase, off `main`. Naming:
+- `claude/central-llm-phase-1-env-credentials`
+- `claude/central-llm-phase-2-usage-recorder`
+- `claude/central-llm-phase-3-billing-dashboard`
+
+Each phase merges before the next opens. The design doc and this plan
+land first (current branch).
+
+### Migration ordering
+Phase 1: 034, 036. Phase 2: 035. The numeric gap is intentional — 035
+lands second but ordering by phase is the user-facing contract.
+
+If phase 1 ships first and phase 2 is delayed, the table count is
+consistent: `system_config` exists, `llm_usage_events` does not. No
+runtime check assumes 035's presence.
+
+### Test strategy per phase
+- Phase 1: extend `tests/llm-orchestrator-config.test.ts`,
+  `tests/wizard/steps.test.ts`, new `tests/db/migrations/034-*` and
+  `036-*`. Manual smoke: fresh container with env vars only.
+- Phase 2: `tests/usage/*` from scratch, isolated with DI. Manual smoke:
+  one real conversation, eyeball the row.
+- Phase 3: `tests/debug/server-billing.test.ts`,
+  `tests/client/billing/*`. Manual smoke: dashboard walkthrough with two
+  seeded subjects.
+
+### Security review checkpoints
+- Phase 1: `bun security` after wizard changes (prompt injection surface
+  for the new misconfigured-bot reply).
+- Phase 3: dedicated `/security-review` of the credentials form route.
+  Token in the request body must be redacted from access logs.
+
+### Documentation updates
+- Phase 1: `CLAUDE.md` env-var section gains `LLM_API_KEY`,
+  `LLM_BASE_URL`, `MAIN_MODEL`, `SMALL_MODEL`, `EMBEDDING_MODEL` as
+  required at startup. `llm_apikey` and friends leave the runtime config
+  key list.
+- Phase 2: no doc change; module is internal.
+- Phase 3: dashboard guide (if one exists) gets a Billing section.
+
+### Open questions to resolve before each phase starts
+Phase 1:
+- Do we hard-fail on missing env vars at startup, or boot and reply
+  "bot misconfigured" until the admin sets them via dashboard
+  (which phase 1 does not have)? Recommendation: hard-fail in phase 1
+  because there is no other way to set them yet; relax to soft-fail
+  when phase 3 lands the admin form.
+- Should we keep `copyAdminLlmConfig` as dead code through phase 1 and
+  remove in phase 2, or remove immediately? Recommendation: remove
+  immediately, smaller diff is easier to review.
+
+Phase 2:
+- One emit point or three? Main, small, and embedding use the same OpenAI
+  client and could share an emitter; separate emitters might be cleaner
+  per modelRole. Decide in phase 2 brainstorm.
+- Where does embedding token count come from when the call is made by
+  `web/distill.ts`? May be unsupported by the provider — store NULL.
+
+Phase 3:
+- `displayName` is best-effort. If a group has no recorded title in
+  `group_user_observations`, do we hit the chat provider live for the
+  name, or show the raw id? Recommendation: raw id only in v1; the live
+  lookup belongs in a future enrichment pass.
+- Window selector default: 30d feels right, but 7d makes the table
+  smaller for ops eyeballing. Pick when the UI lands.
+
+## Sequence diagram (rollout view)
+
+```
+              Phase 1 (env credentials)
+   |---------------------------------------------|
+              brainstorm → design → plan → impl → review → ship
+                                                     |
+                                                     v
+                                  Phase 2 (usage recorder)
+                          |--------------------------------|
+                            brainstorm → design → plan → impl → review → ship
+                                                            |
+                                                            v
+                                          Phase 3 (billing tab + admin form)
+                                  |---------------------------------------|
+                                    brainstorm → design → plan → impl → review → ship
+                                                                          |
+                                                                          v
+                                                            Phase 4 (proposed)
+                                                                  ...
+```
+
+No phase opens its plan stage until the prior phase has merged. Each
+phase brings the codebase to a shippable state on its own.

--- a/docs/superpowers/specs/2026-05-19-central-llm-billing-design.md
+++ b/docs/superpowers/specs/2026-05-19-central-llm-billing-design.md
@@ -1,0 +1,452 @@
+# Central LLM + Initial Billing Telemetry Design
+
+**Date:** 2026-05-19
+**Status:** Draft (initial scope)
+**Approach:** Drop BYOK from the user-visible setup; serve LLM calls from one
+admin-owned credential set; capture per-call usage rows in SQLite; surface them
+through a new dashboard tab.
+
+## Context
+
+Today every user must complete a 5-step LLM wizard (`llm_apikey`,
+`llm_baseurl`, `main_model`, `small_model`, `embedding_model`) before the bot
+will answer anything. The keys live as per-user rows in the `user_config`
+table; `getLlmConfig` reads them through `getCachedConfig` in
+`src/llm-orchestrator-config.ts:43`. New users get admin's values copied in
+on group provisioning via `copyAdminLlmConfig` (`src/config.ts:73`), but DM
+users see the full wizard.
+
+This is friction with no product value: operators of the bot already pay for
+the model, so users do not gain anything by typing credentials, and we get
+nothing in return — no central view of cost, no per-user attribution, no way
+to evaluate pricing because token usage is emitted on the in-process event
+bus and then dropped.
+
+The billing research bundle in `docs/research/billing/` enumerates the
+packaging and provider decisions that come later. Two findings from that
+bundle frame the work below:
+
+- `06-papai-integration-notes.md` §2 calls BYOK out as a packaging fork. Once
+  central LLM is the default, the "managed-LLM" branch becomes the only
+  branch and the BYOK fork can come back later as an explicit feature.
+- `04-metering-and-telemetry.md` §2–§3 prescribes a CloudEvents-shaped
+  metering payload and an outbox table inside the same SQLite database. The
+  shape we persist now should slot into that outbox later without a rewrite.
+
+## Goals
+
+1. New users send their first message and get an answer with zero setup.
+2. Bot admin owns one set of LLM credentials, set once.
+3. Every LLM call produces a durable row keyed by billable subject, model,
+   tokens, and turn id. Tool calls observed by the same turn id.
+4. Debug dashboard gets a Billing tab: subject list with totals, drill-down
+   to per-request rows.
+5. Shape of stored events is forward-compatible with the metering pipeline
+   described in `04-metering-and-telemetry.md` — no rewrite to reach the
+   outbox-plus-vendor pattern later.
+
+## Non-goals
+
+- No real pricing, no rating, no invoices, no Stripe or any PSP.
+- No quota enforcement, no rate gating, no soft caps. The dashboard is
+  read-only.
+- No re-introduction of BYOK as a paid SKU; that is a packaging decision
+  the billing research has not closed.
+- No rewrite of the wizard engine — only the LLM steps move out.
+- No cross-platform identity merge. `platform_user_id` stays the subject
+  key, same trade-off documented in `06-papai-integration-notes.md` §1.
+- No Discord Premium / Telegram Payments work.
+
+## Decisions
+
+### D1. Central credentials live in the `system_config` table, env is bootstrap only
+
+Add a new single-table store:
+
+```sql
+CREATE TABLE system_config (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  updated_by TEXT NOT NULL  -- platform_user_id of bot admin who set it
+);
+```
+
+Keys, all owned by the bot admin: `llm_apikey`, `llm_baseurl`, `main_model`,
+`small_model`, `embedding_model`.
+
+On startup, `src/index.ts` reads optional env vars `LLM_API_KEY`,
+`LLM_BASE_URL`, `MAIN_MODEL`, `SMALL_MODEL`, `EMBEDDING_MODEL` and seeds any
+missing row in `system_config`. Once seeded, env is ignored: DB is the source
+of truth. This matches the existing pattern where `KANEO_CLIENT_URL` is env
+but per-user `kaneo_apikey` is DB.
+
+Rationale for a new table rather than reusing `user_config` with a reserved
+`platform_user_id`:
+
+- Keeps the `users` foreign key on `user_config` clean (migration 023 added
+  FKs there).
+- Auditing — `updated_by` records which admin changed credentials when there
+  is more than one admin in the future.
+- Eliminates ambiguity in `getCachedConfig` callsites: there is no risk of a
+  per-user override silently shadowing a central value.
+
+### D2. Resolution order: system_config only, no per-user fallback
+
+`getLlmConfig(contextId)` in `src/llm-orchestrator-config.ts:43` changes to
+read from `system_config` only. `readConfig(contextId, 'llm_apikey' | ...)`
+in the same file (line 19) stops accepting LLM keys; those keys are removed
+from its union type.
+
+Removed surface (per-user LLM keys):
+
+- `LlmConfigKey` in `src/types/config.ts:15` drops to empty / is removed.
+- `getConfigKeysForProvider` in `src/types/config.ts:30` no longer emits LLM
+  keys into `CONFIG_KEYS` or `ALL_CONFIG_KEYS`.
+- `copyAdminLlmConfig` and `isMissingLlmConfig` in `src/config.ts:69-83` are
+  deleted along with `LLM_COPY_KEYS`. Their only callers in
+  `src/providers/kaneo/provision.ts:229-243` are removed — group provisioning
+  no longer needs to copy keys because all calls read from `system_config`.
+- `SENSITIVE_KEYS` in `src/config.ts:13` loses `llm_apikey`. The masking
+  helper still applies to `kaneo_apikey` and `youtrack_token`.
+
+Migration 034 drops the LLM rows that already exist in `user_config` so the
+table does not carry dead data:
+
+```sql
+DELETE FROM user_config
+WHERE key IN ('llm_apikey', 'llm_baseurl', 'main_model',
+              'small_model', 'embedding_model');
+```
+
+### D3. Wizard loses the LLM steps; gains a "central credentials not set" error path
+
+`src/wizard/steps.ts:34-55` defines the wizard step list. The five LLM steps
+disappear. The wizard becomes:
+
+1. Task provider key (`kaneo_apikey` or `youtrack_token`) — required.
+2. `timezone` — required.
+
+That is roughly 30 seconds of friction instead of two minutes.
+
+`checkRequiredConfig` in `src/llm-orchestrator-config.ts:28` no longer reports
+missing LLM keys at the per-context level. It does still need to fail loudly
+when `system_config` itself is empty — that is a bot operator problem, not a
+user problem. Behavior:
+
+- If `system_config` is missing any of the three required keys (`llm_apikey`,
+  `llm_baseurl`, `main_model`), the orchestrator replies with "The bot is not
+  fully configured. The bot administrator has been notified." and emits an
+  `error` log including the missing keys.
+- The bot admin gets a DM from the bot pointing at the dashboard's
+  credentials form, or instructions to set env vars and restart. This is a
+  rare path; we do not need a polished UI for it in v1.
+
+### D4. Admin sets credentials via debug dashboard form (DM `/admin` deferred)
+
+Phase 1 ships two entry points for the admin:
+
+- **Env-var bootstrap.** Set `LLM_API_KEY`, `LLM_BASE_URL`, `MAIN_MODEL`,
+  `SMALL_MODEL`, `EMBEDDING_MODEL` before first start. Migration 034 seeds
+  them. Sufficient for self-hosters.
+- **Dashboard credentials form.** Existing dashboard already runs behind
+  `DEBUG_TOKEN`; the admin is the only intended viewer. New `POST /admin/llm`
+  route writes a single key into `system_config`. `GET /admin/llm` returns
+  the current set with the API key masked the same way `maskValue` already
+  masks user keys.
+
+A DM `/admin` command is *not* in scope for v1 — it adds new auth surface
+(only bot admin) and a new wizard branch. Defer until the dashboard form
+shows real friction.
+
+### D5. Per-LLM-call usage row, written from the event bus
+
+New table `llm_usage_events` records one row per `llm:end`:
+
+```sql
+CREATE TABLE llm_usage_events (
+  event_id TEXT PRIMARY KEY,                -- ULID, idempotency key
+  occurred_at INTEGER NOT NULL,             -- ms epoch, == event timestamp
+  turn_id TEXT,                             -- nullable, joins to logs
+  storage_context_id TEXT NOT NULL,         -- billing subject scope
+  context_type TEXT NOT NULL,               -- 'dm' | 'group'
+  chat_user_id TEXT NOT NULL,               -- platform_user_id of caller
+  model TEXT NOT NULL,                      -- resolved/actualModel
+  model_role TEXT NOT NULL,                 -- 'main' | 'small' | 'embedding'
+  input_tokens INTEGER,                     -- nullable: provider may omit
+  output_tokens INTEGER,
+  step_count INTEGER NOT NULL,              -- result.steps.length
+  tool_call_count INTEGER NOT NULL,
+  message_count INTEGER NOT NULL,           -- context size at call time
+  finish_reason TEXT,
+  duration_ms INTEGER NOT NULL,
+  response_id TEXT,
+  error TEXT                                -- null on success
+);
+
+CREATE INDEX idx_llm_usage_subject ON llm_usage_events(storage_context_id, occurred_at);
+CREATE INDEX idx_llm_usage_chat_user ON llm_usage_events(chat_user_id, occurred_at);
+CREATE INDEX idx_llm_usage_turn ON llm_usage_events(turn_id);
+CREATE INDEX idx_llm_usage_occurred ON llm_usage_events(occurred_at);
+```
+
+Field-by-field justification anchored to the metering doc:
+
+- `event_id` is the `identifier` in Stripe terms / `id` in CloudEvents terms
+  (see `04-metering-and-telemetry.md` §2). ULID generated in-process before
+  the row is inserted.
+- `storage_context_id` is the "billable subject" key. For DMs that is the
+  user id; for groups, the group id (or `groupId:threadId`). Same value
+  `bot.ts` passes to the orchestrator as `contextId`.
+- `chat_user_id` is preserved separately because in groups the subject is
+  the group but cost should still be attributable to the individual who
+  triggered the call.
+- `model_role` distinguishes main vs small vs embedding for the per-model
+  totals in the dashboard.
+- `input_tokens` / `output_tokens` are nullable because some
+  OpenAI-compatible providers do not return usage; recording `NULL`
+  preserves the row for context-size and tool-call counts and keeps the
+  audit trail.
+
+The row is written **synchronously inside the event handler** when the
+`llm:end` event fires. This is an additional handler subscribed to the
+debug event bus, parallel to `state-collector.ts`. Writing in the same
+process before the next message means latency cost is bounded; SQLite
+inserts at this rate are cheap.
+
+Where to subscribe: a new `src/usage/` module with `recordUsage(event)`
+exported. `src/llm-orchestrator-events.ts:153-202` already builds the
+`llm:end` payload — the recorder reads from the bus rather than the
+orchestrator calling a function directly, so the orchestrator stays
+decoupled.
+
+Module sketch:
+
+```
+src/usage/
+  index.ts          — initUsageRecorder(): subscribes to llm:end + tool events
+  recorder.ts       — recordUsage(payload) -> INSERT into llm_usage_events
+  query.ts          — listSubjects(), getSubjectDetail(id), getRequestRows(id)
+  types.ts          — UsageEvent, SubjectSummary
+```
+
+Tool calls do not get their own table in v1 — the per-turn
+`tool_call_count` is enough for the dashboard. The tool-failure stream the
+debug server already collects (`toolFailures` in `dashboard-types.ts`) is
+already keyed by turn id, so the drill-down join is free.
+
+#### Why this is forward-compatible with the outbox pattern
+
+`04-metering-and-telemetry.md` §3 recommends an `outbox` table that a worker
+drains into Stripe / OpenMeter. `llm_usage_events` is the outbox-shaped
+table, minus a `forwarded` / `committed` flag. When the billing pipeline
+arrives:
+
+- add columns: `forwarded_at INTEGER`, `forward_attempts INTEGER DEFAULT 0`,
+  `forward_error TEXT`.
+- write a worker that selects un-forwarded rows, POSTs CloudEvents to the
+  metering target, and sets `forwarded_at`.
+- the producer side does not change.
+
+So the v1 table *is* the v2 outbox.
+
+### D6. Dashboard Billing tab
+
+The debug dashboard at `client/debug/` is a Svelte app driven by a single
+reactive `DashboardState` (`dashboard.svelte.ts`). Add:
+
+State additions (in `dashboard-types.ts:115-137`):
+
+```ts
+billingSubjects: BillingSubject[]      // list view
+billingDetail: BillingDetail | null    // drill-down, fetched on open
+```
+
+Routes added to `src/debug/server.ts`:
+
+| Route | Returns |
+| --- | --- |
+| `GET /billing/subjects?window=30d` | Array of `BillingSubject` for the list |
+| `GET /billing/subject/:id?window=30d` | `BillingDetail` for one subject |
+| `GET /admin/llm` | Current system_config keys with `llm_apikey` masked |
+| `POST /admin/llm` | `{ key, value }`; writes to `system_config` |
+
+Shapes:
+
+```ts
+interface BillingSubject {
+  storageContextId: string
+  contextType: 'dm' | 'group'
+  displayName: string | null    // username or group title if known
+  totals: {
+    main:      { inputTokens: number; outputTokens: number; calls: number }
+    small:     { inputTokens: number; outputTokens: number; calls: number }
+    embedding: { inputTokens: number; outputTokens: number; calls: number }
+  }
+  toolCalls: number
+  lastActiveAt: number
+}
+
+interface BillingDetail {
+  subject: BillingSubject
+  requests: Array<{
+    eventId: string
+    occurredAt: number
+    turnId: string | null
+    chatUserId: string
+    model: string
+    modelRole: 'main' | 'small' | 'embedding'
+    inputTokens: number | null
+    outputTokens: number | null
+    stepCount: number
+    toolCallCount: number
+    messageCount: number          // context size
+    durationMs: number
+    finishReason: string | null
+    error: string | null
+  }>
+}
+```
+
+`displayName` is best-effort: join to `users.username` when subject is a DM,
+or to `authorized_groups`/`group_user_observations` (already used by the
+group selector) for a group title. If unknown, return null; the UI shows the
+raw id.
+
+UI:
+
+- New "Billing" tab in the dashboard nav, alongside Logs / Turns / Memos /
+  Recurring.
+- Top half: subjects table, sortable by total tokens. Columns: subject,
+  type, main in/out, small in/out, calls, last active.
+- Bottom half: when a row is clicked, fetch `/billing/subject/:id` and show
+  a virtualized table of requests, one row per `llm_usage_events` row.
+- Each request row expands to show the JSON payload (model, finish reason,
+  step count, tool call count, message count, duration).
+- Window selector: 24h / 7d / 30d / all. Default 30d.
+- A small "LLM credentials" form sits at the top of the tab and posts to
+  `POST /admin/llm`. The API key is shown masked; clicking "edit" reveals a
+  blank input so a paste replaces the value.
+
+No charts in v1 — the user explicitly asked for "very basic". Tables only.
+
+### D7. Logging and PII rules
+
+`06-papai-integration-notes.md` §10 calls out that billing fields are
+sensitive. v1 is internal-only and already gated by `DEBUG_TOKEN`, but:
+
+- Never log `llm_apikey` content. The dashboard form posts it, the route
+  writes it, the recorder never reads it.
+- Log `event_id`, `storage_context_id`, `chat_user_id`, `model`, token
+  counts. Do not log `generatedText`, which is on the event bus but is
+  not persisted in `llm_usage_events`.
+- The recorder catches and logs its own errors; it must never throw out
+  into the event bus subscriber chain because that would block other
+  subscribers (state collector, telemetry).
+
+## Migration order
+
+1. **034_system_config** — create `system_config` table, optionally seed
+   from env vars.
+2. **035_llm_usage_events** — create `llm_usage_events` plus indexes.
+3. **036_drop_user_llm_config** — `DELETE FROM user_config WHERE key IN
+   (...)`. Schema change only after step 1 proves out in staging.
+
+Steps 1 and 2 are additive and reversible. Step 3 is irreversible by data
+but reversible by code revert (admin re-runs `/setup` per-user, BYOK back).
+
+## Code changes summary
+
+| File | Change |
+| --- | --- |
+| `src/db/migrations/034_system_config.ts` | New: create table, optional env seeding |
+| `src/db/migrations/035_llm_usage_events.ts` | New: create table + indexes |
+| `src/db/migrations/036_drop_user_llm_config.ts` | New: delete LLM rows from `user_config` |
+| `src/db/schema.ts` | Add `systemConfig`, `llmUsageEvents` Drizzle tables |
+| `src/system-config.ts` | New: `getSystemConfig(key)`, `setSystemConfig(key, value, adminId)` |
+| `src/llm-orchestrator-config.ts:19-47` | Read LLM keys from `system_config`, not `user_config` |
+| `src/llm-orchestrator-config.ts:28` | `checkRequiredConfig` no longer returns LLM keys |
+| `src/llm-orchestrator.ts:99-110` | New "bot misconfigured" reply when system_config is empty |
+| `src/types/config.ts:15` | Remove `LlmConfigKey`; remove LLM keys from `ALL_CONFIG_KEYS` and `CONFIG_KEYS` |
+| `src/config.ts:13,57-83` | Remove `llm_apikey` from `SENSITIVE_KEYS`; delete `LLM_COPY_KEYS`, `copyAdminLlmConfig`, `isMissingLlmConfig` |
+| `src/wizard/steps.ts:34-55` | Remove the five LLM steps |
+| `src/providers/kaneo/provision.ts:229-243` | Remove `copyAdminLlmConfig` calls |
+| `src/usage/index.ts` | New: subscribe to `llm:end`, call recorder |
+| `src/usage/recorder.ts` | New: insert into `llm_usage_events` |
+| `src/usage/query.ts` | New: aggregation queries for dashboard |
+| `src/index.ts` | Call `initUsageRecorder()` after DB init; seed `system_config` from env |
+| `src/debug/server.ts:182-200` | Route `/billing/subjects`, `/billing/subject/:id`, `/admin/llm` (GET, POST) |
+| `client/debug/dashboard-types.ts:115-137` | Add `billingSubjects`, `billingDetail` to `DashboardState` |
+| `client/debug/dashboard.svelte.ts` | New Billing tab component + nav entry |
+| `client/debug/billing/SubjectsTable.svelte` | New |
+| `client/debug/billing/SubjectDetail.svelte` | New |
+| `client/debug/billing/CredentialsForm.svelte` | New |
+
+Tests (under `tests/`):
+
+- `tests/db/migrations/034-system-config.test.ts` — table created, env seed.
+- `tests/db/migrations/035-llm-usage-events.test.ts` — indexes present.
+- `tests/system-config.test.ts` — get/set, masking on `llm_apikey`.
+- `tests/llm-orchestrator-config.test.ts` — extend existing suite for the
+  new resolution order; assert wizard-required keys no longer include LLM.
+- `tests/usage/recorder.test.ts` — `llm:end` event with usage produces one
+  row; missing token usage produces row with NULL tokens; idempotency by
+  `event_id` is preserved on retry.
+- `tests/usage/query.test.ts` — aggregates per subject and per model role.
+- `tests/debug/server-billing.test.ts` — `/billing/subjects` returns the
+  expected shape; `/admin/llm` write is admin-gated by `DEBUG_TOKEN`.
+- `tests/client/billing.test.ts` — subjects render; clicking opens detail
+  fetch.
+
+E2E (`tests/e2e/`) — out of scope for v1; the existing Kaneo E2E does not
+exercise the dashboard.
+
+## Open questions for the next session
+
+1. **Group vs user attribution on the invoice side.** v1 stores both
+   `storage_context_id` and `chat_user_id` so we can roll up either way.
+   Packaging picks the unit later.
+2. **Embedding usage rows.** `src/embeddings.ts:18` and `src/web/distill.ts:88`
+   also build OpenAI-compatible clients. v1 should route them through the
+   same `system_config` keys; whether each embedding call should produce a
+   `model_role='embedding'` row is a judgment call — recommendation is
+   yes, because embeddings on bulk imports are exactly the kind of cost
+   spike the billing research flagged.
+3. **Tool-call cost rows.** Skipped in v1, but
+   `04-metering-and-telemetry.md` §1 lists tool calls as a candidate
+   billable unit. A `tool_call_events` table mirroring `llm_usage_events`
+   is a small follow-up that gives us the per-tool cost mix.
+4. **Aggregation roll-ups.** Querying `llm_usage_events` raw works at the
+   current message volume. At some scale we will want a nightly job that
+   writes daily roll-ups into `llm_usage_daily`. Not needed before the
+   table has months of data.
+5. **Idempotency across restarts.** `event_id` is a process-local ULID. If
+   `recordUsage` ever runs outside the in-process handler (queue, retry),
+   we want the id to be derived deterministically — e.g.
+   `hash(responseId, occurredAt)`. v1 does not need this because the
+   recorder runs synchronously on the bus.
+6. **Cross-platform identity merge.** Still out of scope. When in scope,
+   `llm_usage_events.chat_user_id` joins to whatever identity table
+   replaces `users.platform_user_id`.
+
+## Out of scope, for reference
+
+- Stripe / Paddle / Polar integration (see `03-payment-providers.md`).
+- Quota enforcement, free-tier caps, dunning (see
+  `05-compliance-and-tax.md` §refunds + `06-papai-integration-notes.md` §3).
+- Customer-facing self-serve portal — Stripe Customer Portal when billing
+  ships, not a homegrown UI.
+- OpenTelemetry mirroring of usage metrics — already covered by the
+  approved telemetry design (`2026-04-26-telemetry-metrics-design.md`);
+  usage rows are the source of truth, OTel mirrors aggregates.
+
+## Reading order for the implementor
+
+1. This document.
+2. `docs/research/billing/06-papai-integration-notes.md` for the
+   integration-point map.
+3. `docs/research/billing/04-metering-and-telemetry.md` §1–§4 for the
+   event shape that `llm_usage_events` follows.
+4. `src/llm-orchestrator-events.ts:153-202` to confirm the event payload
+   the recorder reads.
+5. Then start at migration 034.


### PR DESCRIPTION
Drops per-user llm_apikey/llm_baseurl/main_model/small_model/embedding_model
in favor of a single admin-owned system_config table seeded from env vars.
Wizard loses its 5 LLM steps so new users go straight from /start to a working
bot. Adds an llm_usage_events outbox-shaped table (one row per llm:end, keyed
by storage_context_id + chat_user_id + model_role) and a Billing tab in the
debug dashboard with a subjects list and per-request drill-down. Shape aligns
with docs/research/billing/04-metering-and-telemetry.md so the same table can
later be drained by a worker into Stripe/OpenMeter without producer-side changes.