### PR TITLE
docs(design): rework quotas — day/week/month windows, refill algo, attachment storage, 80% notice, deferred-prompt fallback

### DIFF
--- a/docs/design/llm-rate-limiting-and-plans-phases.md
+++ b/docs/design/llm-rate-limiting-and-plans-phases.md
@@ -371,39 +371,88 @@ required pre-merge gate.
 
 ### Phase 20 — Deferred-prompt fallback chain
 
-- **Goal.** Add the §7.4 fallback chain to the deferred-prompt
-  dispatcher so quota exhaustion never silently drops a scheduled
-  reminder:
-  1. on `llm:main` denial, retry the reservation as `llm:small`;
-  2. on `llm:small` denial, deliver a templated non-LLM reminder built
-     from the deferred-prompt row (`originalUserText`, `scheduledFor`,
-     `resetHuman`, subject timezone);
-  3. but if `retryAfterMs <= DEFERRED_PROMPT_GRACE_MS` (default
-     `15 min`), reschedule the dispatch attempt instead of falling back.
+- **Goal.** Implement the §7.4 fallback chain in the deferred-prompt
+  dispatcher so the fire moment is always honoured and quota exhaustion
+  never silently drops a prompt. The chain, executed in order at fire
+  time:
+  1. **Try `llm:main`** for subjects whose `llm:main.*` usage is below
+     `notify_pct` on every limited triple.
+  2. **Proactive `llm:small` degrade** for subjects who have already
+     crossed `notify_pct` on any `llm:main.*` triple — the dispatcher
+     skips `llm:main` reservation entirely and reserves on `llm:small`
+     instead, saving the user's last 20 % of main-model headroom for
+     interactive turns.
+  3. **Hard fallback to `llm:small`** if step 1 was attempted and denied
+     at the gate.
+  4. **Templated non-LLM delivery** as the last resort, only when both
+     `llm:main` and `llm:small` are exhausted.
 
-  Record `delivery_mode` (`'llm_main' | 'llm_small' | 'template' |
-  'deferred_retry'`) per dispatch for metrics.
+  Defer-and-retry is **not** implemented — the design forbids slipping
+  the fire moment around a quota reset. Record two columns per dispatch
+  for metrics:
+  - `delivery_mode: 'llm_main' | 'llm_small' | 'template'`.
+  - `delivery_reason: 'normal' | 'proactive_degrade' | 'main_denied' |
+    'all_denied'`.
+
 - **Touches.**
-  - `src/db/migrations/<M>_deferred_prompt_delivery_mode.ts` (new) — adds
-    `delivery_mode text NOT NULL DEFAULT 'llm_main'` to the
+  - `src/db/migrations/<M>_deferred_prompt_delivery_mode.ts` (new) —
+    adds `delivery_mode text NOT NULL DEFAULT 'llm_main'` and
+    `delivery_reason text NOT NULL DEFAULT 'normal'` to the
     `deferred_prompts` table.
-  - `src/db/deferred-prompts-schema.ts` — export the column.
-  - `src/deferred-prompts/proactive-llm.ts` — wire the chain.
-  - `src/deferred-prompts/templated-reminder.ts` (new) — pure formatter
-    that builds the user-visible reminder string from
-    `(originalUserText, scheduledFor, resetHuman, timezone)`.
+  - `src/db/deferred-prompts-schema.ts` — export the new columns.
+  - `src/deferred-prompts/proactive-llm.ts` — wire the chain; consult
+    the threshold via a new helper (or reuse §7.8's check) before
+    deciding whether to take the proactive degrade branch.
+  - `src/deferred-prompts/templated-delivery.ts` (new) — three pure
+    formatters plus a shared footer constant:
+    - `formatScheduledOneShot(prompt, executionMetadata, timezone)` for
+      `ScheduledPrompt` rows whose `rrule` is `null`.
+    - `formatScheduledRecurring(prompt, executionMetadata, timezone,
+      humanRruleSummary)` for `ScheduledPrompt` rows with an `rrule`.
+    - `formatAlert(prompt, executionMetadata, condition)` for
+      `AlertPrompt` rows; the condition clause is built from the stored
+      `AlertCondition` tree without any LLM call.
+    - All three prefer `execution_metadata.delivery_brief` over the raw
+      `prompt` field when non-empty.
+  - `src/deferred-prompts/threshold-check.ts` (new, or extend an
+    existing helper) — `isMainAtOrAboveNotifyPct(subjectId, nowMs)`
+    returns true if any limited `llm:main.*` triple is at ≥`notify_pct`
+    in its active bucket; pure read from `quota_counter` + `plan_limits`.
+
 - **Tests.**
-  - `tests/deferred-prompts/templated-reminder.test.ts` — formatter shape
-    and timezone formatting.
-  - `tests/deferred-prompts/fallback-chain.test.ts` — all four paths fire
-    correctly; templated path is **never** blocked by quota and is
-    delivered even when every LLM resource is denied; `delivery_mode` is
-    recorded; defer-and-retry actually reschedules and is bounded by
-    `DEFERRED_PROMPT_GRACE_MS`.
-- **Exit criteria.** A subject whose `llm:main` is exhausted still
-  receives every scheduled deferred prompt, either as a small-model
-  message, as a templated reminder, or as a slightly delayed
-  LLM-generated message after the bucket rolls over.
+  - `tests/deferred-prompts/templated-delivery.test.ts` — formatter
+    shape for all three template variants; `delivery_brief` overrides
+    `prompt` when non-empty; condition clause renders correctly for
+    each `FIELD_OPERATORS` combination; shared footer present on every
+    variant.
+  - `tests/deferred-prompts/threshold-check.test.ts` —
+    `isMainAtOrAboveNotifyPct` true on fixed_window crossing, true on
+    rolling_refill crossing, false for unlimited plans, false when
+    only `llm:small` is over threshold.
+  - `tests/deferred-prompts/fallback-chain.test.ts` — exercises every
+    branch:
+    - subject below threshold + main allowed → `delivery_mode =
+      'llm_main'`, `delivery_reason = 'normal'`.
+    - subject ≥`notify_pct` on main + small allowed → `delivery_mode =
+      'llm_small'`, `delivery_reason = 'proactive_degrade'`; assert no
+      `llm:main` reservation was held.
+    - subject below threshold but `llm:main` denied at the gate (race
+      between threshold check and reservation) → `delivery_mode =
+      'llm_small'`, `delivery_reason = 'main_denied'`.
+    - both `llm:main` and `llm:small` denied → `delivery_mode =
+      'template'`, `delivery_reason = 'all_denied'`; the templated
+      path is delivered regardless of quota.
+    - all three prompt types (`scheduled` one-shot, `scheduled`
+      recurring, `alert`) take the templated path correctly when
+      quota-exhausted.
+    - assert the dispatcher never reschedules a fire moment — no
+      defer-and-retry timer is set on any path.
+
+- **Exit criteria.** Every deferred prompt fires at its scheduled time
+  regardless of quota state, with the right model / template chosen per
+  the chain above, and the `delivery_mode` + `delivery_reason` columns
+  reflect which branch was taken. No code path in the dispatcher
+  reschedules a fire moment.
 
 ### Phase 21 — Embedding gate
 

--- a/docs/design/llm-rate-limiting-and-plans-phases.md
+++ b/docs/design/llm-rate-limiting-and-plans-phases.md
@@ -195,10 +195,10 @@ required pre-merge gate.
 
 - **Goal.** Atomic
   `tryIncrementFixedWindow(subjectId, resource, dimension, window, delta,
-  limit, nowMs, notifyPct)` implementing the `fixed_window` branch of §7.1:
+limit, nowMs, notifyPct)` implementing the `fixed_window` branch of §7.1:
   insert-on-conflict with bucket rollover via
   `ON CONFLICT … DO UPDATE … WHERE quota_counter.window_start <
-  excluded.window_start` resetting `count`, `balance`, and
+excluded.window_start` resetting `count`, `balance`, and
   `notified_threshold_pct` to `0`, then a conditional
   `UPDATE … WHERE count + :delta <= :limit RETURNING count`.
 - **Touches.** `src/quota/counter-fixed.ts` (new).
@@ -212,7 +212,7 @@ required pre-merge gate.
 
 - **Goal.**
   `applyDeltaFixedWindow(subjectId, resource, dimension, window, delta,
-  nowMs)` supporting **negative deltas** with
+nowMs)` supporting **negative deltas** with
   `count = MAX(0, count + :delta)` clamp. Used both for `commitQuota`
   reconciliation and for the `attachment.storage_bytes` refund path.
 - **Touches.** Extend `src/quota/counter-fixed.ts`.
@@ -224,14 +224,14 @@ required pre-merge gate.
 
 - **Goal.** Atomic
   `tryReserveRolling(subjectId, resource, dimension, window, delta, limit,
-  nowMs, notifyPct)` implementing §4.4 / §7.1's `rolling_refill` branch:
+nowMs, notifyPct)` implementing §4.4 / §7.1's `rolling_refill` branch:
   insert default row if missing (`balance = limit`, `window_start = nowMs`),
   lazily refill inside the same tx using
   `refilled = floor(elapsed_ms * limit / window_ms)`, advance
   `window_start` by exactly `refilled * window_ms / limit` so fractional
   tokens are preserved, then conditional
   `UPDATE … SET balance = :new_balance - :delta … WHERE :new_balance >=
-  :delta RETURNING balance`. A negative `delta` (refund) computes
+:delta RETURNING balance`. A negative `delta` (refund) computes
   `new_balance = min(limit, balance + refilled - delta)` and unconditionally
   succeeds (clamped at `limit`).
 - **Touches.** `src/quota/counter-rolling.ts` (new).
@@ -249,7 +249,7 @@ required pre-merge gate.
 - **Goal.** Public engine: resolve plan, fan out the right primitive
   (`tryIncrementFixedWindow` for `algorithm = 'fixed_window'`,
   `tryReserveRolling` for `'rolling_refill'`) over every `(dimension,
-  window)` triple in the limits matrix for the resource. On first breach,
+window)` triple in the limits matrix for the resource. On first breach,
   roll back all prior increments **within the same tx**.
 - **Touches.** `src/quota/reserve.ts` (new), `src/quota/index.ts` (new,
   re-export façade).
@@ -295,7 +295,7 @@ required pre-merge gate.
 ### Phase 14 — Orchestrator pre-call gate (main role)
 
 - **Goal.** Insert `reserveQuota('llm:main', { requests: 1, input_tokens:
-  estimateInput(prompt), output_tokens: outputBudget })` immediately before
+estimateInput(prompt), output_tokens: outputBudget })` immediately before
   the `generateText` call. On denial, return the structured "quota
   exhausted" reply (see §8 of spec) and **do not** call the model.
 - **Touches.** `src/llm-orchestrator-support.ts` (pre-call hook),
@@ -331,7 +331,7 @@ required pre-merge gate.
 - **Goal.** Increment `tool.requests.*` before every tool execution in the
   tool wrapper used by `src/tools/`. On denial, return the structured
   failure result described in §8 of spec (`{ success: false, error: {
-  code: 'quota_exceeded', ... } }`).
+code: 'quota_exceeded', ... } }`).
 - **Touches.** `src/tools/tool-execution-wrapper.ts` (or the equivalent
   module — locate via `code_symbol` before starting).
 - **Tests.** `tests/tools/quota-gate.test.ts`: gate fires; structured
@@ -392,7 +392,7 @@ required pre-merge gate.
   for metrics:
   - `delivery_mode: 'llm_main' | 'llm_small' | 'template'`.
   - `delivery_reason: 'normal' | 'proactive_degrade' | 'main_denied' |
-    'all_denied'`.
+'all_denied'`.
 
 - **Touches.**
   - `src/db/migrations/<M>_deferred_prompt_delivery_mode.ts` (new) —
@@ -405,15 +405,15 @@ required pre-merge gate.
     deciding whether to take the proactive degrade branch.
   - `src/deferred-prompts/templated-delivery.ts` (new) — three pure
     formatters plus a shared footer constant:
-    - `formatScheduledOneShot(prompt, executionMetadata, timezone)` for
-      `ScheduledPrompt` rows whose `rrule` is `null`.
-    - `formatScheduledRecurring(prompt, executionMetadata, timezone,
-      humanRruleSummary)` for `ScheduledPrompt` rows with an `rrule`.
-    - `formatAlert(prompt, executionMetadata, condition)` for
-      `AlertPrompt` rows; the condition clause is built from the stored
-      `AlertCondition` tree without any LLM call.
-    - All three prefer `execution_metadata.delivery_brief` over the raw
-      `prompt` field when non-empty.
+    `formatScheduledOneShot(prompt, executionMetadata, timezone)` for
+    `ScheduledPrompt` rows whose `rrule` is `null`;
+    `formatScheduledRecurring(prompt, executionMetadata, timezone,
+humanRruleSummary)` for `ScheduledPrompt` rows with an `rrule`;
+    `formatAlert(prompt, executionMetadata, condition)` for
+    `AlertPrompt` rows (the condition clause is built from the stored
+    `AlertCondition` tree without any LLM call). All three prefer
+    `execution_metadata.delivery_brief` over the raw `prompt` field
+    when non-empty.
   - `src/deferred-prompts/threshold-check.ts` (new, or extend an
     existing helper) — `isMainAtOrAboveNotifyPct(subjectId, nowMs)`
     returns true if any limited `llm:main.*` triple is at ≥`notify_pct`
@@ -430,23 +430,22 @@ required pre-merge gate.
     rolling_refill crossing, false for unlimited plans, false when
     only `llm:small` is over threshold.
   - `tests/deferred-prompts/fallback-chain.test.ts` — exercises every
-    branch:
-    - subject below threshold + main allowed → `delivery_mode =
-      'llm_main'`, `delivery_reason = 'normal'`.
-    - subject ≥`notify_pct` on main + small allowed → `delivery_mode =
-      'llm_small'`, `delivery_reason = 'proactive_degrade'`; assert no
-      `llm:main` reservation was held.
-    - subject below threshold but `llm:main` denied at the gate (race
-      between threshold check and reservation) → `delivery_mode =
-      'llm_small'`, `delivery_reason = 'main_denied'`.
-    - both `llm:main` and `llm:small` denied → `delivery_mode =
-      'template'`, `delivery_reason = 'all_denied'`; the templated
-      path is delivered regardless of quota.
-    - all three prompt types (`scheduled` one-shot, `scheduled`
-      recurring, `alert`) take the templated path correctly when
-      quota-exhausted.
-    - assert the dispatcher never reschedules a fire moment — no
-      defer-and-retry timer is set on any path.
+    branch. **Normal:** subject below threshold + main allowed →
+    `delivery_mode = 'llm_main'`, `delivery_reason = 'normal'`.
+    **Proactive degrade:** subject ≥`notify_pct` on main + small allowed
+    → `delivery_mode = 'llm_small'`, `delivery_reason =
+'proactive_degrade'`; assert no `llm:main` reservation was held.
+    **Main denied:** subject below threshold but `llm:main` denied at
+    the gate (race between threshold check and reservation) →
+    `delivery_mode = 'llm_small'`, `delivery_reason = 'main_denied'`.
+    **All denied:** both `llm:main` and `llm:small` denied →
+    `delivery_mode = 'template'`, `delivery_reason = 'all_denied'`;
+    the templated path is delivered regardless of quota. **Per-type
+    template coverage:** all three prompt types (`scheduled` one-shot,
+    `scheduled` recurring, `alert`) take the templated path correctly
+    when quota-exhausted. **No-defer guarantee:** assert the dispatcher
+    never reschedules a fire moment — no defer-and-retry timer is set
+    on any path.
 
 - **Exit criteria.** Every deferred prompt fires at its scheduled time
   regardless of quota state, with the right model / template chosen per
@@ -693,7 +692,7 @@ exactly like `POST /admin/llm` (see `src/debug/billing-routes.ts`).
 - **Goal.** Snapshot of live `quota_counter` rows for the subject,
   joined with the active plan's limits to render
   `{ used, limit, remaining, resetsAt, algorithm, notifyPct,
-  notifiedThresholdPct, refillRatePerSecond? }` per triple. Used by the
+notifiedThresholdPct, refillRatePerSecond? }` per triple. Used by the
   dashboard Subject Detail card.
 - **Touches.** `src/debug/billing-routes.ts`, `src/debug/billing.ts`
   (read helper).

--- a/docs/design/llm-rate-limiting-and-plans-phases.md
+++ b/docs/design/llm-rate-limiting-and-plans-phases.md
@@ -72,27 +72,50 @@ required pre-merge gate.
 
 - **Goal.** Centralise the type and enum surface so later phases can import
   from one module without circular deps.
