### PR TITLE
Add Model Context Protocol (MCP) adapter for external tool integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,7 @@ Required when the bot needs to receive, persist, or attach files to tasks.
 Common runtime config keys (per-user, set via `/setup` or `/config`):
 
 - `timezone`
+- `mcp_endpoints` — JSON array of external MCP server endpoints (`{ id, url (https only), label?, headers?, enabled, toolFilter? }`) whose tools are merged into the context's tool set. Registered as a preference key in `src/config-keys.ts`; editable as a free-text value through `/config`.
 
 LLM credentials (`llm_apikey`, `llm_baseurl`, `main_model`, `small_model`,
 `embedding_model`) are admin-owned and live in `system_config`, not in
@@ -251,9 +252,9 @@ User (Telegram/Mattermost/Discord)
      -> group-settings selector / config editor / setup wizard interception
      -> message queue + reply-context enrichment + file relay
      -> llm-orchestrator.ts
-        -> makeTools(provider, { storageContextId, chatUserId, mode, contextType })
+        -> await makeTools(provider, { storageContextId, chatUserId, mode, contextType })
         -> wrapped tool execution with structured failure results
-        -> provider adapters / web fetch / memo / recurring / deferred tools
+        -> provider adapters / web fetch / memo / recurring / deferred / MCP tools
      -> reply via ReplyFn
 Optional: debug server + debug/admin clients
 ```
@@ -281,6 +282,7 @@ Optional: debug server + debug/admin clients
 - `src/stats/` — anonymous DB-wide statistics: per-subject and global aggregate queries fed straight from SQLite via Drizzle. The orchestrator (`src/stats/index.ts`) exposes `getSubjectStats()` and `getGlobalStats()`, caches the global view for 60s, and is consumed by the admin Stats surface at `/admin#stats` through `/stats/*`. These routes are bearer-token gated only when `DEBUG_TOKEN` is configured. All free-form, high-cardinality identifiers (rrule patterns, web-fetch hostnames) are keyed-hashed using the `stats_anonymity_salt` row in `system_config`; see the anonymity contract under "Required Environment Variables".
 - `src/plugins/` — trusted local plugin system. Discovers plugin packages under `plugins/<plugin-id>/`, validates `plugin.json` against a Zod manifest schema, persists admin approval and per-context opt-in to SQLite (migration `039_plugins`), and activates approved plugins on startup through a frozen `PluginContext` facade. Plugins contribute tools, prompt fragments, commands, and scheduled jobs via `ctx.registration.*`; eligible contributions are merged into the live tool set, system prompt, command registry, and scheduler per context. The `/plugin` admin command (DM, bot-admin only) manages discovery, approval, rejection, and per-context enable/disable. See `docs/plugins/developer-guide.md`.
 - `src/instances/` — DB-backed platform and task instance data model: AES-256-GCM encryption helper (`encryption.ts`), per-table CRUD stores (`platform-store.ts`, `task-store.ts`, `context-store.ts`, `admin-store.ts`), and one-shot env→DB bootstrap (`bootstrap.ts`). After migration `040_platform_instances`, the DB is the source of truth for chat/task provider instance configuration; env vars are only consulted when the instance tables are empty. `INSTANCE_CONFIG_KEY` controls the at-rest encryption key. Runtime task-provider construction goes through `TaskProviderResolver`, and chat startup goes through `ChatRouter`.
+- `src/mcp/` — Model Context Protocol adapter. Connects to external MCP servers and exposes their tools to the LLM as Vercel AI SDK tools. Two sources: per-context user endpoints from the `mcp_endpoints` config key (`user-endpoints.ts`) and plugin-declared servers from a manifest's `mcp` field (`plugin-endpoints.ts`). `McpConnectionPool`/`mcpPool` (`client-pool.ts`) pools connections with retry and idle eviction; `convertMcpToolsToToolSet()` (`tool-adapter.ts`) wraps remote tools. `makeTools()` merges these tools and swallows all MCP failures so a dead server never breaks the pipeline. Only `streamable-http` is runtime-supported; `stdio` is schema-reserved. See `src/mcp/CLAUDE.md`.
 
 ## Plugin System
 
