### PR TITLE
fix(plugins): remediate plugin lifecycle gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,10 +322,13 @@ Activation receives a frozen `PluginContext` exposing only:
 
 - `ctx.pluginId`, `ctx.contextId` (activation runs against `__system__`), `ctx.permissions`
 - `ctx.log.{debug,info,warn,error}(data, msg)` — pino child logger scoped by `pluginId`. Never log secrets.
-- `ctx.kv.{get,set,delete,list}` — context-scoped string KV, **only** when the `storage` permission is declared. Without it, all KV calls throw. KV is not a secret store.
-- `ctx.registration.{registerTool,registerPromptFragment,registerCommand,registerScheduledJob,registerTaskProviderType}` — registrations are rejected unless the contribution name was declared in `contributes.{tools,promptFragments,commands,jobs,taskProviderTypes}`. `registerTaskProviderType` additionally requires the `provider.task` permission.
+- `ctx.kv.{get,set,delete,list}` — context-scoped string KV, only when the `storage` permission is declared. Without it, all KV calls throw. KV is not a secret store.
+- `ctx.adminConfig.get(key)` — read-only admin-scoped plugin config declared in `configRequirements`.
+- `ctx.providerRuntime` — HTTP helper for provider plugins when `provider.task` or `http` is declared; every hop must match `providerAllowedHosts` and pass public URL checks.
+- `ctx.identity` — available when `identity` is declared and the plugin declares exactly one task provider type.
+- `ctx.registration.{registerTool,registerPromptFragment,registerCommand,registerScheduledJob,registerTaskProviderType}` — registrations are rejected unless declared in `contributes.{tools,promptFragments,commands,jobs,taskProviderTypes}`.
 
-Plugins never receive a raw `TaskProvider`, `ChatProvider`, DB handle, or `process.env`. Tool executions receive a request-scoped `PluginToolRuntimeContext` with `pluginId`, `storageContextId`, `chatUserId`, a permission-gated `taskProvider` facade (`getTask`, `listTasks`, `searchTasks`, `createTask`, `updateTask`), and the plugin/context KV.
+Plugins never receive a raw `TaskProvider`, `ChatProvider`, DB handle, or `process.env`. Tool executions receive a request-scoped `PluginToolRuntimeContext` with `pluginId`, `storageContextId`, `chatUserId`, a permission-gated task-provider facade, optional `identity`, rate-limit helper, and plugin/context KV.
 
 ### Contribution Naming
 
@@ -334,9 +337,9 @@ Plugins never receive a raw `TaskProvider`, `ChatProvider`, DB handle, or `proce
 - Scheduled job owner: `plugin:<pluginId>:<jobName>`, executed only for contexts where the plugin is enabled and eligible.
 - Prompt fragments are synchronous strings or sync functions; appended to the system prompt with a 2,000-char-per-fragment / 8,000-char-total budget.
 
-### Permissions
+### Permissions (MVP)
 
-`PLUGIN_PERMISSIONS` (`src/plugins/types.ts`): `storage`, `scheduler`, `commands`, `chat.send`, `tasks.read`, `tasks.write`, `provider.task`, `identity`, `http`. Runtime-gated today: `storage` (KV access), `tasks.read`/`tasks.write` (task-provider facade methods), `provider.task` (registering a task provider type and presence of the provider facade), `identity` (identity facade, when one task provider type is declared), and `http` (provider HTTP facade). `commands`, `scheduler`, and `chat.send` are declared but not yet separately enforced beyond the contribution-declaration check. Declaring `contributes.taskProviderTypes` requires the `provider.task` permission (manifest `.refine`). Raw chat sending, raw provider access, raw DB access, and arbitrary network access are not exposed.
+`storage`, `scheduler`, `commands`, `chat.send`, `tasks.read`, `tasks.write`, `provider.task`, `identity`, and `http`. Runtime gating exists for storage, task reads/writes, provider HTTP runtime, contributed task-provider registration, and identity facade exposure. Raw chat sending, raw provider access, raw DB access, and arbitrary unallowlisted network access are not exposed.
 
 ### Admin Command
 

--- a/docs/plugins/developer-guide.md
+++ b/docs/plugins/developer-guide.md
@@ -125,6 +125,8 @@ For example, `hello-world` plus `greet` becomes `plugin_hello_world__greet`.
 
 Tool execution receives a request-scoped runtime context with `pluginId`, `storageContextId`, `chatUserId`, a permission-gated `taskProvider` facade, and plugin/context KV. The raw task provider is not exposed.
 
+When a plugin declares `permissions: ["identity"]` and exactly one `contributes.taskProviderTypes` value, tool executions receive `runtimeContext.identity`. The facade supports `lookupForChatUser(chatUserId)` and `recordClaim(chatUserId, providerUserId, providerLogin, displayName?)`. Claims are recorded as `manual_nl` mappings and are not treated as auto-verified.
+
 ## Prompt Fragments
 
 Prompt fragments are synchronous strings or synchronous functions returning strings. Async prompt fragments are not supported. Fragments are delimited in the system prompt and budgeted at 2,000 characters per fragment and 8,000 characters total across active plugins.

--- a/docs/plugins/developer-guide.md
+++ b/docs/plugins/developer-guide.md
@@ -68,6 +68,8 @@ Supported optional fields:
 | `providerConfigSchema`          | Instance-scoped config fields for the contributed provider type.                                                                                  |
 | `providerContextConfigSchema`   | Context-scoped credential/config fields for the contributed provider type.                                                                        |
 | `providerAllowedHosts`          | Host allowlist used by `ctx.providerRuntime.httpFetch()`.                                                                                         |
+| `providerConfigValidator`       | Optional exported validator function name for provider instance and context config.                                                               |
+| `mcp`                           | Optional plugin-owned MCP server config. Runtime support is `streamable-http`; `stdio` is schema-reserved.                                        |
 | `permissions`                   | Permission claims checked by framework facades.                                                                                                   |
 | `defaultEnabled`                | Whether the plugin is selected by default for contexts that have no explicit opt-in/out row.                                                      |
 | `requiredTaskCapabilities`      | Task provider capabilities required before activation and per-context eligibility.                                                                |
@@ -111,10 +113,14 @@ The `ctx` object is frozen and exposes only framework-owned facades:
 | `ctx.permissions`                                   | Readonly set of requested permissions.                                                                                     |
 | `ctx.log.debug/info/warn/error(data, msg)`          | Structured plugin logger. Never log secrets.                                                                               |
 | `ctx.kv.get/set/delete/list`                        | Plugin/context KV store, available only with `storage` permission. KV is not a secret store.                               |
+| `ctx.adminConfig.get(key)`                          | Read-only admin-scoped plugin config for keys declared with `scope: "admin"`.                                              |
+| `ctx.providerRuntime`                               | Provider runtime helpers, present with `provider.task` or `http` permission.                                               |
+| `ctx.identity`                                      | Identity facade, present with `identity` permission when exactly one task provider type is declared.                       |
 | `ctx.registration.registerTool(tool)`               | Register a declared `PluginTool`.                                                                                          |
 | `ctx.registration.registerPromptFragment(fragment)` | Register a declared prompt fragment.                                                                                       |
 | `ctx.registration.registerCommand(command)`         | Register a declared command.                                                                                               |
 | `ctx.registration.registerScheduledJob(job)`        | Register a declared scheduled job.                                                                                         |
+| `ctx.registration.registerTaskProviderType(...)`    | Register the plugin's single declared task provider type. Requires `provider.task`.                                        |
 
 Undeclared registrations throw during activation. Activation failure cleans framework-owned contributions and records runtime diagnostics.
 

--- a/docs/plugins/developer-guide.md
+++ b/docs/plugins/developer-guide.md
@@ -7,7 +7,7 @@ See LICENSE in the project root for details.
 
 # Plugin Developer Guide
 
-Papai plugins are trusted, repository-local extensions loaded from `plugins/<plugin-id>/`. The MVP is for first-party local plugins only: there is no sandbox, marketplace, npm package installation, hot reload, encrypted plugin secret store, provider-as-plugin API, raw provider access, raw DB access, or arbitrary process/env/network facade.
+Papai plugins are trusted, repository-local extensions loaded from `plugins/<plugin-id>/`. The MVP is for first-party local plugins only: there is no sandbox, marketplace, npm package installation, hot reload, encrypted plugin secret store, raw provider access, raw DB access, or arbitrary process/env/network facade. Plugins may register one declared task-provider type through the trusted provider-task plugin API.
 
 ## Quick Start
 
@@ -52,12 +52,13 @@ Papai plugins are trusted, repository-local extensions loaded from `plugins/<plu
 }
 ```
 
-Required fields: `id`, `name`, `version`, `description`, `apiVersion`, and `main`.
+Required fields: `id`, `name`, `version`, `description`, and `apiVersion`.
 
 Supported optional fields:
 
 | Field                           | Description                                                                                                                                       |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `main`                          | Entry point path, defaulting to `index.ts`.                                                                                                       |
 | `contributes.tools`             | Tool names the plugin may register with `ctx.registration.registerTool()`.                                                                        |
 | `contributes.promptFragments`   | Prompt fragment names the plugin may register with `ctx.registration.registerPromptFragment()`.                                                   |
 | `contributes.commands`          | Command names the plugin may register with `ctx.registration.registerCommand()`. Runtime commands are exposed as `plugin_<plugin_id>_<command>`.  |

--- a/docs/plugins/developer-guide.md
+++ b/docs/plugins/developer-guide.md
@@ -125,7 +125,7 @@ For example, `hello-world` plus `greet` becomes `plugin_hello_world__greet`.
 
 Tool execution receives a request-scoped runtime context with `pluginId`, `storageContextId`, `chatUserId`, a permission-gated `taskProvider` facade, and plugin/context KV. The raw task provider is not exposed.
 
-When a plugin declares `permissions: ["identity"]` and exactly one `contributes.taskProviderTypes` value, tool executions receive `runtimeContext.identity`. The facade supports `lookupForChatUser(chatUserId)` and `recordClaim(chatUserId, providerUserId, providerLogin, displayName?)`. Claims are recorded as `manual_nl` mappings and are not treated as auto-verified.
+When a plugin declares `permissions: ["identity"]` and exactly one `contributes.taskProviderTypes` value, tool executions receive `runtimeContext.identity`. Declaring a task provider type also requires `provider.task`, so runtime identity provider plugins need `identity` plus the manifest/provider-task requirements. The facade supports `lookupForChatUser(chatUserId)` and `recordClaim(chatUserId, providerUserId, providerLogin, displayName?)`. Claims are recorded as `manual_nl` mappings and are not treated as auto-verified.
 
 ## Prompt Fragments
 

--- a/docs/plugins/developer-guide.md
+++ b/docs/plugins/developer-guide.md
@@ -56,19 +56,24 @@ Required fields: `id`, `name`, `version`, `description`, `apiVersion`, and `main
 
 Supported optional fields:
 