-- **Touches.** `src/quota/types.ts` (new): `Resource`, `Dimension`, `Window`,
-  `PlanId`, `SubjectId`, `Limit` (struct), `PlanLimitRow`, `PlanRecord`,
-  `ResolvedPlan`, `QuotaSnapshot`, `ReserveResult`, `CommitInput`,
-  `RESOURCES`, `DIMENSIONS`, `WINDOWS`, `WINDOW_MS`.
-- **Touches.** `src/quota/validity.ts` (new): pure `isValidLimitTriple(resource,
-dimension, window)` from §4.2 of the spec; throws nothing, returns boolean.
-- **Tests.** `tests/quota/validity.test.ts`: matrix coverage of every
-  (resource × dimension) pair.
+- **Touches.** `src/quota/types.ts` (new):
+  - `Resource` — `'llm:main' | 'llm:small' | 'llm:embed' | 'tool' |
+'web_fetch' | 'attachment'`.
+  - `Dimension` — `'requests' | 'input_tokens' | 'output_tokens' |
+'cost_usd_micro' | 'storage_bytes'`.
+  - `Window` — `'day' | 'week' | 'month'`.
+  - `Algorithm` — `'fixed_window' | 'rolling_refill'`.
+  - `PlanId`, `SubjectId`, `Limit` (struct including `algorithm` and
+    `notifyPct`), `PlanLimitRow`, `PlanRecord`, `ResolvedPlan`,
+    `QuotaSnapshot`, `ReserveResult`, `CommitInput`.
+  - Const arrays `RESOURCES`, `DIMENSIONS`, `WINDOWS`, `ALGORITHMS`, plus
+    the `WINDOW_MS` map. `month` uses the average length
+    `2_629_800_000 ms` for rolling-refill rate math even though
+    fixed-window calendar buckets are anchored to UTC first-of-month.
+- **Touches.** `src/quota/validity.ts` (new):
+  - `isValidLimitTriple(resource, dimension, window)` from §4.2 of the
+    spec (e.g. rejects `tool × output_tokens`, `attachment × requests`,
+    `llm:* × storage_bytes`).
+  - `isValidAlgorithmForDimension(dimension, algorithm)` rejects
+    `rolling_refill` for stock dimensions (`storage_bytes`).
+  - Both functions throw nothing and return boolean.
+- **Tests.** `tests/quota/validity.test.ts`: full matrix coverage including
+  `attachment × storage_bytes` (allowed), `attachment × requests`
+  (rejected), `llm:* × storage_bytes` (rejected),
+  `tool × output_tokens` (rejected); algorithm validity for every
+  dimension.
 - **Exit criteria.** Importable types and validators; no other file imports
   them yet.
 
 ### Phase 3 — Window math
 
 - **Goal.** Pure function `bucketFor(window, nowMs)` returning
-  `{ windowStart, resetsAt }`. Handles minute/hour/day as `floor(now / ms) * ms`
-  and `month` as **UTC calendar month** start.
+  `{ windowStart, resetsAt, windowMs }`. Handles `day` as
+  `floor(now / 86_400_000) * 86_400_000` UTC, `week` as the start of the
+  **ISO-8601 week (UTC Monday 00:00)**, `month` as **UTC calendar month**
+  start.
 - **Touches.** `src/quota/window.ts` (new).
-- **Tests.** `tests/quota/window.test.ts`: minute boundary, hour boundary, day
-  UTC midnight crossing, month boundary (Jan→Feb, Feb→Mar leap-year, Dec→Jan
-  year rollover).
-- **Exit criteria.** All four windows correct across DST-free UTC math.
+- **Tests.** `tests/quota/window.test.ts`: day UTC midnight crossing; week
+  boundary including Sun→Mon rollover at 23:59:59.999 UTC and ISO year-end
+  weeks (e.g. 2026-01-04 is in ISO week 1, 2026-01-05 starts ISO week 2);
+  month boundary (Jan→Feb, Feb→Mar leap-year, Dec→Jan year rollover).
+  Minute/hour cases are explicitly **not** part of v1 — assert the type
+  system rejects `'minute' as Window`.
+- **Exit criteria.** All three windows correct across DST-free UTC math.
 
 ### Phase 4 — DB migration: tables only
 
@@ -100,28 +123,52 @@ dimension, window)` from §4.2 of the spec; throws nothing, returns boolean.
   **no runtime code reads or writes them yet**.
 - **Touches.**
   - `src/db/migrations/<N>_plans_quotas.ts` (new; N = next number).
-  - `src/db/plans-schema.ts` (new, mirrors style of `llm-usage-events-schema.ts`).
+  - `src/db/plans-schema.ts` (new, mirrors style of
+    `llm-usage-events-schema.ts`).
   - `src/db/schema.ts` (re-export new tables).
-- **Schemas (verbatim against §5 of spec).** `plans`, `plan_limits`,
-  `subject_plan`, `plan_audit`, `quota_counter`, plus the partial unique index
-  `uniq_plans_default` and the `idx_quota_counter_gc` index.
-- **Tests.** `tests/db/plans-migration.test.ts`: applies the migration on a
-  fresh in-memory DB, asserts every table exists, every index exists, partial
-  unique index rejects a second `is_default = 1` row.
-- **Exit criteria.** Migration applies on a fresh DB; `bun typecheck` clean;
-  no consumer code yet.
+- **Schemas (verbatim against §5 of spec).**
+  - `plans` + partial unique index `uniq_plans_default`.
+  - `plan_limits` — including the new
+    `algorithm text NOT NULL DEFAULT 'fixed_window'` and
+    `notify_pct int NOT NULL DEFAULT 80` columns.
+  - `subject_plan`.
+  - `plan_audit`.
+  - `quota_counter` — PK is `(subject_id, resource, dimension, window)`
+    (no `window_start` in the key, since only the active bucket lives in
+    the table). Columns: `algorithm`, `window_start`, `count`, `balance`,
+    `notified_threshold_pct`. Plus `idx_quota_counter_gc` on
+    `window_start`.
+- **Tests.** `tests/db/plans-migration.test.ts`: applies on a fresh
+  in-memory DB; asserts every table and index exists; partial unique index
+  rejects a second `is_default = 1` row; `quota_counter` PK rejects two
+  rows with the same `(subject_id, resource, dimension, window)` even
+  across different `window_start` values (proves the new PK shape);
+  `plan_limits.algorithm` defaults to `fixed_window` and `notify_pct` to
+  `80` on insert without explicit values.
+- **Exit criteria.** Migration applies on a fresh DB; `bun typecheck`
+  clean; no consumer code yet.
 
 ### Phase 5 — Seed migration
 
 - **Goal.** Separate migration that inserts the three seed plans
-  (`free`, `team`, `unlimited`) and binds `ADMIN_USER_ID`'s subject to
-  `unlimited`. Idempotent (`ON CONFLICT DO NOTHING`).
+  (`free`, `team`, `unlimited`) per spec §12.1 and binds `ADMIN_USER_ID`'s
+  subject to `unlimited`. Idempotent (`ON CONFLICT DO NOTHING`).
 - **Touches.** `src/db/migrations/<N+1>_seed_plans.ts` (new). Reads
-  `ADMIN_USER_ID` at migration time and stores it as the `subject_plan` row
-  for the admin user.
-- **Tests.** `tests/db/seed-plans-migration.test.ts`: fresh DB → three rows in
-  `plans`, expected `plan_limits` triples for `free`/`team`, zero limits for
-  `unlimited`, one row in `subject_plan` for the admin.
+  `ADMIN_USER_ID` at migration time and stores it as the `subject_plan`
+  row for the admin user.
+- **Seeded mix.**
+  - `free` mixes algorithms: `llm:main` daily input/output on
+    `rolling_refill`, monthly `input_tokens` cap on `fixed_window`,
+    `tool.requests.day` on `fixed_window`,
+    `attachment.storage_bytes.month` on `fixed_window` (stock dimension),
+    `web_fetch.requests.day` on `rolling_refill` with capacity sized so
+    the previous `20 / minute` hard cap is the long-run average.
+  - `team` is the same shape with higher caps.
+  - `unlimited` has zero `plan_limits` rows.
+- **Tests.** `tests/db/seed-plans-migration.test.ts`: three rows in
+  `plans`; expected `plan_limits` triples per plan with the right
+  `algorithm` and `notify_pct = 80` on each; zero limits for `unlimited`;
+  one row in `subject_plan` for the admin.
 - **Exit criteria.** Migration runs after Phase 4; admin row visible.
 
 ### Phase 6 — Plan repository (read side)
@@ -129,8 +176,9 @@ dimension, window)` from §4.2 of the spec; throws nothing, returns boolean.
 - **Goal.** Thin DB access functions, no orchestration.
 - **Touches.** `src/quota/plan-repository.ts` (new): `listPlans()`,
   `getPlan(planId)`, `listPlanLimits(planId)`, `getSubjectPlan(subjectId)`.
-- **Tests.** `tests/quota/plan-repository.test.ts`: each function against a
-  migrated+seeded DB.
+- **Tests.** `tests/quota/plan-repository.test.ts`: each function against
+  a migrated+seeded DB; asserts the new `algorithm` and `notifyPct` fields
+  survive the round-trip.
 - **Exit criteria.** Functions exported and exercised; no callers yet.
 
 ### Phase 7 — Plan resolver
@@ -143,53 +191,93 @@ dimension, window)` from §4.2 of the spec; throws nothing, returns boolean.
   `group:abc:thread-7` and `group:abc` resolve to the **same** plan).
 - **Exit criteria.** Pure function; no side effects; full branch coverage.
 
-### Phase 8 — Counter primitive: increment
+### Phase 8 — Counter primitive: fixed_window increment
 
-- **Goal.** Atomic `tryIncrement(subjectId, resource, dimension, window,
-delta, limit, nowMs)` mirroring `consumeWebFetchQuota`'s pattern:
-  insert-on-conflict then conditional update with `RETURNING`.
-- **Touches.** `src/quota/counter.ts` (new).
-- **Tests.** `tests/quota/counter.test.ts`: increment under limit, exceed
-  limit, exact-boundary case, two parallel `Promise.all` increments asserting
-  total stays ≤ limit (run with `p-limit(8)`).
+- **Goal.** Atomic
+  `tryIncrementFixedWindow(subjectId, resource, dimension, window, delta,
+  limit, nowMs, notifyPct)` implementing the `fixed_window` branch of §7.1:
+  insert-on-conflict with bucket rollover via
+  `ON CONFLICT … DO UPDATE … WHERE quota_counter.window_start <
+  excluded.window_start` resetting `count`, `balance`, and
+  `notified_threshold_pct` to `0`, then a conditional
+  `UPDATE … WHERE count + :delta <= :limit RETURNING count`.
+- **Touches.** `src/quota/counter-fixed.ts` (new).
+- **Tests.** `tests/quota/counter-fixed.test.ts`: increment under limit;
+  exceed limit; exact-boundary case; two parallel `Promise.all`
+  increments asserting total stays ≤ limit (run with `p-limit(8)`);
+  bucket rollover resets `count` **and** `notified_threshold_pct`.
 - **Exit criteria.** Race-safe primitive; no callers yet.
 
-### Phase 9 — Counter primitive: refund/clamp
+### Phase 9 — Counter primitive: fixed_window refund/clamp
 
-- **Goal.** `applyDelta(subjectId, resource, dimension, window, delta,
-nowMs)` that supports **negative deltas**, clamping `count` at zero. Used
-  for `commitQuota` reconciliation.
-- **Touches.** Extend `src/quota/counter.ts`.
-- **Tests.** Extend `tests/quota/counter.test.ts`: negative delta clamps,
-  multiple refunds within one bucket, idempotent at zero.
-- **Exit criteria.** Single SQL `UPDATE ... SET count = MAX(0, count + :delta)`
-  proven correct.
+- **Goal.**
+  `applyDeltaFixedWindow(subjectId, resource, dimension, window, delta,
+  nowMs)` supporting **negative deltas** with
+  `count = MAX(0, count + :delta)` clamp. Used both for `commitQuota`
+  reconciliation and for the `attachment.storage_bytes` refund path.
+- **Touches.** Extend `src/quota/counter-fixed.ts`.
+- **Tests.** Extend `tests/quota/counter-fixed.test.ts`: negative delta
+  clamps; multiple refunds within one bucket; idempotent at zero.
+- **Exit criteria.** Single SQL clamp proven correct.
 
-### Phase 10 — `reserveQuota`
+### Phase 10 — Counter primitive: rolling_refill reserve + refund
 
-- **Goal.** Public engine: resolve plan, fan out `tryIncrement` over every
-  `(dimension, window)` triple in the limits matrix for the resource. On
-  first breach, roll back all prior increments **within the same tx**.
+- **Goal.** Atomic
+  `tryReserveRolling(subjectId, resource, dimension, window, delta, limit,
+  nowMs, notifyPct)` implementing §4.4 / §7.1's `rolling_refill` branch:
+  insert default row if missing (`balance = limit`, `window_start = nowMs`),
+  lazily refill inside the same tx using
+  `refilled = floor(elapsed_ms * limit / window_ms)`, advance
+  `window_start` by exactly `refilled * window_ms / limit` so fractional
+  tokens are preserved, then conditional
+  `UPDATE … SET balance = :new_balance - :delta … WHERE :new_balance >=
+  :delta RETURNING balance`. A negative `delta` (refund) computes
+  `new_balance = min(limit, balance + refilled - delta)` and unconditionally
+  succeeds (clamped at `limit`).
+- **Touches.** `src/quota/counter-rolling.ts` (new).
+- **Tests.** `tests/quota/counter-rolling.test.ts`: refill across short
+  (<1 token worth of elapsed_ms) and long elapsed_ms; cap at `limit`;
+  fractional-token preservation over many small reserves never loses
+  tokens to rounding; default row created on first call; race-safety via
+  parallel reserves under `p-limit(8)`; refund (negative delta) never
+  exceeds `limit`.
+- **Exit criteria.** Rolling-refill primitive race-safe; fixed-window
+  primitive untouched.
+
+### Phase 11 — `reserveQuota`
+
+- **Goal.** Public engine: resolve plan, fan out the right primitive
+  (`tryIncrementFixedWindow` for `algorithm = 'fixed_window'`,
+  `tryReserveRolling` for `'rolling_refill'`) over every `(dimension,
+  window)` triple in the limits matrix for the resource. On first breach,
+  roll back all prior increments **within the same tx**.
 - **Touches.** `src/quota/reserve.ts` (new), `src/quota/index.ts` (new,
   re-export façade).
 - **Tests.** `tests/quota/reserve.test.ts`:
-  - allowed path returns `remainingByDimension` for every limited triple;
-  - breached path returns `{ breachedDimension, retryAfterMs }` and **leaves
-    `quota_counter` unchanged** for the other dimensions;
+  - allowed path returns `remainingByDimension` for every limited triple
+    (`limit - count` for fixed_window, `balance` for rolling_refill);
+  - breached path returns `{ breachedDimension, retryAfterMs }` with
+    `retryAfterMs` computed correctly for both algorithms (window-end for
+    fixed, `ceil((delta - balance) * window_ms / limit)` for rolling) and
+    **leaves `quota_counter` unchanged** for the other dimensions;
+  - mixed-algorithm plan (one rolling and one fixed row on the same
+    resource) works end-to-end;
   - unlimited plan returns `allowed: true` with no rows touched.
-- **Exit criteria.** Engine works against the migrated+seeded DB; no wiring
-  into orchestrator yet.
+- **Exit criteria.** Engine works against the migrated+seeded DB; no
+  wiring into orchestrator yet.
 
-### Phase 11 — `commitQuota`
+### Phase 12 — `commitQuota`
 
-- **Goal.** Public engine: apply signed deltas to reconcile actuals.
+- **Goal.** Public engine: apply signed deltas to reconcile actuals,
+  dispatching to the per-algorithm primitives used by `reserveQuota`.
 - **Touches.** `src/quota/commit.ts` (new), façade re-export.
-- **Tests.** `tests/quota/commit.test.ts`: over-estimate (negative delta on
-  `input_tokens`), under-estimate (positive delta on `output_tokens`), error
-  refund (negative delta + zero on `requests`), clamp behaviour.
+- **Tests.** `tests/quota/commit.test.ts`: over-estimate (negative delta
+  on `input_tokens`), under-estimate (positive delta on `output_tokens`),
+  error refund (negative delta + zero on `requests`), clamp behaviour for
+  both algorithms.
 - **Exit criteria.** Reconciliation engine complete; still no callers.
 
-### Phase 12 — Audit writer
+### Phase 13 — Audit writer
 
 - **Goal.** `recordAudit(action, actorId, subjectId?, planId?, payload)`
   inserts one row into `plan_audit`. Pure side-effect; no resolver/engine
@@ -197,147 +285,283 @@ nowMs)` that supports **negative deltas**, clamping `count` at zero. Used
 - **Touches.** `src/quota/audit.ts` (new).
 - **Tests.** `tests/quota/audit.test.ts`: each action enum value, JSON
   payload round-trip.
-- **Exit criteria.** Append-only audit primitive ready for use by HTTP/admin
-  layers.
+- **Exit criteria.** Append-only audit primitive ready for use by HTTP /
+  admin layers.
 
 ---
 
 ## Track B — Enforcement wiring (turns the engine on)
 
