### PR TITLE
docs(design): split /dashboard into /debug and /admin — design + phase plan

### DIFF
--- a/docs/design/dashboard-admin-split-design.md
+++ b/docs/design/dashboard-admin-split-design.md
@@ -1,0 +1,518 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Dashboard / Admin Split — Design Spec
+
+Status: draft
+Owner: admin (`ADMIN_USER_ID`)
+Last updated: 2026-05-20
+Branch: `claude/split-dashboard-admin-zaoys`
+
+Companion implementation plan: [`dashboard-admin-split-plan.md`](./dashboard-admin-split-plan.md).
+
+## 1. Purpose
+
+The single `/dashboard` page in `client/debug/` mixes two distinct audiences and
+intents into one screen:
+
+- a **live observability surface** for the engineer running the bot —
+  connection status, log stream, turn timeline, LLM traces, tool failures,
+  in-memory sessions, live wizard state;
+- an **admin backstage surface** for the operator — system-wide LLM
+  credentials, billing per subject, anonymous stats, memos / reminders
+  inventory, identity mappings, authorized groups.
+
+Cramming both into a 3-column panel grid forces compromises everywhere: the
+engineer sees billing data they don't care about; the operator has to scan
+through a live log river to find a credentials form. Visiting the page also
+loads SSE state collectors and live event handlers when the operator only
+wanted to rotate an API key.
+
+This spec splits the page into two purpose-built routes:
+
+- `/debug` — engineer surface; live, ephemeral, SSE-driven.
+- `/admin` — operator surface; durable, configuration-and-records oriented.
+
+Both keep the existing `DEBUG_TOKEN` auth surface. `/dashboard` is preserved
+as a 301 redirect to `/debug` so external bookmarks don't break during the
+transition window.
+
+## 2. Verified context — current state
+
+This section was grounded in the following code, as of the date above.
+
+### 2.1 Current bundle
+
+- Entry: `client/debug/index.ts` mounts `App.svelte` into `#app`.
+- `client/debug/App.svelte` composes **11 panels** + **6 modals** in one
+  view; full file at the path.
+- Build: `scripts/build-client.ts` emits `public/dashboard.{html,js,css}`
+  with `naming: 'dashboard.js'` and inlines component-scoped CSS into
+  one stylesheet.
+- HTML template: `client/debug/dashboard.html`. Single `#app` mount, CSP
+  `default-src 'self'`.
+
+### 2.2 Current layout (from `client/debug/dashboard.css`)
+
+```text
++---------------------------------------------------------------+
+| Header  (connection · uptime · msgs/llm/tools · infra row)    |
++---------------------------------------------------------------+
+| ContextChips  (all · dm · group:<id> · …)                     |
++----------------+----------------------------------------------+
+|                |   panel-grid (3 cols, equal rows)            |
+|  Sessions      |  +-----------+-----------+-----------+       |
+|  List          |  | Turns     | Notifs    | Failures  |       |
+|  ----          |  +-----------+-----------+-----------+       |
+|  Trace         |  | Reminders | Memos     | Context   |       |
+|  List          |  +-----------+-----------+-----------+       |
+|                |  | Billing               | Stats     |       |
+|                |  +-----------------------+-----------+       |
+| (300 px)       +----------------------------------------------+
+|                |   LogExplorer   (full-width, bottom row)     |
++----------------+----------------------------------------------+
+```
+
+CSS grid: `grid-template-columns: 300px 1fr`, `grid-template-rows: 1fr 1fr`,
+with `panels` and `logs` rows on the right side and `sidebar` spanning both
+rows on the left.
+
+### 2.3 Modal pattern
+
+Single primitive at `client/debug/components/Modal.svelte`: viewport-cover
+backdrop, click-outside closes, `aria-label="Close"` X button, no size
+variants, no footer slot. Six callers — SessionDetail, TraceDetail,
+LogDetail, TurnDetail, FailureDetail, Billing subject (which also embeds
+`SubjectStatsPanel` inside).
+
+### 2.4 Concern allocation today
+
+| Panel / area                | Lives in                                                            | Audience       | Live data?       |
+| --------------------------- | ------------------------------------------------------------------- | -------------- | ---------------- |
+| Header counters / infra     | `components/Header.svelte`                                          | engineer       | yes (SSE)        |
+| Context chips               | `components/ContextChips.svelte`                                    | engineer       | derived          |
+| Sessions list               | `components/SessionsList.svelte` + `SessionCard` + `SessionDetail`  | engineer       | yes (SSE)        |
+| LLM trace list              | `components/TraceList.svelte` + `TraceDetail`                       | engineer       | yes (SSE)        |
+| Turns panel                 | `components/TurnsPanel.svelte` + `TurnDetail`                       | engineer       | yes (SSE)        |
+| Notifications               | `components/NotificationsPanel.svelte`                              | engineer       | yes (SSE)        |
+| Tool failures               | `components/ToolFailuresPanel.svelte` + `FailureDetail`             | engineer       | yes (SSE)        |
+| Log explorer                | `components/LogExplorer.svelte` + `LogDetail`                       | engineer       | yes (SSE + REST) |
+| Context: wizards / editors  | `components/ContextPanel.svelte` (mixed)                            | engineer       | yes (SSE)        |
+| Context: identity mappings  | `components/ContextPanel.svelte` (mixed)                            | operator       | yes (SSE)        |
+| Context: authorized groups  | `components/ContextPanel.svelte` (mixed)                            | operator       | yes (SSE)        |
+| Memos                       | `components/MemosPanel.svelte`                                      | operator       | yes (SSE)        |
+| Reminders (recurring + def) | `components/RemindersPanel.svelte`                                  | operator       | yes (SSE)        |
+| Billing                     | `billing/BillingPanel.svelte` + `SubjectsTable` + `SubjectDetail`   | operator       | no (REST poll)   |
+| LLM credentials form        | `billing/CredentialsForm.svelte` (only **write** surface today)     | operator       | no (REST)        |
+| Stats global                | `stats/StatsPanel.svelte`                                           | operator       | no (REST)        |
+| Stats per-subject           | `stats/SubjectStatsPanel.svelte` (rendered inside billing modal)    | operator       | no (REST)        |
+
+### 2.5 Server routes (`src/debug/server.ts`)
+
+Static:
+- `GET /dashboard`, `/dashboard.js`, `/dashboard.css` — static bundle from
+  `public/`.
+
+Engineer-side APIs (debug observability):
+- `GET /events` — SSE stream of state/log/turn/notification/failure events.
+- `GET /logs`, `GET /logs/stats` — log buffer search.
+- `GET /turns/:id` — assembled turn lookup.
+
+Operator-side APIs (admin data):
+- `GET /recurring?userId=`, `GET /deferred?userId=`, `GET /memos?userId=`,
+  `GET /identity?userId=&provider=` — per-user lookups (currently not
+  surfaced in the UI; the UI uses SSE feeds instead).
+- `GET /auth/groups` — authorized group list.
+- `GET /billing/subjects`, `GET /billing/subject/:id` — billing aggregates.
+- `GET /stats/global`, `GET /stats/subject/:id` — anonymous stats.
+- `GET /admin/llm`, `POST /admin/llm` — system LLM credentials.
+  The `POST` route requires `DEBUG_TOKEN` even if other routes are open;
+  the `GET` is subject to the same single `DEBUG_TOKEN` gate as all routes.
+
+All routes share one `isAuthorizedRequest()` check at the top of
+`routeRequest`: if `DEBUG_TOKEN` is set, every request needs the bearer
+token; otherwise all routes are open (loopback-only by hostname default).
+
+## 3. Goals and non-goals
+
+### 3.1 Goals
+
+1. Two distinct pages — `/debug` (engineer) and `/admin` (operator) — each
+   loading only the code and data feeds it needs.
+2. Shared visual identity (dark monospace theme, status dot, count badges,
+   `.panel` shell) without duplicating CSS or types.
+3. Clear, written allocation of every existing panel to one of the two
+   pages, and an explicit plan for the panels that mix concerns
+   (`ContextPanel`).
+4. A modal primitive flexible enough for the two patterns we now have plus
+   the two we'll need next — inspection modal and confirm dialog.
+5. A documented list of files where data schemas live, so future UI
+   generation (LLM-assisted or otherwise) can find the source of truth
+   for every view.
+6. Preserve every existing route, test, and JSON shape; no API breakage
+   in this split.
+7. Admin write surface stays gated by `DEBUG_TOKEN`. Admin **read** surfaces
+   that today are open under the unified `DEBUG_TOKEN` gate stay gated the
+   same way — no security regression.
+
+### 3.2 Non-goals
+
+- No new admin write operations beyond what `/admin/llm` already does.
+  Identity mappings, authorized groups, memos and reminders stay read-only
+  in `/admin` v1; mutations stay in chat / `/setup` / `/config`.
+- No multi-tenant auth (still one `DEBUG_TOKEN`, one admin).
+- No new charts. Stats stays as the existing `<dl>` lists; charts come
+  later.
+- No SPA routing library. Two static bundles, two HTML files, two
+  entrypoints. The /admin page does not need to navigate to /debug at
+  runtime (a header link is sufficient).
+- No design-system refactor; we extract a tiny shared layer
+  (`client/shared/`) rather than adopting a UI kit.
+
+## 4. Target architecture
+
+### 4.1 URLs and bundles
+
+| URL                  | Bundle                  | Audience  | Loads SSE? | Notes                                       |
+| -------------------- | ----------------------- | --------- | ---------- | ------------------------------------------- |
+| `/debug`             | `public/debug.{html,js,css}`  | engineer | yes        | live observability surface                  |
+| `/admin`             | `public/admin.{html,js,css}`  | operator | no\*       | configuration + records; REST only on load |
+| `/dashboard`         | _redirect_ → `/debug`   | —         | —          | 301 with `Location: /debug` for one minor cycle, then remove |
+
+\* `/admin` may open a **filtered** SSE later (e.g. `identity:set` events
+only) but v1 polls on user action. Keeping it REST-only reduces blast
+radius if someone leaves the tab open overnight.
+
+### 4.2 Filesystem layout
+
+```text
+client/
+  shared/                       # new — used by both bundles
+    Modal.svelte                # primitive, gains size + footer
+    Confirm.svelte              # thin wrapper around Modal (action dialog)
+    StatusDot.svelte            # green dot / red dot
+    PanelShell.svelte           # .panel + h2 + count badge
+    PropertiesTable.svelte      # moved from components/
+    TreeView.svelte             # moved from components/
+    helpers.ts                  # formatTime, formatUptime, levelClass, levelName
+    api-types.ts                # what's now dashboard-types.ts, decoupled
+    fetcher-helpers.ts          # readBody / requireOk / errorMessageFrom
+
+  debug/                        # rewritten; SSE-driven only
+    debug.html                  # was dashboard.html
+    index.ts                    # mounts DebugApp
+    DebugApp.svelte             # composes Sessions / Traces / Turns / Notifications / Failures / Logs
+    dashboard.svelte.ts         # renamed to debug.svelte.ts
+    components/
+      Header.svelte
+      ContextChips.svelte
+      SessionsList.svelte
+      SessionCard.svelte
+      SessionDetail.svelte
+      TraceList.svelte
+      TraceDetail.svelte
+      TurnsPanel.svelte
+      TurnDetail.svelte
+      NotificationsPanel.svelte
+      ToolFailuresPanel.svelte
+      FailureDetail.svelte
+      LogExplorer.svelte
+      LogDetail.svelte
+      LiveContextCard.svelte    # wizards + active config editors only
+    handlers.ts                 # unchanged
+    handlers-extras.ts          # trimmed: keep wizard/config-editor; drop identity / auth / memo / recurring / deferred
+    handlers-helpers.ts
+    sse.ts
+    log-bootstrap.ts
+    log-filter.ts
+    debug.css                   # debug-only styles
+
+  admin/                        # new bundle
+    admin.html                  # `<div id="app"></div>` + admin.js + admin.css
+    index.ts                    # mounts AdminApp
+    admin.svelte.ts             # admin-side reactive state
+    AdminApp.svelte             # left nav + section content area
+    sections/
+      SystemSection.svelte      # CredentialsForm + system info
+      BillingSection.svelte     # window selector + SubjectsTable + SubjectDetail modal
+      StatsSection.svelte       # window selector + StatsPanel
+      MemosSection.svelte       # memos browser by userId
+      RemindersSection.svelte   # recurring + deferred browser by userId
+      IdentitiesSection.svelte  # identity mapping browser
+      GroupsSection.svelte      # authorized groups list
+    components/
+      NavSidebar.svelte
+      CredentialsForm.svelte    # moved from billing/, lives here now
+      SubjectsTable.svelte
+      SubjectDetail.svelte
+      SubjectStatsPanel.svelte
+      WindowSelect.svelte       # 24h/7d/30d/all and 1d/7d/30d/all
+    fetchers.ts                 # merges billing/fetchers.ts + stats/fetchers.ts +
+                                # new admin-data fetchers
+    admin.css                   # admin-only styles
+
+src/debug/
+  server.ts                     # routes /debug, /admin, /dashboard→/debug, plus existing APIs
+                                # no other change to routeRequest
+```
+
+### 4.3 Allocation of every current panel
+
+| Current panel               | Destination       | Component path                                            |
+| --------------------------- | ----------------- | --------------------------------------------------------- |
+| Header                      | `/debug`          | `client/debug/components/Header.svelte`                   |
+| ContextChips                | `/debug`          | `client/debug/components/ContextChips.svelte`             |
+| SessionsList + Card + Detail| `/debug`          | `client/debug/components/Sessions*.svelte`                |
+| TraceList + TraceDetail     | `/debug`          | `client/debug/components/Trace*.svelte`                   |
+| TurnsPanel + TurnDetail     | `/debug`          | `client/debug/components/Turn*.svelte`                    |
+| NotificationsPanel          | `/debug`          | `client/debug/components/NotificationsPanel.svelte`       |
+| ToolFailuresPanel + Detail  | `/debug`          | `client/debug/components/Tool*.svelte` + `FailureDetail`  |
+| LogExplorer + LogDetail     | `/debug`          | `client/debug/components/Log*.svelte`                     |
+| ContextPanel → wizards block| `/debug` (split)  | `client/debug/components/LiveContextCard.svelte` (new)    |
+| ContextPanel → identity     | `/admin` (split)  | `client/admin/sections/IdentitiesSection.svelte`          |
+| ContextPanel → auth groups  | `/admin` (split)  | `client/admin/sections/GroupsSection.svelte`              |
+| MemosPanel                  | `/admin`          | `client/admin/sections/MemosSection.svelte`               |
+| RemindersPanel              | `/admin`          | `client/admin/sections/RemindersSection.svelte`           |
+| BillingPanel                | `/admin`          | `client/admin/sections/BillingSection.svelte`             |
+| CredentialsForm             | `/admin`          | `client/admin/components/CredentialsForm.svelte`          |
+| SubjectsTable / SubjectDetail | `/admin`        | `client/admin/components/Subject*.svelte`                 |
+| StatsPanel                  | `/admin`          | `client/admin/sections/StatsSection.svelte`               |
+| SubjectStatsPanel           | `/admin`          | `client/admin/components/SubjectStatsPanel.svelte`        |
+
+### 4.4 `/debug` page layout
+
+```text
++----------------------------------------------------------------------+
+| Header  (connection · uptime · msgs/llm/tools · scheduler · pollers) |
++----------------------------------------------------------------------+
+| ContextChips                                                          |
++--------------------+--------------------------------------------------+
+|                    |   panel-grid (2 cols)                            |
+|  SessionsList      |  +-------------------+----------------------+    |
+|  ----              |  | TurnsPanel        | NotificationsPanel   |    |
+|  TraceList         |  +-------------------+----------------------+    |
+|                    |  | ToolFailuresPanel | LiveContextCard      |    |
+|  (300 px)          |  +-------------------+----------------------+    |
+|                    +--------------------------------------------------+
+|                    |   LogExplorer   (full-width, ≥ 40 % of height)   |
++--------------------+--------------------------------------------------+
+```
+
+Differences from today: from three columns down to two on the right
+(turns, notifications, failures, live-context only). Reminders / Memos /
+Billing / Stats / full Context block move out.
+
+Reasoning: the engineer rarely needs to look at memos to debug a live
+session; removing them gives turns/notifications/failures more breathing
+room and lets logs grow taller.
+
+### 4.5 `/admin` page layout
+
+```text
++----------------------------------------------------------------------+
+| Topbar:  papai admin | connection dot (REST health probe) | tz/now   |
++--------+-------------------------------------------------------------+
+|        |                                                             |
+|  Nav   |   Section content (only one section visible at a time)      |
+|        |                                                             |
+|  • System         (default landing)                                  |
+|  • Billing                                                            |
+|  • Stats                                                              |
+|  • Memos                                                              |
+|  • Reminders                                                          |
+|  • Identities                                                         |
+|  • Groups                                                             |
+|        |                                                             |
+|  Footer:                                                             |
+|   build SHA / link to /debug                                          |
++--------+-------------------------------------------------------------+
+```
+
+- Nav is a 200 px left rail; selection is reflected in `location.hash`
+  (e.g. `/admin#billing`) so deep links and refreshes preserve the view
+  without pulling in a router lib.
+- "System" landing shows: required env presence summary (read-only from
+  what the server reports), then `CredentialsForm`, then a tiny "active
+  build" line. No SSE.
+- Section bodies use a vertical scroll. Each section header has its own
+  `<h2>` and an optional toolbar (window selector, search, refresh).
+- Tables are full-width within the section, never inside a 1/3-column
+  card. Long results paginate by clamping to the existing server-side
+  limits (billing 500, stats already aggregates).
+
+### 4.6 `/admin` sections in detail
+
+- **System.** `CredentialsForm` (the only mutation surface in /admin
+  today). Shows masked `llm_apikey`, plain `llm_baseurl`, `main_model`,
+  `small_model`, `embedding_model`. Edit-and-save still calls
+  `POST /admin/llm` with the same body shape.
+- **Billing.** Window selector (`24h / 7d / 30d / all`), subjects table,
+  row click opens **SubjectDetail modal** (size `lg`) containing
+  request rows + `SubjectStatsPanel` (anonymous per-subject stats).
+- **Stats.** Window selector (`1d / 7d / 30d / all`) + `StatsPanel`
+  global view.
+- **Memos.** "User ID" input + "Load" button. Browses memos by user with
+  `state` filter (active / archived / all). New fetcher hits
+  `GET /memos?userId=&state=`.
+- **Reminders.** "User ID" input + "Load" button. Lists recurring tasks
+  (`GET /recurring?userId=`) and deferred prompts (`GET /deferred?userId=`)
+  side by side.
+- **Identities.** "User ID" + provider select (defaults to `task-provider`).
+  Lists current mappings. v1 read-only; clearing happens via chat tool.
+- **Groups.** Lists authorized groups (`GET /auth/groups`). Read-only.
+
+### 4.7 Modal pattern
+
+Promote `Modal.svelte` into a shared primitive with three additions:
+
+```svelte
+interface Props {
+  open: boolean
+  title: string
+  size?: 'sm' | 'md' | 'lg' | 'xl'   // new — default 'md'
+  onClose: () => void
+  body: Snippet
+  footer?: Snippet                    // new — confirm-dialog actions
+}
+```
+
+Two compositions:
+
+- **Inspection modal** (default). Read-only. No footer snippet — body
+  scrolls inside. Used by SessionDetail / TraceDetail / LogDetail /
+  TurnDetail / FailureDetail / SubjectDetail.
+- **Confirm dialog** (`size: 'sm'`, footer snippet with Cancel/Confirm
+  buttons). New, used the moment we add the first destructive admin
+  action (out of scope for v1 but reserved).
+
+Sizes (max-width): `sm 360 px`, `md 640 px`, `lg 920 px`, `xl 1200 px`.
+All keep the existing click-outside-to-close and Escape handling (Escape
+is **missing today** — add it as part of the move).
+
+### 4.8 Shared visual identity
+
+Both pages share `client/shared/base.css` (extracted from
+`client/debug/dashboard.css`):
+
+- font stack: JetBrains Mono → Fira Code → Cascadia Code → monospace, 12 px.
+- background `#0a0a0a`, foreground `#cccccc`.
+- accent `#00ff88` (connected / active / counters), error `#ff4444`.
+- panel = `background:#111; border:1px solid #222; border-radius:2px;`.
+- `.count-badge`, `.placeholder`, `.status-error`, `.status-success` —
+  kept identical so component code keeps using the same classnames.
+
+`/debug` adds `debug.css` with grid layout + log-explorer styles.
+`/admin` adds `admin.css` with sidebar nav + section container.
+
+## 5. Data schemas — source-of-truth files
+
+These are the files a future UI generator should read first when
+deciding shape / fields for any view. Every type listed is exported.
+
+### 5.1 `/debug` page schemas
+
+| File                                       | What it defines                                                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `src/debug/schemas.ts`                     | Every SSE event Zod schema: `Session`, `Wizard`, `LlmTrace`, `LogEntry`, `StateInitEvent`, `StateStatsEvent`, `CacheEvent`, `UserIdEvent`, `SchedulerTickEvent`, `PollerEvent`, `MessageCacheEvent`, plus token / step / tool-call detail sub-types. |
+| `src/debug/turn-assembly.ts`               | `Turn`, `Notification`, `ToolFailure` (re-exported from `schemas.ts`).                                             |
+| `src/debug/state-collector.ts`             | Shape of the periodic state snapshot dispatched as `state:init` / `state:stats`.                                   |
+| `src/debug/state-collector-utils.ts`       | Session-summary projection used by the collector.                                                                  |
+| `src/debug/llm-trace-collector.ts`         | LLM trace ring buffer shape.                                                                                       |
+| `src/debug/log-buffer.ts`                  | Log entry shape and search params (`level`, `scope`, `turnId`, `q`, `limit`).                                      |
+| `client/debug/dashboard-types.ts` (today)  | Client-side `DashboardState` interface — the canonical reactive shape; will move to `client/shared/api-types.ts`.  |
+
+### 5.2 `/admin` page schemas
+
+| File                                       | What it defines                                                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `src/debug/billing.ts`                     | `BillingWindow`, `BillingSubject`, `BillingDetail`, `BILLING_DETAIL_LIMIT`.                                        |
+| `src/debug/billing-routes.ts`              | Response envelopes: `{ window, subjects }`, `{ window, subject, requests, truncated }`, admin-llm responses.        |
+| `src/debug/admin-llm.ts`                   | `AdminLlmKeyState`, `AdminLlmSnapshot`, `AdminLlmError`, request body schema for `POST /admin/llm`.                |
+| `src/usage/types.ts`                       | `ModelRole`, `ContextType`, `SubjectRoleTotals`, `SubjectSummary`, `RequestRow`, `ToolCallRow`, `ToolCallSubjectSummary`. |
+| `src/usage/query.ts`                       | Functions consumed by billing (subject lists + tool aggregates).                                                   |
+| `src/stats/types.ts`                       | `StatsWindow`, all `*Stats` sub-types, `GlobalStats`, `SubjectStats`, `Percentiles`.                               |
+| `src/stats/index.ts`                       | `getGlobalStats({ window })`, `getSubjectStats(id)` — entrypoints feeding the admin Stats section.                 |
+| `src/system-config.ts`                     | `SystemConfigKey`, `SYSTEM_CONFIG_KEYS`, `SystemConfigEntry`, `maskSystemConfigValue`, `listSystemConfigEntries`.   |
+| `src/memos.ts`                             | `Memo` interface, `ArchiveFilter`. `listMemos(userId, limit, state)` is the route handler input.                   |
+| `src/types/recurring.ts`                   | `TriggerType`, `RecurringTaskInput`, `RecurringTaskRecord`.                                                        |
+| `src/recurring.ts`                         | Re-exports + `listRecurringTasks(userId)`.                                                                          |
+| `src/deferred-prompts/scheduled.ts`        | `ScheduledPrompt` shape; `listScheduledPrompts(userId, status?)`.                                                  |
+| `src/identity/mapping.ts`                  | `SetIdentityMappingParams`, `IdentityMappingDeps`, return shape of `getIdentityMapping`.                            |
+| `src/authorized-groups.ts`                 | `listAuthorizedGroups(): Array<{ group_id, added_by, added_at }>` — the literal admin row.                         |
+| `client/debug/billing/fetchers.ts` (today) | Runtime Zod schemas validating each `/billing/*` and `/admin/llm` response — the client-side schema source.        |
+| `client/debug/stats/fetchers.ts` (today)   | Runtime Zod schemas validating each `/stats/*` response.                                                            |
+| `client/debug/dashboard-types.ts` (today)  | Admin-side type bag: `BillingSubject`, `BillingDetail`, `BillingWindow`, `BillingRequestRow`, `BillingRoleTotals`, `AdminLlmSnapshot`, `AdminLlmKeyState`, `Memo`, `RecurringTask`, `DeferredPrompt`, `IdentityMappingEntry`, `AuthorizedGroupEntry`. Will move to `client/shared/api-types.ts`. |
+
+### 5.3 Shared (used by both pages)
+
+| File                                | What it defines                                                                |
+| ----------------------------------- | ------------------------------------------------------------------------------ |
+| `src/debug/event-bus.ts`            | Event names emitted to subscribers — defines what `/events` can emit.          |
+| `src/debug/turn-assembly.ts`        | Already listed; both pages may reference the turn-id shape (admin not yet).    |
+| `src/auth.ts`                       | `getThreadScopedStorageContextId` — explains why some billing rows are scoped. |
+
+### 5.4 Why this list matters
+
+A UI generator hitting "build me the X section" only needs:
+1. the matching server file (defines the data),
+2. the matching fetcher file (defines the wire shape),
+3. the matching dashboard-types entry (defines the local reactive shape).
+
+Keeping these three in lockstep (and using Zod at the boundary, as
+`fetchers.ts` already does) is what lets us regenerate any section
+without scanning the whole codebase.
+
+## 6. Open questions
+
+1. **`/dashboard` redirect duration.** One release? Two? Tests today
+   assert against `GET /dashboard` returning HTML; we'll need to flip
+   them to assert a 301.
+2. **Admin SSE.** If we later want a live "new memo created" toast in
+   `/admin`, we'd open `/events` with a server-side filter. Out of scope
+   here; mentioned so the navigation layout leaves room for an indicator
+   dot.
+3. **Auth scope.** Today `DEBUG_TOKEN` gates everything uniformly. If we
+   ever want "engineer can see /debug without seeing /admin", we'd add a
+   second token. Keep parity with today for v1; flag it in the plan so
+   the routing helper is structured to allow a second token without a
+   rewrite.
+4. **Tests directory layout.** Today `tests/client/debug/` mirrors
+   `client/debug/`. After the split, mirror that pattern:
+   `tests/client/debug/` + `tests/client/admin/` + `tests/client/shared/`.
+   Existing tests for `components/`, `billing/`, `stats/` will move
+   accordingly; the test files themselves shouldn't need rewrites beyond
+   import paths.
+
+## 7. Risks
+
+- **Build complexity.** `scripts/build-client.ts` becomes two builds (or
+  one build with two entrypoints). Mitigation: factor the build helper to
+  accept `{ entry, html, jsName, cssName }` and call it twice. Component
+  CSS collection is already per-file.
+- **CSS leakage.** Today all component-scoped CSS is concatenated into
+  one stylesheet. Two bundles means two stylesheets — the shared
+  classnames must be in the shared base, otherwise a panel can render
+  unstyled on one page. Mitigation: extract `base.css` first, run both
+  pages against it, then move debug-only and admin-only blocks.
+- **Test fragility.** `tests/debug/server.test.ts` asserts the literal
+  `/dashboard` HTML response. Flip to `/debug` + 301 from `/dashboard`
+  in the same commit that adds the route.
+- **DEBUG_TOKEN regression.** Splitting routes risks accidentally
+  exempting a new admin endpoint from the central auth gate.
+  Mitigation: keep one `isAuthorizedRequest()` call at the top of
+  `routeRequest`; do not add per-route token checks. The phase plan calls
+  this out explicitly.
+
+## 8. Out of scope
+
+- Charts and timeseries on stats. Existing `<dl>` lists are kept.
+- Audit log of admin actions. Out for v1; `POST /admin/llm` already
+  records `updatedBy` so the data is there when we add a panel.
+- Role-based access control with multiple operator accounts.
+- i18n; both pages stay English-only.
+- Theme toggle; dark-only.
+- Mobile layout; both pages assume ≥ 1024 px viewport.

