### PR TITLE
feat(stats): Phase 5 — anonymous DB-wide statistics module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,28 @@ requires `DEBUG_TOKEN` to be set in env (the route returns 401 if it
 is unset, so production-style deployments behind a reverse proxy
 keep the write surface closed by default).
 
+The same dashboard exposes a Stats panel and a per-subject stats view
+backed by `GET /stats/global` and `GET /stats/subject/:id`. Both
+routes require `DEBUG_TOKEN`.
+
+#### Anonymity contract for `/stats/*`
+
+`/stats/global` and `/stats/subject/:id` are constrained to anonymous,
+aggregate-shaped data only:
+
+- Allowed: counts, byte sizes, oldest/newest timestamps, enum
+  distributions (e.g. `byStatus`, `byProvider`, `byExtension`), and
+  hashed/keyed identifiers for high-cardinality strings (rrule
+  patterns, web-fetch hostnames). The keying salt is the
+  `stats_anonymity_salt` row in `system_config`, seeded lazily on
+  first read and never rotated automatically.
+- Never returned: message text, memo bodies, observation text,
+  attachment filenames, raw URLs/paths, usernames or display names,
+  workspace names, tags, project names, status names, RRULE text,
+  any other free-form content.
+
+Any leak of content from these routes is a release-blocking defect.
+
 The remaining credentials live in the per-user config store and are managed through `/setup` and `/config`, not through a `/set` command.
 
 ### File Attachments (S3-compatible Object Storage)
@@ -230,6 +252,7 @@ Optional: debug server + dashboard client
 - `src/web/` — safe public HTTP(S) fetch, extraction, distillation, rate limiting, cache
 - `src/debug/` and `client/debug/` — optional debug server and dashboard UI
 - `src/usage/` — LLM and tool-call usage recorders + read helpers. Subscribes to the in-process event bus and writes one row per LLM turn into `llm_usage_events` (Phase 2) and one row per tool execution into `tool_call_events` (Phase 4). `event_id` on both tables is a deterministic SHA-256 hash so the recorder is safe to move to a queue/retry path later. Both tables carry inert outbox columns (`forwarded_at`, `forward_attempts`, `forward_error`) for a future metering-vendor forwarder.
+- `src/stats/` — anonymous DB-wide statistics: per-subject and global aggregate queries fed straight from SQLite via Drizzle. The orchestrator (`src/stats/index.ts`) exposes `getSubjectStats()` and `getGlobalStats()`, caches the global view for 60s, and is consumed by the dashboard Stats panel through `/stats/*` (DEBUG_TOKEN-gated). All free-form, high-cardinality identifiers (rrule patterns, web-fetch hostnames) are keyed-hashed using the `stats_anonymity_salt` row in `system_config`; see the anonymity contract under "Required Environment Variables".
 
 ## Available Tools
 

--- a/client/debug/App.svelte
+++ b/client/debug/App.svelte
@@ -19,6 +19,8 @@
   import TraceList from './components/TraceList.svelte'
   import TurnDetail from './components/TurnDetail.svelte'
   import TurnsPanel from './components/TurnsPanel.svelte'
+  import StatsPanel from './stats/StatsPanel.svelte'
+  import SubjectStatsPanel from './stats/SubjectStatsPanel.svelte'
 
   import { dashboard } from './dashboard.svelte.js'
   import { fetchInitialLogs, parseLogsArray, collectScopes } from './log-bootstrap.js'
@@ -96,6 +98,7 @@
       onSelectSubject={(subject) => {
         void openBillingSubject(subject)
       }} />
+    <StatsPanel {dashboard} />
   </div>
 
   <LogExplorer {dashboard} onSelectLog={(entry, index) => (selectedLog = { entry, index })} />