-### Phase 13 — Orchestrator pre-call gate (main role)
+### Phase 14 — Orchestrator pre-call gate (main role)
 
 - **Goal.** Insert `reserveQuota('llm:main', { requests: 1, input_tokens:
-estimateInput(prompt), output_tokens: outputBudget })` immediately before
-  the `generateText` call. On denial, return the structured "quota exhausted"
-  reply (see §8 of spec) and **do not** call the model.
+  estimateInput(prompt), output_tokens: outputBudget })` immediately before
+  the `generateText` call. On denial, return the structured "quota
+  exhausted" reply (see §8 of spec) and **do not** call the model.
 - **Touches.** `src/llm-orchestrator-support.ts` (pre-call hook),
   `src/llm-orchestrator-types.ts` (new dep typed via DI).
 - **Tests.** `tests/llm-orchestrator/quota-gate.test.ts`: stub the quota
-  engine; assert the gate is called with the right args; assert `generateText`
-  is not invoked on denial; assert the failure reply contains plan name and
-  reset time.
-- **Exit criteria.** Main-role gate live; small/embed/tool/web still un-gated.
+  engine; assert the gate is called with the right args; assert
+  `generateText` is not invoked on denial; assert the failure reply
+  contains plan name and reset time.
+- **Exit criteria.** Main-role gate live; small / embed / tool / web /
+  attachment still un-gated.
 
-### Phase 14 — Orchestrator commit hook
+### Phase 15 — Orchestrator commit hook
 
-- **Goal.** In the existing `llm:end` / `llm:error` subscriber (same module
-  that calls `recordUsage`), call `commitQuota` with the actual deltas. On
-  error, refund tokens but **not** the request count.
+- **Goal.** In the existing `llm:end` / `llm:error` subscriber (same
+  module that calls `recordUsage`), call `commitQuota` with the actual
+  deltas. On error, refund tokens but **not** the request count.
 - **Touches.** `src/usage/index.ts` (extend `handleEvent`).
-- **Tests.** Extend `tests/usage/index.test.ts`: assert commit is called with
-  the right signed deltas for success and error events.
-- **Exit criteria.** Counters reconcile to actuals; over-/under-estimates
+- **Tests.** Extend `tests/usage/index.test.ts`: assert commit is called
+  with the right signed deltas for success and error events.
+- **Exit criteria.** Counters reconcile to actuals; over- / under-estimates
   visible in the resulting `quota_counter` rows.
 
-### Phase 15 — Small-role gate
+### Phase 16 — Small-role gate
 
-- **Goal.** Mirror Phase 13 for the small-role LLM path. Same module hook,
+- **Goal.** Mirror Phase 14 for the small-role LLM path. Same module hook,
   different `resource` arg.
 - **Touches.** `src/llm-orchestrator-support.ts`.
 - **Tests.** Add small-role coverage in the existing quota-gate test file.
 - **Exit criteria.** Small-role calls denied past their plan limit.
 
-### Phase 16 — Tool wrapper gate
+### Phase 17 — Tool wrapper gate
 
 - **Goal.** Increment `tool.requests.*` before every tool execution in the
-  tool wrapper used by `src/tools/`. On denial, return the structured failure
-  result described in §8 of spec (`{ success: false, error: { code:
-'quota_exceeded', ... } }`).
+  tool wrapper used by `src/tools/`. On denial, return the structured
+  failure result described in §8 of spec (`{ success: false, error: {
+  code: 'quota_exceeded', ... } }`).
 - **Touches.** `src/tools/tool-execution-wrapper.ts` (or the equivalent
   module — locate via `code_symbol` before starting).
-- **Tests.** `tests/tools/quota-gate.test.ts`: gate fires, structured failure
-  returned, `tool_call_events` still recorded for the attempt.
+- **Tests.** `tests/tools/quota-gate.test.ts`: gate fires; structured
+  failure returned; `tool_call_events` still recorded for the attempt.
 - **Exit criteria.** Tool calls denied past their plan limit; LLM sees a
   structured error and can apologise.
 
-### Phase 17 — Web-fetch gate
+### Phase 18 — Web-fetch gate
 
 - **Goal.** Have `consumeWebFetchQuota` delegate to the new engine for the
   limit value (read from the active plan via the resolver). The old
-  `web_rate_limit` table is **still written** for one release as a safety net
-  but is no longer the source of the limit.
-- **Touches.** `src/web/rate-limit.ts`, `src/web/fetch-extract.ts` (only the
-  injection point if needed).
-- **Tests.** Extend `tests/web/rate-limit.test.ts`: plan-driven limit beats
-  the hard-coded constant; subject with `unlimited` is never throttled.
+  `web_rate_limit` table is **still written** for one release as a safety
+  net but is no longer the source of the limit.
+- **Touches.** `src/web/rate-limit.ts`, `src/web/fetch-extract.ts` (only
+  the injection point if needed).
+- **Tests.** Extend `tests/web/rate-limit.test.ts`: plan-driven limit
+  beats the hard-coded constant; subject with `unlimited` is never
+  throttled; rolling-refill bucket allows bursts up to capacity while
+  preserving the long-run average.
 - **Exit criteria.** Plan-driven web-fetch limit live; legacy table still
   written for one release window.
 
-### Phase 18 — Proactive LLM gate
+### Phase 19 — Proactive LLM gate (basic deny)
 
 - **Goal.** Make `src/deferred-prompts/proactive-llm.ts` pass through the
-  same reserve/commit calls as the interactive path.
+  same reserve / commit calls as the interactive path **without** any
+  fallback behaviour yet — denial simply aborts the dispatch and the next
+  scheduler tick retries. This phase exists separately from Phase 20 so
+  the gate can be verified in isolation; Phase 20 layers the UX fallback
+  chain on top.
 - **Touches.** `src/deferred-prompts/proactive-llm.ts`,
   `src/deferred-prompts/proactive-llm-helpers.ts`.
-- **Tests.** Extend the proactive-LLM tests: deny path skips dispatch,
+- **Tests.** Extend the proactive-LLM tests: deny path skips dispatch;
   allow path proceeds normally.
-- **Exit criteria.** A deferred prompt cannot drain a subject past its plan.
+- **Exit criteria.** A deferred prompt cannot drain a subject past its
+  plan; deferred dispatch is observably no-op'd on denial.
 
-### Phase 19 — Embedding gate
+### Phase 20 — Deferred-prompt fallback chain
 
-- **Goal.** Insert `reserveQuota('llm:embed', ...)` in `src/embeddings.ts`.
-  On denial, callers in `src/memos.ts` already degrade to keyword search; this
-  phase only asserts the degradation still triggers.
+- **Goal.** Add the §7.4 fallback chain to the deferred-prompt
+  dispatcher so quota exhaustion never silently drops a scheduled
+  reminder:
+  1. on `llm:main` denial, retry the reservation as `llm:small`;
+  2. on `llm:small` denial, deliver a templated non-LLM reminder built
+     from the deferred-prompt row (`originalUserText`, `scheduledFor`,
+     `resetHuman`, subject timezone);
+  3. but if `retryAfterMs <= DEFERRED_PROMPT_GRACE_MS` (default
+     `15 min`), reschedule the dispatch attempt instead of falling back.
+
+  Record `delivery_mode` (`'llm_main' | 'llm_small' | 'template' |
+  'deferred_retry'`) per dispatch for metrics.
+- **Touches.**
+  - `src/db/migrations/<M>_deferred_prompt_delivery_mode.ts` (new) — adds
+    `delivery_mode text NOT NULL DEFAULT 'llm_main'` to the
+    `deferred_prompts` table.
+  - `src/db/deferred-prompts-schema.ts` — export the column.
+  - `src/deferred-prompts/proactive-llm.ts` — wire the chain.
+  - `src/deferred-prompts/templated-reminder.ts` (new) — pure formatter
+    that builds the user-visible reminder string from
+    `(originalUserText, scheduledFor, resetHuman, timezone)`.
+- **Tests.**
+  - `tests/deferred-prompts/templated-reminder.test.ts` — formatter shape
+    and timezone formatting.
+  - `tests/deferred-prompts/fallback-chain.test.ts` — all four paths fire
+    correctly; templated path is **never** blocked by quota and is
+    delivered even when every LLM resource is denied; `delivery_mode` is
+    recorded; defer-and-retry actually reschedules and is bounded by
+    `DEFERRED_PROMPT_GRACE_MS`.
+- **Exit criteria.** A subject whose `llm:main` is exhausted still
+  receives every scheduled deferred prompt, either as a small-model
+  message, as a templated reminder, or as a slightly delayed
+  LLM-generated message after the bucket rolls over.
+
+### Phase 21 — Embedding gate
+
+- **Goal.** Insert `reserveQuota('llm:embed', ...)` in
+  `src/embeddings.ts`. On denial, callers in `src/memos.ts` already
+  degrade to keyword search; this phase only asserts the degradation
+  still triggers.
 - **Touches.** `src/embeddings.ts`.
 - **Tests.** `tests/embeddings/quota-gate.test.ts`: denial returns the
-  agreed "skip embeddings" signal; `tests/memos/search.test.ts` extended to
-  assert the keyword fallback fires when embeddings are denied.
-- **Exit criteria.** Embedding calls gated; memo search degrades gracefully.
+  agreed "skip embeddings" signal; `tests/memos/search.test.ts` extended
+  to assert the keyword fallback fires when embeddings are denied.
+- **Exit criteria.** Embedding calls gated; memo search degrades
+  gracefully.
 
-### Phase 20 — Garbage collector
+### Phase 22 — Attachment storage gate
+
+- **Goal.** Insert `reserveQuota('attachment', { storage_bytes: size })`
+  before S3 upload completion in the attachment ingest path (§7.7). On
+  denial, abort the upload **before** any S3 write so no partial files
+  exist; the user-visible error is "you're out of attachment storage on
+  plan _{planName}_; delete older files or ask the admin for a higher
+  cap". On delete, call
+  `commitQuota('attachment', { storage_bytes: -size })`.
+- **Touches.** `src/attachments/ingest.ts` (locate via `code_symbol`
+  before starting; module name approximate),
+  `src/attachments/manifest.ts` (or whichever module drives the delete
+  code path), `src/attachments/CLAUDE.md` (note the new invariant).
+- **Tests.**
+  - `tests/attachments/quota-gate.test.ts` — reserve denies path
+    (no S3 write, no `attachment_metadata` row); allow path proceeds
+    normally.
+  - `tests/attachments/delete-refund.test.ts` — delete decrements the
+    counter and clamps at 0 under accounting drift.
+- **Exit criteria.** Subject's `attachment.storage_bytes` counter tracks
+  the real outstanding footprint; ingest aborts cleanly when out of
+  quota.
+
+### Phase 23 — Attachment reconciliation sweep
+
+- **Goal.** Opportunistic background sweep that recomputes
+  `quota_counter.count` for `attachment.storage_bytes` per subject from
+  `SUM(attachment_metadata.size_bytes)` and `UPSERT`s the canonical
+  value, self-healing any accounting drift caused by missed delete
+  events or crashes between S3 and metadata writes.
+- **Touches.** `src/quota/attachment-reconcile.ts` (new); scheduler entry
+  to register it (mirror existing scheduled jobs in `src/index.ts` or
+  wherever periodic jobs are wired). Default cadence: every 1 h.
+- **Tests.** `tests/quota/attachment-reconcile.test.ts`: introduce a
+  positive **and** a negative drift; run the sweep; assert the counter is
+  corrected; assert the sweep never produces negative `count`.
+- **Exit criteria.** Counter drift visibly self-heals on the next sweep.
+
+### Phase 24 — Threshold notice (80 %)
+
+- **Goal.** Implement §7.8. Counter primitives emit
+  `quota:threshold_crossed` on the in-process event bus when post-update
+  usage crosses `notify_pct` for the first time in the active bucket;
+  subscriber in `src/quota/notice.ts` dispatches a templated non-LLM
+  heads-up via the subject's primary chat surface.
+  `notified_threshold_pct` is set inside the same tx that detected the
+  crossing, so the notice is guaranteed to fire at most once per bucket.
+  Reset semantics:
+  - `fixed_window` — column resets to `0` together with `count` on bucket
+    rollover (already handled by the Phase 8 `ON CONFLICT … DO UPDATE`).
+  - `rolling_refill` — column resets to `0` whenever `balance` climbs
+    back above the threshold (`limit - notify_pct * limit / 100`).
+- **Touches.**
+  - `src/quota/counter-fixed.ts` and `src/quota/counter-rolling.ts` —
+    emit the event after a successful update if the crossing condition
+    is met.
+  - `src/quota/notice.ts` (new) — subscriber that resolves the subject's
+    primary chat surface (DM for `user:`, group-main-chat for `group:`,
+    suppress inside threads per §7.8 and coalesce to the next main-chat
+    reply) and posts the formatted message.
+  - `src/quota/notice-template.ts` (new) — pure formatter.
+  - `src/index.ts` — register the subscriber at startup.
+- **Tests.**
+  - `tests/quota/notice-template.test.ts` — formatter shape.
+  - `tests/quota/threshold-emit.test.ts` — both primitives emit exactly
+    once per bucket; rollover re-arms (fixed); recovery above threshold
+    re-arms (rolling); `notify_pct = 0` disables emission.
+  - `tests/quota/notice-subscriber.test.ts` — routes to DM for user
+    subjects; routes to group main chat for group subjects; thread-scoped
+    triggers are coalesced to the next main-chat reply (asserts via a
+    stub `ChatProvider`).
+- **Exit criteria.** A subject crossing 80 % of any limit receives one
+  notice on their primary chat surface; no repeats inside the same
+  bucket; no notice when the admin sets `notify_pct = 0`.
+
+### Phase 25 — Garbage collector
 
 - **Goal.** Opportunistic GC of old `quota_counter` rows on every 1024th
-  write, parameterised by `QUOTA_RETENTION_MS` env var (default `2 ×
-MONTH_MS`). Matches the spec's §5.5.
-- **Touches.** `src/quota/counter.ts` (add the modulo trigger),
-  `src/quota/gc.ts` (new, pure delete query).
-- **Tests.** `tests/quota/gc.test.ts`: GC fires at the right cadence, deletes
-  only rows older than retention.
-- **Exit criteria.** Old buckets disappear; live buckets never deleted.
+  write, parameterised by `QUOTA_RETENTION_MS` env var (default
+  `2 × MONTH_MS`). Matches the spec's §5.5. Stock-dimension rows
+  (`attachment.storage_bytes`) are exempt — their `window_start` never
+  rolls.
+- **Touches.** `src/quota/counter-fixed.ts` and
+  `src/quota/counter-rolling.ts` (add the modulo trigger),
+  `src/quota/gc.ts` (new, pure delete query that excludes
+  `dimension = 'storage_bytes'`).
+- **Tests.** `tests/quota/gc.test.ts`: GC fires at the right cadence;
+  deletes only rows older than retention; never deletes stock rows.
+- **Exit criteria.** Old buckets disappear; live and stock buckets never
+  deleted.
 
 ---
 
 ## Track C — User-facing surface (chat)
 
-### Phase 21 — `get_my_plan` tool
+### Phase 26 — `get_my_plan` tool
 
 - **Goal.** New tool, registered in the tool builder, available in DM and
-  group (`proactive` allowed). Returns the JSON shape from §9.1.
+  group (`proactive` allowed). Returns the JSON shape from §9.1,
+  including `algorithm` and `notifyPct` per limit row.
 - **Touches.** `src/tools/quota/get-my-plan.ts` (new),
-  `src/tools/tools-builder.ts` (register), `src/tools/tool-metadata.ts` (add
-  metadata row).
-- **Tests.** `tests/tools/get-my-plan.test.ts`: shape, gating, subject-id
-  derivation (thread-stripped).
+  `src/tools/tools-builder.ts` (register), `src/tools/tool-metadata.ts`
+  (add metadata row).
+- **Tests.** `tests/tools/get-my-plan.test.ts`: shape includes algorithm
+  and notifyPct; gating; subject-id derivation (thread-stripped).
 - **Exit criteria.** Tool visible to the model and to the dashboard.
 
-### Phase 22 — `get_my_quota` tool
+### Phase 27 — `get_my_quota` tool
 
 - **Goal.** Companion tool returning the live snapshot, one entry per
-  limited triple, with `resetsAt` from Phase 3 math.
+  limited triple, with `algorithm`, `used`, `limit`, `remaining`,
+  `resetsAt` from Phase 3 math (omitted for stock dimensions), and
+  `refillRatePerSecond` for `rolling_refill` entries.
 - **Touches.** `src/tools/quota/get-my-quota.ts` (new), tools-builder,
   tool-metadata.
-- **Tests.** `tests/tools/get-my-quota.test.ts`: snapshot shape, monotonic
-  `remaining`, correct reset for each window.
-- **Exit criteria.** Tool visible and stable across the four window types.
+- **Tests.** `tests/tools/get-my-quota.test.ts`: snapshot shape;
+  monotonic `remaining` across both algorithms; correct reset for each
+  window; `refillRatePerSecond` present only for rolling rows; no
+  `resetsAt` for `attachment.storage_bytes`.
+- **Exit criteria.** Tool visible and stable across the three window
+  types and both algorithms.
 
-### Phase 23 — `/plan` slash command
+### Phase 28 — `/plan` slash command
 
-- **Goal.** Short-circuit handler in `src/bot.ts` and the command registry
-  (`src/commands/`). Replies with a single localised line summarising the
-  active plan. **Zero LLM cost.**
-- **Touches.** `src/commands/plan.ts` (new), `src/commands/index.ts` (register),
-  `src/bot.ts` (route).
-- **Tests.** `tests/commands/plan.test.ts`: DM, group, group thread (asserts
-  the same plan name in main and thread).
-- **Exit criteria.** Command works on all three chat providers' capability
-  surfaces.
+- **Goal.** Short-circuit handler in `src/bot.ts` and the command
+  registry (`src/commands/`). Replies with a single localised line
+  summarising the active plan. **Zero LLM cost.**
+- **Touches.** `src/commands/plan.ts` (new), `src/commands/index.ts`
+  (register), `src/bot.ts` (route).
+- **Tests.** `tests/commands/plan.test.ts`: DM, group, group thread
+  (asserts the same plan name in main and thread).
+- **Exit criteria.** Command works on all three chat providers'
+  capability surfaces.
 
-### Phase 24 — `/quota` slash command
+### Phase 29 — `/quota` slash command
 
-- **Goal.** Same shape as Phase 23 but lists every limited triple.
+- **Goal.** Same shape as Phase 28 but lists every limited triple.
+  Render resets as human-friendly strings; for `rolling_refill` rows the
+  line reads "≈ X / Y, refills fully in Z" rather than a hard reset
+  time. Stock-dimension rows render without a reset clause.
 - **Touches.** `src/commands/quota.ts` (new), registry, `src/bot.ts`.
-- **Tests.** `tests/commands/quota.test.ts`.
-- **Exit criteria.** Command renders correctly with 0, 1, and many limits.
+- **Tests.** `tests/commands/quota.test.ts`: 0 / 1 / many limits;
+  mixed algorithms; stock-dimension row formatted without a reset time.
+- **Exit criteria.** Command renders correctly across plan shapes.
 
 ---
 
@@ -347,126 +571,153 @@ Each route is its own phase to keep diffs small and reviews honest. All
 routes are mounted in `src/debug/server.ts` and gated by `DEBUG_TOKEN`
 exactly like `POST /admin/llm` (see `src/debug/billing-routes.ts`).
 
-### Phase 25 — `GET /admin/plans` and `GET /admin/plans/:id`
+### Phase 30 — `GET /admin/plans` and `GET /admin/plans/:id`
 
 - **Touches.** `src/debug/plans-routes.ts` (new), `src/debug/server.ts`
   (router).
-- **Tests.** `tests/debug/plans-routes.test.ts`: 200 with token, 401 without,
-  shape matches §9.1 of spec.
+- **Tests.** `tests/debug/plans-routes.test.ts`: 200 with token, 401
+  without, shape matches §9.1 of spec (algorithm + notifyPct present).
 - **Exit criteria.** Read API live and tested.
 
-### Phase 26 — `POST /admin/plans`
+### Phase 31 — `POST /admin/plans`
 
-- **Goal.** Create a new plan with limits in a single transaction. Validates
-  every triple via Phase 2's `isValidLimitTriple`. Writes a `plan_create`
-  audit row.
+- **Goal.** Create a new plan with limits in a single transaction.
+  Validates every triple via Phase 2's `isValidLimitTriple` **and** every
+  `(dimension, algorithm)` pair via `isValidAlgorithmForDimension`;
+  defaults `algorithm` and `notify_pct` from
+  `QUOTA_DEFAULT_ALGORITHM` / `QUOTA_NOTIFY_THRESHOLD_PCT` if absent.
+  Writes a `plan_create` audit row.
 - **Touches.** `src/debug/plans-routes.ts`.
-- **Tests.** Happy path; 400 on invalid triple; 409 on duplicate id; audit
-  row written.
-- **Exit criteria.** Plan creation gated by `DEBUG_TOKEN`; audit verifiable.
+- **Tests.** Happy path; 400 on invalid triple; 400 on
+  `rolling_refill` + `storage_bytes`; 409 on duplicate id; audit row
+  written including the algorithm / notify_pct payload.
+- **Exit criteria.** Plan creation gated by `DEBUG_TOKEN`; audit
+  verifiable.
 
-### Phase 27 — `PUT /admin/plans/:id`
+### Phase 32 — `PUT /admin/plans/:id`
 
-- **Goal.** Update name/description/limits. Limits replace atomically (delete
-  - insert in one tx). `plan_update` audit row.
+- **Goal.** Update name / description / limits. Limits replace atomically
+  (delete + insert in one tx). When a row's `algorithm` switches, the
+  matching `quota_counter` row is **dropped** in the same tx (per design
+  §4.4 — we never translate one algorithm's state into the other's).
+  Writes a `plan_update` audit row.
 - **Touches.** `src/debug/plans-routes.ts`.
-- **Tests.** Partial updates, full limits replacement, audit row.
-- **Exit criteria.** Updates atomic; no half-applied limits possible.
+- **Tests.** Partial updates; full limits replacement; algorithm switch
+  drops the counter row; audit row.
+- **Exit criteria.** Updates atomic; no half-applied limits possible; no
+  stale counter survives an algorithm switch.
 
-### Phase 28 — `DELETE /admin/plans/:id`
+### Phase 33 — `DELETE /admin/plans/:id`
 
 - **Goal.** Delete a plan. If subjects are pinned to it, require
   `?fallback=<planId>` query param and reassign pinned subjects to the
   fallback in the same transaction. Default plan cannot be deleted.
 - **Touches.** `src/debug/plans-routes.ts`.
-- **Tests.** No-subjects case, with-subjects requires fallback (409 without),
-  default-plan rejected (400), audit row for each affected subject.
+- **Tests.** No-subjects case; with-subjects requires fallback (409
+  without); default-plan rejected (400); audit row for each affected
+  subject.
 - **Exit criteria.** Safe deletion; admin always has an escape hatch.
 
-### Phase 29 — `PUT /admin/subjects/:subjectId/plan`
+### Phase 34 — `PUT /admin/subjects/:subjectId/plan`
 
 - **Goal.** Assign or override a plan for a subject. Body:
-  `{ planId, expiresAt?, note? }`. Reject thread-scoped ids (409, see §10.2
-  of spec). `subject_assign` audit row.
+  `{ planId, expiresAt?, note? }`. Reject thread-scoped ids (409, see
+  §10.2 of spec). Writes a `subject_assign` audit row.
 - **Touches.** `src/debug/billing-routes.ts` (or a new
-  `src/debug/subjects-routes.ts` if billing-routes is getting large; decide at
-  the start of this phase).
-- **Tests.** Happy path, expiry round-trip, thread-id rejection, audit row.
+  `src/debug/subjects-routes.ts` if billing-routes is getting large;
+  decide at the start of this phase).
+- **Tests.** Happy path; expiry round-trip; thread-id rejection; audit
+  row.
 - **Exit criteria.** Per-subject overrides usable via API.
 
-### Phase 30 — `DELETE /admin/subjects/:subjectId/plan`
+### Phase 35 — `DELETE /admin/subjects/:subjectId/plan`
 
-- **Goal.** Remove an override, falling back to the default plan. Writes a
-  `subject_unassign` audit row.
-- **Touches.** Same module as Phase 29.
+- **Goal.** Remove an override, falling back to the default plan. Writes
+  a `subject_unassign` audit row.
+- **Touches.** Same module as Phase 34.
 - **Tests.** Removes the row; idempotent; audit row.
-- **Exit criteria.** Override removal works; default plan applies afterwards.
+- **Exit criteria.** Override removal works; default plan applies
+  afterwards.
 
-### Phase 31 — `GET /billing/subject/:subjectId/quota`
+### Phase 36 — `GET /billing/subject/:subjectId/quota`
 
-- **Goal.** Snapshot of live `quota_counter` rows for the subject, joined
-  with the active plan's limits to render `{ used, limit, remaining,
-resetsAt }` per triple. Used by the dashboard Subject Detail card.
-- **Touches.** `src/debug/billing-routes.ts`, `src/debug/billing.ts` (read
-  helper).
-- **Tests.** Mixed limited/unlimited triples, empty counters, near-zero
-  remaining.
+- **Goal.** Snapshot of live `quota_counter` rows for the subject,
+  joined with the active plan's limits to render
+  `{ used, limit, remaining, resetsAt, algorithm, notifyPct,
+  notifiedThresholdPct, refillRatePerSecond? }` per triple. Used by the
+  dashboard Subject Detail card.
+- **Touches.** `src/debug/billing-routes.ts`, `src/debug/billing.ts`
+  (read helper).
+- **Tests.** Mixed limited / unlimited triples; empty counters; near-zero
+  remaining; mixed-algorithm rows; threshold already notified vs not;
+  stock-dimension row has no `resetsAt`.
 - **Exit criteria.** Dashboard-ready endpoint live.
 
-### Phase 32 — `GET /admin/plans/audit`
+### Phase 37 — `GET /admin/plans/audit`
 
 - **Goal.** Paginated read of `plan_audit`. Query params: `subjectId?`,
   `since?`, `limit` (default 100, max 500).
 - **Touches.** `src/debug/plans-routes.ts`.
-- **Tests.** Pagination boundary, subject filter, since filter.
+- **Tests.** Pagination boundary; subject filter; since filter.
 - **Exit criteria.** Auditable history visible to admin.
 
 ---
 
 ## Track E — Admin dashboard UI
 
-The dashboard is Svelte 5 with runes. Each phase mirrors the existing layout
-under `client/debug/billing/` and uses the same fetcher pattern.
+The dashboard is Svelte 5 with runes. Each phase mirrors the existing
+layout under `client/debug/billing/` and uses the same fetcher pattern.
 
-### Phase 33 — Plans fetchers + types
+### Phase 38 — Plans fetchers + types
 
 - **Goal.** Type and HTTP-fetch wrappers for every Track D route, plus
-  shared types added to `client/debug/dashboard-types.ts`.
+  shared types added to `client/debug/dashboard-types.ts` (including
+  `Algorithm`, `notifyPct`, and the rolling-refill-specific fields).
 - **Touches.** `client/debug/plans/fetchers.ts` (new),
   `client/debug/dashboard-types.ts`.
 - **Tests.** `tests/client/plans-fetchers.test.ts` (happy-dom) using
   `setMockFetch`.
-- **Exit criteria.** Frontend can talk to every plans/quota endpoint.
+- **Exit criteria.** Frontend can talk to every plans / quota endpoint.
 
-### Phase 34 — `PlansPanel.svelte`
+### Phase 39 — `PlansPanel.svelte`
 
-- **Goal.** List view: id, name, description, is_default, pinned-subject
-  count, created/updated timestamps. "New plan" button (modal in next phase).
+- **Goal.** List view: id, name, description, is_default,
+  pinned-subject count, created / updated timestamps. "New plan" button
+  (modal in next phase).
 - **Touches.** `client/debug/plans/PlansPanel.svelte` (new),
-  `client/debug/App.svelte` (add tab), `client/debug/dashboard.svelte.ts`
-  (state slice).
+  `client/debug/App.svelte` (add tab),
+  `client/debug/dashboard.svelte.ts` (state slice).
 - **Tests.** `tests/client/PlansPanel.test.ts` against the fetcher mock.
-- **Exit criteria.** Tab visible, table renders, refresh works.
+- **Exit criteria.** Tab visible; table renders; refresh works.
 
-### Phase 35 — `PlanEditor.svelte` create flow
+### Phase 40 — `PlanEditor.svelte` create flow
 
 - **Goal.** Modal-form to create a plan, including the limits matrix
-  (`resource` rows × `dimension × window` columns). Inline validation against
-  `isValidLimitTriple`. Calls `POST /admin/plans`.
+  (`resource` rows × `dimension × window` columns). Each cell exposes
+  `limit_value`, an `algorithm` selector (`fixed_window` /
+  `rolling_refill`, defaulting per design §10.1) and an optional
+  `notify_pct` override (inherits `QUOTA_NOTIFY_THRESHOLD_PCT` when
+  empty). Inline validation against `isValidLimitTriple` **and**
+  `isValidAlgorithmForDimension`. Calls `POST /admin/plans`.
 - **Touches.** `client/debug/plans/PlanEditor.svelte` (new),
   `client/debug/components/Modal.svelte` (reuse).
-- **Tests.** `tests/client/PlanEditor-create.test.ts`.
+- **Tests.** `tests/client/PlanEditor-create.test.ts`: happy path; cell
+  validation; algorithm selector hidden / forced to `fixed_window` for
+  stock dimensions; submit payload includes algorithm + notify_pct.
 - **Exit criteria.** Admin can create a plan end-to-end through the UI.
 
-### Phase 36 — `PlanEditor.svelte` edit + delete flow
+### Phase 41 — `PlanEditor.svelte` edit + delete flow
 
-- **Goal.** Reuse the same editor for `PUT`; add a delete button with the
-  fallback-plan picker required by Phase 28.
+- **Goal.** Reuse the same editor for `PUT`; add a delete button with
+  the fallback-plan picker required by Phase 33. Surface a warning when
+  an algorithm change will drop the active `quota_counter` row for that
+  triple.
 - **Touches.** Same component.
-- **Tests.** `tests/client/PlanEditor-edit-delete.test.ts`.
+- **Tests.** `tests/client/PlanEditor-edit-delete.test.ts`: edit happy
+  path; algorithm-switch warning; delete with / without fallback.
 - **Exit criteria.** Full CRUD reachable from the UI.
 
-### Phase 37 — Subjects table: Plan column
+### Phase 42 — Subjects table: Plan column
 
 - **Goal.** Extend `client/debug/billing/SubjectsTable.svelte` with a
   **Plan** column rendered as an inline `<select>`. On change call
@@ -475,30 +726,34 @@ under `client/debug/billing/` and uses the same fetcher pattern.
 - **Tests.** Existing component test extended.
 - **Exit criteria.** Plan reassignment one click from Billing.
 
-### Phase 38 — Subjects table: Quota column
+### Phase 43 — Subjects table: Quota column
 
-- **Goal.** Add a compact bar showing the most-constraining live dimension
-  (e.g. `73 % llm:main input_tokens day`). Fetched in bulk via a new
-  optional `?withQuota=true` query param on `/billing/subjects`.
+- **Goal.** Add a compact bar showing the most-constraining live
+  dimension (e.g. `73 % llm:main input_tokens day`). Fetched in bulk via
+  a new optional `?withQuota=true` query param on `/billing/subjects`.
 - **Touches.** `SubjectsTable.svelte`, `src/debug/billing-routes.ts`,
   `src/debug/billing.ts`.
 - **Tests.** Client component test + route test for the new flag.
 - **Exit criteria.** Quota visible at a glance per subject.
 
-### Phase 39 — Subject Detail: Quota card
+### Phase 44 — Subject Detail: Quota card
 
-- **Goal.** Extend `client/debug/billing/SubjectDetail.svelte` with a card
-  showing every triple's meter + the active plan. "Override plan…" opens a
-  modal with `planId` + optional `expiresAt`.
+- **Goal.** Extend `client/debug/billing/SubjectDetail.svelte` with a
+  card showing every triple's meter, the active plan, an **algorithm
+  badge** per row, and the current `notified_threshold_pct` state.
+  "Override plan…" opens a modal with `planId` + optional `expiresAt`.
 - **Touches.** `SubjectDetail.svelte`, new
   `client/debug/billing/SubjectQuotaCard.svelte`,
   `client/debug/billing/OverridePlanModal.svelte`.
-- **Tests.** Component tests for each new file.
+- **Tests.** Component tests for each new file; meter renders correctly
+  for both algorithms; threshold badge visible after a crossing;
+  stock-dimension row formatted without a reset clause.
 - **Exit criteria.** Admin sees full per-subject picture in one view.
 
-### Phase 40 — Audit log viewer (optional, can land later)
+### Phase 45 — Audit log viewer (optional, can land later)
 
-- **Goal.** Tab under Plans showing the last N audit rows with subject filter.
+- **Goal.** Tab under Plans showing the last N audit rows with subject
+  filter.
 - **Touches.** `client/debug/plans/PlanAuditPanel.svelte` (new).
 - **Tests.** Component test against fetcher mock.
 - **Exit criteria.** Plan changes auditable from the UI.
@@ -507,36 +762,37 @@ under `client/debug/billing/` and uses the same fetcher pattern.
 
 ## Track F — Admin DM commands (no `DEBUG_SERVER` deployments)
 
-### Phase 41 — `/plans` admin command
+### Phase 46 — `/plans` admin command
 
 - **Goal.** Admin DM command listing configured plans (read-only).
 - **Touches.** `src/commands/admin.ts`.
 - **Tests.** `tests/commands/admin-plans.test.ts`.
 - **Exit criteria.** Admin can list plans without a dashboard.
 
-### Phase 42 — `/setplan` admin command
+### Phase 47 — `/setplan` admin command
 
-- **Goal.** `/setplan <subject> <planId> [until=<ISO>]`. Resolves `<subject>`
-  via the existing identity utilities (`@username` / user id / `group:<id>`).
-  Writes a `subject_assign` audit row.
+- **Goal.** `/setplan <subject> <planId> [until=<ISO>]`. Resolves
+  `<subject>` via the existing identity utilities (`@username` / user id
+  / `group:<id>`). Writes a `subject_assign` audit row.
 - **Touches.** `src/commands/admin.ts`.
-- **Tests.** `tests/commands/admin-setplan.test.ts`: by-username, by-id,
-  by-group-id, invalid input, expiry round-trip.
+- **Tests.** `tests/commands/admin-setplan.test.ts`: by-username,
+  by-id, by-group-id, invalid input, expiry round-trip.
 - **Exit criteria.** Admin can re-plan any subject from a Telegram DM.
 
 ---
 
 ## Track G — Cleanup (only after one release window)
 
-### Phase 43 — Stop writing to `web_rate_limit`
+### Phase 48 — Stop writing to `web_rate_limit`
 
-- **Goal.** Once Phase 17 has been live for one release, remove the legacy
-  write path. The table still exists.
+- **Goal.** Once Phase 18 has been live for one release, remove the
+  legacy write path. The table still exists.
 - **Touches.** `src/web/rate-limit.ts`.
-- **Tests.** Existing tests updated; assert no inserts to `web_rate_limit`.
+- **Tests.** Existing tests updated; assert no inserts to
+  `web_rate_limit`.
 - **Exit criteria.** Legacy writes gone; reads (if any) gone.
 
-### Phase 44 — Drop `web_rate_limit` migration
+### Phase 49 — Drop `web_rate_limit` migration
 
 - **Goal.** Drop the table after one further release window.
 - **Touches.** `src/db/migrations/<M>_drop_web_rate_limit.ts` (new),
@@ -550,101 +806,117 @@ under `client/debug/billing/` and uses the same fetcher pattern.
 
 ```text
 1 ──┐