-| Field                         | Description                                                                                                                                       |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `contributes.tools`           | Tool names the plugin may register with `ctx.registration.registerTool()`.                                                                        |
-| `contributes.promptFragments` | Prompt fragment names the plugin may register with `ctx.registration.registerPromptFragment()`.                                                   |
-| `contributes.commands`        | Command names the plugin may register with `ctx.registration.registerCommand()`. Runtime commands are exposed as `plugin_<plugin_id>_<command>`.  |
-| `contributes.jobs`            | Scheduled job names the plugin may register with `ctx.registration.registerScheduledJob()`. Runtime job owners are `plugin:<pluginId>:<jobName>`. |
-| `contributes.configKeys`      | Plugin-owned context config keys shown by docs and admin UX.                                                                                      |
-| `permissions`                 | Permission claims checked by framework facades.                                                                                                   |
-| `defaultEnabled`              | Whether the plugin is selected by default for contexts that have no explicit opt-in/out row.                                                      |
-| `requiredTaskCapabilities`    | Task provider capabilities required before activation and per-context eligibility.                                                                |
-| `requiredChatCapabilities`    | Chat platform capabilities required before activation and per-context eligibility.                                                                |
-| `configRequirements`          | Context-specific config fields that gate tool/prompt/job eligibility when required.                                                               |
-| `activationTimeoutMs`         | Activation timeout in milliseconds, between `100` and `10000`.                                                                                    |
+| Field                           | Description                                                                                                                                       |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `contributes.tools`             | Tool names the plugin may register with `ctx.registration.registerTool()`.                                                                        |
+| `contributes.promptFragments`   | Prompt fragment names the plugin may register with `ctx.registration.registerPromptFragment()`.                                                   |
+| `contributes.commands`          | Command names the plugin may register with `ctx.registration.registerCommand()`. Runtime commands are exposed as `plugin_<plugin_id>_<command>`.  |
+| `contributes.jobs`              | Scheduled job names the plugin may register with `ctx.registration.registerScheduledJob()`. Runtime job owners are `plugin:<pluginId>:<jobName>`. |
+| `contributes.configKeys`        | Plugin-owned context config keys shown by docs and admin UX.                                                                                      |
+| `contributes.taskProviderTypes` | At most one plugin-owned task provider type. Requires `provider.task`.                                                                            |
+| `providerCapabilities`          | Task capabilities exposed by the contributed provider type.                                                                                       |
+| `providerConfigSchema`          | Instance-scoped config fields for the contributed provider type.                                                                                  |
+| `providerContextConfigSchema`   | Context-scoped credential/config fields for the contributed provider type.                                                                        |
+| `providerAllowedHosts`          | Host allowlist used by `ctx.providerRuntime.httpFetch()`.                                                                                         |
+| `permissions`                   | Permission claims checked by framework facades.                                                                                                   |
+| `defaultEnabled`                | Whether the plugin is selected by default for contexts that have no explicit opt-in/out row.                                                      |
+| `requiredTaskCapabilities`      | Task provider capabilities required before activation and per-context eligibility.                                                                |
+| `requiredChatCapabilities`      | Chat platform capabilities required before activation and per-context eligibility.                                                                |
+| `configRequirements`            | Context-specific config fields that gate tool/prompt/job eligibility when required.                                                               |
+| `activationTimeoutMs`           | Activation timeout in milliseconds, between `100` and `10000`.                                                                                    |
 
 The manifest `id` must match the directory name. The entry point must stay inside the plugin directory and must be a relative `.ts` or `.js` path without `..` components.
 
@@ -141,6 +146,8 @@ plugin_<sanitized-plugin-id>_<command-name>
 
 Command handlers receive the normal `IncomingMessage`, `ReplyFn`, and `AuthorizationResult` values. They run through the same chat command registration path as core commands.
 
+Plugin command handlers run only when the plugin is active and eligible for the current command context. Disabled plugins, missing config, or missing capabilities produce a denial message and the plugin handler is not invoked.
+
 ## Scheduled Jobs
 
 Plugin jobs are registered through `ctx.registration.registerScheduledJob()` with an `intervalMs` and an `execute(contextId)` function. Jobs are registered with owner names like `plugin:<pluginId>:<jobName>` and execute only for contexts where the plugin is enabled and eligible.
@@ -149,14 +156,17 @@ Plugin jobs are registered through `ctx.registration.registerScheduledJob()` wit
 
 Supported MVP permissions:
 
-| Permission    | Effect                                                                                  |
-| ------------- | --------------------------------------------------------------------------------------- |
-| `storage`     | Enables plugin KV access. Without it, KV calls fail closed.                             |
-| `tasks.read`  | Enables read methods on the task-provider facade.                                       |
-| `tasks.write` | Enables write methods on the task-provider facade.                                      |
-| `commands`    | Reserved declaration for command-capable plugins; registration is still manifest-gated. |
-| `scheduler`   | Reserved declaration for scheduled-job plugins; registration is still manifest-gated.   |
-| `chat.send`   | Declared in the permission list but no raw chat-send facade is exposed in the MVP.      |
+| Permission      | Effect                                                                                   |
+| --------------- | ---------------------------------------------------------------------------------------- |
+| `storage`       | Enables plugin KV access. Without it, KV calls fail closed.                              |
+| `tasks.read`    | Enables read methods on the task-provider facade.                                        |
+| `tasks.write`   | Enables write methods on the task-provider facade.                                       |
+| `provider.task` | Allows registering one declared task-provider type and exposes provider runtime helpers. |
+| `identity`      | Exposes identity facade when exactly one task-provider type is declared.                 |
+| `http`          | Exposes provider runtime HTTP helper without requiring a contributed task provider.      |
+| `commands`      | Reserved declaration for command-capable plugins; registration is still manifest-gated.  |
+| `scheduler`     | Reserved declaration for scheduled-job plugins; registration is still manifest-gated.    |
+| `chat.send`     | Declared in the permission list but no raw chat-send facade is exposed in the MVP.       |
 
 Unsupported in the MVP: raw chat provider access, raw task provider access, raw DB access, raw environment access, encrypted plugin secrets, arbitrary network access, and sandbox isolation.
 

--- a/src/chat/interaction-router.ts
+++ b/src/chat/interaction-router.ts
@@ -218,7 +218,7 @@ export function routeInteraction(
   }
 
   if (callbackData.startsWith('tgl:')) {
-    return resolvedDeps.handleToolToggleInteraction(interaction, reply)
+    return resolvedDeps.handleToolToggleInteraction(routedInteraction, reply)
   }
 
   log.debug({ callbackData }, 'No route matched for interaction callback')

--- a/src/chat/plugin-interaction-handler.ts
+++ b/src/chat/plugin-interaction-handler.ts
@@ -3,8 +3,8 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import { canManageInteractionTargetContext } from '../commands/plugin-auth.js'
 import { getPluginConfig } from '../config.js'
-import { listManageableGroups } from '../group-settings/access.js'
 import { getMissingGroupTargetMessage } from '../group-settings/target-validation.js'
 import { logger } from '../logger.js'
 import { pluginRegistry, setPluginEnabledForContext } from '../plugins/registry.js'
@@ -20,12 +20,6 @@ function decodeContextId(encoded: string): string | null {
   } catch {
     return null
   }