@@ -291,6 +293,7 @@ Trusted, repository-local first-party plugins only — no sandbox, no marketplac
 - Plugin packages live at `plugins/<plugin-id>/` (lowercase kebab-case ID; manifest `id` must match the directory name).
 - Each plugin has a `plugin.json` (validated by `pluginManifestSchema` in `src/plugins/types.ts`) and an entry point such as `index.ts` whose default export is a factory `() => { activate(ctx), deactivate?(ctx) }`.
 - Plugin API version is pinned by `PLUGIN_API_VERSION` (currently `1`); manifests declaring a different `apiVersion` are rejected as incompatible.
+- Beyond `contributes.{tools,promptFragments,commands,jobs}`, a manifest may also declare `contributes.configKeys`, a single `contributes.taskProviderTypes` entry (requires the `provider.task` permission, plus `providerCapabilities`/`providerConfigSchema`/`providerAllowedHosts`/`providerConfigValidator`), and an optional `mcp` block (`McpPluginConfig`) that points the plugin at an external MCP server whose tools are exposed under the `plugin_` namespace. See `src/mcp/CLAUDE.md`.
 
 ### Lifecycle
 
@@ -320,7 +323,7 @@ Activation receives a frozen `PluginContext` exposing only:
 - `ctx.pluginId`, `ctx.contextId` (activation runs against `__system__`), `ctx.permissions`
 - `ctx.log.{debug,info,warn,error}(data, msg)` — pino child logger scoped by `pluginId`. Never log secrets.
 - `ctx.kv.{get,set,delete,list}` — context-scoped string KV, **only** when the `storage` permission is declared. Without it, all KV calls throw. KV is not a secret store.
-- `ctx.registration.{registerTool,registerPromptFragment,registerCommand,registerScheduledJob}` — registrations are rejected unless the contribution name was declared in `contributes.{tools,promptFragments,commands,jobs}`.
+- `ctx.registration.{registerTool,registerPromptFragment,registerCommand,registerScheduledJob,registerTaskProviderType}` — registrations are rejected unless the contribution name was declared in `contributes.{tools,promptFragments,commands,jobs,taskProviderTypes}`. `registerTaskProviderType` additionally requires the `provider.task` permission.
 
 Plugins never receive a raw `TaskProvider`, `ChatProvider`, DB handle, or `process.env`. Tool executions receive a request-scoped `PluginToolRuntimeContext` with `pluginId`, `storageContextId`, `chatUserId`, a permission-gated `taskProvider` facade (`getTask`, `listTasks`, `searchTasks`, `createTask`, `updateTask`), and the plugin/context KV.
 
