### PR TITLE
feat: align Telegram command menus and Mattermost command syntax

### DIFF
--- a/.claude/hooks/doc-review-stop.mjs
+++ b/.claude/hooks/doc-review-stop.mjs
@@ -1,0 +1,40 @@
+import fs from 'node:fs'
+
+import { buildDocReviewPrompt } from '../../.hooks/docs/build-doc-review-prompt.mjs'
+import { mapFilesToDocs } from '../../.hooks/docs/map-files-to-docs.mjs'
+import { getSessionsDir } from '../../.hooks/tdd/paths.mjs'
+import { SessionState } from '../../.hooks/tdd/session-state.mjs'
+
+try {
+  const ctx = JSON.parse(fs.readFileSync('/dev/stdin', 'utf8'))
+  const { session_id, cwd } = ctx
+
+  const state = new SessionState(session_id, getSessionsDir(cwd))
+  const changedFiles = state.getChangedSourceFiles()
+
+  if (changedFiles.length === 0) {
+    process.exit(0)
+  }
+
+  if (state.getDocReviewSuggested()) {
+    process.exit(0)
+  }
+
+  const docPaths = mapFilesToDocs(changedFiles)
+  const prompt = buildDocReviewPrompt(changedFiles, docPaths)
+
+  state.setDocReviewSuggested(true)
+
+  console.log(JSON.stringify({ decision: 'block', reason: prompt }))
+  process.exit(1)
+} catch (err) {
+  console.error(
+    JSON.stringify({
+      level: 'error',
+      msg: 'Doc review stop hook failed',
+      error: err instanceof Error ? err.message : String(err),
+    }),
+  )
+}
+
+process.exit(0)

--- a/.claude/hooks/pre-tool-use.mjs
+++ b/.claude/hooks/pre-tool-use.mjs
@@ -38,6 +38,15 @@ try {
 
   const state = new SessionState(ctx.session_id, getSessionsDir(ctx.cwd))
   state.setNeedsRecheck(true)
+
+  // Track source file changes for doc review
+  const filePath = ctx.tool_input?.file_path
+  if (filePath) {
+    const { trackSourceWrite } = await import('../../.hooks/docs/track-source-write.mjs')
+    if (trackSourceWrite(filePath)) {
+      state.addChangedSourceFile(filePath)
+    }
+  }
 } catch (err) {
   console.error(
     JSON.stringify({

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,6 +46,17 @@
             "statusMessage": "Running full check..."
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/doc-review-stop.mjs",
+            "timeout": 200,
+            "statusMessage": "Checking doc review..."
+          }
+        ]
       }
     ]
   }

--- a/.hooks/docs/build-doc-review-prompt.mjs
+++ b/.hooks/docs/build-doc-review-prompt.mjs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+/**
+ * Build a suggestion prompt for doc review after source file changes.
+ * @param {string[]} changedFiles - Relative paths of changed source files
+ * @param {string[]} docPaths - Doc file paths to suggest reviewing
+ * @returns {string} Formatted suggestion prompt
+ */
+export function buildDocReviewPrompt(changedFiles, docPaths) {
+  const fileList = changedFiles.map((f) => `- ${f}`).join('\n')
+  const docList = docPaths.map((d) => `- ${d}`).join('\n')
+
+  return [
+    'The following source files were changed this session:',
+    '',
+    fileList,
+    '',
+    'These documentation files may need updating to reflect the changes:',
+    '',
+    docList,
+    '',
+    'Please review and update if needed. If no updates are required, you can ignore this.',
+  ].join('\n')
+}

--- a/.hooks/docs/map-files-to-docs.mjs
+++ b/.hooks/docs/map-files-to-docs.mjs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import path from 'node:path'
+
+// Directories that have a CLAUDE.md file
+const DOCS_DIRS = ['src/tools', 'src/chat', 'src/providers', 'src/commands', 'src/instances']
+
+/**
+ * Map changed source file paths to their nearest relevant documentation files.
+ * @param {string[]} changedFiles - Relative paths of changed source files
+ * @returns {string[]} Deduplicated list of doc file paths to review
+ */
+export function mapFilesToDocs(changedFiles) {
+  if (changedFiles.length === 0) return []
+
+  const docs = new Set()
+  docs.add('CLAUDE.md')
+  docs.add('README.md')
+
+  for (const file of changedFiles) {
+    const dir = path.dirname(file)
+    let current = dir
+    while (current && current !== '.') {
+      const candidate = path.join(current, 'CLAUDE.md')
+      if (DOCS_DIRS.includes(current)) {
+        docs.add(candidate)
+        break
+      }
+      current = path.dirname(current)
+    }
+  }
+
+  return [...docs]
+}

--- a/.hooks/docs/map-files-to-docs.mjs
+++ b/.hooks/docs/map-files-to-docs.mjs
@@ -6,7 +6,7 @@
 import path from 'node:path'
 
 // Directories that have a CLAUDE.md file
-const DOCS_DIRS = ['src/tools', 'src/chat', 'src/providers', 'src/commands', 'src/instances']
+const DOCS_DIRS = ['src/tools', 'src/chat', 'src/providers', 'src/commands']
 
 /**
  * Map changed source file paths to their nearest relevant documentation files.

--- a/.hooks/docs/track-source-write.mjs
+++ b/.hooks/docs/track-source-write.mjs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+/** @type {string[]} */
+export const TRACKED_PREFIXES = ['src/', 'client/', 'plugins/', 'scripts/']
+
+/**
+ * Check if a file path should be tracked for doc review.
+ * Returns true if the path starts with a tracked prefix.
+ * @param {string | null | undefined} filePath - Relative file path
+ * @returns {boolean}
+ */
+export function trackSourceWrite(filePath) {
+  if (!filePath) return false
+  return TRACKED_PREFIXES.some((prefix) => filePath.startsWith(prefix))
+}

--- a/.hooks/tdd/session-state.mjs
+++ b/.hooks/tdd/session-state.mjs
@@ -49,6 +49,8 @@ const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000 // 1 week
  * @property {Map<string, SurfaceSnapshot>} surfaceSnapshots
  * @property {Map<string, MutationSnapshot>} mutationSnapshots
  * @property {Record<string, Array<{ mutator: string; replacement: string; line?: number; description: string }>> | null} sessionMutationBaseline