-    ├── 7 ─────────────── 10 ──┐
-2 ──┤                          │
-    ├── 8 ─── 9 ────────── 11 ─┤
-3 ──┤                          │
-    │                          ├── 13 ─── 14 ─── 15 ─── 16 ─── 17 ─── 18 ─── 19 ─── 20
-4 ── 5 ── 6 ──────────────  12 ┘                │       │       │
-                                                │       │       └── 43 ── 44
-                                                │       └── (no dependents)
-                                                │
-                                                ├── 21 ── 23
-                                                └── 22 ── 24
-                                                │
-                                                ├── 25 ── 26 ── 27 ── 28
-                                                ├── 29 ── 30
-                                                ├── 31
-                                                └── 32
-                                                │
-                                                ├── 33 ── 34 ── 35 ── 36
-                                                │            └── 37 ── 38 ── 39
-                                                │            └── 40
-                                                │
-                                                └── 41 ── 42
+    ├── 7 ───────────────── 11 ──┐
+2 ──┤                             │
+    ├── 8 ─── 9 ─── 10 ────  12 ──┤
+3 ──┤                             │
+    │                             ├── 14 ── 15 ── 16 ── 17 ── 18 ── 19 ── 21
+4 ── 5 ── 6 ──────────────  13 ───┤                            │       │
+                                  │                            │       ├── 22 ── 23
+                                  │                            │       │
+                                  │                            │       └── 24
+                                  │                            │
+                                  │                            ├── 20  (depends on 19)
+                                  │                            │
+                                  │                            └── 25  (depends on 11)
+                                  │
+                                  │                            ├── 48 ── 49  (after 18)
+                                  │
+                                  ├── 26 ── 28
+                                  ├── 27 ── 29
+                                  │
+                                  ├── 30 ── 31 ── 32 ── 33
+                                  ├── 34 ── 35
+                                  ├── 36
+                                  └── 37
+                                  │
+                                  ├── 38 ── 39 ── 40 ── 41
+                                  │              └── 42 ── 43 ── 44
+                                  │              └── 45
+                                  │
+                                  └── 46 ── 47
 ```
 
-Track A (1–12) is strictly sequential. Track B (13–20) is sequential within
-itself but each phase is independently reviewable. Tracks C, D, E, F can
-proceed in parallel after Track B lands, with the dependency edges shown.
-Track G waits for production telemetry to confirm Phase 17 has not regressed
-web-fetch behaviour.
+Track A (1–13) is strictly sequential. Track B (14–25) is sequential
+within itself but each phase is independently reviewable — note that
+Phase 20 (deferred-prompt fallback) layers on Phase 19, Phase 23
+(attachment reconcile) layers on Phase 22, and Phase 24 (threshold
+notice) depends on the counter primitives being emit-aware (Phases 8 and
+10). Tracks C, D, E, F can proceed in parallel after Track B lands, with
+the dependency edges shown. Track G waits for production telemetry to
+confirm Phase 18 has not regressed web-fetch behaviour.
 
 ## Per-phase session checklist
 
 Use this as the checklist for any individual phase. The list is short on
 purpose — the project's hooks and skills enforce the rest.
 
-1. Read the spec section the phase implements. If unclear, open a question
-   in chat **before** writing code.
+1. Read the spec section the phase implements. If unclear, open a
+   question in chat **before** writing code.
 2. Load the relevant superpower skills (`using-superpowers`,
    `test-driven-development`, `writing-plans`).
-3. Write the failing test(s) listed under **Tests**. Run them, see them red.
+3. Write the failing test(s) listed under **Tests**. Run them, see them
+   red.
 4. Implement the smallest change that turns them green.
-5. Run the baseline verification (`bun lint`, `bun typecheck`, `bun test`,
-   `bun format:check`).
+5. Run the baseline verification (`bun lint`, `bun typecheck`,
+   `bun test`, `bun format:check`).
 6. Run `bun check:full` before declaring done.
-7. Commit on the same branch with a message matching the project's commit
-   conventions (see `git log --oneline -20`).
+7. Commit on the same branch with a message matching the project's
+   commit conventions (see `git log --oneline -20`).
 8. Tick off the phase in this file's progress table below.
 
 ## Progress
 
 > Update this table on merge of each phase.
 
-| #   | Phase                                         | Status |
-| --- | --------------------------------------------- | ------ |
-| 1   | Subject id helper                             | todo   |
-| 2   | Quota types and constants                     | todo   |
-| 3   | Window math                                   | todo   |
-| 4   | DB migration: tables only                     | todo   |
-| 5   | Seed migration                                | todo   |
-| 6   | Plan repository (read side)                   | todo   |
-| 7   | Plan resolver                                 | todo   |
-| 8   | Counter primitive: increment                  | todo   |
-| 9   | Counter primitive: refund/clamp               | todo   |
-| 10  | `reserveQuota`                                | todo   |
-| 11  | `commitQuota`                                 | todo   |
-| 12  | Audit writer                                  | todo   |
-| 13  | Orchestrator pre-call gate (main role)        | todo   |
-| 14  | Orchestrator commit hook                      | todo   |
-| 15  | Small-role gate                               | todo   |
-| 16  | Tool wrapper gate                             | todo   |
-| 17  | Web-fetch gate                                | todo   |
-| 18  | Proactive LLM gate                            | todo   |
-| 19  | Embedding gate                                | todo   |
-| 20  | Garbage collector                             | todo   |
-| 21  | `get_my_plan` tool                            | todo   |
-| 22  | `get_my_quota` tool                           | todo   |
-| 23  | `/plan` slash command                         | todo   |
-| 24  | `/quota` slash command                        | todo   |
-| 25  | `GET /admin/plans` and `GET /admin/plans/:id` | todo   |
-| 26  | `POST /admin/plans`                           | todo   |
-| 27  | `PUT /admin/plans/:id`                        | todo   |
-| 28  | `DELETE /admin/plans/:id`                     | todo   |
-| 29  | `PUT /admin/subjects/:subjectId/plan`         | todo   |
-| 30  | `DELETE /admin/subjects/:subjectId/plan`      | todo   |
-| 31  | `GET /billing/subject/:subjectId/quota`       | todo   |
-| 32  | `GET /admin/plans/audit`                      | todo   |
-| 33  | Plans fetchers + types                        | todo   |
-| 34  | `PlansPanel.svelte`                           | todo   |
-| 35  | `PlanEditor.svelte` create flow               | todo   |
-| 36  | `PlanEditor.svelte` edit + delete flow        | todo   |
-| 37  | Subjects table: Plan column                   | todo   |
-| 38  | Subjects table: Quota column                  | todo   |
-| 39  | Subject Detail: Quota card                    | todo   |
-| 40  | Audit log viewer                              | todo   |
-| 41  | `/plans` admin command                        | todo   |
-| 42  | `/setplan` admin command                      | todo   |
-| 43  | Stop writing to `web_rate_limit`              | todo   |
-| 44  | Drop `web_rate_limit` migration               | todo   |
+| #   | Phase                                            | Status |
+| --- | ------------------------------------------------ | ------ |
+| 1   | Subject id helper                                | todo   |
+| 2   | Quota types and constants                        | todo   |
+| 3   | Window math                                      | todo   |
+| 4   | DB migration: tables only                        | todo   |
+| 5   | Seed migration                                   | todo   |
+| 6   | Plan repository (read side)                      | todo   |
+| 7   | Plan resolver                                    | todo   |
+| 8   | Counter primitive: fixed_window increment        | todo   |
+| 9   | Counter primitive: fixed_window refund/clamp     | todo   |
+| 10  | Counter primitive: rolling_refill reserve+refund | todo   |
+| 11  | `reserveQuota`                                   | todo   |
+| 12  | `commitQuota`                                    | todo   |
+| 13  | Audit writer                                     | todo   |
+| 14  | Orchestrator pre-call gate (main role)           | todo   |
+| 15  | Orchestrator commit hook                         | todo   |
+| 16  | Small-role gate                                  | todo   |
+| 17  | Tool wrapper gate                                | todo   |
+| 18  | Web-fetch gate                                   | todo   |
+| 19  | Proactive LLM gate (basic deny)                  | todo   |
+| 20  | Deferred-prompt fallback chain                   | todo   |
+| 21  | Embedding gate                                   | todo   |
+| 22  | Attachment storage gate                          | todo   |
+| 23  | Attachment reconciliation sweep                  | todo   |
+| 24  | Threshold notice (80 %)                          | todo   |
+| 25  | Garbage collector                                | todo   |
+| 26  | `get_my_plan` tool                               | todo   |
+| 27  | `get_my_quota` tool                              | todo   |
+| 28  | `/plan` slash command                            | todo   |
+| 29  | `/quota` slash command                           | todo   |
+| 30  | `GET /admin/plans` and `GET /admin/plans/:id`    | todo   |
+| 31  | `POST /admin/plans`                              | todo   |
+| 32  | `PUT /admin/plans/:id`                           | todo   |
+| 33  | `DELETE /admin/plans/:id`                        | todo   |
+| 34  | `PUT /admin/subjects/:subjectId/plan`            | todo   |
+| 35  | `DELETE /admin/subjects/:subjectId/plan`         | todo   |
+| 36  | `GET /billing/subject/:subjectId/quota`          | todo   |
+| 37  | `GET /admin/plans/audit`                         | todo   |
+| 38  | Plans fetchers + types                           | todo   |
+| 39  | `PlansPanel.svelte`                              | todo   |
+| 40  | `PlanEditor.svelte` create flow                  | todo   |
+| 41  | `PlanEditor.svelte` edit + delete flow           | todo   |
+| 42  | Subjects table: Plan column                      | todo   |
+| 43  | Subjects table: Quota column                     | todo   |
+| 44  | Subject Detail: Quota card                       | todo   |
+| 45  | Audit log viewer                                 | todo   |
+| 46  | `/plans` admin command                           | todo   |
+| 47  | `/setplan` admin command                         | todo   |
+| 48  | Stop writing to `web_rate_limit`                 | todo   |
+| 49  | Drop `web_rate_limit` migration                  | todo   |

--- a/docs/design/llm-rate-limiting-and-plans.md
+++ b/docs/design/llm-rate-limiting-and-plans.md
@@ -72,9 +72,11 @@ This spec was grounded in the following code, current as of the date above:
 - Subjects receive an in-chat heads-up the first time their usage crosses **80 %**
   of any dimension within the active window, so they can pace themselves before
   hitting the hard cap.
-- Deferred prompts degrade gracefully if the subject is out of quota at delivery
-  time — the prompt still fires, just as a non-LLM templated reminder instead
-  of being silently dropped.
+- Deferred prompts (both `scheduled` and `alert` types) always fire on time
+  even under quota pressure: the dispatcher proactively degrades to the
+  small model once the subject crosses `notify_pct`, falls through to a
+  type-specific non-LLM template if every LLM path is exhausted, and never
+  defers a fire moment around a quota reset.
 - Plan changes are audited.
 - All admin write surfaces are `DEBUG_TOKEN`-gated; `/stats/*` is untouched and
   remains anonymous.
@@ -489,51 +491,100 @@ fit inside the user's quota.
 prompt cannot bypass the subject's plan.
 
 The product principle for deferred prompts is different from a normal LLM
-turn, however: the user explicitly asked, in the past, to be reminded at a
-specific time. If we silently drop the reminder because their LLM quota
-ran out, we have **broken a promise** the bot made — and they may not even
-notice until the reminder window is gone. Quota enforcement therefore must
-not turn deferred prompts into a UX regression.
+turn, however. Two non-negotiables shape the design:
 
-**Fallback chain on `reserveQuota('llm:<role>', ...)` denial in the
-deferred-prompts dispatcher:**
+- **Fire time is sacred.** A deferred prompt MUST be delivered at its
+  scheduled fire moment. The dispatcher never slips a prompt around a
+  quota reset — slipping is a slippery slope: a "leave for the airport
+  now" trigger that arrives 15 min after the gate closes is worse than
+  useless, and once delivery has been delayed there is no principled
+  point to stop deferring (the next bucket may also be empty). Always
+  fire on time; degrade the content if you must.
+- **Silent loss is forbidden.** If every LLM path is over quota, the
+  dispatcher still posts a templated, non-LLM message so the user can
+  see *that* the trigger fired, even if not *how* it would normally
+  read.
 
-1. **Templated reminder (always delivered).** The dispatcher composes a
-   non-LLM message from the stored prompt payload, e.g.:
+The two prompt families flow through the same chain but pick a
+type-specific template at the bottom (see `src/deferred-prompts/types.ts`
+— `ScheduledPrompt` covers one-shot `fire_at` and recurring `rrule`
+triggers, `AlertPrompt` covers condition-triggered notifications).
 
-   > Reminder you scheduled for {scheduledFor}: {originalUserText}
-   > _(LLM is over quota right now, so this is a plain reminder. Your quota
-   > resets {resetHuman}. Reply when you're ready and I'll pick it up.)_
+**Fallback chain at fire time (executed in order, top to bottom):**
 
-   This path costs **zero LLM tokens** and is built entirely from columns
-   already on the deferred-prompts row (`originalUserText`,
-   `scheduledFor`, the subject's resolved timezone). It is gated by no
-   quota and cannot itself be rate-limited, because the alternative is
-   silent loss.
+1. **Try `llm:main`.** Default path for subjects below the early-warning
+   threshold: reserve and dispatch with the main model, same code path
+   as an interactive turn.
+2. **Proactive small-model degrade once the subject has crossed
+   `notify_pct` (the same threshold §7.8 uses for the early-warning
+   notice; default 80 %) on any limited `llm:main.*` triple.** When the
+   subject is in that band, the dispatcher rolls back the step-1
+   reservation (if it was speculatively taken) and reissues against
+   `llm:small`. A deferred prompt is not the right thing to spend the
+   user's last 20 % of `llm:main` headroom on — interactive turns are.
+   This is a *preemptive* degradation, not a recovery path: it kicks in
+   while `llm:main` would still answer.
+3. **Hard fallback to `llm:small` on `llm:main` denial.** If step 1 was
+   skipped (because step 2 fired preemptively) and `llm:small` is also
+   over quota, **or** if step 1 was attempted but `llm:main` was denied
+   at the gate, retry the reservation with `llm:small`. Same code path
+   as step 2's small-model call, different `delivery_reason` for
+   metrics.
+4. **Templated delivery (last resort).** Only when both `llm:main` and
+   `llm:small` are out of quota (or otherwise unavailable). The
+   dispatcher composes a non-LLM message from the stored prompt row
+   using the type-specific formatter below. This path costs **zero LLM
+   tokens**, is gated by no quota, and cannot itself be rate-limited —
+   the alternative is silent loss.
 
-2. **Small-model degrade (best effort).** Before falling all the way back
-   to step 1, the dispatcher retries the reservation with
-   `resource = 'llm:small'`. If `llm:small` is not separately exhausted,
-   it generates the reminder with the small model — typically much
-   cheaper, and produces a friendlier message than the template.
+Defer-and-retry is intentionally **not** part of this chain. Slipping
+the fire time around a quota reset trades a small content downgrade for
+a large UX failure, and there is no good place to stop deferring once
+you start. Keep the fire time; degrade the content.
 
-3. **Defer-and-retry (only if reset is imminent).** If
-   `retryAfterMs <= DEFERRED_PROMPT_GRACE_MS` (default `15 min`), the
-   dispatcher reschedules the dispatch attempt for `retryAfterMs + jitter`
-   instead of falling back, so the user gets the full LLM-generated
-   experience after the bucket rolls over. Past that grace window, step 1
-   fires immediately — the user's "reminder time" is closer to the
-   original schedule than to the reset.
+**Per-type templates (last resort, step 4):**
 
-The choice between the three is recorded in the deferred-prompts row
-(`delivery_mode: 'llm_main' | 'llm_small' | 'template' | 'deferred_retry'`)
-so we can measure how often each path fires and tune the seeded plan
-limits if templated delivery dominates.
+Templates live in `src/deferred-prompts/templated-delivery.ts` next to
+each other so wording stays consistent across types. All three render
+purely from columns already on the deferred-prompts row plus the
+subject's resolved timezone — no LLM call, no tool call.
 
-`commitQuota` is **not** called for the templated path — no LLM call was
-made, no tokens were spent. The `requests` counter for `llm:main` is also
-not consumed in that case (reservation was rolled back), so the user keeps
-the same headroom for their next interactive message.
+- **`scheduled` — one-shot (`fire_at`).** "Scheduled prompt fires now:
+  *{deliveryBriefOrPrompt}*". When
+  `execution_metadata.delivery_brief` is non-empty, prefer it over the
+  raw `prompt` field because the creator already framed it for the
+  user.
+- **`scheduled` — recurring (`rrule`).** "Recurring prompt
+  ({humanRruleSummary}) fires now: *{deliveryBriefOrPrompt}*". The
+  recurrence summary is produced locally from the stored `rrule` string
+  by the same helper used in `list_recurring_tasks` output.
+- **`alert` — condition triggered.** "Alert condition met
+  ({humanConditionSummary}): *{deliveryBriefOrPrompt}*". The condition
+  is rendered as a short human-readable clause (e.g. "task *T-42*
+  status changed to *Done*") built directly from the stored
+  `AlertCondition` tree.
+
+All three templates end with the same short footer noting that the LLM
+is over quota right now and that interactive replies are still accepted
+as soon as the bucket refills. The footer string is a single constant
+in the same module.
+
+**Metrics.** Two columns are recorded on the deferred-prompts row per
+dispatch:
+
+- `delivery_mode: 'llm_main' | 'llm_small' | 'template'` — which
+  renderer produced the message that left the bot.
+- `delivery_reason: 'normal' | 'proactive_degrade' | 'main_denied' |
+  'all_denied'` — which branch of the chain triggered.
+
+Together they let the admin tune `notify_pct` and seeded plan limits if
+proactive degrades or template fallbacks start dominating.
+
+`commitQuota` is **not** called for the templated path — no LLM call
+was made, no tokens were spent. The `requests` counter for `llm:main`
+is also not consumed when step 2 fires preemptively (no `llm:main`
+reservation is held in that case), so the user keeps the same headroom
+for their next interactive message.
 
 ### 7.5 Embeddings
 
@@ -810,8 +861,9 @@ No new required env vars. Optional:
   `fixed_window`-with-no-reset.
 - `QUOTA_NOTIFY_THRESHOLD_PCT` — global default for `plan_limits.notify_pct`
   on newly created rows (default `80`; set to `0` to disable the early
-  warning by default).
-- `DEFERRED_PROMPT_GRACE_MS` — see §7.4 (default `15 * 60 * 1000`).
+  warning by default). The deferred-prompts dispatcher reads the same
+  threshold to decide when to proactively degrade to `llm:small` (§7.4
+  step 2).
 
 ### 12.3 Backwards compatibility
 
@@ -856,11 +908,15 @@ Following `tests/CLAUDE.md` and the project's TDD hooks:
     user-visible reply.
   - Tool wrapper emits `quota_exceeded` structured failure.
   - Proactive LLM honours the same gate.
-  - Deferred-prompt fallback chain: `llm:main` denial → `llm:small`
-    retry; `llm:small` denial → templated reminder; reset within grace
-    window → `deferred_retry`. Assert that the templated path is always
-    delivered, never silently dropped, and that `delivery_mode` is
-    recorded.
+  - Deferred-prompt fallback chain: subject below threshold → `llm:main`;
+    subject at ≥`notify_pct` → preemptive `llm:small` (`delivery_reason
+    = 'proactive_degrade'`); `llm:main` denied at the gate → `llm:small`
+    retry (`delivery_reason = 'main_denied'`); both denied → templated
+    delivery (`delivery_reason = 'all_denied'`). Assert the fire time
+    is honoured in every case (no defer-and-retry path exists), the
+    templated branch is never blocked by quota, per-type templates
+    (`scheduled` one-shot, `scheduled` recurring, `alert`) render
+    correctly, and `delivery_mode` + `delivery_reason` are recorded.
   - Embedding denial degrades memo search to keyword (assert existing
     behaviour still holds).
   - Attachment ingest abort: `reserveQuota` denial prevents S3 write.
@@ -882,7 +938,7 @@ Following `tests/CLAUDE.md` and the project's TDD hooks:
 | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | 1     | Tables + `resolvePlan` + `reserveQuota` / `commitQuota` for both `fixed_window` and `rolling_refill` algorithms; wired into orchestrator and tool wrapper. Seed `free`/`team`/`unlimited`. No UI yet.                                                        |
 | 2     | `get_my_plan` / `get_my_quota` tools, `/plan` / `/quota` slash commands. 80 % early-warning notice via `quota:threshold_crossed` subscriber.                                                                                                                 |
-| 3     | Deferred-prompts fallback chain (small-model → templated reminder → deferred retry) and `attachment.storage_bytes` gate with reconciliation sweep.                                                                                                           |
+| 3     | Deferred-prompts fallback chain (proactive small-model degrade at `notify_pct`, hard small-model fallback on `llm:main` denial, per-type templated delivery as last resort; no defer-and-retry) and `attachment.storage_bytes` gate with reconciliation sweep. |
 | 4     | Admin dashboard: Plans panel (with algorithm + `notify_pct` editors), extended Subjects table, per-subject Quota card. `/setplan` admin command.                                                                                                             |
 | 5     | `cost_usd_micro` dimension + model price table + cost meters in the dashboard.                                                                                                                                                                               |
 | 6     | Drop legacy `web_rate_limit` table once phase 1 has been live for one release.                                                                                                                                                                               |
@@ -893,8 +949,8 @@ Following `tests/CLAUDE.md` and the project's TDD hooks:
   see one member starving a group, the cleanest fix is a secondary counter
   keyed by `(subject_id, chat_user_id, resource)` reusing the same gate.
   Combined with the deferred-prompts fallback (§7.4), this would also let
-  us preserve "your personal reminders still fire" even when the group's
-  shared LLM quota is exhausted by another member.
+  us preserve "your personal deferred prompts still fire" even when the
+  group's shared LLM quota is exhausted by another member.
 - **Cost dimension scoping** — for cost, should we expose **billed** cost
   (provider-side, may not be available until later) or **list-price** cost
   (computed from a local model price table)? Recommendation: list-price first

--- a/docs/design/llm-rate-limiting-and-plans.md
+++ b/docs/design/llm-rate-limiting-and-plans.md
@@ -60,14 +60,21 @@ This spec was grounded in the following code, current as of the date above:
 
 - Admin can define, edit, delete named **plans**.
 - Plans express limits across multiple **dimensions** (requests, input tokens,
-  output tokens, tool calls, web fetches) over multiple **windows** (minute, hour,
-  day, calendar month).
+  output tokens, tool calls, web fetches, attachment storage bytes) over
+  multiple **windows** (day, week, calendar month), using either a fixed-window
+  or a rolling-refill (token-bucket) replenishment algorithm chosen per limit.
 - Admin can assign a plan to a **subject** (a user, a group, or a thread-scoped
   group context) and override it later, with optional expiry.
 - Bot enforces limits **before** an LLM call or tool execution and reconciles with
   actuals afterwards.
 - Users can see their plan and their remaining quota via tools (`get_my_plan`,
   `get_my_quota`) and slash commands (`/plan`, `/quota`).
+- Subjects receive an in-chat heads-up the first time their usage crosses **80 %**
+  of any dimension within the active window, so they can pace themselves before
+  hitting the hard cap.
+- Deferred prompts degrade gracefully if the subject is out of quota at delivery
+  time — the prompt still fires, just as a non-LLM templated reminder instead
+  of being silently dropped.
 - Plan changes are audited.
 - All admin write surfaces are `DEBUG_TOKEN`-gated; `/stats/*` is untouched and
   remains anonymous.
@@ -81,8 +88,13 @@ This spec was grounded in the following code, current as of the date above:
   group; one noisy member can spend the group's quota.
 - **Horizontal scale.** SQLite atomic `UPDATE … RETURNING` is safe for the single-
   process bot we run today and would need rework for HA.
-- **Token-bucket smoothing.** v1 uses fixed windows, same idiom as
-  `consumeWebFetchQuota`. Token bucket is a future refinement for TPM only.
+- **Sliding-window log / approximated sliding window.** v1 ships fixed-window
+  and token-bucket (rolling-refill) only — the two algorithms together cover
+  the bursty-vs-smooth axis without needing per-request log retention.
+- **Sub-day windows.** v1 windows are `day | week | month`. Smaller windows
+  (minute / hour) are intentionally dropped: they create noisy edge resets
+  for chat-paced workloads and the rolling-refill algorithm covers the
+  smoothness use-case far better than a one-minute fixed window did.
 
 ## 4. Conceptual model
 
@@ -123,13 +135,14 @@ where the mapping is defined.
 turn and **must not** be conflated with non-LLM resources. v1 introduces an
 orthogonal `resource` axis:
 
-| `resource`  | Meaning                             |
-| ----------- | ----------------------------------- |
-| `llm:main`  | LLM call using the main model role  |
-| `llm:small` | LLM call using the small model role |
-| `llm:embed` | Embedding call (memo search, etc.)  |
-| `tool`      | One tool invocation (any tool name) |
-| `web_fetch` | One `web_fetch` tool execution      |
+| `resource`   | Meaning                                                 |
+| ------------ | ------------------------------------------------------- |
+| `llm:main`   | LLM call using the main model role                      |
+| `llm:small`  | LLM call using the small model role                     |
+| `llm:embed`  | Embedding call (memo search, etc.)                      |
+| `tool`       | One tool invocation (any tool name)                     |
+| `web_fetch`  | One `web_fetch` tool execution                          |
+| `attachment` | Durable file in the attachment workspace (S3-backed)    |
 
 Notes:
 
@@ -137,31 +150,85 @@ Notes:
   counters in a single tx, so a tight `web_fetch` limit and a looser overall
   `tool` limit can coexist.
 - `tool` is **not** a model role; we never put `'tool'` into `llm_usage_events.model_role`.
+- `attachment` is a **stock** resource (current bytes held) rather than a
+  pure flow resource: uploads add to the counter, deletes refund it. See
+  §7.7 for the reserve/commit/refund semantics.
 
 `dimension` enumerates the unit being counted:
 
-| `dimension`      | Applies to              |
-| ---------------- | ----------------------- |
-| `requests`       | every resource          |
-| `input_tokens`   | `llm:*`                 |
-| `output_tokens`  | `llm:main`, `llm:small` |
-| `cost_usd_micro` | `llm:*` (future)        |
+| `dimension`      | Applies to              | Kind  |
+| ---------------- | ----------------------- | ----- |
+| `requests`       | every flow resource     | flow  |
+| `input_tokens`   | `llm:*`                 | flow  |
+| `output_tokens`  | `llm:main`, `llm:small` | flow  |
+| `cost_usd_micro` | `llm:*` (future)        | flow  |
+| `storage_bytes`  | `attachment`            | stock |
 
-Invalid combinations (e.g. `output_tokens` on `tool`) are rejected by the plan
-editor with a 400.
+Invalid combinations (e.g. `output_tokens` on `tool`, `storage_bytes` on
+`llm:*`, `requests` on `attachment`) are rejected by the plan editor with a
+400. "Flow" dimensions count usage that accrues inside a window; "stock"
+dimensions count the current outstanding total and are refunded on delete —
+the underlying counter machinery is the same, only the lifecycle differs.
 
 ### 4.3 Windows
 
-| `window` | Length                       | Reset                                |
-| -------- | ---------------------------- | ------------------------------------ |
-| `minute` | 60 s rolling fixed window    | floor(now / 60 s) × 60 s             |
-| `hour`   | 3600 s rolling fixed window  | floor(now / 3600 s) × 3600 s         |
-| `day`    | 86400 s rolling fixed window | floor(now / 86400 s) × 86400 s (UTC) |
-| `month`  | **Calendar month, UTC**      | UTC first-of-month 00:00             |
+| `window` | Length                  | Reset (fixed_window algorithm)       | Full-refill period (rolling_refill algorithm) |
+| -------- | ----------------------- | ------------------------------------ | --------------------------------------------- |
+| `day`    | 86 400 s                | floor(now / 86 400 s) × 86 400 s UTC | 86 400 s                                      |
+| `week`   | 604 800 s (ISO week)    | UTC Monday 00:00                     | 604 800 s                                     |
+| `month`  | **Calendar month, UTC** | UTC first-of-month 00:00             | average month = 2 629 800 s (30.4375 d)       |
 
 Calendar month is documented because users will ask "when does my quota reset".
-The window key in `quota_counter.window_start` is the Unix ms of the start
-boundary for that bucket.
+For `fixed_window`, the window key in `quota_counter.window_start` is the Unix
+ms of the start boundary for the bucket. For `rolling_refill`, `window_start`
+is reused to mean **last refill timestamp** and the bucket capacity is the
+`plan_limits.limit_value`; the refill rate is `limit_value / window_ms`.
+
+`week` resets on Monday 00:00 UTC to match ISO-8601 week boundaries and the
+project's existing date-formatting conventions; it is **not** a 7-day rolling
+window in `fixed_window` mode (use `rolling_refill` for that shape).
+
+### 4.4 Algorithm: fixed_window vs rolling_refill
+
+Each `plan_limits` row carries an `algorithm` field. The admin picks per
+`(resource, dimension, window)` triple how that limit replenishes, so a single
+plan can mix bursty and smooth limits — e.g. a generous monthly `input_tokens`
+cap on `fixed_window` plus a tighter daily `requests` cap on `rolling_refill`
+to keep the bot's pace healthy.
+
+| `algorithm`      | Behaviour                                                                                          | Best for                                                            |
+| ---------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `fixed_window`   | Counter accumulates inside the bucket and resets hard at the window boundary. Cheap, predictable.  | Calendar-anchored caps ("X per month"), billing-aligned limits      |
+| `rolling_refill` | Token-bucket: capacity = `limit_value`, refill rate = `limit_value / window_ms` accruing linearly. | Smoothing bursty workloads, fair pacing, preventing edge-of-window stampedes |
+
+Why these two and not three: the most-cited industry survey (Stripe, GitHub,
+AWS rate-limit RFCs, Cloudflare's "Counting things in a fast-moving world")
+splits production rate-limiters into **fixed-window**, **sliding-window
+counter**, **sliding-window log**, **leaky bucket**, and **token bucket**.
+Sliding-window counter is essentially a fixed-window with mild smoothing;
+sliding-window log requires per-request storage we don't want; leaky bucket
+and token bucket are duals. We pick **token bucket** because it lets the
+admin express both burst capacity and long-run average in a single setting
+(`limit_value` and `window`) without a separate refill-rate column.
+
+Refill is **lazy** — there is no background tick. Every `reserveQuota` call
+on a `rolling_refill` row first does:
+
+```text
+elapsed_ms      = now - last_refill_at
+refilled        = floor(elapsed_ms * limit_value / window_ms)
+new_balance     = min(limit_value, balance + refilled)
+last_refill_at  = last_refill_at + refilled * window_ms / limit_value
+```
+
+then deducts the request's delta from `new_balance`. The fractional remainder
+of `elapsed_ms` is preserved by advancing `last_refill_at` by exactly the
+amount of refill we accounted for, so no partial tokens are lost over time.
+
+Switching a `plan_limits` row between algorithms drops the existing
+`quota_counter` row for that triple in the same migration — we never try to
+translate one algorithm's state into the other's, which would mostly mislead
+users about how much they have left.
 
 ## 5. Data model
 
@@ -191,15 +258,21 @@ limits configured.
 ```text
 plan_limits
   plan_id     text NOT NULL REFERENCES plans(id) ON DELETE CASCADE
-  resource    text NOT NULL    -- 'llm:main' | 'llm:small' | 'llm:embed' | 'tool' | 'web_fetch'
-  dimension   text NOT NULL    -- 'requests' | 'input_tokens' | 'output_tokens' | 'cost_usd_micro'
-  window      text NOT NULL    -- 'minute' | 'hour' | 'day' | 'month'
+  resource    text NOT NULL    -- 'llm:main' | 'llm:small' | 'llm:embed' | 'tool' | 'web_fetch' | 'attachment'
+  dimension   text NOT NULL    -- 'requests' | 'input_tokens' | 'output_tokens' | 'cost_usd_micro' | 'storage_bytes'
+  window      text NOT NULL    -- 'day' | 'week' | 'month'
+  algorithm   text NOT NULL DEFAULT 'fixed_window'  -- 'fixed_window' | 'rolling_refill'
   limit_value int  NOT NULL    -- > 0; row absence = "unlimited for this triple"
+  notify_pct  int  NOT NULL DEFAULT 80  -- threshold % for the early-warning notice; 0 disables
   PK(plan_id, resource, dimension, window)
 ```
 
 Row absence means "unlimited"; we never store `NULL` or sentinel `-1`. A plan
-with zero `plan_limits` rows is effectively the `unlimited` plan.
+with zero `plan_limits` rows is effectively the `unlimited` plan. The
+`algorithm` column is the admin's choice between fixed-window and
+rolling-refill replenishment for that triple (§4.4). `notify_pct` lets the
+admin tune the early-warning threshold per limit; the seeded plans use the
+global default `QUOTA_NOTIFY_THRESHOLD_PCT` (default `80`).
 
 ### 5.3 `subject_plan`
 
@@ -238,23 +311,42 @@ turn into a schema migration target. It is read-only from the dashboard.
 
 ```text
 quota_counter
-  subject_id      text NOT NULL
-  resource        text NOT NULL
-  dimension       text NOT NULL
-  window          text NOT NULL
-  window_start    int  NOT NULL    -- ms epoch of bucket start
-  count           int  NOT NULL    -- monotonically increasing within bucket
-  PK(subject_id, resource, dimension, window, window_start)
+  subject_id            text NOT NULL
+  resource              text NOT NULL
+  dimension             text NOT NULL
+  window                text NOT NULL
+  algorithm             text NOT NULL    -- mirrors plan_limits.algorithm at write time
+  window_start          int  NOT NULL    -- fixed_window: bucket-start ms; rolling_refill: last refill ms
+  count                 int  NOT NULL    -- fixed_window: usage in this bucket; rolling_refill: 0 (unused)
+  balance               int  NOT NULL    -- rolling_refill: tokens remaining; fixed_window: 0 (unused)
+  notified_threshold_pct int NOT NULL DEFAULT 0  -- highest % at which the user was already warned for this bucket
+  PK(subject_id, resource, dimension, window)
 
 CREATE INDEX idx_quota_counter_gc ON quota_counter(window_start);
 ```
 
-The (subject, resource, dimension, window) tuple is the lookup key; the
-`window_start` row is the active bucket. Old rows are garbage-collected by an
-opportunistic `DELETE WHERE window_start < now - retain_ms` on every Nth write
-(N = 1024, mirroring the existing `web_rate_limit` cleanup pattern). Retention
-defaults to **2 × monthly window** so subjects can still see "you used X last
-month" briefly after rollover.
+The (subject, resource, dimension, window) tuple is the lookup key — only the
+**active** bucket lives in the table, since both algorithms keep just one row
+of state per triple (fixed_window resets the row on bucket rollover;
+rolling_refill mutates `window_start`/`balance` in place). Historical "you
+used X last month" is sourced from `llm_usage_events` and `tool_call_events`,
+not from this table.
+
+Old rows are garbage-collected by an opportunistic
+`DELETE WHERE window_start < now - retain_ms` on every Nth write (N = 1024,
+mirroring the existing `web_rate_limit` cleanup pattern). Retention defaults
+to **2 × monthly window** so a `fixed_window` row from last month survives
+long enough for the dashboard to render the rollover transition cleanly.
+
+`notified_threshold_pct` is the highest percentage at which we have already
+sent an early-warning notice for the **current** bucket. It is reset to `0`
+when the bucket resets (fixed_window) or when `balance` recovers above the
+threshold (rolling_refill). See §7.8.
+
+For `attachment.storage_bytes` (a stock dimension), `count` holds the current
+outstanding byte total and `window`/`window_start` are formal — uploads
+`reserveQuota` with positive deltas, deletes call `commitQuota` with negative
+deltas, and the row is never reset on a window boundary.
 
 ### 5.6 Untouched tables
 
@@ -306,24 +398,60 @@ commitQuota(subjectId, resource, actual, now)
    delta from `estimate` (e.g. `requests = 1`, `input_tokens = tokenEstimate`,
    `output_tokens = outputBudgetReserve`).
 3. For each `(dimension, window)`:
-   - Look up the limit from `plan_limits`. If absent → unlimited; skip.
-   - Run, in one tx:
-     ```sql
-     INSERT INTO quota_counter(...) VALUES (..., 0)
-       ON CONFLICT DO NOTHING;
-     UPDATE quota_counter
-       SET count = count + :delta
-       WHERE subject_id = :sid AND resource = :res
-         AND dimension = :dim AND window = :win
-         AND window_start = :ws
-         AND count + :delta <= :limit
-       RETURNING count;
-     ```
-   - If the `UPDATE` returns no row, the limit would be breached: roll back any
-     dimensions already incremented in this call (the tx handles it) and return
-     `{ allowed: false, ... }` with `retryAfterMs = window_start + window_ms - now`.
+   - Look up the limit and `algorithm` from `plan_limits`. If absent →
+     unlimited; skip.
+   - Branch on `algorithm`:
+     - **`fixed_window`** — derive `window_start` from `window` and `now`, then
+       run, in one tx:
+       ```sql
+       INSERT INTO quota_counter(..., algorithm, window_start, count, balance)
+         VALUES (..., 'fixed_window', :ws, 0, 0)
+         ON CONFLICT(subject_id, resource, dimension, window) DO UPDATE
+           SET window_start = excluded.window_start,
+               count        = 0,
+               balance      = 0,
+               notified_threshold_pct = 0
+           WHERE quota_counter.window_start < excluded.window_start;
+       UPDATE quota_counter
+         SET count = count + :delta
+         WHERE subject_id = :sid AND resource = :res
+           AND dimension = :dim AND window = :win
+           AND count + :delta <= :limit
+         RETURNING count;
+       ```
+       If the `UPDATE` returns no row, the limit would be breached: roll back
+       any dimensions already incremented in this call (the tx handles it) and
+       return `{ allowed: false, ... }` with
+       `retryAfterMs = window_start + window_ms - now`.
+     - **`rolling_refill`** — load the row (creating it with
+       `balance = limit` and `window_start = now` if missing), lazily refill
+       inside the same tx using the formula in §4.4, then:
+       ```sql
+       UPDATE quota_counter
+         SET balance        = :new_balance - :delta,
+             window_start   = :new_last_refill_at,
+             notified_threshold_pct = CASE
+               WHEN :new_balance - :delta > :limit - (:limit * notify_pct / 100)
+                 THEN 0
+                 ELSE notified_threshold_pct
+             END
+         WHERE subject_id = :sid AND resource = :res
+           AND dimension = :dim AND window = :win
+           AND :new_balance >= :delta
+         RETURNING balance;
+       ```
+       If the `UPDATE` returns no row, the bucket lacks the requested tokens;
+       return `{ allowed: false, ... }` with
+       `retryAfterMs = ceil((delta - new_balance) * window_ms / limit_value)` —
+       the time it will take the bucket to refill enough for the request.
 4. On success, return remaining quota for **every** dimension covered, so the
-   caller can surface it to the user / the dashboard.
+   caller can surface it to the user / the dashboard. For `fixed_window` the
+   remaining value is `limit - count`; for `rolling_refill` it is `balance`
+   after the deduction.
+5. **Threshold check (§7.8)** — after a successful update, if the post-update
+   usage crosses `notify_pct` for the first time inside the current bucket,
+   emit a `quota:threshold_crossed` event with the subject, resource,
+   dimension, window, percent, and reset time.
 
 ### 7.2 Reservation vs reconciliation (LLM)
 
@@ -353,12 +481,59 @@ fit inside the user's quota.
   `consumeWebFetchQuota` semantics. Documented as: **the gate counts attempts,
   not successes**.
 
-### 7.4 Proactive LLM
+### 7.4 Proactive LLM and deferred-prompt fallback
 
 `src/deferred-prompts/proactive-llm.ts` already provides
 `storage_context_id` and `chatUserId`. The same `reserveQuota` /
 `commitQuota` calls are inserted in its dispatch path, so a noisy deferred
 prompt cannot bypass the subject's plan.
+
+The product principle for deferred prompts is different from a normal LLM
+turn, however: the user explicitly asked, in the past, to be reminded at a
+specific time. If we silently drop the reminder because their LLM quota
+ran out, we have **broken a promise** the bot made — and they may not even
+notice until the reminder window is gone. Quota enforcement therefore must
+not turn deferred prompts into a UX regression.
+
+**Fallback chain on `reserveQuota('llm:<role>', ...)` denial in the
+deferred-prompts dispatcher:**
+
+1. **Templated reminder (always delivered).** The dispatcher composes a
+   non-LLM message from the stored prompt payload, e.g.:
+
+   > Reminder you scheduled for {scheduledFor}: {originalUserText}
+   > _(LLM is over quota right now, so this is a plain reminder. Your quota
+   > resets {resetHuman}. Reply when you're ready and I'll pick it up.)_
+
+   This path costs **zero LLM tokens** and is built entirely from columns
+   already on the deferred-prompts row (`originalUserText`,
+   `scheduledFor`, the subject's resolved timezone). It is gated by no
+   quota and cannot itself be rate-limited, because the alternative is
+   silent loss.
+
+2. **Small-model degrade (best effort).** Before falling all the way back
+   to step 1, the dispatcher retries the reservation with
+   `resource = 'llm:small'`. If `llm:small` is not separately exhausted,
+   it generates the reminder with the small model — typically much
+   cheaper, and produces a friendlier message than the template.
+
+3. **Defer-and-retry (only if reset is imminent).** If
+   `retryAfterMs <= DEFERRED_PROMPT_GRACE_MS` (default `15 min`), the
+   dispatcher reschedules the dispatch attempt for `retryAfterMs + jitter`
+   instead of falling back, so the user gets the full LLM-generated
+   experience after the bucket rolls over. Past that grace window, step 1
+   fires immediately — the user's "reminder time" is closer to the
+   original schedule than to the reset.
+
+The choice between the three is recorded in the deferred-prompts row
+(`delivery_mode: 'llm_main' | 'llm_small' | 'template' | 'deferred_retry'`)
+so we can measure how often each path fires and tune the seeded plan
+limits if templated delivery dominates.
+
+`commitQuota` is **not** called for the templated path — no LLM call was
+made, no tokens were spent. The `requests` counter for `llm:main` is also
+not consumed in that case (reservation was rolled back), so the user keeps
+the same headroom for their next interactive message.
 
 ### 7.5 Embeddings
 
@@ -371,6 +546,90 @@ effect is a slightly worse memo search rather than a hard failure.
 
 `/plan` and `/quota` are handled by the command interception layer in
 `src/bot.ts` before the orchestrator runs, so they cost **no quota** to invoke.
+
+### 7.7 Attachment storage (stock dimension)
+
+Attachments are different from every other gated resource: usage doesn't
+"happen at a moment in time", it **persists** until the file is removed
+from the workspace. The `attachment.storage_bytes` limit therefore models
+the subject's current outstanding bytes, not a per-window flow.
+
+Lifecycle in `src/attachments/`:
+
+- **On ingest** (`ingestAttachment` / S3 upload completion):
+  `reserveQuota('attachment', { storage_bytes: size })`. If denied, the
+  upload is aborted before any S3 write — the file is not silently
+  half-stored. The user-visible error is "you're out of attachment
+  storage on plan _{planName}_; delete older files or ask the admin for
+  a higher cap".
+- **On delete** (manifest purge, tool-driven removal, or admin override):
+  `commitQuota('attachment', { storage_bytes: -size })`. `commitQuota`
+  clamps `count` at `0` so an accounting drift can never make the
+  counter go negative.
+- **On reconciliation** (manifest GC sweep): an opportunistic background
+  task in `src/attachments/` recomputes the true sum of
+  `attachment_metadata.size_bytes` per subject and `UPSERT`s the
+  `quota_counter.count` so the gate self-heals after any drift.
+
+Stock dimensions ignore `algorithm` (there is no "refill") and ignore
+`window` (`window` is recorded as `'month'` purely so the row shape stays
+uniform; the bucket never resets). The plan editor enforces these
+constraints — `storage_bytes` on anything but `attachment`, or `requests`
+on `attachment`, is rejected.
+
+### 7.8 Early-warning threshold notice (80 %)
+
+A hard cap that the user only learns about at the moment they hit it is a
+bad experience. Every plan limit therefore carries a `notify_pct`
+threshold (default `80 %`, configurable per row); when usage crosses it
+inside the current bucket we send the subject a one-time heads-up.
+
+**Trigger.** After a successful `reserveQuota` update, compute
+`pct = round(100 * used / limit)` (for `rolling_refill`,
+`used = limit - balance`). If `pct >= notify_pct` and
+`pct > quota_counter.notified_threshold_pct`, set
+`notified_threshold_pct = notify_pct` in the same row and publish a
+`quota:threshold_crossed` event on the in-process event bus.
+
+**Delivery.** A new subscriber in `src/quota/notice.ts` consumes the
+event and dispatches a templated, non-LLM message to the subject via
+the active `ChatProvider`:
+
+> Heads up: you've used **{pct} %** of your **{planName}** plan's
+> `{resource}.{dimension}` for this {window}
+> ({used} / {limit}). Your quota resets {resetHuman}.
+
+The notice is sent to the **subject's primary chat surface**:
+
+- For a `user:` subject — DM to the chat user.
+- For a `group:` subject — the group's main chat (not a thread), so the
+  warning is visible to everyone who can spend the quota. If the
+  subject is a group and the platform does not support out-of-band
+  delivery (e.g. silent posts), we suppress the notice when the
+  triggering message arrives inside a thread and instead piggyback on
+  the next group-main-chat reply.
+
+**De-duplication.** The `notified_threshold_pct` column ensures we
+never re-notify for the same `notify_pct` inside the same bucket:
+
+- `fixed_window` — column is reset to `0` together with `count` when the
+  bucket rolls over (see the `ON CONFLICT … DO UPDATE` clause in §7.1).
+- `rolling_refill` — column is reset to `0` once `balance` recovers
+  above the threshold (`limit - notify_pct * limit / 100`), so a user
+  whose bucket refills past 80 % free will be warned again the next
+  time they cross down through the 80 %-used mark. This avoids a single
+  noisy day permanently silencing the warning.
+
+**Why one threshold, not many.** A v1 single-threshold model
+(`notify_pct`) is enough to prove the design. The schema (`int` column,
+not a bitmask of multiple thresholds) deliberately keeps the door open
+for multi-threshold (`50 / 80 / 95`) in v2 without a migration — we just
+store the highest already-notified percentage.
+
+**Why not also email / push.** The bot only knows the subject through
+the chat platform. Surfacing this notice through the same chat surface
+that the user is already talking to keeps the design boundary clean and
+avoids a notification-channel registry in v1.
 
 ## 8. Failure surface
 
@@ -402,9 +661,10 @@ quota-aware path.
     "planName": "Team",
     "description": "Shared team plan",
     "limits": [
-      { "resource": "llm:main", "dimension": "input_tokens", "window": "day", "limit": 200000 },
-      { "resource": "llm:main", "dimension": "output_tokens", "window": "day", "limit": 80000 },
-      { "resource": "tool", "dimension": "requests", "window": "day", "limit": 1000 }
+      { "resource": "llm:main", "dimension": "input_tokens", "window": "day", "algorithm": "rolling_refill", "limit": 200000, "notifyPct": 80 },
+      { "resource": "llm:main", "dimension": "output_tokens", "window": "day", "algorithm": "rolling_refill", "limit": 80000, "notifyPct": 80 },
+      { "resource": "tool", "dimension": "requests", "window": "day", "algorithm": "fixed_window", "limit": 1000, "notifyPct": 80 },
+      { "resource": "attachment", "dimension": "storage_bytes", "window": "month", "algorithm": "fixed_window", "limit": 524288000, "notifyPct": 80 }
     ]
   }
   ```
@@ -415,12 +675,19 @@ quota-aware path.
     "resource": "llm:main",
     "dimension": "input_tokens",
     "window": "day",
+    "algorithm": "rolling_refill",
     "used": 147382,
     "limit": 200000,
     "remaining": 52618,
-    "resetsAt": 1763356800000
+    "resetsAt": 1763356800000,
+    "refillRatePerSecond": 2.31
   }
   ```
+
+  `resetsAt` is the next full-bucket boundary for `fixed_window`, or the
+  projected refill-to-full time for `rolling_refill`. `refillRatePerSecond`
+  is only emitted for `rolling_refill`. For `attachment.storage_bytes`,
+  `resetsAt` is omitted (stock dimension).
 
 Both tools live in `src/tools/quota/`. They follow the existing capability
 gating in `src/tools/CLAUDE.md` (they are always available; no provider
@@ -465,8 +732,12 @@ New **Plans** panel:
 - Table of plans with `id`, `name`, `description`, `is_default`, count of
   pinned subjects, `created_at`, `updated_at`.
 - "New plan" opens `PlanEditor.svelte` with a limits matrix (`resource` rows ×
-  `dimension × window` columns), inline validation against the invalid
-  combinations table in §4.2.
+  `dimension × window` columns). Each cell exposes a `limit_value`, an
+  `algorithm` selector (`fixed_window` / `rolling_refill`, defaulting to
+  `fixed_window` for stock dimensions and the per-deployment default for
+  flow dimensions), and an optional `notify_pct` override (default
+  inherited from `QUOTA_NOTIFY_THRESHOLD_PCT`). Inline validation rejects
+  the invalid combinations from §4.2.
 - "Delete plan" requires choosing a **fallback plan** if any subjects are
   pinned; the server performs the reassignment in the same transaction.
 
@@ -517,11 +788,11 @@ billing surface, which is `DEBUG_TOKEN`-gated. The anonymity contract in
 Migration N (next number after the latest in `src/db/migrations/`) creates the
 five new tables and seeds three plans:
 
-| Plan id     | Default? | Limits                                          |
-| ----------- | -------- | ----------------------------------------------- |
-| `free`      | yes      | conservative `llm:main` and `tool` daily limits |
-| `team`      | no       | higher daily limits, no monthly cap             |
-| `unlimited` | no       | no `plan_limits` rows                           |
+| Plan id     | Default? | Limits                                                                                                                                                                       |
+| ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `free`      | yes      | conservative `llm:main` daily limit (`rolling_refill`), monthly `input_tokens` cap (`fixed_window`), `tool.requests.day` (`fixed_window`), `attachment.storage_bytes.month` (`fixed_window`, stock), `web_fetch.requests.day` seeded so the previous per-minute behaviour is the long-run average |
+| `team`      | no       | higher daily and monthly caps on `llm:main`/`llm:small`, generous attachment storage, `tool.requests.week` (`rolling_refill`)                                                |
+| `unlimited` | no       | no `plan_limits` rows                                                                                                                                                        |
 
 The `ADMIN_USER_ID` subject is bound to `unlimited` in the same migration.
 
@@ -533,15 +804,28 @@ No new required env vars. Optional:
   `2 × MONTH_MS`).
 - `QUOTA_OUTPUT_BUDGET_FALLBACK` — used when the orchestrator config did not
   pin a `maxOutputTokens` (defaults to `2048`).
+- `QUOTA_DEFAULT_ALGORITHM` — `fixed_window` (default) or `rolling_refill`,
+  applied to limit rows whose `algorithm` was not set explicitly at create
+  time. Stock dimensions (`storage_bytes`) ignore this and always behave as
+  `fixed_window`-with-no-reset.
+- `QUOTA_NOTIFY_THRESHOLD_PCT` — global default for `plan_limits.notify_pct`
+  on newly created rows (default `80`; set to `0` to disable the early
+  warning by default).
+- `DEFERRED_PROMPT_GRACE_MS` — see §7.4 (default `15 * 60 * 1000`).
 
 ### 12.3 Backwards compatibility
 
 - Existing `web_rate_limit` table is read-only after this change ships and is
   dropped in a follow-up migration after one release window. `web_fetch` keeps
-  the same behaviour because the `free` plan's `web_fetch.requests.minute`
-  limit is seeded to `20` (current hard-coded value).
+  the same effective ceiling because the `free` plan's
+  `web_fetch.requests.day` is seeded on `rolling_refill` with a capacity that
+  matches the previous `20 / minute` long-run average; bursts up to the
+  capacity are still allowed, which is strictly more permissive than today.
 - `llm_usage_events.forwarded_*` outbox columns are unaffected — the future
   metering forwarder reads them; the new code path does not touch them.
+- The existing `minute` / `hour` literals never appeared on disk (they were
+  only consumed by the old `consumeWebFetchQuota` constants), so dropping
+  them from the `window` enum is a code-only change with no migration cost.
 
 ## 13. Testing strategy
 
@@ -551,43 +835,80 @@ Following `tests/CLAUDE.md` and the project's TDD hooks:
   - `resolvePlan` 3-tier lookup, including thread suffix stripping and
     `expires_at` behaviour.
   - `reserveQuota` atomicity (concurrent calls; assert at most `LIMIT`
-    succeed).
+    succeed) under both `fixed_window` and `rolling_refill` algorithms.
   - `commitQuota` reconciliation (over- and under-estimate, error refund,
     clamp at 0).
-  - Window boundary math (`minute|hour|day` rolling, `month` UTC calendar).
+  - Window boundary math: `day` UTC midnight, `week` UTC Monday 00:00,
+    `month` UTC calendar.
+  - `rolling_refill` lazy-refill formula: refill across short and long
+    `elapsed_ms`, fractional-token preservation via `last_refill_at`
+    advancement, cap at `limit_value`.
+  - Algorithm switch on a `plan_limits` row drops the matching
+    `quota_counter` row in the same tx.
+  - Threshold notification: `notified_threshold_pct` advances exactly once
+    per bucket for `fixed_window`; resets when `balance` climbs back above
+    the threshold for `rolling_refill`.
+  - Stock dimension: `attachment.storage_bytes` upload + delete round-trip
+    leaves `count` unchanged; clamp at 0 on accounting drift; reconciliation
+    sweep recomputes from `attachment_metadata`.
 - **Integration** — `tests/quota/`:
   - Orchestrator pre-call gate fires before `generateText` and shapes the
     user-visible reply.
   - Tool wrapper emits `quota_exceeded` structured failure.
   - Proactive LLM honours the same gate.
+  - Deferred-prompt fallback chain: `llm:main` denial → `llm:small`
+    retry; `llm:small` denial → templated reminder; reset within grace
+    window → `deferred_retry`. Assert that the templated path is always
+    delivered, never silently dropped, and that `delivery_mode` is
+    recorded.
   - Embedding denial degrades memo search to keyword (assert existing
     behaviour still holds).
+  - Attachment ingest abort: `reserveQuota` denial prevents S3 write.
+  - Threshold-crossing notice: first message after crossing 80 % posts a
+    single notice to the subject's primary chat surface and does not
+    repeat within the same bucket.
 - **HTTP** — `tests/debug/`:
   - All admin routes require `DEBUG_TOKEN`.
   - `DELETE /admin/plans/:id` with pinned subjects requires `fallback`.
   - `PUT /admin/subjects/:subjectId/plan` rejects thread-scoped ids.
+  - `POST /admin/plans` rejects invalid `(resource, dimension, window)`
+    combinations and rejects `algorithm = 'rolling_refill'` on stock
+    dimensions.
 - **E2E** — none required for v1 (no chat-platform-specific behaviour).
 
 ## 14. Phased rollout
 
-| Phase | Deliverable                                                                                                                                  |
-| ----- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1     | Tables + `resolvePlan` + `reserveQuota` / `commitQuota` wired into orchestrator and tool wrapper. Seed `free`/`team`/`unlimited`. No UI yet. |
-| 2     | `get_my_plan` / `get_my_quota` tools, `/plan` / `/quota` slash commands.                                                                     |
-| 3     | Admin dashboard: Plans panel + extended Subjects table + per-subject Quota card. `/setplan` admin command.                                   |
-| 4     | `cost_usd_micro` dimension + model price table + cost meters in the dashboard.                                                               |
-| 5     | Drop legacy `web_rate_limit` table once phase 1 has been live for one release.                                                               |
+| Phase | Deliverable                                                                                                                                                                                                                                                  |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1     | Tables + `resolvePlan` + `reserveQuota` / `commitQuota` for both `fixed_window` and `rolling_refill` algorithms; wired into orchestrator and tool wrapper. Seed `free`/`team`/`unlimited`. No UI yet.                                                        |
+| 2     | `get_my_plan` / `get_my_quota` tools, `/plan` / `/quota` slash commands. 80 % early-warning notice via `quota:threshold_crossed` subscriber.                                                                                                                 |
+| 3     | Deferred-prompts fallback chain (small-model → templated reminder → deferred retry) and `attachment.storage_bytes` gate with reconciliation sweep.                                                                                                           |
+| 4     | Admin dashboard: Plans panel (with algorithm + `notify_pct` editors), extended Subjects table, per-subject Quota card. `/setplan` admin command.                                                                                                             |
+| 5     | `cost_usd_micro` dimension + model price table + cost meters in the dashboard.                                                                                                                                                                               |
+| 6     | Drop legacy `web_rate_limit` table once phase 1 has been live for one release.                                                                                                                                                                               |
 
 ## 15. Open questions
 
-- **Token-bucket smoothing for `input_tokens.minute`** — is the bursty
-  fixed-window behaviour acceptable as a v1, or do we need bucket refill for
-  the minute window? (Current best-practice survey suggests fixed-window is
-  fine until real abuse is observed.)
 - **Per-chat-user fairness inside groups** — currently out of scope. If we
   see one member starving a group, the cleanest fix is a secondary counter
   keyed by `(subject_id, chat_user_id, resource)` reusing the same gate.
+  Combined with the deferred-prompts fallback (§7.4), this would also let
+  us preserve "your personal reminders still fire" even when the group's
+  shared LLM quota is exhausted by another member.
 - **Cost dimension scoping** — for cost, should we expose **billed** cost
   (provider-side, may not be available until later) or **list-price** cost
   (computed from a local model price table)? Recommendation: list-price first
   because it can land without changing the LLM call path.
+- **Default algorithm per dimension** — `QUOTA_DEFAULT_ALGORITHM` is a
+  single global. Should the default be expressed as a small per-dimension
+  table (e.g. `requests → rolling_refill`, `input_tokens → fixed_window`)
+  to better match each dimension's typical workload shape?
+- **Multi-threshold early warnings (50 / 80 / 95)** — the schema supports
+  it; the question is whether more pings ahead of the cap improve UX or
+  become noise. Defer until we have real usage from v1.
+- **Notice surface for thread-scoped groups** — when the 80 % notice
+  fires inside a Telegram/Mattermost thread, should we post to the
+  group's main chat (visible to all members who share the cap) or in the
+  thread that triggered it (closer to the actor but invisible to other
+  consumers)? Currently §7.8 picks main-chat for visibility; revisit if
+  groups complain about cross-thread noise.

--- a/docs/design/llm-rate-limiting-and-plans.md
+++ b/docs/design/llm-rate-limiting-and-plans.md
@@ -137,14 +137,14 @@ where the mapping is defined.
 turn and **must not** be conflated with non-LLM resources. v1 introduces an
 orthogonal `resource` axis:
 
-| `resource`   | Meaning                                                 |
-| ------------ | ------------------------------------------------------- |
-| `llm:main`   | LLM call using the main model role                      |
-| `llm:small`  | LLM call using the small model role                     |
-| `llm:embed`  | Embedding call (memo search, etc.)                      |
-| `tool`       | One tool invocation (any tool name)                     |
-| `web_fetch`  | One `web_fetch` tool execution                          |
-| `attachment` | Durable file in the attachment workspace (S3-backed)    |
+| `resource`   | Meaning                                              |
+| ------------ | ---------------------------------------------------- |
+| `llm:main`   | LLM call using the main model role                   |
+| `llm:small`  | LLM call using the small model role                  |
+| `llm:embed`  | Embedding call (memo search, etc.)                   |
+| `tool`       | One tool invocation (any tool name)                  |
+| `web_fetch`  | One `web_fetch` tool execution                       |
+| `attachment` | Durable file in the attachment workspace (S3-backed) |
 
 Notes:
 
@@ -167,8 +167,7 @@ Notes:
 | `storage_bytes`  | `attachment`            | stock |
 
 Invalid combinations (e.g. `output_tokens` on `tool`, `storage_bytes` on
-`llm:*`, `requests` on `attachment`) are rejected by the plan editor with a
-400. "Flow" dimensions count usage that accrues inside a window; "stock"
+`llm:*`, `requests` on `attachment`) are rejected by the plan editor with a 400. "Flow" dimensions count usage that accrues inside a window; "stock"
 dimensions count the current outstanding total and are refunded on delete —
 the underlying counter machinery is the same, only the lifecycle differs.
 
@@ -198,9 +197,9 @@ plan can mix bursty and smooth limits — e.g. a generous monthly `input_tokens`
 cap on `fixed_window` plus a tighter daily `requests` cap on `rolling_refill`
 to keep the bot's pace healthy.
 
-| `algorithm`      | Behaviour                                                                                          | Best for                                                            |
-| ---------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `fixed_window`   | Counter accumulates inside the bucket and resets hard at the window boundary. Cheap, predictable.  | Calendar-anchored caps ("X per month"), billing-aligned limits      |
+| `algorithm`      | Behaviour                                                                                          | Best for                                                                     |
+| ---------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `fixed_window`   | Counter accumulates inside the bucket and resets hard at the window boundary. Cheap, predictable.  | Calendar-anchored caps ("X per month"), billing-aligned limits               |
 | `rolling_refill` | Token-bucket: capacity = `limit_value`, refill rate = `limit_value / window_ms` accruing linearly. | Smoothing bursty workloads, fair pacing, preventing edge-of-window stampedes |
 
 Why these two and not three: the most-cited industry survey (Stripe, GitHub,
@@ -502,7 +501,7 @@ turn, however. Two non-negotiables shape the design:
   fire on time; degrade the content if you must.
 - **Silent loss is forbidden.** If every LLM path is over quota, the
   dispatcher still posts a templated, non-LLM message so the user can
-  see *that* the trigger fired, even if not *how* it would normally
+  see _that_ the trigger fired, even if not _how_ it would normally
   read.
 
 The two prompt families flow through the same chain but pick a
@@ -522,7 +521,7 @@ triggers, `AlertPrompt` covers condition-triggered notifications).
    reservation (if it was speculatively taken) and reissues against
    `llm:small`. A deferred prompt is not the right thing to spend the
    user's last 20 % of `llm:main` headroom on — interactive turns are.
-   This is a *preemptive* degradation, not a recovery path: it kicks in
+   This is a _preemptive_ degradation, not a recovery path: it kicks in
    while `llm:main` would still answer.
 3. **Hard fallback to `llm:small` on `llm:main` denial.** If step 1 was
    skipped (because step 2 fired preemptively) and `llm:small` is also
@@ -550,18 +549,18 @@ purely from columns already on the deferred-prompts row plus the
 subject's resolved timezone — no LLM call, no tool call.
 
 - **`scheduled` — one-shot (`fire_at`).** "Scheduled prompt fires now:
-  *{deliveryBriefOrPrompt}*". When
+  _{deliveryBriefOrPrompt}_". When
   `execution_metadata.delivery_brief` is non-empty, prefer it over the
   raw `prompt` field because the creator already framed it for the
   user.
 - **`scheduled` — recurring (`rrule`).** "Recurring prompt
-  ({humanRruleSummary}) fires now: *{deliveryBriefOrPrompt}*". The
+  ({humanRruleSummary}) fires now: _{deliveryBriefOrPrompt}_". The
   recurrence summary is produced locally from the stored `rrule` string
   by the same helper used in `list_recurring_tasks` output.
 - **`alert` — condition triggered.** "Alert condition met
-  ({humanConditionSummary}): *{deliveryBriefOrPrompt}*". The condition
-  is rendered as a short human-readable clause (e.g. "task *T-42*
-  status changed to *Done*") built directly from the stored
+  ({humanConditionSummary}): _{deliveryBriefOrPrompt}_". The condition
+  is rendered as a short human-readable clause (e.g. "task _T-42_
+  status changed to _Done_") built directly from the stored
   `AlertCondition` tree.
 
 All three templates end with the same short footer noting that the LLM
@@ -575,7 +574,7 @@ dispatch:
 - `delivery_mode: 'llm_main' | 'llm_small' | 'template'` — which
   renderer produced the message that left the bot.
 - `delivery_reason: 'normal' | 'proactive_degrade' | 'main_denied' |
-  'all_denied'` — which branch of the chain triggered.
+'all_denied'` — which branch of the chain triggered.
 
 Together they let the admin tune `notify_pct` and seeded plan limits if
 proactive degrades or template fallbacks start dominating.
@@ -712,15 +711,44 @@ quota-aware path.
     "planName": "Team",
     "description": "Shared team plan",
     "limits": [
-      { "resource": "llm:main", "dimension": "input_tokens", "window": "day", "algorithm": "rolling_refill", "limit": 200000, "notifyPct": 80 },
-      { "resource": "llm:main", "dimension": "output_tokens", "window": "day", "algorithm": "rolling_refill", "limit": 80000, "notifyPct": 80 },
-      { "resource": "tool", "dimension": "requests", "window": "day", "algorithm": "fixed_window", "limit": 1000, "notifyPct": 80 },
-      { "resource": "attachment", "dimension": "storage_bytes", "window": "month", "algorithm": "fixed_window", "limit": 524288000, "notifyPct": 80 }
+      {
+        "resource": "llm:main",
+        "dimension": "input_tokens",
+        "window": "day",
+        "algorithm": "rolling_refill",
+        "limit": 200000,
+        "notifyPct": 80
+      },
+      {
+        "resource": "llm:main",
+        "dimension": "output_tokens",
+        "window": "day",
+        "algorithm": "rolling_refill",
+        "limit": 80000,
+        "notifyPct": 80
+      },
+      {
+        "resource": "tool",
+        "dimension": "requests",
+        "window": "day",
+        "algorithm": "fixed_window",
+        "limit": 1000,
+        "notifyPct": 80
+      },
+      {
+        "resource": "attachment",
+        "dimension": "storage_bytes",
+        "window": "month",
+        "algorithm": "fixed_window",
+        "limit": 524288000,
+        "notifyPct": 80
+      }
     ]
   }
   ```
 - `get_my_quota` (same gating) → for every `(resource, dimension, window)` that
   the plan limits:
+
   ```json
   {
     "resource": "llm:main",
@@ -839,11 +867,11 @@ billing surface, which is `DEBUG_TOKEN`-gated. The anonymity contract in
 Migration N (next number after the latest in `src/db/migrations/`) creates the
 five new tables and seeds three plans:
 
-| Plan id     | Default? | Limits                                                                                                                                                                       |
-| ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Plan id     | Default? | Limits                                                                                                                                                                                                                                                                                            |
+| ----------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `free`      | yes      | conservative `llm:main` daily limit (`rolling_refill`), monthly `input_tokens` cap (`fixed_window`), `tool.requests.day` (`fixed_window`), `attachment.storage_bytes.month` (`fixed_window`, stock), `web_fetch.requests.day` seeded so the previous per-minute behaviour is the long-run average |
-| `team`      | no       | higher daily and monthly caps on `llm:main`/`llm:small`, generous attachment storage, `tool.requests.week` (`rolling_refill`)                                                |
-| `unlimited` | no       | no `plan_limits` rows                                                                                                                                                        |
+| `team`      | no       | higher daily and monthly caps on `llm:main`/`llm:small`, generous attachment storage, `tool.requests.week` (`rolling_refill`)                                                                                                                                                                     |
+| `unlimited` | no       | no `plan_limits` rows                                                                                                                                                                                                                                                                             |
 
 The `ADMIN_USER_ID` subject is bound to `unlimited` in the same migration.
 
@@ -910,7 +938,7 @@ Following `tests/CLAUDE.md` and the project's TDD hooks:
   - Proactive LLM honours the same gate.
   - Deferred-prompt fallback chain: subject below threshold → `llm:main`;
     subject at ≥`notify_pct` → preemptive `llm:small` (`delivery_reason
-    = 'proactive_degrade'`); `llm:main` denied at the gate → `llm:small`
+= 'proactive_degrade'`); `llm:main` denied at the gate → `llm:small`
     retry (`delivery_reason = 'main_denied'`); both denied → templated
     delivery (`delivery_reason = 'all_denied'`). Assert the fire time
     is honoured in every case (no defer-and-retry path exists), the
@@ -934,14 +962,14 @@ Following `tests/CLAUDE.md` and the project's TDD hooks:
 
 ## 14. Phased rollout
 
-| Phase | Deliverable                                                                                                                                                                                                                                                  |
-| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1     | Tables + `resolvePlan` + `reserveQuota` / `commitQuota` for both `fixed_window` and `rolling_refill` algorithms; wired into orchestrator and tool wrapper. Seed `free`/`team`/`unlimited`. No UI yet.                                                        |
-| 2     | `get_my_plan` / `get_my_quota` tools, `/plan` / `/quota` slash commands. 80 % early-warning notice via `quota:threshold_crossed` subscriber.                                                                                                                 |
+| Phase | Deliverable                                                                                                                                                                                                                                                    |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | Tables + `resolvePlan` + `reserveQuota` / `commitQuota` for both `fixed_window` and `rolling_refill` algorithms; wired into orchestrator and tool wrapper. Seed `free`/`team`/`unlimited`. No UI yet.                                                          |
+| 2     | `get_my_plan` / `get_my_quota` tools, `/plan` / `/quota` slash commands. 80 % early-warning notice via `quota:threshold_crossed` subscriber.                                                                                                                   |
 | 3     | Deferred-prompts fallback chain (proactive small-model degrade at `notify_pct`, hard small-model fallback on `llm:main` denial, per-type templated delivery as last resort; no defer-and-retry) and `attachment.storage_bytes` gate with reconciliation sweep. |
-| 4     | Admin dashboard: Plans panel (with algorithm + `notify_pct` editors), extended Subjects table, per-subject Quota card. `/setplan` admin command.                                                                                                             |
-| 5     | `cost_usd_micro` dimension + model price table + cost meters in the dashboard.                                                                                                                                                                               |
-| 6     | Drop legacy `web_rate_limit` table once phase 1 has been live for one release.                                                                                                                                                                               |
+| 4     | Admin dashboard: Plans panel (with algorithm + `notify_pct` editors), extended Subjects table, per-subject Quota card. `/setplan` admin command.                                                                                                               |
+| 5     | `cost_usd_micro` dimension + model price table + cost meters in the dashboard.                                                                                                                                                                                 |
+| 6     | Drop legacy `web_rate_limit` table once phase 1 has been live for one release.                                                                                                                                                                                 |
 
 ## 15. Open questions
 


### PR DESCRIPTION
- Drop minute/hour windows in favour of day/week/month; week is ISO-aligned UTC.
- Introduce per-limit `algorithm` choice between `fixed_window` and
  `rolling_refill` (token-bucket) and extend `quota_counter` with `balance` /
  `last_refill_at` semantics plus a `notified_threshold_pct` column.
- Add `attachment` resource and `storage_bytes` stock dimension with
  upload/delete reserve-refund lifecycle and a manifest reconciliation sweep.
- Add §7.8 early-warning notice when usage crosses `notify_pct` (default 80%),
  with bucket-scoped de-duplication on both algorithms.
- Add §7.4 deferred-prompt fallback chain so quota exhaustion never silently
  drops a scheduled reminder: small-model retry → templated reminder →
  defer-and-retry inside a grace window. Record `delivery_mode` for metrics.
- Refresh seeded plans, env vars, testing matrix, phased rollout, and open
  questions to match the new model.