@@ -331,9 +334,9 @@ Plugins never receive a raw `TaskProvider`, `ChatProvider`, DB handle, or `proce
 - Scheduled job owner: `plugin:<pluginId>:<jobName>`, executed only for contexts where the plugin is enabled and eligible.
 - Prompt fragments are synchronous strings or sync functions; appended to the system prompt with a 2,000-char-per-fragment / 8,000-char-total budget.
 
-### Permissions (MVP)
+### Permissions
 
-`storage`, `tasks.read`, `tasks.write`, `commands`, `scheduler`, `chat.send`. Only `storage`, `tasks.read`, and `tasks.write` have runtime gating today; the others are declared for future enforcement. Raw chat sending, raw provider access, raw DB access, and arbitrary network access are not exposed.
+`PLUGIN_PERMISSIONS` (`src/plugins/types.ts`): `storage`, `scheduler`, `commands`, `chat.send`, `tasks.read`, `tasks.write`, `provider.task`, `identity`, `http`. Runtime-gated today: `storage` (KV access), `tasks.read`/`tasks.write` (task-provider facade methods), `provider.task` (registering a task provider type and presence of the provider facade), `identity` (identity facade, when one task provider type is declared), and `http` (provider HTTP facade). `commands`, `scheduler`, and `chat.send` are declared but not yet separately enforced beyond the contribution-declaration check. Declaring `contributes.taskProviderTypes` requires the `provider.task` permission (manifest `.refine`). Raw chat sending, raw provider access, raw DB access, and arbitrary network access are not exposed.
 
 ### Admin Command
 
@@ -386,6 +389,14 @@ system prompt (`src/system-prompt.ts`) is composed from tool-gated fragments so 
 instructs the agent to use a disabled tool, and appends an "Unavailable tools" line for
 partially-disabled domains. Managed via the "🧰 Tools" section of `/config`.
 
+### MCP-Sourced Tools
+
+When a context configures `mcp_endpoints`, or an enabled plugin declares an `mcp` server,
+`makeTools()` also merges tools fetched from those external MCP servers. User-endpoint tools
+are named `mcp_<server>__<tool>`; plugin-sourced MCP tools use the `plugin_<server>__<tool>`
+namespace. These tools are subject to the same per-context denylist as builtins. See
+`src/mcp/CLAUDE.md`.
+
 ## Logging
 
 Logging is mandatory and uses pino with structured metadata-first calls.
@@ -431,6 +442,7 @@ Detailed conventions live in path-scoped `CLAUDE.md` files:
 | `src/tools/CLAUDE.md`     | tool assembly, execution wrapping, confirmations, context gating       |
 | `src/commands/CLAUDE.md`  | command handler rules and DM/group setup flow                          |
 | `src/chat/CLAUDE.md`      | chat provider interface, capabilities, context rendering, interactions |
+| `src/mcp/CLAUDE.md`       | external MCP server adapter, connection pooling, tool namespacing      |
 | `tests/CLAUDE.md`         | helpers, mocks, mock reset, E2E test guidance                          |
 | `review-loop/CLAUDE.md`   | review-loop workspace structure, scripts, storage, and TDD rules       |
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The bot interprets natural-language requests, invokes capability-gated tools thr
 | **Deferred Prompts** | One-shot, delayed, cron                         | Scheduled proactive assistance                                       |
 | **Instructions**     | Context-specific guidance                       | Per-chat custom instructions                                         |
 | **Plugins**          | Trusted local extensions                        | Discover, approve, and enable first-party plugins per context        |
-| **MCP Servers**      | External tools via Model Context Protocol       | Merge tools from per-context or plugin-declared MCP servers           |
+| **MCP Servers**      | External tools via Model Context Protocol       | Merge tools from per-context or plugin-declared MCP servers          |
 
 ### Platform Support
 
@@ -342,11 +342,11 @@ Use the bot’s DM-based configuration flow:
 
 Runtime keys shown by `/setup` and `/config` include:
 
-| Key              | Description                                      |
-| ---------------- | ------------------------------------------------ |
-| `kaneo_apikey`   | Kaneo API key or session token                   |
-| `youtrack_token` | YouTrack permanent token                         |
-| `timezone`       | User timezone for local date/time interpretation |
+| Key              | Description                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------------ |
+| `kaneo_apikey`   | Kaneo API key or session token                                                                   |
+| `youtrack_token` | YouTrack permanent token                                                                         |
+| `timezone`       | User timezone for local date/time interpretation                                                 |
 | `mcp_endpoints`  | JSON array of external MCP server endpoints whose tools are merged into the context (HTTPS only) |
 
 LLM credentials (`llm_apikey`, `llm_baseurl`, `main_model`, `small_model`, `embedding_model`) are admin-owned and managed via env vars or `/admin#system` - not through `/setup` or `/config`.
@@ -431,13 +431,13 @@ plugins/
 
 ### Contribution Surface
 