+ * @property {string[]} changedSourceFiles
+ * @property {boolean} docReviewSuggested
  */
 
 /**
@@ -100,6 +102,8 @@ export class SessionState {
       mutationSnapshots: new Map(),
       sessionMutationBaseline: null,
       needsRecheck: true,
+      changedSourceFiles: [],
+      docReviewSuggested: false,
     }
   }
 
@@ -172,6 +176,46 @@ export class SessionState {
   setNeedsRecheck(value) {
     this.#ensureLoaded()
     this.#state.needsRecheck = value
+    this.#persist()
+  }
+
+  // Changed source files and doc review
+
+  /**
+   * @returns {string[]}
+   */
+  getChangedSourceFiles() {
+    this.#ensureLoaded()
+    return this.#state.changedSourceFiles
+  }
+
+  /**
+   * @param {string} filePath
+   * @returns {void}
+   */
+  addChangedSourceFile(filePath) {
+    this.#ensureLoaded()
+    if (!this.#state.changedSourceFiles.includes(filePath)) {
+      this.#state.changedSourceFiles.push(filePath)
+      this.#persist()
+    }
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  getDocReviewSuggested() {
+    this.#ensureLoaded()
+    return this.#state.docReviewSuggested
+  }
+
+  /**
+   * @param {boolean} value
+   * @returns {void}
+   */
+  setDocReviewSuggested(value) {
+    this.#ensureLoaded()
+    this.#state.docReviewSuggested = value
     this.#persist()
   }
 

--- a/.opencode/plugins/doc-review.ts
+++ b/.opencode/plugins/doc-review.ts
@@ -1,0 +1,52 @@
+import type { Plugin } from '@opencode-ai/plugin'
+
+import { buildDocReviewPrompt } from '../../.hooks/docs/build-doc-review-prompt.mjs'
+import { mapFilesToDocs } from '../../.hooks/docs/map-files-to-docs.mjs'
+import { trackSourceWrite } from '../../.hooks/docs/track-source-write.mjs'
+import { getSessionsDir } from '../../.hooks/tdd/paths.mjs'
+import { SessionState } from '../../.hooks/tdd/session-state.mjs'
+
+const EDIT_TOOLS = new Set(['write', 'edit', 'multiedit'])
+
+export const DocReview: Plugin = async ({ client, directory }) => {
+  let currentSessionID = ''
+
+  return {
+    'tool.execute.after': async (input) => {
+      currentSessionID = input.sessionID
+
+      if (!EDIT_TOOLS.has(input.tool)) return
+
+      const filePath = input.args['filePath'] as string
+      if (!filePath) return
+
+      if (!trackSourceWrite(filePath)) return
+
+      const state = new SessionState(input.sessionID, getSessionsDir(directory))
+      state.addChangedSourceFile(filePath)
+    },
+
+    'session.idle': async () => {
+      const sessionID = currentSessionID
+      if (!sessionID) return
+
+      const state = new SessionState(sessionID, getSessionsDir(directory))
+      if (state.getDocReviewSuggested()) return
+
+      const changedFiles = state.getChangedSourceFiles()
+      if (changedFiles.length === 0) return
+
+      const docPaths = mapFilesToDocs(changedFiles)
+      const prompt = buildDocReviewPrompt(changedFiles, docPaths)
+
+      state.setDocReviewSuggested(true)
+
+      void client.session.promptAsync({
+        path: { id: sessionID },
+        body: {
+          parts: [{ type: 'text', text: prompt }],
+        },
+      })
+    },
+  }
+}

--- a/.opencode/plugins/tdd-enforcement.ts
+++ b/.opencode/plugins/tdd-enforcement.ts
@@ -97,6 +97,13 @@ export const TddEnforcement: Plugin = async ({ client, directory }) => {
       // [4] trackTestWrite - Record test files written this session
       trackTestWrite(ctx)
 
+      // Track source file changes for doc review
+      const { trackSourceWrite } = await import('../../.hooks/docs/track-source-write.mjs')
+      if (trackSourceWrite(filePath)) {
+        const state = new SessionState(input.sessionID, getSessionsDir(directory))
+        state.addChangedSourceFile(filePath)
+      }
+
       // [5] verifyTestImport - Verify test files import their implementation module
       const importResult = verifyTestImport(ctx)
       if (importResult) {

--- a/.opencode/plugins/tdd-enforcement.ts
+++ b/.opencode/plugins/tdd-enforcement.ts
@@ -97,13 +97,6 @@ export const TddEnforcement: Plugin = async ({ client, directory }) => {
       // [4] trackTestWrite - Record test files written this session
       trackTestWrite(ctx)
 
-      // Track source file changes for doc review
-      const { trackSourceWrite } = await import('../../.hooks/docs/track-source-write.mjs')
-      if (trackSourceWrite(filePath)) {
-        const state = new SessionState(input.sessionID, getSessionsDir(directory))
-        state.addChangedSourceFile(filePath)
-      }
-
       // [5] verifyTestImport - Verify test files import their implementation module
       const importResult = verifyTestImport(ctx)
       if (importResult) {

--- a/docs/superpowers/plans/2026-05-28-mattermost-mention-command-syntax.md
+++ b/docs/superpowers/plans/2026-05-28-mattermost-mention-command-syntax.md
@@ -1,0 +1,374 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mattermost Mention-Prefixed Command Syntax Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Change Mattermost command recognition so papai only accepts mention-prefixed commands of the form `@papai /command`, removes bare `/command` handling, and preserves mention-based natural-language behavior.
+
+**Architecture:** Keep command handlers untouched and localize the behavior change to `MattermostChatProvider`. Add a normalization/classification helper in the provider path so command routing depends on a leading mention followed by slash-like command text, while ordinary mention-addressed natural language still reaches the main message flow.
+
+**Tech Stack:** TypeScript, Bun test runner, Mattermost WebSocket event mapping, existing provider tests in `tests/chat/mattermost/index.test.ts`
+
+---
+
+### Task 1: Lock In The New Mattermost Syntax With Provider Tests
+
+**Files:**
+
+- Modify: `tests/chat/mattermost/index.test.ts`
+- Test: `tests/chat/mattermost/index.test.ts`
+
+- [ ] **Step 1: Add a failing test for mention-prefixed command routing**
+
+```typescript
+test('routes @mention-prefixed slash text to the registered command handler', async () => {
+  setMockFetch(makeFetchWithGroupChannel('O'))
+
+  provider = new MattermostChatProvider()
+  // @ts-expect-error testing private state setup
+  provider.botUsername = 'testbot'
+
+  let commandCalled = false
+  provider.registerCommand('config', () => {
+    commandCalled = true
+    return Promise.resolve()
+  })
+
+  const handlePostedEvent = getPostedEventHandler(provider)
+
+  await handlePostedEvent.call(provider, {
+    sender_name: 'testuser',
+    post: JSON.stringify({
+      id: 'post123',
+      user_id: 'user456',
+      channel_id: 'channel789',
+      message: '@testbot /config',
+      root_id: '',
+      parent_id: '',
+    }),
+  })
+
+  expect(commandCalled).toBe(true)
+
+  restoreFetch()
+})
+```
+
+- [ ] **Step 2: Add a failing test proving bare `/command` no longer routes**
+
+```typescript
+test('does not route bare slash text to papai command handlers', async () => {
+  setMockFetch(makeFetchWithGroupChannel('O'))
+
+  provider = new MattermostChatProvider()
+
+  let commandCalled = false
+  provider.registerCommand('config', () => {
+    commandCalled = true
+    return Promise.resolve()
+  })
+
+  const handlePostedEvent = getPostedEventHandler(provider)
+
+  await handlePostedEvent.call(provider, {
+    sender_name: 'testuser',
+    post: JSON.stringify({
+      id: 'post123',
+      user_id: 'user456',
+      channel_id: 'channel789',
+      message: '/config',
+      root_id: '',
+      parent_id: '',
+    }),
+  })
+
+  expect(commandCalled).toBe(false)
+
+  restoreFetch()
+})
+```
+
+- [ ] **Step 3: Add a failing test for mention-prefixed natural language**
+
+```typescript
+test('keeps mention-prefixed natural language on the message flow', async () => {
+  setMockFetch(makeFetchWithGroupChannel('O'))
+
+  provider = new MattermostChatProvider()
+  // @ts-expect-error testing private state setup
+  provider.botUsername = 'testbot'
+
+  let seen: IncomingMessage | null = null
+  provider.onMessage(async (msg) => {
+    seen = msg
+  })
+
+  const handlePostedEvent = getPostedEventHandler(provider)
+
+  await handlePostedEvent.call(provider, {
+    sender_name: 'testuser',
+    post: JSON.stringify({
+      id: 'post123',
+      user_id: 'user456',
+      channel_id: 'channel789',
+      message: '@testbot summarize this thread',
+      root_id: '',
+      parent_id: '',
+    }),
+  })
+
+  expect(seen).not.toBeNull()
+  expect(seen?.isMentioned).toBe(true)
+  expect(seen?.text).toBe('summarize this thread')
+  expect(seen?.commandMatch).toBeUndefined()
+
+  restoreFetch()
+})
+```
+
+- [ ] **Step 4: Run the focused Mattermost provider tests and confirm failure**
+
+Run: `bun test tests/chat/mattermost/index.test.ts`
+
+Expected: FAIL because the provider still matches bare `/command` and does not normalize mention-prefixed command text.
+
+- [ ] **Step 5: Commit the failing test additions**
+
+```bash
+git add tests/chat/mattermost/index.test.ts
+git commit -m "test(mattermost): cover mention-prefixed command syntax"
+```
+
+### Task 2: Normalize Mention-Prefixed Mattermost Messages Before Command Matching
+
+**Files:**
+
+- Modify: `src/chat/mattermost/index.ts`
+- Test: `tests/chat/mattermost/index.test.ts`
+
+- [ ] **Step 1: Add a small normalization helper inside the Mattermost provider module**
+
+```typescript
+type NormalizedMattermostText = {
+  readonly text: string
+  readonly isMentioned: boolean
+  readonly commandInput: string | null
+}
+
+function normalizeMattermostMessageText(message: string, botUsername: string | null): NormalizedMattermostText {
+  const trimmed = message.trim()
+
+  if (botUsername === null) {
+    return { text: trimmed, isMentioned: false, commandInput: null }
+  }
+
+  const mentionPrefix = `@${botUsername}`
+  if (!trimmed.startsWith(mentionPrefix)) {
+    return { text: trimmed, isMentioned: false, commandInput: null }
+  }
+
+  const remainder = trimmed.slice(mentionPrefix.length).trim()
+  return {
+    text: remainder,
+    isMentioned: true,
+    commandInput: remainder.startsWith('/') ? remainder : null,
+  }
+}
+```
+
+- [ ] **Step 2: Use the normalization helper in `buildPostedMessage()` before command matching**
+
+```typescript
+const normalized = normalizeMattermostMessageText(post.message, this.botUsername)
+const isMentioned = normalized.isMentioned
+const threadId = this.determineThreadId(post, isMentioned, contextType, replyToMessageId)
+const reply = this.buildReplyFn(post.channel_id, post.id, threadId)
+const command = normalized.commandInput === null ? null : this.matchCommand(normalized.commandInput)
+
+const msg: IncomingMessage = {
+  user: { id: post.user_id, username, isAdmin },
+  contextId: post.channel_id,
+  contextType,
+  contextName,
+  contextParentName,
+  isMentioned,
+  text: normalized.text,
+  platformInstanceId: this.platformInstanceId,
+  commandMatch: command === null ? undefined : command.match,
+  messageId: post.id,
+  replyToMessageId,
+  replyContext,
+  threadId,
+  ...(files ? { files } : {}),
+  ...(fileCandidates ? { fileCandidates } : {}),
+}
+```
+
+- [ ] **Step 3: Restrict `matchCommand()` to already-normalized slash input**
+
+```typescript
+private matchCommand(text: string): { handler: CommandHandler; match: string } | null {
+  const trimmed = text.trim()
+  if (!trimmed.startsWith('/')) return null
+
+  for (const [name, handler] of this.commands) {
+    if (trimmed === `/${name}` || trimmed.startsWith(`/${name} `)) {
+      return {
+        handler,
+        match: trimmed.slice(name.length + 1).trim(),
+      }
+    }
+  }
+
+  return null
+}
+```
+
+- [ ] **Step 4: Run the Mattermost provider test suite and confirm the new syntax passes**
+
+Run: `bun test tests/chat/mattermost/index.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit the normalization implementation**
+
+```bash
+git add src/chat/mattermost/index.ts tests/chat/mattermost/index.test.ts
+git commit -m "feat(mattermost): require mention-prefixed commands"
+```
+
+### Task 3: Add Guidance For Empty Mention-Only Messages
+
+**Files:**
+
+- Modify: `tests/chat/mattermost/index.test.ts`
+- Modify: `src/chat/mattermost/index.ts`
+- Test: `tests/chat/mattermost/index.test.ts`
+
+- [ ] **Step 1: Add a failing test for mention-only guidance**
+
+```typescript
+import { createMockReply } from '../../utils/test-helpers.js'
+
+test('replies with guidance when a message only mentions the bot', async () => {
+  setMockFetch(makeFetchWithGroupChannel('O'))
+
+  provider = new MattermostChatProvider()
+  // @ts-expect-error testing private state setup
+  provider.botUsername = 'testbot'
+
+  const replies = createMockReply()
+  provider.onMessage(async (_msg, reply) => {
+    await reply.text('should not be called')
+  })
+
+  // @ts-expect-error testing private method replacement
+  provider.buildReplyFn = () => replies.reply
+
+  const handlePostedEvent = getPostedEventHandler(provider)
+
+  await handlePostedEvent.call(provider, {
+    sender_name: 'testuser',
+    post: JSON.stringify({
+      id: 'post123',
+      user_id: 'user456',
+      channel_id: 'channel789',
+      message: '@testbot',
+      root_id: '',
+      parent_id: '',
+    }),
+  })
+
+  expect(replies.getReplies()).toEqual(['Use `@papai /help` to see commands, or mention me with a question.'])
+
+  restoreFetch()
+})
+```
+
+- [ ] **Step 2: Run the focused empty-mention test and confirm failure**
+
+Run: `bun test tests/chat/mattermost/index.test.ts --test-name-pattern "only mentions the bot"`
+
+Expected: FAIL because empty mention-only input still falls through the normal message path.
+
+- [ ] **Step 3: Handle mention-only empty input before normal message dispatch**
+
+```typescript
+private async handlePostedEvent(data: Record<string, unknown>): Promise<void> {
+  const parsed = parsePostedEvent(data)
+  if (parsed === null) return
+
+  const { post, senderName } = parsed
+  if (post.user_id === this.botUserId) return
+
+  const replyToMessageId = extractReplyId(post.parent_id, post.root_id)
+  cacheIncomingPost(post, replyToMessageId, senderName)
+  const { msg, reply, command, isAdmin } = await this.buildPostedMessage(post, senderName, replyToMessageId)
+
+  if (msg.isMentioned && msg.text === '') {
+    await reply.text('Use `@papai /help` to see commands, or mention me with a question.')
+    return
+  }
+
+  if (command !== null) {
+    const auth = buildScopedCommandAuth(msg, isAdmin, this.platformInstanceId)
+    await command.handler(msg, reply, auth)
+    return
+  }
+
+  if (this.messageHandler !== null) {
+    await this.messageHandler(msg, reply)
+  }
+}
+```
+
+- [ ] **Step 4: Run the Mattermost provider tests again and confirm they pass**
+
+Run: `bun test tests/chat/mattermost/index.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit the mention-only guidance behavior**
+
+```bash
+git add src/chat/mattermost/index.ts tests/chat/mattermost/index.test.ts
+git commit -m "feat(mattermost): guide mention-only messages"
+```
+
+### Task 4: Verify The Full Mattermost Behavior And Repo Checks
+
+**Files:**
+
+- Test: `tests/chat/mattermost/index.test.ts`
+- Test: `tests/bot.test.ts` (only if command flow regressions are discovered)
+
+- [ ] **Step 1: Run the focused Mattermost verification suite**
+
+Run: `bun test tests/chat/mattermost/index.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 2: Run strict lint on the touched source and test file**
+
+Run: `bun run lint:agent-strict -- src/chat/mattermost/index.ts tests/chat/mattermost/index.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 3: Run formatting check on the touched files**
+
+Run: `bun format:check src/chat/mattermost/index.ts tests/chat/mattermost/index.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 4: Commit the verification pass**
+
+```bash
+git add src/chat/mattermost/index.ts tests/chat/mattermost/index.test.ts
+git commit -m "test(mattermost): verify mention command flow"
+```

--- a/docs/superpowers/plans/2026-05-28-telegram-command-publication-alignment.md
+++ b/docs/superpowers/plans/2026-05-28-telegram-command-publication-alignment.md
@@ -1,0 +1,668 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Telegram Command Publication Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Telegram command publication derive from a canonical command manifest, add drift-prevention tests, and let DM `/config` and `/setup` target newly authorized groups immediately after `/group add`.
+
+**Architecture:** Introduce one provider-agnostic command metadata catalog near `src/commands/`, use it to render Telegram Bot API command scopes, and add focused tests that compare the catalog against the registered command surface. Extend manageable-group discovery so authorized-but-unobserved groups are visible in the DM selector with ID fallback labels.
+
+**Tech Stack:** TypeScript, Bun test runner, grammY Telegram Bot API integration, Drizzle-backed SQLite state, existing test helpers in `tests/utils/test-helpers.ts`
+
+---
+
+### Task 1: Add a Canonical Command Catalog
+
+**Files:**
+
+- Create: `src/commands/catalog.ts`
+- Modify: `src/commands/index.ts`
+- Test: `tests/commands/catalog.test.ts`
+
+- [ ] **Step 1: Write the failing catalog test**
+
+```typescript
+import { describe, expect, test } from 'bun:test'
+
+import { getCommandCatalogEntry, listCommandCatalogEntries } from '../../src/commands/catalog.js'
+
+describe('command catalog', () => {
+  test('contains the current papai command surface with Telegram publication metadata', () => {
+    const names = listCommandCatalogEntries().map((entry) => entry.name)
+
+    expect(names).toEqual([
+      'help',
+      'start',
+      'setup',
+      'config',
+      'context',
+      'clear',
+      'group',
+      'groups',
+      'user',
+      'users',
+      'announce',
+      'plugin',
+    ])
+
+    expect(getCommandCatalogEntry('help')).toMatchObject({
+      name: 'help',
+      telegram: {
+        publishInDmUser: true,
+        publishInDmAdmin: true,
+        publishInGroupUser: true,
+        publishInGroupAdmin: true,
+      },
+    })
+
+    expect(getCommandCatalogEntry('setup')).toMatchObject({
+      name: 'setup',
+      telegram: {
+        publishInDmUser: true,
+        publishInDmAdmin: true,
+        publishInGroupUser: false,
+        publishInGroupAdmin: false,
+      },
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the new catalog test and confirm failure**
+
+Run: `bun test tests/commands/catalog.test.ts`
+
+Expected: FAIL because `src/commands/catalog.ts` does not exist yet.
+
+- [ ] **Step 3: Implement the minimal command catalog module**
+
+```typescript
+// src/commands/catalog.ts
+export type TelegramCommandVisibility = {
+  readonly publishInDmUser: boolean
+  readonly publishInDmAdmin: boolean
+  readonly publishInGroupUser: boolean
+  readonly publishInGroupAdmin: boolean
+}
+
+export type CommandCatalogEntry = {
+  readonly name: string
+  readonly description: string
+  readonly telegram: TelegramCommandVisibility
+}
+
+const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
+  {
+    name: 'help',
+    description: 'Show available commands',
+    telegram: {
+      publishInDmUser: true,
+      publishInDmAdmin: true,
+      publishInGroupUser: true,
+      publishInGroupAdmin: true,
+    },
+  },
+  {
+    name: 'start',
+    description: 'Show welcome and getting-started guidance',
+    telegram: {
+      publishInDmUser: true,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+  {
+    name: 'setup',
+    description: 'Interactive configuration wizard',
+    telegram: {
+      publishInDmUser: true,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+  {
+    name: 'config',
+    description: 'View or edit current configuration',
+    telegram: {
+      publishInDmUser: true,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+  {
+    name: 'context',
+    description: 'Show current LLM context usage',
+    telegram: {
+      publishInDmUser: true,
+      publishInDmAdmin: true,
+      publishInGroupUser: true,
+      publishInGroupAdmin: true,
+    },
+  },
+  {
+    name: 'clear',
+    description: 'Clear conversation history and memory',
+    telegram: {
+      publishInDmUser: true,
+      publishInDmAdmin: true,
+      publishInGroupUser: true,
+      publishInGroupAdmin: true,
+    },
+  },
+  {
+    name: 'group',
+    description: 'Manage group authorization or membership',
+    telegram: {
+      publishInDmUser: false,
+      publishInDmAdmin: true,
+      publishInGroupUser: true,
+      publishInGroupAdmin: true,
+    },
+  },
+  {
+    name: 'groups',
+    description: 'List authorized groups',
+    telegram: {
+      publishInDmUser: false,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+  {
+    name: 'user',
+    description: 'Manage users',
+    telegram: {
+      publishInDmUser: false,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+  {
+    name: 'users',
+    description: 'List authorized users',
+    telegram: {
+      publishInDmUser: false,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+  {
+    name: 'announce',
+    description: 'Send announcement to all authorized users',
+    telegram: {
+      publishInDmUser: false,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+  {
+    name: 'plugin',
+    description: 'Manage plugins',
+    telegram: {
+      publishInDmUser: false,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+] as const
+
+export function listCommandCatalogEntries(): readonly CommandCatalogEntry[] {
+  return COMMAND_CATALOG
+}
+
+export function getCommandCatalogEntry(name: string): CommandCatalogEntry {
+  const entry = COMMAND_CATALOG.find((candidate) => candidate.name === name)
+  if (entry === undefined) {
+    throw new Error(`Unknown command catalog entry: ${name}`)
+  }
+  return entry
+}
+```
+
+- [ ] **Step 4: Export the catalog helpers from the commands barrel**
+
+```typescript
+// src/commands/index.ts
+export { getCommandCatalogEntry, listCommandCatalogEntries } from './catalog.js'
+```
+
+- [ ] **Step 5: Run the catalog test and confirm it passes**
+
+Run: `bun test tests/commands/catalog.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit the catalog foundation**
+
+```bash
+git add src/commands/catalog.ts src/commands/index.ts tests/commands/catalog.test.ts
+git commit -m "feat(commands): add telegram publication catalog"
+```
+
+### Task 2: Add a Drift Test Against Bot Command Registration
+
+**Files:**
+
+- Modify: `tests/bot.test.ts`
+- Test: `tests/bot.test.ts`
+
+- [ ] **Step 1: Add a failing bot-level drift test**
+
+```typescript
+test('registered command handlers stay aligned with the command catalog', () => {
+  const { provider, commandHandlers } = createMockChatWithCommandHandlers()
+
+  setupBot(provider, 'admin-1', { processMessage: async () => {} })
+
+  expect([...commandHandlers.keys()].toSorted()).toEqual([
+    'announce',
+    'clear',
+    'config',
+    'context',
+    'group',
+    'groups',
+    'help',
+    'plugin',
+    'setup',
+    'start',
+    'user',
+    'users',
+  ])
+})
+```
+
+- [ ] **Step 2: Run the focused bot test and confirm the initial failure mode**
+
+Run: `bun test tests/bot.test.ts --test-name-pattern "registered command handlers stay aligned with the command catalog"`
+
+Expected: FAIL first if the expected list or helper wiring is incomplete.
+
+- [ ] **Step 3: Tighten the test to compare against the catalog instead of a duplicated list**
+
+```typescript
+import { listCommandCatalogEntries } from '../src/commands/catalog.js'
+
+test('registered command handlers stay aligned with the command catalog', () => {
+  const { provider, commandHandlers } = createMockChatWithCommandHandlers()
+
+  setupBot(provider, 'admin-1', { processMessage: async () => {} })
+
+  expect([...commandHandlers.keys()].toSorted()).toEqual(
+    listCommandCatalogEntries()
+      .map((entry) => entry.name)
+      .toSorted(),
+  )
+})
+```
+
+- [ ] **Step 4: Run the focused bot test and confirm it passes**
+
+Run: `bun test tests/bot.test.ts --test-name-pattern "registered command handlers stay aligned with the command catalog"`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit the drift test**
+
+```bash
+git add tests/bot.test.ts
+git commit -m "test(bot): lock command registration to catalog"
+```
+
+### Task 3: Make Telegram Command Publication Manifest-Driven
+
+**Files:**
+
+- Modify: `src/chat/telegram/commands.ts`
+- Create: `tests/chat/telegram/commands.test.ts`
+- Test: `tests/chat/telegram/commands.test.ts`
+
+- [ ] **Step 1: Write the failing Telegram scope-generation test**
+
+```typescript
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+import { registerTelegramCommands } from '../../../src/chat/telegram/commands.js'
+
+describe('registerTelegramCommands', () => {
+  const setMyCommands = mock(() => Promise.resolve(true))
+
+  beforeEach(() => {
+    setMyCommands.mockClear()
+  })
+
+  test('publishes DM, admin-DM, group, and group-admin scopes from the catalog', async () => {
+    const bot = {
+      api: {
+        setMyCommands,
+      },
+    }
+
+    await registerTelegramCommands(bot as never, '12345')
+
+    expect(setMyCommands.mock.calls).toEqual([
+      [
+        expect.arrayContaining([
+          expect.objectContaining({ command: 'help' }),
+          expect.objectContaining({ command: 'setup' }),
+          expect.objectContaining({ command: 'config' }),
+        ]),
+        { scope: { type: 'all_private_chats' } },
+      ],
+      [
+        expect.arrayContaining([
+          expect.objectContaining({ command: 'user' }),
+          expect.objectContaining({ command: 'plugin' }),
+        ]),
+        { scope: { type: 'chat', chat_id: 12345 } },
+      ],
+      [
+        expect.arrayContaining([
+          expect.objectContaining({ command: 'help' }),
+          expect.objectContaining({ command: 'context' }),
+          expect.objectContaining({ command: 'clear' }),
+          expect.objectContaining({ command: 'group' }),
+        ]),
+        { scope: { type: 'all_group_chats' } },
+      ],
+    ])
+  })
+})
+```
+
+- [ ] **Step 2: Run the new Telegram command publication test and confirm failure**
+
+Run: `bun test tests/chat/telegram/commands.test.ts`
+
+Expected: FAIL because the implementation still only publishes the two old arrays.
+
+- [ ] **Step 3: Replace the hard-coded arrays with catalog-driven helpers**
+
+```typescript
+// src/chat/telegram/commands.ts
+import type { Bot } from 'grammy'
+
+import { listCommandCatalogEntries } from '../../commands/catalog.js'
+import { logger } from '../../logger.js'
+
+const log = logger.child({ scope: 'chat:telegram:commands' })
+
+type TelegramPublishedCommand = {
+  readonly command: string
+  readonly description: string
+}
+
+function commandsForScope(
+  scope: 'dm-user' | 'dm-admin' | 'group-user' | 'group-admin',
+): readonly TelegramPublishedCommand[] {
+  return listCommandCatalogEntries()
+    .filter((entry) => {
+      switch (scope) {
+        case 'dm-user':
+          return entry.telegram.publishInDmUser
+        case 'dm-admin':
+          return entry.telegram.publishInDmAdmin
+        case 'group-user':
+          return entry.telegram.publishInGroupUser
+        case 'group-admin':
+          return entry.telegram.publishInGroupAdmin
+      }
+    })
+    .map((entry) => ({ command: entry.name, description: entry.description }))
+}
+
+function parseAdminChatId(adminUserId: string): number {
+  const parsed = Number.parseInt(adminUserId, 10)
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Telegram admin command scope requires a numeric ADMIN_USER_ID, got: ${adminUserId}`)
+  }
+  return parsed
+}
+
+export async function registerTelegramCommands(bot: Bot, adminUserId: string): Promise<void> {
+  const adminChatId = parseAdminChatId(adminUserId)
+
+  await bot.api.setMyCommands(commandsForScope('dm-user'), { scope: { type: 'all_private_chats' } })
+  await bot.api.setMyCommands(commandsForScope('dm-admin'), { scope: { type: 'chat', chat_id: adminChatId } })
+  await bot.api.setMyCommands(commandsForScope('group-user'), { scope: { type: 'all_group_chats' } })
+
+  const groupAdminCommands = commandsForScope('group-admin')
+  if (groupAdminCommands.length > 0) {
+    await bot.api.setMyCommands(groupAdminCommands, { scope: { type: 'all_chat_administrators' } })
+  }
+
+  log.info({ adminUserId }, 'Telegram command menu registered')
+}
+```
+
+- [ ] **Step 4: Add an explicit invalid-admin-ID failure test**
+
+```typescript
+test('throws when admin user id is not numeric for Telegram chat scope', async () => {
+  const bot = {
+    api: {
+      setMyCommands: mock(() => Promise.resolve(true)),
+    },
+  }
+
+  await expect(registerTelegramCommands(bot as never, 'admin-user')).rejects.toThrow(
+    'Telegram admin command scope requires a numeric ADMIN_USER_ID',
+  )
+})
+```
+
+- [ ] **Step 5: Run the Telegram command publication tests and confirm they pass**
+
+Run: `bun test tests/chat/telegram/commands.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit the manifest-driven Telegram publication**
+
+```bash
+git add src/chat/telegram/commands.ts tests/chat/telegram/commands.test.ts
+git commit -m "feat(telegram): derive command scopes from catalog"
+```
+
+### Task 4: Surface Newly Authorized Groups In DM Selection Without Prior Observation
+
+**Files:**
+
+- Modify: `src/group-settings/types.ts`
+- Modify: `src/group-settings/access.ts`
+- Modify: `tests/group-settings/access.test.ts`
+- Modify: `tests/group-settings/selector.test.ts`
+
+- [ ] **Step 1: Add a failing access-layer test for authorized-but-unobserved groups**
+
+```typescript
+import { addAdmin } from '../../src/instances/admin-store.js'
+
+test('lists authorized scoped groups for an admin even before group metadata is observed', () => {
+  const scopedGroupId = toScopedContextId({
+    platformInstanceId: 'telegram-default',
+    nativeContextId: '-10012345',
+  })
+
+  addAdmin('admin-1', 'telegram-default')
+  addAuthorizedGroup(scopedGroupId, 'admin-1')
+
+  const groups = listManageableGroups('admin-1', 'telegram-default')
+
+  expect(groups).toEqual([
+    expect.objectContaining({
+      contextId: scopedGroupId,
+      displayName: '-10012345',
+      parentName: null,
+    }),
+  ])
+})
+```
+
+- [ ] **Step 2: Run the focused access tests and confirm failure**
+
+Run: `bun test tests/group-settings/access.test.ts`
+
+Expected: FAIL because unobserved authorized groups are not currently returned.
+
+- [ ] **Step 3: Extend manageable-group discovery to merge observed groups with authorized fallback entries**
+
+```typescript
+// src/group-settings/types.ts
+export type KnownGroupContext = {
+  readonly contextId: string
+  readonly provider: string
+  readonly displayName: string
+  readonly parentName: string | null
+  readonly firstSeenAt: string
+  readonly lastSeenAt: string
+  readonly source?: 'observed' | 'authorized-fallback'
+}
+```
+
+```typescript
+// src/group-settings/access.ts
+import { listAuthorizedGroups } from '../authorized-groups.js'
+import { isAdmin } from '../instances/admin-store.js'
+import { getNativeContextId, isScopedContextId, parseScopedContextId } from '../chat/scoped-context.js'
+
+const FALLBACK_PROVIDER = 'unknown'
+
+function fallbackKnownGroupContext(contextId: string): KnownGroupContext {
+  const now = new Date().toISOString()
+  return {
+    contextId,
+    provider: FALLBACK_PROVIDER,
+    displayName: getNativeContextId(contextId),
+    parentName: null,
+    firstSeenAt: now,
+    lastSeenAt: now,
+    source: 'authorized-fallback',
+  }
+}
+
+function appendAuthorizedFallbackGroups(
+  groups: readonly KnownGroupContext[],
+  userId: string,
+  platformInstanceId: string | undefined,
+): KnownGroupContext[] {
+  const existing = new Set(groups.map((group) => group.contextId))
+
+  if (platformInstanceId === undefined || !isAdmin(userId, platformInstanceId)) {
+    return [...groups]
+  }
+
+  const authorizedFallbacks = listAuthorizedGroups()
+    .map((row) => row.group_id)
+    .filter((groupId) => {
+      if (existing.has(groupId)) return false
+      if (!isScopedContextId(groupId)) return false
+      const parsed = parseScopedContextId(groupId)
+      return parsed !== null && parsed.platformInstanceId === platformInstanceId
+    })
+    .map((groupId) => fallbackKnownGroupContext(groupId))
+
+  return [...groups, ...authorizedFallbacks].toSorted((left, right) =>
+    left.displayName.localeCompare(right.displayName),
+  )
+}
+
+export function listManageableGroups(userId: string, ...args: [] | [platformInstanceId: string]): KnownGroupContext[] {
+  const platformInstanceId = args[0]
+  const groups = listAdminGroupContextsForUser(userId, ...args).filter((group) =>
+    isAuthorizedGroupContext(group, platformInstanceId),
+  )
+
+  return appendAuthorizedFallbackGroups(groups, userId, platformInstanceId)
+}
+```
+
+- [ ] **Step 4: Run the access tests and confirm they pass**
+
+Run: `bun test tests/group-settings/access.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Add a selector-level regression test for immediate DM targeting after authorization**
+
+```typescript
+import { addAdmin } from '../../src/instances/admin-store.js'
+
+test('shows a newly authorized scoped group in DM selection before any observation exists', () => {
+  const scopedGroupId = toScopedContextId({
+    platformInstanceId: 'telegram-default',
+    nativeContextId: '-10012345',
+  })
+
+  addAdmin('admin-id', 'telegram-default')
+  addAuthorizedGroup(scopedGroupId, 'admin-id')
+
+  startGroupSettingsSelection('admin-id', 'config', false, 'telegram-default')
+  const result = handleGroupSettingsSelectorMessage('admin-id', 'group', false, 'telegram-default')
+  const response = getResponse(result)
+
+  expect(response.response).toContain('-10012345')
+})
+```
+
+- [ ] **Step 6: Run the selector tests and confirm they pass**
+
+Run: `bun test tests/group-settings/selector.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the immediate group-target discovery change**
+
+```bash
+git add src/group-settings/types.ts src/group-settings/access.ts tests/group-settings/access.test.ts tests/group-settings/selector.test.ts
+git commit -m "feat(group-settings): surface newly authorized telegram groups"
+```
+
+### Task 5: Verify The Combined Telegram Behavior
+
+**Files:**
+
+- Modify: `tests/bot.test.ts` (only if coverage gaps appear)
+- Test: `tests/commands/catalog.test.ts`
+- Test: `tests/chat/telegram/commands.test.ts`
+- Test: `tests/group-settings/access.test.ts`
+- Test: `tests/group-settings/selector.test.ts`
+- Test: `tests/bot.test.ts`
+
+- [ ] **Step 1: Run the focused Telegram verification suite**
+
+Run: `bun test tests/commands/catalog.test.ts tests/chat/telegram/commands.test.ts tests/group-settings/access.test.ts tests/group-settings/selector.test.ts tests/bot.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 2: Run strict lint on the touched sources and tests**
+
+Run: `bun run lint:agent-strict -- src/commands/catalog.ts src/commands/index.ts src/chat/telegram/commands.ts src/group-settings/types.ts src/group-settings/access.ts tests/commands/catalog.test.ts tests/chat/telegram/commands.test.ts tests/group-settings/access.test.ts tests/group-settings/selector.test.ts tests/bot.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 3: Run formatting check for the touched files**
+
+Run: `bun format:check src/commands/catalog.ts src/commands/index.ts src/chat/telegram/commands.ts src/group-settings/types.ts src/group-settings/access.ts tests/commands/catalog.test.ts tests/chat/telegram/commands.test.ts tests/group-settings/access.test.ts tests/group-settings/selector.test.ts tests/bot.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 4: Commit the final Telegram verification pass**
+
+```bash
+git add src/commands/catalog.ts src/commands/index.ts src/chat/telegram/commands.ts src/group-settings/types.ts src/group-settings/access.ts tests/commands/catalog.test.ts tests/chat/telegram/commands.test.ts tests/group-settings/access.test.ts tests/group-settings/selector.test.ts tests/bot.test.ts
+git commit -m "test(telegram): verify command publication alignment"
+```

--- a/docs/superpowers/specs/2026-05-28-mattermost-command-syntax-design.md
+++ b/docs/superpowers/specs/2026-05-28-mattermost-command-syntax-design.md
@@ -1,0 +1,215 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mattermost Mention-Prefixed Command Syntax — Design
+
+**Date:** 2026-05-28
+**Status:** Approved design, pending implementation plan
+**Author:** brainstorming session
+
+## Problem
+
+The current Mattermost provider pretends slash commands are ordinary message text. It stores
+registered commands in-memory and matches incoming WebSocket post text that starts with `/`.
+That does not align with how Mattermost actually handles native slash commands.
+
+In practice, this creates a broken user experience:
+
+- typing `/config` or similar hits Mattermost's native slash-command resolver first
+- because papai has not registered real Mattermost custom slash commands, the user gets
+  “command not found” from Mattermost
+- papai's local `/command` parser is therefore only accidentally useful for message flows that
+  never become real slash commands
+
+The user explicitly chose not to implement real Mattermost custom slash command integrations
+in this project. Instead, Mattermost command syntax should be honest, explicit, and based on
+plain message parsing.
+
+## Goals
+
+- Standardize Mattermost command syntax on plain messages of the form `@papai /command`.
+- Use the same syntax in both Mattermost DMs and channels.
+- Remove support for bare `/command` parsing in the Mattermost provider.
+- Keep existing provider-agnostic command handlers unchanged where possible.
+- Preserve normal mention-based natural-language behavior for non-command messages.
+- Use `@papai /help` as the primary command discovery mechanism.
+
+## Non-Goals
+
+- No implementation of native Mattermost custom slash-command registration.
+- No autocomplete or other provider-native slash discovery.
+- No fallback support for bare `/command` after the change.
+- No redesign of command handlers themselves.
+- No attempt to unify Mattermost syntax with Telegram publication behavior.
+
+## Existing Architecture
+
+- `MattermostChatProvider` listens to WebSocket `posted` events and builds `IncomingMessage`
+  values from regular posts.
+- It currently calls `matchCommand(post.message)` and treats leading `/command` text as a
+  command, even though real Mattermost slash commands never arrive through this path.
+- The general bot architecture already distinguishes between command messages and
+  mention-addressed natural-language messages through `msg.commandMatch` and `msg.isMentioned`.
+- Group noise is ignored unless the message is a command or mentions the bot.
+
+## Design
+
+### 1. Supported Mattermost command syntax
+
+The only supported Mattermost command form becomes:
+
+```text
+@papai /command arguments...
+```
+
+This applies everywhere:
+
+- direct messages
+- public channels
+- private channels
+- thread replies where mention-based message handling already applies
+
+Bare `/command` is no longer a supported papai command form in Mattermost. If a user types
+bare `/config`, Mattermost may reject it or route it elsewhere, and papai will not try to
+recover or emulate support for it.
+
+### 2. Message normalization before command matching
+
+The Mattermost adapter should gain an explicit normalization step before command matching.
+That normalization is provider-local and should not leak Mattermost-specific rules into the
+shared command handlers.
+
+Normalization responsibilities:
+
+- detect whether the bot was mentioned
+- require that the bot mention be the first non-whitespace token for command routing
+- strip the leading bot mention from the message when present
+- trim the remaining text without altering its semantic content
+- classify the normalized remainder as either:
+  - command text if it begins with `/`
+  - mention-addressed natural-language text otherwise
+  - non-actionable noise if there is no bot mention and no supported command form
+
+After normalization, `msg.text`, `msg.isMentioned`, and `msg.commandMatch` must stay
+internally coherent for downstream logic.
+
+Concretely:
+
+- `@papai /config foo` becomes a command with normalized command text `/config foo`
+- `@papai summarize this thread` remains a mention-addressed natural-language message
+- `/config` is not treated as a papai command at all
+
+### 3. Remove legacy bare-slash fallback
+
+The current bare `/command` parser must be removed rather than preserved as compatibility
+fallback.
+
+This is intentional for three reasons:
+
+- it is not a truthful model of Mattermost behavior
+- it creates ambiguous support expectations around native slash commands
+- keeping it undocumented would still produce accidental hidden behavior and future confusion
+
+After the change, all Mattermost command routing should depend on mention-prefixed syntax.
+
+### 4. Discovery model
+
+Discovery is intentionally minimal.
+
+Primary discovery path:
+
+```text
+@papai /help
+```
+
+No extra in-product affordances are required in this design. No autocomplete is expected.
+No alias like `@papai help` is added. The command surface is discoverable through the help
+command and user documentation, but the runtime design itself treats `@papai /help` as the
+canonical entry point.
+
+### 5. Preserve provider-agnostic handler logic
+
+This design changes Mattermost input parsing, not command semantics.
+
+The command handlers under `src/commands/` should continue to receive normal `IncomingMessage`
+values and should not learn anything about Mattermost mention stripping.
+
+That means the Mattermost adapter owns:
+
+- mention detection
+- mention stripping
+- command classification
+- removal of the legacy bare-slash path
+
+The shared command layer continues to own:
+
+- authorization
+- command-specific usage text
+- DM-only and group-only enforcement
+- actual business behavior
+
+## Testing Strategy
+
+Required unit coverage:
+
+- `@papai /config` in a DM routes to the config command handler
+- `@papai /config` in a channel routes to the config command handler, which may then enforce
+  its existing behavior
+- bare `/config` does not route to papai command handlers
+- `@papai some natural language request` still behaves like a normal mention-addressed
+  non-command message
+- normalization preserves correct `commandMatch` extraction after the mention is removed
+- messages without mention and without command syntax remain ignored as normal group noise
+
+The tests should focus on observable provider behavior, not just helper internals.
+
+## Error Handling And Behavioral Rules
+
+- There is no backward-compatibility fallback for bare `/command`.
+- If a user mentions the bot and sends only the mention with no content, papai should reply
+  with short guidance such as "Use `@papai /help` to see commands, or mention me with a
+  question." It should not silently enqueue an empty request.
+- Mention stripping should be strict enough to avoid accidental command routing when the bot
+  is not the addressed recipient.
+
+## Consequences
+
+### Positive
+
+- Mattermost command syntax becomes honest and consistent with the user's chosen product
+  direction.
+- There is no more conflict between papai's pretend slash commands and Mattermost's native
+  slash-command resolver.
+- The change stays localized to the Mattermost adapter instead of forcing handler rewrites.
+
+### Negative
+
+- Native slash autocomplete is gone by design.
+- Existing users who relied on accidental bare `/command` parsing will need to switch to the
+  mention-prefixed syntax.
+- Mattermost command syntax now differs intentionally from Telegram's native slash menu model.
+
+## Implementation Shape
+
+Expected code touch points:
+
+- `src/chat/mattermost/index.ts` for message normalization and command matching changes
+- Mattermost unit tests covering command recognition and natural-language mention behavior
+- possibly small helper extraction under `src/chat/mattermost/` if normalization logic would
+  otherwise make `index.ts` harder to follow
+
+## Open Design Decision Resolved In This Spec
+
+During brainstorming, the user confirmed:
+
+- do not implement real Mattermost custom slash commands
+- require `@papai /command` everywhere, including DMs
+- remove bare `/command` support entirely
+- use `@papai /help` as the primary discovery path
+- treat autocomplete as out of scope
+
+This document treats those decisions as fixed input for the implementation plan.

--- a/docs/superpowers/specs/2026-05-28-telegram-command-publication-design.md
+++ b/docs/superpowers/specs/2026-05-28-telegram-command-publication-design.md
@@ -1,0 +1,226 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Telegram Command Publication Alignment — Design
+
+**Date:** 2026-05-28
+**Status:** Approved design, pending implementation plan
+**Author:** brainstorming session
+
+## Problem
+
+Telegram is the only provider in papai that publishes a native command menu through
+`setMyCommands()`, but the published lists in `src/chat/telegram/commands.ts` have drifted
+from the actual command surface registered in `src/bot.ts`.
+
+Today this creates three concrete problems:
+
+- some working commands do not appear in Telegram autocomplete or the bot menu
+- group menus are not explicitly modeled, so group command discoverability is inconsistent
+- command metadata now lives in more than one place, so future command additions can drift
+  again unless someone remembers to update the Telegram-specific arrays manually
+
+There is a second Telegram-specific UX gap around group configuration. The DM `/config`
+and `/setup` selector currently depends on observed group context data. A newly authorized
+group may not be immediately available in the DM selector until the bot first sees traffic
+from that group. That forces an unnecessary round-trip into the group before the admin can
+finish configuration.
+
+## Goals
+
+- Make Telegram command publication a derived view of a canonical papai command manifest.
+- Add tests that fail when the registered command surface and Telegram publication metadata
+  drift apart.
+- Publish Telegram commands in both DMs and groups using explicit Telegram command scopes.
+- Publish only group-safe commands in Telegram group menus.
+- Preserve existing handler-level auth and DM-only behavior; this design changes publication
+  and group-target discovery, not command semantics.
+- Make a newly authorized group configurable from DM immediately after `/group add`, without
+  requiring a prior in-group message.
+
+## Non-Goals
+
+- No redesign of command handler authorization rules.
+- No change to Discord command behavior.
+- No provider-wide abstraction that forces Mattermost or Discord to consume Telegram-specific
+  publication rules.
+- No attempt to make Telegram publish per-user custom menus beyond the existing admin-vs-user
+  split and explicit group-safe filtering.
+
+## Existing Architecture
+
+- `src/bot.ts` registers the command handlers through `registerHelpCommand`,
+  `registerStartCommand`, `registerSetupCommand`, `registerConfigCommand`,
+  `registerContextCommand`, `registerClearCommand`, `registerAdminCommands`,
+  `registerGroupCommand`, and `registerPluginCommand`.
+- `src/chat/telegram/commands.ts` currently hand-maintains `userCommands` and
+  `adminCommands`, then publishes them with Telegram Bot API scopes.
+- `src/chat/startup.ts` calls `chat.setCommands()` only for providers with the
+  `commands.menu` capability.
+- DM group targeting for `/config` and `/setup` is backed by `group-settings/*` and today is
+  effectively limited by `known_group_contexts` plus observed admin state.
+- Authorized groups are stored separately in `authorized_groups` through
+  `src/authorized-groups.ts` and are added in `src/commands/group.ts`.
+
+## Design
+
+### 1. Canonical command manifest
+
+Introduce a small command manifest module near the provider-agnostic command layer. The
+manifest is the single source of truth for user-visible command metadata, while the existing
+command handlers remain the source of runtime behavior.
+
+Each manifest entry must define:
+
+- command name
+- human description
+- registration source marker or assertion target for tests
+- Telegram publication flags for:
+  - DM user visibility
+  - DM admin visibility
+  - group user visibility
+  - group admin visibility
+
+The intent is not to move handler logic into metadata. The intent is to eliminate the
+current duplicated hand-maintained Telegram arrays and replace them with a single command
+catalog that Telegram publication can render from and tests can validate against.
+
+### 2. Telegram scope generation from the manifest
+
+`src/chat/telegram/commands.ts` should stop declaring static arrays and instead build the
+Telegram Bot API payloads from the canonical manifest.
+
+The generated publication model is:
+
+- all private chats: commands visible to every regular DM user
+- admin DM chat: additional admin-only DM commands for the admin chat ID
+- all group chats: only group-safe commands
+- all chat administrators: additional group-admin-safe commands, if any are distinct from
+  general group-safe commands
+
+This design explicitly chooses group-safe publication only. Commands that are logically
+DM-driven, such as settings flows, are not published in group menus even if their handlers
+have some group-side behavior today.
+
+If Telegram scope publication fails for any scope, the registration call should fail loudly
+with scope-specific logging. Silent partial publication is not acceptable because it creates
+hard-to-diagnose UX drift.
+
+### 3. Group-safe publication rules
+
+The Telegram spec distinguishes between three kinds of command behavior:
+
+- commands safe and useful in groups
+- commands safe only for group admins
+- commands that are fundamentally DM-driven and should not be advertised in group menus
+
+The key clarification from the brainstorming session is that `/config` and `/setup` should
+remain DM-driven for settings targeting even though invoking them in groups currently helps
+populate group discovery. Their current side-effect should not determine menu publication.
+
+Instead, the group menu should advertise only commands that are genuinely meaningful in the
+group itself. This keeps group menus honest and avoids teaching users to enter a settings
+flow in the wrong place.
+
+For the current command surface, the starting interpretation in the implementation plan
+should be:
+
+- publish in Telegram group menus: `/help`, `/context`, `/clear`, `/group`
+- do not publish in Telegram group menus: `/start`, `/setup`, `/config`, `/plugin`, `/user`,
+  `/users`, `/announce`, `/groups`
+
+If implementation discovers that one of the included commands is not actually group-safe in
+practice, the implementation plan should reduce the set rather than broaden it.
+
+### 4. Immediate DM configurability for newly authorized groups
+
+The current observation-based path is insufficient for the desired Telegram admin workflow.
+After a bot admin authorizes a group in DM with `/group add`, that group should become
+available in the DM `/config` and `/setup` selector immediately, without requiring the bot
+to first observe the group.
+
+This design therefore extends manageable-group discovery so it is not solely dependent on
+`known_group_contexts` observations. The selector must be able to surface newly authorized
+groups as soon as authorization exists.
+
+The design direction is:
+
+- preserve observed group metadata as the preferred rich source when available
+- add an authorization-backed fallback path for newly authorized groups that have not yet
+  been observed
+- permit DM selection of those groups immediately after `/group add`
+
+Because an unobserved group may not yet have a friendly display name, the selector may need
+to temporarily fall back to the native/scoped group ID until richer metadata is learned.
+That is acceptable. Immediate configurability is more important than waiting for a display
+name.
+
+### 5. Testing strategy
+
+Add unit tests that make future command drift hard to introduce.
+
+Required coverage:
+
+- every command registered through the bot command setup path must be represented in the
+  canonical manifest or explicitly marked as intentionally unpublished for Telegram
+- Telegram-rendered DM/admin/group command lists must match the expected filtering rules
+- group menus must not include DM-driven commands
+- manifest descriptions and generated Telegram payloads should be asserted in a stable way so
+  command additions require an intentional test update
+- newly authorized groups must be eligible for DM selection immediately, even if they have no
+  prior observation record
+
+The tests are meant to defend the design contract, not snapshot every internal detail.
+
+## Error Handling
+
+- If `ADMIN_USER_ID` cannot be parsed into the Telegram scope shape required for the admin
+  chat-specific command list, command publication should fail with a clear error message.
+- If Telegram rejects a particular scope publication request, logs must identify the exact
+  scope that failed.
+- If a newly authorized but unobserved group appears in the DM selector without a known
+  display name, the UI may show the raw group identifier rather than blocking configuration.
+
+## Consequences
+
+### Positive
+
+- Telegram autocomplete becomes an accurate view of the actual papai command surface.
+- Future command additions must update one manifest instead of multiple disconnected lists.
+- Group menus become deliberate and less confusing.
+- Bot admins can configure a newly authorized group from DM immediately after authorization.
+
+### Negative
+
+- Telegram command metadata becomes more structured, which adds a small maintenance surface.
+- Some commands that technically do something when run from a group will stop being published
+  there if they are classified as DM-driven.
+- The selector logic becomes slightly more complex because it must merge observed and
+  authorization-backed groups.
+
+## Implementation Shape
+
+Expected code touch points:
+
+- new shared command manifest module near `src/commands/`
+- `src/chat/telegram/commands.ts` for manifest-driven Telegram scope rendering
+- Telegram-focused unit tests for command publication and manifest alignment
+- group-target discovery modules under `src/group-settings/` so newly authorized groups can
+  appear in DM selection immediately
+- possibly `src/commands/group.ts` or adjacent helpers if authorization-time metadata needs
+  to be recorded at the point of `/group add`
+
+## Open Design Decision Resolved In This Spec
+
+During brainstorming, the user confirmed:
+
+- Telegram should publish commands in both DMs and groups.
+- Group menus should publish only group-safe commands.
+- `/config` and `/setup` remain DM-driven and should not rely on group-side invocation to
+  make a newly authorized group configurable.
+
+This document treats those decisions as fixed input for the implementation plan.

--- a/opencode.json
+++ b/opencode.json
@@ -3,7 +3,8 @@
   "plugin": [
     "@ekroon/opencode-copilot-instructions",
     "./.opencode/plugins/tdd-enforcement.ts",
-    "./.opencode/plugins/codeindex-reindex.ts"
+    "./.opencode/plugins/codeindex-reindex.ts",
+    "./.opencode/plugins/doc-review.ts"
   ],
   "mcp": {
     "codeindex": {

--- a/src/chat/mattermost/index.ts
+++ b/src/chat/mattermost/index.ts
@@ -66,13 +66,18 @@ export class MattermostChatProvider implements ChatProvider {
   private wsSeq = 1
 
   constructor(...args: [] | [MattermostConstructorConfig]) {
-    const resolved = resolveMattermostConfig(args[0] ?? {})
+    let config: MattermostConstructorConfig
+    if (args[0] === undefined) {
+      config = {}
+    } else {
+      config = args[0]
+    }
+    const resolved = resolveMattermostConfig(config)
     this.baseUrl = resolved.baseUrl
     this.token = resolved.token
     this.platformInstanceId = resolved.platformInstanceId
     log.debug({ platformInstanceId: this.platformInstanceId }, 'MattermostChatProvider constructed')
   }
-
   registerCommand(name: string, handler: CommandHandler): void {
     this.commands.set(name, handler)
   }
@@ -80,7 +85,6 @@ export class MattermostChatProvider implements ChatProvider {
   onMessage(handler: (msg: IncomingMessage, reply: ReplyFn) => Promise<void>): void {
     this.messageHandler = handler
   }
-
   async sendMessage(_platformInstanceId: string, target: DeferredDeliveryTarget, markdown: string): Promise<void> {
     if (target.contextType === 'dm') {
       if (this.botUserId === null) throw new Error('Bot not started')

--- a/src/chat/mattermost/index.ts
+++ b/src/chat/mattermost/index.ts
@@ -30,6 +30,7 @@ import {
   uploadMattermostFile,
 } from './file-helpers.js'
 import { resolveMattermostGroupLabel, resolveMattermostUserLabel } from './label-helpers.js'
+import { normalizeMattermostMessageText } from './message-normalization.js'
 import { mattermostCapabilities, mattermostConfigRequirements, mattermostTraits } from './metadata.js'
 import { buildMattermostReplyContext } from './reply-context.js'
 import { createMattermostReplyFn } from './reply-helpers.js'
@@ -190,10 +191,11 @@ export class MattermostChatProvider implements ChatProvider {
     const teamId = contextType === 'group' ? channelInfo.team_id : undefined
     const teamInfo = teamId === undefined ? null : await fetchMattermostTeamInfo(api, teamId)
     const isAdmin = await checkChannelAdmin(post.channel_id, post.user_id, api)
-    const isMentioned = this.botUsername !== null && post.message.includes(`@${this.botUsername}`)
+    const normalized = normalizeMattermostMessageText(post.message, this.botUsername)
+    const isMentioned = normalized.isMentioned
     const threadId = this.determineThreadId(post, isMentioned, contextType, replyToMessageId)
     const reply = this.buildReplyFn(post.channel_id, post.id, threadId)
-    const command = this.matchCommand(post.message)
+    const command = normalized.commandInput === null ? null : this.matchCommand(normalized.commandInput)
     const uname = post.user_name
     const username = typeof uname === 'string' ? uname : typeof senderName === 'string' ? senderName : null
     const dispName = typeof channelInfo.display_name === 'string' ? channelInfo.display_name : channelInfo.name
@@ -214,7 +216,7 @@ export class MattermostChatProvider implements ChatProvider {
       contextName,
       contextParentName,
       isMentioned,
-      text: post.message,
+      text: normalized.text,
       platformInstanceId: this.platformInstanceId,
       commandMatch: command === null ? undefined : command.match,
       messageId: post.id,

--- a/src/chat/mattermost/index.ts
+++ b/src/chat/mattermost/index.ts
@@ -169,7 +169,9 @@ export class MattermostChatProvider implements ChatProvider {
     cacheIncomingPost(post, replyToMessageId, senderName)
     const { msg, reply, command, isAdmin } = await this.buildPostedMessage(post, senderName, replyToMessageId)
     if (msg.isMentioned && msg.text === '') {
-      await reply.text('Use `@papai /help` to see commands, or mention me with a question.')
+      const mentionHelp =
+        this.botUsername === null ? 'Use `/help` to see commands' : `Use \`@${this.botUsername} /help\` to see commands`
+      await reply.text(`${mentionHelp}, or mention me with a question.`)
       return
     }
     if (command !== null) {
@@ -277,9 +279,7 @@ export class MattermostChatProvider implements ChatProvider {
   downloadFile(fileId: string): Promise<Buffer | null> {
     return downloadMattermostFile(this.baseUrl, this.token, fileId)
   }
-  resolveUserLabel(userId: string): Promise<string | null>
-  resolveUserLabel(userId: string, _context: ResolveUserContext | undefined): Promise<string | null>
-  resolveUserLabel(userId: string, ..._rest: [] | [ResolveUserContext | undefined]): Promise<string | null> {
+  resolveUserLabel(userId: string, _context?: ResolveUserContext): Promise<string | null> {
     return resolveMattermostUserLabel(this.apiFetch.bind(this), userId)
   }
   private wsSend(data: unknown): void {

--- a/src/chat/mattermost/index.ts
+++ b/src/chat/mattermost/index.ts
@@ -66,13 +66,7 @@ export class MattermostChatProvider implements ChatProvider {
   private wsSeq = 1
 
   constructor(...args: [] | [MattermostConstructorConfig]) {
-    let config: MattermostConstructorConfig
-    if (args[0] === undefined) {
-      config = {}
-    } else {
-      config = args[0]
-    }
-    const resolved = resolveMattermostConfig(config)
+    const resolved = resolveMattermostConfig(args[0] ?? {})
     this.baseUrl = resolved.baseUrl
     this.token = resolved.token
     this.platformInstanceId = resolved.platformInstanceId
@@ -170,12 +164,16 @@ export class MattermostChatProvider implements ChatProvider {
     const replyToMessageId = extractReplyId(post.parent_id, post.root_id)
     cacheIncomingPost(post, replyToMessageId, senderName)
     const { msg, reply, command, isAdmin } = await this.buildPostedMessage(post, senderName, replyToMessageId)
+    if (msg.isMentioned && msg.text === '') {
+      await reply.text('Use `@papai /help` to see commands, or mention me with a question.')
+      return
+    }
     if (command !== null) {
       const auth = buildScopedCommandAuth(msg, isAdmin, this.platformInstanceId)
       await command.handler(msg, reply, auth)
-    } else if (this.messageHandler !== null) {
-      await this.messageHandler(msg, reply)
+      return
     }
+    if (this.messageHandler !== null) await this.messageHandler(msg, reply)
   }
 
   async buildPostedMessage(

--- a/src/chat/mattermost/message-normalization.ts
+++ b/src/chat/mattermost/message-normalization.ts
@@ -23,6 +23,20 @@ function isStandaloneMentionAt(text: string, mentionPrefix: string, startIndex: 
   return afterChar === '' || !isUsernameChar(afterChar)
 }
 
+function findStandaloneMentionIndex(text: string, mentionPrefix: string): number {
+  let searchIndex = text.indexOf(mentionPrefix)
+
+  while (searchIndex >= 0) {
+    if (isStandaloneMentionAt(text, mentionPrefix, searchIndex)) {
+      return searchIndex
+    }
+
+    searchIndex = text.indexOf(mentionPrefix, searchIndex + mentionPrefix.length)
+  }
+
+  return -1
+}
+
 export function normalizeMattermostMessageText(message: string, botUsername: string | null): NormalizedMattermostText {
   const trimmed = message.trim()
 
@@ -31,8 +45,8 @@ export function normalizeMattermostMessageText(message: string, botUsername: str
   }
 
   const mentionPrefix = `@${botUsername}`
-  const mentionIndex = trimmed.indexOf(mentionPrefix)
-  const isMentioned = mentionIndex >= 0 && isStandaloneMentionAt(trimmed, mentionPrefix, mentionIndex)
+  const mentionIndex = findStandaloneMentionIndex(trimmed, mentionPrefix)
+  const isMentioned = mentionIndex >= 0
 
   if (!isMentioned || mentionIndex !== 0) {
     return { text: trimmed, isMentioned, commandInput: null }

--- a/src/chat/mattermost/message-normalization.ts
+++ b/src/chat/mattermost/message-normalization.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+export type NormalizedMattermostText = {
+  readonly text: string
+  readonly isMentioned: boolean
+  readonly commandInput: string | null
+}
+
+export function normalizeMattermostMessageText(message: string, botUsername: string | null): NormalizedMattermostText {
+  const trimmed = message.trim()
+
+  if (botUsername === null) {
+    return { text: trimmed, isMentioned: false, commandInput: null }
+  }
+
+  const mentionPrefix = `@${botUsername}`
+  if (!trimmed.startsWith(mentionPrefix)) {
+    return { text: trimmed, isMentioned: false, commandInput: null }
+  }
+
+  const nextChar = trimmed.charAt(mentionPrefix.length)
+  if (nextChar !== '' && !/\s/u.test(nextChar)) {
+    return { text: trimmed, isMentioned: false, commandInput: null }
+  }
+
+  const remainder = trimmed.slice(mentionPrefix.length).trim()
+  return {
+    text: remainder,
+    isMentioned: true,
+    commandInput: remainder.startsWith('/') ? remainder : null,
+  }
+}

--- a/src/chat/mattermost/message-normalization.ts
+++ b/src/chat/mattermost/message-normalization.ts
@@ -9,6 +9,20 @@ export type NormalizedMattermostText = {
   readonly commandInput: string | null
 }
 
+function isUsernameChar(char: string): boolean {
+  return /[\w.-]/u.test(char)
+}
+
+function isStandaloneMentionAt(text: string, mentionPrefix: string, startIndex: number): boolean {
+  const beforeChar = startIndex === 0 ? '' : text.charAt(startIndex - 1)
+  if (beforeChar !== '' && isUsernameChar(beforeChar)) {
+    return false
+  }
+
+  const afterChar = text.charAt(startIndex + mentionPrefix.length)
+  return afterChar === '' || !isUsernameChar(afterChar)
+}
+
 export function normalizeMattermostMessageText(message: string, botUsername: string | null): NormalizedMattermostText {
   const trimmed = message.trim()
 
@@ -17,13 +31,11 @@ export function normalizeMattermostMessageText(message: string, botUsername: str
   }
 
   const mentionPrefix = `@${botUsername}`
-  if (!trimmed.startsWith(mentionPrefix)) {
-    return { text: trimmed, isMentioned: false, commandInput: null }
-  }
+  const mentionIndex = trimmed.indexOf(mentionPrefix)
+  const isMentioned = mentionIndex >= 0 && isStandaloneMentionAt(trimmed, mentionPrefix, mentionIndex)
 
-  const nextChar = trimmed.charAt(mentionPrefix.length)
-  if (nextChar !== '' && !/\s/u.test(nextChar)) {
-    return { text: trimmed, isMentioned: false, commandInput: null }
+  if (!isMentioned || mentionIndex !== 0) {
+    return { text: trimmed, isMentioned, commandInput: null }
   }
 
   const remainder = trimmed.slice(mentionPrefix.length).trim()

--- a/src/chat/router.ts
+++ b/src/chat/router.ts
@@ -290,9 +290,11 @@ export class ChatRouter implements ChatProvider {
 
   private async setCommandsForInstance(instance: ManagedChatInstance, adminUserId: string): Promise<void> {
     if (instance.provider.setCommands === undefined) return
-    await instance.provider.setCommands(adminUserId).catch((error: unknown) => {
+    try {
+      await instance.provider.setCommands(adminUserId)
+    } catch (error) {
       log.warn({ platformInstanceId: instance.id, error: errorMessage(error) }, 'failed to set chat commands')
       throw error
-    })
+    }
   }
 }

--- a/src/chat/router.ts
+++ b/src/chat/router.ts
@@ -289,12 +289,10 @@ export class ChatRouter implements ChatProvider {
   }
 
   private async setCommandsForInstance(instance: ManagedChatInstance, adminUserId: string): Promise<void> {
-    try {
-      if (instance.provider.setCommands !== undefined) {
-        await instance.provider.setCommands(adminUserId)
-      }
-    } catch (error) {
+    if (instance.provider.setCommands === undefined) return
+    await instance.provider.setCommands(adminUserId).catch((error: unknown) => {
       log.warn({ platformInstanceId: instance.id, error: errorMessage(error) }, 'failed to set chat commands')
-    }
+      throw error
+    })
   }
 }

--- a/src/chat/telegram/commands.ts
+++ b/src/chat/telegram/commands.ts
@@ -24,6 +24,7 @@ type TelegramPublishedCommand = {
 type TelegramCommandBot = {
   readonly api: {
     setMyCommands: (commands: readonly TelegramPublishedCommand[], options: TelegramCommandOptions) => Promise<unknown>
+    deleteMyCommands: (options: TelegramCommandOptions) => Promise<unknown>
   }
 }
 
@@ -64,6 +65,8 @@ export async function registerTelegramCommands(bot: TelegramCommandBot, adminUse
   const groupAdminCommands = commandsForScope('group-admin')
   if (groupAdminCommands.length > 0) {
     await bot.api.setMyCommands(groupAdminCommands, { scope: { type: 'all_chat_administrators' } })
+  } else {
+    await bot.api.deleteMyCommands({ scope: { type: 'all_chat_administrators' } })
   }
 
   log.info({ adminUserId }, 'Telegram command menu registered')

--- a/src/chat/telegram/commands.ts
+++ b/src/chat/telegram/commands.ts
@@ -3,30 +3,68 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import type { Bot } from 'grammy'
-
+import { listCommandCatalogEntries } from '../../commands/catalog.js'
 import { logger } from '../../logger.js'
 
 const log = logger.child({ scope: 'chat:telegram:commands' })
 
-const userCommands = [
-  { command: 'help', description: 'Show available commands' },
-  { command: 'setup', description: 'Interactive configuration wizard' },
-  { command: 'config', description: 'View current configuration' },
-  { command: 'clear', description: 'Clear conversation history and memory' },
-  { command: 'context', description: 'Show current LLM context usage' },
-] as const
+type TelegramCommandScope = 'dm-user' | 'dm-admin' | 'group-user' | 'group-admin'
 
-const adminCommands = [
-  ...userCommands,
-  { command: 'user', description: 'Manage users — /user add|remove <id|@username>' },
-  { command: 'users', description: 'List authorized users' },
-] as const
+type TelegramCommandOptions =
+  | { readonly scope: { readonly type: 'all_private_chats' } }
+  | { readonly scope: { readonly type: 'chat'; readonly chat_id: number } }
+  | { readonly scope: { readonly type: 'all_group_chats' } }
+  | { readonly scope: { readonly type: 'all_chat_administrators' } }
 
-export async function registerTelegramCommands(bot: Bot, adminUserId: string): Promise<void> {
-  await bot.api.setMyCommands(userCommands, { scope: { type: 'all_private_chats' } })
-  await bot.api.setMyCommands(adminCommands, {
-    scope: { type: 'chat', chat_id: parseInt(adminUserId, 10) },
-  })
+type TelegramPublishedCommand = {
+  readonly command: string
+  readonly description: string
+}
+
+type TelegramCommandBot = {
+  readonly api: {
+    setMyCommands: (commands: readonly TelegramPublishedCommand[], options: TelegramCommandOptions) => Promise<unknown>
+  }
+}
+
+function commandsForScope(scope: TelegramCommandScope): readonly TelegramPublishedCommand[] {
+  return listCommandCatalogEntries()
+    .filter((entry) => {
+      switch (scope) {
+        case 'dm-user':
+          return entry.telegram.publishInDmUser
+        case 'dm-admin':
+          return entry.telegram.publishInDmAdmin
+        case 'group-user':
+          return entry.telegram.publishInGroupUser
+        case 'group-admin':
+          return entry.telegram.publishInGroupAdmin
+        default:
+          return false
+      }
+    })
+    .map((entry) => ({ command: entry.name, description: entry.description }))
+}
+
+function parseAdminChatId(adminUserId: string): number {
+  if (!/^\d+$/u.test(adminUserId)) {
+    throw new Error(`Telegram admin command scope requires a numeric ADMIN_USER_ID, got: ${adminUserId}`)
+  }
+
+  return Number.parseInt(adminUserId, 10)
+}
+
+export async function registerTelegramCommands(bot: TelegramCommandBot, adminUserId: string): Promise<void> {
+  const adminChatId = parseAdminChatId(adminUserId)
+
+  await bot.api.setMyCommands(commandsForScope('dm-user'), { scope: { type: 'all_private_chats' } })
+  await bot.api.setMyCommands(commandsForScope('dm-admin'), { scope: { type: 'chat', chat_id: adminChatId } })
+  await bot.api.setMyCommands(commandsForScope('group-user'), { scope: { type: 'all_group_chats' } })
+
+  const groupAdminCommands = commandsForScope('group-admin')
+  if (groupAdminCommands.length > 0) {
+    await bot.api.setMyCommands(groupAdminCommands, { scope: { type: 'all_chat_administrators' } })
+  }
+
   log.info({ adminUserId }, 'Telegram command menu registered')
 }

--- a/src/chat/telegram/commands.ts
+++ b/src/chat/telegram/commands.ts
@@ -28,6 +28,28 @@ type TelegramCommandBot = {
   }
 }
 
+async function publishScopeCommands(
+  bot: TelegramCommandBot,
+  commands: readonly TelegramPublishedCommand[],
+  options: TelegramCommandOptions,
+): Promise<void> {
+  try {
+    await bot.api.setMyCommands(commands, options)
+  } catch (error) {
+    log.error({ err: error, scope: options.scope.type }, 'Telegram command publication failed')
+    throw error
+  }
+}
+
+async function clearScopeCommands(bot: TelegramCommandBot, options: TelegramCommandOptions): Promise<void> {
+  try {
+    await bot.api.deleteMyCommands(options)
+  } catch (error) {
+    log.error({ err: error, scope: options.scope.type }, 'Telegram command publication failed')
+    throw error
+  }
+}
+
 function commandsForScope(scope: TelegramCommandScope): readonly TelegramPublishedCommand[] {
   return listCommandCatalogEntries()
     .filter((entry) => {
@@ -58,15 +80,15 @@ function parseAdminChatId(adminUserId: string): number {
 export async function registerTelegramCommands(bot: TelegramCommandBot, adminUserId: string): Promise<void> {
   const adminChatId = parseAdminChatId(adminUserId)
 
-  await bot.api.setMyCommands(commandsForScope('dm-user'), { scope: { type: 'all_private_chats' } })
-  await bot.api.setMyCommands(commandsForScope('dm-admin'), { scope: { type: 'chat', chat_id: adminChatId } })
-  await bot.api.setMyCommands(commandsForScope('group-user'), { scope: { type: 'all_group_chats' } })
+  await publishScopeCommands(bot, commandsForScope('dm-user'), { scope: { type: 'all_private_chats' } })
+  await publishScopeCommands(bot, commandsForScope('dm-admin'), { scope: { type: 'chat', chat_id: adminChatId } })
+  await publishScopeCommands(bot, commandsForScope('group-user'), { scope: { type: 'all_group_chats' } })
 
   const groupAdminCommands = commandsForScope('group-admin')
   if (groupAdminCommands.length > 0) {
-    await bot.api.setMyCommands(groupAdminCommands, { scope: { type: 'all_chat_administrators' } })
+    await publishScopeCommands(bot, groupAdminCommands, { scope: { type: 'all_chat_administrators' } })
   } else {
-    await bot.api.deleteMyCommands({ scope: { type: 'all_chat_administrators' } })
+    await clearScopeCommands(bot, { scope: { type: 'all_chat_administrators' } })
   }
 
   log.info({ adminUserId }, 'Telegram command menu registered')

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -13,6 +13,7 @@ export type TelegramCommandVisibility = {
 export type CommandCatalogEntry = {
   readonly name: string
   readonly description: string
+  readonly registration: string
   readonly telegram: TelegramCommandVisibility
 }
 
@@ -20,6 +21,7 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   {
     name: 'help',
     description: 'Show available commands',
+    registration: 'registerHelpCommand',
     telegram: {
       publishInDmUser: true,
       publishInDmAdmin: true,
@@ -30,6 +32,7 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   {
     name: 'start',
     description: 'Show welcome and getting-started guidance',
+    registration: 'registerStartCommand',
     telegram: {
       publishInDmUser: true,
       publishInDmAdmin: true,
@@ -40,6 +43,7 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   {
     name: 'setup',
     description: 'Interactive configuration wizard',
+    registration: 'registerSetupCommand',
     telegram: {
       publishInDmUser: true,
       publishInDmAdmin: true,
@@ -50,6 +54,7 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   {
     name: 'config',
     description: 'View or edit current configuration',
+    registration: 'registerConfigCommand',
     telegram: {
       publishInDmUser: true,
       publishInDmAdmin: true,
@@ -60,6 +65,7 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   {
     name: 'context',
     description: 'Show current LLM context usage',
+    registration: 'registerContextCommand',
     telegram: {
       publishInDmUser: true,
       publishInDmAdmin: true,
@@ -70,6 +76,7 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   {
     name: 'clear',
     description: 'Clear conversation history and memory',
+    registration: 'registerClearCommand',
     telegram: {
       publishInDmUser: true,
       publishInDmAdmin: true,
@@ -80,6 +87,7 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   {
     name: 'group',
     description: 'Manage group authorization or membership',
+    registration: 'registerGroupCommand',
     telegram: {
       publishInDmUser: false,
       publishInDmAdmin: true,
@@ -90,6 +98,7 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   {
     name: 'groups',
     description: 'List authorized groups',
+    registration: 'registerAdminCommands',
     telegram: {
       publishInDmUser: false,
       publishInDmAdmin: true,
@@ -100,6 +109,7 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   {
     name: 'user',
     description: 'Manage users',
+    registration: 'registerAdminCommands',
     telegram: {
       publishInDmUser: false,
       publishInDmAdmin: true,
@@ -110,6 +120,7 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   {
     name: 'users',
     description: 'List authorized users',
+    registration: 'registerAdminCommands',
     telegram: {
       publishInDmUser: false,
       publishInDmAdmin: true,
@@ -120,6 +131,7 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   {
     name: 'announce',
     description: 'Send announcement to all authorized users',
+    registration: 'registerAdminCommands',
     telegram: {
       publishInDmUser: false,
       publishInDmAdmin: true,
@@ -130,6 +142,7 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   {
     name: 'plugin',
     description: 'Manage plugins',
+    registration: 'registerPluginCommand',
     telegram: {
       publishInDmUser: false,
       publishInDmAdmin: true,

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+export type TelegramCommandVisibility = {
+  readonly publishInDmUser: boolean
+  readonly publishInDmAdmin: boolean
+  readonly publishInGroupUser: boolean
+  readonly publishInGroupAdmin: boolean
+}
+
+export type CommandCatalogEntry = {
+  readonly name: string
+  readonly description: string
+  readonly telegram: TelegramCommandVisibility
+}
+
+const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
+  {
+    name: 'help',
+    description: 'Show available commands',
+    telegram: {
+      publishInDmUser: true,
+      publishInDmAdmin: true,
+      publishInGroupUser: true,
+      publishInGroupAdmin: true,
+    },
+  },
+  {
+    name: 'start',
+    description: 'Show welcome and getting-started guidance',
+    telegram: {
+      publishInDmUser: true,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+  {
+    name: 'setup',
+    description: 'Interactive configuration wizard',
+    telegram: {
+      publishInDmUser: true,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+  {
+    name: 'config',
+    description: 'View or edit current configuration',
+    telegram: {
+      publishInDmUser: true,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+  {
+    name: 'context',
+    description: 'Show current LLM context usage',
+    telegram: {
+      publishInDmUser: true,
+      publishInDmAdmin: true,
+      publishInGroupUser: true,
+      publishInGroupAdmin: true,
+    },
+  },
+  {
+    name: 'clear',
+    description: 'Clear conversation history and memory',
+    telegram: {
+      publishInDmUser: true,
+      publishInDmAdmin: true,
+      publishInGroupUser: true,
+      publishInGroupAdmin: true,
+    },
+  },
+  {
+    name: 'group',
+    description: 'Manage group authorization or membership',
+    telegram: {
+      publishInDmUser: false,
+      publishInDmAdmin: true,
+      publishInGroupUser: true,
+      publishInGroupAdmin: true,
+    },
+  },
+  {
+    name: 'groups',
+    description: 'List authorized groups',
+    telegram: {
+      publishInDmUser: false,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+  {
+    name: 'user',
+    description: 'Manage users',
+    telegram: {
+      publishInDmUser: false,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+  {
+    name: 'users',
+    description: 'List authorized users',
+    telegram: {
+      publishInDmUser: false,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+  {
+    name: 'announce',
+    description: 'Send announcement to all authorized users',
+    telegram: {
+      publishInDmUser: false,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+  {
+    name: 'plugin',
+    description: 'Manage plugins',
+    telegram: {
+      publishInDmUser: false,
+      publishInDmAdmin: true,
+      publishInGroupUser: false,
+      publishInGroupAdmin: false,
+    },
+  },
+]
+
+export function listCommandCatalogEntries(): readonly CommandCatalogEntry[] {
+  return COMMAND_CATALOG
+}
+
+export function getCommandCatalogEntry(name: string): CommandCatalogEntry {
+  const entry = COMMAND_CATALOG.find((candidate) => candidate.name === name)
+
+  if (entry === undefined) {
+    throw new Error(`Unknown command catalog entry: ${name}`)
+  }
+
+  return entry
+}

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -10,10 +10,21 @@ export type TelegramCommandVisibility = {
   readonly publishInGroupAdmin: boolean
 }
 
+export type CommandRegistration =
+  | 'registerAdminCommands'
+  | 'registerClearCommand'
+  | 'registerConfigCommand'
+  | 'registerContextCommand'
+  | 'registerGroupCommand'
+  | 'registerHelpCommand'
+  | 'registerPluginCommand'
+  | 'registerSetupCommand'
+  | 'registerStartCommand'
+
 export type CommandCatalogEntry = {
   readonly name: string
   readonly description: string
-  readonly registration: string
+  readonly registration: CommandRegistration
   readonly telegram: TelegramCommandVisibility
 }
 

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -98,7 +98,7 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   {
     name: 'groups',
     description: 'List authorized groups',
-    registration: 'registerAdminCommands',
+    registration: 'registerGroupCommand',
     telegram: {
       publishInDmUser: false,
       publishInDmAdmin: true,

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -166,13 +166,3 @@ const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
 export function listCommandCatalogEntries(): readonly CommandCatalogEntry[] {
   return COMMAND_CATALOG
 }
-
-export function getCommandCatalogEntry(name: string): CommandCatalogEntry {
-  const entry = COMMAND_CATALOG.find((candidate) => candidate.name === name)
-
-  if (entry === undefined) {
-    throw new Error(`Unknown command catalog entry: ${name}`)
-  }
-
-  return entry
-}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,6 +4,7 @@
 // See LICENSE in the project root for details.
 
 export { registerAdminCommands } from './admin.js'
+export { getCommandCatalogEntry, listCommandCatalogEntries } from './catalog.js'
 export { registerClearCommand } from './clear.js'
 export { registerConfigCommand } from './config.js'
 export { registerContextCommand } from './context.js'

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,7 +4,7 @@
 // See LICENSE in the project root for details.
 
 export { registerAdminCommands } from './admin.js'
-export { getCommandCatalogEntry, listCommandCatalogEntries } from './catalog.js'
+export { listCommandCatalogEntries } from './catalog.js'
 export { registerClearCommand } from './clear.js'
 export { registerConfigCommand } from './config.js'
 export { registerContextCommand } from './context.js'

--- a/src/group-settings/access.ts
+++ b/src/group-settings/access.ts
@@ -3,13 +3,20 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { isAuthorizedGroup } from '../authorized-groups.js'
-import { getNativeContextId, isScopedContextId, toScopedContextId } from '../chat/scoped-context.js'
+import { isAuthorizedGroup, listAuthorizedGroups } from '../authorized-groups.js'
+import {
+  getNativeContextId,
+  isScopedContextId,
+  parseScopedContextId,
+  toScopedContextId,
+} from '../chat/scoped-context.js'
+import { isAdmin } from '../instances/admin-store.js'
 import { logger } from '../logger.js'
 import { listAdminGroupContextsForUser } from './registry.js'
 import type { KnownGroupContext } from './types.js'
 
 const log = logger.child({ scope: 'group-settings:access' })
+const FALLBACK_PROVIDER = 'unknown'
 
 export type GroupMatchResult =
   | { kind: 'match'; group: KnownGroupContext }
@@ -39,6 +46,44 @@ const isAuthorizedGroupContext = (group: KnownGroupContext, platformInstanceId: 
   return isAuthorizedGroup(getNativeContextId(group.contextId))
 }
 
+const fallbackKnownGroupContext = (contextId: string): KnownGroupContext => {
+  const now = new Date().toISOString()
+  return {
+    contextId,
+    provider: FALLBACK_PROVIDER,
+    displayName: getNativeContextId(contextId),
+    parentName: null,
+    firstSeenAt: now,
+    lastSeenAt: now,
+    source: 'authorized-fallback',
+  }
+}
+
+const appendAuthorizedFallbackGroups = (
+  groups: readonly KnownGroupContext[],
+  userId: string,
+  platformInstanceId: string | undefined,
+): KnownGroupContext[] => {
+  if (platformInstanceId === undefined || !isAdmin(userId, platformInstanceId)) {
+    return [...groups]
+  }
+
+  const existing = new Set(groups.map((group) => group.contextId))
+  const fallbackGroups = listAuthorizedGroups()
+    .map((row) => row.group_id)
+    .filter((groupId) => {
+      if (existing.has(groupId) || !isScopedContextId(groupId)) {
+        return false
+      }
+
+      const parsed = parseScopedContextId(groupId)
+      return parsed?.platformInstanceId === platformInstanceId
+    })
+    .map((groupId) => fallbackKnownGroupContext(groupId))
+
+  return [...groups, ...fallbackGroups].toSorted((left, right) => left.displayName.localeCompare(right.displayName))
+}
+
 export function listManageableGroups(userId: string, ...args: [] | [platformInstanceId: string]): KnownGroupContext[] {
   const platformInstanceId = args[0]
   log.debug({ userId }, 'listManageableGroups called')
@@ -47,8 +92,10 @@ export function listManageableGroups(userId: string, ...args: [] | [platformInst
     isAuthorizedGroupContext(group, platformInstanceId),
   )
 
-  log.debug({ userId, groupCount: groups.length }, 'Listed manageable groups')
-  return groups
+  const mergedGroups = appendAuthorizedFallbackGroups(groups, userId, platformInstanceId)
+
+  log.debug({ userId, groupCount: mergedGroups.length }, 'Listed manageable groups')
+  return mergedGroups
 }
 
 export function validateGroupTargetAccess(

--- a/src/group-settings/access.ts
+++ b/src/group-settings/access.ts
@@ -105,7 +105,8 @@ export function validateGroupTargetAccess(
 ): GroupTargetAccessResult {
   const platformInstanceId = args[0]
   const adminGroups = listAdminGroupContextsForUser(userId, ...args)
-  const group = adminGroups.find((candidate) => {
+  const manageableGroups = appendAuthorizedFallbackGroups(adminGroups, userId, platformInstanceId)
+  const group = manageableGroups.find((candidate) => {
     if (candidate.contextId === groupId) return true
     return getAuthorizedGroupId(candidate, platformInstanceId) === groupId
   })

--- a/src/group-settings/types.ts
+++ b/src/group-settings/types.ts
@@ -10,6 +10,7 @@ export type KnownGroupContext = {
   readonly parentName: string | null
   readonly firstSeenAt: string
   readonly lastSeenAt: string
+  readonly source?: 'observed' | 'authorized-fallback'
 }
 
 export type GroupSettingsCommand = 'config' | 'setup'

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -28,6 +28,7 @@ import type {
   ReplyFn,
   ResolveUserContext,
 } from '../src/chat/types.js'
+import { listCommandCatalogEntries } from '../src/commands/catalog.js'
 import { getConfig, setConfig } from '../src/config.js'
 import { getDrizzleDb } from '../src/db/drizzle.js'
 import { groupAdminObservations, groupUserObservations, knownGroupContexts } from '../src/db/schema.js'
@@ -557,6 +558,18 @@ describe('Bot Authorization Gate (setupBot)', () => {
     )
 
     expect(commandHandlers.has('plugin')).toBe(true)
+  })
+
+  test('registered command handlers stay aligned with the command catalog', () => {
+    const { provider, commandHandlers } = createMockChatWithCommandHandlers()
+
+    setupBot(provider, 'admin-1', { processMessage: async () => {} })
+
+    expect([...commandHandlers.keys()].toSorted()).toEqual(
+      listCommandCatalogEntries()
+        .map((entry) => entry.name)
+        .toSorted(),
+    )
   })
 
   test('registers active plugin command contributions', () => {

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -561,11 +561,19 @@ describe('Bot Authorization Gate (setupBot)', () => {
   })
 
   test('registered command handlers stay aligned with the command catalog', () => {
-    const { provider, commandHandlers } = createMockChatWithCommandHandlers()
+    const registeredCommands: string[] = []
+    const baseProvider = createMockChat()
+    const provider: ChatProvider = {
+      ...baseProvider,
+      registerCommand: (name, handler): void => {
+        registeredCommands.push(name)
+        baseProvider.registerCommand(name, handler)
+      },
+    }
 
     setupBot(provider, 'admin-1', { processMessage: async () => {} })
 
-    expect([...commandHandlers.keys()].toSorted()).toEqual(
+    expect(registeredCommands.toSorted()).toEqual(
       listCommandCatalogEntries()
         .map((entry) => entry.name)
         .toSorted(),

--- a/tests/chat/mattermost/index.test.ts
+++ b/tests/chat/mattermost/index.test.ts
@@ -808,6 +808,42 @@ describe('MattermostChatProvider', () => {
       restoreFetch()
     })
 
+    test('recognizes a later standalone mention after an earlier near-match mention', async () => {
+      setMockFetch(makeFetchWithGroupChannel('O'))
+
+      provider = new MattermostChatProvider()
+      // @ts-expect-error - accessing private field for testing
+      provider.botUsername = 'testbot'
+
+      let seen: unknown = null
+      provider.onMessage((msg) => {
+        seen = msg
+        return Promise.resolve()
+      })
+
+      const handlePostedEvent = getPostedEventHandler(provider)
+
+      await handlePostedEvent.call(provider, {
+        sender_name: 'testuser',
+        post: JSON.stringify({
+          id: 'post128',
+          user_id: 'user456',
+          channel_id: 'channel789',
+          message: '@testbotty please ask @testbot',
+          root_id: '',
+          parent_id: '',
+        }),
+      })
+
+      expect(seen).not.toBeNull()
+      assert(isIncomingMessage(seen))
+      const message = seen
+      expect(message.isMentioned).toBe(true)
+      expect(message.text).toBe('@testbotty please ask @testbot')
+
+      restoreFetch()
+    })
+
     test('IncomingMessage contains threadId from replyToMessageId when root_id empty', async () => {
       setMockFetch(makeFetchWithGroupChannel('O'))
 

--- a/tests/chat/mattermost/index.test.ts
+++ b/tests/chat/mattermost/index.test.ts
@@ -527,6 +527,8 @@ describe('MattermostChatProvider', () => {
     test('command auth uses scoped storage context for active platform instance', async () => {
       setMockFetch(makeFetchWithGroupChannel('O'))
       provider = new MattermostChatProvider({ platformInstanceId: 'mattermost-secondary' })
+      // @ts-expect-error - accessing private field for testing
+      provider.botUsername = 'testbot'
       let auth: AuthorizationResult | undefined
       provider.registerCommand('test', (_msg, _reply, commandAuth): Promise<void> => {
         auth = commandAuth
@@ -540,7 +542,7 @@ describe('MattermostChatProvider', () => {
           id: 'post123',
           user_id: 'user456',
           channel_id: 'channel789',
-          message: '/test',
+          message: '@testbot /test',
           root_id: 'threadRoot',
           parent_id: '',
         }),

--- a/tests/chat/mattermost/index.test.ts
+++ b/tests/chat/mattermost/index.test.ts
@@ -722,6 +722,92 @@ describe('MattermostChatProvider', () => {
       restoreFetch()
     })
 
+    test('keeps non-prefix mentions on the normal message flow while preserving isMentioned', async () => {
+      setMockFetch(makeFetchWithGroupChannel('O'))
+
+      provider = new MattermostChatProvider()
+      // @ts-expect-error - accessing private field for testing
+      provider.botUsername = 'testbot'
+
+      let commandCalled = false
+      let seen: unknown = null
+      provider.registerCommand('config', () => {
+        commandCalled = true
+        return Promise.resolve()
+      })
+      provider.onMessage((msg) => {
+        seen = msg
+        return Promise.resolve()
+      })
+
+      const handlePostedEvent = getPostedEventHandler(provider)
+
+      await handlePostedEvent.call(provider, {
+        sender_name: 'testuser',
+        post: JSON.stringify({
+          id: 'post126',
+          user_id: 'user456',
+          channel_id: 'channel789',
+          message: 'hello @testbot',
+          root_id: '',
+          parent_id: '',
+        }),
+      })
+
+      expect(commandCalled).toBe(false)
+      expect(seen).not.toBeNull()
+      assert(isIncomingMessage(seen))
+      const message = seen
+      expect(message.isMentioned).toBe(true)
+      expect(message.text).toBe('hello @testbot')
+      expect(message.commandMatch).toBeUndefined()
+
+      restoreFetch()
+    })
+
+    test('does not treat near-match prefixes as bot mentions or commands', async () => {
+      setMockFetch(makeFetchWithGroupChannel('O'))
+
+      provider = new MattermostChatProvider()
+      // @ts-expect-error - accessing private field for testing
+      provider.botUsername = 'testbot'
+
+      let commandCalled = false
+      let seen: unknown = null
+      provider.registerCommand('config', () => {
+        commandCalled = true
+        return Promise.resolve()
+      })
+      provider.onMessage((msg) => {
+        seen = msg
+        return Promise.resolve()
+      })
+
+      const handlePostedEvent = getPostedEventHandler(provider)
+
+      await handlePostedEvent.call(provider, {
+        sender_name: 'testuser',
+        post: JSON.stringify({
+          id: 'post127',
+          user_id: 'user456',
+          channel_id: 'channel789',
+          message: '@testbotty /config',
+          root_id: '',
+          parent_id: '',
+        }),
+      })
+
+      expect(commandCalled).toBe(false)
+      expect(seen).not.toBeNull()
+      assert(isIncomingMessage(seen))
+      const message = seen
+      expect(message.isMentioned).toBe(false)
+      expect(message.text).toBe('@testbotty /config')
+      expect(message.commandMatch).toBeUndefined()
+
+      restoreFetch()
+    })
+
     test('IncomingMessage contains threadId from replyToMessageId when root_id empty', async () => {
       setMockFetch(makeFetchWithGroupChannel('O'))
 

--- a/tests/chat/mattermost/index.test.ts
+++ b/tests/chat/mattermost/index.test.ts
@@ -751,7 +751,7 @@ describe('MattermostChatProvider', () => {
         }),
       })
 
-      expect(replies.getReplies()).toEqual(['Use `@papai /help` to see commands, or mention me with a question.'])
+      expect(replies.getReplies()).toEqual(['Use `@testbot /help` to see commands, or mention me with a question.'])
 
       restoreFetch()
     })

--- a/tests/chat/mattermost/index.test.ts
+++ b/tests/chat/mattermost/index.test.ts
@@ -557,6 +557,105 @@ describe('MattermostChatProvider', () => {
       restoreFetch()
     })
 
+    test('routes @mention-prefixed slash text to the registered command handler', async () => {
+      setMockFetch(makeFetchWithGroupChannel('O'))
+
+      provider = new MattermostChatProvider()
+      // @ts-expect-error - accessing private field for testing
+      provider.botUsername = 'testbot'
+
+      let commandCalled = false
+      provider.registerCommand('config', () => {
+        commandCalled = true
+        return Promise.resolve()
+      })
+
+      const handlePostedEvent = getPostedEventHandler(provider)
+
+      await handlePostedEvent.call(provider, {
+        sender_name: 'testuser',
+        post: JSON.stringify({
+          id: 'post123',
+          user_id: 'user456',
+          channel_id: 'channel789',
+          message: '@testbot /config',
+          root_id: '',
+          parent_id: '',
+        }),
+      })
+
+      expect(commandCalled).toBe(true)
+
+      restoreFetch()
+    })
+
+    test('does not route bare slash text to papai command handlers', async () => {
+      setMockFetch(makeFetchWithGroupChannel('O'))
+
+      provider = new MattermostChatProvider()
+
+      let commandCalled = false
+      provider.registerCommand('config', () => {
+        commandCalled = true
+        return Promise.resolve()
+      })
+
+      const handlePostedEvent = getPostedEventHandler(provider)
+
+      await handlePostedEvent.call(provider, {
+        sender_name: 'testuser',
+        post: JSON.stringify({
+          id: 'post123',
+          user_id: 'user456',
+          channel_id: 'channel789',
+          message: '/config',
+          root_id: '',
+          parent_id: '',
+        }),
+      })
+
+      expect(commandCalled).toBe(false)
+
+      restoreFetch()
+    })
+
+    test('keeps mention-prefixed natural language on the message flow', async () => {
+      setMockFetch(makeFetchWithGroupChannel('O'))
+
+      provider = new MattermostChatProvider()
+      // @ts-expect-error - accessing private field for testing
+      provider.botUsername = 'testbot'
+
+      let seen: unknown = null
+      provider.onMessage((msg) => {
+        seen = msg
+        return Promise.resolve()
+      })
+
+      const handlePostedEvent = getPostedEventHandler(provider)
+
+      await handlePostedEvent.call(provider, {
+        sender_name: 'testuser',
+        post: JSON.stringify({
+          id: 'post123',
+          user_id: 'user456',
+          channel_id: 'channel789',
+          message: '@testbot summarize this thread',
+          root_id: '',
+          parent_id: '',
+        }),
+      })
+
+      expect(seen).not.toBeNull()
+      assert(isIncomingMessage(seen))
+      const message = seen
+      expect(message.isMentioned).toBe(true)
+      expect(message.text).toBe('summarize this thread')
+      expect(message.commandMatch).toBeUndefined()
+
+      restoreFetch()
+    })
+
     test('IncomingMessage contains threadId from replyToMessageId when root_id empty', async () => {
       setMockFetch(makeFetchWithGroupChannel('O'))
 

--- a/tests/chat/mattermost/index.test.ts
+++ b/tests/chat/mattermost/index.test.ts
@@ -589,6 +589,70 @@ describe('MattermostChatProvider', () => {
       restoreFetch()
     })
 
+    test('routes @mention-prefixed slash text to the registered command handler in dm', async () => {
+      setMockFetch(makeFetchWithGroupChannel('D'))
+
+      provider = new MattermostChatProvider()
+      // @ts-expect-error - accessing private field for testing
+      provider.botUsername = 'testbot'
+
+      let commandCalled = false
+      provider.registerCommand('config', () => {
+        commandCalled = true
+        return Promise.resolve()
+      })
+
+      const handlePostedEvent = getPostedEventHandler(provider)
+
+      await handlePostedEvent.call(provider, {
+        sender_name: 'testuser',
+        post: JSON.stringify({
+          id: 'post124',
+          user_id: 'user456',
+          channel_id: 'dm-channel',
+          message: '@testbot /config',
+          root_id: '',
+          parent_id: '',
+        }),
+      })
+
+      expect(commandCalled).toBe(true)
+
+      restoreFetch()
+    })
+
+    test('preserves commandMatch after removing a mention-prefixed slash command mention', async () => {
+      setMockFetch(makeFetchWithGroupChannel('O'))
+
+      provider = new MattermostChatProvider()
+      // @ts-expect-error - accessing private field for testing
+      provider.botUsername = 'testbot'
+
+      let commandMatch: string | undefined
+      provider.registerCommand('config', (msg) => {
+        commandMatch = msg.commandMatch
+        return Promise.resolve()
+      })
+
+      const handlePostedEvent = getPostedEventHandler(provider)
+
+      await handlePostedEvent.call(provider, {
+        sender_name: 'testuser',
+        post: JSON.stringify({
+          id: 'post125',
+          user_id: 'user456',
+          channel_id: 'channel789',
+          message: '@testbot /config foo',
+          root_id: '',
+          parent_id: '',
+        }),
+      })
+
+      expect(commandMatch).toBe('foo')
+
+      restoreFetch()
+    })
+
     test('does not route bare slash text to papai command handlers', async () => {
       setMockFetch(makeFetchWithGroupChannel('O'))
 

--- a/tests/chat/mattermost/index.test.ts
+++ b/tests/chat/mattermost/index.test.ts
@@ -722,6 +722,40 @@ describe('MattermostChatProvider', () => {
       restoreFetch()
     })
 
+    test('replies with guidance when a message only mentions the bot', async () => {
+      setMockFetch(makeFetchWithGroupChannel('O'))
+
+      provider = new MattermostChatProvider()
+      // @ts-expect-error - accessing private field for testing
+      provider.botUsername = 'testbot'
+
+      const replies = createMockReply()
+      provider.onMessage(async (_msg, reply) => {
+        await reply.text('should not be called')
+      })
+
+      // @ts-expect-error - replacing private method for testing
+      provider.buildReplyFn = (): typeof replies.reply => replies.reply
+
+      const handlePostedEvent = getPostedEventHandler(provider)
+
+      await handlePostedEvent.call(provider, {
+        sender_name: 'testuser',
+        post: JSON.stringify({
+          id: 'post129',
+          user_id: 'user456',
+          channel_id: 'channel789',
+          message: '@testbot',
+          root_id: '',
+          parent_id: '',
+        }),
+      })
+
+      expect(replies.getReplies()).toEqual(['Use `@papai /help` to see commands, or mention me with a question.'])
+
+      restoreFetch()
+    })
+
     test('keeps non-prefix mentions on the normal message flow while preserving isMentioned', async () => {
       setMockFetch(makeFetchWithGroupChannel('O'))
 

--- a/tests/chat/router.test.ts
+++ b/tests/chat/router.test.ts
@@ -576,7 +576,7 @@ describe('ChatRouter', () => {
     expect(groupLabel).toBe('discord:group-1')
   })
 
-  test('continues setting commands when one instance fails', async () => {
+  test('rejects setting commands when one instance fails', async () => {
     const setCommandsById: Record<string, (adminUserId: string, calls: string[]) => Promise<void>> = {
       bad: () => Promise.reject(new Error('command menu failed')),
       good: () => Promise.resolve(),
@@ -592,7 +592,7 @@ describe('ChatRouter', () => {
     router.addInstance('bad', 'telegram', {})
     router.addInstance('good', 'discord', {})
 
-    await expect(router.setCommands('admin-1')).resolves.toBeUndefined()
+    await expect(router.setCommands('admin-1')).rejects.toThrow('command menu failed')
 
     expect(getProvider('bad').setCommandsCalls).toEqual(['admin-1'])
     expect(getProvider('good').setCommandsCalls).toEqual(['admin-1'])

--- a/tests/chat/router.test.ts
+++ b/tests/chat/router.test.ts
@@ -3,7 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { beforeEach, describe, expect, test } from 'bun:test'
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
 
 import { ChatRouter, type ManagedChatInstance, type ManagedChatInstanceFactory } from '../../src/chat/router.js'
 import { dmTarget } from '../../src/chat/types.js'
@@ -24,6 +24,7 @@ import type {
 import { setContextSettings } from '../../src/instances/context-store.js'
 import type { InstanceConfig, PlatformInstanceType } from '../../src/instances/types.js'
 import {
+  createTrackedLoggerMock,
   mockLogger,
   seedCommonTestPlatformInstances,
   seedTestTaskInstance,
@@ -40,6 +41,8 @@ type FakeProvider = ChatProvider & {
   commandHandlers: Record<string, CommandHandler>
   setCommandsCalls: string[]
 }
+
+type RouterModule = typeof import('../../src/chat/router.js')
 
 const fakeReply: ReplyFn = {
   text: () => Promise.resolve(),
@@ -82,6 +85,26 @@ const noopPromise = (): Promise<void> => Promise.resolve()
 const callResolver = (resolve: (() => void) | undefined): void => {
   if (resolve === undefined) throw new Error('resolver missing')
   resolve()
+}
+
+const requireSetCommands = (
+  setCommandsById: Record<string, () => Promise<void>>,
+  id: string,
+): (() => Promise<void>) => {
+  const setCommands = setCommandsById[id]
+  if (setCommands === undefined) throw new Error(`missing setCommands for ${id}`)
+  return setCommands
+}
+
+const isRouterModule = (module: unknown): module is RouterModule =>
+  typeof module === 'object' && module !== null && 'ChatRouter' in module && typeof module.ChatRouter === 'function'
+
+const loadFreshRouterModule = async (): Promise<RouterModule> => {
+  const module: unknown = await import(`../../src/chat/router.js?test=${crypto.randomUUID()}`)
+  if (!isRouterModule(module)) {
+    throw new Error('Failed to load chat router module for testing')
+  }
+  return module
 }
 
 type FakeProviderOptions = Partial<{
@@ -596,6 +619,44 @@ describe('ChatRouter', () => {
 
     expect(getProvider('bad').setCommandsCalls).toEqual(['admin-1'])
     expect(getProvider('good').setCommandsCalls).toEqual(['admin-1'])
+  })
+
+  test('logs and rethrows synchronous command publication failures', async () => {
+    const trackedLogger = createTrackedLoggerMock()
+    void mock.module('../../src/logger.js', () => ({
+      getLogLevel: trackedLogger.getLogLevel,
+      logger: trackedLogger.logger,
+    }))
+    const routerModule = await loadFreshRouterModule()
+    const FreshChatRouter = routerModule.ChatRouter
+
+    const setCommandsById: Record<string, () => Promise<void>> = {
+      bad: () => {
+        throw new Error('sync command failure')
+      },
+      good: () => Promise.resolve(),
+    }
+
+    factory = (id: string, type: PlatformInstanceType): ChatProvider => {
+      const fakeProvider = makeProvider(type, {
+        setCommands: () => requireSetCommands(setCommandsById, id)(),
+      })
+      providers[id] = fakeProvider
+      return fakeProvider
+    }
+
+    const freshRouter = new FreshChatRouter(factory)
+    freshRouter.addInstance('bad', 'telegram', {})
+    freshRouter.addInstance('good', 'discord', {})
+
+    await expect(freshRouter.setCommands('admin-1')).rejects.toThrow('sync command failure')
+
+    expect(getProvider('bad').setCommandsCalls).toEqual(['admin-1'])
+    expect(getProvider('good').setCommandsCalls).toEqual(['admin-1'])
+    expect(trackedLogger.getCallsByLevel('warn')).toContainEqual({
+      level: 'warn',
+      args: [{ platformInstanceId: 'bad', error: 'sync command failure' }, 'failed to set chat commands'],
+    })
   })
 
   test('excludes stopped instances from aggregate metadata and command menus', async () => {

--- a/tests/chat/telegram/commands.test.ts
+++ b/tests/chat/telegram/commands.test.ts
@@ -5,7 +5,9 @@
 
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
 
+import * as commandCatalog from '../../../src/commands/catalog.js'
 import type { CommandCatalogEntry } from '../../../src/commands/catalog.js'
+import { createTrackedLoggerMock, type TrackedLoggerMock } from '../../utils/test-helpers.js'
 
 type TelegramPublishedCommand = {
   readonly command: string
@@ -29,6 +31,19 @@ type TestBot = {
   }
 }
 
+type ExpectedCommandPayload = {
+  readonly command: string
+  readonly description: string
+}
+
+type FailureScenario = {
+  readonly failingScope: string
+  readonly failingCall: number
+  readonly useDelete: boolean
+}
+
+type TelegramCommandsModule = typeof import('../../../src/chat/telegram/commands.js')
+
 function requireCall(calls: readonly SetMyCommandsCall[], index: number): SetMyCommandsCall {
   const call = calls[index]
   if (call === undefined) {
@@ -37,14 +52,37 @@ function requireCall(calls: readonly SetMyCommandsCall[], index: number): SetMyC
   return call
 }
 
+function expectCommandPayload(
+  commands: readonly TelegramPublishedCommand[],
+  expected: readonly ExpectedCommandPayload[],
+): void {
+  expect(commands).toEqual(expected)
+}
+
+function isTelegramCommandsModule(module: unknown): module is TelegramCommandsModule {
+  return (
+    typeof module === 'object' &&
+    module !== null &&
+    'registerTelegramCommands' in module &&
+    typeof module.registerTelegramCommands === 'function'
+  )
+}
+
 describe('registerTelegramCommands', () => {
   let calls: SetMyCommandsCall[]
   let deleteCalls: DeleteMyCommandsCall[]
+  const trackedLogger: TrackedLoggerMock = createTrackedLoggerMock()
 
   async function loadRegisterTelegramCommands(): Promise<
     typeof import('../../../src/chat/telegram/commands.js').registerTelegramCommands
   > {
-    return (await import('../../../src/chat/telegram/commands.js')).registerTelegramCommands
+    const module: unknown = await import(`../../../src/chat/telegram/commands.js?test=${crypto.randomUUID()}`)
+
+    if (!isTelegramCommandsModule(module)) {
+      throw new Error('Failed to load Telegram commands module for testing')
+    }
+
+    return module.registerTelegramCommands
   }
 
   function createBot(): TestBot {
@@ -62,9 +100,64 @@ describe('registerTelegramCommands', () => {
     }
   }
 
+  async function expectPublicationFailureLog(scenario: FailureScenario): Promise<void> {
+    const publicationFailure = new Error('telegram publish failed')
+
+    const bot: TestBot = {
+      api: {
+        setMyCommands: (commands, options) => {
+          calls.push([commands, options])
+          if (!scenario.useDelete && calls.length - 1 === scenario.failingCall) {
+            return Promise.reject(publicationFailure)
+          }
+          return Promise.resolve(true)
+        },
+        deleteMyCommands: (options) => {
+          deleteCalls.push([options])
+          if (scenario.useDelete) {
+            return Promise.reject(publicationFailure)
+          }
+          return Promise.resolve(true)
+        },
+      },
+    }
+
+    if (scenario.useDelete) {
+      void mock.module('../../../src/commands/catalog.js', () => ({
+        listCommandCatalogEntries: (): readonly CommandCatalogEntry[] => [
+          {
+            name: 'help',
+            description: 'Show available commands',
+            registration: 'registerHelpCommand',
+            telegram: {
+              publishInDmUser: true,
+              publishInDmAdmin: true,
+              publishInGroupUser: true,
+              publishInGroupAdmin: false,
+            },
+          },
+        ],
+      }))
+    }
+
+    const registerTelegramCommands = await loadRegisterTelegramCommands()
+
+    await expect(registerTelegramCommands(bot, '12345')).rejects.toThrow('telegram publish failed')
+    expect(trackedLogger.getCallsByLevel('error')).toContainEqual({
+      level: 'error',
+      args: [{ err: publicationFailure, scope: scenario.failingScope }, 'Telegram command publication failed'],
+    })
+  }
+
   beforeEach(() => {
     calls = []
     deleteCalls = []
+    trackedLogger.clearCalls()
+    void mock.module('../../../src/commands/catalog.js', () => ({ ...commandCatalog }))
+    void mock.module('../../../src/logger.js', () => ({
+      getLogLevel: trackedLogger.getLogLevel,
+      logger: trackedLogger.logger,
+    }))
   })
 
   test('publishes DM, admin-DM, group, and group-admin scopes from the catalog', async () => {
@@ -81,37 +174,78 @@ describe('registerTelegramCommands', () => {
     const groupUserCall = requireCall(calls, 2)
     const groupAdminCall = requireCall(calls, 3)
 
-    expect(privateDmCall[0].map((command) => command.command)).toEqual([
-      'help',
-      'start',
-      'setup',
-      'config',
-      'context',
-      'clear',
+    expectCommandPayload(privateDmCall[0], [
+      { command: 'help', description: 'Show available commands' },
+      { command: 'start', description: 'Show welcome and getting-started guidance' },
+      { command: 'setup', description: 'Interactive configuration wizard' },
+      { command: 'config', description: 'View or edit current configuration' },
+      { command: 'context', description: 'Show current LLM context usage' },
+      { command: 'clear', description: 'Clear conversation history and memory' },
     ])
     expect(privateDmCall[1]).toEqual({ scope: { type: 'all_private_chats' } })
 
-    expect(adminDmCall[0].map((command) => command.command)).toEqual([
-      'help',
-      'start',
-      'setup',
-      'config',
-      'context',
-      'clear',
-      'group',
-      'groups',
-      'user',
-      'users',
-      'announce',
-      'plugin',
+    expectCommandPayload(adminDmCall[0], [
+      { command: 'help', description: 'Show available commands' },
+      { command: 'start', description: 'Show welcome and getting-started guidance' },
+      { command: 'setup', description: 'Interactive configuration wizard' },
+      { command: 'config', description: 'View or edit current configuration' },
+      { command: 'context', description: 'Show current LLM context usage' },
+      { command: 'clear', description: 'Clear conversation history and memory' },
+      { command: 'group', description: 'Manage group authorization or membership' },
+      { command: 'groups', description: 'List authorized groups' },
+      { command: 'user', description: 'Manage users' },
+      { command: 'users', description: 'List authorized users' },
+      { command: 'announce', description: 'Send announcement to all authorized users' },
+      { command: 'plugin', description: 'Manage plugins' },
     ])
     expect(adminDmCall[1]).toEqual({ scope: { type: 'chat', chat_id: 12345 } })
 
-    expect(groupUserCall[0].map((command) => command.command)).toEqual(['help', 'context', 'clear', 'group'])
+    expectCommandPayload(groupUserCall[0], [
+      { command: 'help', description: 'Show available commands' },
+      { command: 'context', description: 'Show current LLM context usage' },
+      { command: 'clear', description: 'Clear conversation history and memory' },
+      { command: 'group', description: 'Manage group authorization or membership' },
+    ])
     expect(groupUserCall[1]).toEqual({ scope: { type: 'all_group_chats' } })
 
-    expect(groupAdminCall[0].map((command) => command.command)).toEqual(['help', 'context', 'clear', 'group'])
+    expectCommandPayload(groupAdminCall[0], [
+      { command: 'help', description: 'Show available commands' },
+      { command: 'context', description: 'Show current LLM context usage' },
+      { command: 'clear', description: 'Clear conversation history and memory' },
+      { command: 'group', description: 'Manage group authorization or membership' },
+    ])
     expect(groupAdminCall[1]).toEqual({ scope: { type: 'all_chat_administrators' } })
+  })
+
+  test('throws when admin user id is not numeric for Telegram chat scope', async () => {
+    const bot = createBot()
+    const registerTelegramCommands = await loadRegisterTelegramCommands()
+
+    await expect(registerTelegramCommands(bot, 'admin-user')).rejects.toThrow(
+      'Telegram admin command scope requires a numeric ADMIN_USER_ID',
+    )
+    expect(calls).toHaveLength(0)
+    expect(deleteCalls).toHaveLength(0)
+  })
+
+  test('logs the all_private_chats publication scope before rethrowing', async () => {
+    await expectPublicationFailureLog({ failingScope: 'all_private_chats', failingCall: 0, useDelete: false })
+  })
+
+  test('logs the admin chat publication scope before rethrowing', async () => {
+    await expectPublicationFailureLog({ failingScope: 'chat', failingCall: 1, useDelete: false })
+  })
+
+  test('logs the all_group_chats publication scope before rethrowing', async () => {
+    await expectPublicationFailureLog({ failingScope: 'all_group_chats', failingCall: 2, useDelete: false })
+  })
+
+  test('logs the group-admin publication scope before rethrowing', async () => {
+    await expectPublicationFailureLog({ failingScope: 'all_chat_administrators', failingCall: 3, useDelete: false })
+  })
+
+  test('logs the group-admin clear scope before rethrowing', async () => {
+    await expectPublicationFailureLog({ failingScope: 'all_chat_administrators', failingCall: 3, useDelete: true })
   })
 
   test('clears the group-admin scope when the catalog has no admin-group commands', async () => {
@@ -138,16 +272,5 @@ describe('registerTelegramCommands', () => {
 
     expect(calls).toHaveLength(3)
     expect(deleteCalls).toEqual([[{ scope: { type: 'all_chat_administrators' } }]])
-  })
-
-  test('throws when admin user id is not numeric for Telegram chat scope', async () => {
-    const bot = createBot()
-    const registerTelegramCommands = await loadRegisterTelegramCommands()
-
-    await expect(registerTelegramCommands(bot, 'admin-user')).rejects.toThrow(
-      'Telegram admin command scope requires a numeric ADMIN_USER_ID',
-    )
-    expect(calls).toHaveLength(0)
-    expect(deleteCalls).toHaveLength(0)
   })
 })

--- a/tests/chat/telegram/commands.test.ts
+++ b/tests/chat/telegram/commands.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { registerTelegramCommands } from '../../../src/chat/telegram/commands.js'
+
+type TelegramPublishedCommand = {
+  readonly command: string
+  readonly description: string
+}
+
+type SetMyCommandsCall = [
+  commands: readonly TelegramPublishedCommand[],
+  options: { scope: { type: string; chat_id?: number } },
+]
+
+type TestBot = {
+  readonly api: {
+    setMyCommands: (
+      commands: readonly TelegramPublishedCommand[],
+      options: { scope: { type: string; chat_id?: number } },
+    ) => Promise<boolean>
+  }
+}
+
+function commandNames(commands: readonly TelegramPublishedCommand[]): readonly string[] {
+  return commands.map((command) => command.command)
+}
+
+function expectIncludesCommands(actual: readonly string[], expected: readonly string[]): void {
+  for (const command of expected) {
+    expect(actual.includes(command)).toBe(true)
+  }
+}
+
+function requireCall(calls: readonly SetMyCommandsCall[], index: number): SetMyCommandsCall {
+  const call = calls[index]
+  if (call === undefined) {
+    throw new Error(`Expected setMyCommands call at index ${index}`)
+  }
+  return call
+}
+
+describe('registerTelegramCommands', () => {
+  let calls: SetMyCommandsCall[]
+
+  function createBot(): TestBot {
+    return {
+      api: {
+        setMyCommands: (commands, options) => {
+          calls.push([commands, options])
+          return Promise.resolve(true)
+        },
+      },
+    }
+  }
+
+  beforeEach(() => {
+    calls = []
+  })
+
+  test('publishes DM, admin-DM, group, and group-admin scopes from the catalog', async () => {
+    const bot = createBot()
+
+    await registerTelegramCommands(bot, '12345')
+
+    expect(calls).toHaveLength(4)
+
+    const privateDmCall = requireCall(calls, 0)
+    const adminDmCall = requireCall(calls, 1)
+    const groupUserCall = requireCall(calls, 2)
+    const groupAdminCall = requireCall(calls, 3)
+
+    expectIncludesCommands(commandNames(privateDmCall[0]), ['help', 'setup', 'config'])
+    expect(privateDmCall[1]).toEqual({ scope: { type: 'all_private_chats' } })
+
+    expectIncludesCommands(commandNames(adminDmCall[0]), ['user', 'plugin'])
+    expect(adminDmCall[1]).toEqual({ scope: { type: 'chat', chat_id: 12345 } })
+
+    expectIncludesCommands(commandNames(groupUserCall[0]), ['help', 'context', 'clear', 'group'])
+    expect(groupUserCall[1]).toEqual({ scope: { type: 'all_group_chats' } })
+
+    expectIncludesCommands(commandNames(groupAdminCall[0]), ['help', 'context', 'clear', 'group'])
+    expect(groupAdminCall[1]).toEqual({ scope: { type: 'all_chat_administrators' } })
+  })
+
+  test('throws when admin user id is not numeric for Telegram chat scope', async () => {
+    const bot = createBot()
+
+    await expect(registerTelegramCommands(bot, 'admin-user')).rejects.toThrow(
+      'Telegram admin command scope requires a numeric ADMIN_USER_ID',
+    )
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/tests/chat/telegram/commands.test.ts
+++ b/tests/chat/telegram/commands.test.ts
@@ -3,9 +3,9 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { beforeEach, describe, expect, test } from 'bun:test'
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
 
-import { registerTelegramCommands } from '../../../src/chat/telegram/commands.js'
+import type { CommandCatalogEntry } from '../../../src/commands/catalog.js'
 
 type TelegramPublishedCommand = {
   readonly command: string
@@ -17,22 +17,15 @@ type SetMyCommandsCall = [
   options: { scope: { type: string; chat_id?: number } },
 ]
 
+type DeleteMyCommandsCall = [options: { scope: { type: string; chat_id?: number } }]
+
 type TestBot = {
   readonly api: {
     setMyCommands: (
       commands: readonly TelegramPublishedCommand[],
       options: { scope: { type: string; chat_id?: number } },
     ) => Promise<boolean>
-  }
-}
-
-function commandNames(commands: readonly TelegramPublishedCommand[]): readonly string[] {
-  return commands.map((command) => command.command)
-}
-
-function expectIncludesCommands(actual: readonly string[], expected: readonly string[]): void {
-  for (const command of expected) {
-    expect(actual.includes(command)).toBe(true)
+    deleteMyCommands: (options: { scope: { type: string; chat_id?: number } }) => Promise<boolean>
   }
 }
 
@@ -46,6 +39,13 @@ function requireCall(calls: readonly SetMyCommandsCall[], index: number): SetMyC
 
 describe('registerTelegramCommands', () => {
   let calls: SetMyCommandsCall[]
+  let deleteCalls: DeleteMyCommandsCall[]
+
+  async function loadRegisterTelegramCommands(): Promise<
+    typeof import('../../../src/chat/telegram/commands.js').registerTelegramCommands
+  > {
+    return (await import('../../../src/chat/telegram/commands.js')).registerTelegramCommands
+  }
 
   function createBot(): TestBot {
     return {
@@ -54,45 +54,100 @@ describe('registerTelegramCommands', () => {
           calls.push([commands, options])
           return Promise.resolve(true)
         },
+        deleteMyCommands: (options) => {
+          deleteCalls.push([options])
+          return Promise.resolve(true)
+        },
       },
     }
   }
 
   beforeEach(() => {
     calls = []
+    deleteCalls = []
   })
 
   test('publishes DM, admin-DM, group, and group-admin scopes from the catalog', async () => {
     const bot = createBot()
+    const registerTelegramCommands = await loadRegisterTelegramCommands()
 
     await registerTelegramCommands(bot, '12345')
 
     expect(calls).toHaveLength(4)
+    expect(deleteCalls).toHaveLength(0)
 
     const privateDmCall = requireCall(calls, 0)
     const adminDmCall = requireCall(calls, 1)
     const groupUserCall = requireCall(calls, 2)
     const groupAdminCall = requireCall(calls, 3)
 
-    expectIncludesCommands(commandNames(privateDmCall[0]), ['help', 'setup', 'config'])
+    expect(privateDmCall[0].map((command) => command.command)).toEqual([
+      'help',
+      'start',
+      'setup',
+      'config',
+      'context',
+      'clear',
+    ])
     expect(privateDmCall[1]).toEqual({ scope: { type: 'all_private_chats' } })
 
-    expectIncludesCommands(commandNames(adminDmCall[0]), ['user', 'plugin'])
+    expect(adminDmCall[0].map((command) => command.command)).toEqual([
+      'help',
+      'start',
+      'setup',
+      'config',
+      'context',
+      'clear',
+      'group',
+      'groups',
+      'user',
+      'users',
+      'announce',
+      'plugin',
+    ])
     expect(adminDmCall[1]).toEqual({ scope: { type: 'chat', chat_id: 12345 } })
 
-    expectIncludesCommands(commandNames(groupUserCall[0]), ['help', 'context', 'clear', 'group'])
+    expect(groupUserCall[0].map((command) => command.command)).toEqual(['help', 'context', 'clear', 'group'])
     expect(groupUserCall[1]).toEqual({ scope: { type: 'all_group_chats' } })
 
-    expectIncludesCommands(commandNames(groupAdminCall[0]), ['help', 'context', 'clear', 'group'])
+    expect(groupAdminCall[0].map((command) => command.command)).toEqual(['help', 'context', 'clear', 'group'])
     expect(groupAdminCall[1]).toEqual({ scope: { type: 'all_chat_administrators' } })
+  })
+
+  test('clears the group-admin scope when the catalog has no admin-group commands', async () => {
+    void mock.module('../../../src/commands/catalog.js', () => ({
+      listCommandCatalogEntries: (): readonly CommandCatalogEntry[] => [
+        {
+          name: 'help',
+          description: 'Show available commands',
+          registration: 'registerHelpCommand',
+          telegram: {
+            publishInDmUser: true,
+            publishInDmAdmin: true,
+            publishInGroupUser: true,
+            publishInGroupAdmin: false,
+          },
+        },
+      ],
+    }))
+
+    const bot = createBot()
+    const registerTelegramCommands = await loadRegisterTelegramCommands()
+
+    await registerTelegramCommands(bot, '12345')
+
+    expect(calls).toHaveLength(3)
+    expect(deleteCalls).toEqual([[{ scope: { type: 'all_chat_administrators' } }]])
   })
 
   test('throws when admin user id is not numeric for Telegram chat scope', async () => {
     const bot = createBot()
+    const registerTelegramCommands = await loadRegisterTelegramCommands()
 
     await expect(registerTelegramCommands(bot, 'admin-user')).rejects.toThrow(
       'Telegram admin command scope requires a numeric ADMIN_USER_ID',
     )
     expect(calls).toHaveLength(0)
+    expect(deleteCalls).toHaveLength(0)
   })
 })

--- a/tests/commands/catalog.test.ts
+++ b/tests/commands/catalog.test.ts
@@ -9,7 +9,8 @@ import { getCommandCatalogEntry, listCommandCatalogEntries } from '../../src/com
 
 describe('command catalog', () => {
   test('contains the current papai command surface with Telegram publication metadata', () => {
-    const names = listCommandCatalogEntries().map((entry) => entry.name)
+    const entries = listCommandCatalogEntries()
+    const names = entries.map((entry) => entry.name)
 
     expect(names).toEqual([
       'help',
@@ -45,5 +46,11 @@ describe('command catalog', () => {
         publishInGroupAdmin: false,
       },
     })
+
+    for (const entry of entries) {
+      expect(entry).toHaveProperty('registration')
+      expect(typeof entry.registration).toBe('string')
+      expect(entry.registration.length > 0).toBe(true)
+    }
   })
 })

--- a/tests/commands/catalog.test.ts
+++ b/tests/commands/catalog.test.ts
@@ -5,13 +5,25 @@
 
 import { describe, expect, test } from 'bun:test'
 
-import { getCommandCatalogEntry, listCommandCatalogEntries } from '../../src/commands/catalog.js'
+import {
+  getCommandCatalogEntry,
+  listCommandCatalogEntries,
+  type CommandRegistration,
+} from '../../src/commands/catalog.js'
+import * as commandRegistrations from '../../src/commands/index.js'
+
+function getCommandRegistrationExport(
+  name: CommandRegistration,
+): (typeof commandRegistrations)[keyof typeof commandRegistrations] {
+  return commandRegistrations[name]
+}
 
 describe('command catalog', () => {
   test('contains the current papai command surface with Telegram publication metadata', () => {
     const entries = listCommandCatalogEntries()
     const names = entries.map((entry) => entry.name)
     const registrations = Object.fromEntries(entries.map((entry) => [entry.name, entry.registration]))
+    const telegramVisibility = Object.fromEntries(entries.map((entry) => [entry.name, entry.telegram]))
 
     expect(names).toEqual([
       'help',
@@ -28,20 +40,75 @@ describe('command catalog', () => {
       'plugin',
     ])
 
-    expect(getCommandCatalogEntry('help')).toMatchObject({
-      name: 'help',
-      telegram: {
+    expect(telegramVisibility).toEqual({
+      help: {
         publishInDmUser: true,
         publishInDmAdmin: true,
         publishInGroupUser: true,
         publishInGroupAdmin: true,
       },
-    })
-
-    expect(getCommandCatalogEntry('setup')).toMatchObject({
-      name: 'setup',
-      telegram: {
+      start: {
         publishInDmUser: true,
+        publishInDmAdmin: true,
+        publishInGroupUser: false,
+        publishInGroupAdmin: false,
+      },
+      setup: {
+        publishInDmUser: true,
+        publishInDmAdmin: true,
+        publishInGroupUser: false,
+        publishInGroupAdmin: false,
+      },
+      config: {
+        publishInDmUser: true,
+        publishInDmAdmin: true,
+        publishInGroupUser: false,
+        publishInGroupAdmin: false,
+      },
+      context: {
+        publishInDmUser: true,
+        publishInDmAdmin: true,
+        publishInGroupUser: true,
+        publishInGroupAdmin: true,
+      },
+      clear: {
+        publishInDmUser: true,
+        publishInDmAdmin: true,
+        publishInGroupUser: true,
+        publishInGroupAdmin: true,
+      },
+      group: {
+        publishInDmUser: false,
+        publishInDmAdmin: true,
+        publishInGroupUser: true,
+        publishInGroupAdmin: true,
+      },
+      groups: {
+        publishInDmUser: false,
+        publishInDmAdmin: true,
+        publishInGroupUser: false,
+        publishInGroupAdmin: false,
+      },
+      user: {
+        publishInDmUser: false,
+        publishInDmAdmin: true,
+        publishInGroupUser: false,
+        publishInGroupAdmin: false,
+      },
+      users: {
+        publishInDmUser: false,
+        publishInDmAdmin: true,
+        publishInGroupUser: false,
+        publishInGroupAdmin: false,
+      },
+      announce: {
+        publishInDmUser: false,
+        publishInDmAdmin: true,
+        publishInGroupUser: false,
+        publishInGroupAdmin: false,
+      },
+      plugin: {
+        publishInDmUser: false,
         publishInDmAdmin: true,
         publishInGroupUser: false,
         publishInGroupAdmin: false,
@@ -62,5 +129,12 @@ describe('command catalog', () => {
       announce: 'registerAdminCommands',
       plugin: 'registerPluginCommand',
     })
+
+    for (const entry of entries) {
+      expect(getCommandCatalogEntry(entry.name)).toBe(entry)
+      const registration = getCommandRegistrationExport(entry.registration)
+
+      expect(typeof registration).toBe('function')
+    }
   })
 })

--- a/tests/commands/catalog.test.ts
+++ b/tests/commands/catalog.test.ts
@@ -5,11 +5,8 @@
 
 import { describe, expect, test } from 'bun:test'
 
-import {
-  getCommandCatalogEntry,
-  listCommandCatalogEntries,
-  type CommandRegistration,
-} from '../../src/commands/catalog.js'
+import * as commandCatalog from '../../src/commands/catalog.js'
+import { listCommandCatalogEntries, type CommandRegistration } from '../../src/commands/catalog.js'
 import * as commandRegistrations from '../../src/commands/index.js'
 
 function getCommandRegistrationExport(
@@ -19,6 +16,10 @@ function getCommandRegistrationExport(
 }
 
 describe('command catalog', () => {
+  test('does not expose test-only entry lookup helpers', () => {
+    expect('getCommandCatalogEntry' in commandCatalog).toBe(false)
+  })
+
   test('contains the current papai command surface with Telegram publication metadata', () => {
     const entries = listCommandCatalogEntries()
     const names = entries.map((entry) => entry.name)
@@ -131,7 +132,6 @@ describe('command catalog', () => {
     })
 
     for (const entry of entries) {
-      expect(getCommandCatalogEntry(entry.name)).toBe(entry)
       const registration = getCommandRegistrationExport(entry.registration)
 
       expect(typeof registration).toBe('function')

--- a/tests/commands/catalog.test.ts
+++ b/tests/commands/catalog.test.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { getCommandCatalogEntry, listCommandCatalogEntries } from '../../src/commands/catalog.js'
+
+describe('command catalog', () => {
+  test('contains the current papai command surface with Telegram publication metadata', () => {
+    const names = listCommandCatalogEntries().map((entry) => entry.name)
+
+    expect(names).toEqual([
+      'help',
+      'start',
+      'setup',
+      'config',
+      'context',
+      'clear',
+      'group',
+      'groups',
+      'user',
+      'users',
+      'announce',
+      'plugin',
+    ])
+
+    expect(getCommandCatalogEntry('help')).toMatchObject({
+      name: 'help',
+      telegram: {
+        publishInDmUser: true,
+        publishInDmAdmin: true,
+        publishInGroupUser: true,
+        publishInGroupAdmin: true,
+      },
+    })
+
+    expect(getCommandCatalogEntry('setup')).toMatchObject({
+      name: 'setup',
+      telegram: {
+        publishInDmUser: true,
+        publishInDmAdmin: true,
+        publishInGroupUser: false,
+        publishInGroupAdmin: false,
+      },
+    })
+  })
+})

--- a/tests/commands/catalog.test.ts
+++ b/tests/commands/catalog.test.ts
@@ -11,6 +11,7 @@ describe('command catalog', () => {
   test('contains the current papai command surface with Telegram publication metadata', () => {
     const entries = listCommandCatalogEntries()
     const names = entries.map((entry) => entry.name)
+    const registrations = Object.fromEntries(entries.map((entry) => [entry.name, entry.registration]))
 
     expect(names).toEqual([
       'help',
@@ -47,10 +48,19 @@ describe('command catalog', () => {
       },
     })
 
-    for (const entry of entries) {
-      expect(entry).toHaveProperty('registration')
-      expect(typeof entry.registration).toBe('string')
-      expect(entry.registration.length > 0).toBe(true)
-    }
+    expect(registrations).toEqual({
+      help: 'registerHelpCommand',
+      start: 'registerStartCommand',
+      setup: 'registerSetupCommand',
+      config: 'registerConfigCommand',
+      context: 'registerContextCommand',
+      clear: 'registerClearCommand',
+      group: 'registerGroupCommand',
+      groups: 'registerGroupCommand',
+      user: 'registerAdminCommands',
+      users: 'registerAdminCommands',
+      announce: 'registerAdminCommands',
+      plugin: 'registerPluginCommand',
+    })
   })
 })

--- a/tests/group-settings/access.test.ts
+++ b/tests/group-settings/access.test.ts
@@ -10,12 +10,15 @@ import { addAuthorizedGroup } from '../../src/authorized-groups.js'
 import { toScopedContextId } from '../../src/chat/scoped-context.js'
 import { listManageableGroups, matchManageableGroup } from '../../src/group-settings/access.js'
 import { upsertGroupAdminObservation, upsertKnownGroupContext } from '../../src/group-settings/registry.js'
+import { addAdmin } from '../../src/instances/admin-store.js'
+import { insertPlatformInstance } from '../../src/instances/platform-store.js'
 import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
 
 describe('group settings access', () => {
   beforeEach(async () => {
     mockLogger()
     await setupTestDb()
+    process.env['INSTANCE_CONFIG_KEY'] = '1'.repeat(64)
   })
 
   test('lists only groups where the user is a known admin', () => {
@@ -131,6 +134,24 @@ describe('group settings access', () => {
 
     expect(listManageableGroups('same-native-user', 'telegram-main')).toEqual([])
     expect(listManageableGroups('same-native-user').map((group) => group.contextId)).toEqual(['legacy-group'])
+  })
+
+  test('lists authorized scoped groups for an admin even before group metadata is observed', () => {
+    const scopedGroupId = toScopedContextId({
+      platformInstanceId: 'telegram-default',
+      nativeContextId: '-10012345',
+    })
+
+    insertPlatformInstance({ id: 'telegram-default', type: 'telegram', config: { token: 't' }, status: 'active' })
+    addAdmin('admin-1', 'telegram-default')
+    addAuthorizedGroup(scopedGroupId, 'admin-1')
+
+    const groups = listManageableGroups('admin-1', 'telegram-default')
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.contextId).toBe(scopedGroupId)
+    expect(groups[0]?.displayName).toBe('-10012345')
+    expect(groups[0]?.parentName).toBeNull()
   })
 
   test('matches by context id and display name and reports ambiguity', () => {

--- a/tests/group-settings/access.test.ts
+++ b/tests/group-settings/access.test.ts
@@ -8,7 +8,11 @@ import assert from 'node:assert/strict'
 
 import { addAuthorizedGroup } from '../../src/authorized-groups.js'
 import { toScopedContextId } from '../../src/chat/scoped-context.js'
-import { listManageableGroups, matchManageableGroup } from '../../src/group-settings/access.js'
+import {
+  listManageableGroups,
+  matchManageableGroup,
+  validateGroupTargetAccess,
+} from '../../src/group-settings/access.js'
 import { upsertGroupAdminObservation, upsertKnownGroupContext } from '../../src/group-settings/registry.js'
 import { addAdmin } from '../../src/instances/admin-store.js'
 import { insertPlatformInstance } from '../../src/instances/platform-store.js'
@@ -152,6 +156,19 @@ describe('group settings access', () => {
     expect(groups[0]?.contextId).toBe(scopedGroupId)
     expect(groups[0]?.displayName).toBe('-10012345')
     expect(groups[0]?.parentName).toBeNull()
+  })
+
+  test('accepts a fallback-only scoped group during target validation', () => {
+    const scopedGroupId = toScopedContextId({
+      platformInstanceId: 'telegram-default',
+      nativeContextId: '-10012345',
+    })
+
+    insertPlatformInstance({ id: 'telegram-default', type: 'telegram', config: { token: 't' }, status: 'active' })
+    addAdmin('admin-1', 'telegram-default')
+    addAuthorizedGroup(scopedGroupId, 'admin-1')
+
+    expect(validateGroupTargetAccess('admin-1', scopedGroupId, 'telegram-default')).toEqual({ kind: 'ok' })
   })
 
   test('matches by context id and display name and reports ambiguity', () => {

--- a/tests/group-settings/selector.test.ts
+++ b/tests/group-settings/selector.test.ts
@@ -16,6 +16,8 @@ import {
 } from '../../src/group-settings/selector.js'
 import { deleteGroupSettingsSession, getActiveGroupSettingsTarget } from '../../src/group-settings/state.js'
 import type { GroupSettingsSelectorResult } from '../../src/group-settings/types.js'
+import { addAdmin } from '../../src/instances/admin-store.js'
+import { insertPlatformInstance } from '../../src/instances/platform-store.js'
 import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
 
 const getResponse = (
@@ -42,6 +44,7 @@ describe('group settings selector', () => {
   beforeEach(async () => {
     mockLogger()
     await setupTestDb()
+    process.env['INSTANCE_CONFIG_KEY'] = '1'.repeat(64)
     deleteGroupSettingsSession('user-1')
     deleteGroupSettingsSession('user-1', 'telegram-default')
   })
@@ -102,6 +105,23 @@ describe('group settings selector', () => {
       continueWith: { command: 'config', targetContextId: scopedGroup1 },
     })
     expect(getActiveGroupSettingsTarget('user-1', 'telegram-default')).toBe(scopedGroup1)
+  })
+
+  test('shows a newly authorized scoped group in DM selection before any observation exists', () => {
+    const scopedGroupId = toScopedContextId({
+      platformInstanceId: 'telegram-default',
+      nativeContextId: '-10012345',
+    })
+
+    insertPlatformInstance({ id: 'telegram-default', type: 'telegram', config: { token: 't' }, status: 'active' })
+    addAdmin('admin-id', 'telegram-default')
+    addAuthorizedGroup(scopedGroupId, 'admin-id')
+
+    startGroupSettingsSelection('admin-id', 'config', false, 'telegram-default')
+    const result = handleGroupSettingsSelectorMessage('admin-id', 'group', false, 'telegram-default')
+    const response = getResponse(result)
+
+    expect(response.response).toContain('-10012345')
   })
 
   test('does not double-scope an already-scoped manageable group context', () => {

--- a/tests/group-settings/selector.test.ts
+++ b/tests/group-settings/selector.test.ts
@@ -107,7 +107,7 @@ describe('group settings selector', () => {
     expect(getActiveGroupSettingsTarget('user-1', 'telegram-default')).toBe(scopedGroup1)
   })
 
-  test('shows a newly authorized scoped group in DM selection before any observation exists', () => {
+  test('shows a newly authorized scoped group in DM selection before any observation exists and can continue with it', () => {
     const scopedGroupId = toScopedContextId({
       platformInstanceId: 'telegram-default',
       nativeContextId: '-10012345',
@@ -118,10 +118,16 @@ describe('group settings selector', () => {
     addAuthorizedGroup(scopedGroupId, 'admin-id')
 
     startGroupSettingsSelection('admin-id', 'config', false, 'telegram-default')
-    const result = handleGroupSettingsSelectorMessage('admin-id', 'group', false, 'telegram-default')
-    const response = getResponse(result)
+    const listResult = handleGroupSettingsSelectorMessage('admin-id', 'group', false, 'telegram-default')
+    const response = getResponse(listResult)
+    const selectionResult = handleGroupSettingsSelectorMessage('admin-id', '-10012345', false, 'telegram-default')
 
     expect(response.response).toContain('-10012345')
+    expect(selectionResult).toEqual({
+      handled: true,
+      continueWith: { command: 'config', targetContextId: scopedGroupId },
+    })
+    expect(getActiveGroupSettingsTarget('admin-id', 'telegram-default')).toBe(scopedGroupId)
   })
 
   test('does not double-scope an already-scoped manageable group context', () => {

--- a/tests/hooks/docs/build-doc-review-prompt.test.ts
+++ b/tests/hooks/docs/build-doc-review-prompt.test.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { buildDocReviewPrompt } from '../../../.hooks/docs/build-doc-review-prompt.mjs'
+
+describe('buildDocReviewPrompt', () => {
+  test('builds prompt with changed files and doc paths', () => {
+    const changedFiles = ['src/tools/create-task.ts', 'src/chat/router.ts']
+    const docPaths = ['CLAUDE.md', 'README.md', 'src/tools/CLAUDE.md']
+
+    const result = buildDocReviewPrompt(changedFiles, docPaths)
+
+    expect(result).toContain('source files were changed')
+    expect(result).toContain('src/tools/create-task.ts')
+    expect(result).toContain('src/chat/router.ts')
+    expect(result).toContain('CLAUDE.md')
+    expect(result).toContain('README.md')
+    expect(result).toContain('src/tools/CLAUDE.md')
+    expect(result).toContain('review and update')
+  })
+
+  test('lists changed files in bullet format', () => {
+    const result = buildDocReviewPrompt(['src/a.ts'], ['CLAUDE.md'])
+    expect(result).toContain('- src/a.ts')
+  })
+
+  test('lists doc paths in bullet format', () => {
+    const result = buildDocReviewPrompt(['src/a.ts'], ['CLAUDE.md', 'README.md'])
+    expect(result).toContain('- CLAUDE.md')
+    expect(result).toContain('- README.md')
+  })
+
+  test('includes skip instruction', () => {
+    const result = buildDocReviewPrompt(['src/a.ts'], ['CLAUDE.md'])
+    expect(result).toContain('ignore this')
+  })
+})

--- a/tests/hooks/docs/map-files-to-docs.test.ts
+++ b/tests/hooks/docs/map-files-to-docs.test.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { mapFilesToDocs } from '../../../.hooks/docs/map-files-to-docs.mjs'
+
+describe('mapFilesToDocs', () => {
+  test('returns empty array for empty input', () => {
+    expect(mapFilesToDocs([])).toEqual([])
+  })
+
+  test('always includes root CLAUDE.md and README.md when files exist', () => {
+    const result = mapFilesToDocs(['src/index.ts'])
+    expect(result).toContain('CLAUDE.md')
+    expect(result).toContain('README.md')
+  })
+
+  test('maps src/tools/ file to src/tools/CLAUDE.md', () => {
+    const result = mapFilesToDocs(['src/tools/create-task.ts'])
+    expect(result).toContain('src/tools/CLAUDE.md')
+    expect(result).toContain('CLAUDE.md')
+    expect(result).toContain('README.md')
+  })
+
+  test('maps src/chat/ file to src/chat/CLAUDE.md', () => {
+    const result = mapFilesToDocs(['src/chat/router.ts'])
+    expect(result).toContain('src/chat/CLAUDE.md')
+  })
+
+  test('maps src/providers/ file to src/providers/CLAUDE.md', () => {
+    const result = mapFilesToDocs(['src/providers/kaneo.ts'])
+    expect(result).toContain('src/providers/CLAUDE.md')
+  })
+
+  test('maps src/commands/ file to src/commands/CLAUDE.md', () => {
+    const result = mapFilesToDocs(['src/commands/help.ts'])
+    expect(result).toContain('src/commands/CLAUDE.md')
+  })
+
+  test('deduplicates docs when multiple files map to same doc', () => {
+    const result = mapFilesToDocs(['src/tools/a.ts', 'src/tools/b.ts'])
+    const toolClaudeCount = result.filter((d) => d === 'src/tools/CLAUDE.md').length
+    expect(toolClaudeCount).toBe(1)
+  })
+
+  test('walks up directory tree when no CLAUDE.md in immediate parent', () => {
+    const result = mapFilesToDocs(['src/index.ts'])
+    expect(result).toContain('CLAUDE.md')
+    expect(result).not.toContain('src/CLAUDE.md')
+  })
+
+  test('handles client/ files (no nested CLAUDE.md)', () => {
+    const result = mapFilesToDocs(['client/debug/components/sidebar.tsx'])
+    expect(result).toContain('CLAUDE.md')
+    expect(result).toContain('README.md')
+    expect(result.filter((d) => d.includes('CLAUDE.md')).length).toBe(1)
+  })
+
+  test('handles plugins/ files', () => {
+    const result = mapFilesToDocs(['plugins/hello-world/index.ts'])
+    expect(result).toContain('CLAUDE.md')
+    expect(result).toContain('README.md')
+  })
+
+  test('handles scripts/ files', () => {
+    const result = mapFilesToDocs(['scripts/check.sh'])
+    expect(result).toContain('CLAUDE.md')
+    expect(result).toContain('README.md')
+  })
+
+  test('deduplicates across multiple directories', () => {
+    const result = mapFilesToDocs(['src/tools/a.ts', 'client/debug/b.tsx'])
+    const rootClaudeCount = result.filter((d) => d === 'CLAUDE.md').length
+    expect(rootClaudeCount).toBe(1)
+  })
+})

--- a/tests/hooks/docs/track-source-write.test.ts
+++ b/tests/hooks/docs/track-source-write.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { trackSourceWrite, TRACKED_PREFIXES } from '../../../.hooks/docs/track-source-write.mjs'
+
+describe('trackSourceWrite', () => {
+  test('exports TRACKED_PREFIXES', () => {
+    expect(TRACKED_PREFIXES).toContain('src/')
+    expect(TRACKED_PREFIXES).toContain('client/')
+    expect(TRACKED_PREFIXES).toContain('plugins/')
+    expect(TRACKED_PREFIXES).toContain('scripts/')
+  })
+
+  test('returns true for files in tracked directories', () => {
+    expect(trackSourceWrite('src/tools/foo.ts')).toBe(true)
+    expect(trackSourceWrite('client/debug/bar.tsx')).toBe(true)
+    expect(trackSourceWrite('plugins/hello/index.ts')).toBe(true)
+    expect(trackSourceWrite('scripts/check.sh')).toBe(true)
+  })
+
+  test('returns false for files outside tracked directories', () => {
+    expect(trackSourceWrite('tests/foo.test.ts')).toBe(false)
+    expect(trackSourceWrite('.claude/settings.json')).toBe(false)
+    expect(trackSourceWrite('README.md')).toBe(false)
+    expect(trackSourceWrite('.hooks/tdd/session-state.mjs')).toBe(false)
+    expect(trackSourceWrite('docs/adr/0001.md')).toBe(false)
+  })
+
+  test('returns false for empty or null paths', () => {
+    expect(trackSourceWrite('')).toBe(false)
+    expect(trackSourceWrite(null)).toBe(false)
+    expect(trackSourceWrite(undefined)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- derive Telegram command publication from a shared command catalog and add drift-prevention coverage
- surface newly authorized Telegram groups in DM selection immediately and make router command publication failures fail loudly
- switch Mattermost command parsing to mention-prefixed command syntax with guidance for mention-only messages

## Test Plan
- [x] bun test v1.3.13 (bf2e2cec)
- [x] bun test v1.3.13 (bf2e2cec)
- [x] bun test v1.3.13 (bf2e2cec)
- [x] Checking formatting...

All matched files use the correct format.
Finished in 3767ms on 1929 files using 12 threads.
- [x] Checking formatting...

All matched files use the correct format.
Finished in 3829ms on 1929 files using 12 threads.
- [ ]  (blocked locally because  is missing in this worktree)