@@ -153,6 +156,9 @@
   {#snippet body()}
     {#if dashboard.billingDetail !== null}
       <SubjectDetail detail={dashboard.billingDetail} />
+    {/if}
+    {#if selectedBillingSubject !== null}
+      <SubjectStatsPanel storageContextId={selectedBillingSubject.storageContextId} />
     {/if}
   {/snippet}
 </Modal>

--- a/client/debug/dashboard-types.ts
+++ b/client/debug/dashboard-types.ts
@@ -26,6 +26,7 @@ import type {
   Notification,
   ToolFailure,
 } from '../../src/debug/schemas.js'
+import type { GlobalStats, StatsWindow, SubjectStats } from '../../src/stats/types.js'
 
 export type {
   Fact,
@@ -49,6 +50,9 @@ export type {
   Turn,
   Notification,
   ToolFailure,
+  GlobalStats,
+  StatsWindow,
+  SubjectStats,
 }
 
 export type RecurringTask = {
@@ -196,4 +200,7 @@ export interface DashboardState {
   billingSubjects: BillingSubject[]
   billingDetail: BillingDetail | null
   adminLlm: AdminLlmSnapshot | null
+  statsWindow: StatsWindow
+  globalStats: GlobalStats | null
+  subjectStats: SubjectStats | null
 }

--- a/client/debug/dashboard.svelte.ts
+++ b/client/debug/dashboard.svelte.ts
@@ -33,4 +33,7 @@ export const dashboard = $state<DashboardState>({
   billingSubjects: [],
   billingDetail: null,
   adminLlm: null,
+  statsWindow: '30d',
+  globalStats: null,
+  subjectStats: null,
 })

--- a/client/debug/stats/StatsPanel.svelte
+++ b/client/debug/stats/StatsPanel.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+  import { untrack } from 'svelte'
+
+  import type { DashboardState, StatsWindow } from '../dashboard-types.js'
+  import { fetchStatsGlobal } from './fetchers.js'
+
+  interface Props {
+    dashboard: DashboardState
+  }
+
+  let { dashboard }: Props = $props()
+
+  const WINDOWS: readonly StatsWindow[] = ['1d', '7d', '30d', 'all']
+
+  let loading = $state(false)
+  let error: string | null = $state(null)
+
+  function formatBytes(n: number): string {
+    if (n < 1024) return `${n} B`
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+    if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`
+    return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`
+  }
+
+  async function loadStats(): Promise<void> {
+    loading = true
+    error = null
+    try {
+      dashboard.globalStats = await fetchStatsGlobal(dashboard.statsWindow)
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err)
+    } finally {
+      loading = false
+    }
+  }
+
+  function onWindowChange(event: Event): void {
+    const target = event.currentTarget
+    if (!(target instanceof HTMLSelectElement)) return
+    const next = target.value
+    if (next === '1d' || next === '7d' || next === '30d' || next === 'all') {
+      dashboard.statsWindow = next
+      void loadStats()
+    }
+  }
+
+  $effect(() => {
+    untrack(() => {
+      void loadStats()
+    })
+  })
+</script>
+
+<section class="panel stats-panel">
+  <header class="stats-header">
+    <h2>Stats</h2>
+    <label>
+      Window:
+      <select
+        data-testid="stats-window-select"
+        value={dashboard.statsWindow}
+        onchange={onWindowChange}>
+        {#each WINDOWS as w (w)}
+          <option value={w}>{w}</option>
+        {/each}
+      </select>
+    </label>
+    <button
+      type="button"
+      data-testid="stats-refresh"
+      onclick={() => {
+        void loadStats()
+      }}>{loading ? 'Refreshing…' : 'Refresh'}</button>
+    {#if error !== null}
+      <span class="status-error">{error}</span>
+    {/if}
+  </header>
+
+  {#if dashboard.globalStats !== null}
+    {@const g = dashboard.globalStats}
+    <section class="stats-summary">
+      <h3>Subjects</h3>
+      <dl class="stats-list">
+        <dt>DM total</dt><dd data-testid="stats-dm-total">{g.subjects.dmTotal}</dd>
+        <dt>Group total</dt><dd data-testid="stats-group-total">{g.subjects.groupTotal}</dd>
+        <dt>Active 1d / 7d / 30d</dt>
+        <dd>{g.active.activeIn1d} / {g.active.activeIn7d} / {g.active.activeIn30d}</dd>
+      </dl>
+      <h3>Storage</h3>
+      <dl class="stats-list">
+        <dt>SQLite</dt><dd>{formatBytes(g.storage.sqliteBytes)}</dd>
+        <dt>S3 attachments (active)</dt><dd>{formatBytes(g.storage.s3AttachmentBytes)}</dd>
+      </dl>
+      <h3>Identity mix</h3>
+      <dl class="stats-list">
+        {#each Object.entries(g.identityMix.byProvider) as [provider, count] (provider)}
+          <dt>{provider}</dt><dd>{count}</dd>
+        {/each}
+        <dt>Kaneo workspaces</dt><dd>{g.identityMix.kaneoWorkspaces}</dd>
+      </dl>
+      <h3>Surface mix</h3>
+      <dl class="stats-list">
+        <dt>w/ recurring</dt><dd>{g.surfaceMix.subjectsWithRecurring}</dd>
+        <dt>w/ deferred</dt><dd>{g.surfaceMix.subjectsWithDeferred}</dd>
+        <dt>w/ memos</dt><dd>{g.surfaceMix.subjectsWithMemos}</dd>
+        <dt>w/ instructions</dt><dd>{g.surfaceMix.subjectsWithInstructions}</dd>
+      </dl>
+      <h3>Distributions (memos/subject)</h3>
+      <dl class="stats-list">
+        <dt>count / mean</dt><dd>{g.distributions.memosPerSubject.count} / {g.distributions.memosPerSubject.mean.toFixed(2)}</dd>
+        <dt>p50 / p90 / p99 / max</dt>
+        <dd>{g.distributions.memosPerSubject.p50} / {g.distributions.memosPerSubject.p90} / {g.distributions.memosPerSubject.p99} / {g.distributions.memosPerSubject.max}</dd>
+      </dl>
+      <h3>Top hosts (keyed-hashed)</h3>
+      {#if g.webFetches.topHosts.length === 0}
+        <span class="placeholder">No web fetches</span>
+      {:else}
+        <ul class="stats-list">
+          {#each g.webFetches.topHosts as h (h.hostHash)}
+            <li><code>{h.hostHash.slice(0, 12)}</code>: {h.count}</li>
+          {/each}
+        </ul>
+      {/if}
+      <h3>Top tools</h3>
+      {#if g.toolMix.topTools.length === 0}
+        <span class="placeholder">No tool calls</span>
+      {:else}
+        <ul class="stats-list">
+          {#each g.toolMix.topTools as t (t.toolName)}
+            <li>{t.toolName}: {t.count} (success {(t.successRate * 100).toFixed(0)}%)</li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+  {:else if !loading && error === null}
+    <span class="placeholder">No stats loaded yet</span>
+  {/if}
+</section>

--- a/client/debug/stats/SubjectStatsPanel.svelte
+++ b/client/debug/stats/SubjectStatsPanel.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { untrack } from 'svelte'
+
+  import type { SubjectStats } from '../../../src/stats/types.js'
+  import { fetchStatsSubject } from './fetchers.js'
+
+  interface Props {
+    storageContextId: string
+  }
+
+  let { storageContextId }: Props = $props()
+
+  let data: SubjectStats | null = $state(null)
+  let loading = $state(true)
+  let error: string | null = $state(null)
+
+  function formatBytes(n: number): string {
+    if (n < 1024) return `${n} B`
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+    if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`
+    return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`
+  }
+
+  async function load(): Promise<void> {
+    loading = true
+    error = null
+    try {
+      data = await fetchStatsSubject(storageContextId)
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err)
+    } finally {
+      loading = false
+    }
+  }
+
+  $effect(() => {
+    untrack(() => {
+      void load()
+    })
+  })
+</script>
+
+<section class="subject-stats-panel">
+  <h4>Anonymous stats</h4>
+  {#if loading && data === null && error === null}
+    <span class="placeholder">Loading…</span>
+  {:else if error !== null}
+    <span class="status-error">Stats error: {error}</span>
+  {:else if data !== null}
+    <dl class="stats-list">
+      <dt>memos</dt><dd>{data.memos.total}</dd>
+      <dt>recurring</dt><dd>{data.recurringTasks.total}</dd>
+      <dt>scheduled prompts</dt><dd>{data.scheduledPrompts.total}</dd>
+      <dt>alert prompts</dt><dd>{data.alertPrompts.total}</dd>
+      <dt>instructions</dt><dd>{data.userInstructions.total}</dd>
+      <dt>attachments bytes</dt><dd>{formatBytes(data.attachments.storedBytesTotal)}</dd>
+      <dt>messages</dt><dd>{data.messageMetadata.total}</dd>
+      <dt>turns</dt><dd>{data.conversationHistory.turnCount}</dd>
+      <dt>llm rows</dt><dd>{data.llmUsage.rowCount}</dd>
+      <dt>tool calls</dt><dd>{data.toolCalls.total} ({data.toolCalls.success}✓ / {data.toolCalls.failure}✗)</dd>
+      <dt>web fetches</dt><dd>{data.webFetches.totalRequests}</dd>
+    </dl>
+  {/if}
+</section>

--- a/client/debug/stats/fetchers.ts
+++ b/client/debug/stats/fetchers.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+import type { GlobalStats, StatsWindow, SubjectStats } from '../../../src/stats/types.js'
+
+const PercentilesSchema = z.object({
+  count: z.number(),
+  min: z.number(),
+  p50: z.number(),
+  p90: z.number(),
+  p99: z.number(),
+  max: z.number(),
+  mean: z.number(),
+})
+
+const StatsWindowSchema = z.enum(['1d', '7d', '30d', 'all'])
+
+const GlobalStatsSchema = z.object({
+  generatedAt: z.number(),
+  window: StatsWindowSchema,
+  subjects: z.object({
+    dmTotal: z.number(),
+    groupTotal: z.number(),
+    growthLast30d: z.array(z.object({ date: z.string(), dmAdded: z.number(), groupAdded: z.number() })),
+  }),
+  active: z.object({ activeIn1d: z.number(), activeIn7d: z.number(), activeIn30d: z.number() }),
+  distributions: z.object({
+    memosPerSubject: PercentilesSchema,
+    recurringTasksPerSubject: PercentilesSchema,
+    messageMetadataPerSubject: PercentilesSchema,
+    attachmentBytesPerSubject: PercentilesSchema,
+  }),
+  storage: z.object({ sqliteBytes: z.number(), s3AttachmentBytes: z.number() }),
+  identityMix: z.object({ byProvider: z.record(z.string(), z.number()), kaneoWorkspaces: z.number() }),
+  surfaceMix: z.object({
+    subjectsWithRecurring: z.number(),
+    subjectsWithDeferred: z.number(),
+    subjectsWithMemos: z.number(),
+    subjectsWithInstructions: z.number(),
+  }),
+  webFetches: z.object({
+    topHosts: z.array(z.object({ hostHash: z.string(), count: z.number() })),
+  }),
+  toolMix: z.object({
+    topTools: z.array(z.object({ toolName: z.string(), count: z.number(), successRate: z.number() })),
+    errorTypeCounts: z.record(z.string(), z.number()),
+  }),
+})
+
+const StatsContextTypeSchema = z.enum(['dm', 'group', 'unknown'])
+
+const SubjectStatsSchema = z.object({
+  storageContextId: z.string(),
+  chatUserId: z.string().nullable(),
+  contextType: StatsContextTypeSchema,
+  displayName: z.string().nullable(),
+  memos: z.object({
+    total: z.number(),
+    byStatus: z.record(z.string(), z.number()),
+    tagCardinality: z.object({ distinct: z.number(), meanPerMemo: z.number() }),
+    contentBytesTotal: z.number(),
+    embeddingBytesTotal: z.number(),
+    withEmbedding: z.number(),
+    oldestCreatedAt: z.number().nullable(),
+    newestCreatedAt: z.number().nullable(),
+  }),
+  scheduledPrompts: z.object({
+    total: z.number(),
+    byStatus: z.record(z.string(), z.number()),
+    distinctDeliveryTargets: z.number(),
+  }),
+  alertPrompts: z.object({ total: z.number(), byStatus: z.record(z.string(), z.number()) }),
+  recurringTasks: z.object({
+    total: z.number(),
+    enabled: z.number(),
+    disabled: z.number(),
+    distinctProjects: z.number(),
+    nextRunWithin7d: z.number(),
+    distinctRrulePatterns: z.number(),
+  }),
+  userInstructions: z.object({ total: z.number(), textBytesTotal: z.number() }),
+  attachments: z.object({
+    total: z.number(),
+    byStatus: z.record(z.string(), z.number()),
+    bySourceProvider: z.record(z.string(), z.number()),
+    storedBytesTotal: z.number(),
+    active: z.number(),
+    byExtension: z.record(z.string(), z.number()),
+  }),
+  messageMetadata: z.object({
+    total: z.number(),
+    authoredBySubject: z.number(),
+    oldestTimestamp: z.number().nullable(),
+    newestTimestamp: z.number().nullable(),
+    textBytesTotal: z.number(),
+  }),
+  conversationHistory: z.object({ turnCount: z.number(), summaryPresent: z.boolean() }),
+  userIdentityMappings: z.record(z.string(), z.number()),
+  stagedFiles: z.object({
+    total: z.number(),
+    byStatus: z.record(z.string(), z.number()),
+    bytesTotal: z.number(),
+  }),
+  userBlock: z
+    .object({
+      addedAt: z.string().nullable(),
+      addedByPresent: z.boolean(),
+      kaneoWorkspacePresent: z.boolean(),
+    })
+    .nullable(),
+  groupBlock: z
+    .object({ memberCount: z.number(), distinctAddedBy: z.number(), observationCount: z.number() })
+    .nullable(),
+  webFetches: z.object({ totalRequests: z.number() }),
+  llmUsage: z.object({
+    rowCount: z.number(),
+    inputTokensTotal: z.number(),
+    outputTokensTotal: z.number(),
+  }),
+  toolCalls: z.object({
+    total: z.number(),
+    success: z.number(),
+    failure: z.number(),
+    topTools: z.array(z.object({ toolName: z.string(), count: z.number() })),
+    errorTypeCounts: z.record(z.string(), z.number()),
+  }),
+})
+
+const ErrorBodySchema = z.object({ error: z.string() })
+
+const errorMessageFrom = (body: unknown, fallback: string): string => {
+  const parsed = ErrorBodySchema.safeParse(body)
+  return parsed.success ? parsed.data.error : fallback
+}
+
+const readBody = async (res: Response): Promise<unknown> => {
+  try {
+    return await res.json()
+  } catch {
+    return null
+  }
+}
+
+const requireOk = (res: Response, body: unknown): void => {
+  if (res.ok) return
+  throw new Error(errorMessageFrom(body, `request failed with status ${res.status}`))
+}
+
+export const fetchStatsGlobal = async (window?: StatsWindow): Promise<GlobalStats> => {
+  const path = window === undefined ? '/stats/global' : `/stats/global?window=${encodeURIComponent(window)}`
+  const res = await fetch(path)
+  const body = await readBody(res)
+  requireOk(res, body)
+  return GlobalStatsSchema.parse(body) as GlobalStats
+}
+
+export const fetchStatsSubject = async (storageContextId: string): Promise<SubjectStats> => {
+  const res = await fetch(`/stats/subject/${encodeURIComponent(storageContextId)}`)
+  const body = await readBody(res)
+  requireOk(res, body)
+  return SubjectStatsSchema.parse(body) as SubjectStats
+}

--- a/docs/superpowers/notes/2026-05-20-phase-5-anonymous-stats-brainstorm.md
+++ b/docs/superpowers/notes/2026-05-20-phase-5-anonymous-stats-brainstorm.md
@@ -1,0 +1,709 @@
+# Phase 5 — Anonymous DB-Wide Statistics, Brainstorm
+
+**Date:** 2026-05-20
+**Parent roadmap:** [`../plans/2026-05-19-central-llm-billing-roadmap.md`](../plans/2026-05-19-central-llm-billing-roadmap.md)
+**Phase 3 (merged):** [`../plans/2026-05-19-phase-3-billing-dashboard-plan.md`](../plans/2026-05-19-phase-3-billing-dashboard-plan.md)
+**Phase 4 (merged):** [`../plans/2026-05-20-phase-4-tool-call-rows-plan.md`](../plans/2026-05-20-phase-4-tool-call-rows-plan.md)
+
+Open exploration before the per-phase design and plan land. The roadmap
+already lays out Phase 5 in detail; this brainstorm verifies the surface
+area against the current codebase, resolves the five pre-start open
+questions, and surfaces implementation choices the roadmap leaves to the
+design call.
+
+## Trigger check
+
+The roadmap puts Phase 5 behind a trigger:
+
+> After phase 3 ships and the Billing tab is in operator hands long
+> enough to know which secondary stats they keep asking SQL for.
+
+Phase 3 shipped (`490de03`), Phase 4 shipped immediately after
+(`0437f16`). The Billing tab has not soaked with operators. Same R1/R2
+reading as Phase 4:
+
+- **R1.** The trigger is informational; the user has explicitly
+  decided to start. Brainstorm proceeds.
+- **R2.** Without operator-derived "which stats they keep asking SQL
+  for" evidence, the metric set is a hypothesis.
+
+**Recommendation:** R1, with R2 informing scope. Adopt the roadmap's
+metric list as the v1 contract (it is itself derived from the billing
+research bundle's cost-amplifier candidates) and treat additions as
+follow-on work rather than re-scoping mid-implementation.
+
+## Pre-start open questions — answered
+
+The roadmap lists five questions to resolve before phase 5 starts. The
+user has confirmed adoption of the roadmap recommendations verbatim:
+
+1. **Anonymity contract — hostnames.** Keyed hash with a
+   per-deployment salt; values deterministic within a deployment, not
+   portable across deployments.
+2. **Bot-wide view.** Per-subject id is never exposed in the global
+   view; only distribution shapes (counts, percentiles, enum
+   distributions). No deployment-size threshold needed because there
+   are no per-subject identifiers to deanonymize from.
+3. **Time series.** Phase 5a uses live queries only. The
+   `usage_snapshots` table is deferred to phase 5b and earns its place
+   only when live-query latency degrades.
+4. **External task counts (Kaneo / YouTrack).** Deferred entirely.
+   Live provider calls would turn the stats page into a rate-limit
+   surface.
+5. **Conversation history.** Turn count and summary count only;
+   byte-size of historical text ignored in 5a.
+
+Carried into the design with no further refinement.
+
+## Surface area survey
+
+The roadmap lists 14 source tables and a tool-failures category. Names
+in this codebase differ from the roadmap in two places — confirmed below
+and corrected in the design.
+
+| Roadmap table             | Real table / source                                    | Existence | Notes                                                                                                                                                              |
+| ------------------------- | ------------------------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `memos`                   | `memos` (`src/db/schema.ts:175-193`)                   | yes       | columns: `status`, `tags` (JSON), `content`, `embedding` blob, `created_at`, `updated_at`. Bytes via `length(content)` / `length(embedding)`                       |
+| `scheduled_prompts`       | `scheduled_prompts` (`src/db/deferred-schema.ts:9-36`) | yes       | has `status`, `delivery_context_id`, `audience`. distinct delivery target count from `delivery_context_id`. roadmap also implies `alert_prompts` parallel — add it |
+| `recurring_tasks`         | `recurring_tasks` (`src/db/schema.ts:86-119`)          | yes       | `enabled` is TEXT ('0'/'1'), `project_id`, `rrule`, `next_run`                                                                                                     |
+| `instructions`            | `user_instructions` (`src/db/schema.ts:141-152`)       | yes       | column is `text`, not `content`. Use `length(text)` for bytes                                                                                                      |
+| `attachments`             | `attachments` (`src/db/schema.ts:275-298`)             | yes       | `status`, `source_provider`, `is_active`, `size`. Manifest bytes ≈ `SUM(size)`                                                                                     |
+| `message_metadata`        | `message_metadata` (`src/db/schema.ts:156-173`)        | yes       | `context_id`, `author_id`, `timestamp`, `text`. Hottest table for scans — index considerations                                                                     |
+| conversation history      | `conversation_history` + `memory_summary`              | yes       | `conversation_history.messages` is a JSON blob; turn count is array length. `memory_summary` is one row per user; summary present/absent                           |
+| `user_identity_mappings`  | `user_identity_mappings` (`src/db/schema.ts:212-228`)  | yes       | per `(context_id, provider_name)`. Count grouped by `provider_name`                                                                                                |
+| `staged_files`            | `staged_files` (`src/db/staged-schema.ts:8-31`)        | yes       | `status`, `size`, `context_id`                                                                                                                                     |
+| `users`                   | `users` (`src/db/schema.ts:9-17`)                      | yes       | `added_at`, `added_by`, `kaneo_workspace_id`                                                                                                                       |
+| `group_members`           | `group_members` (`src/db/schema.ts:59-74`)             | yes       | `(group_id, user_id)` PK, `added_by`                                                                                                                               |
+| `group_user_observations` | `group_user_observations` (`src/db/schema.ts:259-273`) | yes       | per-context observation rows; we count only                                                                                                                        |
+| `web_fetch_cache`         | `web_cache` (`src/db/web-schema.ts:8-23`)              | yes       | name correction; no `subject` join — see open question A                                                                                                           |
+| `llm_usage_events`        | `llm_usage_events` (Phase 2)                           | yes       | already surfaced by Phase 3; included for completeness                                                                                                             |
+| tool-failures             | `tool_call_events` (Phase 4) + ring buffer             | yes       | Phase 4 shipped a real durable table; supersedes the ring buffer as a stats source                                                                                 |
+
+Net: no missing tables. Two name corrections (`user_instructions`,
+`web_cache`). One opportunistic addition (`alert_prompts` next to
+`scheduled_prompts`). Phase 4's `tool_call_events` is a strict upgrade
+over the ring buffer for tool-usage breakdowns and powers the Phase 5
+tool-mix view directly.
+
+## Open question A — `web_cache` subject attribution
+
+The roadmap's web-fetch row asks for "distinct hosts (hashed), total
+fetches per subject if join is feasible, bytes stored".
+
+Reality of `web_cache`:
+
+- Keyed by `url_hash`, not by subject. There is no
+  `storage_context_id` column.
+- Rate-limit table `web_rate_limit` is keyed by `actor_id` (which is
+  the subject) and tracks request counts per window — but holds only
+  `(actor_id, window_start, count)`, no URLs.
+
+So we cannot answer "how many fetches did subject X make against
+host Y" from `web_cache` alone. Options:
+
+- **A1.** Per-subject: report only what `web_rate_limit` exposes —
+  total requests across all windows currently in the table, no host
+  breakdown. Bot-wide: distinct hosts (keyed-hash) from `web_cache`,
+  `SUM(LENGTH(excerpt))` for stored bytes. Subject ↔ host join is
+  marked unknown.
+- **A2.** Add a thin per-fetch log going forward (`web_fetches(actor,
+url_hash, fetched_at)`) so future stats can join. New table, new
+  recorder — out of scope for 5a.
+- **A3.** Skip the web-fetch breakdown entirely in 5a.
+
+**Recommendation:** A1. The per-subject "total fetches" comes from
+`web_rate_limit` (a sum over rows for that actor); the bot-wide host
+breakdown comes from `web_cache.url` with keyed-hashing applied
+before exposure. We acknowledge the join is one-sided in the API
+shape (a `webFetchHostBreakdown` field appears only in the global
+view) and accept it.
+
+## Open question B — Module location and shape
+
+Two locations make sense for the stats module:
+
+- **B1.** New `src/stats/` module (per roadmap sketch).
+- **B2.** Extend `src/usage/` with `src/usage/stats.ts` since usage
+  already owns `query.ts`.
+
+The roadmap explicitly sketches B1. B2 would muddle a module whose
+charter is "record + read LLM/tool usage rows" with a charter of "read
+arbitrary domain tables".
+
+**Recommendation:** B1, with the shape from the roadmap:
+
+```
+src/stats/
+  index.ts          — getSubjectStats(id), getGlobalStats(opts)
+  per-table.ts      — one query function per source table
+  aggregate.ts      — percentile + bucket helpers
+  hashing.ts        — keyed hash for rrule patterns + hostnames
+  types.ts          — SubjectStats, GlobalStats, all sub-shapes
+```
+
+Routes go in `src/debug/stats-routes.ts` mirroring
+`src/debug/billing-routes.ts` (Phase 3). The dashboard server in
+`src/debug/server.ts` wires `stats-routes` next to `billing-routes`.
+
+## Open question C — Per-subject scope: which subjects are valid?
+
+Phase 3's `listSubjects()` returns only subjects that have at least
+one row in `llm_usage_events`. Phase 5's per-subject view is requested
+by `storage_context_id`. Two interpretations:
+
+- **C1.** Phase 5 only answers `getSubjectStats(id)` for subjects
+  that already appear in `llm_usage_events`. If a user signed up but
+  never made an LLM call, they have zero stats and the dashboard
+  doesn't list them.
+- **C2.** Phase 5 enumerates subjects from a union of tables
+  (`users`, `authorized_groups`, plus any subject that has rows in
+  the listed tables) so freshly-onboarded users appear.
+
+**Recommendation:** C1 in 5a. The Stats sub-panel lives inside the
+Billing tab, and a subject reaches that panel only by being listed
+in Billing first. Decoupling the two would require a new "All
+subjects" view which is not in the roadmap. C2 can land later if
+operators ask "who signed up but never used the bot".
+
+## Open question D — Subject-type discrimination (DM vs group)
+
+The per-subject view differs between users and groups (roadmap rows
+for `users (for subjects that are users)` and
+`group_members (for subjects that are groups)`).
+
+Phase 3 stores `context_type` ('dm' / 'group') on
+`llm_usage_events` and `tool_call_events`. The most recent
+`llm_usage_events` row for a `storage_context_id` carries the type.
+For subjects with both types in history (rare; would require id
+collision across user and group ids, which is a chat-platform
+property — Telegram groups are negative integers, users positive,
+so no collision in practice), we accept the most-recent-row label.
+
+**Recommendation:** Read `context_type` from the latest
+`llm_usage_events` row for the subject. If the subject has no
+row (shouldn't happen given C1 above), `context_type = 'unknown'`
+and the user-vs-group sub-blocks are both omitted.
+
+## Open question E — Distribution math
+
+Bot-wide aggregates show distribution percentiles (p50/p90/p99 per
+subject) for memo count, recurring task count, message count,
+attachment bytes. Two ways:
+
+- **E1.** Compute in JS — load per-subject counts, sort, pick
+  positions. Cheap up to ~10k subjects; the deployment scale Phase 5
+  targets is well below that.
+- **E2.** SQLite percentile via window functions —
+  `PERCENTILE_CONT` is not in SQLite; possible via `NTILE` + ranking
+  but messy and version-dependent.
+
+**Recommendation:** E1. Simpler, deterministic, easier to test.
+Bench the global view against the seeded 1k subjects + 100k messages
+fixture; if the percentile pass dominates, revisit.
+
+`src/stats/aggregate.ts` exports `percentiles(values: number[],
+ps: readonly number[])` — pure function, easy unit tests.
+
+## Open question F — Hashing: function and salt source
+
+Anonymity contract requires:
+
+- rrule strings (keyed-hash to dedupe for distribution charts without
+  exposing the raw value)
+- web-fetch hostnames (keyed-hash, per-deployment salt)
+
+Sub-questions:
+
+1. **Hash function.** `crypto.createHash('sha256').update(input + salt).digest('hex').slice(0, 16)`
+   — same family as Phase 4's deterministic event id but with a
+   secret salt prepended. Truncation to 16 hex chars keeps the
+   output compact for distribution buckets while leaving 2⁶⁴
+   collision space.
+2. **Salt source.** Reuse `system_config` (Phase 1) with a new key
+   `stats_anonymity_salt`. Seeded on first run via
+   `crypto.randomBytes(16).toString('hex')` if missing. Not exposed
+   to any route. Rotating the salt is a manual `UPDATE system_config`
+   step and invalidates any stored hash-keyed comparisons — fine for
+   this use case because Phase 5 doesn't persist hashes anywhere; it
+   computes them on each query.
+3. **Where the function lives.** `src/stats/hashing.ts` — pure
+   function `keyedHash(value: string): string`. Reads the salt once
+   at module init via a getter that hits `system_config`; cached for
+   the process lifetime.
+
+**Recommendation:** All three as above. The salt seed migration is
+not strictly required — `system_config` already exists; an
+in-process upsert on first use suffices. Decide in design whether
+to make the seed an explicit migration step (cleaner) or a
+lazy-init (lighter).
+
+## Open question G — Forbidden-substring redaction test
+
+Roadmap acceptance criterion:
+
+> No raw text, filename, memo body, message body, observation text,
+> or username appears in the response payload for either route —
+> covered by a redaction-style test that diffs the response against
+> a forbidden substring list.
+
+Practical shape:
+
+- Test fixture seeds rows with **distinctive** strings that would
+  appear in content fields: memo body contains
+  `FORBIDDEN_MEMO_BODY_XYZ`, `message_metadata.text` contains
+  `FORBIDDEN_MESSAGE_TEXT_XYZ`, `user_instructions.text` contains
+  `FORBIDDEN_INSTRUCTION_TEXT_XYZ`, `attachments.filename` contains
+  `FORBIDDEN_FILENAME_XYZ`, `users.username` contains
+  `FORBIDDEN_USERNAME_XYZ`, `group_user_observations.display_label`
+  and `username` contain `FORBIDDEN_GROUP_OBS_XYZ`,
+  `known_group_contexts.display_name` contains
+  `FORBIDDEN_GROUP_NAME_XYZ`, `web_cache.url`/`title`/`excerpt`
+  contain `FORBIDDEN_WEB_CONTENT_XYZ`, etc.
+- Test calls `getGlobalStats()` and `getSubjectStats(subjectId)`,
+  serializes to JSON, then asserts that **none** of the forbidden
+  substrings appear in the serialized payload.
+- Forbidden list lives next to the test, not in the production
+  module — production has no awareness of "what's redacted", only of
+  "what's exposed". The test is the contract.
+
+**Recommendation:** Land this exactly as above in
+`tests/stats/redaction.test.ts`. Treat any failure as
+release-blocking per the roadmap.
+
+Open subquestion: what about `storage_context_id` and
+`chat_user_id`? The roadmap says the per-subject view exposes them
+(they're already in Phase 3 output) but the global view does not.
+The test for `getGlobalStats()` adds those to its forbidden list;
+the test for `getSubjectStats()` does not.
+
+## Open question H — Caching strategy
+
+Roadmap mitigation:
+
+> caching the global view for 60s in-process; per-subject views are
+> fast enough to compute on click.
+
+Two shapes:
+
+- **H1.** A simple `{ data, cachedAt }` cell in
+  `src/stats/index.ts`; `getGlobalStats()` checks freshness, returns
+  cached or recomputes. Stale-while-revalidate is overkill for v1.
+- **H2.** No cache, measure first, add cache only if latency budget
+  breached.
+
+**Recommendation:** H1 with a default 60s TTL, configurable via an
+optional parameter for tests (`getGlobalStats({ noCache: true })`).
+Cheap insurance; matches the roadmap's mitigation language; testable
+with a fixed-clock dependency.
+
+Per-subject views are uncached.
+
+## Open question I — Index audit
+
+Heaviest tables for the queries:
+
+- `memos` (`idx_memos_user_status_created` exists) — counts grouped
+  by `user_id`, `status` → covered by the existing index.
+- `recurring_tasks` (`idx_recurring_tasks_user`, `..._enabled_next`)
+  — both supported.
+- `message_metadata` (`(context_id, message_id)` PK,
+  `idx_message_metadata_expires_at`, `idx_message_metadata_reply_to`)
+  — per-subject counts use `context_id`, supported by PK prefix.
+  Bot-wide totals scan the table — at 100k rows on dev hardware
+  this is sub-100ms; bench in tests.
+- `attachments` (`idx_attachments_context_active`,
+  `idx_attachments_context_checksum`) — per-subject bytes by
+  `context_id` covered.
+- `staged_files` (`idx_staged_context_sender`) — covered.
+- `llm_usage_events` (Phase 2 indexes) — covered.
+- `tool_call_events` (Phase 4 indexes:
+  `(storage_context_id, occurred_at)`, `(tool_name, occurred_at)`)
+  — covered for both per-subject tool mix and bot-wide tool mix.
+- `web_cache` — no subject index needed (no subject column);
+  scanned wholesale for the host distribution.
+- `web_rate_limit` (`(actor_id, window_start)` PK) — per-subject
+  fetch totals covered by PK prefix.
+
+**Recommendation:** No new indexes in 5a. If the global-view bench
+shows a single query dominating (>100ms on the fixture), add the
+narrowest covering index in the same phase, gated on the bench
+output rather than on speculation.
+
+## Open question J — Window semantics
+
+The per-subject Stats sub-panel sits inside the Billing tab, which
+already exposes a window selector (`24h`/`7d`/`30d`/`all`). The
+roadmap says the per-subject counts are not windowed by default —
+they are point-in-time counts of "how many rows exist for this
+subject right now".
+
+- **J1.** All per-subject counts are point-in-time, ignore the
+  window selector. Two tables become exceptions:
+  `llm_usage_events` and `tool_call_events` are inherently
+  time-bounded and already use the Billing window selector.
+  `message_metadata` has a `timestamp` column and could optionally
+  be windowed — but its "oldest/newest" report is point-in-time by
+  definition.
+- **J2.** All counts respect the window. Add a `since` clause to
+  every query. More consistent UX, more code.
+
+**Recommendation:** J1. The roadmap framing is "structural counts
+and sizes per subject" — point-in-time. The Billing tab's window
+selector continues to govern only the LLM/tool tables. For
+bot-wide aggregates the active-subject counts use 1d/7d/30d
+explicitly per roadmap.
+
+## Open question K — Route shape and auth
+
+Phase 3 added two billing routes guarded by `DEBUG_TOKEN`. Phase 5
+adds two more:
+
+- `GET /stats/global` — returns `GlobalStats`.
+- `GET /stats/subject/:id` — returns `SubjectStats` for the given
+  `storage_context_id`.
+
+Both behind the same `DEBUG_TOKEN` guard as Phase 3 routes. No
+write surface. No window query parameter on `/stats/subject` (per
+open question J); only `/stats/global` accepts an optional window
+for the active-subject and growth slices.
+
+URL parameter `id` is url-decoded and passed through as
+`storage_context_id`. No validation beyond non-empty string —
+unknown ids return an empty stats blob (zero counts), not 404. This
+matches Phase 3's `getBillingDetail` returning `null` for unknown
+subjects.
+
+**Open subquestion:** if `getSubjectStats(unknown)` returns an
+empty blob, can the dashboard distinguish "subject exists but has
+no rows" from "subject doesn't exist"? Phase 3 returns `null` to
+the route (HTTP 404). For symmetry, Phase 5's route returns 404
+when the subject is not in the Phase 3 subject list (per C1) and
+otherwise returns the blob.
+
+## Open question L — Tool mix data source
+
+Phase 4 shipped `tool_call_events` with `storage_context_id`,
+`tool_name`, `success`, `error_type`. Phase 5 can:
+
+- **L1.** Use `tool_call_events` directly for both per-subject and
+  bot-wide tool-mix breakdowns: top N tools by call count, success
+  rate, error_type distribution.
+- **L2.** Use the older `recentToolFailures` ring buffer in
+  `src/debug/turn-assembly.ts` (1024-deep, ephemeral). Mostly
+  superseded by L1.
+- **L3.** Roll up from `llm_usage_events.tool_call_count` only —
+  loses the per-tool name breakdown.
+
+**Recommendation:** L1. Phase 4's table is durable and indexed for
+exactly these queries. The roadmap's tool-mix bullet says "refined
+if phase 4 ships the per-tool table" — it has.
+
+## Open question M — Dashboard integration
+
+The roadmap is explicit:
+
+- Subject detail in the Billing tab gains a "Stats" sub-panel.
+- New top-level "Stats" tab shows the bot-wide view.
+
+Client work mirrors Phase 3's structure:
+
+```
+client/debug/stats/
+  StatsTab.svelte         — top-level global view
+  SubjectStatsPanel.svelte — sub-panel for the Billing subject detail
+  fetchers.ts             — typed fetch helpers
+```
+
+`client/debug/dashboard-types.ts` gains `globalStats`, `subjectStats`
+slots in `DashboardState`. `dashboard.svelte.ts` adds a "Stats" tab
+between Billing and the existing tabs (order TBD in design).
+
+**Open subquestion:** does the Stats sub-panel inside Billing share
+state with the Stats tab? Recommendation: no — different fetchers,
+different cache lifetimes. The sub-panel is per-subject; the tab is
+global. Keeping them separate avoids a refresh-storm when switching
+subjects.
+
+## Open question N — Test strategy
+
+Three suites:
+
+- `tests/stats/per-table.test.ts` — each per-table query in
+  isolation against `setupTestDb()` fixtures. Seeds known counts,
+  asserts the helper returns matching counts.
+- `tests/stats/redaction.test.ts` — the forbidden-substring test
+  from open question G. Seeds rows with distinctive content,
+  serializes the API response, asserts no forbidden substring
+  appears.
+- `tests/stats/aggregate.test.ts` — pure-function tests for
+  `percentiles()` and bucket helpers.
+
+Plus route-level integration in
+`tests/debug/server-stats.test.ts` mirroring
+`tests/debug/server-billing.test.ts` (Phase 3): boots a fake
+`DEBUG_TOKEN`-gated server, asserts 401 without token, asserts
+200 + payload shape with token.
+
+Client-side: `tests/client/stats/*` mirroring
+`tests/client/billing/*`.
+
+DI vs `setupTestDb()`: match Phase 2/3/4 — use `setupTestDb()` and
+the migration-chain runner. No DI for the stats module; the
+queries take a Drizzle handle from `getDrizzleDb()`.
+
+## Open question O — Performance bench
+
+Roadmap acceptance:
+
+> Global view renders with 1k seeded subjects + 100k seeded
+> `message_metadata` rows in under 500ms (in-process, on a dev
+> laptop).
+
+Bench shape:
+
+- `tests/stats/perf.test.ts` (or part of the per-table suite) seeds
+  the volumes above, calls `getGlobalStats()`, asserts elapsed
+  wall-clock time < 500ms with a 2× safety margin (so test failure
+  budget is 1000ms in CI). The 500ms target lives in the
+  documentation; the test asserts the looser CI bound.
+
+CI runners are slower than a dev laptop; setting the assertion at
+1000ms reduces flake. Local hand-bench during development confirms
+the 500ms target.
+
+**Recommendation:** Land the bench, asserting <1000ms in CI; comment
+references the 500ms dev-laptop target. If CI flakes, raise to 1500ms
+and open an issue for "global view perf budget" rather than
+suppressing.
+
+## Open question P — Subject-id source for global aggregates
+
+Bot-wide aggregates need a list of "all subjects" to compute
+distributions like "p50 memo count across subjects". Sources:
+
+- `users.platform_user_id` (DM subjects)
+- `authorized_groups.group_id` (group subjects)
+- Union of distinct `storage_context_id` from `llm_usage_events`
+  (subjects that have made calls) — already in Phase 3.
+
+Which to use?
+
+- **P1.** Union of `users` ∪ `authorized_groups`. Counts include
+  subjects who never used the bot. Distribution skews low (lots of
+  zeros).
+- **P2.** Use only subjects with at least one `llm_usage_events`
+  row. Distribution reflects "active subjects" only.
+- **P3.** Both, exposed as separate aggregates.
+
+**Recommendation:** P1. The roadmap's framing ("how heavy is the
+median user") wants the full denominator — subjects who registered
+but never used the bot are a real signal. The Phase 3 list (active
+subjects) is already available in the Billing tab; Phase 5's global
+view is the only place where the broader population is visible.
+
+Active-subject counts (1d/7d/30d) are a separate per-roadmap
+metric, derived from `llm_usage_events.occurred_at` and
+`message_metadata.timestamp`.
+
+## Open question Q — Storage footprint reporting
+
+Roadmap:
+
+> SQLite `page_count * page_size`, plus S3 bucket total bytes from
+> the manifest tally.
+
+SQLite size:
+
+- `PRAGMA page_count;` and `PRAGMA page_size;` give the on-disk
+  size. Drizzle's raw SQL execution can fetch both. Or `fs.stat()`
+  on the DB path — simpler. Use `fs.stat()` because the DB path is
+  already known to the bot.
+
+S3 size:
+
+- Sum `attachments.size` for `is_active=1` rows. Matches the
+  manifest tally because the manifest IS the `attachments` table.
+- Alternative: enumerate S3 keys with the prefix. Cost: an S3 LIST
+  call per dashboard open. Rejected — same rate-limit-surface
+  concern as external task counts.
+
+**Recommendation:** SQLite size via `fs.stat()`; S3 size via
+`SUM(size) WHERE is_active=1`. Both reported as bytes; the
+dashboard formats.
+
+## Open question R — Identity-provider mix
+
+> Identity-provider mix: how many subjects have mapped to Kaneo vs
+> YouTrack identity.
+
+Source: `user_identity_mappings` grouped by `provider_name`.
+`COUNT(DISTINCT context_id) GROUP BY provider_name`. No per-subject
+content — provider name is an enum value (`kaneo`, `youtrack`).
+
+Sub-question: is `users.kaneo_workspace_id IS NOT NULL` a
+separate signal worth reporting? It indicates "the user was
+provisioned a Kaneo workspace", distinct from "has a Kaneo identity
+mapping". Recommendation: yes — report both as
+`identityMix.kaneoMappings`, `identityMix.kaneoWorkspaces`.
+
+## Open question S — Conversation-history specifics
+
+Per the resolved pre-start question 5: turn count + summary count,
+no byte sizes. Implementation:
+
+- Per-subject turn count: `conversation_history.messages` is a JSON
+  array; parse and report length. SQLite has `json_array_length()`
+  — single SQL call per subject. Bot-wide p50/p90/p99: load array
+  lengths for all subjects (or sample), percentile in JS.
+- Per-subject summary present: 1 if
+  `memory_summary.user_id = subject_id` row exists, else 0. Bot-wide:
+  `COUNT(*) FROM memory_summary`.
+
+`json_array_length()` is in SQLite ≥ 3.38 (released 2022); Bun's
+bundled SQLite is well past that. Confirmed in design.
+
+**Recommendation:** Use `json_array_length()` for turn count. No
+JSON parsing in JS.
+
+## Things explicitly NOT to do in Phase 5
+
+- No content storage in any query result. Bytes-only contract from
+  Phase 4 carries forward.
+- No live provider calls (Kaneo `count_tasks`, YouTrack
+  equivalents). External task counts are deferred.
+- No `usage_snapshots` table. 5a is live queries against existing
+  tables.
+- No CSV/JSON export endpoints. Dashboard rendering is the output.
+- No mutation. Phase 5 is read-only.
+- No new indexes unless a bench fails (see open question I).
+- No removal of `recentToolFailures` ring buffer; Phase 4's table
+  is the stats source but the ring buffer continues to serve the
+  live debug view.
+- No deployment-size threshold for the global view; anonymity is
+  enforced by the schema of the response, not by deployment size.
+- No content of any kind in hashed form — keyed-hashing applies only
+  to rrule strings and hostnames, both non-PII enough that hashing
+  is a dedup tool rather than an obfuscation tool.
+
+## Risks identified by the brainstorm
+
+1. **Forbidden-substring test brittleness.** If a future
+   contributor adds a query helper that pulls a content column for a
+   legitimate reason ("just for debugging"), the test catches it
+   only if the seeded fixture exercises that code path. Mitigation:
+   the per-table test fixture seeds content into every domain table
+   the stats module reads, and the redaction test runs both API
+   methods on a deeply-populated fixture.
+
+2. **Global view latency on real-world DBs.** Bench fixture is 1k
+   subjects + 100k messages. Production may be smaller (fine) or
+   larger (Phase 5b becomes relevant). Mitigation: 60s cache for
+   the global view; in-process; per-subject views uncached because
+   they're cheap.
+
+3. **Salt rotation invalidates external comparisons.** If anyone
+   ever screenshots a hashed hostname distribution and compares
+   across deployments, hashes will not match. Documented as
+   intentional in CLAUDE.md anonymity section.
+
+4. **JSON-array parsing on `conversation_history.messages` at
+   scale.** Even with `json_array_length()`, scanning all rows for
+   the global view is O(N rows). Should be fine at 1k subjects;
+   benchmarked in open question O's perf test.
+
+5. **Phase 3 display-name resolver coupling.** Phase 5 reuses
+   `src/debug/billing.ts:decorate` for the per-subject view to
+   surface display names. If that helper changes shape, Phase 5
+   breaks. Mitigation: extract the resolver into
+   `src/debug/subject-display-name.ts` (small refactor, optional
+   in 5a — the design call decides whether to refactor or import as-is).
+
+6. **TDD hook policy.** Same pattern as Phase 2/3/4: every src/
+   edit needs a failing test first. Sequencing: pure-function
+   tests (`aggregate`, `hashing`) → modules → per-table query
+   tests → query modules → redaction test → API module → route
+   tests → routes → client tests → client.
+
+7. **`web_cache` global scan.** No subject column; we accept a
+   table scan for the host-distribution computation. At 10k cached
+   URLs the scan is negligible; document the assumption.
+
+8. **`alert_prompts` parity.** Adding `alert_prompts` to the
+   surface set was opportunistic — easy to forget in the design.
+   Carry forward to the design's per-table list.
+
+## Forward-compatibility check
+
+- **Phase 5b (`usage_snapshots`).** Drop-in: the snapshot writer
+  imports `src/stats/index.ts` and persists daily values. No 5a
+  API change required.
+- **Future external-task counts.** Adding a per-subject
+  `taskCounts: { kaneo?: number; youtrack?: number }` field to
+  `SubjectStats` is additive. The 5a contract documents the
+  field as optional and never present.
+- **Future metering vendor export.** Phase 5 doesn't write data;
+  no outbox columns or forwarder concerns.
+- **Future per-tool drilldown.** Already powered by Phase 4's
+  `tool_call_events` table; further breakdowns (e.g. by error
+  code) are additive to the stats module.
+
+## Summary of decisions to lift into the per-phase design
+
+1. **Module location.** `src/stats/` with `index.ts`, `per-table.ts`,
+   `aggregate.ts`, `hashing.ts`, `types.ts`. Routes in
+   `src/debug/stats-routes.ts`.
+2. **Source tables (corrected).** `memos`, `scheduled_prompts`,
+   `alert_prompts`, `recurring_tasks`, `user_instructions`
+   (column `text`), `attachments`, `message_metadata`,
+   `conversation_history` + `memory_summary` (turn count + summary
+   count only), `user_identity_mappings`, `staged_files`, `users`,
+   `group_members`, `group_user_observations`,
+   `known_group_contexts`, `web_cache` (no subject column),
+   `web_rate_limit` (per-subject fetch counts), `llm_usage_events`,
+   `tool_call_events`. No `instructions` (`user_instructions`); no
+   `web_fetch_cache` (`web_cache`).
+3. **Subject scope.** Per-subject view served only for subjects
+   already in Phase 3's `listSubjects()`. Global view's denominator
+   is `users` ∪ `authorized_groups`.
+4. **Subject-type discrimination.** From the latest
+   `llm_usage_events.context_type` for the subject.
+5. **Hashing.** `sha256(salt + value).slice(0, 16)` for rrule
+   strings and hostnames. Salt in `system_config.stats_anonymity_salt`,
+   seeded on first use.
+6. **Caching.** 60s in-process for the global view; uncached for
+   per-subject.
+7. **Routes.** `GET /stats/global`, `GET /stats/subject/:id`. Both
+   behind `DEBUG_TOKEN`. 404 on unknown subject (matches Phase 3).
+8. **Tool mix.** Sourced from `tool_call_events` (Phase 4).
+9. **Storage footprint.** SQLite via `fs.stat()`; S3 via
+   `SUM(attachments.size) WHERE is_active=1`. No live S3 LIST.
+10. **Web-fetch attribution.** Per-subject total fetches from
+    `web_rate_limit`; bot-wide host distribution (keyed-hashed)
+    from `web_cache`. Subject ↔ host join not provided.
+11. **Conversation history.** Turn count via
+    `json_array_length(messages)`; summary count via row presence
+    in `memory_summary`. No byte sizes.
+12. **Distributions.** Percentile math in JS via
+    `src/stats/aggregate.ts`. No SQL window functions.
+13. **No new indexes.** Bench gates any new index work.
+14. **Redaction test.** Forbidden-substring contract test against
+    a deeply-seeded fixture; both routes covered.
+15. **Bench test.** 1k subjects + 100k messages, CI assertion
+    <1000ms (dev-laptop target 500ms).
+16. **Dashboard.** New top-level "Stats" tab + new sub-panel in the
+    Billing subject detail. Separate fetchers, separate state.
+
+## Out of brainstorm (carry to plan, not design)
+
+- Exact test file locations and T-then-I ordering inside the
+  implementation steps.
+- Commit grouping (likely: types → hashing+aggregate → per-table
+  queries → orchestrator → routes → docs → dashboard client).
+- Manual smoke checklist (seed a small fixture in a dev DB, open
+  the Stats tab, eyeball percentiles + redaction).
+- Whether to add a `bun knip` ignore for the new exports if any
+  consumer wiring lands deferred (same approach as Phase 2's
+  `c0e8960` and Phase 3's `df35a5a`).
+- CLAUDE.md "Anonymity contract" subsection wording (or whether to
+  land it as `docs/stats.md`).
+- Tab ordering in the dashboard (Stats before or after Billing).

--- a/docs/superpowers/plans/2026-05-20-phase-5-anonymous-stats-plan.md
+++ b/docs/superpowers/plans/2026-05-20-phase-5-anonymous-stats-plan.md
@@ -1,0 +1,573 @@
+# Phase 5 — Anonymous DB-Wide Statistics — Implementation Plan
+
+**Date:** 2026-05-20
+**Status:** Draft
+**Branch:** `claude/central-llm-phase-5-anonymous-stats`
+**Per-phase design:** [`../specs/2026-05-20-phase-5-anonymous-stats-design.md`](../specs/2026-05-20-phase-5-anonymous-stats-design.md)
+**Brainstorm:** [`../notes/2026-05-20-phase-5-anonymous-stats-brainstorm.md`](../notes/2026-05-20-phase-5-anonymous-stats-brainstorm.md)
+**Parent roadmap:** [`2026-05-19-central-llm-billing-roadmap.md`](2026-05-19-central-llm-billing-roadmap.md)
+
+## Sequencing principle
+
+The TDD hook gates every `src/` and `client/` edit on a failing test.
+Each step splits into:
+
+- **T**: write the failing test(s).
+- **I**: write the implementation that turns the test(s) green.
+- **R**: refactor only when there's something to refactor.
+
+Steps are ordered so each leaves the tree green between steps. Within
+a step the tree may be red, but never between steps.
+
+Phase 5a is read-only — no migrations and no schema changes. Pure
+helpers ship first, then per-table queries, then the orchestrator,
+then routes, then the dashboard, then docs.
+
+## Step 0 — Pre-flight
+
+- Create + switch to branch `claude/central-llm-phase-5-anonymous-stats`.
+- Confirm `bun test`, `bun typecheck`, `bun lint`, `bun format:check`,
+  `bun knip` all clean on baseline.
+- Confirm Phase 2/3/4 modules exist:
+  - `src/usage/{recorder,index,query,types,event-id,tool-call-recorder}.ts`
+  - `src/db/{llm-usage-events-schema,tool-call-events-schema,system-config-schema}.ts`
+  - `src/debug/{billing,billing-routes,server,admin-llm}.ts`
+- Confirm no `src/stats/` directory exists (greenfield).
+- No new migration number consumed in 5a. Next migration `039_*` is
+  reserved for 5b.
+
+## Step 1 — `src/stats/types.ts`
+
+Pure type-only file. TDD hook still requires a failing test for any
+implementation file but `.d.ts`-equivalent type files are typically
+covered by the consumers' tests. To keep the hook happy and the type
+contract explicit:
+
+**T**: create `tests/stats/types.test.ts` with a single test that
+imports each exported interface from `src/stats/types.ts` and
+constructs a minimal instance. This fails compilation until the
+types exist.
+
+**I**: create `src/stats/types.ts` with the full interface set from
+the design's D2:
+
+- `Percentiles`
+- `SubjectStats`
+- `GlobalStats`
+- `GlobalStatsOptions`
+- helper sub-types (`MemoStats`, `RecurringStats`, etc.) as needed
+
+No runtime code, no imports beyond types. Re-exported from a future
+`src/stats/index.ts`.
+
+## Step 2 — `src/stats/aggregate.ts`
+
+**T**: `tests/stats/aggregate.test.ts`:
+
+- `percentiles([])` returns all zeros, `count: 0`.
+- `percentiles([5])` returns `count: 1`, all percentiles = 5.
+- `percentiles([1,2,3,4,5,6,7,8,9,10])` returns p50 ≈ 5, p90 ≈ 9,
+  p99 ≈ 10, mean = 5.5.
+- `percentiles([10,9,8,...,1])` returns the same shape regardless of
+  input order (function sorts internally).
+- `percentiles([1,1,1,1])` returns all-ones with `count: 4`.
+
+**I**: `src/stats/aggregate.ts` implementing `percentiles(values:
+readonly number[]): Percentiles` from the design's D6. Pure function;
+no DB or filesystem dependency.
+
+## Step 3 — `src/stats/hashing.ts`
+
+**T**: `tests/stats/hashing.test.ts`:
+
+- Seed `system_config.stats_anonymity_salt` row.
+- `keyedHash('foo')` returns 16 hex characters.
+- Same input twice returns the same output (determinism).
+- Different inputs return different outputs.
+- `resetSaltCacheForTests()` + change salt row + next call returns
+  a different hash (salt-rotation invalidation).
+- First call when no salt row exists creates one and returns a hash;
+  the new row is visible in `system_config`.
+- Salt value never appears in the hash output (assert the raw salt
+  substring is not a prefix or suffix of the hash).
+
+**I**: `src/stats/hashing.ts` per the design's D5. Use
+`node:crypto.createHash('sha256')`, `node:crypto.randomBytes` for
+seed, `getDrizzleDb()` for `system_config` access.
+
+## Step 4 — Phase 3 display-name resolver extraction
+
+Refactor that decouples Phase 5 from `src/debug/billing.ts:decorate`.
+
+**T**: `tests/debug/subject-display-name.test.ts`:
+
+- Seed a `users` row with a username; assert
+  `resolveDisplayName(id, 'dm')` returns the username.
+- Seed a `users` row with `username: null`; assert returns `null`.
+- For `contextType: 'group'`, assert returns `null` (5a parity with
+  Phase 3).
+- For unknown `id`, returns `null`.
+- Seed an `llm_usage_events` row with `context_type='dm'`; assert
+  `resolveContextTypeFromUsage(id)` returns `'dm'`.
+- For id with no row, returns `null`.
+
+**I**: create `src/debug/subject-display-name.ts` exporting both
+functions. Update `src/debug/billing.ts:decorate` to call them. No
+behavior change to the Billing routes; their existing tests still pass.
+
+## Step 5 — `src/stats/per-table.ts` — per-subject helpers
+
+One commit per logical group of helpers to keep diffs reviewable;
+each commit lands its T and I together.
+
+### 5a. memos
+
+**T**: `tests/stats/per-table-memos.test.ts`. Seed two subjects' memos
+with known counts/status/tags/content length/embedding presence; call
+`memosForSubject(id)`; assert all fields of the per-subject memo
+block.
+
+**I**: `memosForSubject(storageContextId)` in `src/stats/per-table.ts`.
+
+### 5b. scheduled_prompts + alert_prompts
+
+**T**: `tests/stats/per-table-prompts.test.ts`. Seed scheduled and
+alert prompts; call `scheduledForSubject`, `alertsForSubject`; assert
+counts and `byStatus`.
+
+**I**: both helpers in `src/stats/per-table.ts`.
+
+### 5c. recurring_tasks
+
+**T**: `tests/stats/per-table-recurring.test.ts`. Seed recurring tasks
+with mixed `enabled`, `project_id`, `rrule`, `next_run`; assert
+`recurringForSubject` returns correct totals, distinct projects,
+`nextRunWithin7d` count, and the keyed-hash distinct rrule count.
+
+**I**: `recurringForSubject` in `src/stats/per-table.ts`; reuses
+`keyedHash` for rrule deduplication.
+
+### 5d. user_instructions
+
+**T**: `tests/stats/per-table-instructions.test.ts`. Seed instructions
+with known text lengths; assert `instructionsForSubject` returns
+`total` and `textBytesTotal`.
+
+**I**: `instructionsForSubject` in `src/stats/per-table.ts`.
+
+### 5e. attachments
+
+**T**: `tests/stats/per-table-attachments.test.ts`. Seed attachments
+with mixed status, source_provider, size, is_active, filename
+extension; assert `attachmentsForSubject` returns all fields.
+
+**I**: `attachmentsForSubject` in `src/stats/per-table.ts`. Extension
+bucket extracted from `filename` in JS after the SQL fetch — keep the
+filename in scope only within the function and never on the response.
+
+### 5f. message_metadata
+
+**T**: `tests/stats/per-table-messages.test.ts`. Seed messages with
+known timestamps, author_id values, text lengths; assert counts +
+text bytes + authored-by-subject count + oldest/newest timestamps.
+
+**I**: `messageMetadataForSubject` in `src/stats/per-table.ts`.
+
+### 5g. conversation history + memory_summary
+
+**T**: `tests/stats/per-table-conversation.test.ts`. Seed
+`conversation_history.messages` JSON array (short and long); assert
+`conversationForSubject` returns turn count via
+`json_array_length()`. Seed `memory_summary` row; assert
+`summaryPresentForSubject(id)` returns true; absent ⇒ false.
+
+**I**: `conversationForSubject` + `summaryPresentForSubject` in
+`src/stats/per-table.ts`.
+
+### 5h. user_identity_mappings
+
+**T**: `tests/stats/per-table-identity.test.ts`. Seed mappings for
+several providers; assert `identityForSubject` returns
+`Record<providerName, count>`.
+
+**I**: `identityForSubject` in `src/stats/per-table.ts`.
+
+### 5i. staged_files
+
+**T**: `tests/stats/per-table-staged.test.ts`. Seed staged files;
+assert `stagedForSubject` returns total + byStatus + bytesTotal.
+
+**I**: `stagedForSubject` in `src/stats/per-table.ts`.
+
+### 5j. users / group_members / group_user_observations
+
+**T**: `tests/stats/per-table-user-group.test.ts`. Seed a user, a
+group with members and observations; assert `userBlockForSubject`
+returns the user fields; assert `groupBlockForSubject` returns the
+group fields.
+
+**I**: both helpers in `src/stats/per-table.ts`.
+
+### 5k. web_rate_limit
+
+**T**: `tests/stats/per-table-web.test.ts`. Seed `web_rate_limit`
+rows for two actors; assert `webFetchesForSubject(actor1)` returns
+the summed count.
+
+**I**: `webFetchesForSubject` in `src/stats/per-table.ts`.
+
+### 5l. llm_usage_events + tool_call_events
+
+**T**: `tests/stats/per-table-usage-tools.test.ts`. Seed usage events
+and tool-call events for a subject; assert `llmUsageForSubject`
+returns row count + token totals; assert `toolCallsForSubject`
+returns total/success/failure/topTools/errorTypeCounts.
+
+**I**: both helpers in `src/stats/per-table.ts`.
+
+## Step 6 — `src/stats/per-table.ts` — global helpers
+
+### 6a. subjects + active
+
+**T**: `tests/stats/per-table-global-subjects.test.ts`. Seed users,
+authorized_groups with various `added_at` timestamps; seed
+`llm_usage_events` and `message_metadata` rows for activity windows;
+assert `subjectsGlobal()` returns counts + 30d growth array, and
+`activeSubjectCounts()` returns 1d/7d/30d active counts.
+
+**I**: `subjectsGlobal`, `activeSubjectCounts` in
+`src/stats/per-table.ts`.
+
+### 6b. distributions
+
+**T**: `tests/stats/per-table-global-distributions.test.ts`. Seed 5
+subjects with known memo / recurring / message_metadata / attachment
+byte counts each. Assert `distributionsGlobal()` returns the four
+`Percentiles` objects matching independently-computed values.
+
+**I**: `distributionsGlobal` in `src/stats/per-table.ts` — runs one
+LEFT JOIN per source table, computes percentiles via `aggregate.ts`.
+
+### 6c. storage
+
+**T**: `tests/stats/per-table-global-storage.test.ts`. Seed
+attachments with known `size` and `is_active` mix; assert
+`storageGlobal()` returns `s3AttachmentBytes` summed correctly. For
+`sqliteBytes`, the test stubs the file size to a known value (via a
+dependency-injection seam or by writing a tiny file at the DB path
+and checking — design call inside the step).
+
+**I**: `storageGlobal` in `src/stats/per-table.ts` reads
+`fs.statSync` and sums `attachments.size`.
+
+### 6d. identity mix + surface mix
+
+**T**: `tests/stats/per-table-global-identity-surface.test.ts`. Seed
+identity mappings + users with kaneo_workspace_id; seed subjects with
+mix of memos / recurring / scheduled / instructions; assert
+`identityMixGlobal()` and `surfaceMixGlobal()` return matching counts.
+
+**I**: both helpers in `src/stats/per-table.ts`.
+
+### 6e. web fetches global
+
+**T**: `tests/stats/per-table-global-web.test.ts`. Seed
+`web_cache.url` rows across known hosts; assert
+`webFetchesGlobal()` returns top 20 by keyed-hashed host with
+correct counts. Asserts plain hostnames are NOT in the result
+(redaction smoke).
+
+**I**: `webFetchesGlobal` in `src/stats/per-table.ts`. Extracts host
+via `new URL(url).host`, applies `keyedHash`, groups, sorts, takes
+top 20.
+
+### 6f. tool mix global
+
+**T**: `tests/stats/per-table-global-tool-mix.test.ts`. Seed
+`tool_call_events` rows across tools/subjects/success states; assert
+`toolMixGlobal()` returns top 20 by count + success rate + error
+type counts.
+
+**I**: `toolMixGlobal` in `src/stats/per-table.ts`.
+
+## Step 7 — `src/stats/index.ts` orchestrator
+
+**T**: `tests/stats/index.test.ts`:
+
+- `getSubjectStats(unknownId)` returns `null`.
+- `getSubjectStats(seededDmId)` returns a fully populated
+  `SubjectStats` whose fields equal the corresponding per-table
+  helper outputs (independent calls).
+- `getSubjectStats(seededGroupId)` returns shape with `groupBlock`
+  present, `userBlock` null.
+- `getGlobalStats()` returns shape with all top-level keys present.
+- `getGlobalStats({ noCache: true })` recomputes every call;
+  `getGlobalStats()` (default) returns the same cached object on
+  back-to-back calls within 60s.
+- Cache invalidated when the window parameter changes.
+
+**I**: `src/stats/index.ts` implementing both functions per the
+design's D1, D7 (subject discrimination via
+`resolveContextTypeFromUsage`), D8 (cache).
+
+## Step 8 — `src/debug/stats-routes.ts`
+
+**T**: `tests/debug/server-stats.test.ts`:
+
+- Boot a test server with a known `DEBUG_TOKEN`.
+- `GET /stats/global` without token → 401.
+- `GET /stats/global` with token → 200 + JSON body matching
+  `GlobalStats` shape.
+- `GET /stats/subject/<unknown>` → 404.
+- `GET /stats/subject/<seeded>` → 200 + `SubjectStats` shape.
+- `GET /stats/global?window=7d` → 200 + body with `window: '7d'`.
+- Invalid window → 400 with error message (or falls back to 30d
+  — choose during implementation, document in code).
+
+**I**: `src/debug/stats-routes.ts` exporting a route registrar that
+takes the existing Hono / Bun-server app instance and calls.
+
+Mount it in `src/debug/server.ts` next to the billing route registrar.
+
+## Step 9 — Redaction-style anonymity test
+
+**T+I together (the test IS the implementation contract):**
+
+`tests/stats/redaction.test.ts`. Seeds rows containing distinctive
+forbidden substrings into every text column listed below, then calls
+both routes and asserts no forbidden substring appears in the
+serialized JSON of either response:
+
+| Source                               | Column                                  | Forbidden marker                  |
+| ------------------------------------ | --------------------------------------- | --------------------------------- |
+| `memos`                              | `content`                               | `FORBIDDEN_MEMO_BODY_XYZ`         |
+| `memos`                              | `summary`                               | `FORBIDDEN_MEMO_SUMMARY_XYZ`      |
+| `memos`                              | `tags` (JSON)                           | `FORBIDDEN_MEMO_TAG_XYZ`          |
+| `message_metadata`                   | `text`                                  | `FORBIDDEN_MESSAGE_TEXT_XYZ`      |
+| `message_metadata`                   | `author_username`                       | `FORBIDDEN_AUTHOR_USERNAME_XYZ`   |
+| `user_instructions`                  | `text`                                  | `FORBIDDEN_INSTRUCTION_TEXT_XYZ`  |
+| `attachments`                        | `filename`                              | `FORBIDDEN_FILENAME_XYZ`          |
+| `attachments`                        | `mime_type`                             | `FORBIDDEN_MIME_XYZ`              |
+| `users`                              | `username`                              | `FORBIDDEN_USERNAME_XYZ`          |
+| `group_user_observations`            | `username` + `display_label`            | `FORBIDDEN_GROUP_OBS_XYZ`         |
+| `known_group_contexts`               | `display_name` + `parent_name`          | `FORBIDDEN_GROUP_NAME_XYZ`        |
+| `web_cache`                          | `url` + `title` + `summary` + `excerpt` | `FORBIDDEN_WEB_CONTENT_XYZ`       |
+| `scheduled_prompts`                  | `prompt`                                | `FORBIDDEN_SCHEDULED_PROMPT_XYZ`  |
+| `alert_prompts`                      | `prompt` + `condition`                  | `FORBIDDEN_ALERT_PROMPT_XYZ`      |
+| `recurring_tasks`                    | `title` + `description`                 | `FORBIDDEN_RECURRING_XYZ`         |
+| `conversation_history`               | `messages` JSON content                 | `FORBIDDEN_CONVERSATION_TEXT_XYZ` |
+| `memory_summary`                     | `summary`                               | `FORBIDDEN_SUMMARY_TEXT_XYZ`      |
+| `staged_files`                       | `filename`                              | `FORBIDDEN_STAGED_FILENAME_XYZ`   |
+| `system_config.stats_anonymity_salt` | `value`                                 | `FORBIDDEN_SALT_XYZ`              |
+
+The forbidden list lives next to the test. Each forbidden substring
+also gets a corresponding "should appear" anti-test: seed a row with
+the marker, fetch the route, assert the JSON does NOT contain it.
+Per-route assertions:
+
+- `getGlobalStats()` payload: assert none of the markers AND none of
+  the seeded `storageContextId`/`chatUserId` values appear.
+- `getSubjectStats(seededSubject)` payload: assert none of the
+  markers appear (the seeded subject's own id IS expected and is
+  exempted from the per-subject test's forbidden list).
+
+Treat any failure as release-blocking per the roadmap.
+
+## Step 10 — Perf bench
+
+**T**: `tests/stats/perf.test.ts` (or section in the existing
+`tests/stats/index.test.ts`):
+
+- Seeds 1000 subjects (mix of `users` + `authorized_groups`).
+- Seeds 100,000 `message_metadata` rows distributed across subjects.
+- Seeds 10,000 `memos` rows.
+- Seeds 5000 `tool_call_events` rows.
+- Calls `getGlobalStats({ noCache: true })`.
+- Asserts elapsed wall-clock time < 1000ms.
+- Comment in the test references the 500ms dev-laptop target.
+
+**I**: if the bench fails on first run, add the narrowest covering
+index needed in a new migration `039_stats_indexes.ts`. If the bench
+passes without changes, no index migration.
+
+## Step 11 — Client types and fetchers
+
+**T**: `tests/client/stats/fetchers.test.ts`:
+
+- `getStatsGlobal()` calls `/stats/global` with token; returns
+  parsed `GlobalStats`.
+- `getStatsSubject(id)` calls `/stats/subject/:id`; returns parsed
+  `SubjectStats`.
+- Both surface errors with structured messages on non-2xx.
+
+**I**: `client/debug/stats/fetchers.ts` modeled on
+`client/debug/billing/fetchers.ts`. Update
+`client/debug/dashboard-types.ts` to add `globalStats`,
+`subjectStats`, `statsWindow`.
+
+## Step 12 — Client components
+
+### 12a. `SubjectStatsPanel.svelte`
+
+**T**: `tests/client/stats/SubjectStatsPanel.test.ts`:
+
+- Mounts the component with a mock subject id; loading state shows
+  a placeholder.
+- Resolves to data; verifies the rendered DOM contains memo total,
+  recurring total, attachment bytes formatted, conversation turn
+  count, etc.
+- Loading-error path renders an error message.
+
+**I**: `client/debug/stats/SubjectStatsPanel.svelte` — a single
+collapsible panel mounted on demand inside the Billing subject
+detail. Uses `fetchers.getStatsSubject`. Numbers formatted via the
+existing client byte/number helpers (or new ones if needed —
+co-located with `client/debug/billing/`).
+
+### 12b. `StatsTab.svelte`
+
+**T**: `tests/client/stats/StatsTab.test.ts`:
+
+- Mount the tab, verify it renders subject counts, growth chart
+  data, percentile distributions, identity mix, surface mix, web
+  host breakdown, tool mix.
+- Window selector changes refetch the global view.
+
+**I**: `client/debug/stats/StatsTab.svelte`. Reuses dashboard layout
+helpers; growth chart can be a simple inline bar chart (Svelte
+template) — no chart-lib dependency.
+
+### 12c. Tab wiring
+
+**T**: extend `tests/client/dashboard/dashboard.test.ts` (or the
+component-level test) to assert a "Stats" tab is present and
+clickable next to "Billing".
+
+**I**: `client/debug/dashboard.svelte.ts` adds the Stats tab between
+Billing and the next existing tab; `client/debug/dashboard-types.ts`
+already extended in step 11.
+
+Bundle the Billing-subject-detail extension: import
+`SubjectStatsPanel` and render it inside the existing detail expander.
+
+## Step 13 — Knip + lint hygiene
+
+- Run `bun knip`. If any new exports show as unused (likely none
+  given the client wires them), add an in-file ignore comment
+  following the Phase 2 / Phase 3 pattern in
+  `client/debug/billing/fetchers.ts`.
+- Run `bun lint:agent-strict -- src/stats client/debug/stats`
+  before declaring done.
+
+## Step 14 — Documentation updates
+
+**Files touched:**
+
+- `CLAUDE.md`:
+  - Add `src/stats/` to the Main Modules list under "Architecture".
+  - Add a short "Anonymity contract" subsection under the debug-server
+    section: what `/stats/*` exposes (counts, sizes, timestamps,
+    enum distributions, keyed-hashed hostnames) and what it never
+    exposes (content, filenames, usernames, message text, memo
+    bodies, observation text, raw URLs, etc.).
+  - Note the new `stats_anonymity_salt` row in `system_config`.
+
+- No other doc changes; the bot's chat surface is unchanged.
+
+## Step 15 — Final verification
+
+```bash
+bun typecheck
+bun lint
+bun format:check
+bun knip
+bun test
+bun test:client
+bun security
+bun check:full
+```
+
+All must pass.
+
+Manual smoke checklist (run by the implementer before requesting
+review):
+
+1. Seed a dev DB with 2–3 DM subjects + 1 group, a handful of memos,
+   recurring tasks, attachments, and a few LLM turns.
+2. Start `bun start:debug`.
+3. Open the dashboard. Click "Stats". Verify subject counts, growth
+   chart, distributions, identity mix render.
+4. Open the Billing tab → click a subject → expand the "Stats"
+   sub-panel. Verify per-subject numbers.
+5. Visually scan both views: no usernames, no memo bodies, no
+   message text, no filenames present.
+6. `curl -H "Authorization: Bearer $DEBUG_TOKEN" http://localhost:$DEBUG_PORT/stats/global | jq .`
+   — sanity-check the JSON.
+
+## Acceptance checklist (from the design)
+
+- [ ] `src/stats/` module ships with layout from D1.
+- [ ] `/stats/global` + `/stats/subject/:id` wired behind
+      `DEBUG_TOKEN`.
+- [ ] `tests/stats/redaction.test.ts` passes on a deeply-seeded
+      fixture.
+- [ ] Per-subject counts match hand-rolled SQL aggregates row-for-row.
+- [ ] Global distributions match independently-computed percentiles.
+- [ ] `tests/stats/perf.test.ts` <1000ms on 1k + 100k fixture.
+- [ ] Stats tab + sub-panel render without console errors.
+- [ ] `bun typecheck / lint / format / test / knip / security` all
+      clean.
+- [ ] Manual smoke walks both views and confirms no PII leaks.
+
+## Commit plan
+
+Suggested commit sequence (each must leave the tree green):
+
+1. `feat(stats): types + aggregate helpers (Phase 5)` — D1 types,
+   `aggregate.ts`, tests.
+2. `feat(stats): keyed-hash with system_config salt (Phase 5)` —
+   `hashing.ts`, tests.
+3. `refactor(billing): extract display-name resolver` — Phase 3
+   decoration moved to `src/debug/subject-display-name.ts`; Billing
+   tests still pass.
+4. `feat(stats): per-subject query helpers (Phase 5)` — all 5a–5l
+   helpers from step 5, plus their tests.
+5. `feat(stats): global query helpers (Phase 5)` — all 6a–6f
+   helpers from step 6, plus their tests.
+6. `feat(stats): orchestrator + 60s global-view cache (Phase 5)` —
+   `src/stats/index.ts`, tests.
+7. `feat(stats): /stats routes behind DEBUG_TOKEN (Phase 5)` —
+   `stats-routes.ts`, server wiring, tests.
+8. `test(stats): forbidden-substring anonymity contract (Phase 5)` —
+   `redaction.test.ts`.
+9. `test(stats): 1k subjects + 100k messages perf bench (Phase 5)` —
+   `perf.test.ts`, optional `039_stats_indexes.ts` migration if
+   needed.
+10. `feat(stats): client fetchers + types (Phase 5)` — client side
+    plumbing.
+11. `feat(stats): SubjectStatsPanel + StatsTab + dashboard wiring
+(Phase 5)` — components + tab registration.
+12. `docs(stats): CLAUDE.md anonymity contract + module listing
+(Phase 5)` — doc updates.
+13. `chore(stats): knip ignore for deferred exports (Phase 5)` —
+    only if knip flags anything.
+
+## Rollback
+
+Per the design's Rollback section:
+
+- Remove route registration in `src/debug/server.ts`.
+- Delete `src/stats/` and `tests/stats/`.
+- Revert `src/debug/billing.ts` refactor (optional).
+- Delete `system_config.stats_anonymity_salt` row (optional).
+
+No schema migrations to roll back.
+
+## Out of plan (carry to follow-on phases)
+
+- Phase 5b — `usage_snapshots` table + nightly job.
+- Group display-name resolver.
+- External task counts (Kaneo / YouTrack).
+- CSV / JSON export.
+- Per-tool drill-down panels.
+- `recentToolFailures` retirement.

--- a/docs/superpowers/specs/2026-05-20-phase-5-anonymous-stats-design.md
+++ b/docs/superpowers/specs/2026-05-20-phase-5-anonymous-stats-design.md
@@ -1,0 +1,669 @@
+# Phase 5 — Anonymous DB-Wide Statistics — Design Refinement
+
+**Date:** 2026-05-20
+**Status:** Draft, refining parent spec for Phase 5 scope
+**Parent design:** [`2026-05-19-central-llm-billing-design.md`](./2026-05-19-central-llm-billing-design.md)
+**Roadmap:** [`../plans/2026-05-19-central-llm-billing-roadmap.md`](../plans/2026-05-19-central-llm-billing-roadmap.md)
+**Brainstorm:** [`../notes/2026-05-20-phase-5-anonymous-stats-brainstorm.md`](../notes/2026-05-20-phase-5-anonymous-stats-brainstorm.md)
+**Branch:** `claude/central-llm-phase-5-anonymous-stats`
+
+## Purpose of this document
+
+The parent design covers all five phases at a high level. This file
+narrows its decisions to Phase 5a and lifts the brainstorm's
+resolutions. Where this file and the parent disagree, this file wins
+for Phase 5 only.
+
+## Phase 5 in one paragraph
+
+Add a read-only `src/stats/` module that exposes two functions —
+`getSubjectStats(storageContextId)` and `getGlobalStats({ window })` —
+backed by live queries against existing tables. Surface both through
+new `/stats/subject/:id` and `/stats/global` routes behind the same
+`DEBUG_TOKEN` guard as Phase 3. Add a "Stats" sub-panel inside the
+existing Billing subject detail and a new top-level "Stats" tab in the
+debug dashboard. Anonymity is enforced by the response schema: counts,
+sizes, timestamps, enum distributions, and (only in per-subject view)
+the same opaque ids Phase 3 already exposes — never content,
+filenames, usernames, message text, memo bodies, or observation text.
+A redaction-style test diffs the API responses against a forbidden
+substring list seeded into every domain table. No new migrations in
+5a; the `usage_snapshots` time-series table is deferred to a future
+5b.
+
+## Decisions for Phase 5a
+
+### D1. Module layout and public surface
+
+New module `src/stats/`:
+
+```text
+src/stats/
+  index.ts         — getSubjectStats(id), getGlobalStats(opts)
+  per-table.ts     — one query function per source table
+  aggregate.ts     — percentiles(), bucket helpers
+  hashing.ts       — keyedHash(value)
+  types.ts         — SubjectStats, GlobalStats, all sub-shapes
+```
+
+Public exports from `src/stats/index.ts`:
+
+```ts
+export const getSubjectStats = (storageContextId: string): SubjectStats | null => {
+  /* ... */
+}
+
+export interface GlobalStatsOptions {
+  window?: '1d' | '7d' | '30d' | 'all'
+  noCache?: boolean // bypass the 60s in-process cache, for tests
+}
+
+export const getGlobalStats = (opts?: GlobalStatsOptions): GlobalStats => {
+  /* ... */
+}
+```
+
+Routes live in `src/debug/stats-routes.ts`, mirroring
+`src/debug/billing-routes.ts`:
+
+- `GET /stats/global?window=30d` → `GlobalStats`
+- `GET /stats/subject/:id` → `SubjectStats` (404 when the subject is
+  not in Phase 3's `listSubjects()`)
+
+Both routes are mounted in `src/debug/server.ts` behind the existing
+`DEBUG_TOKEN` middleware that already guards `/billing` and `/admin`.
+
+### D2. Response shapes
+
+```ts
+// src/stats/types.ts
+
+export interface SubjectStats {
+  storageContextId: string
+  chatUserId: string | null
+  contextType: 'dm' | 'group' | 'unknown'
+  displayName: string | null
+  memos: {
+    total: number
+    byStatus: Record<string, number> // 'active' / 'archived' / 'promoted' etc.
+    tagCardinality: { distinct: number; meanPerMemo: number }
+    contentBytesTotal: number
+    embeddingBytesTotal: number
+    withEmbedding: number
+    oldestCreatedAt: number | null // epoch ms
+    newestCreatedAt: number | null
+  }
+  scheduledPrompts: {
+    total: number
+    byStatus: Record<string, number>
+    distinctDeliveryTargets: number
+  }
+  alertPrompts: {
+    total: number
+    byStatus: Record<string, number>
+  }
+  recurringTasks: {
+    total: number
+    enabled: number
+    disabled: number
+    distinctProjects: number
+    nextRunWithin7d: number
+    distinctRrulePatterns: number // keyed-hash count
+  }
+  userInstructions: {
+    total: number
+    textBytesTotal: number
+  }
+  attachments: {
+    total: number
+    byStatus: Record<string, number>
+    bySourceProvider: Record<string, number>
+    storedBytesTotal: number
+    active: number
+    byExtension: Record<string, number> // 'jpg', 'pdf', ... lowercased
+  }
+  messageMetadata: {
+    total: number
+    authoredBySubject: number // author_id === chat_user_id
+    oldestTimestamp: number | null
+    newestTimestamp: number | null
+    textBytesTotal: number
+  }
+  conversationHistory: {
+    turnCount: number
+    summaryPresent: boolean
+  }
+  userIdentityMappings: Record<string, number> // provider_name -> count
+  stagedFiles: {
+    total: number
+    byStatus: Record<string, number>
+    bytesTotal: number
+  }
+  userBlock: {
+    addedAt: string | null
+    addedByPresent: boolean
+    kaneoWorkspacePresent: boolean
+  } | null // present when contextType === 'dm'
+  groupBlock: {
+    memberCount: number
+    distinctAddedBy: number
+    observationCount: number
+  } | null // present when contextType === 'group'
+  webFetches: {
+    totalRequests: number // SUM(count) from web_rate_limit by actor_id
+    // host breakdown lives only in the global view per anonymity contract
+  }
+  llmUsage: {
+    rowCount: number
+    inputTokensTotal: number
+    outputTokensTotal: number
+  }
+  toolCalls: {
+    total: number
+    success: number
+    failure: number
+    topTools: Array<{ toolName: string; count: number }> // top 10
+    errorTypeCounts: Record<string, number>
+  }
+}
+
+export interface GlobalStats {
+  generatedAt: number
+  window: '1d' | '7d' | '30d' | 'all'
+  subjects: {
+    dmTotal: number
+    groupTotal: number
+    growthLast30d: Array<{ date: string; dmAdded: number; groupAdded: number }>
+  }
+  active: {
+    activeIn1d: number
+    activeIn7d: number
+    activeIn30d: number
+  }
+  distributions: {
+    memosPerSubject: Percentiles
+    recurringTasksPerSubject: Percentiles
+    messageMetadataPerSubject: Percentiles
+    attachmentBytesPerSubject: Percentiles
+  }
+  storage: {
+    sqliteBytes: number
+    s3AttachmentBytes: number
+  }
+  identityMix: {
+    byProvider: Record<string, number>
+    kaneoWorkspaces: number
+  }
+  surfaceMix: {
+    subjectsWithRecurring: number
+    subjectsWithDeferred: number
+    subjectsWithMemos: number
+    subjectsWithInstructions: number
+  }
+  webFetches: {
+    topHosts: Array<{ hostHash: string; count: number }> // top 20, keyed-hash
+  }
+  toolMix: {
+    topTools: Array<{ toolName: string; count: number; successRate: number }> // top 20
+    errorTypeCounts: Record<string, number>
+  }
+}
+
+export interface Percentiles {
+  count: number
+  min: number
+  p50: number
+  p90: number
+  p99: number
+  max: number
+  mean: number
+}
+```
+
+The global view never includes a `storageContextId` or `chatUserId`.
+Hosts are keyed-hashed. The forbidden-substring test enforces both.
+
+### D3. Source-table query map
+
+Per-table query helpers in `src/stats/per-table.ts` — one pure function
+per table, each taking a Drizzle handle plus subject id (per-subject
+helpers) or no id (global helpers). All read-only.
+
+| Source table              | Per-subject helper                | Global helper                         | Anonymity notes                                                                 |
+| ------------------------- | --------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------- |
+| `memos`                   | `memosForSubject(id)`             | `memosDistribution()`                 | bytes via `length(content)`, never content. tags `json_each` for cardinality    |
+| `scheduled_prompts`       | `scheduledForSubject(id)`         | `scheduledTotals()`                   | count distinct `delivery_context_id`, never the prompt text                     |
+| `alert_prompts`           | `alertsForSubject(id)`            | `alertsTotals()`                      | count only, never `condition`                                                   |
+| `recurring_tasks`         | `recurringForSubject(id)`         | `recurringTotals()` + distribution    | distinct rrule via `keyedHash(rrule)`                                           |
+| `user_instructions`       | `instructionsForSubject(id)`      | `instructionsTotals()`                | bytes via `length(text)`, never `text`                                          |
+| `attachments`             | `attachmentsForSubject(id)`       | `attachmentsTotals()`                 | bytes via `SUM(size)`, never `filename`. extension bucketed from filename lower |
+| `message_metadata`        | `messageMetadataForSubject(id)`   | `messageMetadataTotals() + distrib`   | `length(text)` for bytes, never `text`/`author_username`                        |
+| `conversation_history`    | `conversationForSubject(id)`      | (covered by `memory_summary` global)  | `json_array_length(messages)`, no `messages` text                               |
+| `memory_summary`          | `summaryPresentForSubject(id)`    | `summaryTotals()`                     | row presence only, never `summary` text                                         |
+| `user_identity_mappings`  | `identityForSubject(id)`          | `identityTotals()`                    | `provider_name` enum and `kaneo_workspace_id IS NOT NULL` from `users`          |
+| `staged_files`            | `stagedForSubject(id)`            | `stagedTotals()`                      | `SUM(size)`, never `filename`                                                   |
+| `users`                   | `userBlockForSubject(id)`         | (covered by subjects.dmTotal)         | `added_at`, `added_by IS NOT NULL`, `kaneo_workspace_id IS NOT NULL`            |
+| `authorized_groups`       | (no per-subject role)             | (covered by subjects.groupTotal)      | `added_at` for growth                                                           |
+| `group_members`           | `groupBlockForSubject(id)`        | (none global)                         | counts only, never `user_id` values                                             |
+| `group_user_observations` | `groupObservationsForSubject(id)` | (none global)                         | count only, never `username` / `display_label`                                  |
+| `web_cache`               | (no subject column)               | `webHostsDistribution()`              | host extracted from `url`, `keyedHash(host)`, never raw url/title/excerpt       |
+| `web_rate_limit`          | `webFetchesForSubject(id)`        | (none global; covered by `web_cache`) | `SUM(count)` only                                                               |
+| `llm_usage_events`        | `llmUsageForSubject(id)`          | `activeSubjectCounts()`               | aggregates only                                                                 |
+| `tool_call_events`        | `toolCallsForSubject(id)`         | `toolMixGlobal()`                     | tool names exposed (already enum); error types exposed (already enum)           |
+
+All helpers live in `src/stats/per-table.ts` and re-export from
+`src/stats/index.ts` as a flat namespace for testing.
+
+### D4. Anonymity envelope
+
+- **Per-subject response.** Exposes the subject's own `storage_context_id`
+  and `chat_user_id` (the caller already supplied the former and Phase
+  3 already exposes both). No other subjects' ids. No content,
+  filenames, usernames, message text, memo bodies, observation text,
+  rrule strings (only their keyed-hash count), or web-cache strings.
+- **Global response.** No `storage_context_id` or `chat_user_id` of
+  any kind. Host breakdown uses `keyedHash(host)`. Provider names
+  remain plain (`kaneo`, `youtrack`); tool names remain plain (they
+  are an enum-like set defined in code).
+
+A `tests/stats/redaction.test.ts` suite enforces both envelopes by
+seeding distinctive substrings into every text column the queries
+touch and asserting the serialized JSON of each response contains
+none of them.
+
+### D5. Hashing — keyed SHA-256
+
+```ts
+// src/stats/hashing.ts
+import { createHash } from 'node:crypto'
+
+let cachedSalt: string | null = null
+
+const loadSalt = (): string => {
+  if (cachedSalt !== null) return cachedSalt
+  const row = getDrizzleDb()
+    .select({ value: systemConfig.value })
+    .from(systemConfig)
+    .where(eq(systemConfig.key, 'stats_anonymity_salt'))
+    .get()
+  if (row) {
+    cachedSalt = row.value
+    return cachedSalt
+  }
+  const newSalt = randomBytes(16).toString('hex')
+  getDrizzleDb()
+    .insert(systemConfig)
+    .values({
+      key: 'stats_anonymity_salt',
+      value: newSalt,
+      updatedAt: Date.now(),
+      updatedBy: 'system:stats',
+    })
+    .run()
+  cachedSalt = newSalt
+  return cachedSalt
+}
+
+export const keyedHash = (value: string): string => {
+  const salt = loadSalt()
+  return createHash('sha256')
+    .update(salt + ':' + value)
+    .digest('hex')
+    .slice(0, 16)
+}
+
+export const resetSaltCacheForTests = (): void => {
+  cachedSalt = null
+}
+```
+
+Salt is lazy-initialized on first call. Tests reset the cache via the
+exported helper. The salt is never returned by any route or read by
+any caller other than `keyedHash`.
+
+Output is 16 hex characters (64 bits) — sufficient for deduplication
+across hundreds of thousands of distinct values without practical
+collisions (~10⁻¹⁴ at 10⁶ values).
+
+### D6. Distribution math
+
+```ts
+// src/stats/aggregate.ts
+
+export const percentiles = (values: readonly number[]): Percentiles => {
+  if (values.length === 0) {
+    return { count: 0, min: 0, p50: 0, p90: 0, p99: 0, max: 0, mean: 0 }
+  }
+  const sorted = [...values].sort((a, b) => a - b)
+  const pick = (p: number): number => sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))]!
+  const sum = sorted.reduce((acc, v) => acc + v, 0)
+  return {
+    count: sorted.length,
+    min: sorted[0]!,
+    p50: pick(50),
+    p90: pick(90),
+    p99: pick(99),
+    max: sorted[sorted.length - 1]!,
+    mean: sum / sorted.length,
+  }
+}
+```
+
+Pure function, no DB dependency. Unit-tested with known inputs.
+
+### D7. Subject discrimination and display name
+
+For each `storage_context_id` reaching `getSubjectStats`:
+
+1. `context_type` derived from the most recent `llm_usage_events` row
+   for that subject. If no row exists, return `null` (404 from the
+   route).
+2. `display_name` resolved via Phase 3's existing logic:
+   - DM: `users.username` for the matching `platform_user_id`.
+   - Group: not resolved in 5a (matches Phase 3); the field reports
+     `null`.
+3. `chat_user_id` taken from the most recent `llm_usage_events` row.
+
+To keep this dry and avoid Phase-3-internal coupling, Phase 5 extracts
+the Phase 3 resolver from `src/debug/billing.ts:decorate` into a new
+`src/debug/subject-display-name.ts` exporting
+`resolveDisplayName(storageContextId, contextType): string | null` and
+`resolveContextTypeFromUsage(storageContextId): 'dm' | 'group' | null`.
+Phase 3's `decorate` is updated to call it. This is the only Phase-3
+file touched by Phase 5.
+
+### D8. Caching
+
+`getGlobalStats()` caches its result in-process for 60 seconds:
+
+```ts
+let cached: { data: GlobalStats; at: number; window: GlobalStatsOptions['window'] } | null = null
+
+export const getGlobalStats = (opts?: GlobalStatsOptions): GlobalStats => {
+  const window = opts?.window ?? '30d'
+  const ttlMs = 60_000
+  if (!opts?.noCache && cached && cached.window === window && Date.now() - cached.at < ttlMs) {
+    return cached.data
+  }
+  const data = computeGlobalStats(window)
+  cached = { data, at: Date.now(), window }
+  return data
+}
+```
+
+Per-subject results are uncached (cheap to recompute on click).
+
+### D9. Window semantics
+
+- **Per-subject endpoint:** all counts are point-in-time. No window
+  query parameter accepted; the URL ignores `?window=` if present.
+- **Global endpoint:** the `window` parameter selects the active-
+  subject slice (`activeIn1d/7d/30d` is always computed regardless;
+  `window` selects which value appears as the highlighted figure in
+  the dashboard) and the growth-chart range. Distributions and
+  totals are point-in-time and ignore the window.
+
+### D10. Conversation history
+
+```sql
+SELECT json_array_length(messages) AS turn_count
+FROM conversation_history
+WHERE user_id = ?;
+```
+
+`json_array_length()` is a builtin in SQLite ≥ 3.38; Bun's bundled
+SQLite is current. A unit test asserts the function returns expected
+values for short and long arrays.
+
+Summary presence is a single-row existence check on `memory_summary`.
+
+### D11. Storage footprint
+
+```ts
+import { stat } from 'node:fs/promises'
+
+const sqliteBytes = (await stat(getDbPath())).size
+
+const s3AttachmentBytes =
+  getDrizzleDb()
+    .select({ total: sql<number>`COALESCE(SUM(size), 0)` })
+    .from(attachments)
+    .where(eq(attachments.isActive, 1))
+    .get()?.total ?? 0
+```
+
+No live S3 LIST. The DB path comes from the existing exported helper
+in `src/db/index.ts` (or the central config). If the path lookup is
+unavailable in some environment, the field is reported as `null` and
+the dashboard renders "unknown".
+
+### D12. Subject-id source for distributions
+
+The denominator for "p50 memos per subject" is the union of
+`users.platform_user_id` and `authorized_groups.group_id`. Each
+subject's count is fetched once via a single SQL query that groups by
+subject id and reports zero for subjects with no rows:
+
+```sql
+SELECT u.platform_user_id AS subject_id, COALESCE(m.cnt, 0) AS cnt
+FROM users u
+LEFT JOIN (SELECT user_id, COUNT(*) AS cnt FROM memos GROUP BY user_id) m
+  ON m.user_id = u.platform_user_id
+UNION ALL
+SELECT g.group_id, COALESCE(m.cnt, 0)
+FROM authorized_groups g
+LEFT JOIN (SELECT user_id, COUNT(*) AS cnt FROM memos GROUP BY user_id) m
+  ON m.user_id = g.group_id;
+```
+
+Percentiles computed in JS via `aggregate.ts:percentiles()`.
+
+### D13. Active-subject counts
+
+Active in 1d / 7d / 30d uses `llm_usage_events.occurred_at` and
+`message_metadata.timestamp` as activity proxies. A subject is "active
+in window W" if either table has a row for `storage_context_id` with
+timestamp ≥ `now - W`. Distinct count via UNION over the two sources.
+
+### D14. Web-fetch reporting
+
+- **Per-subject:** `SUM(count)` from `web_rate_limit` for
+  `actor_id = storage_context_id`. No host breakdown per subject
+  (no join key).
+- **Global:** scan `web_cache.url`, extract host via
+  `new URL(url).host`, `keyedHash(host)`, group by hash, take top 20
+  by count.
+
+### D15. Tool mix
+
+- **Per-subject:** group `tool_call_events` rows by `tool_name` for
+  the subject, return top 10 by count plus error-type counts.
+- **Global:** group all `tool_call_events` rows by `tool_name`,
+  return top 20 with success rate; group by `error_type` ignoring
+  NULL, return totals.
+
+### D16. Identity-provider mix
+
+- **Per-subject:** `user_identity_mappings` rows for the subject,
+  grouped by `provider_name`.
+- **Global:** distinct `context_id` count grouped by `provider_name`,
+  plus `COUNT(*) FROM users WHERE kaneo_workspace_id IS NOT NULL`.
+
+### D17. Test strategy
+
+Three new test files under `tests/stats/`:
+
+- `aggregate.test.ts` — pure `percentiles()` cases (empty, single,
+  uniform, ascending, descending, with duplicates).
+- `hashing.test.ts` — `keyedHash()` determinism, salt cache behavior,
+  output length, salt-rotation invalidation.
+- `per-table.test.ts` — each per-table query helper against a seeded
+  `setupTestDb()` fixture.
+- `redaction.test.ts` — forbidden-substring contract; seeds
+  distinctive strings into every content field; serializes
+  `getGlobalStats()` and `getSubjectStats(seededSubject)`; asserts
+  none of the substrings appear in either payload.
+- `perf.test.ts` — 1k subjects + 100k `message_metadata` rows fixture;
+  asserts `getGlobalStats()` returns in <1000ms (CI safety margin);
+  comment references the 500ms dev-laptop target.
+
+Plus `tests/debug/server-stats.test.ts` mirroring
+`server-billing.test.ts`: 401 without token, 200 + payload shape with
+token, 404 for unknown subject.
+
+Client-side mirror under `tests/client/stats/` for the new
+fetchers/components.
+
+All suites follow the Phase-2/3/4 pattern: `setupTestDb()` + migration
+chain runner; no DI for the stats module.
+
+### D18. Dashboard integration
+
+```text
+client/debug/stats/
+  StatsTab.svelte           — top-level global view
+  SubjectStatsPanel.svelte  — sub-panel within Billing subject detail
+  fetchers.ts               — typed fetchers (getStatsGlobal, getStatsSubject)
+```
+
+`client/debug/dashboard-types.ts` gains:
+
+- `globalStats: GlobalStats | null`
+- `subjectStats: SubjectStats | null`
+- `statsWindow: '1d' | '7d' | '30d' | 'all'`
+
+`client/debug/dashboard.svelte.ts` adds a "Stats" tab adjacent to
+"Billing" (order: Billing → Stats → others). Inside the Billing
+subject detail, a "Stats" expander mounts `SubjectStatsPanel` on
+demand; the fetcher fires only when the user opens it.
+
+### D19. No migrations in 5a
+
+5a is read-only against existing tables. No `usage_snapshots`, no new
+indexes (gated on the perf bench), no schema change. The next
+migration (`039_*`) is reserved for 5b when/if it lands.
+
+The lazy-init of `stats_anonymity_salt` in `system_config` is an
+INSERT into an existing table, not a schema change.
+
+### D20. No backfill, no external calls
+
+- No backfill of historical stats. The dashboard renders live counts.
+- No external provider calls (Kaneo, YouTrack, S3 LIST). Storage and
+  task counts use only local-DB-resident data.
+
+## Non-goals (Phase 5a)
+
+- No `usage_snapshots` time-series table. Deferred to 5b.
+- No CSV/JSON export endpoints. Dashboard rendering is the output.
+- No external task counts (Kaneo / YouTrack `count_tasks`).
+- No live S3 LIST for storage size.
+- No mutation. Read-only across the board.
+- No new SQLite indexes unless the perf bench demands one.
+- No removal or change to the `recentToolFailures` ring buffer.
+- No deployment-size threshold for the global view; the response
+  schema enforces anonymity.
+- No content of any kind in responses, hashed or otherwise — keyed
+  hashing applies only to rrule strings and hostnames as a dedup
+  tool.
+- No display-name resolution for groups (5a matches Phase 3).
+- No charts beyond the 30d growth chart.
+
+## Acceptance contract (Phase 5a)
+
+The Phase 5a PR is shippable when all of these hold:
+
+1. **Module ships.** `src/stats/` exists with the layout in D1; both
+   public functions return well-typed shapes.
+2. **Routes wired.** `GET /stats/global` and `GET /stats/subject/:id`
+   respond behind `DEBUG_TOKEN`; 401 without token, 404 on unknown
+   subject, 200 + payload otherwise.
+3. **Anonymity enforced.** `tests/stats/redaction.test.ts` passes;
+   no forbidden substring appears in either route's payload on a
+   deeply-seeded fixture.
+4. **Per-subject counts correct.** Seeded fixture with known counts;
+   `getSubjectStats()` returns counts that match hand-rolled SQL
+   aggregates row-for-row.
+5. **Global counts correct.** Seeded fixture; `getGlobalStats()`
+   distributions match independently-computed percentiles.
+6. **Bench within budget.** `tests/stats/perf.test.ts` runs the
+   global query against 1k subjects + 100k messages in <1000ms in
+   CI.
+7. **Dashboard renders.** Stats tab and Stats sub-panel mount
+   without console errors against a seeded DB; manually opening the
+   tab shows distributions and the host breakdown with hashed
+   values.
+8. **`bun typecheck / lint / format / test / knip`** all clean (knip
+   exception via comment for any deferred client wiring, per Phase 2
+   pattern).
+9. **`bun security`** clean. New routes are read-only and behind the
+   existing `DEBUG_TOKEN` guard.
+10. **Manual smoke.** Seed a dev DB with a few subjects + memos +
+    recurring tasks; open the dashboard; verify the Stats tab shows
+    realistic numbers and no PII leaks visually.
+
+## Rollback
+
+- Remove `src/debug/stats-routes.ts` registration in
+  `src/debug/server.ts`. Routes vanish; dashboard tabs render zero
+  state.
+- Delete `src/stats/` and `tests/stats/` — no other module depends.
+- Revert the `src/debug/billing.ts` refactor that extracted
+  `subject-display-name.ts` (optional; the refactor stands on its
+  own merits).
+- Delete the `stats_anonymity_salt` row from `system_config` if a
+  fresh start is desired; harmless if left.
+
+No schema migrations to roll back.
+
+## Forward-compatibility check
+
+- **Phase 5b (`usage_snapshots`).** Drop-in: the snapshot writer
+  imports `src/stats/index.ts` and persists daily values from
+  `getGlobalStats()` and `getSubjectStats()`. No API change required.
+- **Future external-task counts.** Adding `externalTasks: { kaneo?:
+number; youtrack?: number }` to `SubjectStats` is additive. The 5a
+  contract documents the field as absent.
+- **Future metering vendor.** Phase 5 doesn't write data; no outbox
+  concerns.
+- **Future group display-name resolver.** Adding it changes the
+  `displayName` field for groups from `null` to a string. No shape
+  break.
+
+## Security review checkpoints
+
+- Run `bun security` after the stats module lands. New routes are
+  read-only.
+- The redaction-style test is the explicit anonymity-contract check.
+  Treat any forbidden-substring leak as a release-blocking defect.
+- The `stats_anonymity_salt` value never appears in any route
+  response. A second redaction test asserts the salt is not present
+  in either route's payload.
+- The `DEBUG_TOKEN` middleware is reused, not re-implemented; same
+  guarantees as Phase 3.
+
+## Documentation updates
+
+- `CLAUDE.md` gains a short "Anonymity contract" subsection under the
+  existing Architecture / debug-server notes: what `/stats/*`
+  exposes (counts, sizes, timestamps, enum distributions, hashed
+  hostnames) and what it never exposes (content of any kind).
+- `CLAUDE.md` dashboard-overview update: list the new Stats tab next
+  to Billing.
+- No user-facing chat-surface doc changes.
+
+## Open follow-ups for later phases
+
+- **Phase 5b — `usage_snapshots`.** Nightly job persists global
+  values + per-subject deltas for time-series charts.
+- **Group display-name resolver.** Resolves group ids to titles via
+  `known_group_contexts` or live provider lookup; useful in both
+  Billing and Stats.
+- **External task counts.** Deferred Kaneo/YouTrack `count_tasks`
+  with strict rate limiting.
+- **CSV / JSON export.** Endpoint that returns the same payloads as
+  downloadable files; trivial follow-on once routes exist.
+- **Per-tool drill-down.** Click a tool name in the Stats tab to see
+  its error-type distribution over time.
+- **`recentToolFailures` retirement.** Once the Stats tab covers the
+  same shape, the ring buffer can shrink or retire.

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -67,6 +67,7 @@
     "src/stats/per-table.ts": ["files", "exports"],
     "src/stats/per-table-content.ts": ["files", "exports"],
     "src/stats/per-table-subject.ts": ["files", "exports"],
+    "src/stats/per-table-usage.ts": ["files", "exports"],
     "src/stats/internal/util.ts": ["files", "exports"],
     // systemConfigCacheForTesting is the cache-reset escape hatch for tests
     // (consumed by tests/utils/test-helpers.ts). Mirrors the userCachesForTesting

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -66,6 +66,7 @@
     "src/stats/hashing.ts": ["files", "exports"],
     "src/stats/per-table.ts": ["files", "exports"],
     "src/stats/per-table-content.ts": ["files", "exports"],
+    "src/stats/per-table-subject.ts": ["files", "exports"],
     "src/stats/internal/util.ts": ["files", "exports"],
     // systemConfigCacheForTesting is the cache-reset escape hatch for tests
     // (consumed by tests/utils/test-helpers.ts). Mirrors the userCachesForTesting

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -93,6 +93,7 @@
     "client/debug/sse.ts": ["exports"],
     "client/debug/types.ts": ["types"],
     "client/debug/billing/fetchers.ts": ["exports"],
+    "client/debug/stats/fetchers.ts": ["exports"],
   },
 
   // Report unused exports even in entry files

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -63,6 +63,7 @@
     // consumers ship, knip can't trace the type-only and pure helper modules.
     "src/stats/types.ts": ["files", "types"],
     "src/stats/aggregate.ts": ["files", "exports"],
+    "src/stats/hashing.ts": ["files", "exports"],
     // systemConfigCacheForTesting is the cache-reset escape hatch for tests
     // (consumed by tests/utils/test-helpers.ts). Mirrors the userCachesForTesting
     // pattern in src/cache.ts, but unlike that one no production code currently

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -65,6 +65,8 @@
     "src/stats/aggregate.ts": ["files", "exports"],
     "src/stats/hashing.ts": ["files", "exports"],
     "src/stats/per-table.ts": ["files", "exports"],
+    "src/stats/per-table-content.ts": ["files", "exports"],
+    "src/stats/internal/util.ts": ["files", "exports"],
     // systemConfigCacheForTesting is the cache-reset escape hatch for tests
     // (consumed by tests/utils/test-helpers.ts). Mirrors the userCachesForTesting
     // pattern in src/cache.ts, but unlike that one no production code currently

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -61,6 +61,7 @@
     // src/stats/* lands incrementally for Phase 5; the per-table helpers and
     // orchestrator wire into the dashboard later in the plan. Until those
     // consumers ship, knip can't trace the type-only and pure helper modules.
+    "src/stats/index.ts": ["files", "exports"],
     "src/stats/types.ts": ["files", "types"],
     "src/stats/aggregate.ts": ["files", "exports"],
     "src/stats/hashing.ts": ["files", "exports"],

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -58,6 +58,11 @@
     "src/usage/query.ts": ["files", "exports"],
     "src/usage/types.ts": ["types"],
     "src/usage/index.ts": ["exports"],
+    // src/stats/* lands incrementally for Phase 5; the per-table helpers and
+    // orchestrator wire into the dashboard later in the plan. Until those
+    // consumers ship, knip can't trace the type-only and pure helper modules.
+    "src/stats/types.ts": ["files", "types"],
+    "src/stats/aggregate.ts": ["files", "exports"],
     // systemConfigCacheForTesting is the cache-reset escape hatch for tests
     // (consumed by tests/utils/test-helpers.ts). Mirrors the userCachesForTesting
     // pattern in src/cache.ts, but unlike that one no production code currently

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -68,6 +68,10 @@
     "src/stats/per-table-content.ts": ["files", "exports"],
     "src/stats/per-table-subject.ts": ["files", "exports"],
     "src/stats/per-table-usage.ts": ["files", "exports"],
+    "src/stats/global-subjects.ts": ["files", "exports"],
+    "src/stats/global-distributions.ts": ["files", "exports"],
+    "src/stats/global-mix.ts": ["files", "exports"],
+    "src/stats/global-web-tools.ts": ["files", "exports"],
     "src/stats/internal/util.ts": ["files", "exports"],
     // systemConfigCacheForTesting is the cache-reset escape hatch for tests
     // (consumed by tests/utils/test-helpers.ts). Mirrors the userCachesForTesting

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -64,6 +64,7 @@
     "src/stats/types.ts": ["files", "types"],
     "src/stats/aggregate.ts": ["files", "exports"],
     "src/stats/hashing.ts": ["files", "exports"],
+    "src/stats/per-table.ts": ["files", "exports"],
     // systemConfigCacheForTesting is the cache-reset escape hatch for tests
     // (consumed by tests/utils/test-helpers.ts). Mirrors the userCachesForTesting
     // pattern in src/cache.ts, but unlike that one no production code currently

--- a/src/debug/billing.ts
+++ b/src/debug/billing.ts
@@ -3,13 +3,14 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { and, desc, eq, gte, inArray } from 'drizzle-orm'
+import { and, desc, eq, gte } from 'drizzle-orm'
 
 import { getDrizzleDb } from '../db/drizzle.js'
-import { llmUsageEvents, users } from '../db/schema.js'
+import { llmUsageEvents } from '../db/schema.js'
 import { logger } from '../logger.js'
 import { listSubjects } from '../usage/query.js'
 import type { ModelRole, RequestRow, SubjectSummary } from '../usage/types.js'
+import { resolveDmDisplayNames } from './subject-display-name.js'
 
 const log = logger.child({ scope: 'debug:billing' })
 
@@ -46,17 +47,6 @@ export const windowToMs = (w: BillingWindow): number | null => WINDOW_MS[w]
 
 const isModelRole = (value: string): value is ModelRole =>
   value === 'main' || value === 'small' || value === 'embedding'
-
-const resolveDmDisplayNames = (subjects: readonly SubjectSummary[]): Map<string, string | null> => {
-  const dmIds = subjects.filter((s) => s.contextType === 'dm').map((s) => s.storageContextId)
-  if (dmIds.length === 0) return new Map()
-  const rows = getDrizzleDb()
-    .select({ id: users.platformUserId, username: users.username })
-    .from(users)
-    .where(inArray(users.platformUserId, dmIds))
-    .all()
-  return new Map(rows.map((r) => [r.id, r.username ?? null]))
-}
 
 const decorate = (subjects: readonly SubjectSummary[]): BillingSubject[] => {
   const names = resolveDmDisplayNames(subjects)

--- a/src/debug/server.ts
+++ b/src/debug/server.ts
@@ -14,6 +14,7 @@ import { listRecurringTasks } from '../recurring.js'
 import { handleAdminLlmGet, handleAdminLlmPost, handleBillingSubject, handleBillingSubjects } from './billing-routes.js'
 import { logBuffer, logBufferStream } from './log-buffer.js'
 import { addClient, init, removeClient, findTurnById } from './state-collector.js'
+import { handleStatsGlobal, handleStatsSubject } from './stats-routes.js'
 
 const log = logger.child({ scope: 'debug-server' })
 
@@ -202,6 +203,8 @@ function routeRequest(req: Request): Response | Promise<Response> {
   if (url.pathname === '/auth/groups') return handleAuthGroups()
   if (url.pathname === '/billing/subjects') return handleBillingSubjects(url)
   if (url.pathname.startsWith('/billing/subject/')) return handleBillingSubject(url)
+  if (url.pathname === '/stats/global') return handleStatsGlobal(url)
+  if (url.pathname.startsWith('/stats/subject/')) return handleStatsSubject(url)
   if (url.pathname === '/admin/llm') {
     if (req.method === 'GET') return handleAdminLlmGet()
     if (req.method === 'POST') return handleAdminLlmPost(req)

--- a/src/debug/stats-routes.ts
+++ b/src/debug/stats-routes.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { getGlobalStats, getSubjectStats } from '../stats/index.js'
+import type { StatsWindow } from '../stats/types.js'
+
+const jsonResponse = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const isStatsWindow = (value: string): value is StatsWindow =>
+  value === '1d' || value === '7d' || value === '30d' || value === 'all'
+
+const parseStatsWindow = (raw: string | null): StatsWindow | null => {
+  if (raw === null) return '30d'
+  return isStatsWindow(raw) ? raw : null
+}
+
+export const handleStatsGlobal = (url: URL): Response => {
+  const window = parseStatsWindow(url.searchParams.get('window'))
+  if (window === null) return jsonResponse(400, { error: 'unknown window' })
+  const stats = getGlobalStats({ window })
+  return jsonResponse(200, stats)
+}
+
+export const handleStatsSubject = (url: URL): Response => {
+  const rawId = url.pathname.slice('/stats/subject/'.length)
+  if (rawId === '') return jsonResponse(400, { error: 'missing subject id' })
+  const subjectId = decodeURIComponent(rawId)
+  const stats = getSubjectStats(subjectId)
+  if (stats === null) return jsonResponse(404, { error: 'subject not found' })
+  return jsonResponse(200, stats)
+}

--- a/src/debug/subject-display-name.ts
+++ b/src/debug/subject-display-name.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { inArray } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { users } from '../db/schema.js'
+
+export type SubjectDisplayInput = {
+  storageContextId: string
+  contextType: string
+}
+
+export const resolveDmDisplayNames = (subjects: readonly SubjectDisplayInput[]): Map<string, string | null> => {
+  const dmIds = subjects.filter((s) => s.contextType === 'dm').map((s) => s.storageContextId)
+  if (dmIds.length === 0) return new Map()
+  const rows = getDrizzleDb()
+    .select({ id: users.platformUserId, username: users.username })
+    .from(users)
+    .where(inArray(users.platformUserId, dmIds))
+    .all()
+  const out = new Map<string, string | null>()
+  for (const r of rows) {
+    if (r.username !== null) out.set(r.id, r.username)
+  }
+  return out
+}

--- a/src/stats/aggregate.ts
+++ b/src/stats/aggregate.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { Percentiles } from './types.js'
+
+const EMPTY: Percentiles = {
+  count: 0,
+  min: 0,
+  p50: 0,
+  p90: 0,
+  p99: 0,
+  max: 0,
+  mean: 0,
+}
+
+function quantile(sorted: readonly number[], q: number): number {
+  const n = sorted.length
+  if (n === 0) return 0
+  if (n === 1) return sorted[0] ?? 0
+  const pos = (n - 1) * q
+  const lo = Math.floor(pos)
+  const hi = Math.ceil(pos)
+  const loVal = sorted[lo] ?? 0
+  const hiVal = sorted[hi] ?? 0
+  if (lo === hi) return loVal
+  return loVal + (hiVal - loVal) * (pos - lo)
+}
+
+export function percentiles(values: readonly number[]): Percentiles {
+  if (values.length === 0) return { ...EMPTY }
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const count = sorted.length
+  const min = sorted[0] ?? 0
+  const max = sorted[count - 1] ?? 0
+
+  let sum = 0
+  for (const v of sorted) sum += v
+  const mean = sum / count
+
+  return {
+    count,
+    min,
+    p50: quantile(sorted, 0.5),
+    p90: quantile(sorted, 0.9),
+    p99: quantile(sorted, 0.99),
+    max,
+    mean,
+  }
+}

--- a/src/stats/global-distributions.ts
+++ b/src/stats/global-distributions.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { sql } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { attachments, memos, messageMetadata, recurringTasks } from '../db/schema.js'
+import { percentiles } from './aggregate.js'
+import type { GlobalDistributions } from './types.js'
+
+function countsBySubject(rows: ReadonlyArray<{ value: number }>): number[] {
+  return rows.map((r) => r.value)
+}
+
+export function distributionsGlobal(): GlobalDistributions {
+  const memoRows = getDrizzleDb()
+    .select({ value: sql<number>`count(*)`.as('value') })
+    .from(memos)
+    .groupBy(memos.userId)
+    .all()
+
+  const recurringRows = getDrizzleDb()
+    .select({ value: sql<number>`count(*)`.as('value') })
+    .from(recurringTasks)
+    .groupBy(recurringTasks.userId)
+    .all()
+
+  const messageRows = getDrizzleDb()
+    .select({ value: sql<number>`count(*)`.as('value') })
+    .from(messageMetadata)
+    .groupBy(messageMetadata.contextId)
+    .all()
+
+  const attachmentRows = getDrizzleDb()
+    .select({ value: sql<number>`coalesce(sum(${attachments.size}), 0)`.as('value') })
+    .from(attachments)
+    .groupBy(attachments.contextId)
+    .all()
+
+  return {
+    memosPerSubject: percentiles(countsBySubject(memoRows)),
+    recurringTasksPerSubject: percentiles(countsBySubject(recurringRows)),
+    messageMetadataPerSubject: percentiles(countsBySubject(messageRows)),
+    attachmentBytesPerSubject: percentiles(countsBySubject(attachmentRows)),
+  }
+}

--- a/src/stats/global-mix.ts
+++ b/src/stats/global-mix.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { statSync } from 'node:fs'
+
+import { eq, sql } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import {
+  attachments,
+  scheduledPrompts,
+  userIdentityMappings,
+  memos,
+  recurringTasks,
+  userInstructions,
+  users,
+} from '../db/schema.js'
+import type { IdentityMixStats, StorageFootprint, SurfaceMixStats } from './types.js'
+
+interface StorageGlobalOptions {
+  dbFileSize?: () => number
+}
+
+function defaultDbFileSize(): number {
+  const dbPath = process.env['DB_PATH'] ?? 'papai.db'
+  try {
+    return statSync(dbPath).size
+  } catch {
+    return 0
+  }
+}
+
+export function storageGlobal(opts: StorageGlobalOptions = {}): StorageFootprint {
+  const row = getDrizzleDb()
+    .select({ total: sql<number>`coalesce(sum(${attachments.size}), 0)`.as('total') })
+    .from(attachments)
+    .where(eq(attachments.isActive, 1))
+    .all()
+  return {
+    s3AttachmentBytes: row[0]?.total ?? 0,
+    sqliteBytes: opts.dbFileSize?.() ?? defaultDbFileSize(),
+  }
+}
+
+export function identityMixGlobal(): IdentityMixStats {
+  const providerRows = getDrizzleDb()
+    .select({
+      providerName: userIdentityMappings.providerName,
+      count: sql<number>`count(*)`.as('count'),
+    })
+    .from(userIdentityMappings)
+    .groupBy(userIdentityMappings.providerName)
+    .all()
+
+  const byProvider: Record<string, number> = {}
+  for (const r of providerRows) byProvider[r.providerName] = r.count
+
+  const kaneoRow = getDrizzleDb()
+    .select({ c: sql<number>`count(*)`.as('c') })
+    .from(users)
+    .where(sql`${users.kaneoWorkspaceId} is not null and ${users.kaneoWorkspaceId} != ''`)
+    .all()
+
+  return { byProvider, kaneoWorkspaces: kaneoRow[0]?.c ?? 0 }
+}
+
+export function surfaceMixGlobal(): SurfaceMixStats {
+  const memoRow = getDrizzleDb()
+    .select({ c: sql<number>`count(distinct ${memos.userId})`.as('c') })
+    .from(memos)
+    .all()
+  const recurringRow = getDrizzleDb()
+    .select({ c: sql<number>`count(distinct ${recurringTasks.userId})`.as('c') })
+    .from(recurringTasks)
+    .all()
+  const deferredRow = getDrizzleDb()
+    .select({ c: sql<number>`count(distinct ${scheduledPrompts.createdByUserId})`.as('c') })
+    .from(scheduledPrompts)
+    .all()
+  const instructionsRow = getDrizzleDb()
+    .select({ c: sql<number>`count(distinct ${userInstructions.contextId})`.as('c') })
+    .from(userInstructions)
+    .all()
+
+  return {
+    subjectsWithMemos: memoRow[0]?.c ?? 0,
+    subjectsWithRecurring: recurringRow[0]?.c ?? 0,
+    subjectsWithDeferred: deferredRow[0]?.c ?? 0,
+    subjectsWithInstructions: instructionsRow[0]?.c ?? 0,
+  }
+}

--- a/src/stats/global-subjects.ts
+++ b/src/stats/global-subjects.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { sql } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { authorizedGroups, llmUsageEvents, messageMetadata, users } from '../db/schema.js'
+import { parseIsoToMs } from './internal/util.js'
+import type { ActiveSubjectCounts, GlobalSubjects, SubjectGrowthPoint } from './types.js'
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+const GROWTH_DAYS = 30
+
+function isoDate(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10)
+}
+
+function accumulateDayCounts(
+  rows: ReadonlyArray<{ addedAt: string }>,
+  counts: Map<string, number>,
+  cutoff: number,
+  now: number,
+): void {
+  for (const r of rows) {
+    const ms = parseIsoToMs(r.addedAt)
+    if (ms === null || ms < cutoff || ms > now) continue
+    const d = isoDate(ms)
+    counts.set(d, (counts.get(d) ?? 0) + 1)
+  }
+}
+
+function buildGrowthPoints(now: number): SubjectGrowthPoint[] {
+  const dmRows = getDrizzleDb().select({ addedAt: users.addedAt }).from(users).all()
+  const groupRows = getDrizzleDb().select({ addedAt: authorizedGroups.addedAt }).from(authorizedGroups).all()
+
+  const dmCounts = new Map<string, number>()
+  const groupCounts = new Map<string, number>()
+  const cutoff = now - GROWTH_DAYS * ONE_DAY_MS
+
+  accumulateDayCounts(dmRows, dmCounts, cutoff, now)
+  accumulateDayCounts(groupRows, groupCounts, cutoff, now)
+
+  const dates = new Set<string>([...dmCounts.keys(), ...groupCounts.keys()])
+  return [...dates]
+    .sort()
+    .map((date) => ({ date, dmAdded: dmCounts.get(date) ?? 0, groupAdded: groupCounts.get(date) ?? 0 }))
+}
+
+export function subjectsGlobal(now: number = Date.now()): GlobalSubjects {
+  const dmRow = getDrizzleDb()
+    .select({ c: sql<number>`count(*)`.as('c') })
+    .from(users)
+    .all()
+  const groupRow = getDrizzleDb()
+    .select({ c: sql<number>`count(*)`.as('c') })
+    .from(authorizedGroups)
+    .all()
+
+  return {
+    dmTotal: dmRow[0]?.c ?? 0,
+    groupTotal: groupRow[0]?.c ?? 0,
+    growthLast30d: buildGrowthPoints(now),
+  }
+}
+
+function activeSubjectsSince(cutoff: number): Set<string> {
+  const ids = new Set<string>()
+  const usage = getDrizzleDb()
+    .select({ id: llmUsageEvents.storageContextId })
+    .from(llmUsageEvents)
+    .where(sql`${llmUsageEvents.occurredAt} >= ${cutoff}`)
+    .all()
+  for (const r of usage) ids.add(r.id)
+  const msgs = getDrizzleDb()
+    .select({ id: messageMetadata.contextId })
+    .from(messageMetadata)
+    .where(sql`${messageMetadata.timestamp} >= ${cutoff}`)
+    .all()
+  for (const r of msgs) ids.add(r.id)
+  return ids
+}
+
+export function activeSubjectCounts(now: number = Date.now()): ActiveSubjectCounts {
+  return {
+    activeIn1d: activeSubjectsSince(now - ONE_DAY_MS).size,
+    activeIn7d: activeSubjectsSince(now - 7 * ONE_DAY_MS).size,
+    activeIn30d: activeSubjectsSince(now - 30 * ONE_DAY_MS).size,
+  }
+}

--- a/src/stats/global-web-tools.ts
+++ b/src/stats/global-web-tools.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { sql } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { toolCallEvents, webCache } from '../db/schema.js'
+import { keyedHash } from './hashing.js'
+import type { ToolMixGlobal, WebFetchHostsGlobal } from './types.js'
+
+const TOP_LIMIT = 20
+
+function extractHost(url: string): string | null {
+  try {
+    return new URL(url).host
+  } catch {
+    return null
+  }
+}
+
+export function webFetchesGlobal(): WebFetchHostsGlobal {
+  const rows = getDrizzleDb().select({ url: webCache.url }).from(webCache).all()
+
+  const hostCounts = new Map<string, number>()
+  for (const r of rows) {
+    const host = extractHost(r.url)
+    if (host === null) continue
+    const h = keyedHash(`host:${host}`)
+    hostCounts.set(h, (hostCounts.get(h) ?? 0) + 1)
+  }
+
+  const topHosts = [...hostCounts.entries()]
+    .map(([hostHash, count]) => ({ hostHash, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, TOP_LIMIT)
+
+  return { topHosts }
+}
+
+export function toolMixGlobal(): ToolMixGlobal {
+  const rows = getDrizzleDb()
+    .select({
+      toolName: toolCallEvents.toolName,
+      total: sql<number>`count(*)`.as('total'),
+      successes: sql<number>`sum(${toolCallEvents.success})`.as('successes'),
+    })
+    .from(toolCallEvents)
+    .groupBy(toolCallEvents.toolName)
+    .all()
+
+  const topTools = rows
+    .map((r) => ({
+      toolName: r.toolName,
+      count: r.total,
+      successRate: r.total === 0 ? 0 : r.successes / r.total,
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, TOP_LIMIT)
+
+  const errorRows = getDrizzleDb()
+    .select({ errorType: toolCallEvents.errorType, c: sql<number>`count(*)`.as('c') })
+    .from(toolCallEvents)
+    .where(sql`${toolCallEvents.errorType} is not null and ${toolCallEvents.errorType} != ''`)
+    .groupBy(toolCallEvents.errorType)
+    .all()
+
+  const errorTypeCounts: Record<string, number> = {}
+  for (const r of errorRows) if (r.errorType !== null) errorTypeCounts[r.errorType] = r.c
+
+  return { topTools, errorTypeCounts }
+}

--- a/src/stats/hashing.ts
+++ b/src/stats/hashing.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { createHash, randomBytes } from 'node:crypto'
+
+import { sql } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { systemConfig } from '../db/schema.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ scope: 'stats-hashing' })
+
+export const STATS_ANONYMITY_SALT_KEY = 'stats_anonymity_salt'
+
+let cachedSalt: string | null = null
+
+export const resetStatsSaltCacheForTesting = (): void => {
+  cachedSalt = null
+}
+
+export function getStatsAnonymitySalt(): string {
+  if (cachedSalt !== null) return cachedSalt
+
+  const db = getDrizzleDb()
+  const existing = db
+    .select()
+    .from(systemConfig)
+    .where(sql`${systemConfig.key} = ${STATS_ANONYMITY_SALT_KEY}`)
+    .all()
+
+  const found = existing[0]?.value
+  if (found !== undefined && found !== '') {
+    cachedSalt = found
+    return found
+  }
+
+  const fresh = randomBytes(32).toString('hex')
+  const now = Date.now()
+  db.insert(systemConfig)
+    .values({ key: STATS_ANONYMITY_SALT_KEY, value: fresh, updatedAt: now, updatedBy: 'stats' })
+    .onConflictDoUpdate({
+      target: systemConfig.key,
+      set: { value: sql`excluded.value`, updatedAt: sql`excluded.updated_at`, updatedBy: sql`excluded.updated_by` },
+    })
+    .run()
+  cachedSalt = fresh
+  log.info({ key: STATS_ANONYMITY_SALT_KEY }, 'stats anonymity salt lazily initialised')
+  return fresh
+}
+
+export function keyedHash(input: string): string {
+  const salt = getStatsAnonymitySalt()
+  return createHash('sha256').update(salt).update('|').update(input).digest('hex')
+}

--- a/src/stats/index.ts
+++ b/src/stats/index.ts
@@ -7,7 +7,6 @@ import { eq } from 'drizzle-orm'
 
 import { getDrizzleDb } from '../db/drizzle.js'
 import { authorizedGroups, llmUsageEvents, users } from '../db/schema.js'
-import { resolveDmDisplayNames } from '../debug/subject-display-name.js'
 import { distributionsGlobal } from './global-distributions.js'
 import { identityMixGlobal, storageGlobal, surfaceMixGlobal } from './global-mix.js'
 import { activeSubjectCounts, subjectsGlobal } from './global-subjects.js'
@@ -68,14 +67,14 @@ export function getSubjectStats(storageContextId: string): SubjectStats | null {
   const { contextType, chatUserId } = resolveContextType(storageContextId)
   if (contextType === 'unknown') return null
 
-  const displayMap = resolveDmDisplayNames([{ storageContextId, contextType }])
-  const displayName = displayMap.get(storageContextId) ?? null
-
+  // displayName is intentionally null in the stats payload — the anonymity
+  // contract forbids exposing usernames. Billing renders display names via
+  // resolveDmDisplayNames on its own.
   return {
     storageContextId,
     chatUserId,
     contextType,
-    displayName,
+    displayName: null,
     memos: memosForSubject(storageContextId),
     scheduledPrompts: scheduledForSubject(storageContextId),
     alertPrompts: alertsForSubject(storageContextId),

--- a/src/stats/index.ts
+++ b/src/stats/index.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { eq } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { authorizedGroups, llmUsageEvents, users } from '../db/schema.js'
+import { resolveDmDisplayNames } from '../debug/subject-display-name.js'
+import { distributionsGlobal } from './global-distributions.js'
+import { identityMixGlobal, storageGlobal, surfaceMixGlobal } from './global-mix.js'
+import { activeSubjectCounts, subjectsGlobal } from './global-subjects.js'
+import { toolMixGlobal, webFetchesGlobal } from './global-web-tools.js'
+import { attachmentsForSubject, conversationForSubject, messageMetadataForSubject } from './per-table-content.js'
+import { groupBlockForSubject, identityForSubject, stagedForSubject, userBlockForSubject } from './per-table-subject.js'
+import { llmUsageForSubject, toolCallsForSubject, webFetchesForSubject } from './per-table-usage.js'
+import {
+  alertsForSubject,
+  instructionsForSubject,
+  memosForSubject,
+  recurringForSubject,
+  scheduledForSubject,
+} from './per-table.js'
+import type { GlobalStats, GlobalStatsOptions, StatsContextType, StatsWindow, SubjectStats } from './types.js'
+
+const CACHE_TTL_MS = 60_000
+
+interface CacheEntry {
+  value: GlobalStats
+  expiresAt: number
+}
+
+const globalCache = new Map<StatsWindow, CacheEntry>()
+
+export function clearStatsCacheForTesting(): void {
+  globalCache.clear()
+}
+
+function resolveContextType(storageContextId: string): { contextType: StatsContextType; chatUserId: string | null } {
+  const userRow = getDrizzleDb()
+    .select({ id: users.platformUserId })
+    .from(users)
+    .where(eq(users.platformUserId, storageContextId))
+    .all()
+  if (userRow[0] !== undefined) return { contextType: 'dm', chatUserId: storageContextId }
+
+  const groupRow = getDrizzleDb()
+    .select({ id: authorizedGroups.groupId })
+    .from(authorizedGroups)
+    .where(eq(authorizedGroups.groupId, storageContextId))
+    .all()
+  if (groupRow[0] !== undefined) return { contextType: 'group', chatUserId: null }
+
+  const usageRow = getDrizzleDb()
+    .select({ contextType: llmUsageEvents.contextType, chatUserId: llmUsageEvents.chatUserId })
+    .from(llmUsageEvents)
+    .where(eq(llmUsageEvents.storageContextId, storageContextId))
+    .limit(1)
+    .all()
+  const r = usageRow[0]
+  if (r === undefined) return { contextType: 'unknown', chatUserId: null }
+  const ct: StatsContextType = r.contextType === 'dm' || r.contextType === 'group' ? r.contextType : 'unknown'
+  return { contextType: ct, chatUserId: r.chatUserId }
+}
+
+export function getSubjectStats(storageContextId: string): SubjectStats | null {
+  const { contextType, chatUserId } = resolveContextType(storageContextId)
+  if (contextType === 'unknown') return null
+
+  const displayMap = resolveDmDisplayNames([{ storageContextId, contextType }])
+  const displayName = displayMap.get(storageContextId) ?? null
+
+  return {
+    storageContextId,
+    chatUserId,
+    contextType,
+    displayName,
+    memos: memosForSubject(storageContextId),
+    scheduledPrompts: scheduledForSubject(storageContextId),
+    alertPrompts: alertsForSubject(storageContextId),
+    recurringTasks: recurringForSubject(storageContextId),
+    userInstructions: instructionsForSubject(storageContextId),
+    attachments: attachmentsForSubject(storageContextId),
+    messageMetadata: messageMetadataForSubject(storageContextId),
+    conversationHistory: conversationForSubject(storageContextId),
+    userIdentityMappings: identityForSubject(storageContextId),
+    stagedFiles: stagedForSubject(storageContextId),
+    userBlock: contextType === 'dm' ? userBlockForSubject(storageContextId) : null,
+    groupBlock: contextType === 'group' ? groupBlockForSubject(storageContextId) : null,
+    webFetches: webFetchesForSubject(storageContextId),
+    llmUsage: llmUsageForSubject(storageContextId),
+    toolCalls: toolCallsForSubject(storageContextId),
+  }
+}
+
+function computeGlobalStats(window: StatsWindow): GlobalStats {
+  return {
+    generatedAt: Date.now(),
+    window,
+    subjects: subjectsGlobal(),
+    active: activeSubjectCounts(),
+    distributions: distributionsGlobal(),
+    storage: storageGlobal(),
+    identityMix: identityMixGlobal(),
+    surfaceMix: surfaceMixGlobal(),
+    webFetches: webFetchesGlobal(),
+    toolMix: toolMixGlobal(),
+  }
+}
+
+export function getGlobalStats(opts: GlobalStatsOptions = {}): GlobalStats {
+  const window: StatsWindow = opts.window ?? '30d'
+  if (opts.noCache === true) return computeGlobalStats(window)
+
+  const now = Date.now()
+  const cached = globalCache.get(window)
+  if (cached !== undefined && cached.expiresAt > now) return cached.value
+
+  const fresh = computeGlobalStats(window)
+  globalCache.set(window, { value: fresh, expiresAt: now + CACHE_TTL_MS })
+  return fresh
+}

--- a/src/stats/internal/util.ts
+++ b/src/stats/internal/util.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+export const parseIsoToMs = (value: string | null): number | null => {
+  if (value === null || value === '') return null
+  const trimmed = value.includes('T') ? value : value.replace(' ', 'T') + 'Z'
+  const ms = Date.parse(trimmed)
+  return Number.isFinite(ms) ? ms : null
+}
+
+export const safeParseTags = (raw: string): readonly string[] => {
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    const out: string[] = []
+    for (const v of parsed) if (typeof v === 'string') out.push(v)
+    return out
+  } catch {
+    return []
+  }
+}

--- a/src/stats/per-table-content.ts
+++ b/src/stats/per-table-content.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { eq, sql } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { attachments, conversationHistory, memorySummary, messageMetadata } from '../db/schema.js'
+import type { AttachmentStats, ConversationStats, MessageMetadataStats } from './types.js'
+
+const extractExtension = (filename: string): string => {
+  const dot = filename.lastIndexOf('.')
+  if (dot === -1 || dot === filename.length - 1) return '(none)'
+  return filename.slice(dot + 1).toLowerCase()
+}
+
+type AttachmentRow = {
+  status: string
+  sourceProvider: string
+  filename: string
+  size: number | null
+  isActive: number
+}
+
+const accumulateAttachmentRow = (row: AttachmentRow, acc: AttachmentStats): void => {
+  acc.total += 1
+  acc.byStatus[row.status] = (acc.byStatus[row.status] ?? 0) + 1
+  acc.bySourceProvider[row.sourceProvider] = (acc.bySourceProvider[row.sourceProvider] ?? 0) + 1
+  if (row.size !== null) acc.storedBytesTotal += row.size
+  if (row.isActive === 1) acc.active += 1
+  const ext = extractExtension(row.filename)
+  acc.byExtension[ext] = (acc.byExtension[ext] ?? 0) + 1
+}
+
+export function attachmentsForSubject(storageContextId: string): AttachmentStats {
+  const rows = getDrizzleDb()
+    .select({
+      status: attachments.status,
+      sourceProvider: attachments.sourceProvider,
+      filename: attachments.filename,
+      size: attachments.size,
+      isActive: attachments.isActive,
+    })
+    .from(attachments)
+    .where(eq(attachments.contextId, storageContextId))
+    .all()
+
+  const acc: AttachmentStats = {
+    total: 0,
+    byStatus: {},
+    bySourceProvider: {},
+    storedBytesTotal: 0,
+    active: 0,
+    byExtension: {},
+  }
+  for (const row of rows) accumulateAttachmentRow(row, acc)
+  return acc
+}
+
+export function messageMetadataForSubject(storageContextId: string): MessageMetadataStats {
+  const row = getDrizzleDb()
+    .select({
+      total: sql<number>`count(*)`.as('total'),
+      authoredBySubject:
+        sql<number>`sum(case when ${messageMetadata.authorId} = ${storageContextId} then 1 else 0 end)`.as(
+          'authored_by_subject',
+        ),
+      oldestTimestamp: sql<number | null>`min(${messageMetadata.timestamp})`.as('oldest'),
+      newestTimestamp: sql<number | null>`max(${messageMetadata.timestamp})`.as('newest'),
+      textBytesTotal: sql<number>`coalesce(sum(length(${messageMetadata.text})), 0)`.as('text_bytes_total'),
+    })
+    .from(messageMetadata)
+    .where(eq(messageMetadata.contextId, storageContextId))
+    .all()
+
+  const r = row[0]
+  if (r === undefined || r.total === 0) {
+    return {
+      total: 0,
+      authoredBySubject: 0,
+      oldestTimestamp: null,
+      newestTimestamp: null,
+      textBytesTotal: 0,
+    }
+  }
+
+  return {
+    total: r.total,
+    authoredBySubject: r.authoredBySubject ?? 0,
+    oldestTimestamp: r.oldestTimestamp,
+    newestTimestamp: r.newestTimestamp,
+    textBytesTotal: r.textBytesTotal,
+  }
+}
+
+const countMessagesArray = (raw: string): number => {
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    return Array.isArray(parsed) ? parsed.length : 0
+  } catch {
+    return 0
+  }
+}
+
+export function conversationForSubject(storageContextId: string): ConversationStats {
+  const historyRows = getDrizzleDb()
+    .select({ messages: conversationHistory.messages })
+    .from(conversationHistory)
+    .where(eq(conversationHistory.userId, storageContextId))
+    .all()
+
+  const summaryRows = getDrizzleDb()
+    .select({ userId: memorySummary.userId })
+    .from(memorySummary)
+    .where(eq(memorySummary.userId, storageContextId))
+    .all()
+
+  const turnCount = historyRows.length === 0 ? 0 : countMessagesArray(historyRows[0]?.messages ?? '')
+  return { turnCount, summaryPresent: summaryRows.length > 0 }
+}

--- a/src/stats/per-table-subject.ts
+++ b/src/stats/per-table-subject.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { eq } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { groupMembers, groupUserObservations, stagedFiles, userIdentityMappings, users } from '../db/schema.js'
+import type { GroupBlockStats, StagedFileStats, UserBlockStats } from './types.js'
+
+export function identityForSubject(storageContextId: string): Record<string, number> {
+  const rows = getDrizzleDb()
+    .select({ providerName: userIdentityMappings.providerName })
+    .from(userIdentityMappings)
+    .where(eq(userIdentityMappings.contextId, storageContextId))
+    .all()
+  const out: Record<string, number> = {}
+  for (const r of rows) out[r.providerName] = (out[r.providerName] ?? 0) + 1
+  return out
+}
+
+export function stagedForSubject(storageContextId: string): StagedFileStats {
+  const rows = getDrizzleDb()
+    .select({ status: stagedFiles.status, size: stagedFiles.size })
+    .from(stagedFiles)
+    .where(eq(stagedFiles.contextId, storageContextId))
+    .all()
+
+  let bytesTotal = 0
+  const byStatus: Record<string, number> = {}
+  for (const r of rows) {
+    byStatus[r.status] = (byStatus[r.status] ?? 0) + 1
+    if (r.size !== null) bytesTotal += r.size
+  }
+  return { total: rows.length, byStatus, bytesTotal }
+}
+
+export function userBlockForSubject(storageContextId: string): UserBlockStats | null {
+  const row = getDrizzleDb()
+    .select({
+      addedAt: users.addedAt,
+      addedBy: users.addedBy,
+      kaneoWorkspaceId: users.kaneoWorkspaceId,
+    })
+    .from(users)
+    .where(eq(users.platformUserId, storageContextId))
+    .all()
+
+  const r = row[0]
+  if (r === undefined) return null
+  return {
+    addedAt: r.addedAt,
+    addedByPresent: r.addedBy.length > 0,
+    kaneoWorkspacePresent: r.kaneoWorkspaceId !== null && r.kaneoWorkspaceId !== '',
+  }
+}
+
+export function groupBlockForSubject(storageContextId: string): GroupBlockStats | null {
+  const memberRows = getDrizzleDb()
+    .select({ userId: groupMembers.userId, addedBy: groupMembers.addedBy })
+    .from(groupMembers)
+    .where(eq(groupMembers.groupId, storageContextId))
+    .all()
+  const obsRows = getDrizzleDb()
+    .select({ userId: groupUserObservations.userId })
+    .from(groupUserObservations)
+    .where(eq(groupUserObservations.contextId, storageContextId))
+    .all()
+
+  if (memberRows.length === 0 && obsRows.length === 0) return null
+
+  const addedBy = new Set<string>()
+  for (const r of memberRows) addedBy.add(r.addedBy)
+
+  return {
+    memberCount: memberRows.length,
+    distinctAddedBy: addedBy.size,
+    observationCount: obsRows.length,
+  }
+}

--- a/src/stats/per-table-usage.ts
+++ b/src/stats/per-table-usage.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { eq, sql } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { llmUsageEvents, toolCallEvents, webRateLimit } from '../db/schema.js'
+import type { LlmUsageSubjectStats, ToolCallSubjectStats, WebFetchSubjectStats } from './types.js'
+
+const TOP_TOOLS_LIMIT = 20
+
+export function webFetchesForSubject(storageContextId: string): WebFetchSubjectStats {
+  const row = getDrizzleDb()
+    .select({ total: sql<number>`coalesce(sum(${webRateLimit.count}), 0)`.as('total') })
+    .from(webRateLimit)
+    .where(eq(webRateLimit.actorId, storageContextId))
+    .all()
+  return { totalRequests: row[0]?.total ?? 0 }
+}
+
+export function llmUsageForSubject(storageContextId: string): LlmUsageSubjectStats {
+  const row = getDrizzleDb()
+    .select({
+      rowCount: sql<number>`count(*)`.as('row_count'),
+      inputTokensTotal: sql<number>`coalesce(sum(${llmUsageEvents.inputTokens}), 0)`.as('input_tokens_total'),
+      outputTokensTotal: sql<number>`coalesce(sum(${llmUsageEvents.outputTokens}), 0)`.as('output_tokens_total'),
+    })
+    .from(llmUsageEvents)
+    .where(eq(llmUsageEvents.storageContextId, storageContextId))
+    .all()
+  const r = row[0]
+  return {
+    rowCount: r?.rowCount ?? 0,
+    inputTokensTotal: r?.inputTokensTotal ?? 0,
+    outputTokensTotal: r?.outputTokensTotal ?? 0,
+  }
+}
+
+export function toolCallsForSubject(storageContextId: string): ToolCallSubjectStats {
+  const rows = getDrizzleDb()
+    .select({ toolName: toolCallEvents.toolName, success: toolCallEvents.success, errorType: toolCallEvents.errorType })
+    .from(toolCallEvents)
+    .where(eq(toolCallEvents.storageContextId, storageContextId))
+    .all()
+
+  let success = 0
+  let failure = 0
+  const toolCounts = new Map<string, number>()
+  const errorTypeCounts: Record<string, number> = {}
+
+  for (const r of rows) {
+    if (r.success === 1) success += 1
+    else failure += 1
+    toolCounts.set(r.toolName, (toolCounts.get(r.toolName) ?? 0) + 1)
+    if (r.errorType !== null && r.errorType !== '') {
+      errorTypeCounts[r.errorType] = (errorTypeCounts[r.errorType] ?? 0) + 1
+    }
+  }
+
+  const topTools = [...toolCounts.entries()]
+    .map(([toolName, count]) => ({ toolName, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, TOP_TOOLS_LIMIT)
+
+  return { total: rows.length, success, failure, topTools, errorTypeCounts }
+}

--- a/src/stats/per-table.ts
+++ b/src/stats/per-table.ts
@@ -8,6 +8,7 @@ import { and, eq, sql } from 'drizzle-orm'
 import { getDrizzleDb } from '../db/drizzle.js'
 import { alertPrompts, memos, recurringTasks, scheduledPrompts, userInstructions } from '../db/schema.js'
 import { keyedHash } from './hashing.js'
+import { parseIsoToMs, safeParseTags } from './internal/util.js'
 import type {
   AlertPromptStats,
   InstructionStats,
@@ -15,25 +16,6 @@ import type {
   RecurringTaskStats,
   ScheduledPromptStats,
 } from './types.js'
-
-const parseIsoToMs = (value: string | null): number | null => {
-  if (value === null || value === '') return null
-  const trimmed = value.includes('T') ? value : value.replace(' ', 'T') + 'Z'
-  const ms = Date.parse(trimmed)
-  return Number.isFinite(ms) ? ms : null
-}
-
-const safeParseTags = (raw: string): readonly string[] => {
-  try {
-    const parsed = JSON.parse(raw) as unknown
-    if (!Array.isArray(parsed)) return []
-    const out: string[] = []
-    for (const v of parsed) if (typeof v === 'string') out.push(v)
-    return out
-  } catch {
-    return []
-  }
-}
 
 type MemoAccum = {
   byStatus: Record<string, number>

--- a/src/stats/per-table.ts
+++ b/src/stats/per-table.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { and, eq, sql } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { alertPrompts, memos, recurringTasks, scheduledPrompts, userInstructions } from '../db/schema.js'
+import { keyedHash } from './hashing.js'
+import type {
+  AlertPromptStats,
+  InstructionStats,
+  MemoStats,
+  RecurringTaskStats,
+  ScheduledPromptStats,
+} from './types.js'
+
+const parseIsoToMs = (value: string | null): number | null => {
+  if (value === null || value === '') return null
+  const trimmed = value.includes('T') ? value : value.replace(' ', 'T') + 'Z'
+  const ms = Date.parse(trimmed)
+  return Number.isFinite(ms) ? ms : null
+}
+
+const safeParseTags = (raw: string): readonly string[] => {
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    const out: string[] = []
+    for (const v of parsed) if (typeof v === 'string') out.push(v)
+    return out
+  } catch {
+    return []
+  }
+}
+
+type MemoAccum = {
+  byStatus: Record<string, number>
+  distinctTags: Set<string>
+  tagTotal: number
+  contentBytesTotal: number
+  embeddingBytesTotal: number
+  withEmbedding: number
+  oldestMs: number | null
+  newestMs: number | null
+}
+
+const newAccum = (): MemoAccum => ({
+  byStatus: {},
+  distinctTags: new Set(),
+  tagTotal: 0,
+  contentBytesTotal: 0,
+  embeddingBytesTotal: 0,
+  withEmbedding: 0,
+  oldestMs: null,
+  newestMs: null,
+})
+
+const embeddingByteLength = (embedding: unknown): number => {
+  if (embedding instanceof Uint8Array) return embedding.byteLength
+  if (typeof embedding === 'string') return Buffer.byteLength(embedding, 'utf8')
+  return 0
+}
+
+type MemoRow = {
+  content: string
+  tags: string
+  embedding: unknown
+  status: string
+  createdAt: string
+}
+
+const accumulateMemoRow = (acc: MemoAccum, row: MemoRow): void => {
+  acc.byStatus[row.status] = (acc.byStatus[row.status] ?? 0) + 1
+  acc.contentBytesTotal += Buffer.byteLength(row.content, 'utf8')
+  if (row.embedding !== null && row.embedding !== undefined) {
+    acc.withEmbedding += 1
+    acc.embeddingBytesTotal += embeddingByteLength(row.embedding)
+  }
+  const tags = safeParseTags(row.tags)
+  acc.tagTotal += tags.length
+  for (const t of tags) acc.distinctTags.add(t)
+  const ms = parseIsoToMs(row.createdAt)
+  if (ms === null) return
+  if (acc.oldestMs === null || ms < acc.oldestMs) acc.oldestMs = ms
+  if (acc.newestMs === null || ms > acc.newestMs) acc.newestMs = ms
+}
+
+export function memosForSubject(storageContextId: string): MemoStats {
+  const rows = getDrizzleDb()
+    .select({
+      content: memos.content,
+      tags: memos.tags,
+      embedding: memos.embedding,
+      status: memos.status,
+      createdAt: memos.createdAt,
+    })
+    .from(memos)
+    .where(eq(memos.userId, storageContextId))
+    .all()
+
+  if (rows.length === 0) {
+    return {
+      total: 0,
+      byStatus: {},
+      tagCardinality: { distinct: 0, meanPerMemo: 0 },
+      contentBytesTotal: 0,
+      embeddingBytesTotal: 0,
+      withEmbedding: 0,
+      oldestCreatedAt: null,
+      newestCreatedAt: null,
+    }
+  }
+
+  const acc = newAccum()
+  for (const row of rows) accumulateMemoRow(acc, row)
+
+  return {
+    total: rows.length,
+    byStatus: acc.byStatus,
+    tagCardinality: { distinct: acc.distinctTags.size, meanPerMemo: acc.tagTotal / rows.length },
+    contentBytesTotal: acc.contentBytesTotal,
+    embeddingBytesTotal: acc.embeddingBytesTotal,
+    withEmbedding: acc.withEmbedding,
+    oldestCreatedAt: acc.oldestMs,
+    newestCreatedAt: acc.newestMs,
+  }
+}
+
+export function scheduledForSubject(storageContextId: string): ScheduledPromptStats {
+  const rows = getDrizzleDb()
+    .select({ status: scheduledPrompts.status, deliveryContextId: scheduledPrompts.deliveryContextId })
+    .from(scheduledPrompts)
+    .where(eq(scheduledPrompts.createdByUserId, storageContextId))
+    .all()
+
+  const byStatus: Record<string, number> = {}
+  const targets = new Set<string>()
+  for (const r of rows) {
+    byStatus[r.status] = (byStatus[r.status] ?? 0) + 1
+    if (r.deliveryContextId !== null && r.deliveryContextId !== '') targets.add(r.deliveryContextId)
+  }
+
+  return { total: rows.length, byStatus, distinctDeliveryTargets: targets.size }
+}
+
+export function alertsForSubject(storageContextId: string): AlertPromptStats {
+  const rows = getDrizzleDb()
+    .select({ status: alertPrompts.status })
+    .from(alertPrompts)
+    .where(eq(alertPrompts.createdByUserId, storageContextId))
+    .all()
+
+  const byStatus: Record<string, number> = {}
+  for (const r of rows) byStatus[r.status] = (byStatus[r.status] ?? 0) + 1
+
+  return { total: rows.length, byStatus }
+}
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
+
+export function recurringForSubject(storageContextId: string): RecurringTaskStats {
+  const rows = getDrizzleDb()
+    .select({
+      projectId: recurringTasks.projectId,
+      rrule: recurringTasks.rrule,
+      enabled: recurringTasks.enabled,
+      nextRun: recurringTasks.nextRun,
+    })
+    .from(recurringTasks)
+    .where(eq(recurringTasks.userId, storageContextId))
+    .all()
+
+  let enabled = 0
+  let disabled = 0
+  const projects = new Set<string>()
+  const rruleHashes = new Set<string>()
+  let nextRunWithin7d = 0
+  const now = Date.now()
+  const cutoff = now + SEVEN_DAYS_MS
+
+  for (const r of rows) {
+    if (r.enabled === '1' || r.enabled === 'true') enabled += 1
+    else disabled += 1
+    projects.add(r.projectId)
+    if (r.rrule !== null && r.rrule !== '') rruleHashes.add(keyedHash(`rrule:${r.rrule}`))
+
+    const nextMs = parseIsoToMs(r.nextRun)
+    if (nextMs !== null && nextMs >= now && nextMs <= cutoff) nextRunWithin7d += 1
+  }
+
+  return {
+    total: rows.length,
+    enabled,
+    disabled,
+    distinctProjects: projects.size,
+    nextRunWithin7d,
+    distinctRrulePatterns: rruleHashes.size,
+  }
+}
+
+export function instructionsForSubject(storageContextId: string): InstructionStats {
+  const row = getDrizzleDb()
+    .select({
+      total: sql<number>`count(*)`.as('total'),
+      textBytesTotal: sql<number>`coalesce(sum(length(${userInstructions.text})), 0)`.as('text_bytes_total'),
+    })
+    .from(userInstructions)
+    .where(and(eq(userInstructions.contextId, storageContextId)))
+    .all()
+
+  const r = row[0]
+  return { total: r?.total ?? 0, textBytesTotal: r?.textBytesTotal ?? 0 }
+}

--- a/src/stats/types.ts
+++ b/src/stats/types.ts
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+export type StatsWindow = '1d' | '7d' | '30d' | 'all'
+
+export type StatsContextType = 'dm' | 'group' | 'unknown'
+
+export interface Percentiles {
+  count: number
+  min: number
+  p50: number
+  p90: number
+  p99: number
+  max: number
+  mean: number
+}
+
+export interface GlobalStatsOptions {
+  window?: StatsWindow
+  noCache?: boolean
+}
+
+export interface MemoStats {
+  total: number
+  byStatus: Record<string, number>
+  tagCardinality: { distinct: number; meanPerMemo: number }
+  contentBytesTotal: number
+  embeddingBytesTotal: number
+  withEmbedding: number
+  oldestCreatedAt: number | null
+  newestCreatedAt: number | null
+}
+
+export interface ScheduledPromptStats {
+  total: number
+  byStatus: Record<string, number>
+  distinctDeliveryTargets: number
+}
+
+export interface AlertPromptStats {
+  total: number
+  byStatus: Record<string, number>
+}
+
+export interface RecurringTaskStats {
+  total: number
+  enabled: number
+  disabled: number
+  distinctProjects: number
+  nextRunWithin7d: number
+  distinctRrulePatterns: number
+}
+
+export interface InstructionStats {
+  total: number
+  textBytesTotal: number
+}
+
+export interface AttachmentStats {
+  total: number
+  byStatus: Record<string, number>
+  bySourceProvider: Record<string, number>
+  storedBytesTotal: number
+  active: number
+  byExtension: Record<string, number>
+}
+
+export interface MessageMetadataStats {
+  total: number
+  authoredBySubject: number
+  oldestTimestamp: number | null
+  newestTimestamp: number | null
+  textBytesTotal: number
+}
+
+export interface ConversationStats {
+  turnCount: number
+  summaryPresent: boolean
+}
+
+export interface StagedFileStats {
+  total: number
+  byStatus: Record<string, number>
+  bytesTotal: number
+}
+
+export interface UserBlockStats {
+  addedAt: string | null
+  addedByPresent: boolean
+  kaneoWorkspacePresent: boolean
+}
+
+export interface GroupBlockStats {
+  memberCount: number
+  distinctAddedBy: number
+  observationCount: number
+}
+
+export interface WebFetchSubjectStats {
+  totalRequests: number
+}
+
+export interface LlmUsageSubjectStats {
+  rowCount: number
+  inputTokensTotal: number
+  outputTokensTotal: number
+}
+
+export interface ToolCallSubjectStats {
+  total: number
+  success: number
+  failure: number
+  topTools: Array<{ toolName: string; count: number }>
+  errorTypeCounts: Record<string, number>
+}
+
+export interface SubjectStats {
+  storageContextId: string
+  chatUserId: string | null
+  contextType: StatsContextType
+  displayName: string | null
+  memos: MemoStats
+  scheduledPrompts: ScheduledPromptStats
+  alertPrompts: AlertPromptStats
+  recurringTasks: RecurringTaskStats
+  userInstructions: InstructionStats
+  attachments: AttachmentStats
+  messageMetadata: MessageMetadataStats
+  conversationHistory: ConversationStats
+  userIdentityMappings: Record<string, number>
+  stagedFiles: StagedFileStats
+  userBlock: UserBlockStats | null
+  groupBlock: GroupBlockStats | null
+  webFetches: WebFetchSubjectStats
+  llmUsage: LlmUsageSubjectStats
+  toolCalls: ToolCallSubjectStats
+}
+
+export interface SubjectGrowthPoint {
+  date: string
+  dmAdded: number
+  groupAdded: number
+}
+
+export interface ActiveSubjectCounts {
+  activeIn1d: number
+  activeIn7d: number
+  activeIn30d: number
+}
+
+export interface GlobalDistributions {
+  memosPerSubject: Percentiles
+  recurringTasksPerSubject: Percentiles
+  messageMetadataPerSubject: Percentiles
+  attachmentBytesPerSubject: Percentiles
+}
+
+export interface StorageFootprint {
+  sqliteBytes: number
+  s3AttachmentBytes: number
+}
+
+export interface IdentityMixStats {
+  byProvider: Record<string, number>
+  kaneoWorkspaces: number
+}
+
+export interface SurfaceMixStats {
+  subjectsWithRecurring: number
+  subjectsWithDeferred: number
+  subjectsWithMemos: number
+  subjectsWithInstructions: number
+}
+
+export interface WebFetchHostsGlobal {
+  topHosts: Array<{ hostHash: string; count: number }>
+}
+
+export interface ToolMixGlobal {
+  topTools: Array<{ toolName: string; count: number; successRate: number }>
+  errorTypeCounts: Record<string, number>
+}
+
+export interface GlobalSubjects {
+  dmTotal: number
+  groupTotal: number
+  growthLast30d: SubjectGrowthPoint[]
+}
+
+export interface GlobalStats {
+  generatedAt: number
+  window: StatsWindow
+  subjects: GlobalSubjects
+  active: ActiveSubjectCounts
+  distributions: GlobalDistributions
+  storage: StorageFootprint
+  identityMix: IdentityMixStats
+  surfaceMix: SurfaceMixStats
+  webFetches: WebFetchHostsGlobal
+  toolMix: ToolMixGlobal
+}

--- a/tests/client/debug/billing/BillingPanel.test.ts
+++ b/tests/client/debug/billing/BillingPanel.test.ts
@@ -50,6 +50,9 @@ const freshState = (): DashboardState => ({
   billingSubjects: [],
   billingDetail: null,
   adminLlm: null,
+  statsWindow: '30d',
+  globalStats: null,
+  subjectStats: null,
 })
 
 const installFetch = (handlers: { subjects?: BillingSubject[]; adminEmpty?: boolean }): string[] => {

--- a/tests/client/debug/components/TurnsPanel.test.ts
+++ b/tests/client/debug/components/TurnsPanel.test.ts
@@ -37,6 +37,9 @@ function freshState(turns: Turn[] = []): DashboardState {
     billingSubjects: [],
     billingDetail: null,
     adminLlm: null,
+    statsWindow: '30d',
+    globalStats: null,
+    subjectStats: null,
   }
 }
 

--- a/tests/client/debug/handlers.test.ts
+++ b/tests/client/debug/handlers.test.ts
@@ -60,6 +60,9 @@ function freshState(): DashboardState {
     billingSubjects: [],
     billingDetail: null,
     adminLlm: null,
+    statsWindow: '30d',
+    globalStats: null,
+    subjectStats: null,
   }
 }
 

--- a/tests/client/debug/sse.test.ts
+++ b/tests/client/debug/sse.test.ts
@@ -35,6 +35,9 @@ function freshState(): DashboardState {
     billingSubjects: [],
     billingDetail: null,
     adminLlm: null,
+    statsWindow: '30d',
+    globalStats: null,
+    subjectStats: null,
   }
 }
 

--- a/tests/client/debug/stats/StatsPanel.test.ts
+++ b/tests/client/debug/stats/StatsPanel.test.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { flushSync, mount, unmount } from 'svelte'
+
+import type { DashboardState } from '../../../../client/debug/dashboard-types.js'
+import StatsPanel from '../../../../client/debug/stats/StatsPanel.svelte'
+import type { GlobalStats } from '../../../../src/stats/types.js'
+import { restoreFetch, setMockFetch } from '../../../utils/test-helpers.js'
+
+const emptyPercentiles = { count: 0, min: 0, p50: 0, p90: 0, p99: 0, max: 0, mean: 0 }
+
+const globalPayload = (overrides: Partial<GlobalStats> = {}): GlobalStats => ({
+  generatedAt: 0,
+  window: '30d',
+  subjects: { dmTotal: 42, groupTotal: 7, growthLast30d: [{ date: '2026-05-01', dmAdded: 1, groupAdded: 0 }] },
+  active: { activeIn1d: 3, activeIn7d: 9, activeIn30d: 21 },
+  distributions: {
+    memosPerSubject: { ...emptyPercentiles, count: 10, p50: 5, p90: 12, max: 30, mean: 6 },
+    recurringTasksPerSubject: emptyPercentiles,
+    messageMetadataPerSubject: emptyPercentiles,
+    attachmentBytesPerSubject: emptyPercentiles,
+  },
+  storage: { sqliteBytes: 1024, s3AttachmentBytes: 2048 },
+  identityMix: { byProvider: { 'task-provider': 5 }, kaneoWorkspaces: 2 },
+  surfaceMix: {
+    subjectsWithRecurring: 3,
+    subjectsWithDeferred: 1,
+    subjectsWithMemos: 4,
+    subjectsWithInstructions: 2,
+  },
+  webFetches: { topHosts: [{ hostHash: 'abc', count: 5 }] },
+  toolMix: { topTools: [{ toolName: 'create_task', count: 8, successRate: 1 }], errorTypeCounts: {} },
+  ...overrides,
+})
+
+const freshState = (): DashboardState =>
+  ({
+    connected: false,
+    stats: { startedAt: 0, totalMessages: 0, totalLlmCalls: 0, totalToolCalls: 0 },
+    sessions: new Map(),
+    wizards: new Map(),
+    scheduler: {},
+    pollers: {},
+    messageCache: {},
+    llmTraces: [],
+    logs: [],
+    logScopes: new Set(),
+    turns: [],
+    notifications: [],
+    toolFailures: [],
+    recurringTasks: [],
+    deferredPrompts: [],
+    memos: [],
+    identityMappings: new Map(),
+    activeConfigEditors: new Set(),
+    authorizedGroups: [],
+    activeContext: 'all',
+    activeLogFilter: {},
+    billingWindow: '30d',
+    billingSubjects: [],
+    billingDetail: null,
+    adminLlm: null,
+    statsWindow: '30d',
+    globalStats: null,
+    subjectStats: null,
+  }) as DashboardState
+
+const installFetch = (handlers: { payload?: GlobalStats; status?: number; error?: string } = {}): string[] => {
+  const calls: string[] = []
+  setMockFetch((url) => {
+    calls.push(url)
+    if (handlers.error !== undefined) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ error: handlers.error }), {
+          status: handlers.status ?? 400,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(handlers.payload ?? globalPayload()), {
+        status: handlers.status ?? 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  })
+  return calls
+}
+
+const render = (state: DashboardState): { target: HTMLElement; component: ReturnType<typeof mount> } => {
+  document.body.innerHTML = '<div id="root"></div>'
+  const target = document.getElementById('root')
+  if (target === null) throw new Error('root missing')
+  const component = mount(StatsPanel, { target, props: { dashboard: state } })
+  return { target, component }
+}
+
+afterEach(() => {
+  restoreFetch()
+})
+
+describe('StatsPanel', () => {
+  test('renders title and window selector', () => {
+    installFetch()
+    const { target, component } = render(freshState())
+    expect(target.textContent).toContain('Stats')
+    const select = target.querySelector<HTMLSelectElement>('[data-testid="stats-window-select"]')
+    expect(select).not.toBeNull()
+    void unmount(component)
+  })
+
+  test('fetches /stats/global on mount and renders DM total + active counts', async () => {
+    const calls = installFetch()
+    const { target, component } = render(freshState())
+    for (let i = 0; i < 10; i++) await Promise.resolve()
+    flushSync()
+    expect(calls.some((url) => url.startsWith('/stats/global'))).toBe(true)
+    expect(target.textContent).toMatch(/42/u)
+    expect(target.textContent).toMatch(/Group total/u)
+    void unmount(component)
+  })
+
+  test('refetches when the window selector changes', async () => {
+    const calls = installFetch()
+    const state = freshState()
+    const { target, component } = render(state)
+    for (let i = 0; i < 10; i++) await Promise.resolve()
+    flushSync()
+    const select = target.querySelector<HTMLSelectElement>('[data-testid="stats-window-select"]')
+    expect(select).not.toBeNull()
+    const selectEl = select!
+    selectEl.value = '7d'
+    selectEl.dispatchEvent(new Event('change', { bubbles: true }))
+    for (let i = 0; i < 10; i++) await Promise.resolve()
+    flushSync()
+    expect(calls.some((url) => url.includes('window=7d'))).toBe(true)
+    void unmount(component)
+  })
+
+  test('renders an error message on non-2xx', async () => {
+    installFetch({ status: 500, error: 'boom' })
+    const { target, component } = render(freshState())
+    for (let i = 0; i < 10; i++) await Promise.resolve()
+    flushSync()
+    expect(target.textContent).toMatch(/boom/u)
+    void unmount(component)
+  })
+})

--- a/tests/client/debug/stats/SubjectStatsPanel.test.ts
+++ b/tests/client/debug/stats/SubjectStatsPanel.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { flushSync, mount, unmount } from 'svelte'
+
+import SubjectStatsPanel from '../../../../client/debug/stats/SubjectStatsPanel.svelte'
+import type { SubjectStats } from '../../../../src/stats/types.js'
+import { restoreFetch, setMockFetch } from '../../../utils/test-helpers.js'
+
+const subjectPayload = (overrides: Partial<SubjectStats> = {}): SubjectStats => ({
+  storageContextId: 'u1',
+  chatUserId: 'u1',
+  contextType: 'dm',
+  displayName: null,
+  memos: {
+    total: 7,
+    byStatus: { active: 7 },
+    tagCardinality: { distinct: 3, meanPerMemo: 0.4 },
+    contentBytesTotal: 1024,
+    embeddingBytesTotal: 0,
+    withEmbedding: 0,
+    oldestCreatedAt: null,
+    newestCreatedAt: null,
+  },
+  scheduledPrompts: { total: 2, byStatus: {}, distinctDeliveryTargets: 1 },
+  alertPrompts: { total: 0, byStatus: {} },
+  recurringTasks: {
+    total: 4,
+    enabled: 3,
+    disabled: 1,
+    distinctProjects: 1,
+    nextRunWithin7d: 2,
+    distinctRrulePatterns: 1,
+  },
+  userInstructions: { total: 1, textBytesTotal: 32 },
+  attachments: {
+    total: 5,
+    byStatus: {},
+    bySourceProvider: {},
+    storedBytesTotal: 4096,
+    active: 5,
+    byExtension: {},
+  },
+  messageMetadata: {
+    total: 100,
+    authoredBySubject: 60,
+    oldestTimestamp: null,
+    newestTimestamp: null,
+    textBytesTotal: 0,
+  },
+  conversationHistory: { turnCount: 11, summaryPresent: true },
+  userIdentityMappings: {},
+  stagedFiles: { total: 0, byStatus: {}, bytesTotal: 0 },
+  userBlock: { addedAt: null, addedByPresent: true, kaneoWorkspacePresent: false },
+  groupBlock: null,
+  webFetches: { totalRequests: 9 },
+  llmUsage: { rowCount: 12, inputTokensTotal: 1234, outputTokensTotal: 567 },
+  toolCalls: { total: 8, success: 7, failure: 1, topTools: [], errorTypeCounts: {} },
+  ...overrides,
+})
+
+const installFetch = (status: number, payload: unknown): void => {
+  setMockFetch(() =>
+    Promise.resolve(
+      new Response(JSON.stringify(payload), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ),
+  )
+}
+
+const render = (storageContextId: string): { target: HTMLElement; component: ReturnType<typeof mount> } => {
+  document.body.innerHTML = '<div id="root"></div>'
+  const target = document.getElementById('root')
+  if (target === null) throw new Error('root missing')
+  const component = mount(SubjectStatsPanel, { target, props: { storageContextId } })
+  return { target, component }
+}
+
+afterEach(() => {
+  restoreFetch()
+})
+
+describe('SubjectStatsPanel', () => {
+  test('renders a loading placeholder before data resolves', () => {
+    installFetch(200, subjectPayload())
+    const { target, component } = render('u1')
+    expect(target.textContent).toContain('Loading')
+    void unmount(component)
+  })
+
+  test('renders memo total, recurring total, attachment bytes, turn count once loaded', async () => {
+    installFetch(200, subjectPayload())
+    const { target, component } = render('u1')
+    for (let i = 0; i < 10; i++) await Promise.resolve()
+    flushSync()
+    expect(target.textContent).toMatch(/memos/iu)
+    expect(target.textContent).toMatch(/recurring/iu)
+    expect(target.textContent).toMatch(/4\.0\s?KB/u)
+    expect(target.textContent).toMatch(/turns/iu)
+    expect(target.textContent).toContain('11')
+    void unmount(component)
+  })
+
+  test('renders an error message on non-2xx', async () => {
+    installFetch(404, { error: 'subject not found' })
+    const { target, component } = render('missing')
+    for (let i = 0; i < 10; i++) await Promise.resolve()
+    flushSync()
+    expect(target.textContent).toMatch(/subject not found/u)
+    void unmount(component)
+  })
+})

--- a/tests/client/debug/stats/fetchers.test.ts
+++ b/tests/client/debug/stats/fetchers.test.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { fetchStatsGlobal, fetchStatsSubject } from '../../../../client/debug/stats/fetchers.js'
+import { restoreFetch, setMockFetch } from '../../../utils/test-helpers.js'
+
+const captured: Array<{ url: string; init: RequestInit }> = []
+
+beforeEach(() => {
+  captured.length = 0
+})
+
+afterEach(() => {
+  restoreFetch()
+})
+
+const installFetch = (status: number, payload: unknown): void => {
+  setMockFetch((url, init) => {
+    captured.push({ url, init })
+    return Promise.resolve(
+      new Response(JSON.stringify(payload), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  })
+}
+
+const emptyPercentiles = { count: 0, min: 0, p50: 0, p90: 0, p99: 0, max: 0, mean: 0 }
+
+const fullGlobalPayload = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  generatedAt: 1000,
+  window: '30d',
+  subjects: { dmTotal: 0, groupTotal: 0, growthLast30d: [] },
+  active: { activeIn1d: 0, activeIn7d: 0, activeIn30d: 0 },
+  distributions: {
+    memosPerSubject: emptyPercentiles,
+    recurringTasksPerSubject: emptyPercentiles,
+    messageMetadataPerSubject: emptyPercentiles,
+    attachmentBytesPerSubject: emptyPercentiles,
+  },
+  storage: { sqliteBytes: 0, s3AttachmentBytes: 0 },
+  identityMix: { byProvider: {}, kaneoWorkspaces: 0 },
+  surfaceMix: {
+    subjectsWithRecurring: 0,
+    subjectsWithDeferred: 0,
+    subjectsWithMemos: 0,
+    subjectsWithInstructions: 0,
+  },
+  webFetches: { topHosts: [] },
+  toolMix: { topTools: [], errorTypeCounts: {} },
+  ...overrides,
+})
+
+const fullSubjectPayload = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  storageContextId: 'u1',
+  chatUserId: 'u1',
+  contextType: 'dm',
+  displayName: null,
+  memos: {
+    total: 0,
+    byStatus: {},
+    tagCardinality: { distinct: 0, meanPerMemo: 0 },
+    contentBytesTotal: 0,
+    embeddingBytesTotal: 0,
+    withEmbedding: 0,
+    oldestCreatedAt: null,
+    newestCreatedAt: null,
+  },
+  scheduledPrompts: { total: 0, byStatus: {}, distinctDeliveryTargets: 0 },
+  alertPrompts: { total: 0, byStatus: {} },
+  recurringTasks: {
+    total: 0,
+    enabled: 0,
+    disabled: 0,
+    distinctProjects: 0,
+    nextRunWithin7d: 0,
+    distinctRrulePatterns: 0,
+  },
+  userInstructions: { total: 0, textBytesTotal: 0 },
+  attachments: {
+    total: 0,
+    byStatus: {},
+    bySourceProvider: {},
+    storedBytesTotal: 0,
+    active: 0,
+    byExtension: {},
+  },
+  messageMetadata: {
+    total: 0,
+    authoredBySubject: 0,
+    oldestTimestamp: null,
+    newestTimestamp: null,
+    textBytesTotal: 0,
+  },
+  conversationHistory: { turnCount: 0, summaryPresent: false },
+  userIdentityMappings: {},
+  stagedFiles: { total: 0, byStatus: {}, bytesTotal: 0 },
+  userBlock: { addedAt: null, addedByPresent: false, kaneoWorkspacePresent: false },
+  groupBlock: null,
+  webFetches: { totalRequests: 0 },
+  llmUsage: { rowCount: 0, inputTokensTotal: 0, outputTokensTotal: 0 },
+  toolCalls: { total: 0, success: 0, failure: 0, topTools: [], errorTypeCounts: {} },
+  ...overrides,
+})
+
+describe('fetchStatsGlobal', () => {
+  test('GETs /stats/global with the requested window', async () => {
+    installFetch(200, fullGlobalPayload({ window: '7d' }))
+    const result = await fetchStatsGlobal('7d')
+    expect(captured[0]?.url).toBe('/stats/global?window=7d')
+    expect(result.window).toBe('7d')
+  })
+
+  test('defaults to no query param when window is omitted', async () => {
+    installFetch(200, fullGlobalPayload())
+    const result = await fetchStatsGlobal()
+    expect(captured[0]?.url).toBe('/stats/global')
+    expect(result.window).toBe('30d')
+  })
+
+  test('throws on non-2xx with the server error message', async () => {
+    installFetch(400, { error: 'unknown window' })
+    await expect(fetchStatsGlobal('7d')).rejects.toThrow('unknown window')
+  })
+})
+
+describe('fetchStatsSubject', () => {
+  test('GETs /stats/subject/<encoded id>', async () => {
+    installFetch(
+      200,
+      fullSubjectPayload({
+        storageContextId: 'group-9:thread-1',
+        contextType: 'group',
+        chatUserId: null,
+        userBlock: null,
+        groupBlock: { memberCount: 1, distinctAddedBy: 1, observationCount: 0 },
+      }),
+    )
+    const result = await fetchStatsSubject('group-9:thread-1')
+    expect(captured[0]?.url).toBe(`/stats/subject/${encodeURIComponent('group-9:thread-1')}`)
+    expect(result.storageContextId).toBe('group-9:thread-1')
+  })
+
+  test('throws on 404 with the server error message', async () => {
+    installFetch(404, { error: 'subject not found' })
+    await expect(fetchStatsSubject('missing')).rejects.toThrow('subject not found')
+  })
+})

--- a/tests/debug/server-stats.test.ts
+++ b/tests/debug/server-stats.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import assert from 'node:assert/strict'
+
+import { users } from '../../src/db/schema.js'
+import { startDebugServer, stopDebugServer } from '../../src/debug/server.js'
+import { getLogLevel } from '../../src/logger.js'
+import { clearStatsCacheForTesting } from '../../src/stats/index.js'
+import { getTestDb, mockLogger, restoreFetch, setupTestDb } from '../utils/test-helpers.js'
+
+const TEST_PORT = 19112
+const TOKEN = 'stats-route-token'
+
+const readJson = async (res: Response): Promise<object> => {
+  const parsed: unknown = JSON.parse(await res.text())
+  assert(typeof parsed === 'object' && parsed !== null, 'expected JSON object')
+  return parsed
+}
+const pick = (obj: object, key: string): unknown => Reflect.get(obj, key)
+
+const authHeaders: HeadersInit = { Authorization: `Bearer ${TOKEN}` }
+
+describe('debug-server stats routes', () => {
+  beforeAll(async () => {
+    mockLogger()
+    await setupTestDb()
+    restoreFetch()
+    process.env['DEBUG_PORT'] = String(TEST_PORT)
+    process.env['DEBUG_TOKEN'] = TOKEN
+    process.env['ADMIN_USER_ID'] = 'admin-1'
+    startDebugServer('test-admin', getLogLevel())
+  })
+
+  beforeEach(async () => {
+    await setupTestDb()
+    clearStatsCacheForTesting()
+  })
+
+  afterAll(() => {
+    stopDebugServer()
+    delete process.env['DEBUG_PORT']
+    delete process.env['DEBUG_TOKEN']
+    delete process.env['ADMIN_USER_ID']
+  })
+
+  test('GET /stats/global without token returns 401', async () => {
+    const res = await fetch(`http://localhost:${TEST_PORT}/stats/global`)
+    expect(res.status).toBe(401)
+    await res.body?.cancel()
+  })
+
+  test('GET /stats/global with token returns GlobalStats shape', async () => {
+    const res = await fetch(`http://localhost:${TEST_PORT}/stats/global`, { headers: authHeaders })
+    expect(res.status).toBe(200)
+    const body = await readJson(res)
+    expect(pick(body, 'window')).toBe('30d')
+    expect(pick(body, 'subjects')).toBeDefined()
+    expect(pick(body, 'active')).toBeDefined()
+    expect(pick(body, 'distributions')).toBeDefined()
+    expect(pick(body, 'storage')).toBeDefined()
+    expect(pick(body, 'identityMix')).toBeDefined()
+    expect(pick(body, 'surfaceMix')).toBeDefined()
+    expect(pick(body, 'webFetches')).toBeDefined()
+    expect(pick(body, 'toolMix')).toBeDefined()
+  })
+
+  test('GET /stats/global?window=7d returns body with window 7d', async () => {
+    const res = await fetch(`http://localhost:${TEST_PORT}/stats/global?window=7d`, { headers: authHeaders })
+    expect(res.status).toBe(200)
+    const body = await readJson(res)
+    expect(pick(body, 'window')).toBe('7d')
+  })
+
+  test('GET /stats/global rejects unknown window with 400', async () => {
+    const res = await fetch(`http://localhost:${TEST_PORT}/stats/global?window=foo`, { headers: authHeaders })
+    expect(res.status).toBe(400)
+    await res.body?.cancel()
+  })
+
+  test('GET /stats/subject/<unknown> returns 404', async () => {
+    const res = await fetch(`http://localhost:${TEST_PORT}/stats/subject/nobody`, { headers: authHeaders })
+    expect(res.status).toBe(404)
+    await res.body?.cancel()
+  })
+
+  test('GET /stats/subject/<seeded> returns SubjectStats shape', async () => {
+    getTestDb().insert(users).values({ platformUserId: 'u1', username: 'alice', addedBy: 'admin' }).run()
+
+    const res = await fetch(`http://localhost:${TEST_PORT}/stats/subject/u1`, { headers: authHeaders })
+    expect(res.status).toBe(200)
+    const body = await readJson(res)
+    expect(pick(body, 'storageContextId')).toBe('u1')
+    expect(pick(body, 'contextType')).toBe('dm')
+    expect(pick(body, 'displayName')).toBe('alice')
+    expect(pick(body, 'memos')).toBeDefined()
+    expect(pick(body, 'llmUsage')).toBeDefined()
+    expect(pick(body, 'toolCalls')).toBeDefined()
+  })
+})

--- a/tests/debug/server-stats.test.ts
+++ b/tests/debug/server-stats.test.ts
@@ -95,7 +95,7 @@ describe('debug-server stats routes', () => {
     const body = await readJson(res)
     expect(pick(body, 'storageContextId')).toBe('u1')
     expect(pick(body, 'contextType')).toBe('dm')
-    expect(pick(body, 'displayName')).toBe('alice')
+    expect(pick(body, 'displayName')).toBeNull()
     expect(pick(body, 'memos')).toBeDefined()
     expect(pick(body, 'llmUsage')).toBeDefined()
     expect(pick(body, 'toolCalls')).toBeDefined()

--- a/tests/debug/stats-routes.test.ts
+++ b/tests/debug/stats-routes.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { handleStatsGlobal, handleStatsSubject } from '../../src/debug/stats-routes.js'
+
+describe('stats-routes module', () => {
+  test('exports the two stats handlers', () => {
+    expect(typeof handleStatsGlobal).toBe('function')
+    expect(typeof handleStatsSubject).toBe('function')
+  })
+})

--- a/tests/debug/subject-display-name.test.ts
+++ b/tests/debug/subject-display-name.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { users } from '../../src/db/schema.js'
+import { resolveDmDisplayNames } from '../../src/debug/subject-display-name.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('resolveDmDisplayNames', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns empty map when no DM subjects are passed', () => {
+    const result = resolveDmDisplayNames([])
+
+    expect(result.size).toBe(0)
+  })
+
+  test('returns empty map when only group subjects are passed', () => {
+    const result = resolveDmDisplayNames([{ storageContextId: 'group:123', contextType: 'group' }])
+
+    expect(result.size).toBe(0)
+  })
+
+  test('resolves DM display names from users.username', () => {
+    getDrizzleDb()
+      .insert(users)
+      .values([
+        { platformUserId: 'u1', username: 'alice', addedBy: 'test' },
+        { platformUserId: 'u2', username: 'bob', addedBy: 'test' },
+      ])
+      .run()
+
+    const result = resolveDmDisplayNames([
+      { storageContextId: 'u1', contextType: 'dm' },
+      { storageContextId: 'u2', contextType: 'dm' },
+    ])
+
+    expect(result.get('u1')).toBe('alice')
+    expect(result.get('u2')).toBe('bob')
+  })
+
+  test('returns null for DM subjects with no users row', () => {
+    const result = resolveDmDisplayNames([{ storageContextId: 'unknown', contextType: 'dm' }])
+
+    expect(result.size).toBe(0)
+  })
+
+  test('ignores group subjects when DM subjects are mixed in', () => {
+    getDrizzleDb()
+      .insert(users)
+      .values([{ platformUserId: 'u1', username: 'alice', addedBy: 'test' }])
+      .run()
+
+    const result = resolveDmDisplayNames([
+      { storageContextId: 'u1', contextType: 'dm' },
+      { storageContextId: 'group:42', contextType: 'group' },
+    ])
+
+    expect(result.get('u1')).toBe('alice')
+    expect(result.has('group:42')).toBe(false)
+  })
+})

--- a/tests/stats/aggregate.test.ts
+++ b/tests/stats/aggregate.test.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { percentiles } from '../../src/stats/aggregate.js'
+
+describe('percentiles', () => {
+  test('empty input returns all zeros with count zero', () => {
+    const result = percentiles([])
+
+    expect(result).toEqual({
+      count: 0,
+      min: 0,
+      p50: 0,
+      p90: 0,
+      p99: 0,
+      max: 0,
+      mean: 0,
+    })
+  })
+
+  test('single value returns count one with all stats equal to that value', () => {
+    const result = percentiles([5])
+
+    expect(result.count).toBe(1)
+    expect(result.min).toBe(5)
+    expect(result.p50).toBe(5)
+    expect(result.p90).toBe(5)
+    expect(result.p99).toBe(5)
+    expect(result.max).toBe(5)
+    expect(result.mean).toBe(5)
+  })
+
+  test('1..10 sorted input yields expected percentiles and mean', () => {
+    const result = percentiles([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+
+    expect(result.count).toBe(10)
+    expect(result.min).toBe(1)
+    expect(result.max).toBe(10)
+    expect(result.mean).toBe(5.5)
+    expect(result.p50).toBeGreaterThanOrEqual(5)
+    expect(result.p50).toBeLessThanOrEqual(6)
+    expect(result.p90).toBeGreaterThanOrEqual(9)
+    expect(result.p90).toBeLessThanOrEqual(10)
+    expect(result.p99).toBeGreaterThanOrEqual(9)
+    expect(result.p99).toBeLessThanOrEqual(10)
+  })
+
+  test('unsorted input is sorted internally and yields identical result', () => {
+    const sorted = percentiles([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    const unsorted = percentiles([10, 3, 7, 1, 9, 5, 2, 8, 4, 6])
+
+    expect(unsorted).toEqual(sorted)
+  })
+
+  test('duplicate values are counted correctly', () => {
+    const result = percentiles([2, 2, 2, 2, 2])
+
+    expect(result.count).toBe(5)
+    expect(result.min).toBe(2)
+    expect(result.max).toBe(2)
+    expect(result.mean).toBe(2)
+    expect(result.p50).toBe(2)
+    expect(result.p90).toBe(2)
+    expect(result.p99).toBe(2)
+  })
+
+  test('does not mutate the input array', () => {
+    const input = [10, 3, 7, 1, 9, 5, 2, 8, 4, 6]
+    const snapshot = [...input]
+
+    percentiles(input)
+
+    expect(input).toEqual(snapshot)
+  })
+})

--- a/tests/stats/global-distributions.test.ts
+++ b/tests/stats/global-distributions.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { attachments, memos, messageMetadata, recurringTasks, users } from '../../src/db/schema.js'
+import { distributionsGlobal } from '../../src/stats/global-distributions.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('distributionsGlobal', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zeroed percentiles when no rows exist', () => {
+    const result = distributionsGlobal()
+    expect(result.memosPerSubject.count).toBe(0)
+    expect(result.recurringTasksPerSubject.count).toBe(0)
+    expect(result.messageMetadataPerSubject.count).toBe(0)
+    expect(result.attachmentBytesPerSubject.count).toBe(0)
+  })
+
+  test('computes percentile distributions per subject across four tables', () => {
+    const subjects = ['s1', 's2', 's3', 's4', 's5']
+
+    getDrizzleDb()
+      .insert(users)
+      .values(subjects.map((id) => ({ platformUserId: id, addedBy: 'admin' })))
+      .run()
+
+    const memoRows = subjects.flatMap((id, idx) =>
+      Array.from({ length: idx + 1 }, (_, k) => ({
+        id: `${id}-m-${String(k)}`,
+        userId: id,
+        content: 'x',
+        tags: '[]',
+      })),
+    )
+    getDrizzleDb().insert(memos).values(memoRows).run()
+
+    const recurringRows = subjects.flatMap((id, idx) =>
+      Array.from({ length: idx + 1 }, (_, k) => ({
+        id: `${id}-r-${String(k)}`,
+        userId: id,
+        projectId: 'p',
+        title: 't',
+        enabled: '1',
+      })),
+    )
+    getDrizzleDb().insert(recurringTasks).values(recurringRows).run()
+
+    const messageRows = subjects.flatMap((id, idx) =>
+      Array.from({ length: idx + 1 }, (_, k) => ({
+        contextId: id,
+        messageId: `${id}-msg-${String(k)}`,
+        timestamp: 1000 + k,
+        expiresAt: 9999,
+      })),
+    )
+    getDrizzleDb().insert(messageMetadata).values(messageRows).run()
+
+    const attachmentRows = subjects.flatMap((id, idx) =>
+      Array.from({ length: idx + 1 }, (_, k) => ({
+        attachmentId: `${id}-a-${String(k)}`,
+        contextId: id,
+        sourceProvider: 'telegram',
+        filename: 'f.bin',
+        size: 100,
+        checksum: 'c',
+        blobKey: 'b',
+        status: 'stored',
+        isActive: 1,
+        createdAt: '2026-01-01T00:00:00Z',
+      })),
+    )
+    getDrizzleDb().insert(attachments).values(attachmentRows).run()
+
+    const result = distributionsGlobal()
+    expect(result.memosPerSubject.count).toBe(5)
+    expect(result.memosPerSubject.min).toBe(1)
+    expect(result.memosPerSubject.max).toBe(5)
+    expect(result.memosPerSubject.mean).toBe(3)
+
+    expect(result.recurringTasksPerSubject.count).toBe(5)
+    expect(result.recurringTasksPerSubject.max).toBe(5)
+
+    expect(result.messageMetadataPerSubject.count).toBe(5)
+    expect(result.messageMetadataPerSubject.max).toBe(5)
+
+    expect(result.attachmentBytesPerSubject.count).toBe(5)
+    expect(result.attachmentBytesPerSubject.min).toBe(100)
+    expect(result.attachmentBytesPerSubject.max).toBe(500)
+  })
+})

--- a/tests/stats/global-mix.test.ts
+++ b/tests/stats/global-mix.test.ts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import {
+  attachments,
+  authorizedGroups,
+  memos,
+  recurringTasks,
+  scheduledPrompts,
+  userIdentityMappings,
+  userInstructions,
+  users,
+} from '../../src/db/schema.js'
+import { identityMixGlobal, storageGlobal, surfaceMixGlobal } from '../../src/stats/global-mix.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('storageGlobal', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zero s3 bytes with no attachments; sqliteBytes via injected sizer', () => {
+    const result = storageGlobal({ dbFileSize: () => 12345 })
+    expect(result.s3AttachmentBytes).toBe(0)
+    expect(result.sqliteBytes).toBe(12345)
+  })
+
+  test('sums active attachment sizes into s3AttachmentBytes', () => {
+    getDrizzleDb()
+      .insert(attachments)
+      .values([
+        {
+          attachmentId: 'a1',
+          contextId: 'u1',
+          sourceProvider: 't',
+          filename: 'a',
+          size: 100,
+          checksum: 'c1',
+          blobKey: 'b1',
+          status: 'stored',
+          isActive: 1,
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+        {
+          attachmentId: 'a2',
+          contextId: 'u2',
+          sourceProvider: 't',
+          filename: 'b',
+          size: 250,
+          checksum: 'c2',
+          blobKey: 'b2',
+          status: 'stored',
+          isActive: 1,
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+        {
+          attachmentId: 'a3',
+          contextId: 'u3',
+          sourceProvider: 't',
+          filename: 'c',
+          size: 999,
+          checksum: 'c3',
+          blobKey: 'b3',
+          status: 'cleared',
+          isActive: 0,
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+      ])
+      .run()
+
+    const result = storageGlobal({ dbFileSize: () => 0 })
+    expect(result.s3AttachmentBytes).toBe(350)
+  })
+})
+
+describe('identityMixGlobal', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns empty mix when no identity rows', () => {
+    expect(identityMixGlobal()).toEqual({ byProvider: {}, kaneoWorkspaces: 0 })
+  })
+
+  test('counts identity mappings per provider and kaneo workspace presence', () => {
+    getDrizzleDb()
+      .insert(users)
+      .values([
+        { platformUserId: 'u1', addedBy: 'admin', kaneoWorkspaceId: 'w1' },
+        { platformUserId: 'u2', addedBy: 'admin', kaneoWorkspaceId: 'w2' },
+        { platformUserId: 'u3', addedBy: 'admin' },
+        { platformUserId: 'u4', addedBy: 'admin', kaneoWorkspaceId: '' },
+      ])
+      .run()
+
+    getDrizzleDb()
+      .insert(userIdentityMappings)
+      .values([
+        { contextId: 'u1', providerName: 'kaneo', matchedAt: '2026-01-01T00:00:00Z' },
+        { contextId: 'u2', providerName: 'kaneo', matchedAt: '2026-01-01T00:00:00Z' },
+        { contextId: 'u3', providerName: 'youtrack', matchedAt: '2026-01-01T00:00:00Z' },
+      ])
+      .run()
+
+    const result = identityMixGlobal()
+    expect(result.byProvider).toEqual({ kaneo: 2, youtrack: 1 })
+    expect(result.kaneoWorkspaces).toBe(2)
+  })
+})
+
+describe('surfaceMixGlobal', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zeros when nothing seeded', () => {
+    expect(surfaceMixGlobal()).toEqual({
+      subjectsWithRecurring: 0,
+      subjectsWithDeferred: 0,
+      subjectsWithMemos: 0,
+      subjectsWithInstructions: 0,
+    })
+  })
+
+  test('counts distinct subjects in each surface table', () => {
+    getDrizzleDb()
+      .insert(users)
+      .values([
+        { platformUserId: 'u1', addedBy: 'admin' },
+        { platformUserId: 'u2', addedBy: 'admin' },
+      ])
+      .run()
+    getDrizzleDb()
+      .insert(authorizedGroups)
+      .values([{ groupId: 'g1', addedBy: 'admin' }])
+      .run()
+
+    getDrizzleDb()
+      .insert(memos)
+      .values([
+        { id: 'm1', userId: 'u1', content: 'x', tags: '[]' },
+        { id: 'm2', userId: 'u1', content: 'x', tags: '[]' },
+        { id: 'm3', userId: 'u2', content: 'x', tags: '[]' },
+      ])
+      .run()
+    getDrizzleDb()
+      .insert(recurringTasks)
+      .values([{ id: 'r1', userId: 'u1', projectId: 'p', title: 't', enabled: '1' }])
+      .run()
+    getDrizzleDb()
+      .insert(scheduledPrompts)
+      .values([
+        {
+          id: 'sp1',
+          createdByUserId: 'u2',
+          deliveryContextId: 'u2',
+          prompt: 'p',
+          fireAt: '2026-01-01T00:00:00Z',
+          status: 'active',
+        },
+      ])
+      .run()
+    getDrizzleDb()
+      .insert(userInstructions)
+      .values([
+        { id: 'i1', contextId: 'u1', text: 't' },
+        { id: 'i2', contextId: 'g1', text: 't' },
+      ])
+      .run()
+
+    const result = surfaceMixGlobal()
+    expect(result.subjectsWithMemos).toBe(2)
+    expect(result.subjectsWithRecurring).toBe(1)
+    expect(result.subjectsWithDeferred).toBe(1)
+    expect(result.subjectsWithInstructions).toBe(2)
+  })
+})

--- a/tests/stats/global-subjects.test.ts
+++ b/tests/stats/global-subjects.test.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { authorizedGroups, llmUsageEvents, messageMetadata, users } from '../../src/db/schema.js'
+import { activeSubjectCounts, subjectsGlobal } from '../../src/stats/global-subjects.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+const ONE_DAY = 24 * 60 * 60 * 1000
+
+describe('subjectsGlobal', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zero counts and empty growth array when no subjects', () => {
+    const result = subjectsGlobal()
+    expect(result.dmTotal).toBe(0)
+    expect(result.groupTotal).toBe(0)
+    expect(result.growthLast30d).toEqual([])
+  })
+
+  test('counts users and authorized groups, builds growth points for last 30 days', () => {
+    const today = new Date()
+    const isoToday = today.toISOString().slice(0, 19).replace('T', ' ')
+    const tenDaysAgo = new Date(today.getTime() - 10 * ONE_DAY).toISOString().slice(0, 19).replace('T', ' ')
+    const fortyDaysAgo = new Date(today.getTime() - 40 * ONE_DAY).toISOString().slice(0, 19).replace('T', ' ')
+
+    getDrizzleDb()
+      .insert(users)
+      .values([
+        { platformUserId: 'u1', addedAt: isoToday, addedBy: 'admin' },
+        { platformUserId: 'u2', addedAt: tenDaysAgo, addedBy: 'admin' },
+        { platformUserId: 'u3', addedAt: fortyDaysAgo, addedBy: 'admin' },
+      ])
+      .run()
+
+    getDrizzleDb()
+      .insert(authorizedGroups)
+      .values([
+        { groupId: 'g1', addedBy: 'admin', addedAt: isoToday },
+        { groupId: 'g2', addedBy: 'admin', addedAt: fortyDaysAgo },
+      ])
+      .run()
+
+    const result = subjectsGlobal()
+
+    expect(result.dmTotal).toBe(3)
+    expect(result.groupTotal).toBe(2)
+
+    const totalDmInWindow = result.growthLast30d.reduce((sum, p) => sum + p.dmAdded, 0)
+    const totalGroupInWindow = result.growthLast30d.reduce((sum, p) => sum + p.groupAdded, 0)
+    expect(totalDmInWindow).toBe(2)
+    expect(totalGroupInWindow).toBe(1)
+  })
+})
+
+describe('activeSubjectCounts', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zero counts when no activity', () => {
+    expect(activeSubjectCounts(Date.now())).toEqual({ activeIn1d: 0, activeIn7d: 0, activeIn30d: 0 })
+  })
+
+  test('counts distinct subjects active in each window across usage + messages', () => {
+    const now = Date.now()
+    const within1d = now - 12 * 60 * 60 * 1000
+    const within7d = now - 3 * ONE_DAY
+    const within30d = now - 20 * ONE_DAY
+    const beyond = now - 60 * ONE_DAY
+
+    getDrizzleDb()
+      .insert(llmUsageEvents)
+      .values([
+        {
+          eventId: 'e1',
+          occurredAt: within1d,
+          storageContextId: 'u1',
+          contextType: 'dm',
+          chatUserId: 'u1',
+          model: 'm',
+          modelRole: 'main',
+          durationMs: 1,
+        },
+        {
+          eventId: 'e2',
+          occurredAt: within7d,
+          storageContextId: 'u2',
+          contextType: 'dm',
+          chatUserId: 'u2',
+          model: 'm',
+          modelRole: 'main',
+          durationMs: 1,
+        },
+        {
+          eventId: 'e3',
+          occurredAt: beyond,
+          storageContextId: 'u4',
+          contextType: 'dm',
+          chatUserId: 'u4',
+          model: 'm',
+          modelRole: 'main',
+          durationMs: 1,
+        },
+      ])
+      .run()
+
+    getDrizzleDb()
+      .insert(messageMetadata)
+      .values([
+        { contextId: 'g1', messageId: 'm1', timestamp: within30d, expiresAt: now + ONE_DAY },
+        { contextId: 'u1', messageId: 'm2', timestamp: within1d, expiresAt: now + ONE_DAY },
+      ])
+      .run()
+
+    const result = activeSubjectCounts(now)
+    expect(result.activeIn1d).toBe(1)
+    expect(result.activeIn7d).toBe(2)
+    expect(result.activeIn30d).toBe(3)
+  })
+})

--- a/tests/stats/global-web-tools.test.ts
+++ b/tests/stats/global-web-tools.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { toolCallEvents, webCache } from '../../src/db/schema.js'
+import { toolMixGlobal, webFetchesGlobal } from '../../src/stats/global-web-tools.js'
+import { keyedHash } from '../../src/stats/hashing.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('webFetchesGlobal', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns empty list when no cache rows', () => {
+    expect(webFetchesGlobal()).toEqual({ topHosts: [] })
+  })
+
+  test('groups by keyed-hashed host, never leaks plain hostnames', () => {
+    getDrizzleDb()
+      .insert(webCache)
+      .values([
+        {
+          urlHash: 'h1',
+          url: 'https://example.com/a',
+          finalUrl: 'https://example.com/a',
+          title: 't',
+          summary: 's',
+          excerpt: 'e',
+          contentType: 'text/html',
+          fetchedAt: 1,
+          expiresAt: 2,
+        },
+        {
+          urlHash: 'h2',
+          url: 'https://example.com/b',
+          finalUrl: 'https://example.com/b',
+          title: 't',
+          summary: 's',
+          excerpt: 'e',
+          contentType: 'text/html',
+          fetchedAt: 1,
+          expiresAt: 2,
+        },
+        {
+          urlHash: 'h3',
+          url: 'https://example.com/c',
+          finalUrl: 'https://example.com/c',
+          title: 't',
+          summary: 's',
+          excerpt: 'e',
+          contentType: 'text/html',
+          fetchedAt: 1,
+          expiresAt: 2,
+        },
+        {
+          urlHash: 'h4',
+          url: 'https://other.org/x',
+          finalUrl: 'https://other.org/x',
+          title: 't',
+          summary: 's',
+          excerpt: 'e',
+          contentType: 'text/html',
+          fetchedAt: 1,
+          expiresAt: 2,
+        },
+      ])
+      .run()
+
+    const result = webFetchesGlobal()
+
+    expect(result.topHosts[0]?.count).toBe(3)
+    expect(result.topHosts[0]?.hostHash).toBe(keyedHash('host:example.com'))
+    expect(result.topHosts[1]?.count).toBe(1)
+    expect(result.topHosts[1]?.hostHash).toBe(keyedHash('host:other.org'))
+
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toContain('example.com')
+    expect(serialized).not.toContain('other.org')
+  })
+})
+
+describe('toolMixGlobal', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns empty mix when no rows', () => {
+    expect(toolMixGlobal()).toEqual({ topTools: [], errorTypeCounts: {} })
+  })
+
+  test('aggregates tool counts, success rate, and error type counts globally', () => {
+    const base = {
+      turnId: 't',
+      contextType: 'dm',
+      chatUserId: 'u1',
+      model: 'm',
+      modelRole: 'main',
+      toolCallId: 'tc',
+    } as const
+
+    getDrizzleDb()
+      .insert(toolCallEvents)
+      .values([
+        { eventId: 't1', storageContextId: 'u1', occurredAt: 1, toolName: 'search_tasks', success: 1, ...base },
+        { eventId: 't2', storageContextId: 'u1', occurredAt: 2, toolName: 'search_tasks', success: 1, ...base },
+        {
+          eventId: 't3',
+          storageContextId: 'u2',
+          occurredAt: 3,
+          toolName: 'search_tasks',
+          success: 0,
+          ...base,
+          errorType: 'provider',
+        },
+        {
+          eventId: 't4',
+          storageContextId: 'u1',
+          occurredAt: 4,
+          toolName: 'create_task',
+          success: 0,
+          ...base,
+          errorType: 'network',
+        },
+        { eventId: 't5', storageContextId: 'u2', occurredAt: 5, toolName: 'create_task', success: 1, ...base },
+      ])
+      .run()
+
+    const result = toolMixGlobal()
+
+    expect(result.topTools[0]?.toolName).toBe('search_tasks')
+    expect(result.topTools[0]?.count).toBe(3)
+    expect(result.topTools[0]?.successRate).toBeCloseTo(2 / 3, 5)
+    expect(result.topTools[1]?.toolName).toBe('create_task')
+    expect(result.topTools[1]?.count).toBe(2)
+    expect(result.topTools[1]?.successRate).toBe(0.5)
+    expect(result.errorTypeCounts).toEqual({ network: 1, provider: 1 })
+  })
+})

--- a/tests/stats/hashing.test.ts
+++ b/tests/stats/hashing.test.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { sql } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { systemConfig } from '../../src/db/schema.js'
+import {
+  STATS_ANONYMITY_SALT_KEY,
+  getStatsAnonymitySalt,
+  keyedHash,
+  resetStatsSaltCacheForTesting,
+} from '../../src/stats/hashing.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('stats hashing', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+    resetStatsSaltCacheForTesting()
+  })
+
+  test('getStatsAnonymitySalt lazily creates a salt on first call', () => {
+    const before = getDrizzleDb()
+      .select()
+      .from(systemConfig)
+      .where(sql`${systemConfig.key} = ${STATS_ANONYMITY_SALT_KEY}`)
+      .all()
+    expect(before).toHaveLength(0)
+
+    const salt = getStatsAnonymitySalt()
+
+    expect(salt).toBeTruthy()
+    expect(salt.length).toBeGreaterThanOrEqual(32)
+
+    const after = getDrizzleDb()
+      .select()
+      .from(systemConfig)
+      .where(sql`${systemConfig.key} = ${STATS_ANONYMITY_SALT_KEY}`)
+      .all()
+    expect(after).toHaveLength(1)
+    expect(after[0]?.value).toBe(salt)
+  })
+
+  test('getStatsAnonymitySalt returns the same salt across calls', () => {
+    const first = getStatsAnonymitySalt()
+    const second = getStatsAnonymitySalt()
+
+    expect(second).toBe(first)
+  })
+
+  test('keyedHash is deterministic for the same input', () => {
+    const a = keyedHash('hostname:example.com')
+    const b = keyedHash('hostname:example.com')
+
+    expect(a).toBe(b)
+  })
+
+  test('keyedHash returns different values for different inputs', () => {
+    const a = keyedHash('hostname:example.com')
+    const b = keyedHash('hostname:other.com')
+
+    expect(a).not.toBe(b)
+  })
+
+  test('keyedHash output is a hex string of length 64 (SHA-256)', () => {
+    const hash = keyedHash('any-input')
+
+    expect(hash).toMatch(/^[0-9a-f]{64}$/u)
+  })
+
+  test('keyedHash output depends on the salt', () => {
+    const beforeSalt = getStatsAnonymitySalt()
+    const beforeHash = keyedHash('hostname:example.com')
+
+    // Rotate the salt by clearing and reseeding.
+    getDrizzleDb()
+      .delete(systemConfig)
+      .where(sql`${systemConfig.key} = ${STATS_ANONYMITY_SALT_KEY}`)
+      .run()
+    resetStatsSaltCacheForTesting()
+
+    const afterSalt = getStatsAnonymitySalt()
+    const afterHash = keyedHash('hostname:example.com')
+
+    expect(afterSalt).not.toBe(beforeSalt)
+    expect(afterHash).not.toBe(beforeHash)
+  })
+})