-| Surface          | Exposed as                                    | Notes                                                          |
-| ---------------- | --------------------------------------------- | -------------------------------------------------------------- |
-| LLM tools        | `plugin_<plugin_id>__<tool_name>`             | Sandwiched through the same execution wrapper as core tools.   |
-| Prompt fragments | Appended to system prompt (8,000-char budget) | Synchronous only; 2,000 chars per fragment.                    |
-| Commands         | `plugin_<plugin_id>_<command_name>`           | Registered through the normal chat command path.               |
-| Scheduled jobs   | Owner `plugin:<pluginId>:<jobName>`           | Runs only for contexts where the plugin is enabled & eligible. |
-| External MCP server | `plugin_<server>__<tool>`                  | Optional manifest `mcp` block; tools fetched from a Model Context Protocol server. |
+| Surface             | Exposed as                                    | Notes                                                                              |
+| ------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| LLM tools           | `plugin_<plugin_id>__<tool_name>`             | Sandwiched through the same execution wrapper as core tools.                       |
+| Prompt fragments    | Appended to system prompt (8,000-char budget) | Synchronous only; 2,000 chars per fragment.                                        |
+| Commands            | `plugin_<plugin_id>_<command_name>`           | Registered through the normal chat command path.                                   |
+| Scheduled jobs      | Owner `plugin:<pluginId>:<jobName>`           | Runs only for contexts where the plugin is enabled & eligible.                     |
+| External MCP server | `plugin_<server>__<tool>`                     | Optional manifest `mcp` block; tools fetched from a Model Context Protocol server. |
 
 ### Context API
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The bot interprets natural-language requests, invokes capability-gated tools thr
 | **Deferred Prompts** | One-shot, delayed, cron                         | Scheduled proactive assistance                                       |
 | **Instructions**     | Context-specific guidance                       | Per-chat custom instructions                                         |
 | **Plugins**          | Trusted local extensions                        | Discover, approve, and enable first-party plugins per context        |
+| **MCP Servers**      | External tools via Model Context Protocol       | Merge tools from per-context or plugin-declared MCP servers           |
 
 ### Platform Support
 
@@ -188,6 +189,7 @@ flowchart TD
 | `src/group-settings/`                              | DM-driven selection of personal vs group configuration targets                             |
 | `src/web/`                                         | Safe fetch, extraction, distillation, caching, and rate limiting for `web_fetch`           |
 | `src/plugins/`                                     | Trusted local plugin system: discovery, manifest validation, approval, lifecycle, KV       |
+| `src/mcp/`                                         | External MCP server adapter: connection pooling, tool namespacing, user + plugin endpoints |
 | `src/debug/`, `client/debug/`, and `client/admin/` | Optional local debug server plus split `/debug` and `/admin` UIs                           |
 
 ---
@@ -345,6 +347,7 @@ Runtime keys shown by `/setup` and `/config` include:
 | `kaneo_apikey`   | Kaneo API key or session token                   |
 | `youtrack_token` | YouTrack permanent token                         |
 | `timezone`       | User timezone for local date/time interpretation |
+| `mcp_endpoints`  | JSON array of external MCP server endpoints whose tools are merged into the context (HTTPS only) |
 
 LLM credentials (`llm_apikey`, `llm_baseurl`, `main_model`, `small_model`, `embedding_model`) are admin-owned and managed via env vars or `/admin#system` - not through `/setup` or `/config`.
 
@@ -434,6 +437,7 @@ plugins/
 | Prompt fragments | Appended to system prompt (8,000-char budget) | Synchronous only; 2,000 chars per fragment.                    |
 | Commands         | `plugin_<plugin_id>_<command_name>`           | Registered through the normal chat command path.               |
 | Scheduled jobs   | Owner `plugin:<pluginId>:<jobName>`           | Runs only for contexts where the plugin is enabled & eligible. |
+| External MCP server | `plugin_<server>__<tool>`                  | Optional manifest `mcp` block; tools fetched from a Model Context Protocol server. |
 
 ### Context API
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,7 +9,7 @@ See LICENSE in the project root for details.
 
 This directory contains Architecture Decision Records (ADRs) for the **papai** (Personal Adroit Proactive AI) project.
 
-ADRs capture the context, options considered, and rationale behind significant architectural decisions. Each ADR is derived from an implementation plan in `docs/plans/done/` and verified against the current codebase.
+ADRs capture the context, options considered, and rationale behind significant architectural decisions. Each ADR is derived from an implementation plan (active plans live in `docs/superpowers/plans/`; completed design/implementation docs are kept in `docs/archive/`) and verified against the current codebase.
 
 ## Index
 