--- a/docs/design/dashboard-admin-split-plan.md
+++ b/docs/design/dashboard-admin-split-plan.md
@@ -1,0 +1,474 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Dashboard / Admin Split — Implementation Plan
+
+Companion to [`dashboard-admin-split-design.md`](./dashboard-admin-split-design.md).
+Each phase is sized to fit **one coding session** (plan → tests → impl →
+verify → commit, no overflow). The phases are ordered so the tree stays
+green and shippable between any two.
+
+## How to use this document
+
+- **Order matters.** Phases are bottom-up: shared primitives first, then
+  the two bundles, then the server routes, then the section moves, then
+  cleanup. Don't skip ahead — later phases assume earlier ones landed.
+- **One phase per commit / PR.** Branch:
+  `claude/split-dashboard-admin-zaoys`.
+- **TDD is enforced by hooks** on `src/**` and `client/**`. Write the
+  test first; the write-policy gate will reject implementation before a
+  failing test exists. Phases below already follow that order.
+- **Every phase ends with the same verification baseline** (omitted from
+  each phase for brevity, run them anyway):
+
+```bash
+bun lint
+bun typecheck
+bun test            # curated main suite
+bun test:client     # dashboard UI tests
+bun format:check
+bun build:client    # both bundles produce non-empty artifacts
+```
+
+`bun check:full` is the required pre-merge gate.
+
+## Conventions used by every phase
+
+| Field         | Meaning                                                                |
+| ------------- | ---------------------------------------------------------------------- |
+| Goal          | One-sentence summary of the phase outcome.                             |
+| Touches       | Files created or modified. Numbers are illustrative; expect ±1.        |
+| Depends on    | Phase numbers that must be merged first.                               |
+| Tests         | Test files added (always added before implementation under TDD hooks). |
+| Exit criteria | Observable state when the phase is complete.                           |
+
+---
+
+## Track A — Shared primitives, no behaviour change yet
+
+### Phase 1 — Extract `client/shared/` skeleton
+
+- **Goal.** Create a shared client directory holding only what both pages
+  will use. No callers change yet; this is purely an additive move.
+- **Touches.** Create `client/shared/`:
+  - `helpers.ts` — copy of `client/debug/helpers.ts` (formatTime,
+    formatUptime, levelClass, levelName).
+  - `api-types.ts` — content of today's `client/debug/dashboard-types.ts`,
+    minus the `DashboardState` interface (which is debug-specific).
+    Export the admin-side types unchanged.
+  - `fetcher-helpers.ts` — extract `readBody`, `requireOk`,
+    `errorMessageFrom`, `ErrorBodySchema` from
+    `client/debug/billing/fetchers.ts`.
+  - `Modal.svelte` — copy of `client/debug/components/Modal.svelte` with
+    Escape-key close added.
+  - `PropertiesTable.svelte`, `TreeView.svelte` — copied verbatim.
+  - `StatusDot.svelte`, `PanelShell.svelte` — new tiny wrappers that
+    re-implement today's inline markup.
+- **Tests.**
+  - `tests/client/shared/Modal.test.ts` — open/close, Escape closes,
+    click-outside closes, click-inside does not close.
+  - `tests/client/shared/api-types.test.ts` — type-only assertions
+    survive `tsc`.
+  - `tests/client/shared/fetcher-helpers.test.ts` — covers `readBody`
+    (json + non-json), `requireOk` (ok / 4xx / 5xx),
+    `errorMessageFrom` fallback.
+- **Depends on.** —
+- **Exit criteria.** `client/shared/` exists, is fully tested, and is
+  imported by **zero** files. `client/debug/` still works exactly as
+  before.
+
+### Phase 2 — Migrate `client/debug/` to consume `client/shared/`
+
+- **Goal.** Make `/dashboard` (still served) use the shared primitives.
+  Catches divergence before we split into two bundles.
+- **Touches.**
+  - `client/debug/components/Modal.svelte` — delete; replace every
+    import with `from '../../shared/Modal.js'`.
+  - `client/debug/components/PropertiesTable.svelte`,
+    `TreeView.svelte` — delete; redirect imports.
+  - `client/debug/helpers.ts` — delete; re-import from `../shared/helpers.js`.
+  - `client/debug/dashboard-types.ts` — keep only `DashboardState` +
+    `DashboardWizard` + `DashboardStats`. Re-export everything else
+    from `../shared/api-types.js` so existing imports stay valid.
+  - `client/debug/billing/fetchers.ts` — pull `readBody`, `requireOk`,
+    `errorMessageFrom`, `ErrorBodySchema` from
+    `../../shared/fetcher-helpers.js`.
+  - `client/debug/stats/fetchers.ts` — same.
+- **Tests.** Existing `tests/client/debug/**` must still pass without
+  modification.
+- **Depends on.** Phase 1.
+- **Exit criteria.** No file under `client/debug/components/` exports
+  `Modal.svelte`, `PropertiesTable.svelte`, `TreeView.svelte`, or the
+  helper functions; they all import from `client/shared/`. Bundle size
+  is within ±2 % of pre-phase.
+
+### Phase 3 — Two-entrypoint build script
+
+- **Goal.** Teach `scripts/build-client.ts` to build N bundles from a
+  list. Today it builds one. After this phase it still produces exactly
+  the same output (`dashboard.*`) because only one entry is listed — the
+  generalisation is the point.
+- **Touches.**
+  - `scripts/build-client.ts` — refactor into `buildBundle({ entry,
+    htmlSrc, jsName, htmlName, cssName })`. Loop over a config array.
+    For this phase the config holds **one** entry:
+    `{ entry: 'client/debug/index.ts', htmlSrc: 'client/debug/dashboard.html',
+    jsName: 'dashboard.js', htmlName: 'dashboard.html',
+    cssName: 'dashboard.css' }`. Shared base CSS read once.
+  - `client/shared/base.css` (new) — extracted from
+    `client/debug/dashboard.css`: reset, body, font stack, panel,
+    count-badge, placeholder, status-error, status-success, modal.
+    The remainder stays as `dashboard.css` (debug-specific layout +
+    log explorer styles).
+- **Tests.**
+  - `tests/scripts/build-client.test.ts` — invoke buildBundle for the
+    debug entry against a temp `outdir`, assert non-empty
+    `dashboard.{html,js,css}` are produced and the CSS contains both
+    base and component-scoped rules. (Repo currently has no
+    `tests/scripts/`; create it; add to the main test glob if necessary.)
+- **Depends on.** Phase 2.
+- **Exit criteria.** `bun build:client` emits the exact same artifacts
+  (modulo whitespace ordering inside `dashboard.css`).
+  `tests/debug/server.test.ts` still passes.
+
+---
+
+## Track B — `/debug` page extraction (parallel-safe)
+
+### Phase 4 — Carve out `DebugApp.svelte`
+
+- **Goal.** Build a new `DebugApp.svelte` that composes only the
+  observability panels per design §4.4. Run it under the existing
+  `/dashboard` route for one phase so we can compare side-by-side.
+- **Touches.**
+  - `client/debug/DebugApp.svelte` — new. Header + ContextChips +
+    SessionsList/TraceList sidebar + 2-column panel grid
+    (TurnsPanel, NotificationsPanel, ToolFailuresPanel,
+    `LiveContextCard.svelte`) + LogExplorer + modals
+    (Session / Trace / Log / Turn / Failure).
+  - `client/debug/components/LiveContextCard.svelte` — new. Renders
+    only `wizards` + `activeConfigEditors` from the old `ContextPanel`.
+  - `client/debug/App.svelte` — temporarily becomes a thin alias:
+    `<DebugApp {dashboard} />` while we cut other panels out.
+  - `client/debug/dashboard.svelte.ts` — drop fields not consumed by
+    DebugApp: `memos`, `recurringTasks`, `deferredPrompts`,
+    `identityMappings`, `authorizedGroups`, `billingWindow`,
+    `billingSubjects`, `billingDetail`, `adminLlm`, `statsWindow`,
+    `globalStats`, `subjectStats`. The handler functions that wrote
+    them move out in Phase 5.
+- **Tests.**
+  - `tests/client/debug/components/DebugApp.test.ts` — mounts
+    DebugApp with a minimal state, asserts presence of each retained
+    section, asserts the absence of `[data-testid="billing-*"]`,
+    `[data-testid="stats-*"]`, memos, reminders.
+  - Existing `tests/client/debug/components/App.test.ts` — flip to
+    assert the new layout; do **not** delete (App is now an alias).
+- **Depends on.** Phase 2 (shared Modal in place).
+- **Exit criteria.** `/dashboard` still works; visually the admin panels
+  are gone; the engineer panels look right; existing debug-only tests
+  still pass.
+
+### Phase 5 — Trim `client/debug/handlers-extras.ts`
+
+- **Goal.** Move admin-only SSE handlers out of the debug bundle so the
+  debug bundle doesn't even know how to populate memos/recurring/etc.
+- **Touches.**
+  - `client/debug/handlers-extras.ts` — keep only
+    `handleConfigEditorEvent`. Delete `handleRecurringEvent`,
+    `handleDeferredEvent`, `handleMemoEvent`, `handleIdentityEvent`,
+    `handleAuthEvent` from this file.
+  - `client/debug/sse.ts` — drop their wiring from
+    `recurringHandlers()` / `contextHandlers()`. Keep
+    `config_editor:opened/closed/step`.
+  - Save the deleted handlers verbatim into
+    `client/admin/handlers-admin-extras.ts` (new; unused yet — Phase 9
+    wires it). This is a temporary file and Phase 11 inlines it.
+- **Tests.**
+  - `tests/client/debug/handlers.test.ts` — assert the moved handlers
+    are no longer exported from the debug module.
+  - `tests/client/debug/sse.test.ts` — assert the debug event map no
+    longer contains `memo:created`, `memo:archived`, `identity:set`,
+    `identity:cleared`, `auth:group_authorized`, `auth:group_revoked`,
+    `recurring:*`, `deferred:*`.
+- **Depends on.** Phase 4.
+- **Exit criteria.** Debug bundle no longer touches admin-only state.
+  Live wizard / config-editor indicator still works on `/debug`.
+
+### Phase 6 — Rename `/dashboard` → `/debug`, add 301 redirect
+
+- **Goal.** Flip the URL. Tests update in lock-step.
+- **Touches.**
+  - `client/debug/dashboard.html` → `client/debug/debug.html` (rename;
+    update bundle config in `build-client.ts` accordingly to emit
+    `debug.{html,js,css}`).
+  - `client/debug/dashboard.svelte.ts` → `client/debug/debug.svelte.ts`
+    (rename + update imports).
+  - `client/debug/dashboard.css` → `client/debug/debug.css` (rename).
+  - `src/debug/server.ts`:
+    - `handleDashboardFile()` → `handleDebugFile()` matching `/debug`,
+      `/debug.js`, `/debug.css`.
+    - Add `if (pathname === '/dashboard') return new Response(null, {
+      status: 301, headers: { Location: '/debug' } })`.
+  - `tests/debug/server.test.ts` — flip to `/debug` + assert 301 from
+    `/dashboard`.
+  - `tests/debug/dashboard-smoke.test.ts` — rename references to /debug.
+  - `client/debug/index.ts` — keep `mountApp` exported; selector
+    `#app` unchanged.
+- **Tests.**
+  - All renamed tests pass with the new URL.
+  - New test: `GET /dashboard` returns 301 with `Location: /debug`.
+- **Depends on.** Phase 5.
+- **Exit criteria.** `bun start:debug` opens at `http://127.0.0.1:9100/debug`
+  and shows the engineer page. `/dashboard` redirects.
+
+---
+
+## Track C — `/admin` page bring-up
+
+### Phase 7 — Empty `/admin` bundle and route
+
+- **Goal.** Ship an /admin route that returns an empty shell so the URL
+  exists and is testable. No sections wired yet.
+- **Touches.**
+  - `client/admin/admin.html` (new) — `<div id="app"></div>` + scripts.
+  - `client/admin/index.ts` (new) — mounts `AdminApp`.
+  - `client/admin/AdminApp.svelte` (new) — sidebar + topbar + empty
+    section pane with "select a section" placeholder.
+  - `client/admin/admin.svelte.ts` (new) — admin-side reactive state
+    with empty fields for the future sections.
+  - `client/admin/admin.css` (new) — sidebar + topbar styles only.
+  - `client/admin/components/NavSidebar.svelte` (new) —
+    `[System, Billing, Stats, Memos, Reminders, Identities, Groups]`,
+    hash-routed via `location.hash`.
+  - `scripts/build-client.ts` — add a second entry for the admin
+    bundle. Bundle outputs: `public/admin.{html,js,css}`.
+  - `src/debug/server.ts` — `handleAdminFile()` matching `/admin`,
+    `/admin.js`, `/admin.css`. Keep them behind the same
+    `isAuthorizedRequest()` gate.
+- **Tests.**
+  - `tests/debug/server.test.ts` — `GET /admin`, `/admin.js`,
+    `/admin.css` all return non-empty 200s.
+  - `tests/client/admin/AdminApp.test.ts` — mounts the app, asserts
+    the seven nav items, asserts default selection is `System`,
+    asserts switching hash to `#billing` updates the visible section.
+  - `tests/scripts/build-client.test.ts` — assert both bundles build.
+- **Depends on.** Phase 3 (multi-entry build).
+- **Exit criteria.** `/admin` renders an empty shell; hash routing
+  works; no admin section is wired yet.
+
+### Phase 8 — System section (Credentials form)
+
+- **Goal.** Move the LLM credentials form into `/admin` so the **only
+  write surface** lives in the admin page from day one.
+- **Touches.**
+  - `client/admin/components/CredentialsForm.svelte` — copied verbatim
+    from `client/debug/billing/CredentialsForm.svelte`; imports updated
+    to use `client/shared/fetcher-helpers.js`.
+  - `client/admin/fetchers.ts` (new) — re-export
+    `fetchAdminLlm`, `submitAdminLlm` (lifted from the debug billing
+    fetchers).
+  - `client/admin/sections/SystemSection.svelte` — wraps
+    `CredentialsForm` + a small read-only block listing required env
+    presence (from a new `GET /admin/system` route that returns
+    `{ chatProvider, taskProvider, debugServer, adminUserSet }`).
+  - `src/debug/server.ts` — register `GET /admin/system` (read-only,
+    same gate as everything else; no new data exposure beyond enum
+    booleans).
+  - `client/debug/billing/CredentialsForm.svelte` — delete; remove
+    from `BillingPanel.svelte` (still rendered on /dashboard for one
+    more phase via the temporary App.svelte shim — actually, by Phase
+    6 /dashboard is gone, so this is a clean delete).
+- **Tests.**
+  - `tests/client/admin/sections/SystemSection.test.ts` — renders
+    masked apikey row, edit/save flow against a mocked fetch.
+  - `tests/debug/admin-llm-route.test.ts` — unchanged; route shape
+    didn't move.
+  - `tests/debug/server.test.ts` — add `GET /admin/system` coverage.
+- **Depends on.** Phase 7.
+- **Exit criteria.** `/admin#system` shows the credentials editor;
+  posting to `/admin/llm` still works; nothing in `/debug` lets you
+  edit credentials anymore.
+
+### Phase 9 — Billing section
+
+- **Goal.** Move the entire billing surface into `/admin#billing`.
+- **Touches.**
+  - `client/admin/sections/BillingSection.svelte` — window selector +
+    subjects table + opens SubjectDetail modal.
+  - `client/admin/components/SubjectsTable.svelte`,
+    `SubjectDetail.svelte`,
+    `SubjectStatsPanel.svelte`,
+    `WindowSelect.svelte` — moved from `client/debug/billing/` and
+    `client/debug/stats/`.
+  - `client/admin/fetchers.ts` — append `fetchBillingSubjects`,
+    `fetchBillingDetail`, `fetchStatsSubject` (the last is used by
+    SubjectStatsPanel inside the billing modal).
+  - `client/debug/billing/` — directory deleted.
+- **Tests.**
+  - `tests/client/admin/sections/BillingSection.test.ts` — port the
+    existing `tests/client/debug/billing/*` tests with updated imports.
+  - `tests/debug/billing-route.test.ts` — unchanged.
+- **Depends on.** Phase 8.
+- **Exit criteria.** `/admin#billing` lists subjects, opens detail
+  modal, and renders the per-subject anonymous stats inside. `/debug`
+  has no billing references left.
+
+### Phase 10 — Stats section
+
+- **Goal.** Move global stats to `/admin#stats`.
+- **Touches.**
+  - `client/admin/sections/StatsSection.svelte` — window selector +
+    StatsPanel content rendered inline.
+  - `client/admin/fetchers.ts` — append `fetchStatsGlobal`.
+  - `client/debug/stats/` — directory deleted.
+- **Tests.**
+  - `tests/client/admin/sections/StatsSection.test.ts` — port from
+    `tests/client/debug/stats/StatsPanel.test.ts`.
+  - Existing `tests/debug/stats-routes.test.ts` — unchanged.
+- **Depends on.** Phase 9.
+- **Exit criteria.** `/admin#stats` shows the global stats lists.
+
+### Phase 11 — Memos, Reminders, Identities, Groups sections
+
+- **Goal.** Move the four user-data browsers into `/admin`. v1 read-only.
+- **Touches.**
+  - `client/admin/sections/MemosSection.svelte` — userId input +
+    state filter + table backed by `GET /memos?userId=&state=`.
+  - `client/admin/sections/RemindersSection.svelte` — userId input,
+    two tables (recurring / deferred) backed by
+    `GET /recurring?userId=` and `GET /deferred?userId=`.
+  - `client/admin/sections/IdentitiesSection.svelte` — userId +
+    provider input, single lookup backed by
+    `GET /identity?userId=&provider=`.
+  - `client/admin/sections/GroupsSection.svelte` — full list backed
+    by `GET /auth/groups`.
+  - `client/admin/fetchers.ts` — append the four fetchers (with
+    Zod-validated response schemas, same pattern as today's billing
+    fetchers).
+  - Delete `client/debug/components/MemosPanel.svelte`,
+    `RemindersPanel.svelte`, `ContextPanel.svelte`.
+  - Delete `client/admin/handlers-admin-extras.ts` (the temporary
+    holding pen from Phase 5).
+- **Tests.**
+  - `tests/client/admin/sections/MemosSection.test.ts`,
+    `RemindersSection.test.ts`,
+    `IdentitiesSection.test.ts`,
+    `GroupsSection.test.ts` — happy path + empty state + error state
+    for each.
+  - `tests/client/admin/fetchers.test.ts` — Zod schemas reject
+    malformed responses.
+  - Server-side route tests in `tests/debug/server.test.ts` already
+    cover `/recurring`, `/deferred`, `/memos`, `/identity`,
+    `/auth/groups` — unchanged.
+- **Depends on.** Phase 10.
+- **Exit criteria.** Every former panel on the old `/dashboard` has a
+  home: engineer panels on `/debug`, operator panels on `/admin`. No
+  dead code.
+
+---
+
+## Track D — Tidy-up and polish
+
+### Phase 12 — Cleanup
+
+- **Goal.** Remove the temporary shim `client/debug/App.svelte` (or
+  reduce it to just `<DebugApp />`), tighten CSS imports, prune
+  unused fields from the dashboard state.
+- **Touches.**
+  - `client/debug/App.svelte` — delete; `index.ts` mounts
+    `DebugApp` directly.
+  - `client/debug/debug.svelte.ts` — drop any field that no remaining
+    component reads. `bun knip` flags them.
+  - `client/shared/base.css` — confirm both bundles import it; remove
+    duplicated rules from `debug.css` and `admin.css`.
+- **Tests.**
+  - `bun knip` clean.
+  - Existing tests unchanged.
+- **Depends on.** Phase 11.
+- **Exit criteria.** `bun check:full` green; no dead exports flagged.
+
+### Phase 13 — Documentation
+
+- **Goal.** Update top-level docs to reflect the split.
+- **Touches.**
+  - `CLAUDE.md` — change "the dashboard at `/dashboard` exposes a
+    Billing panel" to describe the split: `/debug` (engineer surface)
+    and `/admin` (operator surface). Update the description of the
+    Billing / Stats sections to point to `/admin#billing` /
+    `/admin#stats`. Mention the 301 from `/dashboard`.
+  - `README.md` — refresh the debug-server section accordingly.
+  - This design doc gains a "Status: implemented" tag and a final
+    date.
+- **Tests.** —
+- **Depends on.** Phase 12.
+- **Exit criteria.** Top-level docs read accurately for any future
+  contributor.
+
+### Phase 14 — Modal primitive: size + footer + Escape (deferred enhancement)
+
+- **Goal.** Promote the shared `Modal.svelte` to a sized + footer-slot
+  primitive so the next admin destructive action (out of scope here)
+  can land without modal-rewrite friction.
+- **Touches.**
+  - `client/shared/Modal.svelte` — add `size?: 'sm' | 'md' | 'lg' |
+    'xl'` and `footer?: Snippet`. CSS classes `.modal--sm/md/lg/xl`.
+  - `client/shared/Confirm.svelte` — new; thin wrapper around Modal
+    with `size: 'sm'` + Cancel/Confirm footer.
+  - All current callers keep using defaults — no visible change.
+- **Tests.**
+  - `tests/client/shared/Modal.test.ts` — size variants render the
+    matching class; footer snippet renders when provided.
+  - `tests/client/shared/Confirm.test.ts` — Cancel and Confirm both
+    fire, click-outside fires Cancel.
+- **Depends on.** Phase 12.
+- **Exit criteria.** Modal supports the patterns called out in
+  §4.7 of the design spec, ready for the first admin action.
+
+## Cross-cutting checklist
+
+Before each PR is opened:
+
+- [ ] Branch is `claude/split-dashboard-admin-zaoys`.
+- [ ] `bun lint` + `bun typecheck` + `bun test` + `bun test:client` +
+      `bun format:check` + `bun build:client` all green.
+- [ ] No new admin route added without the central
+      `isAuthorizedRequest()` gate (grep
+      `src/debug/server.ts` for `/admin/` after the diff).
+- [ ] No new ungated **write** route on any path.
+- [ ] No `eslint-disable`, `oxlint-disable`, `@ts-ignore`,
+      `@ts-nocheck`, or `.oxlintrc.json` edits (hooks block them
+      anyway; double-check before pushing).
+- [ ] Tests for any new component live at the mirrored path under
+      `tests/client/{debug,admin,shared}/`.
+- [ ] If a panel is moved, the **old import path is gone** in the same
+      commit — don't leave a re-export shim behind.
+
+## Rollback plan
+
+If a phase wedges the tree:
+
+- Phases 1-3 are additive; revert the phase commit only.
+- Phase 4 + 5 + 6 cluster — these together move /dashboard to /debug.
+  If a regression escapes, revert all three commits in order (6 → 5 →
+  4). The 301 redirect lets stale links keep working post-revert.
+- Phases 7-11 are per-section; reverting one phase only loses that
+  section, leaving /admin shell + earlier sections intact.
+- Phases 12-14 are cleanup; reverting them never affects functionality.
+
+## Out-of-scope follow-ups (post-split)
+
+Listed here so the plan is honest about what comes next without
+expanding the scope of this PR series:
+
+- Admin → destructive actions (revoke group, clear identity mapping,
+  archive memo) with Confirm dialogs (Phase 14 primitive lands first).
+- Stats charts (sparklines for distributions; Chart.js or hand-rolled
+  SVG — open).
+- Separate auth tokens for `/debug` vs `/admin` (today both share
+  `DEBUG_TOKEN`).
+- Filtered SSE for the admin page (live "new memo created" toast).
+- Build SHA / git rev surfaced in both pages' footers.


### PR DESCRIPTION
Audit of client/debug/App.svelte and src/debug/server.ts, then a written
allocation of every existing panel to one of two purpose-built routes:
- /debug — engineer surface, SSE-driven (header, sessions, traces, turns,
  notifications, tool failures, live context, log explorer)
- /admin — operator surface, REST-driven (system credentials, billing,
  stats, memos, reminders, identities, authorized groups)

Includes a 14-phase implementation plan in the repo's standard
phase-decomposition style, plus a data-schema source-of-truth index for
future UI generation.