--- a/tests/stats/index.test.ts
+++ b/tests/stats/index.test.ts
@@ -49,7 +49,7 @@ describe('getSubjectStats', () => {
     expect(result?.storageContextId).toBe('u1')
     expect(result?.contextType).toBe('dm')
     expect(result?.chatUserId).toBe('u1')
-    expect(result?.displayName).toBe('alice')
+    expect(result?.displayName).toBeNull()
     expect(result?.userBlock).not.toBeNull()
     expect(result?.groupBlock).toBeNull()
     expect(result?.llmUsage.rowCount).toBe(1)

--- a/tests/stats/index.test.ts
+++ b/tests/stats/index.test.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { authorizedGroups, groupMembers, llmUsageEvents, users } from '../../src/db/schema.js'
+import { clearStatsCacheForTesting, getGlobalStats, getSubjectStats } from '../../src/stats/index.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('getSubjectStats', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+    clearStatsCacheForTesting()
+  })
+
+  test('returns null for unknown subject', () => {
+    expect(getSubjectStats('nobody')).toBeNull()
+  })
+
+  test('returns populated SubjectStats with userBlock for a DM subject', () => {
+    getDrizzleDb()
+      .insert(users)
+      .values([{ platformUserId: 'u1', addedBy: 'admin', username: 'alice' }])
+      .run()
+    getDrizzleDb()
+      .insert(llmUsageEvents)
+      .values([
+        {
+          eventId: 'e1',
+          occurredAt: 1000,
+          storageContextId: 'u1',
+          contextType: 'dm',
+          chatUserId: 'u1',
+          model: 'm',
+          modelRole: 'main',
+          inputTokens: 50,
+          outputTokens: 25,
+          durationMs: 1,
+        },
+      ])
+      .run()
+
+    const result = getSubjectStats('u1')
+    expect(result).not.toBeNull()
+    expect(result?.storageContextId).toBe('u1')
+    expect(result?.contextType).toBe('dm')
+    expect(result?.chatUserId).toBe('u1')
+    expect(result?.displayName).toBe('alice')
+    expect(result?.userBlock).not.toBeNull()
+    expect(result?.groupBlock).toBeNull()
+    expect(result?.llmUsage.rowCount).toBe(1)
+    expect(result?.llmUsage.inputTokensTotal).toBe(50)
+  })
+
+  test('returns SubjectStats with groupBlock present for a group subject', () => {
+    getDrizzleDb()
+      .insert(authorizedGroups)
+      .values([{ groupId: 'g1', addedBy: 'admin' }])
+      .run()
+    getDrizzleDb()
+      .insert(groupMembers)
+      .values([{ groupId: 'g1', userId: 'u1', addedBy: 'admin' }])
+      .run()
+
+    const result = getSubjectStats('g1')
+    expect(result).not.toBeNull()
+    expect(result?.contextType).toBe('group')
+    expect(result?.userBlock).toBeNull()
+    expect(result?.groupBlock).not.toBeNull()
+    expect(result?.groupBlock?.memberCount).toBe(1)
+  })
+})
+
+describe('getGlobalStats', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+    clearStatsCacheForTesting()
+  })
+
+  test('returns shape with all top-level keys', () => {
+    const result = getGlobalStats()
+    expect(result.subjects).toBeDefined()
+    expect(result.active).toBeDefined()
+    expect(result.distributions).toBeDefined()
+    expect(result.storage).toBeDefined()
+    expect(result.identityMix).toBeDefined()
+    expect(result.surfaceMix).toBeDefined()
+    expect(result.webFetches).toBeDefined()
+    expect(result.toolMix).toBeDefined()
+    expect(typeof result.generatedAt).toBe('number')
+  })
+
+  test('caches result across back-to-back default calls', () => {
+    const a = getGlobalStats()
+    const b = getGlobalStats()
+    expect(a).toBe(b)
+  })
+
+  test('noCache option recomputes every call', () => {
+    const a = getGlobalStats({ noCache: true })
+    const b = getGlobalStats({ noCache: true })
+    expect(a).not.toBe(b)
+  })
+
+  test('cache invalidated when window parameter changes', () => {
+    const a = getGlobalStats({ window: '7d' })
+    const b = getGlobalStats({ window: '30d' })
+    expect(a).not.toBe(b)
+    expect(a.window).toBe('7d')
+    expect(b.window).toBe('30d')
+  })
+})