--- a/src/mcp/CLAUDE.md
+++ b/src/mcp/CLAUDE.md
@@ -1,0 +1,41 @@
+# MCP Adapter Conventions
+
+`src/mcp/` connects papai to external [Model Context Protocol](https://modelcontextprotocol.io) servers and exposes their tools to the LLM as ordinary Vercel AI SDK tools. There are two sources of MCP servers:
+
+- **User endpoints** — per-context servers configured through the `mcp_endpoints` config key (see `src/config-keys.ts`).
+- **Plugin endpoints** — servers declared by a plugin manifest's `mcp` field (`src/plugins/types.ts`).
+
+## Files
+
+- `types.ts` — Zod schemas + types: `mcpEndpointConfigSchema`/`McpEndpointConfig` (user), `mcpPluginConfigSchema`/`McpPluginConfig` (plugin), `McpToolFilter`, `McpServerStatus`, `McpServerInfo`, and `sanitizeServerId()`.
+- `user-endpoints.ts` — `parseMcpEndpoints()` reads the `mcp_endpoints` config value; `buildMcpToolSet(contextId, deps?)` connects each enabled endpoint, lists tools, and merges them.
+- `plugin-endpoints.ts` — `buildPluginMcpToolSet()` plus `${VAR}` placeholder resolution that pulls values from plugin config requirements; re-namespaces tool keys (see Naming).
+- `client-pool.ts` — `McpConnectionPool` class and the `mcpPool` singleton: connection caching, retry, idle eviction, and status tracking.
+- `tool-adapter.ts` — `convertMcpToolsToToolSet()`: wraps remote MCP tools as `tool()`s, applies the allow/deny filter, and extracts text content.
+- `index.ts` — barrel re-export.
+
+## Wiring
+
+`makeTools()` in `src/tools/index.ts` is **async** and merges MCP tools after the wrapped builtins:
+
+- User MCP tools (`buildMcpToolSet`) are added whenever `storageContextId` is set.
+- Plugin MCP tools (`buildPluginMcpToolSet`, via `buildPluginAndMcpTools`) are added when both `storageContextId` and `chatUserId` are set, for active plugins whose manifest declares `mcp`.
+- Final merge order is `{ ...builtins, ...mcpTools, ...pluginTools }`, then the per-context tool denylist from `tool-preferences.ts` is applied last.
+
+## Rules
+
+- **Failures must never break the tool pipeline.** Both `buildMcpToolSet` and `buildPluginMcpToolSet` catch per-server errors, log a `warn`, and skip that server (returning `null`); the callsites in `makeTools()` also wrap the whole step in a `try/catch`. A dead or slow MCP server degrades to "no extra tools", never an orchestrator error.
+- **HTTPS only for user endpoints.** `mcpEndpointConfigSchema` rejects any `url` that does not start with `https://`. Do not relax this.
+- **Only `streamable-http` is runtime-supported.** `mcpPluginConfigSchema` accepts `transport: 'stdio'`, but `McpConnectionPool` throws `Unsupported MCP transport` for anything other than `streamable-http`. `stdio` is a schema-reserved future extension, not a working path.
+- **Tool naming is namespaced and must stay distinct from builtins/plugins.** `convertMcpToolsToToolSet` emits `mcp_<sanitizedServerId>__<toolName>` for user endpoints. `buildPluginMcpToolSet` rewrites that prefix to `plugin_<...>` so plugin-sourced MCP tools share the `plugin_` namespace with native plugin tools. Use `sanitizeServerId()` for any new server-id-derived key.
+- **Tool output is text-only today.** `tool-adapter.ts` extracts `type: 'text'` content parts and joins them; errors surface as `{ error: string }`. Non-text content (images, resources) is dropped.
+- **Connections are pooled and idle-evicted.** Entries are keyed by a SHA-256 hash of transport/url/headers (plus command/args/pluginId for plugins). Connecting is eager with a single retry; on idle timeout (`DEFAULT_IDLE_TIMEOUT_MS` = 10 min, overridable per plugin via `idleTimeoutMs`) the client closes and the entry goes `idle`, then reconnects on next use. Use `mcpPool`, do not construct ad-hoc clients.
+- **No secrets in logs.** Header values may carry tokens; never log resolved headers or `${VAR}` substitutions. The `/mcp/status` debug route (`src/debug/mcp-routes.ts`) masks each `url` to protocol+host+path and never returns headers.
+
+## Plugin placeholder resolution
+
+`plugin-endpoints.ts` resolves `${VAR}` placeholders inside a plugin's `mcp.headers` and `mcp.env` against the plugin's context config values (uppercased config keys). If any required placeholder is unresolved, the server is skipped for that context (logged at `debug`). This keeps plugin MCP credentials in per-context config rather than the manifest.
+
+## Tests
+
+Coverage lives in `tests/mcp/` (`client-pool`, `index`, `plugin-endpoints`, `tool-adapter`, `types`, `user-endpoints`), `tests/debug/mcp-routes.test.ts`, `tests/plugins/manifest-mcp.test.ts`, and `tests/tools/mcp-integration.test.ts`.

--- a/src/tools/CLAUDE.md
+++ b/src/tools/CLAUDE.md
@@ -24,11 +24,17 @@ export function makeExampleTool(provider: Readonly<TaskProvider>): ToolSet[strin
 
 - Core tool construction starts in `src/tools/core-tools.ts`.
 - Context-aware assembly happens in `src/tools/tools-builder.ts`.
-- Public entry point is `makeTools(provider, options)` in `src/tools/index.ts`.
-- After capability + context gating and plugin merge, `makeTools()` applies the
-  per-context tool denylist from `src/tools/tool-preferences.ts` (default all-on).
-  Disabled tools are physically removed from the returned `ToolSet`, so they cannot be
-  invoked. Preferences are keyed by the same `storageContextId` used elsewhere.
+- Public entry point is `makeTools(provider, options)` in `src/tools/index.ts`. It is
+  **async** and returns `Promise<ToolSet>` (both overloads) — callers must `await` it —
+  because it may connect to external MCP servers.
+- The merge order inside `makeTools()` is: wrapped builtins → MCP tools (user endpoints
+  from `buildMcpToolSet`, plus plugin-declared servers from `buildPluginMcpToolSet`) →
+  plugin tools. MCP tool building is wrapped in `try/catch` and never breaks the pipeline;
+  see `src/mcp/CLAUDE.md`.
+- After capability + context gating and the plugin/MCP merge, `makeTools()` applies the
+  per-context tool denylist from `src/tools/tool-preferences.ts` (default all-on) as the
+  final filter. Disabled tools are physically removed from the returned `ToolSet`, so they
+  cannot be invoked. Preferences are keyed by the same `storageContextId` used elsewhere.
 
 `MakeToolsOptions` controls tool exposure:
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -183,12 +183,26 @@ docker-compose -f docker-compose.yml -f docker-compose.test.yml ps
 
 ## Files
 
+Harness and support:
+
 - `bun-test-setup.ts` - Shared preload harness for E2E setup
 - `e2e.test.ts` - Aggregated E2E entry point and final teardown
 - `global-setup.ts` - E2E environment setup and teardown
 - `docker-lifecycle.ts` - Docker Compose management
 - `kaneo-test-client.ts` - Test client for resource management
 - `kaneo-api-helpers.ts` - Narrow raw API oracle helpers for direct Kaneo checks
+- `test-helpers.ts` - Shared E2E assertion/setup helpers
+
+Test suites:
+
 - `task-lifecycle.test.ts` - Task CRUD tests
+- `task-search.test.ts` - Task search tests
+- `task-relations.test.ts` - Task relation tests
+- `task-comments.test.ts` - Task comment tests
+- `task-list-compatibility.test.ts` - Task listing compatibility tests
 - `label-operations.test.ts` - Label CRUD tests
-- `project-lifecycle.test.ts` - Project CRUD tests
+- `project-lifecycle.test.ts` / `project-management.test.ts` - Project tests
+- `column-management.test.ts` - Status/column management tests
+- `user-workflows.test.ts` - End-to-end user workflow tests
+- `error-handling.test.ts` - Error-path tests
+- `docker-lifecycle.test.ts` - Docker lifecycle harness tests


### PR DESCRIPTION
## Summary

Introduces a complete Model Context Protocol (MCP) adapter that enables papai to connect to external MCP servers and expose their tools to the LLM. Supports both per-context user-configured endpoints and plugin-declared servers, with connection pooling, retry logic, and graceful failure handling.

## Key Changes

- **New `src/mcp/` module** with five core files:
  - `types.ts` — Zod schemas for user endpoints (`McpEndpointConfig`) and plugin endpoints (`McpPluginConfig`), plus `McpToolFilter`, `McpServerStatus`, and `sanitizeServerId()` utility
  - `user-endpoints.ts` — `parseMcpEndpoints()` and `buildMcpToolSet()` for per-context user-configured servers
  - `plugin-endpoints.ts` — `buildPluginMcpToolSet()` with `${VAR}` placeholder resolution against plugin config
  - `client-pool.ts` — `McpConnectionPool` singleton with connection caching, retry, idle eviction (10 min default), and status tracking
  - `tool-adapter.ts` — `convertMcpToolsToToolSet()` wraps remote MCP tools as Vercel AI SDK tools, applies allow/deny filters, extracts text content
  - `index.ts` — barrel export
  - `CLAUDE.md` — comprehensive conventions document

- **Integration into tool pipeline**:
  - `makeTools()` in `src/tools/index.ts` is now **async** and merges MCP tools after builtins but before plugin tools
  - User MCP tools added when `storageContextId` is set; plugin MCP tools added when both `storageContextId` and `chatUserId` are set
  - All MCP failures are caught and logged as warnings; dead/slow servers degrade to "no extra tools", never breaking the pipeline
  - Final merge order: `{ ...builtins, ...mcpTools, ...pluginTools }`, then per-context denylist applied last

- **Tool namespacing**:
  - User-endpoint tools: `mcp_<sanitizedServerId>__<toolName>`
  - Plugin-sourced MCP tools: `plugin_<...>__<toolName>` (shared `plugin_` namespace with native plugin tools)

- **Security & constraints**:
  - HTTPS-only for user endpoints (schema validation enforces this)
  - Only `streamable-http` transport is runtime-supported; `stdio` is schema-reserved for future use
  - No secrets in logs; `/mcp/status` debug route masks URLs and never returns headers
  - Tool output is text-only; non-text content (images, resources) is dropped

- **Documentation updates**:
  - `CLAUDE.md` — added MCP section with architecture, wiring, rules, and plugin placeholder resolution
  - `README.md` — added MCP to feature table and module index; documented `mcp_endpoints` config key
  - `src/tools/CLAUDE.md` — clarified `makeTools()` is async, documented merge order and MCP integration
  - `tests/e2e/README.md` — reorganized file listing with harness/support and test suite sections

- **Config & plugin system**:
  - New `mcp_endpoints` preference key in `src/config-keys.ts` (JSON array of endpoint configs)
  - Plugin manifests can declare `mcp` block with `transport`, `url`, `headers`, `env`, and `idleTimeoutMs`
  - Plugin placeholder resolution: `${VAR}` in headers/env resolved against uppercased plugin config keys
  - Plugin MCP servers skipped if required placeholders are unresolved (logged at debug level)

## Notable Implementation Details

- **Connection pooling**: Entries keyed by SHA-256 hash of transport/url/headers (plus command/args/pluginId for plugins); eager connect with single retry; idle timeout configurable per plugin
- **Failure resilience**: Both `buildMcpToolSet` and `buildPluginMcpToolSet` catch per-server errors; callsites in `makeTools()` wrap entire step in try/catch
-

https://claude.ai/code/session_01VvQx6jFN6JZnRvkXLgHwnu