### PR TITLE
fix(auth): include actual group id in unauthorized-group hints

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -51,16 +51,16 @@ const checkAuthorization = (userId: string, username: string | null | undefined)
   return false
 }
 export { checkAuthorizationExtended, getThreadScopedStorageContextId }
-function getUnauthorizedReplyText(auth: AuthorizationResult): string | null {
+function getUnauthorizedReplyText(auth: AuthorizationResult, groupId: string): string | null {
   if (auth.reason === 'group_not_allowed')
-    return 'This group is not authorized to use this bot. Ask the bot admin to run `/group add <group-id>` in a DM with the bot.'
+    return `This group is not authorized to use this bot. Ask the bot admin to run \`/group add ${groupId}\` in a DM with the bot.`
   if (auth.reason === 'group_member_not_allowed')
     return "You're not authorized to use this bot in this group. Ask a group admin to add you with `/group adduser <user-id|@username>`"
   if (auth.reason === 'dm_not_allowed') return 'You are not authorized to use this bot.'
   return null
 }
-async function replyToUnauthorized(reply: ReplyFn, auth: AuthorizationResult): Promise<void> {
-  const message = getUnauthorizedReplyText(auth)
+async function replyToUnauthorized(reply: ReplyFn, auth: AuthorizationResult, groupId: string): Promise<void> {
+  const message = getUnauthorizedReplyText(auth, groupId)
   if (message !== null) await reply.text(message)
 }
 function shouldDeferUnauthorizedDmCommand(commandName: string, msg: IncomingMessage): boolean {
@@ -90,7 +90,7 @@ function createObservedCommandHandler(
     const auth = resolveMessageAuth(msg)
     if (!auth.allowed) {
       if (shouldDeferUnauthorizedDmCommand(commandName, msg)) await handler(msg, tracked.reply, auth)
-      else await replyToUnauthorized(tracked.reply, auth)
+      else await replyToUnauthorized(tracked.reply, auth, msg.contextId)
       emitReplyCompletedIfNeeded(tracked, msg.user.id, auth.storageContextId, start)
       return
     }
@@ -175,7 +175,7 @@ async function handleMessage(
   deps: BotDeps,
 ): Promise<void> {
   if (!auth.allowed) {
-    if (msg.isMentioned) await replyToUnauthorized(reply, auth)
+    if (msg.isMentioned) await replyToUnauthorized(reply, auth, msg.contextId)
     return
   }
   if (shouldIgnoreGroupMessage(msg)) return
@@ -262,7 +262,7 @@ async function routeIncomingInteraction(interaction: IncomingInteraction, reply:
       interaction.user.isAdmin,
     )
     if (!auth.allowed) {
-      await replyToUnauthorized(reply, auth)
+      await replyToUnauthorized(reply, auth, interaction.contextId)
       return
     }
     await routeInteraction(interaction, reply, auth)

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -21,9 +21,9 @@ const GROUP_SETUP_ADMIN_ONLY =
 const NO_DELETE_WARNING =
   '⚠️ This platform does not support automatic deletion of messages containing secrets. Please manually delete your messages after entering API keys and tokens.\n\n'
 
-function getUnauthorizedReplyText(auth: AuthorizationResult): string {
+function getUnauthorizedReplyText(auth: AuthorizationResult, groupId: string): string {
   if (auth.reason === 'group_not_allowed') {
-    return 'This group is not authorized to use this bot. Ask the bot admin to run `/group add <group-id>` in a DM with the bot.'
+    return `This group is not authorized to use this bot. Ask the bot admin to run \`/group add ${groupId}\` in a DM with the bot.`
   }
   if (auth.reason === 'group_member_not_allowed') {
     return "You're not authorized to use this bot in this group. Ask a group admin to add you with `/group adduser <user-id|@username>`"
@@ -105,7 +105,9 @@ export async function startSetupForTarget(
   const isGroupTarget = targetContextId !== userId
 
   if (isGroupTarget && !resolvedDeps.isAuthorizedGroup(targetContextId)) {
-    await reply.text('This group is not authorized yet. Ask the bot admin to run `/group add <group-id>` in DM first.')
+    await reply.text(
+      `This group is not authorized yet. Ask the bot admin to run \`/group add ${targetContextId}\` in DM first.`,
+    )
     return
   }
 
@@ -152,7 +154,7 @@ export function registerSetupCommand(
 ): void {
   const handler: CommandHandler = async (msg, reply, auth) => {
     if (!auth.allowed) {
-      await reply.text(getUnauthorizedReplyText(auth))
+      await reply.text(getUnauthorizedReplyText(auth, msg.contextId))
       return
     }
 

--- a/src/group-settings/target-validation.ts
+++ b/src/group-settings/target-validation.ts
@@ -9,7 +9,7 @@ export function getMissingGroupTargetMessage(userId: string, groupId: string): s
   const access = validateGroupTargetAccess(userId, groupId)
 
   if (access.kind === 'not_authorized') {
-    return 'That group is no longer authorized for bot use. Ask the bot admin to run `/group add <group-id>` in DM, then run /config or /setup again.'
+    return `That group is no longer authorized for bot use. Ask the bot admin to run \`/group add ${groupId}\` in DM, then run /config or /setup again.`
   }
 
   return 'You are no longer recognized as an admin for that group. Run /config or /setup again to choose a different target.'

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -770,7 +770,7 @@ describe('Bot Authorization Gate (setupBot)', () => {
     await messageHandler!(groupMessage, reply)
 
     expect(textCalls).toHaveLength(1)
-    expect(textCalls[0]).toContain('/group add <group-id>')
+    expect(textCalls[0]).toContain('/group add group-blocked')
     expect(listManageableGroups('group-admin')).toHaveLength(0)
   })
 
@@ -964,7 +964,7 @@ describe('Bot Authorization Gate (setupBot)', () => {
     await messageHandler!(createDmMessage('dm-admin', 'timezone'), reply)
 
     expect(textCalls).toEqual([
-      'That group is no longer authorized for bot use. Ask the bot admin to run `/group add <group-id>` in DM, then run /config or /setup again.',
+      'That group is no longer authorized for bot use. Ask the bot admin to run `/group add group-ops` in DM, then run /config or /setup again.',
     ])
     expect(getActiveGroupSettingsTarget('dm-admin')).toBeNull()
   })
@@ -1019,7 +1019,7 @@ describe('Bot Authorization Gate (setupBot)', () => {
     await setupHandler!(groupMessage, reply, createAuth('group-user', { isGroupAdmin: true }))
 
     expect(textCalls).toHaveLength(1)
-    expect(textCalls[0]).toContain('/group add <group-id>')
+    expect(textCalls[0]).toContain('/group add group-denied')
   })
 
   test('denies group command execution when group is allowlisted but user is not permitted', async () => {
@@ -1192,7 +1192,7 @@ describe('Bot Authorization Gate (setupBot)', () => {
     expect(processMessageCallCount).toBe(0)
     expect(textCalls).toHaveLength(1)
     expect(textCalls[0]).toContain('not authorized')
-    expect(textCalls[0]).toContain('/group add <group-id>')
+    expect(textCalls[0]).toContain('/group add group-auth')
   })
 
   test('replies with member-level hint for unauthorized user in allowlisted mentioned group', async () => {
@@ -1399,7 +1399,7 @@ describe('Bot Authorization Gate (setupBot)', () => {
     await interactionHandler!(interaction, reply)
 
     expect(textCalls).toHaveLength(1)
-    expect(textCalls[0]).toContain('/group add <group-id>')
+    expect(textCalls[0]).toContain('/group add group-missing')
   })
 
   test('interaction handler replies with member hint for allowlisted groups', async () => {

--- a/tests/chat/interaction-router.test.ts
+++ b/tests/chat/interaction-router.test.ts
@@ -271,7 +271,7 @@ describe('routeInteraction', () => {
 
     expect(handled).toBe(true)
     expect(replies).toEqual([
-      'That group is no longer authorized for bot use. Ask the bot admin to run `/group add <group-id>` in DM, then run /config or /setup again.',
+      'That group is no longer authorized for bot use. Ask the bot admin to run `/group add group-9` in DM, then run /config or /setup again.',
     ])
     expect(getActiveGroupSettingsTarget(interaction.user.id)).toBeNull()
   })

--- a/tests/commands/setup.test.ts
+++ b/tests/commands/setup.test.ts
@@ -107,7 +107,7 @@ describe('/setup command', () => {
     )
 
     expect(textCalls[0]).toBe(
-      'This group is not authorized to use this bot. Ask the bot admin to run `/group add <group-id>` in a DM with the bot.',
+      'This group is not authorized to use this bot. Ask the bot admin to run `/group add group-1` in a DM with the bot.',
     )
   })
 
@@ -209,6 +209,6 @@ describe('/setup command', () => {
 
     await startSetupForTarget('admin-1', reply, 'group-1', deps)
 
-    expect(textCalls[0]).toContain('/group add <group-id>')
+    expect(textCalls[0]).toContain('/group add group-1')
   })
 })


### PR DESCRIPTION
When a bot replies in a group it is not allowed in, group members
cannot easily look up the platform group id to forward to the bot
admin. Substitute the real group id into the `/group add ...` hint
so the admin gets a copy-pasteable command.

https://claude.ai/code/session_012KwPc7NZaFiCMDxyiZ8kW4