--- a/tests/stats/internal/util.test.ts
+++ b/tests/stats/internal/util.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { parseIsoToMs, safeParseTags } from '../../../src/stats/internal/util.js'
+
+describe('parseIsoToMs', () => {
+  test('returns null for null or empty input', () => {
+    expect(parseIsoToMs(null)).toBeNull()
+    expect(parseIsoToMs('')).toBeNull()
+  })
+
+  test('parses standard ISO timestamps', () => {
+    expect(parseIsoToMs('2026-01-01T00:00:00Z')).toBe(Date.parse('2026-01-01T00:00:00Z'))
+  })
+
+  test('parses space-separated SQLite datetime by inserting T and Z', () => {
+    expect(parseIsoToMs('2026-01-01 00:00:00')).toBe(Date.parse('2026-01-01T00:00:00Z'))
+  })
+
+  test('returns null on garbage input', () => {
+    expect(parseIsoToMs('not-a-date')).toBeNull()
+  })
+})
+
+describe('safeParseTags', () => {
+  test('returns an array of strings on valid JSON array', () => {
+    expect(safeParseTags('["a","b"]')).toEqual(['a', 'b'])
+  })
+
+  test('skips non-string entries', () => {
+    expect(safeParseTags('["a",1,"b",null]')).toEqual(['a', 'b'])
+  })
+
+  test('returns empty array on malformed JSON', () => {
+    expect(safeParseTags('not-json')).toEqual([])
+  })
+
+  test('returns empty array on non-array JSON', () => {
+    expect(safeParseTags('{"a":1}')).toEqual([])
+  })
+})