-}
-
-function canManageTargetContext(interaction: IncomingInteraction, targetContextId: string): boolean {
-  if (interaction.contextType !== 'dm') return targetContextId === interaction.storageContextId
-  if (targetContextId === interaction.user.id) return true
-  return listManageableGroups(interaction.user.id).some((group) => group.contextId === targetContextId)
 }
 
 function getMissingRequiredConfigLabels(entry: PluginRegistryEntry, contextId: string): readonly string[] {
@@ -70,6 +64,12 @@ async function handleDisablePlugin(
   interaction: IncomingInteraction,
   reply: ReplyFn,
 ): Promise<void> {
+  const entry = pluginRegistry.getEntry(pluginId)
+  if (entry === undefined || entry.state !== 'active') {
+    await replyTextPreferReplace(reply, `Plugin \`${pluginId}\` is not available.`)
+    return
+  }
+
   setPluginEnabledForContext(pluginId, contextId, false)
   log.info({ pluginId, contextId, userId: interaction.user.id }, 'Plugin disabled via interaction')
   await replyTextPreferReplace(reply, `⭕ Plugin \`${pluginId}\` disabled.`)
@@ -97,7 +97,8 @@ export async function handlePluginInteraction(interaction: IncomingInteraction, 
     await replyTextPreferReplace(reply, 'Invalid plugin action. Please try again.')
     return true
   }
-  if (!canManageTargetContext(interaction, contextId)) {
+  const authorization = canManageInteractionTargetContext(interaction, contextId)
+  if (!authorization.allowed) {
     await replyTextPreferReplace(reply, getMissingGroupTargetMessage(interaction.user.id, contextId))
     return true
   }

--- a/src/chat/router-helpers.ts
+++ b/src/chat/router-helpers.ts
@@ -87,7 +87,7 @@ export const traitsForManagedInstance = (instance: ManagedChatInstance | undefin
 export const capabilitiesForManagedInstance = (
   instance: ManagedChatInstance | undefined,
 ): ReadonlySet<ChatCapability> => {
-  if (instance === undefined || instance.status !== 'active') return new Set()
+  if (instance === undefined || !activeInstanceStatuses.has(instance.status)) return new Set()
   return instance.provider.capabilities
 }
 

--- a/src/chat/tool-toggle-interaction-handler.ts
+++ b/src/chat/tool-toggle-interaction-handler.ts
@@ -4,6 +4,7 @@
 // See LICENSE in the project root for details.
 
 import { safeBuildProvider } from '../commands/context-tool-resolution.js'
+import { canManageInteractionTargetContext } from '../commands/plugin-auth.js'
 import {
   buildDomainDrillView,
   buildDomainListView,
@@ -11,7 +12,6 @@ import {
   resolveToolNameCode,
   type ToolMenuView,
 } from '../commands/tool-config-view.js'
-import { listManageableGroups } from '../group-settings/access.js'
 import { getMissingGroupTargetMessage } from '../group-settings/target-validation.js'
 import { logger } from '../logger.js'
 import { getToolMetadata, TOOL_METADATA, type ToolDomain } from '../tools/tool-metadata.js'
@@ -34,12 +34,6 @@ function decodeContextId(encoded: string): string | null {
   } catch {
     return null
   }
-}
-
-function canManageTargetContext(interaction: IncomingInteraction, targetContextId: string): boolean {
-  if (interaction.contextType !== 'dm') return targetContextId === interaction.storageContextId
-  if (targetContextId === interaction.user.id) return true
-  return listManageableGroups(interaction.user.id).some((group) => group.contextId === targetContextId)
 }
 
 function availableToolNames(targetContextId: string, actorUserId: string, contextType: 'dm' | 'group'): string[] {
@@ -142,7 +136,8 @@ export async function handleToolToggleInteraction(interaction: IncomingInteracti
     await replyTextPreferReplace(reply, 'Invalid tool action. Please try again.')
     return true
   }
-  if (!canManageTargetContext(interaction, contextId)) {
+  const authorization = canManageInteractionTargetContext(interaction, contextId)
+  if (!authorization.allowed) {
     await replyTextPreferReplace(reply, getMissingGroupTargetMessage(interaction.user.id, contextId))
     return true
   }

--- a/src/commands/plugin-auth.ts
+++ b/src/commands/plugin-auth.ts
@@ -3,7 +3,8 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import type { ReplyFn } from '../chat/types.js'
+import type { IncomingInteraction, ReplyFn } from '../chat/types.js'
+import { listManageableGroups } from '../group-settings/access.js'
 import { isAdmin } from '../instances/admin-store.js'
 import { getContextSettings } from '../instances/context-store.js'
 
@@ -36,6 +37,20 @@ export const canManageTargetContext = (
   const platformInstanceId = settings === null ? sourcePlatformInstanceId : settings.platformInstanceId
   if (isAdmin(userId, platformInstanceId)) return { allowed: true }
   return { allowed: false, reason: 'not_authorized' }
+}
+
+export const canManageInteractionTargetContext = (
+  interaction: IncomingInteraction,
+  targetContextId: string,
+): TargetContextAuthorization => {
+  if (interaction.contextType !== 'dm') {
+    return targetContextId === interaction.storageContextId
+      ? { allowed: true }
+      : { allowed: false, reason: 'not_authorized' }
+  }
+  if (targetContextId === interaction.user.id) return { allowed: true }
+  const manageable = listManageableGroups(interaction.user.id).some((group) => group.contextId === targetContextId)
+  return manageable ? { allowed: true } : { allowed: false, reason: 'not_authorized' }
 }
 
 export const replyTargetAuthorizationFailure = async (

--- a/src/commands/plugin-auth.ts
+++ b/src/commands/plugin-auth.ts
@@ -3,6 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import { toStorageContextId } from '../chat/scoped-context.js'
 import type { IncomingInteraction, ReplyFn } from '../chat/types.js'
 import { listManageableGroups } from '../group-settings/access.js'
 import { isAdmin } from '../instances/admin-store.js'
@@ -48,8 +49,12 @@ export const canManageInteractionTargetContext = (
       ? { allowed: true }
       : { allowed: false, reason: 'not_authorized' }
   }
-  if (targetContextId === interaction.user.id) return { allowed: true }
-  const manageable = listManageableGroups(interaction.user.id).some((group) => group.contextId === targetContextId)
+  if (targetContextId === interaction.storageContextId || targetContextId === interaction.user.id)
+    return { allowed: true }
+  const manageable = listManageableGroups(interaction.user.id, interaction.platformInstanceId).some((group) => {
+    if (group.contextId === targetContextId) return true
+    return toStorageContextId(interaction.platformInstanceId, group.contextId) === targetContextId
+  })
   return manageable ? { allowed: true } : { allowed: false, reason: 'not_authorized' }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,29 +109,7 @@ const processMessage: BotDeps['processMessage'] = (...args) =>
 const stagedDownloadFn = createStagedDownloadFn()
 const botDeps: BotDeps = { processMessage, stagedDownloadFn }
 
-setupBot(chatProvider, adminUserId, botDeps)
-
-await chatProvider.start()
-
-void registerCommandMenuIfSupported(chatProvider, adminUserId)
-
-const [firstActivePlatformInstance] = activePlatformInstances
-const announcementPlatformInstanceId =
-  firstActivePlatformInstance === undefined ? undefined : firstActivePlatformInstance.id
-if (announcementPlatformInstanceId === undefined) {
-  log.warn('Skipping startup announcement: cannot determine current platform instance')
-} else {
-  void announceNewVersion(chatProvider, announcementPlatformInstanceId, adminUserId)
-}
-
-startScheduler(chatProvider)
-
-startPollers(chatProvider, (contextId) => defaultTaskProviderResolver.resolve(contextId))
-
-// Start the central scheduler with all cleanup tasks
-scheduler.startAll()
-
-// Discover and activate plugins
+// Discover and activate plugins before command registration so contributed commands are registered.
 const pluginDir = 'plugins'
 const { plugins: discoveredPlugins, errors: pluginErrors } = discoverPlugins(pluginDir)
 if (pluginErrors.length > 0) {
@@ -154,6 +132,28 @@ log.info(
   { activeCount: getActivatedPluginIds().length, requestedCount: toActivate.length },
   'Plugin activation complete',
 )
+
+setupBot(chatProvider, adminUserId, botDeps)
+
+await chatProvider.start()
+
+void registerCommandMenuIfSupported(chatProvider, adminUserId)
+
+const [firstActivePlatformInstance] = activePlatformInstances
+const announcementPlatformInstanceId =
+  firstActivePlatformInstance === undefined ? undefined : firstActivePlatformInstance.id
+if (announcementPlatformInstanceId === undefined) {
+  log.warn('Skipping startup announcement: cannot determine current platform instance')
+} else {
+  void announceNewVersion(chatProvider, announcementPlatformInstanceId, adminUserId)
+}
+
+startScheduler(chatProvider)
+
+startPollers(chatProvider, (contextId) => defaultTaskProviderResolver.resolve(contextId))
+
+// Start the central scheduler with all cleanup tasks
+scheduler.startAll()
 
 let stopDebugServerFn: (() => void) | null = null
 

--- a/src/instances/context-store.ts
+++ b/src/instances/context-store.ts
@@ -49,6 +49,11 @@ export const getContextSettings = (contextId: string): ContextSettings | null =>
   return row === undefined ? null : rowToSettings(row)
 }
 
+export const listContextSettings = (): ContextSettings[] => {
+  const rows = getDrizzleDb().select().from(contextSettings).all()
+  return rows.map((row) => rowToSettings(row))
+}
+
 export const listContextsByTaskInstance = (taskInstanceId: string): ContextSettings[] => {
   const rows = getDrizzleDb()
     .select()

--- a/src/plugins/command-contributions.ts
+++ b/src/plugins/command-contributions.ts
@@ -6,6 +6,8 @@
 import type { ChatProvider, CommandHandler } from '../chat/types.js'
 import { sanitizePluginId } from './contribution-names.js'
 import { contributionRegistry } from './contributions.js'
+import { formatPluginEligibilityMessage } from './eligibility-message.js'
+import { getPluginContextEligibility } from './registry.js'
 
 export function namespacedCommandName(pluginId: string, commandName: string): string {
   return `plugin_${sanitizePluginId(pluginId)}_${commandName}`
@@ -16,6 +18,11 @@ export function registerPluginCommands(chat: ChatProvider): void {
     contributions.commands.forEach((command) => {
       const commandName = namespacedCommandName(contributions.pluginId, command.name)
       const handler: CommandHandler = async (message, reply, auth) => {
+        const eligibility = getPluginContextEligibility(contributions.pluginId, auth.storageContextId)
+        if (!eligibility.eligible) {
+          await reply.text(formatPluginEligibilityMessage(contributions.pluginId, eligibility))
+          return
+        }
         await Promise.resolve(command.execute(message, reply, auth))
       }
       chat.registerCommand(commandName, handler)

--- a/src/plugins/contributions.ts
+++ b/src/plugins/contributions.ts
@@ -14,7 +14,7 @@ import { scheduler } from '../scheduler-instance.js'
 import { wrapToolExecution } from '../tools/wrap-tool-execution.js'
 import { namespacedJobName, namespacedToolName } from './contribution-names.js'
 import { getPluginContextEligibility } from './registry.js'
-import { getEnabledContextsForPlugin } from './store.js'
+import { getScheduledJobContextIds } from './scheduled-contexts.js'
 import { buildPluginToolRuntimeContext, type PluginToolSetRuntime } from './tool-runtime.js'
 import type {
   PluginCommand,
@@ -216,7 +216,7 @@ export async function runPluginScheduledJob(...args: RunPluginScheduledJobArgs):
 
   const deps = getScheduledJobDeps(args)
 
-  await getEnabledContextsForPlugin(pluginId).reduce(async (chain, contextId) => {
+  await getScheduledJobContextIds(pluginId, contributions.manifest).reduce(async (chain, contextId) => {
     await chain
     try {
       const eligibility = getPluginContextEligibility(pluginId, contextId)

--- a/src/plugins/eligibility-message.ts
+++ b/src/plugins/eligibility-message.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { PluginContextEligibility } from './registry.js'
+
+export function formatPluginEligibilityMessage(pluginId: string, eligibility: PluginContextEligibility): string {
+  if (eligibility.eligible) return `Plugin \`${pluginId}\` is available.`
+  if (eligibility.reason === 'inactive') return `Plugin \`${pluginId}\` is not active.`
+  if (eligibility.reason === 'disabled') return `Plugin \`${pluginId}\` is disabled for this context.`
+  if (eligibility.reason === 'config_missing') {
+    return `Plugin \`${pluginId}\` is missing required configuration: ${eligibility.missingKeys.join(', ')}.`
+  }
+  if (eligibility.reason === 'capability_missing') {
+    return `Plugin \`${pluginId}\` is missing required capabilities: ${eligibility.missingCapabilities.join(', ')}.`
+  }
+  return `Plugin \`${pluginId}\` is not available.`
+}

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -10,7 +10,10 @@ import { buildPluginContext } from './context.js'
 import { contributionRegistry } from './contributions.js'
 import { pluginRegistry } from './registry.js'
 import { recordRuntimeEvent } from './store.js'
-import { deactivateContributedTaskProviderTypes } from './task-provider-lifecycle.js'
+import {
+  deactivateContributedTaskProviderTypes,
+  unregisterContributedTaskProviderTypes,
+} from './task-provider-lifecycle.js'
 import type { DiscoveredPlugin, PluginFactory, PluginInstance } from './types.js'
 
 function isPluginFactory(value: unknown): value is PluginFactory {
@@ -123,7 +126,19 @@ export async function activatePlugins(plugins: DiscoveredPlugin[]): Promise<void
   log.info({ activated, failed, total: plugins.length }, 'Plugin activation complete')
 }
 
-async function deactivateOne(pluginId: string): Promise<void> {
+export type DeactivateAllPluginsOptions = Readonly<{
+  retireContributedProviders?: boolean
+}>
+
+const cleanupContributedTaskProviderTypes = (pluginId: string, options: DeactivateAllPluginsOptions): void => {
+  if (options.retireContributedProviders === true) {
+    deactivateContributedTaskProviderTypes(pluginId)
+    return
+  }
+  unregisterContributedTaskProviderTypes(pluginId)
+}
+
+async function deactivateOne(pluginId: string, options: DeactivateAllPluginsOptions): Promise<void> {
   const entry = pluginRegistry.getEntry(pluginId)
   if (entry === undefined || entry.state !== 'active') return
 
@@ -136,7 +151,7 @@ async function deactivateOne(pluginId: string): Promise<void> {
     }
     activeInstances.delete(pluginId)
     contributionRegistry.deregister(pluginId)
-    deactivateContributedTaskProviderTypes(pluginId)
+    cleanupContributedTaskProviderTypes(pluginId, options)
     pluginRegistry.markDeactivated(pluginId)
     recordRuntimeEvent(pluginId, 'deactivated')
     log.info({ pluginId }, 'Plugin deactivated')
@@ -145,19 +160,19 @@ async function deactivateOne(pluginId: string): Promise<void> {
     log.error({ pluginId, error: msg }, 'Plugin deactivation error (continuing)')
     activeInstances.delete(pluginId)
     contributionRegistry.deregister(pluginId)
-    deactivateContributedTaskProviderTypes(pluginId)
+    cleanupContributedTaskProviderTypes(pluginId, options)
     recordRuntimeEvent(pluginId, 'error', `Deactivation error: ${msg}`)
   }
 }
 
 /** Deactivate all active plugins in reverse activation order. */
-export async function deactivateAllPlugins(): Promise<void> {
+export async function deactivateAllPlugins(options: DeactivateAllPluginsOptions = {}): Promise<void> {
   const toDeactivate = [...activationOrder].reverse()
   if (toDeactivate.length === 0) return
 
   log.info({ count: toDeactivate.length }, 'Deactivating plugins')
 
-  await toDeactivate.reduce((chain, id) => chain.then(() => deactivateOne(id)), Promise.resolve())
+  await toDeactivate.reduce((chain, id) => chain.then(() => deactivateOne(id, options)), Promise.resolve())
 
   activeInstances.clear()
   activationOrder.length = 0

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -6,11 +6,11 @@
 import pLimit from 'p-limit'
 
 import { logger } from '../logger.js'
-import { unregisterContributedTaskProviderType } from '../providers/registry.js'
 import { buildPluginContext } from './context.js'
 import { contributionRegistry } from './contributions.js'
 import { pluginRegistry } from './registry.js'
 import { recordRuntimeEvent } from './store.js'
+import { deactivateContributedTaskProviderTypes } from './task-provider-lifecycle.js'
 import type { DiscoveredPlugin, PluginFactory, PluginInstance } from './types.js'
 
 function isPluginFactory(value: unknown): value is PluginFactory {
@@ -99,7 +99,7 @@ async function activateOne(plugin: DiscoveredPlugin): Promise<boolean> {
     log.error({ pluginId: manifest.id, error: msg }, 'Plugin activation failed')
     activeInstances.delete(manifest.id)
     contributionRegistry.deregister(manifest.id)
-    unregisterContributedTaskProviderType(manifest.id)
+    deactivateContributedTaskProviderTypes(manifest.id)
     pluginRegistry.markError(manifest.id, `Activation failed: ${msg}`)
     recordRuntimeEvent(manifest.id, 'error', `Activation failed: ${msg}`)
     return false
@@ -136,7 +136,7 @@ async function deactivateOne(pluginId: string): Promise<void> {
     }
     activeInstances.delete(pluginId)
     contributionRegistry.deregister(pluginId)
-    unregisterContributedTaskProviderType(pluginId)
+    deactivateContributedTaskProviderTypes(pluginId)
     pluginRegistry.markDeactivated(pluginId)
     recordRuntimeEvent(pluginId, 'deactivated')
     log.info({ pluginId }, 'Plugin deactivated')
@@ -145,7 +145,7 @@ async function deactivateOne(pluginId: string): Promise<void> {
     log.error({ pluginId, error: msg }, 'Plugin deactivation error (continuing)')
     activeInstances.delete(pluginId)
     contributionRegistry.deregister(pluginId)
-    unregisterContributedTaskProviderType(pluginId)
+    deactivateContributedTaskProviderTypes(pluginId)
     recordRuntimeEvent(pluginId, 'error', `Deactivation error: ${msg}`)
   }
 }

--- a/src/plugins/prompt-contributions.ts
+++ b/src/plugins/prompt-contributions.ts
@@ -32,7 +32,16 @@ export function buildPluginPromptSection(activePluginIds: string[]): string {
         break
       }
 
-      const rawContent = typeof fragment.content === 'function' ? fragment.content() : fragment.content
+      let rawContent: string
+      try {
+        rawContent = typeof fragment.content === 'function' ? fragment.content() : fragment.content
+      } catch (error) {
+        log.warn(
+          { pluginId, fragmentName: fragment.name, error: error instanceof Error ? error.message : String(error) },
+          'Plugin prompt fragment threw — skipping',
+        )
+        continue
+      }
       const truncated =
         rawContent.length > MAX_FRAGMENT_LENGTH_PER_PLUGIN
           ? rawContent.slice(0, MAX_FRAGMENT_LENGTH_PER_PLUGIN - '[truncated]'.length) + '[truncated]'

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -70,7 +70,7 @@ async function validateHop(
   assertPublicUrl: (url: URL) => Promise<void>,
 ): Promise<void> {
   if (!hostSet.has(url.hostname.toLowerCase())) {
-    throw new Error(`Host ${url.hostname} is not allowed`)
+    throw new Error(`Host '${url.hostname}' is not in the plugin providerAllowedHosts allowlist`)
   }
   await assertPublicUrl(url)
 }

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -70,7 +70,7 @@ async function validateHop(
   assertPublicUrl: (url: URL) => Promise<void>,
 ): Promise<void> {
   if (!hostSet.has(url.hostname.toLowerCase())) {
-    throw new Error(`Host '${url.hostname}' is not in the plugin providerAllowedHosts allowlist`)
+    throw new Error(`Host ${url.hostname} is not allowed`)
   }
   await assertPublicUrl(url)
 }
@@ -117,12 +117,12 @@ export function buildProviderRuntime(
   logger: PluginLogger,
   deps: ProviderRuntimeDeps = defaultDeps,
 ): PluginProviderRuntime {
-  // Private enforcement set. Never exposed directly — callers get a separate
-  // copy so mutating the exposed set cannot affect enforcement.
+  // Private enforcement set. Never exposed directly; httpFetch closes over this
+  // copy, so mutations to the exposed Set cannot affect enforcement.
   const hostSet: ReadonlySet<string> = new Set(allowedHosts.map((h) => h.toLowerCase()))
 
-  // Expose a separate Set instance so that mutations to the exposed copy do NOT
-  // affect the private enforcement set that httpFetch closes over.
+  // This is a diagnostic copy, not a security boundary. Object.freeze() does not
+  // make Set entries immutable; security comes from the private hostSet above.
   const exposedHosts: ReadonlySet<string> = Object.freeze(new Set(hostSet))
 
   return Object.freeze({

--- a/src/plugins/registry-context-eligibility.ts
+++ b/src/plugins/registry-context-eligibility.ts
@@ -43,6 +43,16 @@ const missingFromSet = <Capability extends string>(
 
 const emptyTaskCapabilities = (): ReadonlySet<TaskCapability> => new Set<TaskCapability>()
 
+const safeTaskCapabilities = (
+  taskInstance: NonNullable<ReturnType<typeof getTaskInstance>>,
+): ReadonlySet<TaskCapability> => {
+  try {
+    return getCapabilitiesForTaskInstance(taskInstance)
+  } catch {
+    return emptyTaskCapabilities()
+  }
+}
+
 const emptyChatCapabilities = (): ReadonlySet<ChatCapability> => new Set<ChatCapability>()
 
 function getMissingRequiredCapabilities(plugin: DiscoveredPlugin, contextId: string): readonly string[] {
@@ -53,7 +63,7 @@ function getMissingRequiredCapabilities(plugin: DiscoveredPlugin, contextId: str
   const taskCapabilities =
     taskInstance === null || taskInstance.status !== 'active'
       ? emptyTaskCapabilities()
-      : getCapabilitiesForTaskInstance(taskInstance)
+      : safeTaskCapabilities(taskInstance)
   const router = getRuntimeChatRouter()
   const chatCapabilities =
     router === null ? emptyChatCapabilities() : router.getPlatformInstanceCapabilities(settings.platformInstanceId)

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -3,9 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import type { ChatCapability } from '../chat/types.js'
 import { logger } from '../logger.js'
-import type { TaskCapability } from '../providers/types.js'
 import { checkPluginCompatibility } from './compatibility.js'
 import {
   NO_ACTIVE_INSTANCE_COMPATIBILITY_REASON,
@@ -149,22 +147,6 @@ export class PluginRegistry {
     entry.state = 'rejected'
     log.info({ pluginId }, 'Plugin rejected')
     return true
-  }
-
-  evaluateCompatibility(
-    pluginId: string,
-    taskCapabilities: ReadonlySet<TaskCapability>,
-    chatCapabilities: ReadonlySet<ChatCapability>,
-  ): void {
-    const entry = this.entries.get(pluginId)
-    if (entry === undefined || entry.state !== 'approved') return
-
-    const result = checkPluginCompatibility(entry.discoveredPlugin.manifest, taskCapabilities, chatCapabilities)
-    if (!result.compatible) {
-      entry.state = 'incompatible'
-      entry.compatibilityReason = result.reason
-      log.warn({ pluginId, reason: result.reason }, 'Plugin marked incompatible')
-    }
   }
 
   evaluateCompatibilityAcrossInstances(instances: readonly PluginCompatibilityInstance[]): void {

--- a/src/plugins/runtime-types.ts
+++ b/src/plugins/runtime-types.ts
@@ -9,6 +9,7 @@ import type { z } from 'zod'
 import type { AuthorizationResult, IncomingMessage, ReplyFn } from '../chat/types.js'
 import type { TaskProvider } from '../providers/types.js'
 import type { PluginContext } from './context.js'
+import type { PluginIdentityFacade } from './identity-facade.js'
 
 export type PluginTaskProviderFacade = Pick<
   TaskProvider,
@@ -21,6 +22,7 @@ export type PluginToolRuntimeContext = {
   chatUserId: string
   taskProvider: PluginTaskProviderFacade
   kv: PluginContext['kv']
+  identity?: PluginIdentityFacade
   rateLimit: {
     check(actorId: string): { allowed: boolean; retryAfterSec?: number }
   }

--- a/src/plugins/scheduled-contexts.ts
+++ b/src/plugins/scheduled-contexts.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { listContextSettings } from '../instances/context-store.js'
+import { getContextStatesForPlugin } from './store.js'
+import type { PluginManifest } from './types.js'
+
+export const getScheduledJobContextIds = (pluginId: string, manifest: PluginManifest): string[] => {
+  const explicitStates = getContextStatesForPlugin(pluginId)
+  if (!manifest.defaultEnabled) {
+    return explicitStates.filter((row) => row.enabled).map((row) => row.contextId)
+  }
+
+  const explicitDisabled = new Set(explicitStates.filter((row) => !row.enabled).map((row) => row.contextId))
+  const explicitEnabled = explicitStates.filter((row) => row.enabled).map((row) => row.contextId)
+  const configuredDefaults = listContextSettings()
+    .map((settings) => settings.contextId)
+    .filter((contextId) => !explicitDisabled.has(contextId))
+
+  return [...new Set([...configuredDefaults, ...explicitEnabled])]
+}

--- a/src/plugins/startup-compatibility.ts
+++ b/src/plugins/startup-compatibility.ts
@@ -14,9 +14,14 @@ const EMPTY_TASK_CAPABILITIES: ReadonlySet<TaskCapability> = new Set()
 const EMPTY_CHAT_CAPABILITIES: ReadonlySet<ChatCapability> = new Set()
 
 const activeTaskCapabilitySets = (taskInstances: readonly TaskInstance[]): readonly ReadonlySet<TaskCapability>[] =>
-  taskInstances
-    .filter((instance) => instance.status === 'active')
-    .map((instance) => getCapabilitiesForTaskInstance(instance))
+  taskInstances.flatMap((instance) => {
+    if (instance.status !== 'active') return []
+    try {
+      return [getCapabilitiesForTaskInstance(instance)]
+    } catch {
+      return []
+    }
+  })
 
 const activeChatCapabilitySets = (
   router: ChatRouter,

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -133,6 +133,15 @@ export function getEnabledContextsForPlugin(pluginId: string): string[] {
     .map((r) => r.contextId)
 }
 
+export function getContextStatesForPlugin(pluginId: string): Array<{ contextId: string; enabled: boolean }> {
+  const db = getDrizzleDb()
+  return db
+    .select({ contextId: pluginContextState.contextId, enabled: pluginContextState.enabled })
+    .from(pluginContextState)
+    .where(eq(pluginContextState.pluginId, pluginId))
+    .all()
+}
+
 // ---- KV store ----
 
 export function kvGet(pluginId: string, contextId: string, key: string): string | undefined {

--- a/src/plugins/store.ts
+++ b/src/plugins/store.ts
@@ -123,16 +123,6 @@ export function getEnabledPluginsForContext(contextId: string): string[] {
     .map((r) => r.pluginId)
 }
 
-export function getEnabledContextsForPlugin(pluginId: string): string[] {
-  const db = getDrizzleDb()
-  return db
-    .select({ contextId: pluginContextState.contextId })
-    .from(pluginContextState)
-    .where(and(eq(pluginContextState.pluginId, pluginId), eq(pluginContextState.enabled, true)))
-    .all()
-    .map((r) => r.contextId)
-}
-
 export function getContextStatesForPlugin(pluginId: string): Array<{ contextId: string; enabled: boolean }> {
   const db = getDrizzleDb()
   return db

--- a/src/plugins/task-provider-lifecycle.ts
+++ b/src/plugins/task-provider-lifecycle.ts
@@ -26,6 +26,17 @@ const defaultDeps: DeactivateContributedTaskProviderTypesDeps = {
   updateTaskInstance,
 }
 
+export function unregisterContributedTaskProviderTypes(
+  pluginId: string,
+  deps: Pick<DeactivateContributedTaskProviderTypesDeps, 'unregisterTypesForPlugin'> = defaultDeps,
+): string[] {
+  const removedTypes = deps.unregisterTypesForPlugin(pluginId)
+  if (removedTypes.length > 0) {
+    log.info({ pluginId, providerTypes: removedTypes }, 'Unregistered contributed task provider types')
+  }
+  return removedTypes
+}
+
 export function deactivateContributedTaskProviderTypes(
   pluginId: string,
   deps: DeactivateContributedTaskProviderTypesDeps = defaultDeps,
@@ -42,7 +53,7 @@ export function deactivateContributedTaskProviderTypes(
     deps.updateTaskInstance(instance.id, { config: undefined, status: 'stopped' })
   }
 
-  const removedTypes = deps.unregisterTypesForPlugin(pluginId)
+  const removedTypes = unregisterContributedTaskProviderTypes(pluginId, deps)
   log.warn(
     { pluginId, providerTypes: removedTypes, stoppedTaskInstanceIds: affectedInstances.map((instance) => instance.id) },
     'Deactivated contributed task provider types',

--- a/src/plugins/task-provider-lifecycle.ts
+++ b/src/plugins/task-provider-lifecycle.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { listTaskInstances, updateTaskInstance } from '../instances/task-store.js'
+import { logger } from '../logger.js'
+import {
+  listContributedTaskProviderTypesForPlugin,
+  unregisterContributedTaskProviderType,
+} from '../providers/registry.js'
+
+const log = logger.child({ scope: 'plugins:task-provider-lifecycle' })
+
+export type DeactivateContributedTaskProviderTypesDeps = Readonly<{
+  listTypesForPlugin: typeof listContributedTaskProviderTypesForPlugin
+  unregisterTypesForPlugin: typeof unregisterContributedTaskProviderType
+  listTaskInstances: typeof listTaskInstances
+  updateTaskInstance: typeof updateTaskInstance
+}>
+
+const defaultDeps: DeactivateContributedTaskProviderTypesDeps = {
+  listTypesForPlugin: listContributedTaskProviderTypesForPlugin,
+  unregisterTypesForPlugin: unregisterContributedTaskProviderType,
+  listTaskInstances,
+  updateTaskInstance,
+}
+
+export function deactivateContributedTaskProviderTypes(
+  pluginId: string,
+  deps: DeactivateContributedTaskProviderTypesDeps = defaultDeps,
+): string[] {
+  const providerTypes = deps.listTypesForPlugin(pluginId)
+  if (providerTypes.length === 0) return []
+
+  const providerTypeSet = new Set(providerTypes)
+  const affectedInstances = deps
+    .listTaskInstances()
+    .filter((instance) => instance.status === 'active' && providerTypeSet.has(instance.type))
+
+  for (const instance of affectedInstances) {
+    deps.updateTaskInstance(instance.id, { config: undefined, status: 'stopped' })
+  }
+
+  const removedTypes = deps.unregisterTypesForPlugin(pluginId)
+  log.warn(
+    { pluginId, providerTypes: removedTypes, stoppedTaskInstanceIds: affectedInstances.map((instance) => instance.id) },
+    'Deactivated contributed task provider types',
+  )
+  return removedTypes
+}

--- a/src/plugins/tool-runtime.ts
+++ b/src/plugins/tool-runtime.ts
@@ -5,6 +5,7 @@
 
 import type { TaskProvider } from '../providers/types.js'
 import { consumeWebFetchQuota } from '../web/rate-limit.js'
+import { buildIdentityFacade } from './identity-facade.js'
 import { kvDelete, kvGet, kvList, kvSet } from './store.js'
 import type { PluginManifest, PluginTaskProviderFacade, PluginToolRuntimeContext } from './types.js'
 
@@ -91,6 +92,13 @@ function buildRateLimit(): PluginToolRuntimeContext['rateLimit'] {
   })
 }
 
+const buildRuntimeIdentity = (manifest: PluginManifest): PluginToolRuntimeContext['identity'] => {
+  const [providerType] = manifest.contributes.taskProviderTypes
+  if (!manifest.permissions.includes('identity')) return undefined
+  if (manifest.contributes.taskProviderTypes.length !== 1 || providerType === undefined) return undefined
+  return buildIdentityFacade(providerType)
+}
+
 export function buildPluginToolRuntimeContext(
   pluginId: string,
   manifest: PluginManifest,
@@ -108,6 +116,7 @@ export function buildPluginToolRuntimeContext(
       permissions.has('tasks.write'),
     ),
     kv: buildRuntimeKv(pluginId, runtime.storageContextId, permissions.has('storage')),
+    identity: buildRuntimeIdentity(manifest),
     rateLimit: buildRateLimit(),
   })
 }

--- a/src/plugins/tool-runtime.ts
+++ b/src/plugins/tool-runtime.ts
@@ -105,6 +105,7 @@ export function buildPluginToolRuntimeContext(
   runtime: PluginToolSetRuntime,
 ): PluginToolRuntimeContext {
   const permissions = new Set(manifest.permissions)
+  const identity = buildRuntimeIdentity(manifest)
   return Object.freeze({
     pluginId,
     storageContextId: runtime.storageContextId,
@@ -116,7 +117,7 @@ export function buildPluginToolRuntimeContext(
       permissions.has('tasks.write'),
     ),
     kv: buildRuntimeKv(pluginId, runtime.storageContextId, permissions.has('storage')),
-    identity: buildRuntimeIdentity(manifest),
+    ...(identity === undefined ? {} : { identity }),
     rateLimit: buildRateLimit(),
   })
 }

--- a/src/providers/builtin-descriptors.ts
+++ b/src/providers/builtin-descriptors.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { ALL_CAPABILITIES, KANEO_TRAITS } from './kaneo/constants.js'
+import type { TaskCapability } from './task-capability.js'
+import type { ProviderConfigField, TaskProviderTrait } from './types.js'
+import { YOUTRACK_CAPABILITIES, YOUTRACK_TRAITS } from './youtrack/constants.js'
+
+export type BuiltinDescriptorSeed = {
+  type: string
+  displayName: string
+  capabilities: ReadonlySet<TaskCapability>
+  instanceConfigSchema: readonly ProviderConfigField[]
+  contextConfigSchema: readonly ProviderConfigField[]
+  traits: ReadonlySet<TaskProviderTrait>
+}
+
+export const builtinDescriptorSeeds: readonly BuiltinDescriptorSeed[] = [
+  {
+    type: 'kaneo',
+    displayName: 'Kaneo',
+    capabilities: ALL_CAPABILITIES,
+    traits: KANEO_TRAITS,
+    instanceConfigSchema: [
+      { key: 'baseUrl', label: 'Kaneo URL', required: true, sensitive: false, scope: 'instance' },
+      { key: 'internalUrl', label: 'Kaneo Internal URL', required: false, sensitive: false, scope: 'instance' },
+    ],
+    contextConfigSchema: [
+      {
+        key: 'credential',
+        label: 'Kaneo API Key',
+        required: true,
+        sensitive: true,
+        scope: 'context',
+        storageKey: 'kaneo_apikey',
+      },
+      {
+        key: 'workspaceId',
+        label: 'Workspace ID',
+        required: true,
+        sensitive: false,
+        scope: 'context',
+        storageKey: 'kaneo_workspace_id',
+      },
+    ],
+  },
+  {
+    type: 'youtrack',
+    displayName: 'YouTrack',
+    capabilities: YOUTRACK_CAPABILITIES,
+    traits: YOUTRACK_TRAITS,
+    instanceConfigSchema: [
+      { key: 'baseUrl', label: 'YouTrack URL', required: true, sensitive: false, scope: 'instance' },
+    ],
+    contextConfigSchema: [
+      {
+        key: 'token',
+        label: 'YouTrack Permanent Token',
+        required: true,
+        sensitive: true,
+        scope: 'context',
+        storageKey: 'youtrack_token',
+      },
+    ],
+  },
+]

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -134,7 +134,7 @@ export function registerContributedTaskProviderType(type: string, entry: Contrib
   log.info({ type, pluginId: entry.pluginId }, 'Registered contributed task provider type')
 }
 
-/** Remove all contributed types owned by a plugin (deactivation / failure cleanup). */
+/** List contributed types owned by a plugin. */
 export function listContributedTaskProviderTypesForPlugin(pluginId: string): string[] {
   return [...pluginContributedTaskProviderFactories.entries()]
     .filter(([, entry]) => entry.pluginId === pluginId)

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -5,11 +5,10 @@
 
 import type { TaskInstance } from '../instances/types.js'
 import { logger } from '../logger.js'
-import { ALL_CAPABILITIES, KANEO_TRAITS } from './kaneo/constants.js'
+import { builtinDescriptorSeeds } from './builtin-descriptors.js'
 import { isKaneoSessionCookie, KaneoProvider, type KaneoConfig } from './kaneo/index.js'
 import type { TaskCapability } from './task-capability.js'
 import type { ProviderConfigField, TaskProvider, TaskProviderTrait } from './types.js'
-import { YOUTRACK_CAPABILITIES, YOUTRACK_TRAITS } from './youtrack/constants.js'
 import { YouTrackProvider } from './youtrack/index.js'
 
 const log = logger.child({ scope: 'provider:registry' })
@@ -136,13 +135,23 @@ export function registerContributedTaskProviderType(type: string, entry: Contrib
 }
 
 /** Remove all contributed types owned by a plugin (deactivation / failure cleanup). */
-export function unregisterContributedTaskProviderType(pluginId: string): void {
+export function listContributedTaskProviderTypesForPlugin(pluginId: string): string[] {
+  return [...pluginContributedTaskProviderFactories.entries()]
+    .filter(([, entry]) => entry.pluginId === pluginId)
+    .map(([type]) => type)
+}
+
+/** Remove all contributed types owned by a plugin (deactivation / failure cleanup). */
+export function unregisterContributedTaskProviderType(pluginId: string): string[] {
+  const removedTypes: string[] = []
   for (const [type, entry] of pluginContributedTaskProviderFactories) {
     if (entry.pluginId === pluginId) {
       pluginContributedTaskProviderFactories.delete(type)
+      removedTypes.push(type)
       log.debug({ type, pluginId }, 'Unregistered contributed task provider type')
     }
   }
+  return removedTypes
 }
 
 /** Look up a contributed task provider entry by type. */
@@ -165,15 +174,6 @@ export type TaskProviderTypeDescriptor = {
   traits: ReadonlySet<TaskProviderTrait>
   /** Temporary compatibility surface for code that still reads the legacy combined configSchema. */
   configSchema: readonly ProviderConfigField[]
-}
-
-type BuiltinDescriptorSeed = {
-  type: string
-  displayName: string
-  capabilities: ReadonlySet<TaskCapability>
-  instanceConfigSchema: readonly ProviderConfigField[]
-  contextConfigSchema: readonly ProviderConfigField[]
-  traits: ReadonlySet<TaskProviderTrait>
 }
 
 const legacyConfigSchema = (descriptor: TaskProviderTypeDescriptor): readonly ProviderConfigField[] => [
@@ -202,56 +202,6 @@ const contributedContextFields = (entry: ContributedTaskProviderEntry): readonly
   if (entry.contextConfigSchema !== undefined) return normalizeContributedFields(entry.contextConfigSchema)
   return normalizeContributedFields(entry.configSchema).filter((field) => field.scope === 'context')
 }
-
-const builtinDescriptorSeeds: readonly BuiltinDescriptorSeed[] = [
-  {
-    type: 'kaneo',
-    displayName: 'Kaneo',
-    capabilities: ALL_CAPABILITIES,
-    traits: KANEO_TRAITS,
-    instanceConfigSchema: [
-      { key: 'baseUrl', label: 'Kaneo URL', required: true, sensitive: false, scope: 'instance' },
-      { key: 'internalUrl', label: 'Kaneo Internal URL', required: false, sensitive: false, scope: 'instance' },
-    ],
-    contextConfigSchema: [
-      {
-        key: 'credential',
-        label: 'Kaneo API Key',
-        required: true,
-        sensitive: true,
-        scope: 'context',
-        storageKey: 'kaneo_apikey',
-      },
-      {
-        key: 'workspaceId',
-        label: 'Workspace ID',
-        required: true,
-        sensitive: false,
-        scope: 'context',
-        storageKey: 'kaneo_workspace_id',
-      },
-    ],
-  },
-  {
-    type: 'youtrack',
-    displayName: 'YouTrack',
-    capabilities: YOUTRACK_CAPABILITIES,
-    traits: YOUTRACK_TRAITS,
-    instanceConfigSchema: [
-      { key: 'baseUrl', label: 'YouTrack URL', required: true, sensitive: false, scope: 'instance' },
-    ],
-    contextConfigSchema: [
-      {
-        key: 'token',
-        label: 'YouTrack Permanent Token',
-        required: true,
-        sensitive: true,
-        scope: 'context',
-        storageKey: 'youtrack_token',
-      },
-    ],
-  },
-]
 
 /** Look up a single task-provider type descriptor (built-in or contributed). */
 export function getTaskProviderDescriptor(type: string): TaskProviderTypeDescriptor | undefined {

--- a/src/providers/resolver.ts
+++ b/src/providers/resolver.ts
@@ -126,7 +126,20 @@ export class TaskProviderResolver {
     if (config === null) return null
 
     log.info({ contextId, taskInstanceId: instance.id, taskProvider: instance.type }, 'Task provider resolved')
-    return this.deps.createProvider(instance.type, config)
+    try {
+      return this.deps.createProvider(instance.type, config)
+    } catch (error) {
+      log.warn(
+        {
+          contextId,
+          taskInstanceId: instance.id,
+          taskProvider: instance.type,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        'Cannot resolve task provider: provider creation failed',
+      )
+      return null
+    }
   }
 
   resolveStrict(contextId: string): TaskProvider {

--- a/tests/chat/interaction-router.test.ts
+++ b/tests/chat/interaction-router.test.ts
@@ -250,6 +250,30 @@ describe('routeInteraction', () => {
     expect(seenStorageIds).toEqual([scopedContextId])
   })
 
+  test('routes tool toggle callbacks with scoped auth context instead of native interaction storage', async () => {
+    const scopedContextId = toScopedContextId({ platformInstanceId: 'telegram-secondary', nativeContextId: 'user-1' })
+    const seenStorageIds: string[] = []
+
+    const handled = await routeInteraction(
+      { ...interaction, callbackData: 'tgl:dom:memo:dXNlci0x', storageContextId: 'user-1' },
+      reply,
+      { ...createMockAuth(true), storageContextId: scopedContextId },
+      {
+        handleGroupSettingsInteraction: () => Promise.resolve(false),
+        handleConfigInteraction: () => Promise.resolve(false),
+        handleWizardInteraction: () => Promise.resolve(false),
+        handlePluginInteraction: () => Promise.resolve(false),
+        handleToolToggleInteraction: (routedInteraction) => {
+          seenStorageIds.push(routedInteraction.storageContextId)
+          return Promise.resolve(true)
+        },
+      },
+    )
+
+    expect(handled).toBe(true)
+    expect(seenStorageIds).toEqual([scopedContextId])
+  })
+
   test('routes wizard callbacks through the wizard interaction dependency', async () => {
     const calls: string[] = []
     const handled = await routeInteraction(

--- a/tests/chat/plugin-interaction-handler.test.ts
+++ b/tests/chat/plugin-interaction-handler.test.ts
@@ -5,9 +5,12 @@
 
 import { beforeEach, describe, expect, test } from 'bun:test'
 
+import { addAuthorizedGroup } from '../../src/authorized-groups.js'
 import { handlePluginInteraction } from '../../src/chat/plugin-interaction-handler.js'
+import { toScopedContextId } from '../../src/chat/scoped-context.js'
 import type { IncomingInteraction } from '../../src/chat/types.js'
 import { setPluginConfig } from '../../src/config.js'
+import { upsertGroupAdminObservation, upsertKnownGroupContext } from '../../src/group-settings/registry.js'
 import { pluginRegistry } from '../../src/plugins/registry.js'
 import { getPluginContextState, isPluginEnabledForContext } from '../../src/plugins/store.js'
 import type { DiscoveredPlugin } from '../../src/plugins/types.js'
@@ -109,6 +112,31 @@ describe('handlePluginInteraction', () => {
     expect(textCalls[0]).toContain('enabled')
   })
 
+  test('enables a plugin for a scoped personal DM target context', async () => {
+    const pluginId = 'interaction-scoped-personal-plugin'
+    const platformInstanceId = 'telegram-default'
+    const contextId = toScopedContextId({ platformInstanceId, nativeContextId: 'interaction-user-scoped' })
+    const plugin = makePlugin(pluginId)
+    pluginRegistry.registerDiscovered(plugin)
+    pluginRegistry.approve(pluginId, 'admin', plugin.manifestHash)
+    pluginRegistry.markActive(pluginId)
+    setPluginConfig(contextId, pluginId, 'api_token', 'secret-token')
+
+    const { reply, textCalls } = createMockReply()
+    const handled = await handlePluginInteraction(
+      {
+        ...makeInteraction(`plg:enable:${pluginId}:${encodeContextId(contextId)}`, 'interaction-user-scoped'),
+        platformInstanceId,
+        storageContextId: contextId,
+      },
+      reply,
+    )
+
+    expect(handled).toBe(true)
+    expect(isPluginEnabledForContext(pluginId, contextId)).toBe(true)
+    expect(textCalls[0]).toContain('enabled')
+  })
+
   test('rejects plugin actions for group targets the user cannot manage', async () => {
     const pluginId = 'interaction-group-target-plugin'
     const plugin = makePlugin(pluginId)
@@ -142,5 +170,54 @@ describe('handlePluginInteraction', () => {
 
     expect(textCalls[0]).toContain('not available')
     expect(getPluginContextState('no-such-plugin', 'admin-user')).toBeUndefined()
+  })
+
+  test('disable interaction refuses inactive plugin instead of writing a ghost row', async () => {
+    const pluginId = 'inactive-disable-plugin'
+    const plugin = makePlugin(pluginId)
+    pluginRegistry.registerDiscovered(plugin)
+    pluginRegistry.approve(pluginId, 'admin', plugin.manifestHash)
+
+    const { reply, textCalls } = createMockReply()
+    await handlePluginInteraction(
+      makeInteraction(`plg:disable:${pluginId}:${encodeContextId('admin-user')}`, 'admin-user'),
+      reply,
+    )
+
+    expect(textCalls[0]).toContain('not available')
+    expect(getPluginContextState(pluginId, 'admin-user')).toBeUndefined()
+  })
+
+  test('rejects group plugin actions scoped to another platform instance', async () => {
+    const pluginId = 'interaction-cross-platform-group-plugin'
+    const plugin = makePlugin(pluginId)
+    pluginRegistry.registerDiscovered(plugin)
+    pluginRegistry.approve(pluginId, 'admin', plugin.manifestHash)
+    pluginRegistry.markActive(pluginId)
+    const targetContextId = toScopedContextId({ platformInstanceId: 'other-platform', nativeContextId: 'group-1' })
+    upsertKnownGroupContext({
+      contextId: targetContextId,
+      provider: 'telegram',
+      displayName: 'Other Platform Group',
+      parentName: null,
+    })
+    upsertGroupAdminObservation({
+      provider: 'telegram',
+      contextId: targetContextId,
+      userId: 'admin-user',
+      username: 'alice',
+      isAdmin: true,
+    })
+    addAuthorizedGroup(targetContextId, 'admin-user')
+
+    const { reply, textCalls } = createMockReply()
+    const handled = await handlePluginInteraction(
+      makeInteraction(`plg:disable:${pluginId}:${encodeContextId(targetContextId)}`, 'admin-user'),
+      reply,
+    )
+
+    expect(handled).toBe(true)
+    expect(textCalls[0]).toContain('no longer recognized as an admin')
+    expect(getPluginContextState(pluginId, targetContextId)).toBeUndefined()
   })
 })

--- a/tests/chat/plugin-interaction-handler.test.ts
+++ b/tests/chat/plugin-interaction-handler.test.ts
@@ -9,7 +9,7 @@ import { handlePluginInteraction } from '../../src/chat/plugin-interaction-handl
 import type { IncomingInteraction } from '../../src/chat/types.js'
 import { setPluginConfig } from '../../src/config.js'
 import { pluginRegistry } from '../../src/plugins/registry.js'
-import { isPluginEnabledForContext } from '../../src/plugins/store.js'
+import { getPluginContextState, isPluginEnabledForContext } from '../../src/plugins/store.js'
 import type { DiscoveredPlugin } from '../../src/plugins/types.js'
 import { PLUGIN_API_VERSION } from '../../src/plugins/types.js'
 import { createMockReply, mockLogger, setupTestDb } from '../utils/test-helpers.js'
@@ -125,5 +125,22 @@ describe('handlePluginInteraction', () => {
     expect(handled).toBe(true)
     expect(isPluginEnabledForContext(pluginId, 'group-unknown')).toBe(false)
     expect(textCalls[0]).toContain('no longer recognized as an admin')
+  })
+
+  test('disable interaction refuses unknown plugin instead of writing a ghost row', async () => {
+    const { reply, textCalls } = createMockReply()
+    await handlePluginInteraction(
+      {
+        ...makeInteraction(
+          `plg:disable:no-such-plugin:${Buffer.from('admin-user').toString('base64url')}`,
+          'admin-user',
+        ),
+        storageContextId: 'admin-user',
+      },
+      reply,
+    )
+
+    expect(textCalls[0]).toContain('not available')
+    expect(getPluginContextState('no-such-plugin', 'admin-user')).toBeUndefined()
   })
 })

--- a/tests/chat/tool-toggle-interaction-handler.test.ts
+++ b/tests/chat/tool-toggle-interaction-handler.test.ts
@@ -6,6 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 
 import { userCachesForTesting } from '../../src/cache.js'
+import { toScopedContextId } from '../../src/chat/scoped-context.js'
 import { handleToolToggleInteraction } from '../../src/chat/tool-toggle-interaction-handler.js'
 import type { IncomingInteraction } from '../../src/chat/types.js'
 import { getToolPrefs } from '../../src/tools/tool-preferences.js'
@@ -48,6 +49,19 @@ describe('handleToolToggleInteraction', () => {
     const handled = await handleToolToggleInteraction(dmInteraction(`tgl:dom:memo:${CTX}`), reply)
     expect(handled).toBe(true)
     expect(getToolPrefs(USER).disabledDomains).toContain('memo')
+  })
+
+  it('toggling a domain off accepts a scoped personal DM target context', async () => {
+    const scopedContextId = toScopedContextId({ platformInstanceId: 'telegram-default', nativeContextId: USER })
+    const scopedCtx = Buffer.from(scopedContextId).toString('base64url')
+    const { reply } = createMockReply()
+    const handled = await handleToolToggleInteraction(
+      { ...dmInteraction(`tgl:dom:memo:${scopedCtx}`), storageContextId: scopedContextId },
+      reply,
+    )
+
+    expect(handled).toBe(true)
+    expect(getToolPrefs(scopedContextId).disabledDomains).toContain('memo')
   })
 
   it('rejects toggling for a context the user cannot manage', async () => {

--- a/tests/commands/plugin.test.ts
+++ b/tests/commands/plugin.test.ts
@@ -479,12 +479,12 @@ describe('registerPluginCommand', () => {
       manifest: { ...plugin.manifest, requiredTaskCapabilities: ['tasks.delete'] },
     })
     pluginRegistry.approve(plugin.manifest.id, 'admin-user', plugin.manifestHash)
-    pluginRegistry.evaluateCompatibility(plugin.manifest.id, new Set(), new Set())
+    pluginRegistry.evaluateCompatibilityAcrossInstances([{ taskCapabilities: new Set(), chatCapabilities: new Set() }])
 
     const output = await runPluginCommand('info incompatible-plugin')
 
     expect(output).toContain('incompatible')
-    expect(output).toContain('Required task capability missing')
+    expect(output).toContain('No active instance satisfies required capabilities')
   })
 
   test('shows runtime error diagnostics in plugin info', async () => {

--- a/tests/plugins/contributions.test.ts
+++ b/tests/plugins/contributions.test.ts
@@ -1002,6 +1002,39 @@ describe('buildPluginPromptSection', () => {
     expect(called).toBe(true)
   })
 
+  test('prompt section skips throwing fragment and keeps later fragments', () => {
+    const manifest = makeManifest({
+      contributes: {
+        tools: [],
+        promptFragments: ['bad', 'good'],
+        commands: [],
+        jobs: [],
+        configKeys: [],
+        taskProviderTypes: [],
+      },
+    })
+    contributionRegistry.register(
+      'test-plugin',
+      {
+        tools: [],
+        promptFragments: [
+          {
+            name: 'bad',
+            content: (): string => {
+              throw new Error('fragment boom')
+            },
+          },
+          { name: 'good', content: 'SAFE_FRAGMENT' },
+        ],
+        commands: [],
+        jobs: [],
+      },
+      manifest,
+    )
+
+    expect(buildPluginPromptSection(['test-plugin'])).toContain('SAFE_FRAGMENT')
+  })
+
   test('truncates fragment exceeding per-plugin limit', () => {
     const manifest = makeManifest()
     const longContent = 'x'.repeat(MAX_FRAGMENT_LENGTH_PER_PLUGIN + 100)

--- a/tests/plugins/contributions.test.ts
+++ b/tests/plugins/contributions.test.ts
@@ -397,6 +397,49 @@ describe('PluginContributionRegistry', () => {
     expect(taskState!.running).toBe(true)
   })
 
+  test('scheduled jobs run for configured contexts when plugin is default enabled', async () => {
+    const seenContexts: string[] = []
+    const manifest = makeManifest({
+      defaultEnabled: true,
+      contributes: {
+        tools: [],
+        promptFragments: [],
+        commands: [],
+        jobs: ['daily'],
+        configKeys: [],
+        taskProviderTypes: [],
+      },
+    })
+    markPluginActive(manifest)
+    seedTestPlatformInstance({ id: 'telegram-a' })
+    seedTestTaskInstance({ id: 'task-a' })
+    setContextSettings({ contextId: 'ctx-default-a', taskInstanceId: 'task-a', platformInstanceId: 'telegram-a' })
+    setContextSettings({ contextId: 'ctx-default-b', taskInstanceId: 'task-a', platformInstanceId: 'telegram-a' })
+    setPluginEnabledForContext('test-plugin', 'ctx-default-b', false)
+    contributionRegistry.register(
+      'test-plugin',
+      {
+        tools: [],
+        promptFragments: [],
+        commands: [],
+        jobs: [
+          {
+            name: 'daily',
+            intervalMs: 60_000,
+            execute: (contextId): void => {
+              seenContexts.push(contextId)
+            },
+          },
+        ],
+      },
+      manifest,
+    )
+
+    await runPluginScheduledJob('test-plugin', 'daily')
+
+    expect(seenContexts).toEqual(['ctx-default-a'])
+  })
+
   test('scheduled jobs skip contexts that are not plugin eligible', async () => {
     const seenContexts: string[] = []
     const manifest = makeManifest({

--- a/tests/plugins/contributions.test.ts
+++ b/tests/plugins/contributions.test.ts
@@ -397,7 +397,7 @@ describe('PluginContributionRegistry', () => {
     expect(taskState!.running).toBe(true)
   })
 
-  test('scheduled jobs run for configured contexts when plugin is default enabled', async () => {
+  test('scheduled jobs include configured and explicit contexts once when plugin is default enabled', async () => {
     const seenContexts: string[] = []
     const manifest = makeManifest({
       defaultEnabled: true,
@@ -415,7 +415,9 @@ describe('PluginContributionRegistry', () => {
     seedTestTaskInstance({ id: 'task-a' })
     setContextSettings({ contextId: 'ctx-default-a', taskInstanceId: 'task-a', platformInstanceId: 'telegram-a' })
     setContextSettings({ contextId: 'ctx-default-b', taskInstanceId: 'task-a', platformInstanceId: 'telegram-a' })
+    setPluginEnabledForContext('test-plugin', 'ctx-default-a', true)
     setPluginEnabledForContext('test-plugin', 'ctx-default-b', false)
+    setPluginEnabledForContext('test-plugin', 'ctx-explicit', true)
     contributionRegistry.register(
       'test-plugin',
       {
@@ -437,7 +439,8 @@ describe('PluginContributionRegistry', () => {
 
     await runPluginScheduledJob('test-plugin', 'daily')
 
-    expect(seenContexts).toEqual(['ctx-default-a'])
+    expect(seenContexts).toHaveLength(2)
+    expect(new Set(seenContexts)).toEqual(new Set(['ctx-default-a', 'ctx-explicit']))
   })
 
   test('scheduled jobs skip contexts that are not plugin eligible', async () => {

--- a/tests/plugins/contributions.test.ts
+++ b/tests/plugins/contributions.test.ts
@@ -260,6 +260,7 @@ describe('PluginContributionRegistry', () => {
         taskProviderTypes: [],
       },
     })
+    markPluginActive(manifest)
     contributionRegistry.register(
       'test-plugin',
       {
@@ -278,6 +279,7 @@ describe('PluginContributionRegistry', () => {
       },
       manifest,
     )
+    setPluginEnabledForContext('test-plugin', 'user-1', true)
     const { provider, commandHandlers } = createMockChatWithCommandHandlers()
 
     registerPluginCommands(provider)
@@ -296,6 +298,60 @@ describe('PluginContributionRegistry', () => {
 
     expect(commandHandlers.has('plugin_test_plugin_sync')).toBe(true)
     expect(executed).toBe(true)
+  })
+
+  test('plugin command handler refuses execution when plugin is disabled for the context', async () => {
+    let executed = false
+    const textCalls: string[] = []
+    const manifest = makeManifest({
+      contributes: {
+        tools: [],
+        promptFragments: [],
+        commands: ['sync'],
+        jobs: [],
+        configKeys: [],
+        taskProviderTypes: [],
+      },
+    })
+    markPluginActive(manifest)
+    contributionRegistry.register(
+      'test-plugin',
+      {
+        tools: [],
+        promptFragments: [],
+        commands: [
+          {
+            name: 'sync',
+            description: 'Sync plugin data',
+            execute: (): void => {
+              executed = true
+            },
+          },
+        ],
+        jobs: [],
+      },
+      manifest,
+    )
+    setPluginEnabledForContext('test-plugin', 'user-1', false)
+    const { provider, commandHandlers } = createMockChatWithCommandHandlers()
+
+    registerPluginCommands(provider)
+    await commandHandlers.get('plugin_test_plugin_sync')!(
+      createDmMessage('user-1'),
+      {
+        text: (text) => {
+          textCalls.push(text)
+          return Promise.resolve()
+        },
+        formatted: () => Promise.resolve(),
+        typing: () => {},
+        buttons: () => Promise.resolve(),
+      },
+      createAuth('user-1'),
+    )
+
+    expect(executed).toBe(false)
+    expect(textCalls[0]).toContain('disabled')
   })
 
   test('runs scheduled jobs only for explicitly enabled plugin contexts', async () => {

--- a/tests/plugins/integration.test.ts
+++ b/tests/plugins/integration.test.ts
@@ -123,7 +123,9 @@ describe('plugin lifecycle integration', () => {
 
     pluginRegistry.registerDiscovered(plugin)
     pluginRegistry.approve(plugin.manifest.id, 'admin-user', plugin.manifestHash)
-    pluginRegistry.evaluateCompatibility(plugin.manifest.id, provider.capabilities, new Set())
+    pluginRegistry.evaluateCompatibilityAcrossInstances([
+      { taskCapabilities: provider.capabilities, chatCapabilities: new Set() },
+    ])
     await activatePlugins(pluginRegistry.getApprovedCompatiblePlugins())
     setPluginEnabledForContext(plugin.manifest.id, 'ctx-enabled', true)
 
@@ -186,7 +188,9 @@ describe('plugin lifecycle integration', () => {
     const plugin = discoverSinglePlugin(rootDir)
     pluginRegistry.registerDiscovered(plugin)
     pluginRegistry.approve(plugin.manifest.id, 'admin-user', plugin.manifestHash)
-    pluginRegistry.evaluateCompatibility(plugin.manifest.id, provider.capabilities, new Set())
+    pluginRegistry.evaluateCompatibilityAcrossInstances([
+      { taskCapabilities: provider.capabilities, chatCapabilities: new Set() },
+    ])
 
     await activatePlugins(pluginRegistry.getApprovedCompatiblePlugins())
 

--- a/tests/plugins/loader.test.ts
+++ b/tests/plugins/loader.test.ts
@@ -8,6 +8,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 
+import { getTaskInstance, insertTaskInstance } from '../../src/instances/task-store.js'
 import { contributionRegistry } from '../../src/plugins/contributions.js'
 import { activatePlugins, deactivateAllPlugins, getActivatedPluginIds } from '../../src/plugins/loader.js'
 import { pluginRegistry } from '../../src/plugins/registry.js'
@@ -301,5 +302,35 @@ describe('activatePlugins', () => {
 
     await deactivateAllPlugins()
     expect(getContributedTaskProviderType('demo')).toBeUndefined()
+  })
+
+  test('stops active task instances that depend on a deactivated contributed provider type', async () => {
+    const entryPoint = writeTempPluginModule(`
+      export default function createPlugin() {
+        return {
+          activate(ctx) {
+            ctx.registration.registerTaskProviderType('demo-stop', { factory: () => ({}) })
+          },
+        }
+      }
+    `)
+    const plugin = makePlugin('provider-stop-plugin', entryPoint, {
+      permissions: ['provider.task'],
+      contributes: {
+        tools: [],
+        promptFragments: [],
+        commands: [],
+        jobs: [],
+        configKeys: [],
+        taskProviderTypes: ['demo-stop'],
+      },
+    })
+    approvePlugin(plugin)
+    insertTaskInstance({ id: 'demo-stop-instance', type: 'demo-stop', config: {}, status: 'active' })
+
+    await activatePlugins([plugin])
+    await deactivateAllPlugins()
+
+    expect(getTaskInstance('demo-stop-instance')?.status).toBe('stopped')
   })
 })

--- a/tests/plugins/loader.test.ts
+++ b/tests/plugins/loader.test.ts
@@ -304,7 +304,7 @@ describe('activatePlugins', () => {
     expect(getContributedTaskProviderType('demo')).toBeUndefined()
   })
 
-  test('stops active task instances that depend on a deactivated contributed provider type', async () => {
+  test('keeps active task instances when plugin runtime shuts down normally', async () => {
     const entryPoint = writeTempPluginModule(`
       export default function createPlugin() {
         return {
@@ -331,6 +331,36 @@ describe('activatePlugins', () => {
     await activatePlugins([plugin])
     await deactivateAllPlugins()
 
-    expect(getTaskInstance('demo-stop-instance')?.status).toBe('stopped')
+    expect(getTaskInstance('demo-stop-instance')?.status).toBe('active')
+  })
+
+  test('stops active task instances when contributed provider type is retired', async () => {
+    const entryPoint = writeTempPluginModule(`
+      export default function createPlugin() {
+        return {
+          activate(ctx) {
+            ctx.registration.registerTaskProviderType('demo-retire', { factory: () => ({}) })
+          },
+        }
+      }
+    `)
+    const plugin = makePlugin('provider-retire-plugin', entryPoint, {
+      permissions: ['provider.task'],
+      contributes: {
+        tools: [],
+        promptFragments: [],
+        commands: [],
+        jobs: [],
+        configKeys: [],
+        taskProviderTypes: ['demo-retire'],
+      },
+    })
+    approvePlugin(plugin)
+    insertTaskInstance({ id: 'demo-retire-instance', type: 'demo-retire', config: {}, status: 'active' })
+
+    await activatePlugins([plugin])
+    await deactivateAllPlugins({ retireContributedProviders: true })
+
+    expect(getTaskInstance('demo-retire-instance')?.status).toBe('stopped')
   })
 })

--- a/tests/plugins/provider-runtime.test.ts
+++ b/tests/plugins/provider-runtime.test.ts
@@ -141,7 +141,9 @@ describe('buildProviderRuntime.httpFetch', () => {
     const addToSet = Reflect.get(Set.prototype, 'add')
     Reflect.apply(addToSet, runtime.allowedHosts, ['evil.example'])
 
-    await expect(runtime.httpFetch('https://evil.example/data')).rejects.toThrow('Host evil.example is not allowed')
+    await expect(runtime.httpFetch('https://evil.example/data')).rejects.toThrow(
+      "Host 'evil.example' is not in the plugin providerAllowedHosts allowlist",
+    )
   })
 
   test('fetch receives an AbortSignal even when caller provides no init', async () => {

--- a/tests/plugins/provider-runtime.test.ts
+++ b/tests/plugins/provider-runtime.test.ts
@@ -133,6 +133,17 @@ describe('buildProviderRuntime.httpFetch', () => {
     expect(runtime.allowedHosts.has('evil.example.com')).toBe(false)
   })
 
+  test('mutating exposed allowedHosts does not affect httpFetch enforcement', async () => {
+    const runtime = buildProviderRuntime(['allowed.example'], makeLogger(), {
+      fetch: () => Promise.resolve(new Response('ok')),
+      assertPublicUrl: () => Promise.resolve(),
+    })
+    const addToSet = Reflect.get(Set.prototype, 'add')
+    Reflect.apply(addToSet, runtime.allowedHosts, ['evil.example'])
+
+    await expect(runtime.httpFetch('https://evil.example/data')).rejects.toThrow('Host evil.example is not allowed')
+  })
+
   test('fetch receives an AbortSignal even when caller provides no init', async () => {
     mockLogger()
     const capturedSignals: Array<AbortSignal | null | undefined> = []

--- a/tests/plugins/registry-context-eligibility.test.ts
+++ b/tests/plugins/registry-context-eligibility.test.ts
@@ -6,12 +6,15 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
 
 import { setPluginConfig } from '../../src/config.js'
+import { setContextSettings } from '../../src/instances/context-store.js'
+import { insertTaskInstance } from '../../src/instances/task-store.js'
 import { getPluginContextEligibilityForEntry } from '../../src/plugins/registry-context-eligibility.js'
+import { getPluginContextEligibility, pluginRegistry } from '../../src/plugins/registry.js'
 import type { PluginRegistryEntry } from '../../src/plugins/registry.js'
 import { setPluginAdminConfig } from '../../src/plugins/store.js'
 import type { DiscoveredPlugin } from '../../src/plugins/types.js'
 import { PLUGIN_API_VERSION } from '../../src/plugins/types.js'
-import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+import { mockLogger, seedTestPlatformInstance, setupTestDb } from '../utils/test-helpers.js'
 
 function makePlugin(overrides?: Partial<DiscoveredPlugin>): DiscoveredPlugin {
   return {
@@ -103,5 +106,33 @@ describe('admin-scoped config eligibility', () => {
 
     const result = getPluginContextEligibilityForEntry(makeActiveEntry(plugin), 'test-plugin', 'ctx-1')
     expect(result).toEqual({ eligible: true })
+  })
+
+  test('returns capability_missing instead of throwing when assigned task provider type is unknown', () => {
+    const pluginId = 'unknown-provider-eligibility-plugin'
+    const contextId = 'ctx-unknown-provider'
+    const plugin = makePlugin({
+      manifest: {
+        ...makePlugin().manifest,
+        id: pluginId,
+        name: 'Unknown Provider Eligibility Plugin',
+        defaultEnabled: true,
+        requiredTaskCapabilities: ['workItems.list'],
+      },
+      manifestHash: 'hash-unknown-provider-eligibility',
+    })
+    insertTaskInstance({ id: 'ghost-task', type: 'ghost-provider', config: {}, status: 'active' })
+    seedTestPlatformInstance({ id: 'telegram-a' })
+    setContextSettings({ contextId, taskInstanceId: 'ghost-task', platformInstanceId: 'telegram-a' })
+
+    pluginRegistry.registerDiscovered(plugin)
+    pluginRegistry.approve(pluginId, 'admin', 'hash-unknown-provider-eligibility')
+    pluginRegistry.markActive(pluginId)
+
+    expect(getPluginContextEligibility(pluginId, contextId)).toEqual({
+      eligible: false,
+      reason: 'capability_missing',
+      missingCapabilities: ['workItems.list'],
+    })
   })
 })

--- a/tests/plugins/registry.test.ts
+++ b/tests/plugins/registry.test.ts
@@ -187,23 +187,25 @@ describe('PluginRegistry', () => {
     expectEntryState(registry, 'test-plugin', 'approved')
   })
 
-  test('evaluateCompatibility marks incompatible when capability missing', () => {
+  test('evaluateCompatibilityAcrossInstances marks incompatible when capability missing', () => {
     const plugin = makePlugin({
       manifest: { ...makePlugin().manifest, requiredTaskCapabilities: ['tasks.delete'] },
     })
     registry.registerDiscovered(plugin)
     registry.approve('test-plugin', 'admin', 'hash-abc')
-    registry.evaluateCompatibility('test-plugin', new Set(), new Set())
+    registry.evaluateCompatibilityAcrossInstances([{ taskCapabilities: new Set(), chatCapabilities: new Set() }])
     expectEntryState(registry, 'test-plugin', 'incompatible')
   })
 
-  test('evaluateCompatibility leaves compatible plugin as approved', () => {
+  test('evaluateCompatibilityAcrossInstances leaves compatible plugin as approved', () => {
     const plugin = makePlugin({
       manifest: { ...makePlugin().manifest, requiredTaskCapabilities: ['tasks.delete'] },
     })
     registry.registerDiscovered(plugin)
     registry.approve('test-plugin', 'admin', 'hash-abc')
-    registry.evaluateCompatibility('test-plugin', new Set(['tasks.delete']), new Set())
+    registry.evaluateCompatibilityAcrossInstances([
+      { taskCapabilities: new Set(['tasks.delete']), chatCapabilities: new Set() },
+    ])
     expectEntryState(registry, 'test-plugin', 'approved')
   })
 
@@ -312,12 +314,14 @@ describe('PluginRegistry', () => {
     })
     registry.registerDiscovered(plugin)
     registry.approve('test-plugin', 'admin', 'hash-abc')
-    registry.evaluateCompatibility('test-plugin', new Set(), new Set())
+    registry.evaluateCompatibilityAcrossInstances([{ taskCapabilities: new Set(), chatCapabilities: new Set() }])
     expectEntryState(registry, 'test-plugin', 'incompatible')
 
     const restartedRegistry = new PluginRegistry()
     restartedRegistry.registerDiscovered(plugin)
-    restartedRegistry.evaluateCompatibility('test-plugin', new Set(['tasks.delete']), new Set())
+    restartedRegistry.evaluateCompatibilityAcrossInstances([
+      { taskCapabilities: new Set(['tasks.delete']), chatCapabilities: new Set() },
+    ])
 
     expectEntryState(restartedRegistry, 'test-plugin', 'approved')
     expect(restartedRegistry.getApprovedCompatiblePlugins()).toHaveLength(1)

--- a/tests/plugins/startup-compatibility.test.ts
+++ b/tests/plugins/startup-compatibility.test.ts
@@ -61,6 +61,18 @@ describe('startup plugin compatibility collection', () => {
     expect(entry.chatCapabilities.has('messages.buttons')).toBe(true)
   })
 
+  test('includes chat capabilities from configured platform instances before router startup', () => {
+    const router = new ChatRouter(
+      (): ChatProvider => createMockChat({ capabilities: new Set<ChatCapability>(['messages.buttons']) }),
+    )
+    router.addInstance('telegram-a', 'telegram', { token: 'x' })
+
+    const result = collectStartupCompatibilityInstances(router, [], [platformInstance('telegram-a', 'active')])
+
+    expect(result).toHaveLength(1)
+    expect(singleCompatibilityEntry(result).chatCapabilities.has('messages.buttons')).toBe(true)
+  })
+
   test('builds a Cartesian product of active task and chat capability sets', async () => {
     const chatCapabilities: Record<string, Set<ChatCapability>> = {
       'discord-a': new Set<ChatCapability>(['users.resolve']),

--- a/tests/plugins/startup-compatibility.test.ts
+++ b/tests/plugins/startup-compatibility.test.ts
@@ -108,4 +108,20 @@ describe('startup plugin compatibility collection', () => {
     expect(entry.taskCapabilities.size).toBe(0)
     expect(entry.chatCapabilities.size).toBe(0)
   })
+
+  test('skips unknown task provider types while collecting startup compatibility', () => {
+    const router = new ChatRouter(() => createMockChat())
+    router.addInstance('telegram-a', 'telegram', { token: 'x' })
+
+    const instances = collectStartupCompatibilityInstances(
+      router,
+      [
+        { id: 'ghost-task', type: 'ghost-provider', config: {}, status: 'active', createdAt: new Date().toISOString() },
+        { id: 'kaneo-a', type: 'kaneo', config: {}, status: 'active', createdAt: new Date().toISOString() },
+      ],
+      [{ id: 'telegram-a', type: 'telegram', config: {}, status: 'active', createdAt: new Date().toISOString() }],
+    )
+
+    expect(instances.length).toBeGreaterThan(0)
+  })
 })

--- a/tests/plugins/tool-runtime.test.ts
+++ b/tests/plugins/tool-runtime.test.ts
@@ -91,6 +91,7 @@ describe('buildPluginToolRuntimeContext', () => {
     )
 
     expect(runtime.identity).toBeDefined()
+    expect(runtime).toHaveProperty('identity')
     expect(runtime.identity?.lookupForChatUser('chat-user-1')).toBeNull()
   })
 
@@ -113,5 +114,50 @@ describe('buildPluginToolRuntimeContext', () => {
     )
 
     expect(runtime.identity).toBeUndefined()
+    expect(runtime).not.toHaveProperty('identity')
+  })
+
+  test('tool runtime omits identity facade when plugin contributes no provider types', () => {
+    const runtime = buildPluginToolRuntimeContext(
+      'no-provider-plugin',
+      {
+        ...makeManifest(),
+        permissions: ['identity'],
+        contributes: {
+          tools: [],
+          promptFragments: [],
+          commands: [],
+          jobs: [],
+          configKeys: [],
+          taskProviderTypes: [],
+        },
+      },
+      { provider: createMockProvider(), storageContextId: 'ctx-1', chatUserId: 'chat-user-1' },
+    )
+
+    expect(runtime.identity).toBeUndefined()
+    expect(runtime).not.toHaveProperty('identity')
+  })
+
+  test('tool runtime omits identity facade when plugin contributes multiple provider types', () => {
+    const runtime = buildPluginToolRuntimeContext(
+      'multi-provider-plugin',
+      {
+        ...makeManifest(),
+        permissions: ['identity'],
+        contributes: {
+          tools: [],
+          promptFragments: [],
+          commands: [],
+          jobs: [],
+          configKeys: [],
+          taskProviderTypes: ['identity-provider-a', 'identity-provider-b'],
+        },
+      } as PluginManifest,
+      { provider: createMockProvider(), storageContextId: 'ctx-1', chatUserId: 'chat-user-1' },
+    )
+
+    expect(runtime.identity).toBeUndefined()
+    expect(runtime).not.toHaveProperty('identity')
   })
 })

--- a/tests/plugins/tool-runtime.test.ts
+++ b/tests/plugins/tool-runtime.test.ts
@@ -71,4 +71,47 @@ describe('buildPluginToolRuntimeContext', () => {
       expect(lastResult.retryAfterSec!).toBeGreaterThan(0)
     })
   })
+
+  test('tool runtime exposes identity facade for identity provider plugins', () => {
+    const runtime = buildPluginToolRuntimeContext(
+      'identity-plugin',
+      {
+        ...makeManifest(),
+        permissions: ['identity'],
+        contributes: {
+          tools: [],
+          promptFragments: [],
+          commands: [],
+          jobs: [],
+          configKeys: [],
+          taskProviderTypes: ['identity-provider'],
+        },
+      },
+      { provider: createMockProvider(), storageContextId: 'ctx-1', chatUserId: 'chat-user-1' },
+    )
+
+    expect(runtime.identity).toBeDefined()
+    expect(runtime.identity?.lookupForChatUser('chat-user-1')).toBeNull()
+  })
+
+  test('tool runtime omits identity facade when plugin lacks identity permission', () => {
+    const runtime = buildPluginToolRuntimeContext(
+      'no-identity-plugin',
+      {
+        ...makeManifest(),
+        permissions: [],
+        contributes: {
+          tools: [],
+          promptFragments: [],
+          commands: [],
+          jobs: [],
+          configKeys: [],
+          taskProviderTypes: ['identity-provider'],
+        },
+      },
+      { provider: createMockProvider(), storageContextId: 'ctx-1', chatUserId: 'chat-user-1' },
+    )
+
+    expect(runtime.identity).toBeUndefined()
+  })
 })

--- a/tests/providers/resolver.test.ts
+++ b/tests/providers/resolver.test.ts
@@ -74,6 +74,19 @@ describe('TaskProviderResolver', () => {
     expect(created).toEqual([])
   })
 
+  test('returns null when assigned task instance type is not registered', () => {
+    insertTaskInstance({ id: 'missing-provider', type: 'ghost-provider', config: {}, status: 'active' })
+    setContextSettings({
+      contextId: 'ctx-plugin-gone',
+      taskInstanceId: 'missing-provider',
+      platformInstanceId: 'telegram-default',
+    })
+
+    const resolver = new TaskProviderResolver()
+
+    expect(resolver.resolve('ctx-plugin-gone')).toBeNull()
+  })
+
   test('builds a YouTrack provider from instance URL and per-context token', () => {
     insertTaskInstance({ id: 'yt-prod', type: 'youtrack', config: { url: 'https://yt.invalid' }, status: 'active' })
     setContextSettings({ contextId: 'ctx-1', taskInstanceId: 'yt-prod', platformInstanceId: 'telegram-default' })


### PR DESCRIPTION
## Summary
- Fail closed for unknown or deactivated contributed task providers and preserve provider-backed instances on normal shutdown.
- Gate plugin commands, scheduled jobs, prompt fragments, identity runtime, and interaction toggles through consistent eligibility/lifecycle handling.
- Remove stale compatibility API and refresh plugin provider/identity documentation.

## Test Plan
- bun test tests/plugins
- bun test tests/providers/resolver.test.ts tests/chat/plugin-interaction-handler.test.ts tests/chat/tool-toggle-interaction-handler.test.ts tests/commands/plugin.test.ts tests/bot.test.ts
- bun typecheck
- bun lint
- bun format:check
- bun check:full