### PR TITLE
docs(billing): add Phase 2 brainstorm, per-phase design, and plan

### DIFF
--- a/docs/superpowers/notes/2026-05-19-phase-2-usage-recorder-brainstorm.md
+++ b/docs/superpowers/notes/2026-05-19-phase-2-usage-recorder-brainstorm.md
@@ -1,0 +1,514 @@
+# Phase 2 — Usage Telemetry Recorder, Brainstorm
+
+**Date:** 2026-05-19
+**Parent plan:** [`../plans/2026-05-19-central-llm-billing-roadmap.md`](../plans/2026-05-19-central-llm-billing-roadmap.md)
+**Parent design:** [`../specs/2026-05-19-central-llm-billing-design.md`](../specs/2026-05-19-central-llm-billing-design.md)
+**Phase 1 (merged):** [`../plans/2026-05-19-phase-1-central-llm-credentials-plan.md`](../plans/2026-05-19-phase-1-central-llm-credentials-plan.md)
+
+Open exploration before the per-phase design and plan land. Goal: surface
+options, name trade-offs, resolve the open questions the roadmap lists for
+Phase 2, and check whether any code surface the parent design missed needs
+to be added to scope.
+
+## Surface area survey
+
+The roadmap and parent design D5 list a `src/usage/` module subscribing to
+`llm:end` plus a migration. A read of the actual emit code surfaces a
+short list of gaps that the per-phase design must close.
+
+| Location                                  | Today                                                                                                   | Phase 2 implication                                                                                       |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `src/llm-orchestrator-events.ts:153-202`  | `emitLlmEnd` payload does NOT carry `chatUserId` or `contextType`                                       | Extend the emit signature; recorder needs both to populate `chat_user_id` and `context_type`              |
+| `src/llm-orchestrator-events.ts:184`      | All `llm:*` events go through `emitUser`, scope `{ kind: 'user', userId: contextId }` even for groups   | Scope kind is misleading for groups but we still have `contextId` and we plan to pass `contextType` explicitly — leave scope alone |
+| `src/debug/event-bus.ts:34`               | `emitUser` short-circuits when `listeners.size === 0`                                                   | Recorder MUST subscribe at startup so the bus always has ≥1 listener; otherwise events drop on the floor   |
+| `src/llm-orchestrator-support.ts:161-181` | `emitLlmError` already exists and fires on the throw path (`llm-orchestrator.ts:252`)                   | Recorder subscribes to both `llm:end` and `llm:error`; failure rows fall out for free                      |
+| `src/embeddings.ts:33-48`                 | `getEmbedding` calls `embed()` directly, no event emitted                                               | Embedding callsites need a direct recorder call (or a new emit); cannot rely on the orchestrator bus       |
+| `src/web/distill.ts:96-128`               | `distillWebContent` calls `generateText` directly with the small model, no event emitted                | Same — direct recorder call, `modelRole: 'small'`                                                          |
+| `src/debug/state-collector.ts:74-85`      | Existing subscriber that wires `subscribe()`/`unsubscribe()` only when a debug client is connected      | Pattern to mirror but NOT to copy verbatim — the recorder subscribes unconditionally at startup            |
+| `src/db/migrations/034_system_config.ts`  | Recent migration example, plain `db.run()` SQL                                                          | Migration 035 follows this shape                                                                           |
+| `src/db/schema.ts:28`                     | `systemConfig` re-exported from `system-config-schema.ts`                                               | New Drizzle table in `llm-usage-events-schema.ts`, re-exported from `schema.ts`                            |
+| `src/system-config.ts`                    | Recent Drizzle-using module (insert + select), good API shape to mirror                                 | Recorder uses `getDrizzleDb()` + Drizzle insert; query module same pattern                                 |
+| `src/index.ts:74-83`                      | After `initDb()` + `seedSystemConfigFromEnv()`; calls into singletons (`scheduler`, `startScheduler`)   | Add `initUsageRecorder()` after the system-config seed step                                                |
+
+Net: ~10 files touched in `src/`, plus the new `src/usage/` module (4
+files), plus the new Drizzle schema file, plus tests. The parent design
+omits the emit signature extension; that's the most important
+elaboration from this survey.
+
+## Open question A — Three emitters or one?
+
+The roadmap explicitly flags this:
+
+> Main, small, and embedding use the same OpenAI client and could share an
+> emitter; separate emitters might be cleaner per modelRole. Decide in
+> phase 2 brainstorm.
+
+Three options:
+
+- **A1. Extend the bus.** Add `emitLlmEnd` calls from `embeddings.ts` and
+  `web/distill.ts` with a new `modelRole` parameter and the rest of the
+  fields. Recorder subscribes to `llm:end` and reads `modelRole` to
+  decide which row shape to insert.
+- **A2. Direct recorder API for non-orchestrator callsites.** Keep
+  `emitLlmEnd` as-is for the main-model path (bus → recorder via
+  subscriber). Add `recordEmbeddingUsage()` / `recordDistillUsage()`
+  functions in `src/usage/recorder.ts` that the embedding and distill
+  modules call directly. Two write paths, one DB sink.
+- **A3. Direct API everywhere.** Remove the bus → recorder dependency.
+  `invokeModel` calls the recorder directly after `emitLlmEnd`.
+
+Trade-offs:
+
+- A1 keeps a single subscriber pattern. Cost: now `embeddings.ts` and
+  `web/distill.ts` import the event bus, which they don't today. Also
+  the `llm:end` payload widens to fit all three modelRoles (some fields
+  meaningless for embeddings: step_count, tool_call_count, message_count).
+- A2 keeps the bus shape narrow (only the orchestrator emits) and treats
+  embeddings/distill as bespoke. Cost: two code paths to maintain;
+  symmetry breaks down the line if we add a fourth modelRole.
+- A3 is the cleanest but couples `llm-orchestrator-invoke.ts` to the
+  recorder, and adds another import edge in the hot path. The bus was
+  introduced precisely so that consumers don't have to know about each
+  other.
+
+**Recommendation:** A2 — direct recorder API for embeddings and distill,
+bus subscription for the main-model orchestrator path. Reasons:
+
+1. The bus dispatch already exists for `llm:end` and we'd be duplicating
+   it for nothing in the orchestrator path.
+2. Embeddings have no meaningful step/tool/message counts. Forcing them
+   through the bus payload either fakes those fields or makes them
+   nullable, both ugly.
+3. The recorder module presents a unified `recordUsage(payload)` API at
+   its boundary; the source (bus vs direct) is hidden from callers.
+4. Future fourth modelRole (e.g. dedicated "router" model) re-uses the
+   same direct API.
+
+Open subquestion: does `web/distill.ts` need the storage context? Today
+it passes `storageContextId` through its public API. So we can attribute
+distill usage to the correct subject. Good.
+
+Open subquestion: where do embeddings get the storage context? Looking
+at the callsites:
+
+- `src/tools/save-memo.ts:38` — userId is in scope, that's the storage
+  context for DMs (and for groups, this is the memo's user — which is
+  arguably the right subject because memos are per-user even in group
+  context).
+- `src/tools/search-memos.ts:95` — same.
+
+Recommendation: pass `storageContextId` and `chatUserId` to
+`tryGetEmbedding` so they end up in the recorder row. The current
+callsite already has both in scope.
+
+## Open question B — Where does embedding token count come from?
+
+Roadmap:
+
+> Where does embedding token count come from when the call is made by
+> `web/distill.ts`? May be unsupported by the provider — store NULL.
+
+`web/distill.ts` is a `generateText` call, not an embedding — that
+specific subquestion is misnamed in the roadmap. The real instances:
+
+- `embeddings.ts` calls `embed()` from `ai`. The return shape is
+  `{ embedding, usage? }`. The Vercel AI SDK populates `usage` if the
+  underlying OpenAI-compatible response carries it (most do; some
+  self-hosted endpoints don't). Already nullable in the SDK.
+- `web/distill.ts` calls `generateText()`, which returns a `usage`
+  field. Same story — provider may omit.
+
+**Decision:** the design's `input_tokens` / `output_tokens` columns are
+already NULLABLE per D5; recorder writes NULL when the SDK didn't
+populate `usage`. No new work, just don't crash on null.
+
+Open subquestion: `embed()` and `embedMany()` differ in shape. We use
+`embed()` (single-value) everywhere today. If `embedMany()` shows up
+later, the recorder writes one row per call (not per item) so the
+arithmetic in the dashboard is "tokens / call" — fine for now.
+
+## Open question C — Idempotency strategy
+
+Roadmap:
+
+> Idempotency: ULID per event, generated in-process. `event_id` is a
+> primary key — duplicate inserts fail loudly in tests, never silently.
+
+Design D5:
+
+> `event_id` is the `identifier` in Stripe terms / `id` in CloudEvents
+> terms. ULID generated in-process before the row is inserted.
+
+Open question 5 in the parent design:
+
+> `event_id` is a process-local ULID. If `recordUsage` ever runs outside
+> the in-process handler (queue, retry), we want the id to be derived
+> deterministically — e.g. `hash(responseId, occurredAt)`. v1 does not
+> need this because the recorder runs synchronously on the bus.
+
+Three options for v1:
+
+- **C1. `ulid` package.** Time-sortable IDs, ~3KB dep. The codebase
+  doesn't currently use `ulid`; introducing it just for this is an
+  unnecessary dependency.
+- **C2. `crypto.randomUUID()`.** Already used elsewhere (`memos.ts:15`,
+  `recurring.ts:25`). Random, not sortable, but `occurred_at` does
+  sorting for us. Zero new deps.
+- **C3. Deterministic hash of `(responseId, occurredAt, modelRole)`.**
+  Phase 4's future shape. Costs nothing today, but the data model
+  decision should be Phase 4's, not Phase 2's.
+
+**Recommendation:** C2 — `crypto.randomUUID()`. Matches existing
+codebase. Phase 4 can change to deterministic if/when the recorder
+leaves the in-process bus. Don't paint the table into a deterministic-id
+corner before the outbox need is real.
+
+"Duplicate inserts fail loudly in tests": the recorder will catch
+DB exceptions and log at `error` level (per parent design D7 — "never
+throw into the bus chain"). Tests that want to assert duplicate-insert
+behavior either spy on the logger or assert row count via the query
+helper. Acceptable.
+
+## Open question D — Subscribing at startup vs on-demand
+
+`src/debug/event-bus.ts:34` short-circuits when no listeners are
+registered:
+
+```ts
+export function emitUser(type: string, userId: string, data: Record<string, unknown>, turnId?: string): void {
+  if (listeners.size === 0) return
+  dispatch(makeEvent(type, data, { kind: 'user', userId }, turnId))
+}
+```
+
+`state-collector.ts:74-85` subscribes only when the first debug client
+connects and unsubscribes when the last one disconnects, leveraging that
+short-circuit to keep the dispatch path cold when nobody is watching.
+
+The recorder must subscribe **at process start**, unconditionally,
+because usage rows are needed whether or not a debug client is open.
+This has a side effect: `listeners.size` is now always ≥1, so the
+short-circuit never fires. The full `dispatch()` path runs on every emit
+— including `state-collector`'s `onEvent` if it's also subscribed.
+
+Is that a problem?
+
+- `dispatch()` is an in-process Set iteration. With 1–2 listeners and no
+  network/disk in the hot path of the loop, the cost is negligible.
+- The expensive bits of the payload build (`buildStepsDetail`,
+  `estimateToolSchemaBytes`, JSON walking) happen inside
+  `emitLlmEnd`/`emitLlmStart` BEFORE the call to `emitUser`. So they
+  already run regardless of listener count. We're not regressing
+  anything by ensuring the listener exists.
+- `state-collector.ts:101` `onEvent` first checks
+  `isVisibleToAdmin(event.scope, ...)`. If admin visibility hasn't been
+  configured yet, events are dropped. So `state-collector` doesn't do
+  meaningful work for non-admin scopes regardless.
+
+**Decision:** recorder calls `subscribe(handler)` in `initUsageRecorder()`,
+which is called from `src/index.ts` after `seedSystemConfigFromEnv()`.
+No teardown — the recorder lives for the process lifetime. The graceful
+shutdown path in `src/index.ts:154` doesn't need to call back into the
+recorder.
+
+## Open question E — Bus subscriber vs direct insert: failure isolation
+
+Design D7:
+
+> The recorder catches and logs its own errors; it must never throw out
+> into the event bus subscriber chain because that would block other
+> subscribers (state collector, telemetry).
+
+`event-bus.ts:29-31` `dispatch()` iterates `listeners` with NO try/catch
+around individual `fn(event)` calls. If a listener throws, the loop
+terminates early. Confirmed by reading the code.
+
+Therefore the recorder MUST catch internally. Pattern:
+
+```ts
+function onEvent(event: DebugEvent): void {
+  try {
+    if (event.type === 'llm:end') recordFromLlmEnd(event)
+    else if (event.type === 'llm:error') recordFromLlmError(event)
+  } catch (error) {
+    log.error({ err: error, eventType: event.type }, 'usage recorder failure')
+  }
+}
+```
+
+Open subquestion: should we wrap *every* listener in `dispatch` with a
+try/catch defensively? That's a broader-than-Phase-2 change to the bus.
+Not in scope; flag for a follow-up.
+
+## Open question F — `chat_user_id` and `context_type` propagation
+
+`emitLlmEnd` today takes `(contextId, mainModel, result, startTime,
+messages, tools, routing, turnId)`. Missing: `chatUserId`, `contextType`.
+
+Both are available in `invokeModel`:
+
+- `chatUserId` — present in `processMessage` (`llm-orchestrator.ts:220`)
+  and would need to be threaded through `callLlm` → `invokeModel`.
+- `contextType` — already at `processMessage` (line 223), threaded into
+  `callLlm` (line 245).
+
+Two options:
+
+- **F1. Add to the event payload.** Extend `emitLlmEnd`'s signature to
+  take `chatUserId` and `contextType`. Plumb through `invokeModel`'s
+  args (`InvokeModelArgs` in `llm-orchestrator-types.ts:55`). One-line
+  payload addition in events.ts.
+- **F2. Add to the scope.** Already established: scope kind for groups
+  would be `{ kind: 'group', groupId }` via `emitGroup`. But scope
+  doesn't carry `chatUserId`. So at minimum we still need to extend
+  payload for `chatUserId`. Switching to `emitGroup` for groups is a
+  separate cleanup orthogonal to Phase 2.
+
+**Recommendation:** F1. Extend payload only. Leave the scope-kind
+inconsistency for a future cleanup.
+
+Open subquestion: `emitLlmError` (`llm-orchestrator-support.ts:161`)
+currently takes `(contextId, _configContextId, error, turnId)`. To
+populate `chat_user_id` and `context_type` on failure rows, extend that
+signature too. Caller (`llm-orchestrator.ts:252`) has both in scope.
+
+## Open question G — `storage_context_id` semantics
+
+Design D5:
+
+> `storage_context_id` is the "billable subject" key. For DMs that is
+> the user id; for groups, the group id (or `groupId:threadId`). Same
+> value `bot.ts` passes to the orchestrator as `contextId`.
+
+So the column directly mirrors `processMessage`'s `contextId` arg. For
+thread-scoped groups (Telegram, Mattermost), this is `groupId:threadId`;
+for Discord, just `groupId` (per CLAUDE.md: "Discord group contexts are
+not thread-scoped today"). Recorder treats `contextId` opaquely. Good.
+
+Open subquestion: does any consumer want to roll up across threads of a
+single group? Phase 3's billing tab might want that. We can't
+reconstruct `groupId` from `groupId:threadId` without parsing the
+string. Solution:
+
+- For now, store `storage_context_id` verbatim. Phase 3 can split the
+  string on `:` if it wants a group-level roll-up; alternatively, Phase
+  3 may add a `parent_storage_context_id` column. Phase 2 does NOT
+  speculate.
+
+## Open question H — Query module surface
+
+Roadmap:
+
+> `query.ts` — read helpers (used by phase 3 but landed here so the
+> public surface is testable end-to-end).
+
+What exactly to ship in Phase 2:
+
+- **H1. Just what's tested.** `listSubjects(window)`,
+  `getSubjectDetail(id, window)`, both with a window argument that
+  filters by `occurred_at`. Returns rows ready for the dashboard
+  shape (per design D6).
+- **H2. Just count + raw queries.** Bare functions to count rows,
+  select by subject, no aggregation logic. Phase 3 builds the rollup.
+- **H3. Everything in design D6.** Both the list and detail shapes,
+  fully aggregated by model_role.
+
+**Recommendation:** H1, scoped to the design D6 shapes. The Drizzle
+query is small; landing it in Phase 2 with tests proves the schema
+supports the queries we'll need. Phase 3 then just wires the routes.
+
+Open subquestion: window selector values. Roadmap Phase 3 says
+"24h / 7d / 30d / all" for the UI. Phase 2 query takes a `windowMs`
+number (or `null` for "all") and lets Phase 3 map labels to numbers.
+
+## Open question I — Drizzle schema vs raw SQL in the migration
+
+The migration is the source of truth for the table. The Drizzle table
+in `src/db/llm-usage-events-schema.ts` is the type surface for the
+recorder and query module. They must agree.
+
+Two options:
+
+- **I1. Migration uses raw SQL (matching `034_system_config.ts`),
+  Drizzle table is hand-written separately.** Two places to keep in
+  sync. Tests assert the DB shape (columns, indexes, PK) so drift is
+  caught.
+- **I2. Migration uses Drizzle to create the table.** Avoids hand-sync
+  but the migration runner uses `bun:sqlite` `Database` directly, and
+  the Drizzle runner expects a different connection shape. Looking at
+  `034_system_config.ts:13-22`: it's plain `db.run(SQL)`. Match that.
+
+**Recommendation:** I1. Plain SQL in migration, hand-written Drizzle
+table. Match the existing pattern. The migration test asserts schema
+shape; a unit test on the Drizzle table asserts a round-trip insert →
+select reads the same columns. Drift becomes a test failure.
+
+## Open question J — Where to subscribe: state-collector or new module?
+
+Option **J1**: extend `state-collector.ts` to also write rows.
+- Pro: one subscriber, one place.
+- Con: collector is for ephemeral SSE broadcasting; persistence
+  responsibility doesn't belong there. Also collector subscribes
+  on-demand; recorder needs unconditional.
+
+Option **J2**: new `src/usage/` module with its own subscriber.
+- Pro: clean separation, matches the parent design D5 sketch exactly.
+- Con: another subscriber to register.
+
+**Recommendation:** J2. The parent design already specifies the module
+layout; deviating would be a regression in clarity.
+
+## Open question K — What's in `src/usage/types.ts`?
+
+Per parent design and roadmap:
+
+- `UsageEvent` — the input shape for `recordUsage()`. Fields match the
+  `llm_usage_events` columns plus a tagged `source: 'bus' | 'embedding' | 'distill'`?
+  Probably not needed — the recorder just inserts; `modelRole` already
+  distinguishes.
+- `SubjectSummary` — the per-subject aggregate for the list view (per
+  design D6 `BillingSubject`).
+- `RequestRow` — one request row for the detail view (per design D6
+  `BillingDetail['requests'][number]`).
+
+Fields exposed by the query module are read-shape types; recorder's
+input is a write-shape type. Keep them separate so the recorder type
+doesn't grow display-only fields like `displayName`.
+
+## Open question L — Test-DB pattern
+
+Phase 1's `tests/system-config.test.ts` uses `setupTestDb()` from
+`tests/utils/test-helpers.ts` which spins up a file-backed temp DB and
+runs all migrations. Phase 2 tests follow that same pattern.
+
+For migration-035 tests specifically (in `tests/db/migrations/`), copy
+the `034_system_config.test.ts` pattern: `new Database(':memory:')` per
+test, no migrations besides 035 (or run the chain up to 035).
+
+For recorder unit tests, the cleanest path is DI: `recordUsage(payload, deps)`
+where `deps.db` is injectable. Then tests pass an in-memory DB. Matches
+the codebase's DI-first style for new modules (per `tests/CLAUDE.md`).
+However, `src/system-config.ts` (the recent template) does NOT take a
+db dep — it calls `getDrizzleDb()` directly, relying on `setupTestDb()`
+to wire the singleton. Either approach is consistent with house style;
+DI is preferred for new modules.
+
+**Recommendation:** Pattern after `system-config.ts` (call
+`getDrizzleDb()` directly, tests use `setupTestDb()`). Adding a
+dependency parameter only complicates callsites in `embeddings.ts` and
+`web/distill.ts` for no real test-isolation gain. The test-helper-based
+setup already gives us a clean per-test DB.
+
+## Things explicitly NOT to do in Phase 2
+
+- No new dashboard routes. Phase 3.
+- No dashboard UI / Billing tab. Phase 3.
+- No `tool_call_events` per-tool table. Phase 4.
+- No `forwarded_at` / outbox columns. Phase 4.
+- No `/admin` DM command. Phase 3 (or never).
+- No change to the existing `state-collector` behavior or subscriber
+  lifecycle. The recorder is a parallel additive subscriber.
+- No removal of `llm:error` event — keep it; recorder consumes both.
+- No change to the chat-side context flow.
+- No retroactive backfill: rows start being written from the
+  Phase-2-deploy moment forward.
+
+## Risks identified by the brainstorm that weren't in the parent doc
+
+1. **Bus short-circuit on empty listener set.** Subscriber registration
+   order in `src/index.ts` matters. `initUsageRecorder()` MUST run
+   before any code path that could emit `llm:end` (i.e. before
+   `setupBot`). The parent doc doesn't call this out explicitly.
+2. **`emitLlmEnd` signature extension.** Parent design D5 says "the
+   recorder reads from the bus rather than the orchestrator calling a
+   function directly, so the orchestrator stays decoupled". Half true —
+   the bus is the dispatcher, but the payload needs new fields
+   (`chatUserId`, `contextType`) that the orchestrator IS responsible
+   for putting there. This is a tightly bounded API extension, not
+   coupling.
+3. **`emitLlmError` payload is thinner.** It has `error`, `model`,
+   `contextId`, `turnId` only. Recorder rows for the error path will
+   have many NULL fields. Acceptable per the table schema
+   (most fields nullable except `step_count`, `tool_call_count`,
+   `message_count`, `duration_ms`, `storage_context_id`, `context_type`,
+   `chat_user_id`, `model`, `model_role`, `event_id`, `occurred_at`).
+   Need to relax NOT NULL on the count and duration fields for failure
+   rows, OR provide sensible defaults: `0` for counts, `Date.now() - llmStartTime`
+   for duration. Defaults are simpler and preserve the schema.
+
+   The cleanest fix: extend `emitLlmError` to take the same context
+   fields (`chatUserId`, `contextType`, `mainModel`, `startTime`,
+   `messages.length`, `tools` count) and put defaults of 0 where there
+   are no data.
+4. **`buildStepsDetail` runs on every emit.** Already runs today; not
+   new. Mentioned only because flagging the "always-on subscriber"
+   change in (D) made me re-check it.
+5. **Concurrent inserts.** With WAL mode (set at
+   `src/db/index.ts:68`), SQLite handles concurrent inserts on a single
+   table. Recorder is single-threaded inside Bun; not a real concern.
+6. **`embeddings.ts` is currently a function-export module.** Threading
+   `storageContextId`/`chatUserId` through `tryGetEmbedding(text, apiKey, baseUrl, model, deps)`
+   means widening the signature. Callsites: 2 (`save-memo.ts:38`,
+   `search-memos.ts:95`). Bearable. Alternative: accept an optional
+   `context` object so old callers don't have to change. Lean toward
+   required fields since they're always available at the callsites.
+7. **TDD hook policy.** Same as Phase 1: every `src/` edit needs a
+   failing test first. Plan must sequence T → I per file. The
+   recorder + query module ship with their own tests under
+   `tests/usage/`.
+
+## Forward-compatibility check
+
+- **Phase 3 (billing dashboard).** Query module already supplies the
+  shapes; routes call them. Recorder is invisible to Phase 3 from a
+  read-path perspective. ✓
+- **Phase 4 (tool-call rows).** Adds a new table mirroring
+  `llm_usage_events`. Recorder pattern reusable. Idempotency key
+  becomes deterministic; v2 schema migration adds outbox columns to
+  this table. No painted corners. ✓
+- **Phase 5 (anonymous stats).** Counts and aggregates only; reads
+  `llm_usage_events.occurred_at` for active-subject calculations.
+  Already covered by indexes. ✓
+
+No corners painted.
+
+## Summary of decisions to lift into the per-phase design
+
+1. **Subscriber lives in `src/usage/`** (new module), subscribed at
+   startup, unconditional, no teardown. Wired in `src/index.ts` between
+   `seedSystemConfigFromEnv()` and the chat-provider start.
+2. **`emitLlmEnd` payload gains `chatUserId` and `contextType`.**
+   `emitLlmError` gains the same fields plus optional `mainModel`,
+   `startTime`, and `messageCount` so the failure-row insert can
+   populate the same non-null columns as success rows.
+3. **`InvokeModelArgs` gains `chatUserId` and `contextType`.** Plumbed
+   from `processMessage` through `callLlm` to `invokeModel`.
+4. **Embedding and distill callsites use a direct recorder API** —
+   `recordUsage(payload)` — rather than emitting bus events. The bus
+   path stays orchestrator-only.
+5. **`crypto.randomUUID()` for `event_id`.** No `ulid` dependency.
+   Phase 4 may switch to deterministic later.
+6. **Drizzle table in `src/db/llm-usage-events-schema.ts`, re-exported
+   from `schema.ts`.** Mirrors `system_config` layout.
+7. **Migration 035 uses plain SQL** (matching `034_system_config.ts`),
+   creates the table + four indexes per design D5.
+8. **Recorder wraps internal work in try/catch and logs at `error`**
+   level; never rethrows into the bus dispatch chain.
+9. **Query module ships in Phase 2** with `listSubjects(windowMs)` and
+   `getSubjectDetail(id, windowMs)` matching the design D6 shapes;
+   tests assert aggregates against hand-rolled SQL.
+10. **Failure rows still record** — recorder subscribes to both
+    `llm:end` and `llm:error`. NOT NULL count/duration fields receive
+    default 0 / elapsed-ms-since-start respectively on the error path.
+11. **`storage_context_id` stores `contextId` verbatim** (including
+    `groupId:threadId` for thread-scoped groups). Phase 3 / Phase 5
+    decide whether to add a parent-id column later.
+
+## Out of brainstorm (carry to plan, not design)
+
+- Exact test file locations and the T-then-I ordering inside Step
+  patterns.
+- Whether to run `bun typecheck` after each substep or only at the end.
+- Commit grouping strategy when the diff lands.
+- Manual smoke checklist (write a message → row appears → fail a
+  message → error row appears → verify subjects query).

--- a/docs/superpowers/notes/2026-05-19-phase-2-usage-recorder-brainstorm.md
+++ b/docs/superpowers/notes/2026-05-19-phase-2-usage-recorder-brainstorm.md
@@ -16,19 +16,19 @@ The roadmap and parent design D5 list a `src/usage/` module subscribing to
 `llm:end` plus a migration. A read of the actual emit code surfaces a
 short list of gaps that the per-phase design must close.
 
-| Location                                  | Today                                                                                                   | Phase 2 implication                                                                                       |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `src/llm-orchestrator-events.ts:153-202`  | `emitLlmEnd` payload does NOT carry `chatUserId` or `contextType`                                       | Extend the emit signature; recorder needs both to populate `chat_user_id` and `context_type`              |
-| `src/llm-orchestrator-events.ts:184`      | All `llm:*` events go through `emitUser`, scope `{ kind: 'user', userId: contextId }` even for groups   | Scope kind is misleading for groups but we still have `contextId` and we plan to pass `contextType` explicitly — leave scope alone |
-| `src/debug/event-bus.ts:34`               | `emitUser` short-circuits when `listeners.size === 0`                                                   | Recorder MUST subscribe at startup so the bus always has ≥1 listener; otherwise events drop on the floor   |
-| `src/llm-orchestrator-support.ts:161-181` | `emitLlmError` already exists and fires on the throw path (`llm-orchestrator.ts:252`)                   | Recorder subscribes to both `llm:end` and `llm:error`; failure rows fall out for free                      |
-| `src/embeddings.ts:33-48`                 | `getEmbedding` calls `embed()` directly, no event emitted                                               | Embedding callsites need a direct recorder call (or a new emit); cannot rely on the orchestrator bus       |
-| `src/web/distill.ts:96-128`               | `distillWebContent` calls `generateText` directly with the small model, no event emitted                | Same — direct recorder call, `modelRole: 'small'`                                                          |
-| `src/debug/state-collector.ts:74-85`      | Existing subscriber that wires `subscribe()`/`unsubscribe()` only when a debug client is connected      | Pattern to mirror but NOT to copy verbatim — the recorder subscribes unconditionally at startup            |
-| `src/db/migrations/034_system_config.ts`  | Recent migration example, plain `db.run()` SQL                                                          | Migration 035 follows this shape                                                                           |
-| `src/db/schema.ts:28`                     | `systemConfig` re-exported from `system-config-schema.ts`                                               | New Drizzle table in `llm-usage-events-schema.ts`, re-exported from `schema.ts`                            |
-| `src/system-config.ts`                    | Recent Drizzle-using module (insert + select), good API shape to mirror                                 | Recorder uses `getDrizzleDb()` + Drizzle insert; query module same pattern                                 |
-| `src/index.ts:74-83`                      | After `initDb()` + `seedSystemConfigFromEnv()`; calls into singletons (`scheduler`, `startScheduler`)   | Add `initUsageRecorder()` after the system-config seed step                                                |
+| Location                                  | Today                                                                                                 | Phase 2 implication                                                                                                                |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `src/llm-orchestrator-events.ts:153-202`  | `emitLlmEnd` payload does NOT carry `chatUserId` or `contextType`                                     | Extend the emit signature; recorder needs both to populate `chat_user_id` and `context_type`                                       |
+| `src/llm-orchestrator-events.ts:184`      | All `llm:*` events go through `emitUser`, scope `{ kind: 'user', userId: contextId }` even for groups | Scope kind is misleading for groups but we still have `contextId` and we plan to pass `contextType` explicitly — leave scope alone |
+| `src/debug/event-bus.ts:34`               | `emitUser` short-circuits when `listeners.size === 0`                                                 | Recorder MUST subscribe at startup so the bus always has ≥1 listener; otherwise events drop on the floor                           |
+| `src/llm-orchestrator-support.ts:161-181` | `emitLlmError` already exists and fires on the throw path (`llm-orchestrator.ts:252`)                 | Recorder subscribes to both `llm:end` and `llm:error`; failure rows fall out for free                                              |
+| `src/embeddings.ts:33-48`                 | `getEmbedding` calls `embed()` directly, no event emitted                                             | Embedding callsites need a direct recorder call (or a new emit); cannot rely on the orchestrator bus                               |
+| `src/web/distill.ts:96-128`               | `distillWebContent` calls `generateText` directly with the small model, no event emitted              | Same — direct recorder call, `modelRole: 'small'`                                                                                  |
+| `src/debug/state-collector.ts:74-85`      | Existing subscriber that wires `subscribe()`/`unsubscribe()` only when a debug client is connected    | Pattern to mirror but NOT to copy verbatim — the recorder subscribes unconditionally at startup                                    |
+| `src/db/migrations/034_system_config.ts`  | Recent migration example, plain `db.run()` SQL                                                        | Migration 035 follows this shape                                                                                                   |
+| `src/db/schema.ts:28`                     | `systemConfig` re-exported from `system-config-schema.ts`                                             | New Drizzle table in `llm-usage-events-schema.ts`, re-exported from `schema.ts`                                                    |
+| `src/system-config.ts`                    | Recent Drizzle-using module (insert + select), good API shape to mirror                               | Recorder uses `getDrizzleDb()` + Drizzle insert; query module same pattern                                                         |
+| `src/index.ts:74-83`                      | After `initDb()` + `seedSystemConfigFromEnv()`; calls into singletons (`scheduler`, `startScheduler`) | Add `initUsageRecorder()` after the system-config seed step                                                                        |
 
 Net: ~10 files touched in `src/`, plus the new `src/usage/` module (4
 files), plus the new Drizzle schema file, plus tests. The parent design
@@ -236,7 +236,7 @@ function onEvent(event: DebugEvent): void {
 }
 ```
 
-Open subquestion: should we wrap *every* listener in `dispatch` with a
+Open subquestion: should we wrap _every_ listener in `dispatch` with a
 try/catch defensively? That's a broader-than-Phase-2 change to the bus.
 Not in scope; flag for a follow-up.
 
@@ -346,12 +346,14 @@ select reads the same columns. Drift becomes a test failure.
 ## Open question J — Where to subscribe: state-collector or new module?
 
 Option **J1**: extend `state-collector.ts` to also write rows.
+
 - Pro: one subscriber, one place.
 - Con: collector is for ephemeral SSE broadcasting; persistence
   responsibility doesn't belong there. Also collector subscribes
   on-demand; recorder needs unconditional.
 
 Option **J2**: new `src/usage/` module with its own subscriber.
+
 - Pro: clean separation, matches the parent design D5 sketch exactly.
 - Con: another subscriber to register.
 
@@ -440,6 +442,7 @@ setup already gives us a clean per-test DB.
    fields (`chatUserId`, `contextType`, `mainModel`, `startTime`,
    `messages.length`, `tools` count) and put defaults of 0 where there
    are no data.
+
 4. **`buildStepsDetail` runs on every emit.** Already runs today; not
    new. Mentioned only because flagging the "always-on subscriber"
    change in (D) made me re-check it.

--- a/docs/superpowers/plans/2026-05-19-phase-2-usage-recorder-plan.md
+++ b/docs/superpowers/plans/2026-05-19-phase-2-usage-recorder-plan.md
@@ -24,7 +24,7 @@ Steps are ordered so each leaves the tree green between steps.
 - `bun test` should pass on the baseline. If not, stop and investigate.
 - `bun typecheck` should pass. Same.
 - Confirm Phase 1's `system_config` table is in place (`grep
-  migration034SystemConfig src/db/index.ts`).
+migration034SystemConfig src/db/index.ts`).
 
 ## Step 1 — Migration 035 (`llm_usage_events` table + indexes)
 
@@ -290,6 +290,7 @@ already carries it).
 **R**: none.
 
 **Verify**:
+
 ```
 bun test tests/embeddings.test.ts
 bun test tests/tools/save-memo.test.ts
@@ -324,6 +325,7 @@ the call. If the calling tool is `web_fetch`, its tool options
 already carry both.
 
 **Verify**:
+
 ```
 bun test tests/web/distill.test.ts
 bun test tests/web/<callsite>.test.ts
@@ -357,7 +359,7 @@ test.
   call returns. Row fields match the orchestrator inputs.
 - A `processMessage` where `generateText` throws produces one row
   with `error` populated, NULL token/response fields, `model_role:
-  'main'`.
+'main'`.
 
 If the existing orchestrator test file is too tangled to extend
 cleanly, add a focused `tests/usage/end-to-end.test.ts` that drives
@@ -438,18 +440,18 @@ Per the roadmap:
 
 ## Risks + mitigations
 
-| Risk                                                                         | Mitigation                                                                                                                       |
-| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| TDD hook blocks an `src/` edit because the new test was not yet written      | Strict T → I sequencing inside each step; the order is documented above                                                          |
-| `emitLlmEnd` signature change ripples through multiple files                 | Step 5 batches all callers; tests cover the new fields in one suite                                                              |
-| Bus dispatch no longer short-circuits, hot-path cost                         | The expensive payload builders run upstream of dispatch regardless; net cost is a single Set-iteration step per emit             |
-| Recorder exception kills the bus                                             | Catch internally per design D2.2; integration test asserts other listeners still fire after a failing recorder                   |
-| `embed()` shape difference across `@ai-sdk` versions                         | Treat `usage` as `{ tokens?: number } \| undefined` and pass through `?? null`; never crash on missing fields                    |
-| Tool-option `contextType` not actually exposed to the embedding tools today  | Audit `MakeToolsOptions` flow in `src/tools/tools-builder.ts` during Step 7; thread if missing — this is a small, bounded change |
-| Migration 035 collides with an in-flight `claude/phase-2*` branch elsewhere  | Branch ownership: only this branch is authorized; CI enforces unique migration ids                                               |
-| Test isolation: cache state in `usage/index.ts` persists across tests        | Use the standard test-helpers reset path; expose a `resetUsageRecorderForTesting()` helper if needed                             |
-| `recordUsage` from inside the bus dispatcher creates re-entrancy on the bus  | Recorder does NOT emit any bus events; pure DB insert. Confirmed.                                                                |
-| `bun security` flags the new SQL                                             | Drizzle parameterizes by default; raw SQL only in the migration. Inspect any finding rather than silencing.                      |
+| Risk                                                                        | Mitigation                                                                                                                       |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| TDD hook blocks an `src/` edit because the new test was not yet written     | Strict T → I sequencing inside each step; the order is documented above                                                          |
+| `emitLlmEnd` signature change ripples through multiple files                | Step 5 batches all callers; tests cover the new fields in one suite                                                              |
+| Bus dispatch no longer short-circuits, hot-path cost                        | The expensive payload builders run upstream of dispatch regardless; net cost is a single Set-iteration step per emit             |
+| Recorder exception kills the bus                                            | Catch internally per design D2.2; integration test asserts other listeners still fire after a failing recorder                   |
+| `embed()` shape difference across `@ai-sdk` versions                        | Treat `usage` as `{ tokens?: number } \| undefined` and pass through `?? null`; never crash on missing fields                    |
+| Tool-option `contextType` not actually exposed to the embedding tools today | Audit `MakeToolsOptions` flow in `src/tools/tools-builder.ts` during Step 7; thread if missing — this is a small, bounded change |
+| Migration 035 collides with an in-flight `claude/phase-2*` branch elsewhere | Branch ownership: only this branch is authorized; CI enforces unique migration ids                                               |
+| Test isolation: cache state in `usage/index.ts` persists across tests       | Use the standard test-helpers reset path; expose a `resetUsageRecorderForTesting()` helper if needed                             |
+| `recordUsage` from inside the bus dispatcher creates re-entrancy on the bus | Recorder does NOT emit any bus events; pure DB insert. Confirmed.                                                                |
+| `bun security` flags the new SQL                                            | Drizzle parameterizes by default; raw SQL only in the migration. Inspect any finding rather than silencing.                      |
 
 ## Out-of-plan checklist before Step 13
 

--- a/docs/superpowers/plans/2026-05-19-phase-2-usage-recorder-plan.md
+++ b/docs/superpowers/plans/2026-05-19-phase-2-usage-recorder-plan.md
@@ -1,0 +1,476 @@
+# Phase 2 — Usage Telemetry Recorder — Implementation Plan
+
+**Date:** 2026-05-19
+**Status:** Draft
+**Branch:** `claude/phase-2-llm-billing-J6vnM`
+**Per-phase design:** [`../specs/2026-05-19-phase-2-usage-recorder-design.md`](../specs/2026-05-19-phase-2-usage-recorder-design.md)
+**Brainstorm:** [`../notes/2026-05-19-phase-2-usage-recorder-brainstorm.md`](../notes/2026-05-19-phase-2-usage-recorder-brainstorm.md)
+**Parent roadmap:** [`2026-05-19-central-llm-billing-roadmap.md`](2026-05-19-central-llm-billing-roadmap.md)
+
+## Sequencing principle
+
+The TDD hook (`CLAUDE.md` "TDD Enforcement") gates every `src/` edit on
+a failing test. Each implementation step is split into:
+
+- **T**: write the failing test(s).
+- **I**: write the implementation that turns the tests green.
+- **R**: refactor — only when there's something to refactor.
+
+Steps are ordered so each leaves the tree green between steps.
+
+## Step 0 — Pre-flight
+
+- Confirm we are on branch `claude/phase-2-llm-billing-J6vnM`.
+- `bun test` should pass on the baseline. If not, stop and investigate.
+- `bun typecheck` should pass. Same.
+- Confirm Phase 1's `system_config` table is in place (`grep
+  migration034SystemConfig src/db/index.ts`).
+
+## Step 1 — Migration 035 (`llm_usage_events` table + indexes)
+
+**T**: add `tests/db/migrations/035-llm-usage-events.test.ts` covering:
+
+- Table exists after migration runs.
+- All 4 indexes exist (`idx_llm_usage_subject`, `idx_llm_usage_chat_user`,
+  `idx_llm_usage_turn`, `idx_llm_usage_occurred`).
+- Inserting a minimal row works (PK + NOT NULL columns populated).
+- Inserting two rows with the same `event_id` fails (PK).
+- Inserting NULL into a NOT NULL column (`storage_context_id`,
+  `context_type`, `chat_user_id`, `model`, `model_role`, `duration_ms`,
+  `occurred_at`) fails.
+- Optional columns (`turn_id`, `input_tokens`, `output_tokens`,
+  `finish_reason`, `response_id`, `error`) accept NULL.
+- `step_count`, `tool_call_count`, `message_count` default to 0 when
+  omitted from the INSERT column list.
+- Running the migration twice is idempotent (`IF NOT EXISTS` on table
+  and indexes).
+
+Copy structure from
+`tests/db/migrations/034_system_config.test.ts`.
+
+**I**: add `src/db/migrations/035_llm_usage_events.ts` per design D7.
+Register in `src/db/index.ts` between
+`migration034SystemConfig` and `migration036DropUserLlmConfig`
+(both the import and the `MIGRATIONS` array).
+
+**R**: none.
+
+**Verify**: `bun test tests/db/migrations/035-llm-usage-events.test.ts`.
+
+## Step 2 — Drizzle schema
+
+**T**: add a unit test `tests/db/llm-usage-events-schema.test.ts`
+covering:
+
+- A Drizzle `insert(llmUsageEvents).values({...}).run()` followed by
+  `select().from(llmUsageEvents).all()` round-trips all fields,
+  including nullable ones returning `null`.
+- `setupTestDb()` runs migrations so the table exists.
+
+**I**:
+
+- Add `src/db/llm-usage-events-schema.ts` per design D6.
+- Re-export `llmUsageEvents` and `LlmUsageEventRow` from
+  `src/db/schema.ts`.
+
+**R**: none.
+
+**Verify**: `bun test tests/db/llm-usage-events-schema.test.ts && bun typecheck`.
+
+## Step 3 — Types and recorder skeleton
+
+This step ships `types.ts` and the recorder implementation without
+wiring it into the bus yet.
+
+**T**: `tests/usage/recorder.test.ts`:
+
+- `recordUsage({ ...validPayload })` inserts a row; subsequent SELECT
+  returns the same fields, with NULLs preserved.
+- `recordUsage` generates a unique `event_id` per call (two consecutive
+  calls produce two distinct rows).
+- `recordUsage` does not throw when given an unusable payload — it
+  logs at `error` level and returns. (Simulate by mocking
+  `getDrizzleDb()` to return an object whose `.insert()` throws.)
+- `recordUsage` accepts `input_tokens: null` and `output_tokens: null`
+  on success rows.
+- `recordUsage` accepts an `error` string and persists it.
+- Default counts (0) are respected when caller passes 0 explicitly.
+
+DI shape: the recorder uses `getDrizzleDb()` directly (matching
+`system-config.ts`). For the "insert throws" test, use `mock.module`
+to override `getDrizzleDb` for that test only.
+
+**I**:
+
+- `src/usage/types.ts` — type exports per design D2.1.
+- `src/usage/recorder.ts` — `recordUsage` implementation per design
+  D2.2. Module-local `log = logger.child({ scope: 'usage:recorder' })`.
+
+**R**: none.
+
+**Verify**: `bun test tests/usage/recorder.test.ts && bun typecheck`.
+
+## Step 4 — Query module
+
+**T**: `tests/usage/query.test.ts`:
+
+- `listSubjects({ windowMs: null })` over a seeded fixture (3 subjects
+  × multiple modelRoles) returns one `SubjectSummary` per
+  `storage_context_id` with totals matching hand-rolled SUM/COUNT.
+- `listSubjects({ windowMs: 24 * 3600 * 1000 })` filters by time
+  correctly (rows older than 24h are excluded).
+- `listSubjects` populates all three `modelRole` slots in `totals`,
+  even when a subject has no rows for one role (zeros).
+- `getSubjectDetail('subject-1', { windowMs: null })` returns rows
+  ordered by `occurredAt` descending.
+- `getSubjectDetail` filters by `storageContextId` (rows from other
+  subjects excluded).
+- `getSubjectDetail` filters by window.
+- Empty seed: `listSubjects` returns `[]`, `getSubjectDetail` returns
+  `[]`.
+
+**I**: `src/usage/query.ts` per design D8. Helper `pivotByRole(rows)`
+folds the per-role aggregate rows into the `SubjectSummary` shape.
+
+**R**: extract `pivotByRole` if it becomes its own logical unit, but
+keep it module-local.
+
+**Verify**: `bun test tests/usage/query.test.ts && bun typecheck`.
+
+## Step 5 — `emitLlmEnd` and `emitLlmError` signature extensions
+
+This step changes the emit functions' shape. Hot-path code; both
+implementation and its callers must update in one batch so the tree
+stays green at step boundary.
+
+**T**:
+
+- Extend `tests/llm-orchestrator-events.test.ts` to assert the
+  extended `emitLlmEnd` payload contains `chatUserId` and `contextType`.
+  The existing assertions on `model`, `messageCount`, etc. continue
+  to hold.
+- Extend `tests/llm-orchestrator-support.test.ts` (create if absent)
+  to assert `emitLlmError` payload contains `error`, `model`,
+  `chatUserId`, `contextType`, `durationMs`, `messageCount`.
+- Drop assertions on the unused `emitLlmEnd` overloads (if any).
+
+**I**:
+
+- `src/llm-orchestrator-events.ts:153-202` — collapse `emitLlmEnd` to
+  one signature `(contextId, chatUserId, contextType, mainModel, result, startTime, messages, tools, routing, turnId)`.
+  Update the emit payload to include `chatUserId` and `contextType`.
+- `src/llm-orchestrator-support.ts:161-181` — update `emitLlmError`
+  signature per design D3.2.
+- `src/llm-orchestrator-types.ts:55` — add `chatUserId` and
+  `contextType` to `InvokeModelArgs`.
+- `src/llm-orchestrator-invoke.ts:97,108` — pass new fields into
+  `emitLlmStart` (kept as-is; brainstorm flagged this is not necessary
+  for the recorder but it keeps the start/end pair symmetric — DECISION:
+  leave `emitLlmStart` unchanged to minimize blast radius; the
+  recorder only consumes `llm:end`. Update only `emitLlmEnd`.)
+- `src/llm-orchestrator-tools.ts` — find `prepareLlmInvocation`,
+  thread `chatUserId` and `contextType` into the returned
+  `InvokeModelArgs`. Adjust its signature and callers.
+- `src/llm-orchestrator.ts:217-256` — capture `startedAt` and
+  `messageCount` before the `try`; resolve `mainModel` before the
+  `try`; pass to `emitLlmError` on the catch path. Thread
+  `chatUserId`, `contextType`, `mainModel` into `callLlm` and onward
+  to `prepareLlmInvocation`.
+
+**R**: none.
+
+**Verify**:
+
+```
+bun test tests/llm-orchestrator-events.test.ts
+bun test tests/llm-orchestrator-support.test.ts
+bun test tests/llm-orchestrator.test.ts
+bun typecheck
+```
+
+Note for the TDD hook: each `src/` edit needs its test green by the
+time the hook runs. Sequence T-then-I within this step strictly:
+
+1. Update tests for `emitLlmEnd` first.
+2. Update `src/llm-orchestrator-events.ts`.
+3. Update tests for `emitLlmError`.
+4. Update `src/llm-orchestrator-support.ts`.
+5. Update tests for `InvokeModelArgs` consumers (if any).
+6. Update `src/llm-orchestrator-types.ts`,
+   `src/llm-orchestrator-tools.ts`,
+   `src/llm-orchestrator-invoke.ts`,
+   `src/llm-orchestrator.ts`.
+
+If a callsite update causes an unrelated test to red, fix forward in
+the same step; do not leave intermediate red between steps.
+
+## Step 6 — Bus subscriber (`src/usage/index.ts`)
+
+**T**: `tests/usage/recorder-integration.test.ts`:
+
+- After `initUsageRecorder()`, emitting an `llm:end` event via
+  `emitUser('llm:end', ...)` with a populated payload produces a row
+  with the expected `model`, `model_role: 'main'`,
+  `storage_context_id`, `chat_user_id`, `context_type`,
+  `step_count`, `tool_call_count`, `message_count`, `duration_ms`,
+  `finish_reason`, `response_id`, `input_tokens`, `output_tokens`,
+  `turn_id`, `error: null`.
+- Emitting `llm:error` produces a row with `error` populated,
+  `model_role: 'main'`, NULL `input_tokens` / `output_tokens` /
+  `response_id` / `finish_reason`, and the fields from the error
+  payload.
+- Other event types (`llm:start`, `tool:request`, etc.) produce no
+  rows.
+- A second `initUsageRecorder()` call does not register a second
+  subscriber (idempotency in test harness setup). Either a guard
+  inside `initUsageRecorder` or the helper `subscribe()` semantics
+  (it's a `Set`, so identical fn references dedupe naturally) — use
+  a module-local boolean to be explicit.
+- A recorder exception (mock `recordUsage` to throw) does not
+  propagate; the test asserts a second listener registered after the
+  failing handler still receives the event.
+
+**I**: `src/usage/index.ts`:
+
+- `initUsageRecorder()` exported; uses a module-local `initialised`
+  flag to no-op on second call.
+- `handleEvent(event)` dispatches on `event.type`.
+- `recordFromLlmEnd(event)` — read fields from `event.data`,
+  build a `UsageEvent`, call `recordUsage`. Wrap in try/catch
+  internally so a malformed event doesn't kill the subscriber.
+- `recordFromLlmError(event)` — same shape but with `error` set and
+  count/duration fields filled from the payload (defaults to 0
+  where missing).
+
+**R**: none.
+
+**Verify**: `bun test tests/usage/recorder-integration.test.ts && bun typecheck`.
+
+## Step 7 — Embedding callsites
+
+**T**: `tests/embeddings.test.ts` (extend; create if absent):
+
+- `tryGetEmbedding(text, key, url, model, context, deps)` with a mock
+  `embed` that returns `{ embedding: [...], usage: { tokens: 42 } }`
+  inserts a row with `model_role: 'embedding'`, `input_tokens: 42`,
+  `output_tokens: null`, `step_count: 0`, `tool_call_count: 0`,
+  `message_count: 0`, and the context fields from the call.
+- Same call with `usage` undefined inserts the row with
+  `input_tokens: null`.
+- A throwing `embed` causes `tryGetEmbedding` to return `null` AND
+  insert a row with `error` populated.
+
+**I**:
+
+- `src/embeddings.ts` — add `EmbeddingCallContext` type;
+  widen `getEmbedding` and `tryGetEmbedding` signatures. Insert
+  `recordUsage` calls after success and inside the catch.
+
+The new param breaks two callsites — they need updating in the same
+step or tests for those callsites fail.
+
+**T (memo callsites)**: `tests/tools/save-memo.test.ts`,
+`tests/tools/search-memos.test.ts`:
+
+- Calling the tool with a known storageContextId / chatUserId emits a
+  recorder row tagged with those values when the embedding model is
+  configured.
+
+**I (memo callsites)**:
+
+- `src/tools/save-memo.ts:38` — build `EmbeddingCallContext` from
+  `userId` (storage), `contextType` (from tool options), `userId`
+  (chat user — same as storage in DM-only memo context). Pass it.
+- `src/tools/search-memos.ts:95` — same.
+
+Confirm `contextType` is exposed by the tool factory's options. If
+not, thread it through (`src/tools/CLAUDE.md` says `MakeToolsOptions`
+already carries it).
+
+**R**: none.
+
+**Verify**:
+```
+bun test tests/embeddings.test.ts
+bun test tests/tools/save-memo.test.ts
+bun test tests/tools/search-memos.test.ts
+bun typecheck
+```
+
+## Step 8 — Web distill callsite
+
+**T**: `tests/web/distill.test.ts`:
+
+- `distillWebContent({ storageContextId, contextType, chatUserId, title, content })`
+  inserts a row with `model_role: 'small'`, `step_count >= 1`,
+  `tool_call_count: 0`, `message_count: 1`, the context fields, and
+  `model` matching the small model (or main model fallback).
+- A throwing `generateText` causes `distillWebContent` to throw AND
+  insert an error row.
+
+**I**:
+
+- `src/web/distill.ts` — widen `distillWebContent` input type; call
+  `recordUsage` after `generateText` (success) and in a try/catch on
+  failure.
+
+**T (callsite)**: find where `distillWebContent` is called from. Use
+`grep distillWebContent src/`. Likely `src/web/fetch.ts` or a
+`web_fetch` tool. Update its test to assert the context fields flow
+through.
+
+**I (callsite)**: thread `chatUserId` and `contextType` through to
+the call. If the calling tool is `web_fetch`, its tool options
+already carry both.
+
+**Verify**:
+```
+bun test tests/web/distill.test.ts
+bun test tests/web/<callsite>.test.ts
+bun typecheck
+```
+
+## Step 9 — `initUsageRecorder` wiring in `src/index.ts`
+
+**T**: no new unit test — `src/index.ts` is not exercised by the test
+runner. Manual smoke in Step 12 covers it.
+
+**I**:
+
+- Add `import { initUsageRecorder } from './usage/index.js'`.
+- Call `initUsageRecorder()` after `seedSystemConfigFromEnv()` /
+  `missingSystemConfigKeys()` block, before `initializeMessageCache()`.
+
+**R**: none.
+
+**Verify**: `bun typecheck`.
+
+## Step 10 — Cross-cutting type and orchestrator-end test
+
+Now that all writers are in place, write the end-to-end orchestrator
+test.
+
+**T**: `tests/llm-orchestrator.test.ts` — extend (or add new test):
+
+- A `processMessage` happy path (mock `generateText` to return a
+  minimal result) produces one row in `llm_usage_events` after the
+  call returns. Row fields match the orchestrator inputs.
+- A `processMessage` where `generateText` throws produces one row
+  with `error` populated, NULL token/response fields, `model_role:
+  'main'`.
+
+If the existing orchestrator test file is too tangled to extend
+cleanly, add a focused `tests/usage/end-to-end.test.ts` that drives
+`processMessage` directly.
+
+**I**: no new src code; this test validates the wiring done in earlier
+steps. If it fails, fix in the relevant earlier step's code.
+
+**R**: none.
+
+**Verify**: `bun test tests/llm-orchestrator.test.ts && bun typecheck`.
+
+## Step 11 — Full suite + lint + typecheck + security
+
+Run in order; do not skip:
+
+1. `bun typecheck`
+2. `bun lint`
+3. `bun test` — main curated suite
+4. `bun test:client` — dashboard tests (should be untouched but
+   confirm no upstream type leak broke a client import)
+5. `bun format:check` (run `bun format` to fix if needed)
+6. `bun security` — Semgrep
+
+Any failure pauses the plan and we fix forward.
+
+## Step 12 — Manual smoke (mandatory acceptance)
+
+1. Fresh DB (`rm papai.db*` in a scratch dir).
+2. `LLM_API_KEY=… LLM_BASE_URL=… MAIN_MODEL=… EMBEDDING_MODEL=… ADMIN_USER_ID=… CHAT_PROVIDER=telegram TASK_PROVIDER=kaneo KANEO_CLIENT_URL=… bun start`.
+3. Verify startup logs include `"usage recorder initialised"`.
+4. Send a single chat message and let it complete normally.
+5. `sqlite3 papai.db 'SELECT event_id, model_role, model, storage_context_id, chat_user_id, context_type, step_count, tool_call_count, message_count, input_tokens, output_tokens, duration_ms, error FROM llm_usage_events ORDER BY occurred_at DESC LIMIT 5'`
+   - Expect one `model_role='main'` row with populated counts and
+     either tokens or NULLs (depending on provider).
+6. Save a memo (`save a note: testing usage recorder`). The bot calls
+   `tryGetEmbedding` which records.
+   - Expect a `model_role='embedding'` row, `input_tokens` populated
+     if your endpoint returns usage.
+7. Trigger `web_fetch` on a URL with >8000 chars of content so distill
+   runs. Expect a `model_role='small'` row.
+8. Force an error: temporarily set `LLM_API_KEY` to an invalid value
+   in `system_config`, restart, send a message. Expect a row with
+   `error` set, `model_role='main'`.
+9. Reset key, restart, verify normal behavior resumes.
+
+Capture the SQL output in the PR description as smoke evidence.
+
+## Step 13 — Commit + push
+
+One commit per substep is overkill for review. Group:
+
+- **Commit A**: migration 035 + Drizzle schema + their tests.
+- **Commit B**: `src/usage/` module (types, recorder, query) + their
+  tests.
+- **Commit C**: `emitLlmEnd`/`emitLlmError` signature extension +
+  `InvokeModelArgs` plumbing + orchestrator test updates.
+- **Commit D**: bus subscriber (`src/usage/index.ts`) + integration
+  tests + `initUsageRecorder()` wiring in `src/index.ts`.
+- **Commit E**: embedding callsite updates (`embeddings.ts`,
+  `save-memo.ts`, `search-memos.ts`) + tests.
+- **Commit F**: distill callsite update + tests.
+
+If a hook fails on a commit, fix the underlying issue and create a
+new commit (no `--amend`, no `--no-verify` per `CLAUDE.md`).
+
+Push to `claude/phase-2-llm-billing-J6vnM` with
+`git push -u origin claude/phase-2-llm-billing-J6vnM`.
+
+## Step 14 — Review
+
+Per the roadmap:
+
+- `bun security` already run in Step 11; investigate any findings.
+- Manual smoke notes from Step 12 in the PR description so reviewer
+  can reproduce.
+- No dashboard walkthrough applicable (Phase 3 territory).
+
+## Risks + mitigations
+
+| Risk                                                                         | Mitigation                                                                                                                       |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| TDD hook blocks an `src/` edit because the new test was not yet written      | Strict T → I sequencing inside each step; the order is documented above                                                          |
+| `emitLlmEnd` signature change ripples through multiple files                 | Step 5 batches all callers; tests cover the new fields in one suite                                                              |
+| Bus dispatch no longer short-circuits, hot-path cost                         | The expensive payload builders run upstream of dispatch regardless; net cost is a single Set-iteration step per emit             |
+| Recorder exception kills the bus                                             | Catch internally per design D2.2; integration test asserts other listeners still fire after a failing recorder                   |
+| `embed()` shape difference across `@ai-sdk` versions                         | Treat `usage` as `{ tokens?: number } \| undefined` and pass through `?? null`; never crash on missing fields                    |
+| Tool-option `contextType` not actually exposed to the embedding tools today  | Audit `MakeToolsOptions` flow in `src/tools/tools-builder.ts` during Step 7; thread if missing — this is a small, bounded change |
+| Migration 035 collides with an in-flight `claude/phase-2*` branch elsewhere  | Branch ownership: only this branch is authorized; CI enforces unique migration ids                                               |
+| Test isolation: cache state in `usage/index.ts` persists across tests        | Use the standard test-helpers reset path; expose a `resetUsageRecorderForTesting()` helper if needed                             |
+| `recordUsage` from inside the bus dispatcher creates re-entrancy on the bus  | Recorder does NOT emit any bus events; pure DB insert. Confirmed.                                                                |
+| `bun security` flags the new SQL                                             | Drizzle parameterizes by default; raw SQL only in the migration. Inspect any finding rather than silencing.                      |
+
+## Out-of-plan checklist before Step 13
+
+- [ ] No `eslint-disable`, `oxlint-disable`, `@ts-ignore`, or
+      `@ts-nocheck` comments anywhere (hook policy)
+- [ ] `bun knip` shows no new unused exports
+- [ ] `bun duplicates` does not regress
+- [ ] `tests/CLAUDE.md` style respected for new tests (DI-first,
+      mock-reset, no top-level mock.module without local reason)
+- [ ] All new modules ship with structured pino logging at the
+      documented levels
+- [ ] `tests/usage/recorder.test.ts` covers the "recorder must not
+      throw" invariant explicitly
+
+## Notes for follow-up phases
+
+- The `displayName` field for `SubjectSummary` (parent design D6)
+  remains a Phase 3 concern.
+- The HTTP routes `/billing/subjects`, `/billing/subject/:id`,
+  `/admin/llm` are all Phase 3.
+- Per-tool drill-down (Phase 4) reuses the recorder pattern with a
+  parallel `tool_call_events` table.
+- The deterministic `event_id` (Phase 4) swaps `crypto.randomUUID()`
+  for a hash; the column type doesn't change.

--- a/docs/superpowers/specs/2026-05-19-phase-2-usage-recorder-design.md
+++ b/docs/superpowers/specs/2026-05-19-phase-2-usage-recorder-design.md
@@ -1,0 +1,719 @@
+# Phase 2 — Usage Telemetry Recorder, Per-Phase Design
+
+**Date:** 2026-05-19
+**Status:** Draft
+**Branch:** `claude/phase-2-llm-billing-J6vnM`
+**Parent design:** [`2026-05-19-central-llm-billing-design.md`](2026-05-19-central-llm-billing-design.md)
+**Phase 1 (merged):** [`2026-05-19-phase-1-central-llm-credentials-design.md`](2026-05-19-phase-1-central-llm-credentials-design.md)
+**Brainstorm:** [`../notes/2026-05-19-phase-2-usage-recorder-brainstorm.md`](../notes/2026-05-19-phase-2-usage-recorder-brainstorm.md)
+
+This per-phase design refines parent §D5 ("Per-LLM-call usage row,
+written from the event bus"). The parent doc covered the table schema
+and forward-compatibility argument; this doc bakes in the brainstorm's
+decisions on emit signatures, embedding/distill recording paths,
+subscriber lifecycle, and the query module surface.
+
+## D1. Table schema
+
+Unchanged from parent §D5, repeated here for self-containment.
+
+```sql
+CREATE TABLE IF NOT EXISTS llm_usage_events (
+  event_id           TEXT PRIMARY KEY,                -- crypto.randomUUID()
+  occurred_at        INTEGER NOT NULL,                -- ms epoch
+  turn_id            TEXT,                            -- nullable
+  storage_context_id TEXT NOT NULL,                   -- billing subject scope
+  context_type       TEXT NOT NULL,                   -- 'dm' | 'group'
+  chat_user_id       TEXT NOT NULL,                   -- platform_user_id of caller
+  model              TEXT NOT NULL,                   -- requested model id
+  model_role         TEXT NOT NULL,                   -- 'main' | 'small' | 'embedding'
+  input_tokens       INTEGER,                         -- nullable: provider may omit
+  output_tokens      INTEGER,                         -- nullable
+  step_count         INTEGER NOT NULL DEFAULT 0,
+  tool_call_count    INTEGER NOT NULL DEFAULT 0,
+  message_count      INTEGER NOT NULL DEFAULT 0,      -- context size at call time
+  finish_reason      TEXT,                            -- nullable
+  duration_ms        INTEGER NOT NULL,
+  response_id        TEXT,                            -- nullable
+  error              TEXT                             -- null on success
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_usage_subject     ON llm_usage_events(storage_context_id, occurred_at);
+CREATE INDEX IF NOT EXISTS idx_llm_usage_chat_user   ON llm_usage_events(chat_user_id, occurred_at);
+CREATE INDEX IF NOT EXISTS idx_llm_usage_turn        ON llm_usage_events(turn_id);
+CREATE INDEX IF NOT EXISTS idx_llm_usage_occurred    ON llm_usage_events(occurred_at);
+```
+
+Change from parent: `step_count`, `tool_call_count`, `message_count`
+gain `DEFAULT 0` so the failure path (which doesn't have access to a
+step/tool count) writes a valid row without the recorder having to
+fabricate values.
+
+## D2. Module layout (`src/usage/`)
+
+```
+src/usage/
+  index.ts        — initUsageRecorder(): subscribes to llm:end + llm:error
+  recorder.ts     — recordUsage(payload): INSERT into llm_usage_events
+  query.ts        — listSubjects(windowMs), getSubjectDetail(id, windowMs)
+  types.ts        — UsageEvent (write), SubjectSummary, RequestRow (read)
+```
+
+`src/db/llm-usage-events-schema.ts` holds the Drizzle table definition,
+re-exported from `src/db/schema.ts`.
+
+### D2.1 Public API
+
+`src/usage/recorder.ts`:
+
+```ts
+export type ModelRole = 'main' | 'small' | 'embedding'
+
+export type UsageEvent = {
+  occurredAt: number              // ms epoch, defaults to Date.now() when omitted
+  turnId: string | null
+  storageContextId: string
+  contextType: 'dm' | 'group'
+  chatUserId: string
+  model: string
+  modelRole: ModelRole
+  inputTokens: number | null
+  outputTokens: number | null
+  stepCount: number               // 0 for embeddings
+  toolCallCount: number           // 0 for embeddings
+  messageCount: number            // 0 for embeddings, 1 for distill
+  finishReason: string | null
+  durationMs: number
+  responseId: string | null
+  error: string | null            // null on success
+}
+
+export function recordUsage(event: UsageEvent): void
+```
+
+`src/usage/index.ts`:
+
+```ts
+export function initUsageRecorder(): void
+```
+
+`src/usage/query.ts`:
+
+```ts
+export type UsageWindow = { windowMs: number | null }  // null = all-time
+
+export function listSubjects(window: UsageWindow): SubjectSummary[]
+export function getSubjectDetail(storageContextId: string, window: UsageWindow): RequestRow[]
+```
+
+`src/usage/types.ts`:
+
+```ts
+export type SubjectSummary = {
+  storageContextId: string
+  contextType: 'dm' | 'group'
+  totals: {
+    main:      { inputTokens: number; outputTokens: number; calls: number }
+    small:     { inputTokens: number; outputTokens: number; calls: number }
+    embedding: { inputTokens: number; outputTokens: number; calls: number }
+  }
+  toolCalls: number              // sum of tool_call_count
+  lastActiveAt: number           // max occurred_at
+}
+
+export type RequestRow = {
+  eventId: string
+  occurredAt: number
+  turnId: string | null
+  chatUserId: string
+  model: string
+  modelRole: ModelRole
+  inputTokens: number | null
+  outputTokens: number | null
+  stepCount: number
+  toolCallCount: number
+  messageCount: number
+  durationMs: number
+  finishReason: string | null
+  error: string | null
+}
+```
+
+`SubjectSummary.displayName` from parent §D6 lives in Phase 3 — the
+recorder doesn't join to `users`/`authorized_groups`. Phase 3 resolves
+the display name when building the dashboard payload.
+
+### D2.2 Recorder internals
+
+```ts
+// src/usage/recorder.ts
+export function recordUsage(event: UsageEvent): void {
+  try {
+    getDrizzleDb()
+      .insert(llmUsageEvents)
+      .values({
+        eventId: crypto.randomUUID(),
+        occurredAt: event.occurredAt,
+        turnId: event.turnId,
+        storageContextId: event.storageContextId,
+        contextType: event.contextType,
+        chatUserId: event.chatUserId,
+        model: event.model,
+        modelRole: event.modelRole,
+        inputTokens: event.inputTokens,
+        outputTokens: event.outputTokens,
+        stepCount: event.stepCount,
+        toolCallCount: event.toolCallCount,
+        messageCount: event.messageCount,
+        finishReason: event.finishReason,
+        durationMs: event.durationMs,
+        responseId: event.responseId,
+        error: event.error,
+      })
+      .run()
+  } catch (error) {
+    log.error(
+      { err: error instanceof Error ? error.message : String(error), modelRole: event.modelRole },
+      'recordUsage failed',
+    )
+  }
+}
+```
+
+The try/catch is the safety net required by parent §D7 — failures in
+the recorder must not escape into the event-bus dispatch loop, which
+has no per-listener exception handling (`src/debug/event-bus.ts:29-31`).
+
+### D2.3 Bus subscriber
+
+```ts
+// src/usage/index.ts
+export function initUsageRecorder(): void {
+  subscribe(handleEvent)
+  log.info('usage recorder initialised')
+}
+
+function handleEvent(event: DebugEvent): void {
+  if (event.type === 'llm:end') {
+    recordFromLlmEnd(event)
+  } else if (event.type === 'llm:error') {
+    recordFromLlmError(event)
+  }
+}
+```
+
+`recordFromLlmEnd` and `recordFromLlmError` read the known payload
+fields out of `event.data` with explicit type narrowing, build a
+`UsageEvent`, and call `recordUsage`.
+
+## D3. Emit-signature extensions
+
+### D3.1 `emitLlmEnd`
+
+Extend payload with two fields, plumbed through the third overload only
+(the one already used in `invokeModel`):
+
+```ts
+// src/llm-orchestrator-events.ts (new payload fields shown ★)
+emitUser(
+  'llm:end',
+  contextId,
+  {
+    model: mainModel,
+    steps: result.steps.length,
+    totalDuration: Date.now() - startTime,
+    tokenUsage: result.usage,
+    responseId: result.response.id,
+    actualModel: result.response.modelId,
+    finishReason: result.finishReason,
+    messageCount: messages.length,
+    chatUserId,                        // ★ new
+    contextType,                       // ★ new
+    ...buildToolTelemetry(tools, routing),
+    generatedText: result.text,
+    stepsDetail: buildStepsDetail(result.steps),
+  },
+  turnId,
+)
+```
+
+Signature gain: `(..., chatUserId: string, contextType: 'dm' | 'group')`.
+Since this function has three overloads today (no-routing, routing-only,
+routing + turnId), we collapse to ONE supported shape going forward.
+The other overloads are unused (`grep` confirms `invokeModel` is the
+sole caller and always passes routing + turnId). Simplify to a single
+typed signature.
+
+Drop the unused overloads. `emitLlmStart` keeps its overloads because
+its callsite still uses one of them (no routing path); only `emitLlmEnd`
+is simplified.
+
+### D3.2 `emitLlmError`
+
+```ts
+// src/llm-orchestrator-support.ts
+export const emitLlmError = (
+  contextId: string,
+  chatUserId: string,
+  contextType: 'dm' | 'group',
+  mainModel: string,
+  startTime: number,
+  messageCount: number,
+  error: unknown,
+  turnId?: string,
+): void => {
+  emitUser(
+    'llm:error',
+    contextId,
+    {
+      error: error instanceof Error ? error.message : String(error),
+      model: mainModel,
+      chatUserId,
+      contextType,
+      durationMs: Date.now() - startTime,
+      messageCount,
+    },
+    turnId,
+  )
+}
+```
+
+Caller (`llm-orchestrator.ts:252`) passes the values it already has.
+
+### D3.3 `InvokeModelArgs` plumbing
+
+`src/llm-orchestrator-types.ts:55`:
+
+```ts
+export type InvokeModelArgs = {
+  contextId: string
+  chatUserId: string                       // ★ new
+  contextType: 'dm' | 'group'              // ★ new
+  mainModel: string
+  model: ReturnType<ReturnType<typeof createOpenAICompatible>>
+  provider: TaskProvider
+  tools: ToolSet
+  toolRouting: ToolRoutingInfo | undefined
+  messages: ModelMessage[]
+  deps: LlmOrchestratorDeps
+}
+```
+
+`llm-orchestrator.ts`'s `callLlm` already takes both; just include them
+when building `InvokeModelArgs`. The current `prepareLlmInvocation`
+helper (`llm-orchestrator-tools.ts`) assembles `InvokeModelArgs` —
+extend it to pass `chatUserId` and `contextType` through.
+
+For the error path: `processMessage` records the LLM start time
+(implicit via the `try` block) and message count. Capture both into
+locals before `try` so they're available in the `catch`:
+
+```ts
+const startedAt = Date.now()
+const messageCount = baseHistory.length + 1  // + the user turn
+try {
+  ...
+} catch (error) {
+  emitLlmError(contextId, chatUserId, contextType, mainModel, startedAt, messageCount, error, resolvedTurnId)
+  ...
+}
+```
+
+Open question — `mainModel` at the `processMessage` level: today it's
+resolved inside `callLlm` via `resolveModelName`. We can either thread
+it back out for the catch or call `resolveModelName()` again in the
+catch (cheap, system_config cache). Simpler: resolve once in
+`processMessage` before the try, pass into `callLlm`.
+
+## D4. Direct recorder calls (embedding + distill)
+
+### D4.1 `src/embeddings.ts`
+
+Widen `getEmbedding` / `tryGetEmbedding` to take a `context` parameter:
+
+```ts
+export type EmbeddingCallContext = {
+  storageContextId: string
+  contextType: 'dm' | 'group'
+  chatUserId: string
+}
+
+export async function tryGetEmbedding(
+  text: string,
+  apiKey: string,
+  baseUrl: string,
+  model: string,
+  context: EmbeddingCallContext,
+  deps: EmbeddingsDeps = defaultEmbeddingsDeps,
+): Promise<number[] | null>
+```
+
+After the `embed()` call, build a `UsageEvent` and call `recordUsage`:
+
+```ts
+const start = Date.now()
+const { embedding, usage } = await deps.embed({ model: provider.embeddingModel(model), value: text })
+recordUsage({
+  occurredAt: start,
+  turnId: null,
+  storageContextId: context.storageContextId,
+  contextType: context.contextType,
+  chatUserId: context.chatUserId,
+  model,
+  modelRole: 'embedding',
+  inputTokens: usage?.tokens ?? null,   // single-value embed returns tokens count
+  outputTokens: null,                    // embeddings have no output tokens
+  stepCount: 0,
+  toolCallCount: 0,
+  messageCount: 0,
+  finishReason: null,
+  durationMs: Date.now() - start,
+  responseId: null,
+  error: null,
+})
+```
+
+Failure path inside `tryGetEmbedding` — record an error row too:
+
+```ts
+try { ... } catch (error) {
+  recordUsage({ ...sameShape, error: error.message, durationMs: Date.now() - start })
+}
+```
+
+Note on `usage` shape: `embed()` from the Vercel AI SDK returns
+`{ embedding, usage: { tokens: number } | undefined }`. We map `tokens`
+to `input_tokens`; `output_tokens` stays null for embeddings.
+
+Callsite updates:
+
+- `src/tools/save-memo.ts:38` — pass
+  `{ storageContextId: userId, contextType: <dm | group>, chatUserId: <author> }`.
+  Need to look up what `userId` represents in the save-memo context;
+  the brainstorm noted memos are per-user even in groups, so:
+  - `storageContextId: userId` (the memo's owner)
+  - `contextType: 'dm'` (memos are per-user; even in group chats, the
+    save_memo tool is called against the user's own memos)
+  - `chatUserId: userId`
+- `src/tools/search-memos.ts:95` — same.
+
+The tool factories don't currently receive `contextType` explicitly, but
+they do receive `MakeToolsOptions` which includes it
+(`src/tools/CLAUDE.md`). Thread it through.
+
+### D4.2 `src/web/distill.ts`
+
+Same pattern — widen `distillWebContent` input to require
+`chatUserId` and `contextType` (it already takes `storageContextId`):
+
+```ts
+export async function distillWebContent(
+  input: {
+    readonly storageContextId: string
+    readonly contextType: 'dm' | 'group'       // ★ new
+    readonly chatUserId: string                // ★ new
+    readonly title: string
+    readonly content: string
+    readonly goal?: string
+  },
+  deps: DistillDeps = defaultDeps,
+): Promise<DistilledContent>
+```
+
+After `generateText` returns, build a UsageEvent and call `recordUsage`
+with `modelRole: 'small'`, `messageCount: 1` (the prompt is a single
+synthetic message), `stepCount: result.steps?.length ?? 1`,
+`toolCallCount: 0`.
+
+Callsite: `src/web/fetch.ts` (or wherever `distillWebContent` is
+called). Find and update.
+
+## D5. `initUsageRecorder` wiring
+
+`src/index.ts`, between `seedSystemConfigFromEnv()` (line 74) and
+`initializeMessageCache()` (line 83):
+
+```ts
+seedSystemConfigFromEnv()
+const missingSystemKeys = missingSystemConfigKeys()
+if (missingSystemKeys.length > 0) {
+  log.warn(...)
+}
+
+initUsageRecorder()    // ★ new
+
+initializeMessageCache()
+```
+
+`initUsageRecorder` must run BEFORE the chat provider starts and before
+any other event subscriber wires in. The subscriber being present makes
+`listeners.size >= 1` permanently, so `emitUser` no longer
+short-circuits — but that's fine: the expensive payload-build work
+inside `emitLlmEnd` already runs regardless of listener count (it's
+upstream of the bus dispatch).
+
+No teardown: the recorder lives for the process lifetime; the graceful
+shutdown path doesn't need to call into the recorder.
+
+## D6. Drizzle schema
+
+`src/db/llm-usage-events-schema.ts`:
+
+```ts
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core'
+
+export const llmUsageEvents = sqliteTable(
+  'llm_usage_events',
+  {
+    eventId:          text('event_id').primaryKey(),
+    occurredAt:       integer('occurred_at').notNull(),
+    turnId:           text('turn_id'),
+    storageContextId: text('storage_context_id').notNull(),
+    contextType:      text('context_type').notNull(),
+    chatUserId:       text('chat_user_id').notNull(),
+    model:            text('model').notNull(),
+    modelRole:        text('model_role').notNull(),
+    inputTokens:      integer('input_tokens'),
+    outputTokens:     integer('output_tokens'),
+    stepCount:        integer('step_count').notNull().default(0),
+    toolCallCount:    integer('tool_call_count').notNull().default(0),
+    messageCount:     integer('message_count').notNull().default(0),
+    finishReason:     text('finish_reason'),
+    durationMs:       integer('duration_ms').notNull(),
+    responseId:       text('response_id'),
+    error:            text('error'),
+  },
+  (table) => [
+    index('idx_llm_usage_subject').on(table.storageContextId, table.occurredAt),
+    index('idx_llm_usage_chat_user').on(table.chatUserId, table.occurredAt),
+    index('idx_llm_usage_turn').on(table.turnId),
+    index('idx_llm_usage_occurred').on(table.occurredAt),
+  ],
+)
+
+export type LlmUsageEventRow = typeof llmUsageEvents.$inferSelect
+```
+
+`src/db/schema.ts` gets:
+
+```ts
+export { llmUsageEvents } from './llm-usage-events-schema.js'
+export type { LlmUsageEventRow } from './llm-usage-events-schema.js'
+```
+
+## D7. Migration 035
+
+`src/db/migrations/035_llm_usage_events.ts`, plain SQL matching the
+shape of `034_system_config.ts`:
+
+```ts
+const up = (db: Database): void => {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS llm_usage_events (
+      event_id           TEXT PRIMARY KEY,
+      occurred_at        INTEGER NOT NULL,
+      turn_id            TEXT,
+      storage_context_id TEXT NOT NULL,
+      context_type       TEXT NOT NULL,
+      chat_user_id       TEXT NOT NULL,
+      model              TEXT NOT NULL,
+      model_role         TEXT NOT NULL,
+      input_tokens       INTEGER,
+      output_tokens      INTEGER,
+      step_count         INTEGER NOT NULL DEFAULT 0,
+      tool_call_count    INTEGER NOT NULL DEFAULT 0,
+      message_count      INTEGER NOT NULL DEFAULT 0,
+      finish_reason      TEXT,
+      duration_ms        INTEGER NOT NULL,
+      response_id        TEXT,
+      error              TEXT
+    )
+  `)
+  db.run(`CREATE INDEX IF NOT EXISTS idx_llm_usage_subject   ON llm_usage_events(storage_context_id, occurred_at)`)
+  db.run(`CREATE INDEX IF NOT EXISTS idx_llm_usage_chat_user ON llm_usage_events(chat_user_id, occurred_at)`)
+  db.run(`CREATE INDEX IF NOT EXISTS idx_llm_usage_turn      ON llm_usage_events(turn_id)`)
+  db.run(`CREATE INDEX IF NOT EXISTS idx_llm_usage_occurred  ON llm_usage_events(occurred_at)`)
+  log.info('migration 035: created llm_usage_events table + indexes')
+}
+```
+
+Registered in `src/db/index.ts` between `migration034SystemConfig` and
+`migration036DropUserLlmConfig`. The numeric ordering is preserved
+(034 → 035 → 036) even though Phase 1 shipped only 034 + 036; the new
+035 slots in cleanly.
+
+Idempotent (`IF NOT EXISTS` on table and indexes), so re-running on an
+already-migrated DB is a no-op.
+
+## D8. Query module
+
+`src/usage/query.ts`:
+
+```ts
+export function listSubjects(window: UsageWindow): SubjectSummary[] {
+  const since = window.windowMs === null ? 0 : Date.now() - window.windowMs
+
+  // Aggregate per (storage_context_id, model_role)
+  const rows = getDrizzleDb()
+    .select({
+      storageContextId: llmUsageEvents.storageContextId,
+      contextType: llmUsageEvents.contextType,
+      modelRole: llmUsageEvents.modelRole,
+      calls: sql<number>`count(*)`,
+      inputTokens: sql<number>`coalesce(sum(${llmUsageEvents.inputTokens}), 0)`,
+      outputTokens: sql<number>`coalesce(sum(${llmUsageEvents.outputTokens}), 0)`,
+      toolCalls: sql<number>`coalesce(sum(${llmUsageEvents.toolCallCount}), 0)`,
+      lastActiveAt: sql<number>`max(${llmUsageEvents.occurredAt})`,
+    })
+    .from(llmUsageEvents)
+    .where(gte(llmUsageEvents.occurredAt, since))
+    .groupBy(
+      llmUsageEvents.storageContextId,
+      llmUsageEvents.contextType,
+      llmUsageEvents.modelRole,
+    )
+    .all()
+
+  // Pivot model_role into the three columns of SubjectSummary
+  return pivotByRole(rows)
+}
+
+export function getSubjectDetail(storageContextId: string, window: UsageWindow): RequestRow[] {
+  const since = window.windowMs === null ? 0 : Date.now() - window.windowMs
+  return getDrizzleDb()
+    .select({ /* RequestRow columns */ })
+    .from(llmUsageEvents)
+    .where(and(
+      eq(llmUsageEvents.storageContextId, storageContextId),
+      gte(llmUsageEvents.occurredAt, since),
+    ))
+    .orderBy(desc(llmUsageEvents.occurredAt))
+    .all()
+}
+```
+
+`pivotByRole` is a small in-memory transform: group rows by
+`storageContextId`, fold each `modelRole`'s aggregates into the right
+slot of `SubjectSummary.totals`, fill missing roles with zeros.
+
+## D9. Failure handling
+
+Per parent §D7 and brainstorm Q (E), the recorder catches and logs all
+exceptions. The DB constraint check (`event_id` is PK with
+`crypto.randomUUID()`) means collisions are astronomically rare in
+practice; a collision still produces a single logged `error` line and
+the next event proceeds normally.
+
+The recorder does NOT:
+
+- rethrow
+- retry on transient errors (SQLite write contention with WAL is not a
+  real concern at this volume)
+- maintain in-memory buffering or batching (single-row inserts are
+  cheap; the bus is in-process)
+
+If `getDrizzleDb()` somehow returns a closed connection (test harness
+edge case), the catch absorbs the error.
+
+## D10. Logging
+
+- Recorder logs `info` on `initUsageRecorder` (once per process).
+- `error` on insert failure with `eventType` and exception message.
+- `debug` (optional) inside `recordUsage` with the modelRole and
+  contextId for hot-path tracing; can be filtered out via `LOG_LEVEL`.
+
+Per parent §D7, the recorder NEVER logs:
+
+- `apiKey` content
+- `generatedText` content (it's in the bus payload but we don't persist
+  it)
+- raw token contents
+
+## D11. Forward-compatibility checks (carry-through from brainstorm)
+
+| Future                       | This-phase shape                                                                                                       |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Phase 3 dashboard            | Query module already returns the design D6 shapes; routes just wire them                                               |
+| Phase 4 tool-call table      | Mirror this module pattern; the `tool_call_count` field stays as a fast aggregate                                      |
+| Phase 4 outbox columns       | `ALTER TABLE ADD COLUMN forwarded_at INTEGER`, no schema migration required for the existing rows                      |
+| Phase 5 anonymous stats      | Reads `occurred_at`, `storage_context_id`, `chat_user_id` for active-subject counts; indexes already there             |
+| Deterministic event_id       | Phase 4 swap is local: change `crypto.randomUUID()` to a hash of `(response_id, occurred_at, model_role)` and migrate  |
+
+## D12. Out of scope
+
+- HTTP routes / dashboard UI (parent §D6 → Phase 3).
+- DM `/admin` command (parent §D4 → Phase 3 or never).
+- Tool-call per-row table (Phase 4).
+- Outbox forwarder (Phase 4).
+- Per-tool drill-down beyond the per-turn count.
+- Daily roll-ups; raw query at this volume is fine.
+- Charts in the dashboard; tables only in Phase 3.
+
+## D13. Code-change file list
+
+| File                                            | Change                                                                                                    |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `src/db/migrations/035_llm_usage_events.ts`     | New: create table + 4 indexes                                                                             |
+| `src/db/index.ts:48-119`                        | Register `migration035LlmUsageEvents` between 034 and 036                                                 |
+| `src/db/llm-usage-events-schema.ts`             | New: Drizzle table                                                                                        |
+| `src/db/schema.ts:28`                           | Re-export `llmUsageEvents` and `LlmUsageEventRow`                                                         |
+| `src/usage/recorder.ts`                         | New: `recordUsage`, `UsageEvent` type                                                                     |
+| `src/usage/index.ts`                            | New: `initUsageRecorder`, bus subscriber                                                                  |
+| `src/usage/query.ts`                            | New: `listSubjects`, `getSubjectDetail`                                                                   |
+| `src/usage/types.ts`                            | New: `SubjectSummary`, `RequestRow`, `ModelRole`, `UsageWindow`                                           |
+| `src/index.ts:74-83`                            | Call `initUsageRecorder()` after `seedSystemConfigFromEnv`                                                |
+| `src/llm-orchestrator-events.ts:153-202`        | Extend `emitLlmEnd` payload with `chatUserId`, `contextType`; simplify to single signature                |
+| `src/llm-orchestrator-support.ts:161-181`       | Extend `emitLlmError` with `chatUserId`, `contextType`, `mainModel`, `startTime`, `messageCount`          |
+| `src/llm-orchestrator-types.ts:55`              | Add `chatUserId`, `contextType` to `InvokeModelArgs`                                                      |
+| `src/llm-orchestrator-invoke.ts:97,108`         | Pass new fields through to emit calls                                                                     |
+| `src/llm-orchestrator-tools.ts`                 | If `prepareLlmInvocation` builds `InvokeModelArgs`, thread the new fields                                 |
+| `src/llm-orchestrator.ts:217-256`               | Capture `startedAt`/`messageCount`/`mainModel` before try, pass to `emitLlmError`; thread to `callLlm`    |
+| `src/embeddings.ts:33-63`                       | Add `EmbeddingCallContext` parameter; call `recordUsage` after embed (success and failure)                |
+| `src/tools/save-memo.ts:38`                     | Pass embedding context to `tryGetEmbedding`                                                               |
+| `src/tools/search-memos.ts:95`                  | Same                                                                                                      |
+| `src/web/distill.ts:96-128`                     | Accept `chatUserId`, `contextType` in input; call `recordUsage` after `generateText`                      |
+| `src/web/fetch.ts` (or wherever distill is called) | Thread the new fields through                                                                          |
+
+Tests (under `tests/`):
+
+| Test file                                              | Coverage                                                                       |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| `tests/db/migrations/035-llm-usage-events.test.ts`     | Table + 4 indexes; NOT NULL; default 0 on counts; idempotency                  |
+| `tests/usage/recorder.test.ts`                         | Round-trip insert; failure path logs but doesn't throw; null tokens accepted   |
+| `tests/usage/recorder-integration.test.ts`             | `llm:end` event in → row out; `llm:error` event in → row out with error set    |
+| `tests/usage/query.test.ts`                            | `listSubjects` aggregates correctly across model roles + windows; pivot logic  |
+| `tests/llm-orchestrator-events.test.ts`                | Extended payload contains chatUserId/contextType; existing assertions still pass |
+| `tests/llm-orchestrator-support.test.ts`               | `emitLlmError` extended payload                                                |
+| `tests/embeddings.test.ts`                             | `tryGetEmbedding` records on success + failure                                 |
+| `tests/web/distill.test.ts`                            | `distillWebContent` records on success + failure                               |
+| `tests/llm-orchestrator.test.ts`                       | `emitLlmError` is called with the captured fields on the throw path            |
+
+## D14. Acceptance (from roadmap, refined)
+
+- After a real LLM turn, one row appears in `llm_usage_events` with
+  populated `model`, `model_role='main'`, `turn_id`, `storage_context_id`,
+  `chat_user_id`, `context_type`, `step_count >= 1`,
+  `tool_call_count >= 0`, `message_count >= 1`, `duration_ms > 0`.
+- After a save_memo with embedding model configured, one row with
+  `model_role='embedding'` and `input_tokens` populated if the provider
+  returned usage.
+- After a web_fetch that triggers distillation, one row with
+  `model_role='small'`.
+- A thrown `generateText` (mocked in a test) still produces one row with
+  `error` populated and `model_role='main'`.
+- A recorder exception (mocked) is logged and dropped; the
+  `state-collector` subscriber continues to fire.
+- `listSubjects({ windowMs: 7 * 24 * 3600 * 1000 })` returns rows whose
+  totals sum equals the raw-SQL aggregate over the same window.
+
+## D15. Rollback
+
+- Revert the orchestrator and module changes (no public API surfaces
+  shipped beyond `src/usage/` and the bus payload extension; both are
+  internal).
+- The migration is additive — leaving `llm_usage_events` in place is
+  harmless if the recorder is removed.
+- For a clean rollback: drop migration 035's registration in
+  `src/db/index.ts`; the table stays in deployed DBs but no longer
+  receives writes. Optional `DROP TABLE llm_usage_events` in a follow-up
+  migration if storage matters.

--- a/docs/superpowers/specs/2026-05-19-phase-2-usage-recorder-design.md
+++ b/docs/superpowers/specs/2026-05-19-phase-2-usage-recorder-design.md
@@ -70,7 +70,7 @@ re-exported from `src/db/schema.ts`.
 export type ModelRole = 'main' | 'small' | 'embedding'
 
 export type UsageEvent = {
-  occurredAt: number              // ms epoch, defaults to Date.now() when omitted
+  occurredAt: number // ms epoch, defaults to Date.now() when omitted
   turnId: string | null
   storageContextId: string
   contextType: 'dm' | 'group'
@@ -79,13 +79,13 @@ export type UsageEvent = {
   modelRole: ModelRole
   inputTokens: number | null
   outputTokens: number | null
-  stepCount: number               // 0 for embeddings
-  toolCallCount: number           // 0 for embeddings
-  messageCount: number            // 0 for embeddings, 1 for distill
+  stepCount: number // 0 for embeddings
+  toolCallCount: number // 0 for embeddings
+  messageCount: number // 0 for embeddings, 1 for distill
   finishReason: string | null
   durationMs: number
   responseId: string | null
-  error: string | null            // null on success
+  error: string | null // null on success
 }
 
 export function recordUsage(event: UsageEvent): void
@@ -100,7 +100,7 @@ export function initUsageRecorder(): void
 `src/usage/query.ts`:
 
 ```ts
-export type UsageWindow = { windowMs: number | null }  // null = all-time
+export type UsageWindow = { windowMs: number | null } // null = all-time
 
 export function listSubjects(window: UsageWindow): SubjectSummary[]
 export function getSubjectDetail(storageContextId: string, window: UsageWindow): RequestRow[]
@@ -113,12 +113,12 @@ export type SubjectSummary = {
   storageContextId: string
   contextType: 'dm' | 'group'
   totals: {
-    main:      { inputTokens: number; outputTokens: number; calls: number }
-    small:     { inputTokens: number; outputTokens: number; calls: number }
+    main: { inputTokens: number; outputTokens: number; calls: number }
+    small: { inputTokens: number; outputTokens: number; calls: number }
     embedding: { inputTokens: number; outputTokens: number; calls: number }
   }
-  toolCalls: number              // sum of tool_call_count
-  lastActiveAt: number           // max occurred_at
+  toolCalls: number // sum of tool_call_count
+  lastActiveAt: number // max occurred_at
 }
 
 export type RequestRow = {
@@ -227,8 +227,8 @@ emitUser(
     actualModel: result.response.modelId,
     finishReason: result.finishReason,
     messageCount: messages.length,
-    chatUserId,                        // ★ new
-    contextType,                       // ★ new
+    chatUserId, // ★ new
+    contextType, // ★ new
     ...buildToolTelemetry(tools, routing),
     generatedText: result.text,
     stepsDetail: buildStepsDetail(result.steps),
@@ -287,8 +287,8 @@ Caller (`llm-orchestrator.ts:252`) passes the values it already has.
 ```ts
 export type InvokeModelArgs = {
   contextId: string
-  chatUserId: string                       // ★ new
-  contextType: 'dm' | 'group'              // ★ new
+  chatUserId: string // ★ new
+  contextType: 'dm' | 'group' // ★ new
   mainModel: string
   model: ReturnType<ReturnType<typeof createOpenAICompatible>>
   provider: TaskProvider
@@ -361,8 +361,8 @@ recordUsage({
   chatUserId: context.chatUserId,
   model,
   modelRole: 'embedding',
-  inputTokens: usage?.tokens ?? null,   // single-value embed returns tokens count
-  outputTokens: null,                    // embeddings have no output tokens
+  inputTokens: usage?.tokens ?? null, // single-value embed returns tokens count
+  outputTokens: null, // embeddings have no output tokens
   stepCount: 0,
   toolCallCount: 0,
   messageCount: 0,
@@ -410,8 +410,8 @@ Same pattern — widen `distillWebContent` input to require
 export async function distillWebContent(
   input: {
     readonly storageContextId: string
-    readonly contextType: 'dm' | 'group'       // ★ new
-    readonly chatUserId: string                // ★ new
+    readonly contextType: 'dm' | 'group' // ★ new
+    readonly chatUserId: string // ★ new
     readonly title: string
     readonly content: string
     readonly goal?: string
@@ -465,23 +465,23 @@ import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core'
 export const llmUsageEvents = sqliteTable(
   'llm_usage_events',
   {
-    eventId:          text('event_id').primaryKey(),
-    occurredAt:       integer('occurred_at').notNull(),
-    turnId:           text('turn_id'),
+    eventId: text('event_id').primaryKey(),
+    occurredAt: integer('occurred_at').notNull(),
+    turnId: text('turn_id'),
     storageContextId: text('storage_context_id').notNull(),
-    contextType:      text('context_type').notNull(),
-    chatUserId:       text('chat_user_id').notNull(),
-    model:            text('model').notNull(),
-    modelRole:        text('model_role').notNull(),
-    inputTokens:      integer('input_tokens'),
-    outputTokens:     integer('output_tokens'),
-    stepCount:        integer('step_count').notNull().default(0),
-    toolCallCount:    integer('tool_call_count').notNull().default(0),
-    messageCount:     integer('message_count').notNull().default(0),
-    finishReason:     text('finish_reason'),
-    durationMs:       integer('duration_ms').notNull(),
-    responseId:       text('response_id'),
-    error:            text('error'),
+    contextType: text('context_type').notNull(),
+    chatUserId: text('chat_user_id').notNull(),
+    model: text('model').notNull(),
+    modelRole: text('model_role').notNull(),
+    inputTokens: integer('input_tokens'),
+    outputTokens: integer('output_tokens'),
+    stepCount: integer('step_count').notNull().default(0),
+    toolCallCount: integer('tool_call_count').notNull().default(0),
+    messageCount: integer('message_count').notNull().default(0),
+    finishReason: text('finish_reason'),
+    durationMs: integer('duration_ms').notNull(),
+    responseId: text('response_id'),
+    error: text('error'),
   },
   (table) => [
     index('idx_llm_usage_subject').on(table.storageContextId, table.occurredAt),
@@ -567,11 +567,7 @@ export function listSubjects(window: UsageWindow): SubjectSummary[] {
     })
     .from(llmUsageEvents)
     .where(gte(llmUsageEvents.occurredAt, since))
-    .groupBy(
-      llmUsageEvents.storageContextId,
-      llmUsageEvents.contextType,
-      llmUsageEvents.modelRole,
-    )
+    .groupBy(llmUsageEvents.storageContextId, llmUsageEvents.contextType, llmUsageEvents.modelRole)
     .all()
 
   // Pivot model_role into the three columns of SubjectSummary
@@ -581,12 +577,11 @@ export function listSubjects(window: UsageWindow): SubjectSummary[] {
 export function getSubjectDetail(storageContextId: string, window: UsageWindow): RequestRow[] {
   const since = window.windowMs === null ? 0 : Date.now() - window.windowMs
   return getDrizzleDb()
-    .select({ /* RequestRow columns */ })
+    .select({
+      /* RequestRow columns */
+    })
     .from(llmUsageEvents)
-    .where(and(
-      eq(llmUsageEvents.storageContextId, storageContextId),
-      gte(llmUsageEvents.occurredAt, since),
-    ))
+    .where(and(eq(llmUsageEvents.storageContextId, storageContextId), gte(llmUsageEvents.occurredAt, since)))
     .orderBy(desc(llmUsageEvents.occurredAt))
     .all()
 }
@@ -631,13 +626,13 @@ Per parent §D7, the recorder NEVER logs:
 
 ## D11. Forward-compatibility checks (carry-through from brainstorm)
 
-| Future                       | This-phase shape                                                                                                       |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Phase 3 dashboard            | Query module already returns the design D6 shapes; routes just wire them                                               |
-| Phase 4 tool-call table      | Mirror this module pattern; the `tool_call_count` field stays as a fast aggregate                                      |
-| Phase 4 outbox columns       | `ALTER TABLE ADD COLUMN forwarded_at INTEGER`, no schema migration required for the existing rows                      |
-| Phase 5 anonymous stats      | Reads `occurred_at`, `storage_context_id`, `chat_user_id` for active-subject counts; indexes already there             |
-| Deterministic event_id       | Phase 4 swap is local: change `crypto.randomUUID()` to a hash of `(response_id, occurred_at, model_role)` and migrate  |
+| Future                  | This-phase shape                                                                                                      |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Phase 3 dashboard       | Query module already returns the design D6 shapes; routes just wire them                                              |
+| Phase 4 tool-call table | Mirror this module pattern; the `tool_call_count` field stays as a fast aggregate                                     |
+| Phase 4 outbox columns  | `ALTER TABLE ADD COLUMN forwarded_at INTEGER`, no schema migration required for the existing rows                     |
+| Phase 5 anonymous stats | Reads `occurred_at`, `storage_context_id`, `chat_user_id` for active-subject counts; indexes already there            |
+| Deterministic event_id  | Phase 4 swap is local: change `crypto.randomUUID()` to a hash of `(response_id, occurred_at, model_role)` and migrate |
 
 ## D12. Out of scope
 
@@ -651,42 +646,42 @@ Per parent §D7, the recorder NEVER logs:
 
 ## D13. Code-change file list
 
-| File                                            | Change                                                                                                    |
-| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `src/db/migrations/035_llm_usage_events.ts`     | New: create table + 4 indexes                                                                             |
-| `src/db/index.ts:48-119`                        | Register `migration035LlmUsageEvents` between 034 and 036                                                 |
-| `src/db/llm-usage-events-schema.ts`             | New: Drizzle table                                                                                        |
-| `src/db/schema.ts:28`                           | Re-export `llmUsageEvents` and `LlmUsageEventRow`                                                         |
-| `src/usage/recorder.ts`                         | New: `recordUsage`, `UsageEvent` type                                                                     |
-| `src/usage/index.ts`                            | New: `initUsageRecorder`, bus subscriber                                                                  |
-| `src/usage/query.ts`                            | New: `listSubjects`, `getSubjectDetail`                                                                   |
-| `src/usage/types.ts`                            | New: `SubjectSummary`, `RequestRow`, `ModelRole`, `UsageWindow`                                           |
-| `src/index.ts:74-83`                            | Call `initUsageRecorder()` after `seedSystemConfigFromEnv`                                                |
-| `src/llm-orchestrator-events.ts:153-202`        | Extend `emitLlmEnd` payload with `chatUserId`, `contextType`; simplify to single signature                |
-| `src/llm-orchestrator-support.ts:161-181`       | Extend `emitLlmError` with `chatUserId`, `contextType`, `mainModel`, `startTime`, `messageCount`          |
-| `src/llm-orchestrator-types.ts:55`              | Add `chatUserId`, `contextType` to `InvokeModelArgs`                                                      |
-| `src/llm-orchestrator-invoke.ts:97,108`         | Pass new fields through to emit calls                                                                     |
-| `src/llm-orchestrator-tools.ts`                 | If `prepareLlmInvocation` builds `InvokeModelArgs`, thread the new fields                                 |
-| `src/llm-orchestrator.ts:217-256`               | Capture `startedAt`/`messageCount`/`mainModel` before try, pass to `emitLlmError`; thread to `callLlm`    |
-| `src/embeddings.ts:33-63`                       | Add `EmbeddingCallContext` parameter; call `recordUsage` after embed (success and failure)                |
-| `src/tools/save-memo.ts:38`                     | Pass embedding context to `tryGetEmbedding`                                                               |
-| `src/tools/search-memos.ts:95`                  | Same                                                                                                      |
-| `src/web/distill.ts:96-128`                     | Accept `chatUserId`, `contextType` in input; call `recordUsage` after `generateText`                      |
+| File                                               | Change                                                                                                 |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `src/db/migrations/035_llm_usage_events.ts`        | New: create table + 4 indexes                                                                          |
+| `src/db/index.ts:48-119`                           | Register `migration035LlmUsageEvents` between 034 and 036                                              |
+| `src/db/llm-usage-events-schema.ts`                | New: Drizzle table                                                                                     |
+| `src/db/schema.ts:28`                              | Re-export `llmUsageEvents` and `LlmUsageEventRow`                                                      |
+| `src/usage/recorder.ts`                            | New: `recordUsage`, `UsageEvent` type                                                                  |
+| `src/usage/index.ts`                               | New: `initUsageRecorder`, bus subscriber                                                               |
+| `src/usage/query.ts`                               | New: `listSubjects`, `getSubjectDetail`                                                                |
+| `src/usage/types.ts`                               | New: `SubjectSummary`, `RequestRow`, `ModelRole`, `UsageWindow`                                        |
+| `src/index.ts:74-83`                               | Call `initUsageRecorder()` after `seedSystemConfigFromEnv`                                             |
+| `src/llm-orchestrator-events.ts:153-202`           | Extend `emitLlmEnd` payload with `chatUserId`, `contextType`; simplify to single signature             |
+| `src/llm-orchestrator-support.ts:161-181`          | Extend `emitLlmError` with `chatUserId`, `contextType`, `mainModel`, `startTime`, `messageCount`       |
+| `src/llm-orchestrator-types.ts:55`                 | Add `chatUserId`, `contextType` to `InvokeModelArgs`                                                   |
+| `src/llm-orchestrator-invoke.ts:97,108`            | Pass new fields through to emit calls                                                                  |
+| `src/llm-orchestrator-tools.ts`                    | If `prepareLlmInvocation` builds `InvokeModelArgs`, thread the new fields                              |
+| `src/llm-orchestrator.ts:217-256`                  | Capture `startedAt`/`messageCount`/`mainModel` before try, pass to `emitLlmError`; thread to `callLlm` |
+| `src/embeddings.ts:33-63`                          | Add `EmbeddingCallContext` parameter; call `recordUsage` after embed (success and failure)             |
+| `src/tools/save-memo.ts:38`                        | Pass embedding context to `tryGetEmbedding`                                                            |
+| `src/tools/search-memos.ts:95`                     | Same                                                                                                   |
+| `src/web/distill.ts:96-128`                        | Accept `chatUserId`, `contextType` in input; call `recordUsage` after `generateText`                   |
 | `src/web/fetch.ts` (or wherever distill is called) | Thread the new fields through                                                                          |
 
 Tests (under `tests/`):
 
-| Test file                                              | Coverage                                                                       |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------ |
-| `tests/db/migrations/035-llm-usage-events.test.ts`     | Table + 4 indexes; NOT NULL; default 0 on counts; idempotency                  |
-| `tests/usage/recorder.test.ts`                         | Round-trip insert; failure path logs but doesn't throw; null tokens accepted   |
-| `tests/usage/recorder-integration.test.ts`             | `llm:end` event in → row out; `llm:error` event in → row out with error set    |
-| `tests/usage/query.test.ts`                            | `listSubjects` aggregates correctly across model roles + windows; pivot logic  |
-| `tests/llm-orchestrator-events.test.ts`                | Extended payload contains chatUserId/contextType; existing assertions still pass |
-| `tests/llm-orchestrator-support.test.ts`               | `emitLlmError` extended payload                                                |
-| `tests/embeddings.test.ts`                             | `tryGetEmbedding` records on success + failure                                 |
-| `tests/web/distill.test.ts`                            | `distillWebContent` records on success + failure                               |
-| `tests/llm-orchestrator.test.ts`                       | `emitLlmError` is called with the captured fields on the throw path            |
+| Test file                                          | Coverage                                                                         |
+| -------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `tests/db/migrations/035-llm-usage-events.test.ts` | Table + 4 indexes; NOT NULL; default 0 on counts; idempotency                    |
+| `tests/usage/recorder.test.ts`                     | Round-trip insert; failure path logs but doesn't throw; null tokens accepted     |
+| `tests/usage/recorder-integration.test.ts`         | `llm:end` event in → row out; `llm:error` event in → row out with error set      |
+| `tests/usage/query.test.ts`                        | `listSubjects` aggregates correctly across model roles + windows; pivot logic    |
+| `tests/llm-orchestrator-events.test.ts`            | Extended payload contains chatUserId/contextType; existing assertions still pass |
+| `tests/llm-orchestrator-support.test.ts`           | `emitLlmError` extended payload                                                  |
+| `tests/embeddings.test.ts`                         | `tryGetEmbedding` records on success + failure                                   |
+| `tests/web/distill.test.ts`                        | `distillWebContent` records on success + failure                                 |
+| `tests/llm-orchestrator.test.ts`                   | `emitLlmError` is called with the captured fields on the throw path              |
 
 ## D14. Acceptance (from roadmap, refined)
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -52,6 +52,12 @@
     "src/attachments/workspace.ts": ["exports"],
     "src/debug/state-collector.ts": ["exports"],
     "src/debug/turn-assembly.ts": ["exports"],
+    // src/usage/query.ts and src/usage/types.ts ship the public query surface
+    // that the Phase 3 billing dashboard will consume; nothing in src/ imports
+    // them yet, but the recorder tests in tests/usage/ exercise the queries.
+    "src/usage/query.ts": ["files", "exports"],
+    "src/usage/types.ts": ["types"],
+    "src/usage/index.ts": ["exports"],
     "tests/scripts/behavior-audit-integration.helpers.ts": ["exports", "types"],
     "tests/scripts/behavior-audit-integration.runtime-helpers.ts": ["exports", "types"],
     "tests/scripts/behavior-audit-integration.support.ts": ["exports", "types"],

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -45,6 +45,7 @@ import { migration031StagedFiles } from './migrations/031_staged_files.js'
 import { migration032StagedAttachmentId } from './migrations/032_staged_attachment_id.js'
 import { migration033StagedFilesUniquePlatformContext } from './migrations/033_staged_files_unique_platform_context.js'
 import { migration034SystemConfig } from './migrations/034_system_config.js'
+import { migration035LlmUsageEvents } from './migrations/035_llm_usage_events.js'
 import { migration036DropUserLlmConfig } from './migrations/036_drop_user_llm_config.js'
 
 const getDbPath = (): string => {
@@ -115,6 +116,7 @@ export const MIGRATIONS: readonly Migration[] = [
   migration032StagedAttachmentId,
   migration033StagedFilesUniquePlatformContext,
   migration034SystemConfig,
+  migration035LlmUsageEvents,
   migration036DropUserLlmConfig,
 ]
 

--- a/src/db/llm-usage-events-schema.ts
+++ b/src/db/llm-usage-events-schema.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core'
+
+export const llmUsageEvents = sqliteTable(
+  'llm_usage_events',
+  {
+    eventId: text('event_id').primaryKey(),
+    occurredAt: integer('occurred_at').notNull(),
+    turnId: text('turn_id'),
+    storageContextId: text('storage_context_id').notNull(),
+    contextType: text('context_type').notNull(),
+    chatUserId: text('chat_user_id').notNull(),
+    model: text('model').notNull(),
+    modelRole: text('model_role').notNull(),
+    inputTokens: integer('input_tokens'),
+    outputTokens: integer('output_tokens'),
+    stepCount: integer('step_count').notNull().default(0),
+    toolCallCount: integer('tool_call_count').notNull().default(0),
+    messageCount: integer('message_count').notNull().default(0),
+    finishReason: text('finish_reason'),
+    durationMs: integer('duration_ms').notNull(),
+    responseId: text('response_id'),
+    error: text('error'),
+  },
+  (table) => [
+    index('idx_llm_usage_subject').on(table.storageContextId, table.occurredAt),
+    index('idx_llm_usage_chat_user').on(table.chatUserId, table.occurredAt),
+    index('idx_llm_usage_turn').on(table.turnId),
+    index('idx_llm_usage_occurred').on(table.occurredAt),
+  ],
+)
+
+export type LlmUsageEventRow = typeof llmUsageEvents.$inferSelect

--- a/src/db/migrations/035_llm_usage_events.ts
+++ b/src/db/migrations/035_llm_usage_events.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { Database } from 'bun:sqlite'
+
+import { logger } from '../../logger.js'
+import type { Migration } from '../migrate.js'
+
+const log = logger.child({ scope: 'migration:035' })
+
+const up = (db: Database): void => {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS llm_usage_events (
+      event_id           TEXT PRIMARY KEY,
+      occurred_at        INTEGER NOT NULL,
+      turn_id            TEXT,
+      storage_context_id TEXT NOT NULL,
+      context_type       TEXT NOT NULL,
+      chat_user_id       TEXT NOT NULL,
+      model              TEXT NOT NULL,
+      model_role         TEXT NOT NULL,
+      input_tokens       INTEGER,
+      output_tokens      INTEGER,
+      step_count         INTEGER NOT NULL DEFAULT 0,
+      tool_call_count    INTEGER NOT NULL DEFAULT 0,
+      message_count      INTEGER NOT NULL DEFAULT 0,
+      finish_reason      TEXT,
+      duration_ms        INTEGER NOT NULL,
+      response_id        TEXT,
+      error              TEXT
+    )
+  `)
+  db.run('CREATE INDEX IF NOT EXISTS idx_llm_usage_subject ON llm_usage_events(storage_context_id, occurred_at)')
+  db.run('CREATE INDEX IF NOT EXISTS idx_llm_usage_chat_user ON llm_usage_events(chat_user_id, occurred_at)')
+  db.run('CREATE INDEX IF NOT EXISTS idx_llm_usage_turn ON llm_usage_events(turn_id)')
+  db.run('CREATE INDEX IF NOT EXISTS idx_llm_usage_occurred ON llm_usage_events(occurred_at)')
+  log.info('migration 035: created llm_usage_events table and indexes')
+}
+
+export const migration035LlmUsageEvents: Migration = {
+  id: '035_llm_usage_events',
+  up,
+}
+
+export default migration035LlmUsageEvents

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -26,6 +26,7 @@ export const userConfig = sqliteTable(
 )
 
 export { systemConfig } from './system-config-schema.js'
+export { llmUsageEvents, type LlmUsageEventRow } from './llm-usage-events-schema.js'
 
 export const conversationHistory = sqliteTable('conversation_history', {
   userId: text('user_id').primaryKey(),
@@ -295,5 +296,4 @@ export const attachments = sqliteTable(
   ],
 )
 export type AttachmentRow = typeof attachments.$inferSelect
-export { stagedFiles } from './staged-schema.js'
-export type { StagedFileRow } from './staged-schema.js'
+export { stagedFiles, type StagedFileRow } from './staged-schema.js'

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -7,6 +7,8 @@ import { createOpenAICompatible, type OpenAICompatibleProvider } from '@ai-sdk/o
 import { embed } from 'ai'
 
 import { logger } from './logger.js'
+import { recordUsage } from './usage/recorder.js'
+import type { ContextType } from './usage/types.js'
 
 const log = logger.child({ scope: 'embeddings' })
 
@@ -30,21 +32,94 @@ const defaultEmbeddingsDeps: EmbeddingsDeps = {
   getProvider,
 }
 
+export type EmbeddingCallContext = {
+  storageContextId: string
+  contextType: ContextType
+  chatUserId: string
+}
+
+type EmbedReturnShape = { embedding: number[]; usage?: { tokens?: number } }
+
+const extractInputTokens = (result: EmbedReturnShape): number | null => {
+  const tokens = result.usage?.tokens
+  return typeof tokens === 'number' ? tokens : null
+}
+
+const recordEmbeddingSuccess = (
+  context: EmbeddingCallContext,
+  model: string,
+  startedAt: number,
+  result: EmbedReturnShape,
+): void => {
+  recordUsage({
+    occurredAt: startedAt,
+    turnId: null,
+    storageContextId: context.storageContextId,
+    contextType: context.contextType,
+    chatUserId: context.chatUserId,
+    model,
+    modelRole: 'embedding',
+    inputTokens: extractInputTokens(result),
+    outputTokens: null,
+    stepCount: 0,
+    toolCallCount: 0,
+    messageCount: 0,
+    finishReason: null,
+    durationMs: Date.now() - startedAt,
+    responseId: null,
+    error: null,
+  })
+}
+
+const recordEmbeddingFailure = (
+  context: EmbeddingCallContext,
+  model: string,
+  startedAt: number,
+  error: unknown,
+): void => {
+  recordUsage({
+    occurredAt: startedAt,
+    turnId: null,
+    storageContextId: context.storageContextId,
+    contextType: context.contextType,
+    chatUserId: context.chatUserId,
+    model,
+    modelRole: 'embedding',
+    inputTokens: null,
+    outputTokens: null,
+    stepCount: 0,
+    toolCallCount: 0,
+    messageCount: 0,
+    finishReason: null,
+    durationMs: Date.now() - startedAt,
+    responseId: null,
+    error: error instanceof Error ? error.message : String(error),
+  })
+}
+
 export async function getEmbedding(
   text: string,
   apiKey: string,
   baseUrl: string,
   model: string,
+  context?: EmbeddingCallContext,
   deps: EmbeddingsDeps = defaultEmbeddingsDeps,
 ): Promise<number[]> {
   log.debug({ textLength: text.length, model }, 'getEmbedding called')
   const provider = deps.getProvider(apiKey, baseUrl)
-  const { embedding } = await deps.embed({
-    model: provider.embeddingModel(model),
-    value: text,
-  })
-  log.info({ model, dimension: embedding.length }, 'Embedding generated')
-  return embedding
+  const startedAt = Date.now()
+  try {
+    const result = await deps.embed({
+      model: provider.embeddingModel(model),
+      value: text,
+    })
+    if (context !== undefined) recordEmbeddingSuccess(context, model, startedAt, result)
+    log.info({ model, dimension: result.embedding.length }, 'Embedding generated')
+    return result.embedding
+  } catch (error) {
+    if (context !== undefined) recordEmbeddingFailure(context, model, startedAt, error)
+    throw error
+  }
 }
 
 export async function tryGetEmbedding(
@@ -52,10 +127,11 @@ export async function tryGetEmbedding(
   apiKey: string,
   baseUrl: string,
   model: string,
+  context?: EmbeddingCallContext,
   deps: EmbeddingsDeps = defaultEmbeddingsDeps,
 ): Promise<number[] | null> {
   try {
-    return await getEmbedding(text, apiKey, baseUrl, model, deps)
+    return await getEmbedding(text, apiKey, baseUrl, model, context, deps)
   } catch (error) {
     log.warn({ error: error instanceof Error ? error.message : String(error), model }, 'Embedding generation failed')
     return null

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { buildProviderForUser } from './providers/factory.js'
 import { scheduler } from './scheduler-instance.js'
 import { startScheduler, stopScheduler } from './scheduler.js'
 import { missingSystemConfigKeys, seedSystemConfigFromEnv } from './system-config.js'
+import { initUsageRecorder } from './usage/index.js'
 import { addUser } from './users.js'
 
 const log = logger.child({ scope: 'main' })
@@ -79,6 +80,8 @@ if (missingSystemKeys.length > 0) {
     'system_config is incomplete; the bot will reply "misconfigured" until these keys are set',
   )
 }
+
+initUsageRecorder()
 
 initializeMessageCache()
 

--- a/src/llm-orchestrator-events.ts
+++ b/src/llm-orchestrator-events.ts
@@ -151,36 +151,17 @@ export function emitLlmStart(
 }
 
 export function emitLlmEnd(
-  ...args:
-    | [
-        contextId: string,
-        mainModel: string,
-        result: ResolvedStreamTextResult,
-        startTime: number,
-        messages: ModelMessage[],
-        tools: ToolSet,
-      ]
-    | [
-        contextId: string,
-        mainModel: string,
-        result: ResolvedStreamTextResult,
-        startTime: number,
-        messages: ModelMessage[],
-        tools: ToolSet,
-        routing: ToolRoutingTelemetry,
-      ]
-    | [
-        contextId: string,
-        mainModel: string,
-        result: ResolvedStreamTextResult,
-        startTime: number,
-        messages: ModelMessage[],
-        tools: ToolSet,
-        routing: ToolRoutingTelemetry | undefined,
-        turnId: string,
-      ]
+  contextId: string,
+  chatUserId: string,
+  contextType: 'dm' | 'group',
+  mainModel: string,
+  result: ResolvedStreamTextResult,
+  startTime: number,
+  messages: ModelMessage[],
+  tools: ToolSet,
+  routing: ToolRoutingTelemetry | undefined,
+  turnId: string,
 ): void {
-  const [contextId, mainModel, result, startTime, messages, tools, routing, turnId] = args
   emitUser(
     'llm:end',
     contextId,
@@ -193,6 +174,8 @@ export function emitLlmEnd(
       actualModel: result.response.modelId,
       finishReason: result.finishReason,
       messageCount: messages.length,
+      chatUserId,
+      contextType,
       ...buildToolTelemetry(tools, routing),
       generatedText: result.text,
       stepsDetail: buildStepsDetail(result.steps),

--- a/src/llm-orchestrator-invoke.ts
+++ b/src/llm-orchestrator-invoke.ts
@@ -92,7 +92,7 @@ const buildToolCallFinishHandler =
 export const invokeModel = async (
   args: InvokeModelArgs & { reply: ReplyFn | undefined; turnId: string },
 ): ReturnType<LlmOrchestratorDeps['generateText']> => {
-  const { contextId, mainModel, model, provider, tools, messages, deps, reply, turnId } = args
+  const { contextId, chatUserId, contextType, mainModel, model, provider, tools, messages, deps, reply, turnId } = args
   const start = Date.now()
   emitLlmStart(contextId, mainModel, messages, tools, args.toolRouting, turnId)
   const result = await deps.generateText({
@@ -105,7 +105,7 @@ export const invokeModel = async (
     experimental_onToolCallStart: buildToolCallStartHandler(contextId, turnId),
     experimental_onToolCallFinish: buildToolCallFinishHandler(contextId, reply, turnId),
   })
-  emitLlmEnd(contextId, mainModel, result, start, messages, tools, args.toolRouting, turnId)
+  emitLlmEnd(contextId, chatUserId, contextType, mainModel, result, start, messages, tools, args.toolRouting, turnId)
   return result
 }
 

--- a/src/llm-orchestrator-support.ts
+++ b/src/llm-orchestrator-support.ts
@@ -9,7 +9,6 @@ import type { ReplyFn } from './chat/types.js'
 import { emitGlobal, emitUser } from './debug/event-bus.js'
 import { extractAppError, getAppErrorDetails, getUserMessage } from './errors.js'
 import { logger } from './logger.js'
-import { getSystemConfig } from './system-config.js'
 import { buildToolFailureResult, isToolFailureResult, type ToolFailureResult } from './tool-failure.js'
 
 const log = logger.child({ scope: 'llm-orchestrator:support' })
@@ -160,21 +159,24 @@ export async function handleOrchestratorMessageError(
 
 export const emitLlmError = (
   contextId: string,
-  _configContextId: string | undefined,
+  chatUserId: string,
+  contextType: 'dm' | 'group',
+  mainModel: string,
+  startTime: number,
+  messageCount: number,
   error: unknown,
   turnId?: string,
 ): void => {
-  const model = getSystemConfig('main_model')
-  let emittedModel = 'unknown'
-  if (model !== null) {
-    emittedModel = model
-  }
   emitUser(
     'llm:error',
     contextId,
     {
       error: error instanceof Error ? error.message : String(error),
-      model: emittedModel,
+      model: mainModel,
+      chatUserId,
+      contextType,
+      durationMs: Date.now() - startTime,
+      messageCount,
     },
     turnId,
   )

--- a/src/llm-orchestrator-types.ts
+++ b/src/llm-orchestrator-types.ts
@@ -54,6 +54,8 @@ type ToolRoutingInfo = {
 
 export type InvokeModelArgs = {
   contextId: string
+  chatUserId: string
+  contextType: 'dm' | 'group'
   mainModel: string
   model: ReturnType<ReturnType<typeof createOpenAICompatible>>
   provider: TaskProvider

--- a/src/llm-orchestrator.ts
+++ b/src/llm-orchestrator.ts
@@ -136,18 +136,21 @@ const buildToolRoutingTelemetry = (
   exposedToolCount: routingResult.exposedToolCount,
 })
 
-const callLlm = async (
-  reply: ReplyFn,
-  contextId: string,
-  chatUserId: string,
-  username: string | null,
-  history: readonly ModelMessage[],
-  userText: string,
-  contextType: 'dm' | 'group',
-  deps: LlmOrchestratorDeps,
-  configContextId: string | undefined,
-  turnId: string,
-): Promise<{ response: { messages: ModelMessage[] } }> => {
+type CallLlmArgs = {
+  reply: ReplyFn
+  contextId: string
+  chatUserId: string
+  username: string | null
+  history: readonly ModelMessage[]
+  userText: string
+  contextType: 'dm' | 'group'
+  deps: LlmOrchestratorDeps
+  configContextId: string | undefined
+  turnId: string
+}
+
+const callLlm = async (args: CallLlmArgs): Promise<{ response: { messages: ModelMessage[] } }> => {
+  const { reply, contextId, chatUserId, username, history, userText, contextType, deps, configContextId, turnId } = args
   const configId = resolveConfigId(contextId, configContextId)
   if (contextType === 'dm') {
     await deps.maybeProvisionKaneo(reply, configId, username)
@@ -170,6 +173,8 @@ const callLlm = async (
   )
   const result = await invokeModelWithTyping(reply, {
     contextId,
+    chatUserId,
+    contextType,
     mainModel,
     model,
     provider,
@@ -234,23 +239,57 @@ export const processMessage = async (
   }
   const { baseHistory, modelMessage, historyMessage } = await buildHistory(contextId, userText, newAttachmentIds)
   appendHistory(contextId, [historyMessage])
+  const failureCtx: ProcessFailureContext = {
+    contextId,
+    chatUserId,
+    contextType,
+    mainModel: resolveModelName(),
+    startedAt: Date.now(),
+    messageCount: baseHistory.length + 1,
+    turnId: resolvedTurnId,
+    baseHistory,
+  }
   try {
-    const result = await callLlm(
+    const result = await callLlm({
       reply,
       contextId,
       chatUserId,
       username,
-      [...baseHistory, modelMessage],
+      history: [...baseHistory, modelMessage],
       userText,
       contextType,
       deps,
       configContextId,
-      resolvedTurnId,
-    )
+      turnId: resolvedTurnId,
+    })
     appendAssistantHistory(contextId, [...baseHistory, historyMessage], result.response.messages)
   } catch (error) {
-    emitLlmError(contextId, configContextId, error, resolvedTurnId)
-    saveHistory(contextId, baseHistory)
-    await handleOrchestratorMessageError(reply, contextId, error)
+    await handleProcessFailure(reply, failureCtx, error)
   }
+}
+
+type ProcessFailureContext = {
+  contextId: string
+  chatUserId: string
+  contextType: 'dm' | 'group'
+  mainModel: string
+  startedAt: number
+  messageCount: number
+  turnId: string
+  baseHistory: readonly ModelMessage[]
+}
+
+const handleProcessFailure = async (reply: ReplyFn, ctx: ProcessFailureContext, error: unknown): Promise<void> => {
+  emitLlmError(
+    ctx.contextId,
+    ctx.chatUserId,
+    ctx.contextType,
+    ctx.mainModel,
+    ctx.startedAt,
+    ctx.messageCount,
+    error,
+    ctx.turnId,
+  )
+  saveHistory(ctx.contextId, ctx.baseHistory)
+  await handleOrchestratorMessageError(reply, ctx.contextId, error)
 }

--- a/src/tools/save-memo.ts
+++ b/src/tools/save-memo.ts
@@ -35,7 +35,11 @@ export function makeSaveMemoTool(userId: string): ToolSet[string] {
       const baseUrl = getSystemConfig('llm_baseurl')
       const embeddingModel = getSystemConfig('embedding_model')
       if (apiKey !== null && baseUrl !== null && embeddingModel !== null) {
-        void tryGetEmbedding(content, apiKey, baseUrl, embeddingModel)
+        void tryGetEmbedding(content, apiKey, baseUrl, embeddingModel, {
+          storageContextId: userId,
+          contextType: 'dm',
+          chatUserId: userId,
+        })
           .then((embedding) => {
             if (embedding !== null) {
               updateMemoEmbedding(userId, memo.id, new Float32Array(embedding))

--- a/src/tools/search-memos.ts
+++ b/src/tools/search-memos.ts
@@ -92,7 +92,11 @@ async function trySemanticMode(
   const embeddingModel = getSystemConfig('embedding_model')
   if (apiKey === null || baseUrl === null || embeddingModel === null) return { available: false }
 
-  const queryVec = await tryGetEmbedding(query, apiKey, baseUrl, embeddingModel)
+  const queryVec = await tryGetEmbedding(query, apiKey, baseUrl, embeddingModel, {
+    storageContextId: userId,
+    contextType: 'dm',
+    chatUserId: userId,
+  })
   if (queryVec === null) return { available: false }
 
   const results = trySemanticSearch(userId, queryVec, limit)

--- a/src/tools/tools-builder.ts
+++ b/src/tools/tools-builder.ts
@@ -207,9 +207,14 @@ function addInstructionTools(tools: ToolSet, contextId: string | undefined): voi
   tools['list_instructions'] = makeListInstructionsTool(contextId)
   tools['delete_instruction'] = makeDeleteInstructionTool(contextId)
 }
-function addWebFetchTool(tools: ToolSet, storageContextId: string | undefined, actorUserId: string | undefined): void {
+function addWebFetchTool(
+  tools: ToolSet,
+  storageContextId: string | undefined,
+  actorUserId: string | undefined,
+  contextType: ContextType | undefined,
+): void {
   if (storageContextId === undefined) return
-  tools['web_fetch'] = makeWebFetchTool(storageContextId, actorUserId)
+  tools['web_fetch'] = makeWebFetchTool(storageContextId, actorUserId, contextType)
 }
 function addMemoTools(tools: ToolSet, provider: TaskProvider, userId: string | undefined): void {
   if (userId === undefined) return
@@ -280,7 +285,7 @@ export function buildTools(
   addMemoTools(tools, provider, chatUserId)
   addInstructionTools(tools, contextId)
   addLookupGroupHistoryTool(tools, chatUserId, contextId)
-  addWebFetchTool(tools, contextId, chatUserId)
+  addWebFetchTool(tools, contextId, chatUserId, contextType)
   maybeAddIdentityTools(tools, provider, chatUserId, contextType)
   if (mode === 'normal' && chatUserId !== undefined) {
     addDeferredPromptTools(tools, chatUserId, contextId, contextType, username)

--- a/src/tools/web-fetch.ts
+++ b/src/tools/web-fetch.ts
@@ -59,6 +59,7 @@ function logWebFetchSuccess(
 function createWebFetchExecutor(
   storageContextId: string,
   actorUserId: string | undefined,
+  contextType: 'dm' | 'group' | undefined,
   deps: WebFetchToolDeps,
 ): (
   input: WebFetchToolInput,
@@ -67,7 +68,7 @@ function createWebFetchExecutor(
   return async ({ url, goal }: WebFetchToolInput, { abortSignal }: ToolExecutionOptions) => {
     try {
       log.debug({ storageContextId, actorUserId, url, hasGoal: goal !== undefined }, 'Executing web_fetch')
-      const result = await deps.fetchAndExtract({ storageContextId, actorUserId, url, goal, abortSignal })
+      const result = await deps.fetchAndExtract({ storageContextId, actorUserId, contextType, url, goal, abortSignal })
       logWebFetchSuccess(storageContextId, actorUserId, result)
       return result
     } catch (error) {
@@ -89,12 +90,13 @@ function createWebFetchExecutor(
 export function makeWebFetchTool(
   storageContextId: string,
   actorUserId?: string,
+  contextType?: 'dm' | 'group',
   deps: WebFetchToolDeps = defaultDeps,
 ): ToolSet[string] {
   return tool({
     description:
       'Fetch a public URL and return a bounded summary and excerpt for answering questions or for later memo/task creation when the user explicitly asks.',
     inputSchema: webFetchInputSchema,
-    execute: createWebFetchExecutor(storageContextId, actorUserId, deps),
+    execute: createWebFetchExecutor(storageContextId, actorUserId, contextType, deps),
   })
 }

--- a/src/usage/index.ts
+++ b/src/usage/index.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { subscribe, unsubscribe, type DebugEvent } from '../debug/event-bus.js'
+import { logger } from '../logger.js'
+import { recordUsage, type UsageEvent } from './recorder.js'
+import type { ContextType } from './types.js'
+
+const log = logger.child({ scope: 'usage:subscriber' })
+
+let initialised = false
+
+const asString = (value: unknown): string | null => (typeof value === 'string' ? value : null)
+const asNumber = (value: unknown): number | null => (typeof value === 'number' ? value : null)
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
+
+const asContextType = (value: unknown): ContextType | null => {
+  if (value === 'dm' || value === 'group') return value
+  return null
+}
+
+const buildUsageFromLlmEnd = (event: DebugEvent): UsageEvent | null => {
+  if (event.scope.kind !== 'user') return null
+  const data = event.data
+  const chatUserId = asString(data['chatUserId'])
+  const contextType = asContextType(data['contextType'])
+  const model = asString(data['model'])
+  if (chatUserId === null || contextType === null || model === null) return null
+
+  const tokenUsage = data['tokenUsage']
+  let inputTokens: number | null = null
+  let outputTokens: number | null = null
+  if (isRecord(tokenUsage)) {
+    inputTokens = asNumber(tokenUsage['inputTokens'])
+    outputTokens = asNumber(tokenUsage['outputTokens'])
+  }
+
+  const turnId = event.turnId ?? null
+  return {
+    occurredAt: event.timestamp,
+    turnId,
+    storageContextId: event.scope.userId,
+    contextType,
+    chatUserId,
+    model,
+    modelRole: 'main',
+    inputTokens,
+    outputTokens,
+    stepCount: asNumber(data['steps']) ?? 0,
+    toolCallCount: asNumber(data['toolCount']) ?? 0,
+    messageCount: asNumber(data['messageCount']) ?? 0,
+    finishReason: asString(data['finishReason']),
+    durationMs: asNumber(data['totalDuration']) ?? 0,
+    responseId: asString(data['responseId']),
+    error: null,
+  }
+}
+
+const buildUsageFromLlmError = (event: DebugEvent): UsageEvent | null => {
+  if (event.scope.kind !== 'user') return null
+  const data = event.data
+  const chatUserId = asString(data['chatUserId'])
+  const contextType = asContextType(data['contextType'])
+  const model = asString(data['model'])
+  const errorMessage = asString(data['error'])
+  if (chatUserId === null || contextType === null || model === null || errorMessage === null) return null
+
+  return {
+    occurredAt: event.timestamp,
+    turnId: event.turnId ?? null,
+    storageContextId: event.scope.userId,
+    contextType,
+    chatUserId,
+    model,
+    modelRole: 'main',
+    inputTokens: null,
+    outputTokens: null,
+    stepCount: 0,
+    toolCallCount: 0,
+    messageCount: asNumber(data['messageCount']) ?? 0,
+    finishReason: null,
+    durationMs: asNumber(data['durationMs']) ?? 0,
+    responseId: null,
+    error: errorMessage,
+  }
+}
+
+const handleEvent = (event: DebugEvent): void => {
+  try {
+    let usage: UsageEvent | null = null
+    if (event.type === 'llm:end') usage = buildUsageFromLlmEnd(event)
+    else if (event.type === 'llm:error') usage = buildUsageFromLlmError(event)
+    if (usage === null) return
+    recordUsage(usage)
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), eventType: event.type },
+      'usage subscriber handler failure',
+    )
+  }
+}
+
+export const initUsageRecorder = (): void => {
+  if (initialised) return
+  subscribe(handleEvent)
+  initialised = true
+  log.info('usage recorder initialised')
+}
+
+export const resetUsageRecorderForTesting = (): void => {
+  if (!initialised) return
+  unsubscribe(handleEvent)
+  initialised = false
+}

--- a/src/usage/query.ts
+++ b/src/usage/query.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { and, desc, eq, gte, sql } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { llmUsageEvents } from '../db/schema.js'
+import type { ContextType, ModelRole, RequestRow, SubjectRoleTotals, SubjectSummary, UsageWindow } from './types.js'
+
+const computeSince = (window: UsageWindow): number => (window.windowMs === null ? 0 : Date.now() - window.windowMs)
+
+const emptyRoleTotals = (): SubjectRoleTotals => ({ inputTokens: 0, outputTokens: 0, calls: 0 })
+
+type RoleAggregateRow = {
+  storageContextId: string
+  contextType: string
+  modelRole: string
+  calls: number
+  inputTokens: number
+  outputTokens: number
+  toolCalls: number
+  lastActiveAt: number
+}
+
+const isModelRole = (value: string): value is ModelRole =>
+  value === 'main' || value === 'small' || value === 'embedding'
+
+const isContextType = (value: string): value is ContextType => value === 'dm' || value === 'group'
+
+const blankSummary = (storageContextId: string, contextType: ContextType): SubjectSummary => ({
+  storageContextId,
+  contextType,
+  totals: { main: emptyRoleTotals(), small: emptyRoleTotals(), embedding: emptyRoleTotals() },
+  toolCalls: 0,
+  lastActiveAt: 0,
+})
+
+const pivotByRole = (rows: readonly RoleAggregateRow[]): SubjectSummary[] => {
+  const map = new Map<string, SubjectSummary>()
+  for (const row of rows) {
+    if (!isContextType(row.contextType)) continue
+    if (!isModelRole(row.modelRole)) continue
+    const existing = map.get(row.storageContextId) ?? blankSummary(row.storageContextId, row.contextType)
+    existing.totals[row.modelRole] = {
+      inputTokens: row.inputTokens,
+      outputTokens: row.outputTokens,
+      calls: row.calls,
+    }
+    existing.toolCalls += row.toolCalls
+    if (row.lastActiveAt > existing.lastActiveAt) existing.lastActiveAt = row.lastActiveAt
+    map.set(row.storageContextId, existing)
+  }
+  return Array.from(map.values())
+}
+
+export const listSubjects = (window: UsageWindow): SubjectSummary[] => {
+  const since = computeSince(window)
+  const rows = getDrizzleDb()
+    .select({
+      storageContextId: llmUsageEvents.storageContextId,
+      contextType: llmUsageEvents.contextType,
+      modelRole: llmUsageEvents.modelRole,
+      calls: sql<number>`count(*)`,
+      inputTokens: sql<number>`coalesce(sum(${llmUsageEvents.inputTokens}), 0)`,
+      outputTokens: sql<number>`coalesce(sum(${llmUsageEvents.outputTokens}), 0)`,
+      toolCalls: sql<number>`coalesce(sum(${llmUsageEvents.toolCallCount}), 0)`,
+      lastActiveAt: sql<number>`max(${llmUsageEvents.occurredAt})`,
+    })
+    .from(llmUsageEvents)
+    .where(gte(llmUsageEvents.occurredAt, since))
+    .groupBy(llmUsageEvents.storageContextId, llmUsageEvents.contextType, llmUsageEvents.modelRole)
+    .all()
+  return pivotByRole(rows)
+}
+
+export const getSubjectDetail = (storageContextId: string, window: UsageWindow): RequestRow[] => {
+  const since = computeSince(window)
+  const rows = getDrizzleDb()
+    .select()
+    .from(llmUsageEvents)
+    .where(and(eq(llmUsageEvents.storageContextId, storageContextId), gte(llmUsageEvents.occurredAt, since)))
+    .orderBy(desc(llmUsageEvents.occurredAt))
+    .all()
+  return rows.flatMap((row): RequestRow[] => {
+    if (!isModelRole(row.modelRole)) return []
+    return [
+      {
+        eventId: row.eventId,
+        occurredAt: row.occurredAt,
+        turnId: row.turnId,
+        chatUserId: row.chatUserId,
+        model: row.model,
+        modelRole: row.modelRole,
+        inputTokens: row.inputTokens,
+        outputTokens: row.outputTokens,
+        stepCount: row.stepCount,
+        toolCallCount: row.toolCallCount,
+        messageCount: row.messageCount,
+        durationMs: row.durationMs,
+        finishReason: row.finishReason,
+        error: row.error,
+      },
+    ]
+  })
+}

--- a/src/usage/recorder.ts
+++ b/src/usage/recorder.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { llmUsageEvents } from '../db/schema.js'
+import { logger } from '../logger.js'
+import type { ContextType, ModelRole } from './types.js'
+
+const log = logger.child({ scope: 'usage:recorder' })
+
+export type UsageEvent = {
+  occurredAt: number
+  turnId: string | null
+  storageContextId: string
+  contextType: ContextType
+  chatUserId: string
+  model: string
+  modelRole: ModelRole
+  inputTokens: number | null
+  outputTokens: number | null
+  stepCount: number
+  toolCallCount: number
+  messageCount: number
+  finishReason: string | null
+  durationMs: number
+  responseId: string | null
+  error: string | null
+}
+
+export const recordUsage = (event: UsageEvent): void => {
+  try {
+    getDrizzleDb()
+      .insert(llmUsageEvents)
+      .values({
+        eventId: crypto.randomUUID(),
+        occurredAt: event.occurredAt,
+        turnId: event.turnId,
+        storageContextId: event.storageContextId,
+        contextType: event.contextType,
+        chatUserId: event.chatUserId,
+        model: event.model,
+        modelRole: event.modelRole,
+        inputTokens: event.inputTokens,
+        outputTokens: event.outputTokens,
+        stepCount: event.stepCount,
+        toolCallCount: event.toolCallCount,
+        messageCount: event.messageCount,
+        finishReason: event.finishReason,
+        durationMs: event.durationMs,
+        responseId: event.responseId,
+        error: event.error,
+      })
+      .run()
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), modelRole: event.modelRole },
+      'recordUsage failed',
+    )
+  }
+}

--- a/src/usage/types.ts
+++ b/src/usage/types.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+export type ModelRole = 'main' | 'small' | 'embedding'
+
+export type ContextType = 'dm' | 'group'
+
+export type UsageWindow = { windowMs: number | null }
+
+export type SubjectRoleTotals = {
+  inputTokens: number
+  outputTokens: number
+  calls: number
+}
+
+export type SubjectSummary = {
+  storageContextId: string
+  contextType: ContextType
+  totals: {
+    main: SubjectRoleTotals
+    small: SubjectRoleTotals
+    embedding: SubjectRoleTotals
+  }
+  toolCalls: number
+  lastActiveAt: number
+}
+
+export type RequestRow = {
+  eventId: string
+  occurredAt: number
+  turnId: string | null
+  chatUserId: string
+  model: string
+  modelRole: ModelRole
+  inputTokens: number | null
+  outputTokens: number | null
+  stepCount: number
+  toolCallCount: number
+  messageCount: number
+  durationMs: number
+  finishReason: string | null
+  error: string | null
+}

--- a/src/web/distill.ts
+++ b/src/web/distill.ts
@@ -8,6 +8,8 @@ import { generateText, type LanguageModel } from 'ai'
 
 import { logger } from '../logger.js'
 import { getSystemConfig, type SystemConfigKey } from '../system-config.js'
+import { recordUsage } from '../usage/recorder.js'
+import type { ContextType } from '../usage/types.js'
 import { fetchWithoutTimeout } from '../utils/fetch.js'
 
 const log = logger.child({ scope: 'web:distill' })
@@ -93,13 +95,88 @@ const defaultDeps: DistillDeps = {
     })(modelId),
 }
 
+export type DistillCallContext = {
+  contextType: ContextType
+  chatUserId: string
+}
+
+type DistillInput = {
+  readonly storageContextId: string
+  readonly title: string
+  readonly content: string
+  readonly goal?: string
+  readonly contextType?: ContextType
+  readonly chatUserId?: string
+}
+
+type GenerateTextLikeResult = {
+  text: string
+  usage?: { inputTokens?: number; outputTokens?: number }
+  finishReason?: string
+  steps?: ReadonlyArray<unknown>
+}
+
+const getDistillCallContext = (input: DistillInput): DistillCallContext | null => {
+  if (input.contextType === undefined || input.chatUserId === undefined) return null
+  return { contextType: input.contextType, chatUserId: input.chatUserId }
+}
+
+const recordDistillSuccess = (
+  input: DistillInput,
+  context: DistillCallContext,
+  modelId: string,
+  startedAt: number,
+  result: GenerateTextLikeResult,
+): void => {
+  recordUsage({
+    occurredAt: startedAt,
+    turnId: null,
+    storageContextId: input.storageContextId,
+    contextType: context.contextType,
+    chatUserId: context.chatUserId,
+    model: modelId,
+    modelRole: 'small',
+    inputTokens: typeof result.usage?.inputTokens === 'number' ? result.usage.inputTokens : null,
+    outputTokens: typeof result.usage?.outputTokens === 'number' ? result.usage.outputTokens : null,
+    stepCount: Array.isArray(result.steps) ? Math.max(result.steps.length, 1) : 1,
+    toolCallCount: 0,
+    messageCount: 1,
+    finishReason: typeof result.finishReason === 'string' ? result.finishReason : null,
+    durationMs: Date.now() - startedAt,
+    responseId: null,
+    error: null,
+  })
+}
+
+const recordDistillFailure = (
+  input: DistillInput,
+  context: DistillCallContext,
+  modelId: string,
+  startedAt: number,
+  error: unknown,
+): void => {
+  recordUsage({
+    occurredAt: startedAt,
+    turnId: null,
+    storageContextId: input.storageContextId,
+    contextType: context.contextType,
+    chatUserId: context.chatUserId,
+    model: modelId,
+    modelRole: 'small',
+    inputTokens: null,
+    outputTokens: null,
+    stepCount: 0,
+    toolCallCount: 0,
+    messageCount: 1,
+    finishReason: null,
+    durationMs: Date.now() - startedAt,
+    responseId: null,
+    error: error instanceof Error ? error.message : String(error),
+  })
+}
+
 export async function distillWebContent(
-  input: {
-    readonly storageContextId: string
-    readonly title: string
-    readonly content: string
-    readonly goal?: string
-  },
+  input: DistillInput,
   deps: DistillDeps = defaultDeps,
 ): Promise<DistilledContent> {
   log.debug(
@@ -119,11 +196,20 @@ export async function distillWebContent(
   const { apiKey, baseUrl, modelId } = getModelConfig()
   const model = deps.buildModel(apiKey, baseUrl, modelId)
   const prompt = buildPrompt(input.title, input.goal ?? DEFAULT_GOAL, input.content)
-  const result = await deps.generateText({
-    model,
-    prompt,
-    timeout: 1_200_000,
-  })
+  const callContext = getDistillCallContext(input)
+  const startedAt = Date.now()
+  let result: GenerateTextLikeResult
+  try {
+    result = await deps.generateText({
+      model,
+      prompt,
+      timeout: 1_200_000,
+    })
+  } catch (error) {
+    if (callContext !== null) recordDistillFailure(input, callContext, modelId, startedAt, error)
+    throw error
+  }
+  if (callContext !== null) recordDistillSuccess(input, callContext, modelId, startedAt, result)
 
   return logDistilledContent(input.storageContextId, modelId, parseDistilledContent(result.text))
 }

--- a/src/web/fetch-extract.ts
+++ b/src/web/fetch-extract.ts
@@ -22,6 +22,7 @@ export const DEFAULT_TTL_MS = 15 * 60 * 1000
 type FetchAndExtractInput = {
   storageContextId: string
   actorUserId?: string
+  contextType?: 'dm' | 'group'
   url: string
   goal?: string
   abortSignal?: AbortSignal
@@ -190,6 +191,8 @@ async function distillProcessedContent(
       title: processed.title,
       content: processed.content,
       goal: input.goal,
+      ...(input.contextType === undefined ? {} : { contextType: input.contextType }),
+      ...(input.actorUserId === undefined ? {} : { chatUserId: input.actorUserId }),
     })
   } catch (error) {
     if (isAppError(error)) {

--- a/tests/db/llm-usage-events-schema.test.ts
+++ b/tests/db/llm-usage-events-schema.test.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { llmUsageEvents, type LlmUsageEventRow } from '../../src/db/schema.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('llmUsageEvents Drizzle table', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('inserts and selects a fully populated row', () => {
+    getDrizzleDb()
+      .insert(llmUsageEvents)
+      .values({
+        eventId: 'evt-1',
+        occurredAt: 1_700_000_000_000,
+        turnId: 'turn-1',
+        storageContextId: 'ctx-1',
+        contextType: 'dm',
+        chatUserId: 'user-1',
+        model: 'main-model',
+        modelRole: 'main',
+        inputTokens: 100,
+        outputTokens: 200,
+        stepCount: 1,
+        toolCallCount: 0,
+        messageCount: 3,
+        finishReason: 'stop',
+        durationMs: 1234,
+        responseId: 'resp-1',
+        error: null,
+      })
+      .run()
+
+    const rows: LlmUsageEventRow[] = getDrizzleDb().select().from(llmUsageEvents).all()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toEqual({
+      eventId: 'evt-1',
+      occurredAt: 1_700_000_000_000,
+      turnId: 'turn-1',
+      storageContextId: 'ctx-1',
+      contextType: 'dm',
+      chatUserId: 'user-1',
+      model: 'main-model',
+      modelRole: 'main',
+      inputTokens: 100,
+      outputTokens: 200,
+      stepCount: 1,
+      toolCallCount: 0,
+      messageCount: 3,
+      finishReason: 'stop',
+      durationMs: 1234,
+      responseId: 'resp-1',
+      error: null,
+    })
+  })
+
+  test('round-trips NULLs in optional columns', () => {
+    getDrizzleDb()
+      .insert(llmUsageEvents)
+      .values({
+        eventId: 'evt-nulls',
+        occurredAt: 1_700_000_000_000,
+        turnId: null,
+        storageContextId: 'ctx',
+        contextType: 'group',
+        chatUserId: 'user',
+        model: 'm',
+        modelRole: 'embedding',
+        inputTokens: null,
+        outputTokens: null,
+        stepCount: 0,
+        toolCallCount: 0,
+        messageCount: 0,
+        finishReason: null,
+        durationMs: 5,
+        responseId: null,
+        error: null,
+      })
+      .run()
+
+    const rows: LlmUsageEventRow[] = getDrizzleDb().select().from(llmUsageEvents).all()
+    expect(rows).toHaveLength(1)
+    const row = rows[0]
+    expect(row?.turnId).toBeNull()
+    expect(row?.inputTokens).toBeNull()
+    expect(row?.outputTokens).toBeNull()
+    expect(row?.finishReason).toBeNull()
+    expect(row?.responseId).toBeNull()
+    expect(row?.error).toBeNull()
+  })
+
+  test('records an error row with the error column populated', () => {
+    getDrizzleDb()
+      .insert(llmUsageEvents)
+      .values({
+        eventId: 'evt-err',
+        occurredAt: 1_700_000_000_000,
+        turnId: 'turn-err',
+        storageContextId: 'ctx',
+        contextType: 'dm',
+        chatUserId: 'user',
+        model: 'main-model',
+        modelRole: 'main',
+        inputTokens: null,
+        outputTokens: null,
+        stepCount: 0,
+        toolCallCount: 0,
+        messageCount: 2,
+        finishReason: null,
+        durationMs: 42,
+        responseId: null,
+        error: 'network error',
+      })
+      .run()
+
+    const row = getDrizzleDb().select().from(llmUsageEvents).all()[0]
+    expect(row?.error).toBe('network error')
+  })
+})

--- a/tests/db/migrations/035_llm_usage_events.test.ts
+++ b/tests/db/migrations/035_llm_usage_events.test.ts
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { Database } from 'bun:sqlite'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { migration035LlmUsageEvents } from '../../../src/db/migrations/035_llm_usage_events.js'
+import { mockLogger } from '../../utils/test-helpers.js'
+
+const getNames = (db: Database, type: 'table' | 'index'): string[] =>
+  db
+    .query<{ name: string }, [string]>('SELECT name FROM sqlite_master WHERE type = ?')
+    .all(type)
+    .map((row) => row.name)
+
+interface LlmUsageEventRow {
+  event_id: string
+  occurred_at: number
+  turn_id: string | null
+  storage_context_id: string
+  context_type: string
+  chat_user_id: string
+  model: string
+  model_role: string
+  input_tokens: number | null
+  output_tokens: number | null
+  step_count: number
+  tool_call_count: number
+  message_count: number
+  finish_reason: string | null
+  duration_ms: number
+  response_id: string | null
+  error: string | null
+}
+
+const insertRow = (
+  db: Database,
+  overrides: Partial<Record<keyof LlmUsageEventRow, string | number | null>> = {},
+): void => {
+  const row: Record<keyof LlmUsageEventRow, string | number | null> = {
+    event_id: 'evt-1',
+    occurred_at: 1_700_000_000_000,
+    turn_id: 'turn-1',
+    storage_context_id: 'ctx-1',
+    context_type: 'dm',
+    chat_user_id: 'user-1',
+    model: 'main-model',
+    model_role: 'main',
+    input_tokens: 100,
+    output_tokens: 200,
+    step_count: 1,
+    tool_call_count: 0,
+    message_count: 3,
+    finish_reason: 'stop',
+    duration_ms: 1234,
+    response_id: 'resp-1',
+    error: null,
+    ...overrides,
+  }
+  db.run(
+    `INSERT INTO llm_usage_events
+       (event_id, occurred_at, turn_id, storage_context_id, context_type,
+        chat_user_id, model, model_role, input_tokens, output_tokens,
+        step_count, tool_call_count, message_count, finish_reason,
+        duration_ms, response_id, error)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    [
+      row.event_id,
+      row.occurred_at,
+      row.turn_id,
+      row.storage_context_id,
+      row.context_type,
+      row.chat_user_id,
+      row.model,
+      row.model_role,
+      row.input_tokens,
+      row.output_tokens,
+      row.step_count,
+      row.tool_call_count,
+      row.message_count,
+      row.finish_reason,
+      row.duration_ms,
+      row.response_id,
+      row.error,
+    ],
+  )
+}
+
+describe('migration035LlmUsageEvents', () => {
+  let db: Database
+
+  beforeEach(() => {
+    mockLogger()
+    db = new Database(':memory:')
+  })
+
+  afterEach(() => {
+    db.close()
+  })
+
+  test('creates the llm_usage_events table', () => {
+    migration035LlmUsageEvents.up(db)
+
+    expect(getNames(db, 'table')).toContain('llm_usage_events')
+  })
+
+  test('creates the four expected indexes', () => {
+    migration035LlmUsageEvents.up(db)
+
+    const indexes = getNames(db, 'index')
+    expect(indexes).toContain('idx_llm_usage_subject')
+    expect(indexes).toContain('idx_llm_usage_chat_user')
+    expect(indexes).toContain('idx_llm_usage_turn')
+    expect(indexes).toContain('idx_llm_usage_occurred')
+  })
+
+  test('round-trips a fully populated row', () => {
+    migration035LlmUsageEvents.up(db)
+
+    insertRow(db)
+
+    const rows = db.query<LlmUsageEventRow, []>('SELECT * FROM llm_usage_events').all()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toEqual({
+      event_id: 'evt-1',
+      occurred_at: 1_700_000_000_000,
+      turn_id: 'turn-1',
+      storage_context_id: 'ctx-1',
+      context_type: 'dm',
+      chat_user_id: 'user-1',
+      model: 'main-model',
+      model_role: 'main',
+      input_tokens: 100,
+      output_tokens: 200,
+      step_count: 1,
+      tool_call_count: 0,
+      message_count: 3,
+      finish_reason: 'stop',
+      duration_ms: 1234,
+      response_id: 'resp-1',
+      error: null,
+    })
+  })
+
+  test('rejects duplicate event_id (primary key)', () => {
+    migration035LlmUsageEvents.up(db)
+
+    insertRow(db, { event_id: 'evt-dup' })
+
+    expect(() => {
+      insertRow(db, { event_id: 'evt-dup', storage_context_id: 'ctx-2' })
+    }).toThrow()
+  })
+
+  test('rejects NULL in NOT NULL columns', () => {
+    migration035LlmUsageEvents.up(db)
+
+    // event_id is PRIMARY KEY but SQLite historically allows NULL in a
+    // non-INTEGER PK; matches the migration 034 convention which exercises
+    // NOT NULL on payload columns only.
+    const notNullColumns: Array<keyof LlmUsageEventRow> = [
+      'occurred_at',
+      'storage_context_id',
+      'context_type',
+      'chat_user_id',
+      'model',
+      'model_role',
+      'duration_ms',
+    ]
+    const expectNullRejected = (column: keyof LlmUsageEventRow): void => {
+      expect(() => {
+        insertRow(db, { event_id: `evt-${column}`, [column]: null })
+      }).toThrow()
+    }
+    notNullColumns.forEach(expectNullRejected)
+  })
+
+  test('accepts NULL in nullable columns', () => {
+    migration035LlmUsageEvents.up(db)
+
+    insertRow(db, {
+      event_id: 'evt-nulls',
+      turn_id: null,
+      input_tokens: null,
+      output_tokens: null,
+      finish_reason: null,
+      response_id: null,
+      error: null,
+    })
+
+    const row = db
+      .query<LlmUsageEventRow, [string]>('SELECT * FROM llm_usage_events WHERE event_id = ?')
+      .get('evt-nulls')
+    expect(row?.turn_id).toBeNull()
+    expect(row?.input_tokens).toBeNull()
+    expect(row?.output_tokens).toBeNull()
+    expect(row?.finish_reason).toBeNull()
+    expect(row?.response_id).toBeNull()
+    expect(row?.error).toBeNull()
+  })
+
+  test('step_count, tool_call_count, message_count default to 0', () => {
+    migration035LlmUsageEvents.up(db)
+
+    db.run(
+      `INSERT INTO llm_usage_events
+         (event_id, occurred_at, storage_context_id, context_type,
+          chat_user_id, model, model_role, duration_ms)
+       VALUES (?,?,?,?,?,?,?,?)`,
+      ['evt-defaults', 1_700_000_000_000, 'ctx', 'dm', 'user', 'm', 'main', 10],
+    )
+
+    const row = db
+      .query<LlmUsageEventRow, [string]>('SELECT * FROM llm_usage_events WHERE event_id = ?')
+      .get('evt-defaults')
+    expect(row?.step_count).toBe(0)
+    expect(row?.tool_call_count).toBe(0)
+    expect(row?.message_count).toBe(0)
+  })
+
+  test('running the migration twice is idempotent', () => {
+    migration035LlmUsageEvents.up(db)
+
+    expect(() => {
+      migration035LlmUsageEvents.up(db)
+    }).not.toThrow()
+
+    expect(getNames(db, 'table')).toContain('llm_usage_events')
+    const indexes = getNames(db, 'index')
+    expect(indexes).toContain('idx_llm_usage_subject')
+    expect(indexes).toContain('idx_llm_usage_chat_user')
+    expect(indexes).toContain('idx_llm_usage_turn')
+    expect(indexes).toContain('idx_llm_usage_occurred')
+  })
+})

--- a/tests/embeddings.test.ts
+++ b/tests/embeddings.test.ts
@@ -5,10 +5,12 @@
 
 import { mock, beforeEach, describe, expect, test } from 'bun:test'
 
+import { getDrizzleDb } from '../src/db/drizzle.js'
+import { llmUsageEvents } from '../src/db/schema.js'
 import { getEmbedding, tryGetEmbedding } from '../src/embeddings.js'
-import { mockLogger } from './utils/test-helpers.js'
+import { mockLogger, setupTestDb } from './utils/test-helpers.js'
 
-type EmbedResult = { embedding: number[] }
+type EmbedResult = { embedding: number[]; usage?: { tokens: number } }
 type MockProvider = { embeddingModel: (name: string) => string }
 
 describe('getEmbedding', () => {
@@ -42,8 +44,9 @@ describe('getEmbedding', () => {
 describe('tryGetEmbedding', () => {
   let embedImpl = (): Promise<EmbedResult> => Promise.resolve({ embedding: [0.1, 0.2, 0.3] })
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mockLogger()
+    await setupTestDb()
     embedImpl = (): Promise<EmbedResult> => Promise.resolve({ embedding: [0.1, 0.2, 0.3] })
     void mock.module('ai', () => ({
       embed: (..._args: unknown[]): Promise<EmbedResult> => embedImpl(),
@@ -65,5 +68,69 @@ describe('tryGetEmbedding', () => {
     embedImpl = (): Promise<EmbedResult> => Promise.reject(new Error('Network error'))
     const result = await tryGetEmbedding('test', 'key', 'http://localhost', 'model')
     expect(result).toBeNull()
+  })
+
+  test('records a usage row with input tokens when usage is returned', async () => {
+    embedImpl = (): Promise<EmbedResult> => Promise.resolve({ embedding: [1, 2, 3], usage: { tokens: 42 } })
+    await tryGetEmbedding('hi', 'key', 'http://localhost', 'embed-model', {
+      storageContextId: 'subject-1',
+      contextType: 'dm',
+      chatUserId: 'user-1',
+    })
+
+    const rows = getDrizzleDb().select().from(llmUsageEvents).all()
+    expect(rows).toHaveLength(1)
+    const row = rows[0]
+    expect(row?.modelRole).toBe('embedding')
+    expect(row?.model).toBe('embed-model')
+    expect(row?.storageContextId).toBe('subject-1')
+    expect(row?.contextType).toBe('dm')
+    expect(row?.chatUserId).toBe('user-1')
+    expect(row?.inputTokens).toBe(42)
+    expect(row?.outputTokens).toBeNull()
+    expect(row?.stepCount).toBe(0)
+    expect(row?.toolCallCount).toBe(0)
+    expect(row?.messageCount).toBe(0)
+    expect(row?.error).toBeNull()
+  })
+
+  test('records a usage row with null tokens when usage is missing', async () => {
+    embedImpl = (): Promise<EmbedResult> => Promise.resolve({ embedding: [1, 2, 3] })
+    await tryGetEmbedding('hi', 'key', 'http://localhost', 'embed-model', {
+      storageContextId: 'subject-2',
+      contextType: 'dm',
+      chatUserId: 'user-2',
+    })
+
+    const row = getDrizzleDb().select().from(llmUsageEvents).all()[0]
+    expect(row?.inputTokens).toBeNull()
+  })
+
+  test('records a usage row with error populated when embed() throws', async () => {
+    embedImpl = (): Promise<EmbedResult> => Promise.reject(new Error('boom'))
+    const result = await tryGetEmbedding('hi', 'key', 'http://localhost', 'embed-model', {
+      storageContextId: 'subject-err',
+      contextType: 'group',
+      chatUserId: 'user-err',
+    })
+    expect(result).toBeNull()
+
+    const rows = getDrizzleDb().select().from(llmUsageEvents).all()
+    expect(rows).toHaveLength(1)
+    const row = rows[0]
+    expect(row?.error).toBe('boom')
+    expect(row?.modelRole).toBe('embedding')
+    expect(row?.storageContextId).toBe('subject-err')
+    expect(row?.contextType).toBe('group')
+    expect(row?.chatUserId).toBe('user-err')
+    expect(row?.inputTokens).toBeNull()
+  })
+
+  test('omits the usage row when no context is supplied', async () => {
+    embedImpl = (): Promise<EmbedResult> => Promise.resolve({ embedding: [1, 2, 3], usage: { tokens: 5 } })
+    await tryGetEmbedding('hi', 'key', 'http://localhost', 'embed-model')
+
+    const rows = getDrizzleDb().select().from(llmUsageEvents).all()
+    expect(rows).toEqual([])
   })
 })

--- a/tests/llm-orchestrator-events.test.ts
+++ b/tests/llm-orchestrator-events.test.ts
@@ -103,7 +103,18 @@ describe('llm-orchestrator-events', () => {
         const tools = makeTools(provider, { storageContextId: 'ctx-1', chatUserId: 'user-1' })
         const startTime = Date.now() - 1000
 
-        emitLlmEnd('ctx-1', 'gpt-4', result, startTime, [{ role: 'user', content: 'hi' }], tools)
+        emitLlmEnd(
+          'ctx-1',
+          'user-1',
+          'dm',
+          'gpt-4',
+          result,
+          startTime,
+          [{ role: 'user', content: 'hi' }],
+          tools,
+          undefined,
+          'turn-1',
+        )
 
         const capturedEvent = capture()
         const capturedScope = captureScope()
@@ -122,6 +133,48 @@ describe('llm-orchestrator-events', () => {
         expect(capturedEvent['generatedText']).toBe('Done!')
         expect(Array.isArray(capturedEvent['stepsDetail'])).toBe(true)
         expect(typeof capturedEvent['totalDuration']).toBe('number')
+        expect(capturedEvent['chatUserId']).toBe('user-1')
+        expect(capturedEvent['contextType']).toBe('dm')
+      } finally {
+        unsubscribe(listener)
+      }
+    })
+
+    test('emits llm:end event with chatUserId and contextType for groups', async () => {
+      const { subscribe, unsubscribe } = await import('../src/debug/event-bus.js')
+
+      const { capture, listener } = makeEventCapture('llm:end')
+      subscribe(listener)
+
+      try {
+        const result: ResolvedStreamTextResult = {
+          text: 'Hi',
+          toolCalls: [],
+          toolResults: [],
+          steps: [],
+          response: { messages: [], id: 'resp-2', modelId: 'gpt-4' },
+          usage: { inputTokens: 1, outputTokens: 1 },
+          finishReason: 'stop',
+        }
+        const provider = createMockProvider()
+        const tools = makeTools(provider, { storageContextId: 'ctx-grp', chatUserId: 'user-2' })
+        emitLlmEnd(
+          'ctx-grp',
+          'user-2',
+          'group',
+          'gpt-4',
+          result,
+          Date.now() - 10,
+          [{ role: 'user', content: 'hi' }],
+          tools,
+          undefined,
+          'turn-2',
+        )
+
+        const captured = capture()
+        assert.ok(isRecord(captured))
+        expect(captured['chatUserId']).toBe('user-2')
+        expect(captured['contextType']).toBe('group')
       } finally {
         unsubscribe(listener)
       }
@@ -222,9 +275,18 @@ describe('llm-orchestrator-events', () => {
           finishReason: 'stop',
         }
 
-        emitLlmEnd('ctx-1', 'gpt-4', result, Date.now() - 1000, [{ role: 'user', content: 'hi' }], {
-          x: cyclicTool,
-        })
+        emitLlmEnd(
+          'ctx-1',
+          'user-1',
+          'dm',
+          'gpt-4',
+          result,
+          Date.now() - 1000,
+          [{ role: 'user', content: 'hi' }],
+          { x: cyclicTool },
+          undefined,
+          'turn-cyclic',
+        )
 
         const capturedEvent = capture()
         assert.ok(isRecord(capturedEvent))

--- a/tests/llm-orchestrator-support.test.ts
+++ b/tests/llm-orchestrator-support.test.ts
@@ -4,11 +4,14 @@
 // See LICENSE in the project root for details.
 
 import { describe, expect, mock, test } from 'bun:test'
+import assert from 'node:assert/strict'
 
 import { providerError } from '../src/errors.js'
-import { handleOrchestratorMessageError, handleToolCallFinish } from '../src/llm-orchestrator-support.js'
+import { emitLlmError, handleOrchestratorMessageError, handleToolCallFinish } from '../src/llm-orchestrator-support.js'
 import { buildToolFailureResult } from '../src/tool-failure.js'
 import { createMockReply } from './utils/test-helpers.js'
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
 
 describe('llm-orchestrator-support', () => {
   test('handleToolCallFinish emits structured failures and replies with the user message', () => {
@@ -68,5 +71,60 @@ describe('llm-orchestrator-support', () => {
     await handleOrchestratorMessageError(reply, 'ctx-2', providerError.projectNotFound('PRJ-1'), deps)
 
     expect(getReplies()).toEqual(['Project "PRJ-1" was not found.'])
+  })
+
+  describe('emitLlmError', () => {
+    test('emits llm:error with chatUserId, contextType, durationMs, messageCount', async () => {
+      const { subscribe, unsubscribe } = await import('../src/debug/event-bus.js')
+
+      const events: Array<{ type: string; data: unknown; turnId?: string }> = []
+      const listener = (event: { type: string; data: unknown; turnId?: string }): void => {
+        events.push(event)
+      }
+      subscribe(listener)
+
+      try {
+        emitLlmError('ctx-err', 'user-err', 'group', 'main-model', Date.now() - 50, 7, new Error('boom'), 'turn-err')
+
+        expect(events).toHaveLength(1)
+        const event = events[0]
+        assert.ok(event !== undefined)
+        expect(event.type).toBe('llm:error')
+        assert.ok(isRecord(event.data))
+        const data = event.data
+        expect(data['error']).toBe('boom')
+        expect(data['model']).toBe('main-model')
+        expect(data['chatUserId']).toBe('user-err')
+        expect(data['contextType']).toBe('group')
+        expect(data['messageCount']).toBe(7)
+        expect(data['durationMs']).toEqual(expect.any(Number))
+        expect(Number(data['durationMs'])).toBeGreaterThanOrEqual(50)
+        expect(event.turnId).toBe('turn-err')
+      } finally {
+        unsubscribe(listener)
+      }
+    })
+
+    test('extracts message from non-Error error values', async () => {
+      const { subscribe, unsubscribe } = await import('../src/debug/event-bus.js')
+
+      const events: Array<{ type: string; data: unknown }> = []
+      const listener = (event: { type: string; data: unknown }): void => {
+        events.push(event)
+      }
+      subscribe(listener)
+
+      try {
+        emitLlmError('ctx', 'user', 'dm', 'm', Date.now(), 1, 'plain-string-error')
+        expect(events).toHaveLength(1)
+        const event = events[0]
+        assert.ok(event !== undefined)
+        expect(event.type).toBe('llm:error')
+        assert.ok(isRecord(event.data))
+        expect(event.data['error']).toBe('plain-string-error')
+      } finally {
+        unsubscribe(listener)
+      }
+    })
   })
 })

--- a/tests/tools/web-fetch.test.ts
+++ b/tests/tools/web-fetch.test.ts
@@ -29,7 +29,7 @@ describe('makeWebFetchTool', () => {
       }),
     )
 
-    const tool = makeWebFetchTool('group-123', 'user-456', { fetchAndExtract })
+    const tool = makeWebFetchTool('group-123', 'user-456', 'group', { fetchAndExtract })
     const result = await getToolExecutor(tool)(
       { url: 'https://example.com/article', goal: 'Summarize the release notes' },
       { toolCallId: '1', messages: [], abortSignal: abortController.signal },
@@ -38,6 +38,7 @@ describe('makeWebFetchTool', () => {
     expect(fetchAndExtract).toHaveBeenCalledWith({
       storageContextId: 'group-123',
       actorUserId: 'user-456',
+      contextType: 'group',
       url: 'https://example.com/article',
       goal: 'Summarize the release notes',
       abortSignal: abortController.signal,
@@ -69,7 +70,7 @@ describe('makeWebFetchTool', () => {
     const expectedError = new Error('fetch failed')
     const fetchAndExtract = mock(() => Promise.reject(expectedError))
 
-    const tool = makeWebFetchTool('group-123', 'user-456', { fetchAndExtract })
+    const tool = makeWebFetchTool('group-123', 'user-456', 'group', { fetchAndExtract })
 
     await expect(
       getToolExecutor(tool)(

--- a/tests/usage/query.test.ts
+++ b/tests/usage/query.test.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getSubjectDetail, listSubjects } from '../../src/usage/query.js'
+import { recordUsage, type UsageEvent } from '../../src/usage/recorder.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+const seed = (overrides: Partial<UsageEvent>): void => {
+  recordUsage({
+    occurredAt: 1_700_000_000_000,
+    turnId: 'turn',
+    storageContextId: 'ctx',
+    contextType: 'dm',
+    chatUserId: 'user',
+    model: 'm',
+    modelRole: 'main',
+    inputTokens: 10,
+    outputTokens: 20,
+    stepCount: 1,
+    toolCallCount: 0,
+    messageCount: 1,
+    finishReason: 'stop',
+    durationMs: 100,
+    responseId: 'resp',
+    error: null,
+    ...overrides,
+  })
+}
+
+describe('listSubjects', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns empty when no rows recorded', () => {
+    expect(listSubjects({ windowMs: null })).toEqual([])
+  })
+
+  test('groups by storage_context_id with per-role totals', () => {
+    seed({ storageContextId: 'ctx-A', modelRole: 'main', inputTokens: 100, outputTokens: 200 })
+    seed({ storageContextId: 'ctx-A', modelRole: 'main', inputTokens: 50, outputTokens: 80 })
+    seed({ storageContextId: 'ctx-A', modelRole: 'small', inputTokens: 30, outputTokens: 40 })
+    seed({ storageContextId: 'ctx-A', modelRole: 'embedding', inputTokens: 5, outputTokens: null })
+    seed({ storageContextId: 'ctx-B', modelRole: 'main', inputTokens: 7, outputTokens: 9 })
+
+    const result = listSubjects({ windowMs: null })
+    expect(result).toHaveLength(2)
+
+    const a = result.find((s) => s.storageContextId === 'ctx-A')
+    expect(a).toBeDefined()
+    expect(a?.totals.main).toEqual({ inputTokens: 150, outputTokens: 280, calls: 2 })
+    expect(a?.totals.small).toEqual({ inputTokens: 30, outputTokens: 40, calls: 1 })
+    expect(a?.totals.embedding).toEqual({ inputTokens: 5, outputTokens: 0, calls: 1 })
+
+    const b = result.find((s) => s.storageContextId === 'ctx-B')
+    expect(b?.totals.main).toEqual({ inputTokens: 7, outputTokens: 9, calls: 1 })
+    expect(b?.totals.small).toEqual({ inputTokens: 0, outputTokens: 0, calls: 0 })
+    expect(b?.totals.embedding).toEqual({ inputTokens: 0, outputTokens: 0, calls: 0 })
+  })
+
+  test('preserves contextType per subject', () => {
+    seed({ storageContextId: 'ctx-dm', contextType: 'dm' })
+    seed({ storageContextId: 'ctx-grp', contextType: 'group' })
+
+    const result = listSubjects({ windowMs: null })
+    expect(result.find((s) => s.storageContextId === 'ctx-dm')?.contextType).toBe('dm')
+    expect(result.find((s) => s.storageContextId === 'ctx-grp')?.contextType).toBe('group')
+  })
+
+  test('sums tool_call_count across all roles for the subject', () => {
+    seed({ storageContextId: 'ctx', modelRole: 'main', toolCallCount: 3 })
+    seed({ storageContextId: 'ctx', modelRole: 'main', toolCallCount: 2 })
+    seed({ storageContextId: 'ctx', modelRole: 'small', toolCallCount: 1 })
+
+    const result = listSubjects({ windowMs: null })
+    expect(result[0]?.toolCalls).toBe(6)
+  })
+
+  test('uses the max occurred_at as lastActiveAt', () => {
+    seed({ storageContextId: 'ctx', occurredAt: 1_700_000_000_000 })
+    seed({ storageContextId: 'ctx', occurredAt: 1_700_000_500_000 })
+    seed({ storageContextId: 'ctx', occurredAt: 1_700_000_100_000 })
+
+    const result = listSubjects({ windowMs: null })
+    expect(result[0]?.lastActiveAt).toBe(1_700_000_500_000)
+  })
+
+  test('filters by windowMs against now', () => {
+    const now = Date.now()
+    seed({ storageContextId: 'ctx-old', occurredAt: now - 10 * 24 * 3600 * 1000 })
+    seed({ storageContextId: 'ctx-recent', occurredAt: now - 1000 })
+
+    const result = listSubjects({ windowMs: 24 * 3600 * 1000 })
+    expect(result.map((s) => s.storageContextId)).toEqual(['ctx-recent'])
+  })
+
+  test('treats NULL input/output tokens as 0 in the sum', () => {
+    seed({ storageContextId: 'ctx', modelRole: 'main', inputTokens: null, outputTokens: null })
+    seed({ storageContextId: 'ctx', modelRole: 'main', inputTokens: 5, outputTokens: 7 })
+
+    const result = listSubjects({ windowMs: null })
+    expect(result[0]?.totals.main).toEqual({ inputTokens: 5, outputTokens: 7, calls: 2 })
+  })
+})
+
+describe('getSubjectDetail', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns empty when no rows match the subject', () => {
+    seed({ storageContextId: 'other' })
+    expect(getSubjectDetail('missing', { windowMs: null })).toEqual([])
+  })
+
+  test('returns rows for the given storage_context_id, ordered by occurred_at desc', () => {
+    seed({ storageContextId: 'ctx', occurredAt: 1000, turnId: 'turn-a', model: 'm', modelRole: 'main' })
+    seed({ storageContextId: 'ctx', occurredAt: 3000, turnId: 'turn-c', model: 'm', modelRole: 'small' })
+    seed({ storageContextId: 'ctx', occurredAt: 2000, turnId: 'turn-b', model: 'm', modelRole: 'main' })
+    seed({ storageContextId: 'other', occurredAt: 4000, turnId: 'turn-other' })
+
+    const rows = getSubjectDetail('ctx', { windowMs: null })
+    expect(rows.map((r) => r.turnId)).toEqual(['turn-c', 'turn-b', 'turn-a'])
+  })
+
+  test('shape matches RequestRow', () => {
+    seed({
+      storageContextId: 'ctx',
+      occurredAt: 1_700_000_000_000,
+      turnId: 'turn',
+      chatUserId: 'user',
+      model: 'main-model',
+      modelRole: 'main',
+      inputTokens: 100,
+      outputTokens: 200,
+      stepCount: 1,
+      toolCallCount: 0,
+      messageCount: 3,
+      durationMs: 1234,
+      finishReason: 'stop',
+      error: null,
+    })
+
+    const row = getSubjectDetail('ctx', { windowMs: null })[0]
+    expect(row).toBeDefined()
+    expect(row?.eventId).toMatch(/^[0-9a-f-]{36}$/u)
+    expect(row?.occurredAt).toBe(1_700_000_000_000)
+    expect(row?.turnId).toBe('turn')
+    expect(row?.chatUserId).toBe('user')
+    expect(row?.model).toBe('main-model')
+    expect(row?.modelRole).toBe('main')
+    expect(row?.inputTokens).toBe(100)
+    expect(row?.outputTokens).toBe(200)
+    expect(row?.stepCount).toBe(1)
+    expect(row?.toolCallCount).toBe(0)
+    expect(row?.messageCount).toBe(3)
+    expect(row?.durationMs).toBe(1234)
+    expect(row?.finishReason).toBe('stop')
+    expect(row?.error).toBeNull()
+  })
+
+  test('filters by windowMs', () => {
+    const now = Date.now()
+    seed({ storageContextId: 'ctx', occurredAt: now - 10 * 24 * 3600 * 1000, turnId: 'old' })
+    seed({ storageContextId: 'ctx', occurredAt: now - 1000, turnId: 'recent' })
+
+    const rows = getSubjectDetail('ctx', { windowMs: 24 * 3600 * 1000 })
+    expect(rows.map((r) => r.turnId)).toEqual(['recent'])
+  })
+})

--- a/tests/usage/recorder-integration.test.ts
+++ b/tests/usage/recorder-integration.test.ts
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { llmUsageEvents } from '../../src/db/schema.js'
+import { emitUser, subscribe, unsubscribe } from '../../src/debug/event-bus.js'
+import { initUsageRecorder, resetUsageRecorderForTesting } from '../../src/usage/index.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+const noopListener = (): void => {}
+
+describe('usage recorder bus integration', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+    resetUsageRecorderForTesting()
+    initUsageRecorder()
+  })
+
+  afterEach(() => {
+    resetUsageRecorderForTesting()
+  })
+
+  test('llm:end event produces a recorder row with main model role', () => {
+    emitUser(
+      'llm:end',
+      'ctx-1',
+      {
+        model: 'main-model',
+        steps: 2,
+        totalDuration: 1500,
+        tokenUsage: { inputTokens: 100, outputTokens: 200 },
+        responseId: 'resp-1',
+        actualModel: 'main-model',
+        finishReason: 'stop',
+        messageCount: 4,
+        chatUserId: 'user-1',
+        contextType: 'dm',
+        toolCount: 5,
+        exposedToolCount: 5,
+        fullToolCount: 5,
+        toolSchemaBytes: 1000,
+        generatedText: 'response text',
+        stepsDetail: [],
+      },
+      'turn-1',
+    )
+
+    const rows = getDrizzleDb().select().from(llmUsageEvents).all()
+    expect(rows).toHaveLength(1)
+    const row = rows[0]
+    expect(row?.storageContextId).toBe('ctx-1')
+    expect(row?.chatUserId).toBe('user-1')
+    expect(row?.contextType).toBe('dm')
+    expect(row?.model).toBe('main-model')
+    expect(row?.modelRole).toBe('main')
+    expect(row?.inputTokens).toBe(100)
+    expect(row?.outputTokens).toBe(200)
+    expect(row?.stepCount).toBe(2)
+    expect(row?.toolCallCount).toBe(5)
+    expect(row?.messageCount).toBe(4)
+    expect(row?.finishReason).toBe('stop')
+    expect(row?.durationMs).toBe(1500)
+    expect(row?.responseId).toBe('resp-1')
+    expect(row?.turnId).toBe('turn-1')
+    expect(row?.error).toBeNull()
+  })
+
+  test('llm:end accepts NULL token counts when tokenUsage fields are undefined', () => {
+    emitUser(
+      'llm:end',
+      'ctx-2',
+      {
+        model: 'm',
+        steps: 1,
+        totalDuration: 10,
+        tokenUsage: { inputTokens: undefined, outputTokens: undefined },
+        responseId: undefined,
+        actualModel: undefined,
+        finishReason: 'stop',
+        messageCount: 1,
+        chatUserId: 'user-2',
+        contextType: 'group',
+        toolCount: 0,
+        exposedToolCount: 0,
+        fullToolCount: 0,
+        toolSchemaBytes: 0,
+        generatedText: '',
+        stepsDetail: [],
+      },
+      'turn-2',
+    )
+
+    const row = getDrizzleDb().select().from(llmUsageEvents).all()[0]
+    expect(row?.inputTokens).toBeNull()
+    expect(row?.outputTokens).toBeNull()
+    expect(row?.responseId).toBeNull()
+    expect(row?.contextType).toBe('group')
+  })
+
+  test('llm:error event produces a recorder row with error populated', () => {
+    emitUser(
+      'llm:error',
+      'ctx-3',
+      {
+        error: 'boom',
+        model: 'main-model',
+        chatUserId: 'user-3',
+        contextType: 'dm',
+        durationMs: 42,
+        messageCount: 2,
+      },
+      'turn-3',
+    )
+
+    const rows = getDrizzleDb().select().from(llmUsageEvents).all()
+    expect(rows).toHaveLength(1)
+    const row = rows[0]
+    expect(row?.error).toBe('boom')
+    expect(row?.model).toBe('main-model')
+    expect(row?.modelRole).toBe('main')
+    expect(row?.chatUserId).toBe('user-3')
+    expect(row?.contextType).toBe('dm')
+    expect(row?.durationMs).toBe(42)
+    expect(row?.messageCount).toBe(2)
+    expect(row?.inputTokens).toBeNull()
+    expect(row?.outputTokens).toBeNull()
+    expect(row?.responseId).toBeNull()
+    expect(row?.finishReason).toBeNull()
+    expect(row?.turnId).toBe('turn-3')
+    expect(row?.stepCount).toBe(0)
+    expect(row?.toolCallCount).toBe(0)
+  })
+
+  test('unrelated event types are ignored', () => {
+    emitUser('tool:request', 'ctx-4', { toolName: 'x', toolCallId: 'c-1', args: {} }, 'turn-4')
+    emitUser('llm:start', 'ctx-4', { model: 'm', messageCount: 1, toolCount: 0 }, 'turn-4')
+
+    const rows = getDrizzleDb().select().from(llmUsageEvents).all()
+    expect(rows).toEqual([])
+  })
+
+  test('a second initUsageRecorder() does not register a duplicate subscriber', () => {
+    initUsageRecorder()
+    initUsageRecorder()
+
+    emitUser(
+      'llm:end',
+      'ctx-dup',
+      {
+        model: 'm',
+        steps: 1,
+        totalDuration: 1,
+        tokenUsage: { inputTokens: 1, outputTokens: 1 },
+        finishReason: 'stop',
+        messageCount: 1,
+        chatUserId: 'user',
+        contextType: 'dm',
+        toolCount: 0,
+        exposedToolCount: 0,
+        fullToolCount: 0,
+        toolSchemaBytes: 0,
+        generatedText: '',
+        stepsDetail: [],
+      },
+      'turn-dup',
+    )
+
+    const rows = getDrizzleDb().select().from(llmUsageEvents).all()
+    expect(rows).toHaveLength(1)
+  })
+
+  test('a malformed event is dropped without disrupting other subscribers', () => {
+    const received: string[] = []
+    const otherListener = (event: { type: string }): void => {
+      received.push(event.type)
+    }
+    subscribe(otherListener)
+
+    try {
+      // Missing required fields — recorder must not throw.
+      emitUser('llm:end', 'ctx-bad', { partial: 'payload' }, 'turn-bad')
+      // Bus should still deliver to other subscribers.
+      expect(received).toEqual(['llm:end'])
+    } finally {
+      unsubscribe(otherListener)
+    }
+  })
+
+  test('listener references are kept stable so unsubscribe (resetUsageRecorderForTesting) works', () => {
+    // First emit goes through.
+    emitUser(
+      'llm:end',
+      'ctx-stable',
+      {
+        model: 'm',
+        steps: 1,
+        totalDuration: 1,
+        tokenUsage: { inputTokens: 1, outputTokens: 1 },
+        finishReason: 'stop',
+        messageCount: 1,
+        chatUserId: 'user',
+        contextType: 'dm',
+        toolCount: 0,
+        exposedToolCount: 0,
+        fullToolCount: 0,
+        toolSchemaBytes: 0,
+        generatedText: '',
+        stepsDetail: [],
+      },
+      'turn-stable-1',
+    )
+
+    resetUsageRecorderForTesting()
+    // Bus has no listeners (recorder unsubscribed); add a noop so emitUser
+    // still dispatches and we can verify the recorder didn't write.
+    subscribe(noopListener)
+
+    try {
+      emitUser(
+        'llm:end',
+        'ctx-stable',
+        {
+          model: 'm',
+          steps: 1,
+          totalDuration: 1,
+          tokenUsage: { inputTokens: 1, outputTokens: 1 },
+          finishReason: 'stop',
+          messageCount: 1,
+          chatUserId: 'user',
+          contextType: 'dm',
+          toolCount: 0,
+          exposedToolCount: 0,
+          fullToolCount: 0,
+          toolSchemaBytes: 0,
+          generatedText: '',
+          stepsDetail: [],
+        },
+        'turn-stable-2',
+      )
+
+      const rows = getDrizzleDb().select().from(llmUsageEvents).all()
+      expect(rows).toHaveLength(1)
+      expect(rows[0]?.turnId).toBe('turn-stable-1')
+    } finally {
+      unsubscribe(noopListener)
+    }
+  })
+})

--- a/tests/usage/recorder.test.ts
+++ b/tests/usage/recorder.test.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { llmUsageEvents } from '../../src/db/schema.js'
+import { recordUsage, type UsageEvent } from '../../src/usage/recorder.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+const validEvent = (overrides: Partial<UsageEvent> = {}): UsageEvent => ({
+  occurredAt: 1_700_000_000_000,
+  turnId: 'turn-1',
+  storageContextId: 'ctx-1',
+  contextType: 'dm',
+  chatUserId: 'user-1',
+  model: 'main-model',
+  modelRole: 'main',
+  inputTokens: 100,
+  outputTokens: 200,
+  stepCount: 1,
+  toolCallCount: 0,
+  messageCount: 3,
+  finishReason: 'stop',
+  durationMs: 1234,
+  responseId: 'resp-1',
+  error: null,
+  ...overrides,
+})
+
+describe('recordUsage', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('inserts a fully populated row', () => {
+    recordUsage(validEvent())
+
+    const rows = getDrizzleDb().select().from(llmUsageEvents).all()
+    expect(rows).toHaveLength(1)
+    const row = rows[0]
+    expect(row?.eventId).toMatch(/^[0-9a-f-]{36}$/u)
+    expect(row?.storageContextId).toBe('ctx-1')
+    expect(row?.contextType).toBe('dm')
+    expect(row?.chatUserId).toBe('user-1')
+    expect(row?.model).toBe('main-model')
+    expect(row?.modelRole).toBe('main')
+    expect(row?.inputTokens).toBe(100)
+    expect(row?.outputTokens).toBe(200)
+    expect(row?.stepCount).toBe(1)
+    expect(row?.toolCallCount).toBe(0)
+    expect(row?.messageCount).toBe(3)
+    expect(row?.finishReason).toBe('stop')
+    expect(row?.durationMs).toBe(1234)
+    expect(row?.responseId).toBe('resp-1')
+    expect(row?.error).toBeNull()
+    expect(row?.turnId).toBe('turn-1')
+    expect(row?.occurredAt).toBe(1_700_000_000_000)
+  })
+
+  test('generates a unique event_id per call', () => {
+    recordUsage(validEvent())
+    recordUsage(validEvent())
+
+    const rows = getDrizzleDb().select().from(llmUsageEvents).all()
+    expect(rows).toHaveLength(2)
+    expect(rows[0]?.eventId).not.toBe(rows[1]?.eventId)
+  })
+
+  test('accepts NULL tokens on a success row', () => {
+    recordUsage(validEvent({ inputTokens: null, outputTokens: null }))
+
+    const row = getDrizzleDb().select().from(llmUsageEvents).all()[0]
+    expect(row?.inputTokens).toBeNull()
+    expect(row?.outputTokens).toBeNull()
+    expect(row?.error).toBeNull()
+  })
+
+  test('persists an error string on the error row shape', () => {
+    recordUsage(
+      validEvent({
+        inputTokens: null,
+        outputTokens: null,
+        responseId: null,
+        finishReason: null,
+        stepCount: 0,
+        toolCallCount: 0,
+        error: 'boom',
+      }),
+    )
+
+    const row = getDrizzleDb().select().from(llmUsageEvents).all()[0]
+    expect(row?.error).toBe('boom')
+    expect(row?.inputTokens).toBeNull()
+    expect(row?.outputTokens).toBeNull()
+    expect(row?.responseId).toBeNull()
+    expect(row?.finishReason).toBeNull()
+  })
+
+  test('persists embedding-role rows with zeroed counts', () => {
+    recordUsage(
+      validEvent({
+        modelRole: 'embedding',
+        stepCount: 0,
+        toolCallCount: 0,
+        messageCount: 0,
+        finishReason: null,
+        responseId: null,
+      }),
+    )
+
+    const row = getDrizzleDb().select().from(llmUsageEvents).all()[0]
+    expect(row?.modelRole).toBe('embedding')
+    expect(row?.stepCount).toBe(0)
+    expect(row?.toolCallCount).toBe(0)
+    expect(row?.messageCount).toBe(0)
+  })
+
+  test('does not throw when the underlying insert fails', async () => {
+    type RunStep = { run: () => never }
+    type ValuesStep = { values: (input: unknown) => RunStep }
+    type InsertStep = { insert: (table: unknown) => ValuesStep }
+    const throwingDb: InsertStep = {
+      insert: (): ValuesStep => ({
+        values: (): RunStep => ({
+          run: (): never => {
+            throw new Error('simulated db failure')
+          },
+        }),
+      }),
+    }
+    void mock.module('../../src/db/drizzle.js', () => ({
+      getDrizzleDb: (): InsertStep => throwingDb,
+    }))
+    const { recordUsage: freshRecord } = await import('../../src/usage/recorder.js')
+
+    expect(() => {
+      freshRecord(validEvent())
+    }).not.toThrow()
+  })
+})

--- a/tests/web/distill.test.ts
+++ b/tests/web/distill.test.ts
@@ -5,6 +5,8 @@
 
 import { beforeEach, describe, expect, test } from 'bun:test'
 
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { llmUsageEvents } from '../../src/db/schema.js'
 import { resetSystemConfigCacheForTesting, setSystemConfig } from '../../src/system-config.js'
 import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
 
@@ -18,9 +20,15 @@ type DistillWebContent = (
     title: string
     content: string
     goal?: string
+    contextType?: 'dm' | 'group'
+    chatUserId?: string
   },
   deps?: {
-    generateText: (options: { model: unknown; prompt: string; timeout: number }) => Promise<{ text: string }>
+    generateText: (options: {
+      model: unknown
+      prompt: string
+      timeout: number
+    }) => Promise<{ text: string; usage?: { inputTokens?: number; outputTokens?: number } }>
     buildModel: (apiKey: string, baseUrl: string, modelId: string) => unknown
   },
 ) => Promise<{ summary: string; excerpt: string; truncated: boolean }>
@@ -147,5 +155,95 @@ describe('distillWebContent', () => {
       excerpt: 'Single paragraph summary only',
       truncated: true,
     })
+  })
+
+  test('records a usage row with modelRole="small" when context fields are provided', async () => {
+    const runDistill = getDistillWebContent(distillWebContent)
+
+    seedSystemLlm({ smallModel: 'small-model' })
+
+    await runDistill(
+      {
+        storageContextId: 'ctx-distill',
+        contextType: 'group',
+        chatUserId: 'user-distill',
+        title: 'Big page',
+        content: createLongContent(),
+      },
+      {
+        buildModel: () => ({ id: 'small-model' }),
+        generateText: () =>
+          Promise.resolve({ text: 'summary\n\nexcerpt', usage: { inputTokens: 30, outputTokens: 12 } }),
+      },
+    )
+
+    const rows = getDrizzleDb().select().from(llmUsageEvents).all()
+    expect(rows).toHaveLength(1)
+    const row = rows[0]
+    expect(row?.modelRole).toBe('small')
+    expect(row?.model).toBe('small-model')
+    expect(row?.storageContextId).toBe('ctx-distill')
+    expect(row?.contextType).toBe('group')
+    expect(row?.chatUserId).toBe('user-distill')
+    expect(row?.inputTokens).toBe(30)
+    expect(row?.outputTokens).toBe(12)
+    expect(row?.messageCount).toBe(1)
+    expect(row?.toolCallCount).toBe(0)
+    expect(row?.stepCount).toBeGreaterThanOrEqual(1)
+    expect(row?.error).toBeNull()
+  })
+
+  test('records an error row when generateText throws', async () => {
+    const runDistill = getDistillWebContent(distillWebContent)
+
+    seedSystemLlm({ smallModel: 'small-model' })
+
+    await expect(
+      runDistill(
+        {
+          storageContextId: 'ctx-fail',
+          contextType: 'dm',
+          chatUserId: 'user-fail',
+          title: 'Big page',
+          content: createLongContent(),
+        },
+        {
+          buildModel: () => ({ id: 'small-model' }),
+          generateText: () => Promise.reject(new Error('upstream down')),
+        },
+      ),
+    ).rejects.toThrow('upstream down')
+
+    const rows = getDrizzleDb().select().from(llmUsageEvents).all()
+    expect(rows).toHaveLength(1)
+    const row = rows[0]
+    expect(row?.error).toBe('upstream down')
+    expect(row?.modelRole).toBe('small')
+    expect(row?.storageContextId).toBe('ctx-fail')
+    expect(row?.contextType).toBe('dm')
+    expect(row?.chatUserId).toBe('user-fail')
+    expect(row?.inputTokens).toBeNull()
+    expect(row?.outputTokens).toBeNull()
+  })
+
+  test('omits the row when context fields are absent', async () => {
+    const runDistill = getDistillWebContent(distillWebContent)
+
+    seedSystemLlm({ smallModel: 'small-model' })
+
+    await runDistill(
+      {
+        storageContextId: 'ctx-no-context',
+        title: 'Big page',
+        content: createLongContent(),
+      },
+      {
+        buildModel: () => ({ id: 'small-model' }),
+        generateText: () => Promise.resolve({ text: 'summary\n\nexcerpt' }),
+      },
+    )
+
+    const rows = getDrizzleDb().select().from(llmUsageEvents).all()
+    expect(rows).toEqual([])
   })
 })

--- a/tests/web/fetch-extract.test.ts
+++ b/tests/web/fetch-extract.test.ts
@@ -193,6 +193,7 @@ describe('fetchAndExtract', () => {
       title: 'docs.example.org',
       content: 'Plain body content',
       goal: 'Capture action items',
+      chatUserId: 'actor-7',
     })
     expect(putCachedWebFetch).toHaveBeenCalledWith(
       'https://example.com/path',


### PR DESCRIPTION
Brainstorm enumerates the ~10-file surface area, resolves the roadmap's
open questions (single direct-recorder API for embedding/distill; bus
subscription for orchestrator path; randomUUID over ULID; subscribe at
startup), and flags the bus short-circuit and missing chat_user_id /
context_type fields the parent design hadn't elaborated.

Per-phase design locks the llm_usage_events schema (DEFAULT 0 on count
columns so error rows insert cleanly), the src/usage/ module API
(recordUsage, initUsageRecorder, listSubjects, getSubjectDetail), the
emitLlmEnd / emitLlmError signature extensions, and the direct
recordUsage calls from embeddings.ts and web/distill.ts.

Plan sequences 14 TDD-hook-safe steps: migration 035 + Drizzle schema
first, then the src/usage/ module with tests, then the orchestrator
emit-signature extensions, then bus subscriber wiring, then the
embedding and distill direct-call paths.