--- a/tests/stats/per-table-attachments.test.ts
+++ b/tests/stats/per-table-attachments.test.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { attachments } from '../../src/db/schema.js'
+import { attachmentsForSubject } from '../../src/stats/per-table-content.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('attachmentsForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zero-shape when subject has no attachments', () => {
+    expect(attachmentsForSubject('nobody')).toEqual({
+      total: 0,
+      byStatus: {},
+      bySourceProvider: {},
+      storedBytesTotal: 0,
+      active: 0,
+      byExtension: {},
+    })
+  })
+
+  test('aggregates counts, status/provider mix, bytes, active, extension mix', () => {
+    getDrizzleDb()
+      .insert(attachments)
+      .values([
+        {
+          attachmentId: 'a1',
+          contextId: 'u1',
+          sourceProvider: 'telegram',
+          filename: 'photo.JPG',
+          size: 1000,
+          checksum: 'c1',
+          blobKey: 'b1',
+          status: 'stored',
+          isActive: 1,
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+        {
+          attachmentId: 'a2',
+          contextId: 'u1',
+          sourceProvider: 'telegram',
+          filename: 'doc.pdf',
+          size: 500,
+          checksum: 'c2',
+          blobKey: 'b2',
+          status: 'stored',
+          isActive: 1,
+          createdAt: '2026-01-02T00:00:00Z',
+        },
+        {
+          attachmentId: 'a3',
+          contextId: 'u1',
+          sourceProvider: 'mattermost',
+          filename: 'archive.tar.gz',
+          size: 200,
+          checksum: 'c3',
+          blobKey: 'b3',
+          status: 'cleared',
+          isActive: 0,
+          createdAt: '2026-01-03T00:00:00Z',
+        },
+        {
+          attachmentId: 'a4',
+          contextId: 'u1',
+          sourceProvider: 'telegram',
+          filename: 'no_extension',
+          size: null,
+          checksum: 'c4',
+          blobKey: 'b4',
+          status: 'stored',
+          isActive: 1,
+          createdAt: '2026-01-04T00:00:00Z',
+        },
+        {
+          attachmentId: 'a5',
+          contextId: 'other',
+          sourceProvider: 'telegram',
+          filename: 'leak.txt',
+          size: 9999,
+          checksum: 'c5',
+          blobKey: 'b5',
+          status: 'stored',
+          isActive: 1,
+          createdAt: '2026-01-05T00:00:00Z',
+        },
+      ])
+      .run()
+
+    const result = attachmentsForSubject('u1')
+
+    expect(result.total).toBe(4)
+    expect(result.byStatus).toEqual({ stored: 3, cleared: 1 })
+    expect(result.bySourceProvider).toEqual({ telegram: 3, mattermost: 1 })
+    expect(result.storedBytesTotal).toBe(1000 + 500 + 200)
+    expect(result.active).toBe(3)
+    expect(result.byExtension['jpg']).toBe(1)
+    expect(result.byExtension['pdf']).toBe(1)
+    expect(result.byExtension['gz']).toBe(1)
+    expect(result.byExtension['(none)']).toBe(1)
+  })
+})

--- a/tests/stats/per-table-content.test.ts
+++ b/tests/stats/per-table-content.test.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  attachmentsForSubject,
+  conversationForSubject,
+  messageMetadataForSubject,
+} from '../../src/stats/per-table-content.js'
+
+describe('per-table-content helpers smoke check', () => {
+  test('all content helpers exported as functions', () => {
+    expect(typeof attachmentsForSubject).toBe('function')
+    expect(typeof messageMetadataForSubject).toBe('function')
+    expect(typeof conversationForSubject).toBe('function')
+  })
+})

--- a/tests/stats/per-table-conversation.test.ts
+++ b/tests/stats/per-table-conversation.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { conversationHistory, memorySummary } from '../../src/db/schema.js'
+import { conversationForSubject } from '../../src/stats/per-table-content.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('conversationForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zero turns and no summary when nothing seeded', () => {
+    expect(conversationForSubject('nobody')).toEqual({ turnCount: 0, summaryPresent: false })
+  })
+
+  test('counts JSON array length and detects summary presence', () => {
+    getDrizzleDb()
+      .insert(conversationHistory)
+      .values({ userId: 'u1', messages: JSON.stringify([{ role: 'user' }, { role: 'assistant' }, { role: 'user' }]) })
+      .run()
+    getDrizzleDb().insert(memorySummary).values({ userId: 'u1', summary: 's', updatedAt: '2026-01-01T00:00:00Z' }).run()
+
+    const result = conversationForSubject('u1')
+
+    expect(result.turnCount).toBe(3)
+    expect(result.summaryPresent).toBe(true)
+  })
+
+  test('handles empty array and missing summary', () => {
+    getDrizzleDb().insert(conversationHistory).values({ userId: 'u1', messages: '[]' }).run()
+
+    const result = conversationForSubject('u1')
+
+    expect(result.turnCount).toBe(0)
+    expect(result.summaryPresent).toBe(false)
+  })
+
+  test('handles malformed JSON gracefully', () => {
+    getDrizzleDb().insert(conversationHistory).values({ userId: 'u1', messages: 'not-json' }).run()
+
+    const result = conversationForSubject('u1')
+
+    expect(result.turnCount).toBe(0)
+  })
+})

--- a/tests/stats/per-table-identity.test.ts
+++ b/tests/stats/per-table-identity.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { userIdentityMappings } from '../../src/db/schema.js'
+import { identityForSubject } from '../../src/stats/per-table-subject.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('identityForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns empty record when subject has no mappings', () => {
+    expect(identityForSubject('nobody')).toEqual({})
+  })
+
+  test('returns mapping counts grouped by provider name', () => {
+    getDrizzleDb()
+      .insert(userIdentityMappings)
+      .values([
+        { contextId: 'u1', providerName: 'kaneo', providerUserId: 'k1', matchedAt: '2026-01-01T00:00:00Z' },
+        { contextId: 'u1', providerName: 'youtrack', providerUserId: 'y1', matchedAt: '2026-01-02T00:00:00Z' },
+        { contextId: 'other', providerName: 'kaneo', providerUserId: 'k2', matchedAt: '2026-01-03T00:00:00Z' },
+      ])
+      .run()
+
+    const result = identityForSubject('u1')
+
+    expect(result).toEqual({ kaneo: 1, youtrack: 1 })
+  })
+})

--- a/tests/stats/per-table-instructions.test.ts
+++ b/tests/stats/per-table-instructions.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { userInstructions } from '../../src/db/schema.js'
+import { instructionsForSubject } from '../../src/stats/per-table.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('instructionsForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zero-shape when subject has no instructions', () => {
+    expect(instructionsForSubject('nobody')).toEqual({ total: 0, textBytesTotal: 0 })
+  })
+
+  test('aggregates total count and text-byte total', () => {
+    getDrizzleDb()
+      .insert(userInstructions)
+      .values([
+        { id: 'i1', contextId: 'u1', text: 'hello' },
+        { id: 'i2', contextId: 'u1', text: 'world!' },
+        { id: 'i3', contextId: 'other', text: 'leak' },
+      ])
+      .run()
+
+    const result = instructionsForSubject('u1')
+
+    expect(result.total).toBe(2)
+    expect(result.textBytesTotal).toBe(5 + 6)
+  })
+})

--- a/tests/stats/per-table-memos.test.ts
+++ b/tests/stats/per-table-memos.test.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { memos } from '../../src/db/schema.js'
+import { memosForSubject } from '../../src/stats/per-table.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('memosForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns all-zero shape when subject has no memos', () => {
+    const result = memosForSubject('nobody')
+
+    expect(result).toEqual({
+      total: 0,
+      byStatus: {},
+      tagCardinality: { distinct: 0, meanPerMemo: 0 },
+      contentBytesTotal: 0,
+      embeddingBytesTotal: 0,
+      withEmbedding: 0,
+      oldestCreatedAt: null,
+      newestCreatedAt: null,
+    })
+  })
+
+  test('aggregates counts, status mix, content bytes, tag cardinality and embedding presence', () => {
+    const blob1 = new Uint8Array([1, 2, 3, 4])
+    const blob2 = new Uint8Array([5, 6])
+
+    getDrizzleDb()
+      .insert(memos)
+      .values([
+        {
+          id: 'm1',
+          userId: 'u1',
+          content: 'aaaa',
+          tags: '["work","urgent"]',
+          status: 'active',
+          embedding: blob1,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+        {
+          id: 'm2',
+          userId: 'u1',
+          content: 'bb',
+          tags: '["work"]',
+          status: 'active',
+          embedding: blob2,
+          createdAt: '2026-01-02T00:00:00Z',
+          updatedAt: '2026-01-02T00:00:00Z',
+        },
+        {
+          id: 'm3',
+          userId: 'u1',
+          content: 'c',
+          tags: '["personal"]',
+          status: 'archived',
+          createdAt: '2026-01-03T00:00:00Z',
+          updatedAt: '2026-01-03T00:00:00Z',
+        },
+        {
+          id: 'm4',
+          userId: 'other',
+          content: 'should not count',
+          tags: '["leak"]',
+          status: 'active',
+          createdAt: '2026-01-04T00:00:00Z',
+          updatedAt: '2026-01-04T00:00:00Z',
+        },
+      ])
+      .run()
+
+    const result = memosForSubject('u1')
+
+    expect(result.total).toBe(3)
+    expect(result.byStatus).toEqual({ active: 2, archived: 1 })
+    expect(result.contentBytesTotal).toBe(4 + 2 + 1)
+    expect(result.embeddingBytesTotal).toBe(4 + 2)
+    expect(result.withEmbedding).toBe(2)
+    expect(result.tagCardinality.distinct).toBe(3)
+    expect(result.tagCardinality.meanPerMemo).toBeCloseTo(4 / 3, 5)
+    const oldest = result.oldestCreatedAt
+    const newest = result.newestCreatedAt
+    expect(oldest).not.toBeNull()
+    expect(newest).not.toBeNull()
+    expect(Number(oldest)).toBeLessThan(Number(newest))
+  })
+})

--- a/tests/stats/per-table-messages.test.ts
+++ b/tests/stats/per-table-messages.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { messageMetadata } from '../../src/db/schema.js'
+import { messageMetadataForSubject } from '../../src/stats/per-table-content.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('messageMetadataForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zero-shape when subject has no messages', () => {
+    expect(messageMetadataForSubject('nobody')).toEqual({
+      total: 0,
+      authoredBySubject: 0,
+      oldestTimestamp: null,
+      newestTimestamp: null,
+      textBytesTotal: 0,
+    })
+  })
+
+  test('aggregates total, authored-by-subject count, oldest/newest, text bytes', () => {
+    getDrizzleDb()
+      .insert(messageMetadata)
+      .values([
+        {
+          contextId: 'u1',
+          messageId: '1',
+          authorId: 'u1',
+          text: 'hello',
+          timestamp: 1000,
+          expiresAt: 9000,
+        },
+        {
+          contextId: 'u1',
+          messageId: '2',
+          authorId: 'someone-else',
+          text: 'world!',
+          timestamp: 2000,
+          expiresAt: 9000,
+        },
+        {
+          contextId: 'u1',
+          messageId: '3',
+          authorId: 'u1',
+          text: null,
+          timestamp: 3000,
+          expiresAt: 9000,
+        },
+        {
+          contextId: 'other',
+          messageId: '4',
+          authorId: 'other',
+          text: 'leak',
+          timestamp: 9999,
+          expiresAt: 9999,
+        },
+      ])
+      .run()
+
+    const result = messageMetadataForSubject('u1')
+
+    expect(result.total).toBe(3)
+    expect(result.authoredBySubject).toBe(2)
+    expect(result.oldestTimestamp).toBe(1000)
+    expect(result.newestTimestamp).toBe(3000)
+    expect(result.textBytesTotal).toBe(5 + 6)
+  })
+})

--- a/tests/stats/per-table-prompts.test.ts
+++ b/tests/stats/per-table-prompts.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { alertPrompts, scheduledPrompts } from '../../src/db/schema.js'
+import { alertsForSubject, scheduledForSubject } from '../../src/stats/per-table.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('scheduledForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zero-shape when subject has no scheduled prompts', () => {
+    const result = scheduledForSubject('nobody')
+
+    expect(result).toEqual({ total: 0, byStatus: {}, distinctDeliveryTargets: 0 })
+  })
+
+  test('aggregates totals, byStatus, and distinct delivery contexts', () => {
+    getDrizzleDb()
+      .insert(scheduledPrompts)
+      .values([
+        {
+          id: 's1',
+          createdByUserId: 'u1',
+          deliveryContextId: 'u1',
+          prompt: 'p',
+          fireAt: '2026-02-01T00:00:00Z',
+          status: 'active',
+        },
+        {
+          id: 's2',
+          createdByUserId: 'u1',
+          deliveryContextId: 'u1',
+          prompt: 'p',
+          fireAt: '2026-02-02T00:00:00Z',
+          status: 'active',
+        },
+        {
+          id: 's3',
+          createdByUserId: 'u1',
+          deliveryContextId: 'group:42',
+          prompt: 'p',
+          fireAt: '2026-02-03T00:00:00Z',
+          status: 'cancelled',
+        },
+        {
+          id: 's4',
+          createdByUserId: 'other',
+          deliveryContextId: 'other',
+          prompt: 'p',
+          fireAt: '2026-02-04T00:00:00Z',
+          status: 'active',
+        },
+      ])
+      .run()
+
+    const result = scheduledForSubject('u1')
+
+    expect(result.total).toBe(3)
+    expect(result.byStatus).toEqual({ active: 2, cancelled: 1 })
+    expect(result.distinctDeliveryTargets).toBe(2)
+  })
+})
+
+describe('alertsForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zero-shape when subject has no alert prompts', () => {
+    const result = alertsForSubject('nobody')
+
+    expect(result).toEqual({ total: 0, byStatus: {} })
+  })
+
+  test('aggregates totals and byStatus', () => {
+    getDrizzleDb()
+      .insert(alertPrompts)
+      .values([
+        { id: 'a1', createdByUserId: 'u1', prompt: 'p', condition: 'c', status: 'active' },
+        { id: 'a2', createdByUserId: 'u1', prompt: 'p', condition: 'c', status: 'paused' },
+        { id: 'a3', createdByUserId: 'u1', prompt: 'p', condition: 'c', status: 'active' },
+        { id: 'a4', createdByUserId: 'other', prompt: 'p', condition: 'c', status: 'active' },
+      ])
+      .run()
+
+    const result = alertsForSubject('u1')
+
+    expect(result.total).toBe(3)
+    expect(result.byStatus).toEqual({ active: 2, paused: 1 })
+  })
+})

--- a/tests/stats/per-table-recurring.test.ts
+++ b/tests/stats/per-table-recurring.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { recurringTasks, users } from '../../src/db/schema.js'
+import { recurringForSubject } from '../../src/stats/per-table.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('recurringForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+    getDrizzleDb()
+      .insert(users)
+      .values([
+        { platformUserId: 'u1', addedBy: 'test' },
+        { platformUserId: 'other', addedBy: 'test' },
+      ])
+      .run()
+  })
+
+  test('returns zero-shape when subject has no recurring tasks', () => {
+    const result = recurringForSubject('u1')
+
+    expect(result).toEqual({
+      total: 0,
+      enabled: 0,
+      disabled: 0,
+      distinctProjects: 0,
+      nextRunWithin7d: 0,
+      distinctRrulePatterns: 0,
+    })
+  })
+
+  test('aggregates total, enabled/disabled, distinct projects, next-run-within-7d, distinct rrule patterns', () => {
+    const now = Date.now()
+    const within7d = new Date(now + 2 * 24 * 60 * 60 * 1000).toISOString()
+    const beyond7d = new Date(now + 30 * 24 * 60 * 60 * 1000).toISOString()
+
+    getDrizzleDb()
+      .insert(recurringTasks)
+      .values([
+        {
+          id: 'r1',
+          userId: 'u1',
+          projectId: 'p1',
+          title: 't',
+          enabled: '1',
+          rrule: 'FREQ=DAILY',
+          nextRun: within7d,
+        },
+        {
+          id: 'r2',
+          userId: 'u1',
+          projectId: 'p1',
+          title: 't',
+          enabled: '1',
+          rrule: 'FREQ=DAILY',
+          nextRun: within7d,
+        },
+        {
+          id: 'r3',
+          userId: 'u1',
+          projectId: 'p2',
+          title: 't',
+          enabled: '0',
+          rrule: 'FREQ=WEEKLY',
+          nextRun: beyond7d,
+        },
+        {
+          id: 'r4',
+          userId: 'u1',
+          projectId: 'p2',
+          title: 't',
+          enabled: '1',
+          rrule: null,
+          nextRun: null,
+        },
+        {
+          id: 'r5',
+          userId: 'other',
+          projectId: 'p9',
+          title: 't',
+          enabled: '1',
+          rrule: 'FREQ=MONTHLY',
+          nextRun: within7d,
+        },
+      ])
+      .run()
+
+    const result = recurringForSubject('u1')
+
+    expect(result.total).toBe(4)
+    expect(result.enabled).toBe(3)
+    expect(result.disabled).toBe(1)
+    expect(result.distinctProjects).toBe(2)
+    expect(result.nextRunWithin7d).toBe(2)
+    expect(result.distinctRrulePatterns).toBe(2)
+  })
+})

--- a/tests/stats/per-table-staged.test.ts
+++ b/tests/stats/per-table-staged.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { stagedFiles } from '../../src/db/schema.js'
+import { stagedForSubject } from '../../src/stats/per-table-subject.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('stagedForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zero-shape when subject has no staged files', () => {
+    expect(stagedForSubject('nobody')).toEqual({ total: 0, byStatus: {}, bytesTotal: 0 })
+  })
+
+  test('aggregates total, status mix and total bytes', () => {
+    getDrizzleDb()
+      .insert(stagedFiles)
+      .values([
+        {
+          stagedId: 's1',
+          contextId: 'u1',
+          senderId: 'u1',
+          filename: 'f.txt',
+          platformFileId: 'p1',
+          sourceProvider: 'telegram',
+          status: 'staged',
+          size: 100,
+          createdAt: '2026-01-01',
+          expiresAt: '2026-01-02',
+        },
+        {
+          stagedId: 's2',
+          contextId: 'u1',
+          senderId: 'u1',
+          filename: 'g.txt',
+          platformFileId: 'p2',
+          sourceProvider: 'telegram',
+          status: 'staged',
+          size: 50,
+          createdAt: '2026-01-01',
+          expiresAt: '2026-01-02',
+        },
+        {
+          stagedId: 's3',
+          contextId: 'u1',
+          senderId: 'u1',
+          filename: 'h.txt',
+          platformFileId: 'p3',
+          sourceProvider: 'telegram',
+          status: 'attached',
+          size: null,
+          createdAt: '2026-01-01',
+          expiresAt: '2026-01-02',
+        },
+        {
+          stagedId: 's4',
+          contextId: 'other',
+          senderId: 'other',
+          filename: 'x.txt',
+          platformFileId: 'p4',
+          sourceProvider: 'telegram',
+          status: 'staged',
+          size: 999,
+          createdAt: '2026-01-01',
+          expiresAt: '2026-01-02',
+        },
+      ])
+      .run()
+
+    const result = stagedForSubject('u1')
+
+    expect(result.total).toBe(3)
+    expect(result.byStatus).toEqual({ staged: 2, attached: 1 })
+    expect(result.bytesTotal).toBe(150)
+  })
+})

--- a/tests/stats/per-table-subject.test.ts
+++ b/tests/stats/per-table-subject.test.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  groupBlockForSubject,
+  identityForSubject,
+  stagedForSubject,
+  userBlockForSubject,
+} from '../../src/stats/per-table-subject.js'
+
+describe('per-table-subject helpers smoke check', () => {
+  test('all subject helpers exported as functions', () => {
+    expect(typeof identityForSubject).toBe('function')
+    expect(typeof stagedForSubject).toBe('function')
+    expect(typeof userBlockForSubject).toBe('function')
+    expect(typeof groupBlockForSubject).toBe('function')
+  })
+})

--- a/tests/stats/per-table-usage-tools.test.ts
+++ b/tests/stats/per-table-usage-tools.test.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { llmUsageEvents, toolCallEvents } from '../../src/db/schema.js'
+import { llmUsageForSubject, toolCallsForSubject } from '../../src/stats/per-table-usage.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('llmUsageForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zero-shape when subject has no events', () => {
+    expect(llmUsageForSubject('nobody')).toEqual({ rowCount: 0, inputTokensTotal: 0, outputTokensTotal: 0 })
+  })
+
+  test('aggregates row count and token totals across events', () => {
+    getDrizzleDb()
+      .insert(llmUsageEvents)
+      .values([
+        {
+          eventId: 'e1',
+          occurredAt: 1000,
+          storageContextId: 'u1',
+          contextType: 'dm',
+          chatUserId: 'u1',
+          model: 'm',
+          modelRole: 'main',
+          inputTokens: 100,
+          outputTokens: 50,
+          durationMs: 10,
+        },
+        {
+          eventId: 'e2',
+          occurredAt: 2000,
+          storageContextId: 'u1',
+          contextType: 'dm',
+          chatUserId: 'u1',
+          model: 'm',
+          modelRole: 'small',
+          inputTokens: 20,
+          outputTokens: 10,
+          durationMs: 10,
+        },
+        {
+          eventId: 'e3',
+          occurredAt: 3000,
+          storageContextId: 'u1',
+          contextType: 'dm',
+          chatUserId: 'u1',
+          model: 'm',
+          modelRole: 'main',
+          inputTokens: null,
+          outputTokens: null,
+          durationMs: 10,
+        },
+        {
+          eventId: 'e4',
+          occurredAt: 1000,
+          storageContextId: 'other',
+          contextType: 'dm',
+          chatUserId: 'other',
+          model: 'm',
+          modelRole: 'main',
+          inputTokens: 9999,
+          outputTokens: 9999,
+          durationMs: 10,
+        },
+      ])
+      .run()
+
+    const result = llmUsageForSubject('u1')
+
+    expect(result.rowCount).toBe(3)
+    expect(result.inputTokensTotal).toBe(120)
+    expect(result.outputTokensTotal).toBe(60)
+  })
+})
+
+describe('toolCallsForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zero-shape when subject has no tool-call events', () => {
+    expect(toolCallsForSubject('nobody')).toEqual({
+      total: 0,
+      success: 0,
+      failure: 0,
+      topTools: [],
+      errorTypeCounts: {},
+    })
+  })
+
+  test('aggregates total, success/failure, top tools and error type counts', () => {
+    const base = {
+      turnId: 't',
+      contextType: 'dm',
+      chatUserId: 'u1',
+      model: 'm',
+      modelRole: 'main',
+      toolCallId: 'tc',
+    } as const
+
+    getDrizzleDb()
+      .insert(toolCallEvents)
+      .values([
+        { eventId: 't1', storageContextId: 'u1', occurredAt: 1, toolName: 'search_tasks', success: 1, ...base },
+        { eventId: 't2', storageContextId: 'u1', occurredAt: 2, toolName: 'search_tasks', success: 1, ...base },
+        { eventId: 't3', storageContextId: 'u1', occurredAt: 3, toolName: 'search_tasks', success: 1, ...base },
+        {
+          eventId: 't4',
+          storageContextId: 'u1',
+          occurredAt: 4,
+          toolName: 'create_task',
+          success: 0,
+          errorType: 'network',
+          ...base,
+        },
+        {
+          eventId: 't5',
+          storageContextId: 'u1',
+          occurredAt: 5,
+          toolName: 'create_task',
+          success: 0,
+          errorType: 'network',
+          ...base,
+        },
+        {
+          eventId: 't6',
+          storageContextId: 'u1',
+          occurredAt: 6,
+          toolName: 'get_task',
+          success: 0,
+          errorType: 'provider',
+          ...base,
+        },
+        { eventId: 't7', storageContextId: 'other', occurredAt: 7, toolName: 'leak', success: 1, ...base },
+      ])
+      .run()
+
+    const result = toolCallsForSubject('u1')
+
+    expect(result.total).toBe(6)
+    expect(result.success).toBe(3)
+    expect(result.failure).toBe(3)
+    expect(result.topTools[0]?.toolName).toBe('search_tasks')
+    expect(result.topTools[0]?.count).toBe(3)
+    expect(result.errorTypeCounts).toEqual({ network: 2, provider: 1 })
+  })
+})

--- a/tests/stats/per-table-usage.test.ts
+++ b/tests/stats/per-table-usage.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { llmUsageForSubject, toolCallsForSubject, webFetchesForSubject } from '../../src/stats/per-table-usage.js'
+
+describe('per-table-usage helpers smoke check', () => {
+  test('all usage helpers exported as functions', () => {
+    expect(typeof webFetchesForSubject).toBe('function')
+    expect(typeof llmUsageForSubject).toBe('function')
+    expect(typeof toolCallsForSubject).toBe('function')
+  })
+})

--- a/tests/stats/per-table-user-group.test.ts
+++ b/tests/stats/per-table-user-group.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { groupMembers, groupUserObservations, users } from '../../src/db/schema.js'
+import { groupBlockForSubject, userBlockForSubject } from '../../src/stats/per-table-subject.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('userBlockForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns null when no users row exists', () => {
+    expect(userBlockForSubject('nobody')).toBeNull()
+  })
+
+  test('returns flags for an existing user without leaking PII', () => {
+    getDrizzleDb()
+      .insert(users)
+      .values({
+        platformUserId: 'u1',
+        username: 'alice',
+        addedAt: '2026-01-01T00:00:00Z',
+        addedBy: 'admin',
+        kaneoWorkspaceId: 'ws-1',
+      })
+      .run()
+
+    const result = userBlockForSubject('u1')
+
+    expect(result).not.toBeNull()
+    expect(result?.addedAt).toBe('2026-01-01T00:00:00Z')
+    expect(result?.addedByPresent).toBe(true)
+    expect(result?.kaneoWorkspacePresent).toBe(true)
+  })
+})
+
+describe('groupBlockForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns null when group has no members and no observations', () => {
+    expect(groupBlockForSubject('group:0')).toBeNull()
+  })
+
+  test('aggregates member count, distinct added_by, and observation count', () => {
+    getDrizzleDb()
+      .insert(groupMembers)
+      .values([
+        { groupId: 'group:1', userId: 'u1', addedBy: 'admin' },
+        { groupId: 'group:1', userId: 'u2', addedBy: 'admin' },
+        { groupId: 'group:1', userId: 'u3', addedBy: 'someone-else' },
+      ])
+      .run()
+    getDrizzleDb()
+      .insert(groupUserObservations)
+      .values([
+        {
+          provider: 'telegram',
+          contextId: 'group:1',
+          userId: 'u1',
+          displayLabel: 'A',
+          lastSeenAt: '2026-01-01T00:00:00Z',
+        },
+        {
+          provider: 'telegram',
+          contextId: 'group:1',
+          userId: 'u2',
+          displayLabel: 'B',
+          lastSeenAt: '2026-01-02T00:00:00Z',
+        },
+      ])
+      .run()
+
+    const result = groupBlockForSubject('group:1')
+
+    expect(result).not.toBeNull()
+    expect(result?.memberCount).toBe(3)
+    expect(result?.distinctAddedBy).toBe(2)
+    expect(result?.observationCount).toBe(2)
+  })
+})

--- a/tests/stats/per-table-web.test.ts
+++ b/tests/stats/per-table-web.test.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { webRateLimit } from '../../src/db/schema.js'
+import { webFetchesForSubject } from '../../src/stats/per-table-usage.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('webFetchesForSubject', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('returns zero when subject has no rate-limit rows', () => {
+    expect(webFetchesForSubject('nobody')).toEqual({ totalRequests: 0 })
+  })
+
+  test('sums the count column across all rate-limit windows for the actor', () => {
+    getDrizzleDb()
+      .insert(webRateLimit)
+      .values([
+        { actorId: 'u1', windowStart: 1000, count: 3 },
+        { actorId: 'u1', windowStart: 2000, count: 5 },
+        { actorId: 'other', windowStart: 1000, count: 99 },
+      ])
+      .run()
+
+    expect(webFetchesForSubject('u1').totalRequests).toBe(8)
+  })
+})

--- a/tests/stats/per-table.test.ts
+++ b/tests/stats/per-table.test.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  alertsForSubject,
+  instructionsForSubject,
+  memosForSubject,
+  recurringForSubject,
+  scheduledForSubject,
+} from '../../src/stats/per-table.js'
+
+describe('per-table helpers smoke check', () => {
+  test('all per-subject helpers are exported as functions', () => {
+    expect(typeof memosForSubject).toBe('function')
+    expect(typeof scheduledForSubject).toBe('function')
+    expect(typeof alertsForSubject).toBe('function')
+    expect(typeof recurringForSubject).toBe('function')
+    expect(typeof instructionsForSubject).toBe('function')
+  })
+})

--- a/tests/stats/perf.test.ts
+++ b/tests/stats/perf.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { clearStatsCacheForTesting, getGlobalStats } from '../../src/stats/index.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+// Target on a dev laptop is ~500ms. The CI/headroom budget is 1000ms.
+const PERF_BUDGET_MS = 1000
+
+const DM_SUBJECTS = 700
+const GROUP_SUBJECTS = 300
+const TOTAL_SUBJECTS = DM_SUBJECTS + GROUP_SUBJECTS
+const MESSAGE_ROWS = 100_000
+const MEMO_ROWS = 10_000
+const TOOL_CALL_ROWS = 5_000
+
+function seedFixtures(): void {
+  const sqlite = getDrizzleDb().$client
+
+  sqlite.run('BEGIN')
+  try {
+    const insertUser = sqlite.prepare('INSERT INTO users (platform_user_id, added_by, added_at) VALUES (?, ?, ?)')
+    const insertGroup = sqlite.prepare('INSERT INTO authorized_groups (group_id, added_by, added_at) VALUES (?, ?, ?)')
+    const baseAddedAt = new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString()
+    for (let i = 0; i < DM_SUBJECTS; i++) insertUser.run(`u${i}`, 'admin', baseAddedAt)
+    for (let i = 0; i < GROUP_SUBJECTS; i++) insertGroup.run(`g${i}`, 'admin', baseAddedAt)
+
+    const insertMessage = sqlite.prepare(
+      'INSERT INTO message_metadata (context_id, message_id, author_id, timestamp, expires_at) VALUES (?, ?, ?, ?, ?)',
+    )
+    const now = Date.now()
+    for (let i = 0; i < MESSAGE_ROWS; i++) {
+      const subjectIndex = i % TOTAL_SUBJECTS
+      const contextId = subjectIndex < DM_SUBJECTS ? `u${subjectIndex}` : `g${subjectIndex - DM_SUBJECTS}`
+      const ts = now - (i % (30 * 24 * 60 * 60 * 1000))
+      insertMessage.run(contextId, `m${i}`, contextId, ts, ts + 1_000_000)
+    }
+
+    const insertMemo = sqlite.prepare(
+      'INSERT INTO memos (id, user_id, content, summary, tags, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    )
+    const memoCreatedAt = new Date().toISOString()
+    for (let i = 0; i < MEMO_ROWS; i++) {
+      const userId = `u${i % DM_SUBJECTS}`
+      insertMemo.run(`memo${i}`, userId, 'c', null, '[]', 'active', memoCreatedAt, memoCreatedAt)
+    }
+
+    const insertTool = sqlite.prepare(
+      'INSERT INTO tool_call_events (event_id, turn_id, occurred_at, storage_context_id, context_type, chat_user_id, model, model_role, tool_name, tool_call_id, success, forward_attempts) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)',
+    )
+    const toolNames = ['create_task', 'update_task', 'search_tasks', 'list_tasks', 'web_fetch']
+    for (let i = 0; i < TOOL_CALL_ROWS; i++) {
+      const subjectIndex = i % TOTAL_SUBJECTS
+      const isDm = subjectIndex < DM_SUBJECTS
+      const subject = isDm ? `u${subjectIndex}` : `g${subjectIndex - DM_SUBJECTS}`
+      insertTool.run(
+        `e${i}`,
+        `t${i}`,
+        now - (i % (7 * 24 * 60 * 60 * 1000)),
+        subject,
+        isDm ? 'dm' : 'group',
+        isDm ? subject : `u${i % DM_SUBJECTS}`,
+        'm',
+        'main',
+        toolNames[i % toolNames.length] ?? 'create_task',
+        `tc${i}`,
+        i % 7 === 0 ? 0 : 1,
+      )
+    }
+
+    sqlite.run('COMMIT')
+  } catch (err) {
+    sqlite.run('ROLLBACK')
+    throw err
+  }
+}
+
+describe('stats perf bench', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+    clearStatsCacheForTesting()
+    seedFixtures()
+  })
+
+  test(`getGlobalStats({ noCache: true }) completes under ${PERF_BUDGET_MS}ms with 1k subjects + 100k messages`, () => {
+    const start = performance.now()
+    const result = getGlobalStats({ noCache: true })
+    const elapsed = performance.now() - start
+
+    expect(result.subjects.dmTotal).toBe(DM_SUBJECTS)
+    expect(result.subjects.groupTotal).toBe(GROUP_SUBJECTS)
+    expect(elapsed).toBeLessThan(PERF_BUDGET_MS)
+  })
+})

--- a/tests/stats/redaction.test.ts
+++ b/tests/stats/redaction.test.ts
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import {
+  alertPrompts,
+  attachments,
+  authorizedGroups,
+  conversationHistory,
+  groupUserObservations,
+  knownGroupContexts,
+  memorySummary,
+  memos,
+  messageMetadata,
+  recurringTasks,
+  scheduledPrompts,
+  stagedFiles,
+  systemConfig,
+  userInstructions,
+  users,
+  webCache,
+} from '../../src/db/schema.js'
+import { clearStatsCacheForTesting, getGlobalStats, getSubjectStats } from '../../src/stats/index.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+const FORBIDDEN_MARKERS = [
+  'FORBIDDEN_MEMO_BODY_XYZ',
+  'FORBIDDEN_MEMO_SUMMARY_XYZ',
+  'FORBIDDEN_MEMO_TAG_XYZ',
+  'FORBIDDEN_MESSAGE_TEXT_XYZ',
+  'FORBIDDEN_AUTHOR_USERNAME_XYZ',
+  'FORBIDDEN_INSTRUCTION_TEXT_XYZ',
+  'FORBIDDEN_FILENAME_XYZ',
+  'FORBIDDEN_MIME_XYZ',
+  'FORBIDDEN_USERNAME_XYZ',
+  'FORBIDDEN_GROUP_OBS_XYZ',
+  'FORBIDDEN_GROUP_NAME_XYZ',
+  'FORBIDDEN_WEB_CONTENT_XYZ',
+  'FORBIDDEN_SCHEDULED_PROMPT_XYZ',
+  'FORBIDDEN_ALERT_PROMPT_XYZ',
+  'FORBIDDEN_RECURRING_XYZ',
+  'FORBIDDEN_CONVERSATION_TEXT_XYZ',
+  'FORBIDDEN_SUMMARY_TEXT_XYZ',
+  'FORBIDDEN_STAGED_FILENAME_XYZ',
+  'FORBIDDEN_SALT_XYZ',
+] as const
+
+const SUBJECT_ID = 'subject-redaction-1'
+
+function seedForbiddenRows(): void {
+  const db = getDrizzleDb()
+
+  db.insert(users).values({ platformUserId: SUBJECT_ID, addedBy: 'admin', username: 'FORBIDDEN_USERNAME_XYZ' }).run()
+  db.insert(authorizedGroups).values({ groupId: 'group-redaction-1', addedBy: 'admin' }).run()
+
+  db.insert(memos)
+    .values({
+      id: 'm1',
+      userId: SUBJECT_ID,
+      content: 'memo body FORBIDDEN_MEMO_BODY_XYZ',
+      summary: 'memo summary FORBIDDEN_MEMO_SUMMARY_XYZ',
+      tags: JSON.stringify(['FORBIDDEN_MEMO_TAG_XYZ']),
+    })
+    .run()
+
+  db.insert(messageMetadata)
+    .values({
+      contextId: SUBJECT_ID,
+      messageId: 'msg1',
+      authorId: SUBJECT_ID,
+      authorUsername: 'FORBIDDEN_AUTHOR_USERNAME_XYZ',
+      text: 'message text FORBIDDEN_MESSAGE_TEXT_XYZ',
+      timestamp: 1000,
+      expiresAt: 9999999,
+    })
+    .run()
+
+  db.insert(userInstructions)
+    .values({ id: 'i1', contextId: SUBJECT_ID, text: 'instruction FORBIDDEN_INSTRUCTION_TEXT_XYZ' })
+    .run()
+
+  db.insert(attachments)
+    .values({
+      attachmentId: 'a1',
+      contextId: SUBJECT_ID,
+      sourceProvider: 'telegram',
+      filename: 'FORBIDDEN_FILENAME_XYZ.bin',
+      mimeType: 'application/FORBIDDEN_MIME_XYZ',
+      size: 100,
+      checksum: 'c',
+      blobKey: 'b',
+      status: 'stored',
+      isActive: 1,
+      createdAt: '2026-01-01T00:00:00Z',
+    })
+    .run()
+
+  db.insert(groupUserObservations)
+    .values({
+      provider: 'telegram',
+      contextId: 'group-redaction-1',
+      userId: 'u-obs',
+      username: 'FORBIDDEN_GROUP_OBS_XYZ',
+      displayLabel: 'FORBIDDEN_GROUP_OBS_XYZ-label',
+      lastSeenAt: '2026-01-01T00:00:00Z',
+    })
+    .run()
+
+  db.insert(knownGroupContexts)
+    .values({
+      provider: 'telegram',
+      contextId: 'group-redaction-1',
+      displayName: 'FORBIDDEN_GROUP_NAME_XYZ',
+      parentName: 'FORBIDDEN_GROUP_NAME_XYZ-parent',
+      firstSeenAt: '2026-01-01T00:00:00Z',
+      lastSeenAt: '2026-01-01T00:00:00Z',
+    })
+    .run()
+
+  db.insert(webCache)
+    .values({
+      urlHash: 'wh1',
+      url: 'https://FORBIDDEN_WEB_CONTENT_XYZ.example.com/path',
+      finalUrl: 'https://FORBIDDEN_WEB_CONTENT_XYZ.example.com/path',
+      title: 'FORBIDDEN_WEB_CONTENT_XYZ-title',
+      summary: 'FORBIDDEN_WEB_CONTENT_XYZ-summary',
+      excerpt: 'FORBIDDEN_WEB_CONTENT_XYZ-excerpt',
+      contentType: 'text/html',
+      fetchedAt: 1,
+      expiresAt: 2,
+    })
+    .run()
+
+  db.insert(scheduledPrompts)
+    .values({
+      id: 'sp1',
+      createdByUserId: SUBJECT_ID,
+      prompt: 'FORBIDDEN_SCHEDULED_PROMPT_XYZ',
+      fireAt: '2026-01-01T00:00:00Z',
+    })
+    .run()
+
+  db.insert(alertPrompts)
+    .values({
+      id: 'ap1',
+      createdByUserId: SUBJECT_ID,
+      prompt: 'FORBIDDEN_ALERT_PROMPT_XYZ',
+      condition: 'FORBIDDEN_ALERT_PROMPT_XYZ-condition',
+    })
+    .run()
+
+  db.insert(recurringTasks)
+    .values({
+      id: 'rt1',
+      userId: SUBJECT_ID,
+      projectId: 'p',
+      title: 'FORBIDDEN_RECURRING_XYZ',
+      description: 'FORBIDDEN_RECURRING_XYZ-desc',
+      enabled: '1',
+    })
+    .run()
+
+  db.insert(conversationHistory)
+    .values({
+      userId: SUBJECT_ID,
+      messages: JSON.stringify([{ role: 'user', content: 'FORBIDDEN_CONVERSATION_TEXT_XYZ' }]),
+    })
+    .run()
+
+  db.insert(memorySummary)
+    .values({ userId: SUBJECT_ID, summary: 'FORBIDDEN_SUMMARY_TEXT_XYZ', updatedAt: '2026-01-01T00:00:00Z' })
+    .run()
+
+  db.insert(stagedFiles)
+    .values({
+      stagedId: 'sf1',
+      contextId: SUBJECT_ID,
+      senderId: SUBJECT_ID,
+      filename: 'FORBIDDEN_STAGED_FILENAME_XYZ.bin',
+      platformFileId: 'pf1',
+      sourceProvider: 'telegram',
+      status: 'staged',
+      createdAt: '2026-01-01T00:00:00Z',
+      expiresAt: '2026-12-31T00:00:00Z',
+    })
+    .run()
+
+  db.insert(systemConfig)
+    .values({ key: 'stats_anonymity_salt', value: 'FORBIDDEN_SALT_XYZ', updatedAt: 0, updatedBy: 'test' })
+    .run()
+}
+
+describe('stats redaction contract (release-blocking)', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+    clearStatsCacheForTesting()
+    seedForbiddenRows()
+  })
+
+  test('getGlobalStats output contains none of the forbidden markers', () => {
+    const serialized = JSON.stringify(getGlobalStats({ noCache: true }))
+    for (const marker of FORBIDDEN_MARKERS) expect(serialized).not.toContain(marker)
+  })
+
+  test('getSubjectStats output contains none of the forbidden markers', () => {
+    const result = getSubjectStats(SUBJECT_ID)
+    expect(result).not.toBeNull()
+    const serialized = JSON.stringify(result)
+    for (const marker of FORBIDDEN_MARKERS) expect(serialized).not.toContain(marker)
+  })
+})

--- a/tests/stats/types.test.ts
+++ b/tests/stats/types.test.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import type { GlobalStats, GlobalStatsOptions, Percentiles, StatsWindow, SubjectStats } from '../../src/stats/types.js'
+
+describe('stats types', () => {
+  test('Percentiles is a structural shape with seven numeric fields', () => {
+    const sample: Percentiles = {
+      count: 0,
+      min: 0,
+      p50: 0,
+      p90: 0,
+      p99: 0,
+      max: 0,
+      mean: 0,
+    }
+
+    expect(Object.keys(sample)).toHaveLength(7)
+  })
+
+  test('GlobalStatsOptions accepts an optional window and noCache', () => {
+    const a: GlobalStatsOptions = {}
+    const b: GlobalStatsOptions = { window: '30d', noCache: true }
+
+    expect(a).toBeDefined()
+    expect(b.window).toBe('30d')
+  })
+
+  test('StatsWindow union covers the documented windows', () => {
+    const windows: StatsWindow[] = ['1d', '7d', '30d', 'all']
+
+    expect(windows).toHaveLength(4)
+  })
+
+  test('SubjectStats can be constructed with all required shape fields', () => {
+    const empty: SubjectStats = {
+      storageContextId: 's',
+      chatUserId: null,
+      contextType: 'dm',
+      displayName: null,
+      memos: {
+        total: 0,
+        byStatus: {},
+        tagCardinality: { distinct: 0, meanPerMemo: 0 },
+        contentBytesTotal: 0,
+        embeddingBytesTotal: 0,
+        withEmbedding: 0,
+        oldestCreatedAt: null,
+        newestCreatedAt: null,
+      },
+      scheduledPrompts: { total: 0, byStatus: {}, distinctDeliveryTargets: 0 },
+      alertPrompts: { total: 0, byStatus: {} },
+      recurringTasks: {
+        total: 0,
+        enabled: 0,
+        disabled: 0,
+        distinctProjects: 0,
+        nextRunWithin7d: 0,
+        distinctRrulePatterns: 0,
+      },
+      userInstructions: { total: 0, textBytesTotal: 0 },
+      attachments: {
+        total: 0,
+        byStatus: {},
+        bySourceProvider: {},
+        storedBytesTotal: 0,
+        active: 0,
+        byExtension: {},
+      },
+      messageMetadata: {
+        total: 0,
+        authoredBySubject: 0,
+        oldestTimestamp: null,
+        newestTimestamp: null,
+        textBytesTotal: 0,
+      },
+      conversationHistory: { turnCount: 0, summaryPresent: false },
+      userIdentityMappings: {},
+      stagedFiles: { total: 0, byStatus: {}, bytesTotal: 0 },
+      userBlock: null,
+      groupBlock: null,
+      webFetches: { totalRequests: 0 },
+      llmUsage: { rowCount: 0, inputTokensTotal: 0, outputTokensTotal: 0 },
+      toolCalls: { total: 0, success: 0, failure: 0, topTools: [], errorTypeCounts: {} },
+    }
+
+    expect(empty.storageContextId).toBe('s')
+  })
+
+  test('GlobalStats has the documented top-level keys', () => {
+    const sample: GlobalStats = {
+      generatedAt: 0,
+      window: 'all',
+      subjects: { dmTotal: 0, groupTotal: 0, growthLast30d: [] },
+      active: { activeIn1d: 0, activeIn7d: 0, activeIn30d: 0 },
+      distributions: {
+        memosPerSubject: { count: 0, min: 0, p50: 0, p90: 0, p99: 0, max: 0, mean: 0 },
+        recurringTasksPerSubject: { count: 0, min: 0, p50: 0, p90: 0, p99: 0, max: 0, mean: 0 },
+        messageMetadataPerSubject: { count: 0, min: 0, p50: 0, p90: 0, p99: 0, max: 0, mean: 0 },
+        attachmentBytesPerSubject: { count: 0, min: 0, p50: 0, p90: 0, p99: 0, max: 0, mean: 0 },
+      },
+      storage: { sqliteBytes: 0, s3AttachmentBytes: 0 },
+      identityMix: { byProvider: {}, kaneoWorkspaces: 0 },
+      surfaceMix: {
+        subjectsWithRecurring: 0,
+        subjectsWithDeferred: 0,
+        subjectsWithMemos: 0,
+        subjectsWithInstructions: 0,
+      },
+      webFetches: { topHosts: [] },
+      toolMix: { topTools: [], errorTypeCounts: {} },
+    }
+
+    const expectedKeys = [
+      'generatedAt',
+      'window',
+      'subjects',
+      'active',
+      'distributions',
+      'storage',
+      'identityMix',
+      'surfaceMix',
+      'webFetches',
+      'toolMix',
+    ]
+    expect(Object.keys(sample).sort()).toEqual(expectedKeys.sort())
+  })
+})


### PR DESCRIPTION
## Summary

- Ships `src/stats/` with anonymous per-subject and global aggregate queries fed directly from SQLite via Drizzle, exposing `getSubjectStats()` / `getGlobalStats()` with a 60s global-view cache.
- Surfaces the data behind `GET /stats/global` and `GET /stats/subject/:id` (DEBUG_TOKEN-gated) plus a dashboard Stats panel and a per-subject view inside the Billing modal.
- Enforces the anonymity contract: counts, sizes, timestamps, enum distributions, and keyed-hashed identifiers only — never content, filenames, usernames, message text, memo bodies, or raw URLs. Hashing salt is the `stats_anonymity_salt` row in `system_config`, seeded lazily on first read.
- Documents the contract and the new module in `CLAUDE.md`.

Implements Phase 5 of `docs/superpowers/plans/2026-05-19-central-llm-billing-roadmap.md` per `docs/superpowers/plans/2026-05-20-phase-5-anonymous-stats-plan.md`.

## Test plan

- [x] `bun check:full` — 12/12 (lint, typecheck, format:check, license-headers, knip, test, test:client, duplicates, review-loop:lint/typecheck/format:check/test)
- [x] Anonymity test sweeps every `/stats/*` response for forbidden substrings (raw hostnames, usernames, message text, etc.).
- [x] Perf bench: `getGlobalStats({ noCache: true })` against 1k subjects + 100k messages + 10k memos + 5k tool-call events completes well under the 1000ms budget.
- [ ] Manual smoke: open dashboard → Stats panel → switch window selector → open Billing modal → verify per-subject anonymous view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)