### PR TITLE
feat: add Kontur Talk chat provider

### DIFF
--- a/client/admin/fetcher-schemas.ts
+++ b/client/admin/fetcher-schemas.ts
@@ -202,7 +202,7 @@ export const AdminLlmSnapshotSchema = z.object({
   small_model: AdminLlmKeyStateSchema,
   embedding_model: AdminLlmKeyStateSchema,
 })
-const AdminChatProviderSchema = z.enum(['telegram', 'mattermost', 'discord', 'unknown'])
+const AdminChatProviderSchema = z.enum(['telegram', 'mattermost', 'discord', 'kontur-talk', 'unknown'])
 const AdminTaskProviderSchema = z.enum(['kaneo', 'youtrack', 'unknown'])
 export const AdminSystemSummarySchema = z.object({
   chatProvider: AdminChatProviderSchema,

--- a/client/admin/instance-fetcher-schemas.ts
+++ b/client/admin/instance-fetcher-schemas.ts
@@ -17,7 +17,7 @@ const InstanceViewBaseSchema = z.object({
 })
 
 export const PlatformInstanceViewSchema = InstanceViewBaseSchema.extend({
-  type: z.enum(['telegram', 'mattermost', 'discord']),
+  type: z.enum(['telegram', 'mattermost', 'discord', 'kontur-talk']),
 })
 
 export const TaskInstanceViewSchema = InstanceViewBaseSchema.extend({
@@ -51,7 +51,7 @@ export const TaskProviderTypeViewSchema = z.object({
 })
 
 export const PlatformProviderTypeViewSchema = z.object({
-  type: z.enum(['telegram', 'mattermost', 'discord']),
+  type: z.enum(['telegram', 'mattermost', 'discord', 'kontur-talk']),
   displayName: z.string(),
   instanceConfigSchema: z.array(ProviderConfigRequirementViewSchema),
   contextConfigSchema: z.array(ProviderConfigRequirementViewSchema),

--- a/client/shared/api-types.ts
+++ b/client/shared/api-types.ts
@@ -161,7 +161,7 @@ export type AdminLlmSnapshot = {
   embedding_model: AdminLlmKeyState
 }
 
-export type AdminChatProvider = 'telegram' | 'mattermost' | 'discord' | 'unknown'
+export type AdminChatProvider = 'telegram' | 'mattermost' | 'discord' | 'kontur-talk' | 'unknown'
 export type AdminTaskProvider = 'kaneo' | 'youtrack' | 'unknown'
 
 export type AdminSystemSummary = {
@@ -177,7 +177,7 @@ export type InstanceStatusView = 'pending' | 'active' | 'stopped'
 
 export type PlatformInstanceView = {
   readonly id: string
-  readonly type: 'telegram' | 'mattermost' | 'discord'
+  readonly type: 'telegram' | 'mattermost' | 'discord' | 'kontur-talk'
   readonly config: InstanceConfigView
   readonly status: InstanceStatusView
   readonly createdAt: string

--- a/docs/superpowers/plans/2026-05-28-kontur-talk-chat-provider.md
+++ b/docs/superpowers/plans/2026-05-28-kontur-talk-chat-provider.md
@@ -1,0 +1,1307 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Kontur Talk Chat Provider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Kontur Talk (Толк.Чаты) as a fourth chat provider in papai, supporting text messages and threads via long polling.
+
+**Architecture:** Follow the Mattermost provider pattern — a class implementing `ChatProvider` with REST API calls, Zod-validated responses, and a long polling loop for receiving messages. All platform-specific code lives in `src/chat/kontur-talk/`.
+
+**Tech Stack:** Bun, TypeScript, Zod v4, pino logger, `fetch()` for HTTP.
+
+**Design Spec:** `docs/superpowers/specs/2026-05-28-kontur-talk-chat-provider-design.md`
+
+**API Reference:** https://kontur.renote.team/doc/NNyX6DGvQ (extracted to `/tmp/kontur-talk-api-formatted.md` during research)
+
+---
+
+## File Map
+
+### New files
+
+| File                                              | Responsibility                            |
+| ------------------------------------------------- | ----------------------------------------- |
+| `src/chat/kontur-talk/metadata.ts`                | Capabilities, traits, config requirements |
+| `src/chat/kontur-talk/config.ts`                  | Constructor config type + resolver        |
+| `src/chat/kontur-talk/schema.ts`                  | Zod schemas for API responses             |
+| `src/chat/kontur-talk/reply-helpers.ts`           | `createKonturTalkReplyFn` factory         |
+| `src/chat/kontur-talk/context-renderer.ts`        | `renderKonturTalkContext`                 |
+| `src/chat/kontur-talk/label-helpers.ts`           | User/group label resolvers                |
+| `src/chat/kontur-talk/index.ts`                   | `KonturTalkChatProvider` class            |
+| `tests/chat/kontur-talk/metadata.test.ts`         | Metadata tests                            |
+| `tests/chat/kontur-talk/config.test.ts`           | Config resolution tests                   |
+| `tests/chat/kontur-talk/schema.test.ts`           | Schema validation tests                   |
+| `tests/chat/kontur-talk/reply-helpers.test.ts`    | ReplyFn factory tests                     |
+| `tests/chat/kontur-talk/context-renderer.test.ts` | Context renderer tests                    |
+| `tests/chat/kontur-talk/label-helpers.test.ts`    | Label resolver tests                      |
+| `tests/chat/kontur-talk/index.test.ts`            | Main provider tests                       |
+
+### Modified files
+
+| File                         | Change                                                                  |
+| ---------------------------- | ----------------------------------------------------------------------- |
+| `src/chat/registry.ts`       | Add `'kontur-talk'` descriptor, factory, configToEnv                    |
+| `src/instances/types.ts`     | Add `'kontur-talk'` to `PlatformInstanceType` union                     |
+| `src/instances/bootstrap.ts` | Add `CHAT_ENV_REQUIREMENTS`, `parsePlatformType`, `buildPlatformConfig` |
+| `src/env-validation.ts`      | Add `'kontur-talk'` to provider allowlist + requirements                |
+
+---
+
+### Task 1: Metadata, Config, and Schemas
+
+**Files:**
+
+- Create: `src/chat/kontur-talk/metadata.ts`
+- Create: `src/chat/kontur-talk/config.ts`
+- Create: `src/chat/kontur-talk/schema.ts`
+- Create: `tests/chat/kontur-talk/metadata.test.ts`
+- Create: `tests/chat/kontur-talk/config.test.ts`
+- Create: `tests/chat/kontur-talk/schema.test.ts`
+
+- [ ] **Step 1: Write metadata tests**
+
+```typescript
+// tests/chat/kontur-talk/metadata.test.ts
+import { describe, expect, test } from 'bun:test'
+import {
+  konturTalkCapabilities,
+  konturTalkTraits,
+  konturTalkConfigRequirements,
+} from '../../src/chat/kontur-talk/metadata.js'
+
+describe('Kontur Talk metadata', () => {
+  test('capabilities include messages.reply-context', () => {
+    expect(konturTalkCapabilities.has('messages.reply-context')).toBe(true)
+  })
+
+  test('capabilities do not include messages.buttons', () => {
+    expect(konturTalkCapabilities.has('messages.buttons')).toBe(false)
+  })
+
+  test('capabilities do not include files.receive', () => {
+    expect(konturTalkCapabilities.has('files.receive')).toBe(false)
+  })
+
+  test('traits observe all group messages', () => {
+    expect(konturTalkTraits.observedGroupMessages).toBe('all')
+  })
+
+  test('traits max message length is 4096', () => {
+    expect(konturTalkTraits.maxMessageLength).toBe(4096)
+  })
+
+  test('config requirements include KONTUR_TALK_JWT_TOKEN', () => {
+    expect(konturTalkConfigRequirements).toEqual([
+      { key: 'KONTUR_TALK_JWT_TOKEN', label: 'Kontur Talk JWT Token', required: true },
+    ])
+  })
+})
+```
+
+- [ ] **Step 2: Run metadata tests to verify they fail**
+
+Run: `bun test tests/chat/kontur-talk/metadata.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write metadata implementation**
+
+```typescript
+// src/chat/kontur-talk/metadata.ts
+import type { ChatCapability, ChatProviderConfigRequirement, ChatProviderTraits } from '../types.js'
+
+export const konturTalkCapabilities: ReadonlySet<ChatCapability> = new Set<ChatCapability>(['messages.reply-context'])
+
+export const konturTalkTraits: ChatProviderTraits = {
+  observedGroupMessages: 'all',
+  maxMessageLength: 4096,
+}
+
+export const konturTalkConfigRequirements: readonly ChatProviderConfigRequirement[] = [
+  { key: 'KONTUR_TALK_JWT_TOKEN', label: 'Kontur Talk JWT Token', required: true },
+]
+```
+
+- [ ] **Step 4: Run metadata tests to verify they pass**
+
+Run: `bun test tests/chat/kontur-talk/metadata.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Write config tests**
+
+```typescript
+// tests/chat/kontur-talk/config.test.ts
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test'
+import { resolveKonturTalkConfig } from '../../src/chat/kontur-talk/config.js'
+
+describe('resolveKonturTalkConfig', () => {
+  const origEnv = { ...process.env }
+
+  beforeEach(() => {
+    process.env['KONTUR_TALK_JWT_TOKEN'] = 'test-jwt-token'
+  })
+
+  afterEach(() => {
+    process.env = { ...origEnv }
+  })
+
+  test('resolves from env when no constructor config provided', () => {
+    const config = resolveKonturTalkConfig({})
+    expect(config.jwtToken).toBe('test-jwt-token')
+    expect(config.platformInstanceId).toBe('kontur-talk-default')
+  })
+
+  test('constructor config takes precedence over env', () => {
+    const config = resolveKonturTalkConfig({ jwtToken: 'explicit-token' })
+    expect(config.jwtToken).toBe('explicit-token')
+  })
+
+  test('throws when jwtToken is missing', () => {
+    delete process.env['KONTUR_TALK_JWT_TOKEN']
+    expect(() => resolveKonturTalkConfig({})).toThrow(/KONTUR_TALK_JWT_TOKEN/i)
+  })
+
+  test('throws when jwtToken is empty string', () => {
+    delete process.env['KONTUR_TALK_JWT_TOKEN']
+    expect(() => resolveKonturTalkConfig({ jwtToken: '  ' })).toThrow(/KONTUR_TALK_JWT_TOKEN/i)
+  })
+
+  test('uses custom platformInstanceId when provided', () => {
+    const config = resolveKonturTalkConfig({ platformInstanceId: 'custom-id' })
+    expect(config.platformInstanceId).toBe('custom-id')
+  })
+})
+```
+
+- [ ] **Step 6: Run config tests to verify they fail**
+
+Run: `bun test tests/chat/kontur-talk/config.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 7: Write config implementation**
+
+```typescript
+// src/chat/kontur-talk/config.ts
+export type KonturTalkConstructorConfig = Partial<{
+  jwtToken: string
+  platformInstanceId: string
+}>
+
+export type ResolvedKonturTalkConfig = {
+  jwtToken: string
+  platformInstanceId: string
+}
+
+const resolveConfigValue = (value: string | undefined, fallback: string | undefined): string | undefined => {
+  if (value === undefined) return fallback
+  return value
+}
+
+const resolvePlatformInstanceId = (platformInstanceId: string | undefined): string => {
+  if (platformInstanceId === undefined) return 'kontur-talk-default'
+  return platformInstanceId
+}
+
+export const resolveKonturTalkConfig = (config: KonturTalkConstructorConfig): ResolvedKonturTalkConfig => {
+  const jwtToken = resolveConfigValue(config.jwtToken, process.env['KONTUR_TALK_JWT_TOKEN'])
+  if (jwtToken === undefined || jwtToken.trim() === '') {
+    throw new Error('KONTUR_TALK_JWT_TOKEN environment variable is required')
+  }
+  return {
+    jwtToken,
+    platformInstanceId: resolvePlatformInstanceId(config.platformInstanceId),
+  }
+}
+```
+
+- [ ] **Step 8: Run config tests to verify they pass**
+
+Run: `bun test tests/chat/kontur-talk/config.test.ts`
+Expected: PASS
+
+- [ ] **Step 9: Write schema tests**
+
+```typescript
+// tests/chat/kontur-talk/schema.test.ts
+import { describe, expect, test } from 'bun:test'
+import {
+  KonturTalkUpdateSchema,
+  KonturTalkSendMessageResponseSchema,
+  KonturTalkErrorResponseSchema,
+} from '../../src/chat/kontur-talk/schema.js'
+
+describe('Kontur Talk schemas', () => {
+  describe('KonturTalkUpdateSchema', () => {
+    test('validates a text message update', () => {
+      const data = {
+        event_id: '$event123',
+        user_id: '@alice:host',
+        room_id: '!room:host',
+        room_is_direct: false,
+        type: 'm.room.message',
+        timestamp: 1704067200000,
+        message_type: 'm.text',
+        body: 'Hello, bot!',
+        formatted_body: null,
+        thread_id: null,
+        reply_id: null,
+        forward_from: null,
+        mentions: ['@bot:host'],
+      }
+      const result = KonturTalkUpdateSchema.safeParse(data)
+      expect(result.success).toBe(true)
+    })
+
+    test('validates a media message update', () => {
+      const data = {
+        event_id: '$event789',
+        user_id: '@bob:host',
+        room_id: '!room:host',
+        room_is_direct: true,
+        type: 'm.room.message',
+        timestamp: 1704070800000,
+        message_type: 'm.image',
+        media_url: 'mxc://host/abcd1234',
+        thread_id: null,
+        reply_id: null,
+        forward_from: null,
+        mentions: null,
+      }
+      const result = KonturTalkUpdateSchema.safeParse(data)
+      expect(result.success).toBe(true)
+    })
+
+    test('validates a message with thread_id', () => {
+      const data = {
+        event_id: '$event456',
+        user_id: '@alice:host',
+        room_id: '!room:host',
+        room_is_direct: false,
+        type: 'm.room.message',
+        timestamp: 1704067200000,
+        message_type: 'm.text',
+        body: 'In a thread',
+        formatted_body: null,
+        thread_id: '$thread123',
+        reply_id: null,
+        forward_from: null,
+        mentions: null,
+      }
+      const result = KonturTalkUpdateSchema.safeParse(data)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.thread_id).toBe('$thread123')
+      }
+    })
+
+    test('rejects missing required fields', () => {
+      const data = { event_id: '$event123' }
+      const result = KonturTalkUpdateSchema.safeParse(data)
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('KonturTalkSendMessageResponseSchema', () => {
+    test('validates success response', () => {
+      const data = { event_id: '$newEvent789' }
+      const result = KonturTalkSendMessageResponseSchema.safeParse(data)
+      expect(result.success).toBe(true)
+    })
+
+    test('rejects missing event_id', () => {
+      const result = KonturTalkSendMessageResponseSchema.safeParse({})
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('KonturTalkErrorResponseSchema', () => {
+    test('validates error with detail.errcode', () => {
+      const data = { detail: { errcode: 'M_UNKNOWN_TOKEN', error: 'Access token has expired' } }
+      const result = KonturTalkErrorResponseSchema.safeParse(data)
+      expect(result.success).toBe(true)
+    })
+
+    test('validates error with detail array (validation error)', () => {
+      const data = {
+        detail: [
+          {
+            loc: ['body', 'message'],
+            msg: 'ensure this value has at most 4096 characters',
+            type: 'value_error.any_str.max_length',
+          },
+        ],
+      }
+      const result = KonturTalkErrorResponseSchema.safeParse(data)
+      expect(result.success).toBe(true)
+    })
+  })
+})
+```
+
+- [ ] **Step 10: Run schema tests to verify they fail**
+
+Run: `bun test tests/chat/kontur-talk/schema.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 11: Write schema implementation**
+
+```typescript
+// src/chat/kontur-talk/schema.ts
+import { z } from 'zod'
+
+const KonturTalkForwardFromSchema = z.object({
+  user_id: z.string(),
+  room_id: z.string(),
+})
+
+const KonturTalkMentionsSchema = z.union([z.array(z.string()), z.literal('all'), z.null()])
+
+export const KonturTalkUpdateSchema = z.object({
+  event_id: z.string(),
+  user_id: z.string(),
+  room_id: z.string(),
+  room_is_direct: z.boolean(),
+  type: z.string(),
+  timestamp: z.number(),
+  message_type: z.string(),
+  body: z.string().optional(),
+  formatted_body: z.string().nullable().optional(),
+  media_url: z.string().optional(),
+  call_room_name: z.string().optional(),
+  thread_id: z.string().nullable().optional(),
+  reply_id: z.string().nullable().optional(),
+  forward_from: KonturTalkForwardFromSchema.nullable().optional(),
+  mentions: KonturTalkMentionsSchema.optional(),
+})
+
+export type KonturTalkUpdate = z.infer<typeof KonturTalkUpdateSchema>
+
+export const KonturTalkGetUpdatesResponseSchema = z.object({
+  updates: z.array(KonturTalkUpdateSchema),
+})
+
+export const KonturTalkSendMessageResponseSchema = z.object({
+  event_id: z.string(),
+})
+
+export const KonturTalkErrorResponseSchema = z.object({
+  detail: z.union([
+    z.object({
+      errcode: z.string(),
+      error: z.string(),
+    }),
+    z.array(
+      z.object({
+        loc: z.array(z.union([z.string(), z.number()])),
+        msg: z.string(),
+        type: z.string(),
+      }),
+    ),
+  ]),
+})
+```
+
+- [ ] **Step 12: Run schema tests to verify they pass**
+
+Run: `bun test tests/chat/kontur-talk/schema.test.ts`
+Expected: PASS
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/chat/kontur-talk/metadata.ts src/chat/kontur-talk/config.ts src/chat/kontur-talk/schema.ts tests/chat/kontur-talk/metadata.test.ts tests/chat/kontur-talk/config.test.ts tests/chat/kontur-talk/schema.test.ts
+git commit -m "feat(kontur-talk): add metadata, config, and schema foundations"
+```
+
+---
+
+### Task 2: Reply Helpers
+
+**Files:**
+
+- Create: `src/chat/kontur-talk/reply-helpers.ts`
+- Create: `tests/chat/kontur-talk/reply-helpers.test.ts`
+
+- [ ] **Step 1: Write reply helpers tests**
+
+```typescript
+// tests/chat/kontur-talk/reply-helpers.test.ts
+import { describe, expect, test } from 'bun:test'
+import type { ReplyFn } from '../../../src/chat/types.js'
+import { createKonturTalkReplyFn } from '../../../src/chat/kontur-talk/reply-helpers.js'
+
+function makeReplyFn(): { reply: ReplyFn; posts: unknown[] } {
+  const posts: unknown[] = []
+  const apiFetch = (_method: string, _path: string, body: unknown): Promise<unknown> => {
+    posts.push(body)
+    return Promise.resolve({ event_id: '$newEvent' })
+  }
+  const reply = createKonturTalkReplyFn({
+    roomId: '!room:host',
+    threadId: undefined,
+    apiFetch,
+  })
+  return { reply, posts }
+}
+
+describe('createKonturTalkReplyFn', () => {
+  test('text() sends plain format message', async () => {
+    const { reply, posts } = makeReplyFn()
+    await reply.text('Hello')
+    expect(posts).toEqual([{ room_id: '!room:host', message: 'Hello', format: 'plain', thread_id: null, mentions: [] }])
+  })
+
+  test('formatted() sends markdown format message', async () => {
+    const { reply, posts } = makeReplyFn()
+    await reply.formatted('**bold**')
+    expect(posts).toEqual([
+      { room_id: '!room:host', message: '**bold**', format: 'markdown', thread_id: null, mentions: [] },
+    ])
+  })
+
+  test('text() passes thread_id when present', async () => {
+    const posts: unknown[] = []
+    const apiFetch = (_method: string, _path: string, body: unknown): Promise<unknown> => {
+      posts.push(body)
+      return Promise.resolve({ event_id: '$newEvent' })
+    }
+    const reply = createKonturTalkReplyFn({
+      roomId: '!room:host',
+      threadId: '$thread123',
+      apiFetch,
+    })
+    await reply.text('In thread')
+    expect(posts).toEqual([
+      { room_id: '!room:host', message: 'In thread', format: 'plain', thread_id: '$thread123', mentions: [] },
+    ])
+  })
+
+  test('text() uses option threadId over default', async () => {
+    const posts: unknown[] = []
+    const apiFetch = (_method: string, _path: string, body: unknown): Promise<unknown> => {
+      posts.push(body)
+      return Promise.resolve({ event_id: '$newEvent' })
+    }
+    const reply = createKonturTalkReplyFn({
+      roomId: '!room:host',
+      threadId: '$defaultThread',
+      apiFetch,
+    })
+    await reply.text('Override', { threadId: '$otherThread' })
+    expect((posts[0] as Record<string, unknown>)['thread_id']).toBe('$otherThread')
+  })
+
+  test('typing() is a no-op', () => {
+    const { reply } = makeReplyFn()
+    expect(() => reply.typing()).not.toThrow()
+  })
+
+  test('buttons() throws', async () => {
+    const { reply } = makeReplyFn()
+    await expect(reply.buttons('content', { buttons: [] })).rejects.toThrow(/does not support/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run reply helpers tests to verify they fail**
+
+Run: `bun test tests/chat/kontur-talk/reply-helpers.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write reply helpers implementation**
+
+```typescript
+// src/chat/kontur-talk/reply-helpers.ts
+import type { ButtonReplyOptions, ReplyFn, ReplyOptions } from '../types.js'
+
+interface KonturTalkReplyHelpersParams {
+  roomId: string
+  threadId?: string
+  apiFetch: (method: string, path: string, body: unknown) => Promise<unknown>
+}
+
+export function createKonturTalkReplyFn(params: KonturTalkReplyHelpersParams): ReplyFn {
+  const { roomId, threadId, apiFetch } = params
+
+  const send = async (message: string, format: string, options?: ReplyOptions): Promise<void> => {
+    await apiFetch('POST', '/send_message', {
+      room_id: roomId,
+      message,
+      format,
+      thread_id: options?.threadId ?? threadId ?? null,
+      mentions: [],
+    })
+  }
+
+  return {
+    text: (content: string, options?: ReplyOptions) => send(content, 'plain', options),
+    formatted: (markdown: string, options?: ReplyOptions) => send(markdown, 'markdown', options),
+    typing: () => {},
+    buttons: (_content: string, _options: ButtonReplyOptions): Promise<void> => {
+      return Promise.reject(
+        new Error(
+          'Kontur Talk does not support interactive buttons. Use supportsInteractiveButtons() to check before calling reply.buttons().',
+        ),
+      )
+    },
+  }
+}
+```
+
+- [ ] **Step 4: Run reply helpers tests to verify they pass**
+
+Run: `bun test tests/chat/kontur-talk/reply-helpers.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/chat/kontur-talk/reply-helpers.ts tests/chat/kontur-talk/reply-helpers.test.ts
+git commit -m "feat(kontur-talk): add reply helpers"
+```
+
+---
+
+### Task 3: Context Renderer and Label Helpers
+
+**Files:**
+
+- Create: `src/chat/kontur-talk/context-renderer.ts`
+- Create: `src/chat/kontur-talk/label-helpers.ts`
+- Create: `tests/chat/kontur-talk/context-renderer.test.ts`
+- Create: `tests/chat/kontur-talk/label-helpers.test.ts`
+
+- [ ] **Step 1: Write context renderer tests**
+
+```typescript
+// tests/chat/kontur-talk/context-renderer.test.ts
+import { describe, expect, test } from 'bun:test'
+import { renderKonturTalkContext } from '../../../src/chat/kontur-talk/context-renderer.js'
+import type { ContextSnapshot } from '../../../src/chat/types.js'
+
+const makeSnapshot = (overrides?: Partial<ContextSnapshot>): ContextSnapshot => ({
+  modelName: 'gpt-4',
+  totalTokens: 1000,
+  maxTokens: 8000,
+  approximate: false,
+  sections: [],
+  ...overrides,
+})
+
+describe('renderKonturTalkContext', () => {
+  test('returns formatted method', () => {
+    const result = renderKonturTalkContext(makeSnapshot())
+    expect(result.method).toBe('formatted')
+  })
+
+  test('includes model name and token count', () => {
+    const result = renderKonturTalkContext(makeSnapshot())
+    expect(result.content).toContain('gpt-4')
+    expect(result.content).toContain('1,000')
+  })
+
+  test('includes percentage when maxTokens is set', () => {
+    const result = renderKonturTalkContext(makeSnapshot({ totalTokens: 4000, maxTokens: 8000 }))
+    expect(result.content).toContain('50.0%')
+  })
+
+  test('handles null maxTokens', () => {
+    const result = renderKonturTalkContext(makeSnapshot({ maxTokens: null }))
+    expect(result.method).toBe('formatted')
+    expect(result.content).not.toContain('undefined')
+  })
+})
+```
+
+- [ ] **Step 2: Run context renderer tests to verify they fail**
+
+Run: `bun test tests/chat/kontur-talk/context-renderer.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write context renderer implementation**
+
+```typescript
+// src/chat/kontur-talk/context-renderer.ts
+import { buildContextGrid, SECTION_EMOJIS } from '../../commands/context-grid.js'
+import type { ContextRendered, ContextSection, ContextSnapshot } from '../types.js'
+
+const formatNumber = (n: number): string => n.toLocaleString('en-US')
+
+const buildHeader = (snapshot: ContextSnapshot): string => {
+  const total = formatNumber(snapshot.totalTokens)
+  if (snapshot.maxTokens === null) {
+    return `**Context** · ${snapshot.modelName} · ${total} tokens`
+  }
+  const max = formatNumber(snapshot.maxTokens)
+  const pct = ((snapshot.totalTokens / snapshot.maxTokens) * 100).toFixed(1)
+  return `**Context** · ${snapshot.modelName} · ${total} / ${max} tokens (${pct}%)`
+}
+
+const emojiFor = (label: string): string => SECTION_EMOJIS[label] ?? '⬜'
+
+const topRow = (section: ContextSection): string =>
+  `| ${emojiFor(section.label)} **${section.label}** | ${formatNumber(section.tokens)} |`
+
+const childRow = (child: ContextSection): string => {
+  const label = child.detail === undefined ? child.label : `${child.label} (${child.detail})`
+  return `| ↳ ${label} | ${formatNumber(child.tokens)} |`
+}
+
+const detailRow = (detail: string): string => `| ↳ ${detail} |  |`
+
+const buildTable = (snapshot: ContextSnapshot): string => {
+  const lines = ['| Section | Tokens |', '| ------ | ------:|']
+  for (const section of snapshot.sections) {
+    lines.push(topRow(section))
+    if (section.children !== undefined) {
+      for (const child of section.children) lines.push(childRow(child))
+    }
+    if (section.detail !== undefined) lines.push(detailRow(section.detail))
+  }
+  return lines.join('\n')
+}
+
+export const renderKonturTalkContext = (snapshot: ContextSnapshot): ContextRendered => {
+  const header = buildHeader(snapshot)
+  const grid = buildContextGrid(snapshot)
+  const table = buildTable(snapshot)
+  const footer = snapshot.approximate ? '\n\n_token counts are approximate_' : ''
+  return { method: 'formatted', content: `${header}\n\n${grid}\n\n${table}${footer}` }
+}
+```
+
+- [ ] **Step 4: Run context renderer tests to verify they pass**
+
+Run: `bun test tests/chat/kontur-talk/context-renderer.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Write label helpers tests**
+
+```typescript
+// tests/chat/kontur-talk/label-helpers.test.ts
+import { describe, expect, test } from 'bun:test'
+import { resolveKonturTalkUserLabel, resolveKonturTalkGroupLabel } from '../../../src/chat/kontur-talk/label-helpers.js'
+
+describe('resolveKonturTalkUserLabel', () => {
+  test('returns user_id as-is when no display name API', async () => {
+    const apiFetch = (): Promise<unknown> => Promise.resolve({})
+    const result = await resolveKonturTalkUserLabel(apiFetch, '@alice:host')
+    expect(result).toBe('@alice:host')
+  })
+
+  test('returns null for empty userId', async () => {
+    const apiFetch = (): Promise<unknown> => Promise.resolve({})
+    const result = await resolveKonturTalkUserLabel(apiFetch, '')
+    expect(result).toBeNull()
+  })
+})
+
+describe('resolveKonturTalkGroupLabel', () => {
+  test('returns null (no group info API)', async () => {
+    const apiFetch = (): Promise<unknown> => Promise.resolve({})
+    const result = await resolveKonturTalkGroupLabel(apiFetch, '!room:host')
+    expect(result).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 6: Run label helpers tests to verify they fail**
+
+Run: `bun test tests/chat/kontur-talk/label-helpers.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 7: Write label helpers implementation**
+
+```typescript
+// src/chat/kontur-talk/label-helpers.ts
+type ApiFetchFn = (method: string, path: string, body: unknown) => Promise<unknown>
+
+export async function resolveKonturTalkUserLabel(_apiFetch: ApiFetchFn, userId: string): Promise<string | null> {
+  if (userId.trim() === '') return null
+  return userId
+}
+
+export async function resolveKonturTalkGroupLabel(_apiFetch: ApiFetchFn, _groupId: string): Promise<string | null> {
+  return null
+}
+```
+
+- [ ] **Step 8: Run label helpers tests to verify they pass**
+
+Run: `bun test tests/chat/kontur-talk/label-helpers.test.ts`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/chat/kontur-talk/context-renderer.ts src/chat/kontur-talk/label-helpers.ts tests/chat/kontur-talk/context-renderer.test.ts tests/chat/kontur-talk/label-helpers.test.ts
+git commit -m "feat(kontur-talk): add context renderer and label helpers"
+```
+
+---
+
+### Task 4: Main Provider Class — Constructor, Start/Stop, Message Loop
+
+**Files:**
+
+- Create: `src/chat/kontur-talk/index.ts`
+- Create: `tests/chat/kontur-talk/index.test.ts`
+
+- [ ] **Step 1: Write constructor and lifecycle tests**
+
+```typescript
+// tests/chat/kontur-talk/index.test.ts
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test'
+import { KonturTalkChatProvider } from '../../../src/chat/kontur-talk/index.js'
+import { setMockFetch, restoreFetch } from '../../utils/test-helpers.js'
+
+// JWT token with sub="bot123" (base64-encoded)
+const TEST_JWT = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJib3QxMjMiLCJvd25lciI6ImFkbWluMSIsImlhdCI6MTc1NzA2MTc3N30.test'
+
+describe('KonturTalkChatProvider', () => {
+  const origEnv = { ...process.env }
+
+  beforeEach(() => {
+    process.env['KONTUR_TALK_JWT_TOKEN'] = TEST_JWT
+  })
+
+  afterEach(() => {
+    process.env = { ...origEnv }
+    restoreFetch()
+  })
+
+  test('name is kontur-talk', () => {
+    const provider = new KonturTalkChatProvider()
+    expect(provider.name).toBe('kontur-talk')
+  })
+
+  test('capabilities include messages.reply-context', () => {
+    const provider = new KonturTalkChatProvider()
+    expect(provider.capabilities.has('messages.reply-context')).toBe(true)
+  })
+
+  test('capabilities do not include messages.buttons', () => {
+    const provider = new KonturTalkChatProvider()
+    expect(provider.capabilities.has('messages.buttons')).toBe(false)
+  })
+
+  test('traits observe all group messages', () => {
+    const provider = new KonturTalkChatProvider()
+    expect(provider.traits.observedGroupMessages).toBe('all')
+  })
+
+  test('traits max message length is 4096', () => {
+    const provider = new KonturTalkChatProvider()
+    expect(provider.traits.maxMessageLength).toBe(4096)
+  })
+
+  test('thread capabilities support threads', () => {
+    const provider = new KonturTalkChatProvider()
+    expect(provider.threadCapabilities.supportsThreads).toBe(true)
+    expect(provider.threadCapabilities.canCreateThreads).toBe(true)
+    expect(provider.threadCapabilities.threadScope).toBe('message')
+  })
+
+  test('config requirements include KONTUR_TALK_JWT_TOKEN', () => {
+    const provider = new KonturTalkChatProvider()
+    expect(provider.configRequirements).toEqual([
+      { key: 'KONTUR_TALK_JWT_TOKEN', label: 'Kontur Talk JWT Token', required: true },
+    ])
+  })
+
+  test('start() extracts botUserId from JWT', async () => {
+    let capturedUrl: string | undefined
+    setMockFetch(async (url: string) => {
+      capturedUrl = url
+      return new Response(JSON.stringify({ updates: [] }), { status: 200 })
+    })
+    const provider = new KonturTalkChatProvider()
+    await provider.start()
+    expect(provider.botUserId).toBe('bot123')
+    await provider.stop()
+  })
+
+  test('stop() sets running to false', async () => {
+    setMockFetch(async () => new Response(JSON.stringify({ updates: [] }), { status: 200 }))
+    const provider = new KonturTalkChatProvider()
+    await provider.start()
+    await provider.stop()
+    expect(provider.running).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run constructor tests to verify they fail**
+
+Run: `bun test tests/chat/kontur-talk/index.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write main provider class (constructor, start, stop)**
+
+```typescript
+// src/chat/kontur-talk/index.ts
+import { logger } from '../../logger.js'
+import type {
+  ChatCapability,
+  ChatProvider,
+  ChatProviderConfigRequirement,
+  ChatProviderTraits,
+  ContextRendered,
+  ContextSnapshot,
+  DeferredDeliveryTarget,
+  IncomingMessage,
+  ReplyFn,
+  ThreadCapabilities,
+} from '../types.js'
+import { resolveKonturTalkConfig, type KonturTalkConstructorConfig } from './config.js'
+import { renderKonturTalkContext } from './context-renderer.js'
+import { konturTalkCapabilities, konturTalkConfigRequirements, konturTalkTraits } from './metadata.js'
+import { createKonturTalkReplyFn } from './reply-helpers.js'
+import {
+  KonturTalkGetUpdatesResponseSchema,
+  KonturTalkSendMessageResponseSchema,
+  KonturTalkUpdateSchema,
+} from './schema.js'
+
+const BASE_URL = 'https://chat.ktalk.ru/_matrix/client/strangler/api/v1'
+
+const log = logger.child({ scope: 'chat:kontur-talk' })
+
+export class KonturTalkChatProvider implements ChatProvider {
+  readonly name = 'kontur-talk'
+  readonly threadCapabilities: ThreadCapabilities = {
+    supportsThreads: true,
+    canCreateThreads: true,
+    threadScope: 'message',
+  }
+  readonly capabilities: ReadonlySet<ChatCapability> = konturTalkCapabilities
+  readonly traits: ChatProviderTraits = konturTalkTraits
+  readonly configRequirements: readonly ChatProviderConfigRequirement[] = konturTalkConfigRequirements
+
+  private readonly jwtToken: string
+  private readonly platformInstanceId: string
+  private messageHandler: ((msg: IncomingMessage, reply: ReplyFn) => Promise<void>) | null = null
+  private botUserId: string | null = null
+  private running = false
+
+  constructor(config?: KonturTalkConstructorConfig) {
+    const resolved = resolveKonturTalkConfig(config ?? {})
+    this.jwtToken = resolved.jwtToken
+    this.platformInstanceId = resolved.platformInstanceId
+  }
+
+  getBotUserId(): string | null {
+    return this.botUserId
+  }
+
+  isRunning(): boolean {
+    return this.running
+  }
+
+  private extractBotUserId(): string {
+    const parts = this.jwtToken.split('.')
+    if (parts.length < 2 || parts[1] === undefined) {
+      throw new Error('Invalid JWT token: missing payload')
+    }
+    const payload = JSON.parse(atob(parts[1]))
+    if (typeof payload.sub !== 'string' || payload.sub.trim() === '') {
+      throw new Error('Invalid JWT token: missing sub claim')
+    }
+    return payload.sub
+  }
+
+  private buildUrl(endpoint: string): string {
+    return `${BASE_URL}/bot/${this.jwtToken}${endpoint}`
+  }
+
+  private async apiFetch(method: string, endpoint: string, body?: unknown): Promise<unknown> {
+    const url = this.buildUrl(endpoint)
+    const options: RequestInit = {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+    }
+    if (body !== undefined) {
+      options.body = JSON.stringify(body)
+    }
+    const response = await fetch(url, options)
+    if (!response.ok) {
+      const errorBody = await response.text()
+      throw new Error(`Kontur Talk API error ${response.status}: ${errorBody}`)
+    }
+    return response.json()
+  }
+
+  async start(): Promise<void> {
+    this.botUserId = this.extractBotUserId()
+    this.running = true
+    log.info({ botUserId: this.botUserId }, 'Kontur Talk bot started')
+    void this.pollLoop()
+  }
+
+  stop(): Promise<void> {
+    this.running = false
+    log.info('Kontur Talk bot stopped')
+    return Promise.resolve()
+  }
+
+  private async pollLoop(): Promise<void> {
+    while (this.running) {
+      try {
+        const data = await this.apiFetch('GET', '/get_updates?timeout=30')
+        const parsed = KonturTalkGetUpdatesResponseSchema.safeParse(data)
+        if (!parsed.success) {
+          log.warn({ error: parsed.error }, 'Failed to parse get_updates response')
+          continue
+        }
+        for (const update of parsed.data.updates) {
+          if (update.user_id === this.botUserId) continue
+          await this.handleUpdate(update)
+        }
+      } catch (e) {
+        if (!this.running) break
+        log.warn({ error: e instanceof Error ? e.message : String(e) }, 'Poll loop error')
+        await new Promise((resolve) => setTimeout(resolve, 5000))
+      }
+    }
+  }
+
+  private async handleUpdate(update: Record<string, unknown>): Promise<void> {
+    // Implemented in Task 5
+  }
+
+  onMessage(handler: (msg: IncomingMessage, reply: ReplyFn) => Promise<void>): void {
+    this.messageHandler = handler
+  }
+
+  async sendMessage(_platformInstanceId: string, target: DeferredDeliveryTarget, markdown: string): Promise<void> {
+    if (target.contextType === 'dm') {
+      log.warn('Kontur Talk does not support proactive DM delivery')
+      return
+    }
+    await this.apiFetch('POST', '/send_message', {
+      room_id: target.contextId,
+      message: markdown,
+      format: 'markdown',
+      thread_id: target.threadId ?? null,
+      mentions: [],
+    })
+  }
+
+  renderContext(snapshot: ContextSnapshot): ContextRendered {
+    return renderKonturTalkContext(snapshot)
+  }
+}
+```
+
+- [ ] **Step 4: Run constructor tests to verify they pass**
+
+Run: `bun test tests/chat/kontur-talk/index.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/chat/kontur-talk/index.ts tests/chat/kontur-talk/index.test.ts
+git commit -m "feat(kontur-talk): add provider class with constructor, start/stop, and message loop"
+```
+
+---
+
+### Task 5: Main Provider Class — Message Handling and sendMessage
+
+**Files:**
+
+- Modify: `src/chat/kontur-talk/index.ts`
+- Modify: `tests/chat/kontur-talk/index.test.ts`
+
+- [ ] **Step 1: Write message handling tests**
+
+Add to `tests/chat/kontur-talk/index.test.ts`:
+
+```typescript
+describe('message handling', () => {
+  test('handleUpdate dispatches text message to messageHandler', async () => {
+    const received: IncomingMessage[] = []
+    setMockFetch(async () => new Response(JSON.stringify({ updates: [] }), { status: 200 }))
+    const provider = new KonturTalkChatProvider()
+    await provider.start()
+    provider.onMessage(async (msg, _reply) => {
+      received.push(msg)
+    })
+
+    // Simulate an update by calling the private handleUpdate via poll loop
+    // We test through the public API by verifying onMessage is called
+    await provider.stop()
+  })
+
+  test('sendMessage for group sends to API', async () => {
+    let capturedBody: unknown
+    setMockFetch(async (_url: string, options?: RequestInit) => {
+      capturedBody = options?.body ? JSON.parse(options.body as string) : undefined
+      return new Response(JSON.stringify({ event_id: '$sent' }), { status: 200 })
+    })
+    const provider = new KonturTalkChatProvider()
+    await provider.start()
+
+    await provider.sendMessage(
+      'kontur-talk-default',
+      {
+        contextId: '!room:host',
+        contextType: 'group',
+        threadId: null,
+        audience: 'shared',
+        mentionUserIds: [],
+        createdByUserId: 'user1',
+        createdByUsername: null,
+      },
+      'Hello group',
+    )
+
+    expect(capturedBody).toEqual({
+      room_id: '!room:host',
+      message: 'Hello group',
+      format: 'markdown',
+      thread_id: null,
+      mentions: [],
+    })
+
+    await provider.stop()
+  })
+
+  test('sendMessage for DM logs warning and returns', async () => {
+    let fetchCalled = false
+    setMockFetch(async () => {
+      fetchCalled = true
+      return new Response(JSON.stringify({ event_id: '$sent' }), { status: 200 })
+    })
+    const provider = new KonturTalkChatProvider()
+    await provider.start()
+
+    await provider.sendMessage(
+      'kontur-talk-default',
+      {
+        contextId: '@user:host',
+        contextType: 'dm',
+        threadId: null,
+        audience: 'personal',
+        mentionUserIds: [],
+        createdByUserId: 'user1',
+        createdByUsername: null,
+      },
+      'Hello DM',
+    )
+
+    // DM delivery is not supported, so no API call should be made
+    // (the initial fetch is from the poll loop, not sendMessage)
+    await provider.stop()
+  })
+
+  test('sendMessage passes threadId when present', async () => {
+    let capturedBody: unknown
+    setMockFetch(async (_url: string, options?: RequestInit) => {
+      if (options?.body) {
+        capturedBody = JSON.parse(options.body as string)
+      }
+      return new Response(JSON.stringify({ event_id: '$sent' }), { status: 200 })
+    })
+    const provider = new KonturTalkChatProvider()
+    await provider.start()
+
+    await provider.sendMessage(
+      'kontur-talk-default',
+      {
+        contextId: '!room:host',
+        contextType: 'group',
+        threadId: '$thread123',
+        audience: 'shared',
+        mentionUserIds: [],
+        createdByUserId: 'user1',
+        createdByUsername: null,
+      },
+      'In thread',
+    )
+
+    expect((capturedBody as Record<string, unknown>)['thread_id']).toBe('$thread123')
+    await provider.stop()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/chat/kontur-talk/index.test.ts`
+Expected: FAIL — handleUpdate not implemented, sendMessage for DM may make API calls
+
+- [ ] **Step 3: Implement handleUpdate and fix sendMessage**
+
+Update `src/chat/kontur-talk/index.ts` — replace the stub `handleUpdate` and update `sendMessage`:
+
+```typescript
+  private async handleUpdate(update: Record<string, unknown>): Promise<void> {
+    const parsed = KonturTalkUpdateSchema.safeParse(update)
+    if (!parsed.success) {
+      log.warn({ error: parsed.error }, 'Failed to parse update')
+      return
+    }
+    const data = parsed.data
+
+    const isMentioned = this.isMentioned(data.mentions)
+    const threadId = data.thread_id ?? undefined
+    const replyToMessageId = data.reply_id ?? undefined
+
+    const msg: IncomingMessage = {
+      user: { id: data.user_id, name: data.user_id },
+      contextId: data.room_id,
+      contextType: data.room_is_direct ? 'dm' : 'group',
+      isMentioned,
+      text: data.body ?? '',
+      messageId: data.event_id,
+      threadId,
+      replyToMessageId,
+      platformInstanceId: this.platformInstanceId,
+    }
+
+    const reply = createKonturTalkReplyFn({
+      roomId: data.room_id,
+      threadId,
+      apiFetch: this.apiFetch.bind(this),
+    })
+
+    if (this.messageHandler !== null) {
+      await this.messageHandler(msg, reply)
+    }
+  }
+
+  private isMentioned(mentions: unknown): boolean {
+    if (this.botUserId === null) return false
+    if (mentions === 'all') return true
+    if (Array.isArray(mentions)) {
+      return mentions.some((m) => typeof m === 'string' && m.includes(this.botUserId!))
+    }
+    return false
+  }
+```
+
+Also add the import for `KonturTalkUpdateSchema` at the top of the file.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/chat/kontur-talk/index.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/chat/kontur-talk/index.ts tests/chat/kontur-talk/index.test.ts
+git commit -m "feat(kontur-talk): add message handling and sendMessage"
+```
+
+---
+
+### Task 6: Registration and Bootstrap
+
+**Files:**
+
+- Modify: `src/chat/registry.ts`
+- Modify: `src/instances/types.ts`
+- Modify: `src/instances/bootstrap.ts`
+- Modify: `src/env-validation.ts`
+
+- [ ] **Step 1: Add 'kontur-talk' to PlatformInstanceType**
+
+In `src/instances/types.ts`, add `'kontur-talk'` to the `PlatformInstanceType` union:
+
+```typescript
+export type PlatformInstanceType = 'telegram' | 'mattermost' | 'discord' | 'kontur-talk'
+```
+
+- [ ] **Step 2: Add Kontur Talk to env validation**
+
+In `src/env-validation.ts`:
+
+- Add `'kontur-talk'` to the provider name check (the `if` condition)
+- Add `kontur-talk: ['KONTUR_TALK_JWT_TOKEN']` to the requirements record
+
+- [ ] **Step 3: Add Kontur Talk to bootstrap**
+
+In `src/instances/bootstrap.ts`:
+
+- Add `kontur-talk: ['KONTUR_TALK_JWT_TOKEN']` to `CHAT_ENV_REQUIREMENTS`
+- Add `'kontur-talk'` to `parsePlatformType` return value
+- Add `case 'kontur-talk': return { jwtToken: getTrimmedEnv('KONTUR_TALK_JWT_TOKEN') ?? '' }` to `buildPlatformConfig`
+
+- [ ] **Step 4: Add Kontur Talk to registry**
+
+In `src/chat/registry.ts`:
+
+- Import `KonturTalkChatProvider` from `./kontur-talk/index.js`
+- Import `konturTalkCapabilities`, `konturTalkTraits` from `./kontur-talk/metadata.js`
+- Add descriptor to `platformDescriptors` array
+- Add factory to `registerChatProvider` calls
+- Add `kontur-talk` case to `configToEnv` function
+
+- [ ] **Step 5: Write registry tests**
+
+Add to `tests/chat/registry.test.ts`:
+
+```typescript
+test('createChatProvider("kontur-talk") creates provider', () => {
+  process.env['KONTUR_TALK_JWT_TOKEN'] = 'test-token'
+  const provider = createChatProvider('kontur-talk', { env: process.env as Record<string, string | undefined> })
+  expect(provider.name).toBe('kontur-talk')
+})
+
+test('createChatProvider("kontur-talk") throws when JWT token is missing', () => {
+  expect(() => createChatProvider('kontur-talk', { env: {} })).toThrow()
+})
+```
+
+- [ ] **Step 6: Run full test suite to verify**
+
+Run: `bun test`
+Expected: PASS (all existing tests still pass, new tests pass)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/chat/registry.ts src/instances/types.ts src/instances/bootstrap.ts src/env-validation.ts tests/chat/registry.test.ts
+git commit -m "feat(kontur-talk): register provider in registry, bootstrap, and env validation"
+```
+
+---
+
+### Task 7: Integration Verification
+
+- [ ] **Step 1: Run lint**
+
+Run: `bun lint`
+Expected: PASS — no lint errors in new files
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `bun typecheck`
+Expected: PASS — no type errors
+
+- [ ] **Step 3: Run format check**
+
+Run: `bun format:check`
+Expected: PASS — formatting is correct
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `bun test`
+Expected: PASS — all tests pass
+
+- [ ] **Step 5: Commit any fixes**
+
+If any of the above fail, fix the issues and commit:
+
+```bash
+git add -A
+git commit -m "fix(kontur-talk): lint/typecheck/format fixes"
+```

--- a/docs/superpowers/specs/2026-05-28-kontur-talk-chat-provider-design.md
+++ b/docs/superpowers/specs/2026-05-28-kontur-talk-chat-provider-design.md
@@ -1,0 +1,160 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Kontur Talk Chat Provider Design
+
+## Summary
+
+Add Kontur Talk (Толк.Чаты) as a fourth chat provider in papai. The bot communicates via the Kontur Talk Chat Bot API using long polling for receiving messages and REST for sending. MVP scope: text messages and threads only; media support deferred to Phase 2.
+
+## Context
+
+Kontur Talk is a corporate messenger by SKB Kontur. Its Chat Bot API is Matrix-compatible (room IDs like `!room:host`, user IDs like `@user:host`). Bots are created in the Talk.Chats space settings UI, which generates a JWT token used for all API calls.
+
+API documentation: https://kontur.renote.team/doc/NNyX6DGvQ
+
+## Capabilities & Traits
+
+| Property                              | Value                    |
+| ------------------------------------- | ------------------------ |
+| `name`                                | `'kontur-talk'`          |
+| `capabilities`                        | `messages.reply-context` |
+| `traits.observedGroupMessages`        | `'all'`                  |
+| `traits.maxMessageLength`             | `4096`                   |
+| `threadCapabilities.supportsThreads`  | `true`                   |
+| `threadCapabilities.canCreateThreads` | `true`                   |
+| `threadCapabilities.threadScope`      | `'message'`              |
+| `configRequirements`                  | `KONTUR_TALK_JWT_TOKEN`  |
+
+Absent capabilities (no API support): `commands.menu`, `interactions.callbacks`, `messages.buttons`, `messages.delete`, `messages.redact`, `files.receive`, `users.resolve`.
+
+## File Structure
+
+All platform-specific code in `src/chat/kontur-talk/`:
+
+| File                  | Purpose                                                                      |
+| --------------------- | ---------------------------------------------------------------------------- |
+| `index.ts`            | `KonturTalkChatProvider` class implementing `ChatProvider`                   |
+| `config.ts`           | Config resolution (`KonturTalkConstructorConfig` -> resolved config)         |
+| `schema.ts`           | Zod schemas for API responses (updates, send_message, errors)                |
+| `metadata.ts`         | `konturTalkCapabilities`, `konturTalkTraits`, `konturTalkConfigRequirements` |
+| `context-renderer.ts` | Renders `ContextSnapshot` as formatted markdown table                        |
+| `reply-helpers.ts`    | Constructs `ReplyFn` (text, formatted, typing)                               |
+| `label-helpers.ts`    | `resolveKonturTalkUserLabel()`, `resolveKonturTalkGroupLabel()`              |
+
+## Authentication & API Layer
+
+**Base URL** (hardcoded): `https://chat.ktalk.ru/_matrix/client/strangler/api/v1`
+
+**Auth**: JWT token passed as URL path segment. All requests go through:
+
+```
+{base_url}/bot/{jwt_token}/{endpoint}
+```
+
+**API layer**: Private `apiFetch(method, path, body?)` method on the provider class. Constructs the full URL, uses `fetch()` with JSON content type. All REST calls go through this.
+
+**Constructor config**:
+
+```typescript
+type KonturTalkConstructorConfig = {
+  jwtToken?: string // optional, falls back to KONTUR_TALK_JWT_TOKEN env
+  platformInstanceId?: string
+}
+```
+
+**Bot identity**: No `/users/me` endpoint. Extract `sub` from JWT payload via `JSON.parse(atob(token.split('.')[1]))`. Store as `botUserId` for self-message filtering.
+
+**Env validation**: Add `KONTUR_TALK_JWT_TOKEN` to the validation map in `env-validation.ts`.
+
+## Message Loop
+
+Long polling via `GET /get_updates?timeout=30`.
+
+1. `start()`: Extract `botUserId` from JWT. Start polling loop.
+2. Polling loop: `while (this.running)` — call `get_updates`, process each update, poll again immediately on success. On error, wait 5s before retry.
+3. `stop()`: Set `this.running = false`. The in-flight request resolves naturally (30s timeout).
+
+**Self-message filtering**: Skip updates where `user_id` matches `botUserId`.
+
+No WebSocket support in the API — long polling only.
+
+## Message Mapping
+
+### IncomingMessage
+
+| Field                | Source                                                   |
+| -------------------- | -------------------------------------------------------- |
+| `user.id`            | `user_id` (e.g. `@alice:host`)                           |
+| `user.name`          | `user_id` (no display name API)                          |
+| `contextId`          | `room_id`                                                |
+| `contextType`        | `room_is_direct ? 'dm' : 'group'`                        |
+| `isMentioned`        | `botUserId` in `mentions` array, or `mentions === 'all'` |
+| `text`               | `body`                                                   |
+| `messageId`          | `event_id`                                               |
+| `threadId`           | `thread_id` if present                                   |
+| `replyToMessageId`   | `reply_id` if present                                    |
+| `platformInstanceId` | Injected by router                                       |
+
+### Command matching
+
+Simple `/command args` pattern on `body`, same as Mattermost.
+
+### ReplyFn
+
+| Method          | Implementation                           |
+| --------------- | ---------------------------------------- |
+| `text()`        | `send_message` with `format: 'plain'`    |
+| `formatted()`   | `send_message` with `format: 'markdown'` |
+| `typing()`      | No-op (no typing indicator API)          |
+| `buttons()`     | Throws (no interactive buttons)          |
+| `replaceText`   | Not available                            |
+| `file`          | Not available (Phase 2)                  |
+| `redactMessage` | Not available                            |
+| `deleteMessage` | Not available                            |
+
+All `send_message` calls pass `thread_id` from the incoming message's `threadId`.
+
+## Thread Handling
+
+- Incoming messages with `thread_id` set are inside a thread. Passed through to `IncomingMessage.threadId`.
+- When the bot replies with `thread_id: null` in a group, the API implicitly creates a thread. No explicit thread-creation endpoint needed.
+- `thread_id` flows into `storageContextId` via `getThreadScopedStorageContextId()`, giving each thread isolated conversation history, memory, memos, etc.
+- Thread scope label: `'message'` — thread IDs are opaque strings from the API.
+
+## sendMessage (Deferred Delivery)
+
+`sendMessage()` on the provider handles deferred delivery (proactive sends, recurring tasks):
+
+- For groups: Send directly to `room_id` from `DeferredDeliveryTarget.contextId`.
+- For DMs: The API has no create-DM endpoint. Proactive DM delivery is not supported in the MVP. `sendMessage()` returns `false` for DM targets. This matches the provider's capability profile (no `users.resolve`).
+- `thread_id` from `DeferredDeliveryTarget.threadId` if present.
+
+## Registration & Bootstrap
+
+1. **Registry** (`src/chat/registry.ts`): Add `'kontur-talk'` entry mapping to `new KonturTalkChatProvider(deps)`.
+2. **Env validation** (`src/env-validation.ts`): Add `'kontur-talk'` to the provider allowlist with `KONTUR_TALK_JWT_TOKEN` requirement.
+3. **Bootstrap** (`src/instances/bootstrap.ts`): Add `'kontur-talk'` to `CHAT_PROVIDER` enum and its env mapping.
+4. **Platform descriptors**: Add Kontur Talk descriptor to `listPlatformProviderTypes()` for the admin UI.
+
+## Limitations (MVP)
+
+- No media upload/download (Phase 2)
+- No interactive buttons or callbacks
+- No message delete/edit
+- No typing indicators
+- No user display name resolution (user_id shown as-is)
+- No bot command menu (commands registered at app level only)
+- Long polling only (no WebSocket)
+- Max 10 bots per space (API limit)
+- Max 4096 characters per message
+
+## Future: Phase 2 — Media Support
+
+- `upload_image`: Multipart form upload, returns MXC URL. Add `file` to ReplyFn.
+- `download_media`: POST with MXC URL, returns binary data. Add `files.receive` capability.
+- Support `m.image`, `m.video`, `m.file`, `m.audio` message types in incoming message parsing.

--- a/src/chat/kontur-talk/config.ts
+++ b/src/chat/kontur-talk/config.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+export type KonturTalkConstructorConfig = Partial<{
+  jwtToken: string
+  platformInstanceId: string
+}>
+
+export type ResolvedKonturTalkConfig = {
+  jwtToken: string
+  platformInstanceId: string
+}
+
+const resolveConfigValue = (value: string | undefined, fallback: string | undefined): string | undefined => {
+  if (value === undefined) return fallback
+  return value
+}
+
+const resolvePlatformInstanceId = (platformInstanceId: string | undefined): string => {
+  if (platformInstanceId === undefined) return 'kontur-talk-default'
+  return platformInstanceId
+}
+
+export const resolveKonturTalkConfig = (config: KonturTalkConstructorConfig): ResolvedKonturTalkConfig => {
+  const jwtToken = resolveConfigValue(config.jwtToken, process.env['KONTUR_TALK_JWT_TOKEN'])
+  if (jwtToken === undefined || jwtToken.trim() === '') {
+    throw new Error('KONTUR_TALK_JWT_TOKEN environment variable is required')
+  }
+  return {
+    jwtToken,
+    platformInstanceId: resolvePlatformInstanceId(config.platformInstanceId),
+  }
+}

--- a/src/chat/kontur-talk/context-renderer.ts
+++ b/src/chat/kontur-talk/context-renderer.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { buildContextGrid, SECTION_EMOJIS } from '../../commands/context-grid.js'
+import type { ContextRendered, ContextSection, ContextSnapshot } from '../types.js'
+
+const formatNumber = (n: number): string => n.toLocaleString('en-US')
+
+const buildHeader = (snapshot: ContextSnapshot): string => {
+  const total = formatNumber(snapshot.totalTokens)
+  if (snapshot.maxTokens === null) {
+    return `**Context** · ${snapshot.modelName} · ${total} tokens`
+  }
+  const max = formatNumber(snapshot.maxTokens)
+  const pct = ((snapshot.totalTokens / snapshot.maxTokens) * 100).toFixed(1)
+  return `**Context** · ${snapshot.modelName} · ${total} / ${max} tokens (${pct}%)`
+}
+
+const emojiFor = (label: string): string => SECTION_EMOJIS[label] ?? '⬜'
+
+const topRow = (section: ContextSection): string =>
+  `| ${emojiFor(section.label)} **${section.label}** | ${formatNumber(section.tokens)} |`
+
+const childRow = (child: ContextSection): string => {
+  const label = child.detail === undefined ? child.label : `${child.label} (${child.detail})`
+  return `| ↳ ${label} | ${formatNumber(child.tokens)} |`
+}
+
+const detailRow = (detail: string): string => `| ↳ ${detail} |  |`
+
+const buildTable = (snapshot: ContextSnapshot): string => {
+  const lines = ['| Section | Tokens |', '| ------ | ------:|']
+  for (const section of snapshot.sections) {
+    lines.push(topRow(section))
+    if (section.children !== undefined) {
+      for (const child of section.children) lines.push(childRow(child))
+    }
+    if (section.detail !== undefined) lines.push(detailRow(section.detail))
+  }
+  return lines.join('\n')
+}
+
+export const renderKonturTalkContext = (snapshot: ContextSnapshot): ContextRendered => {
+  const header = buildHeader(snapshot)
+  const grid = buildContextGrid(snapshot)
+  const table = buildTable(snapshot)
+  const footer = snapshot.approximate ? '\n\n_token counts are approximate_' : ''
+  return { method: 'formatted', content: `${header}\n\n${grid}\n\n${table}${footer}` }
+}

--- a/src/chat/kontur-talk/index.ts
+++ b/src/chat/kontur-talk/index.ts
@@ -16,14 +16,16 @@ import type {
   DeferredDeliveryTarget,
   IncomingMessage,
   ReplyFn,
+  ResolveUserContext,
   ThreadCapabilities,
 } from '../types.js'
 import { resolveKonturTalkConfig, type KonturTalkConstructorConfig } from './config.js'
 import { renderKonturTalkContext } from './context-renderer.js'
+import { resolveKonturTalkGroupLabel, resolveKonturTalkUserLabel } from './label-helpers.js'
 import { konturTalkCapabilities, konturTalkConfigRequirements, konturTalkTraits } from './metadata.js'
 import { createKonturTalkReplyFn } from './reply-helpers.js'
 import type { KonturTalkUpdate } from './schema.js'
-import { KonturTalkGetUpdatesResponseSchema } from './schema.js'
+import { KonturTalkGetUpdatesResponseSchema, KonturTalkSendMessageResponseSchema } from './schema.js'
 
 const BASE_URL = 'https://chat.ktalk.ru/_matrix/client/strangler/api/v1'
 
@@ -233,7 +235,17 @@ export class KonturTalkChatProvider implements ChatProvider {
       format: 'markdown',
       thread_id: target.threadId ?? null,
       mentions: [],
+    }).then((data) => {
+      KonturTalkSendMessageResponseSchema.parse(data)
     })
+  }
+
+  resolveUserLabel(userId: string, _context: ResolveUserContext | undefined): Promise<string | null> {
+    return resolveKonturTalkUserLabel((m, p, b) => this.apiFetch(m, p, b), userId)
+  }
+
+  resolveGroupLabel(groupId: string): Promise<string | null> {
+    return resolveKonturTalkGroupLabel((m, p, b) => this.apiFetch(m, p, b), groupId)
   }
 
   renderContext(snapshot: ContextSnapshot): ContextRendered {

--- a/src/chat/kontur-talk/index.ts
+++ b/src/chat/kontur-talk/index.ts
@@ -4,6 +4,7 @@
 // See LICENSE in the project root for details.
 
 import { logger } from '../../logger.js'
+import { buildScopedCommandAuth } from '../command-auth.js'
 import type {
   ChatCapability,
   ChatProvider,
@@ -20,6 +21,7 @@ import type {
 import { resolveKonturTalkConfig, type KonturTalkConstructorConfig } from './config.js'
 import { renderKonturTalkContext } from './context-renderer.js'
 import { konturTalkCapabilities, konturTalkConfigRequirements, konturTalkTraits } from './metadata.js'
+import { createKonturTalkReplyFn } from './reply-helpers.js'
 import type { KonturTalkUpdate } from './schema.js'
 import { KonturTalkGetUpdatesResponseSchema } from './schema.js'
 
@@ -164,10 +166,55 @@ export class KonturTalkChatProvider implements ChatProvider {
     }, Promise.resolve())
   }
 
-  private handleUpdate(_update: KonturTalkUpdate): Promise<void> {
-    // Stub — implemented in Task 5
-    void _update
-    return Promise.resolve()
+  private isMentioned(mentions: unknown): boolean {
+    if (this.botUserId === null) return false
+    if (mentions === 'all') return true
+    if (Array.isArray(mentions)) {
+      return mentions.some((m) => typeof m === 'string' && m.includes(this.botUserId!))
+    }
+    return false
+  }
+
+  private async handleUpdate(update: KonturTalkUpdate): Promise<void> {
+    const text = update.body ?? ''
+    const mentioned = this.isMentioned(update.mentions)
+
+    const msg: IncomingMessage = {
+      user: {
+        id: update.user_id,
+        username: update.user_id,
+        isAdmin: false,
+      },
+      contextId: update.room_id,
+      contextType: update.room_is_direct ? 'dm' : 'group',
+      isMentioned: mentioned,
+      text,
+      messageId: update.event_id,
+      threadId: update.thread_id ?? undefined,
+      replyToMessageId: update.reply_id ?? undefined,
+      platformInstanceId: this.platformInstanceId,
+    }
+
+    const reply = createKonturTalkReplyFn({
+      roomId: update.room_id,
+      threadId: update.thread_id ?? undefined,
+      apiFetch: (method, path, body) => this.apiFetch(method, path, body),
+    })
+
+    if (text.startsWith('/')) {
+      const firstSpace = text.indexOf(' ')
+      const commandName = (firstSpace === -1 ? text.slice(1) : text.slice(1, firstSpace)).toLowerCase()
+      const handler = this.commands.get(commandName)
+      if (handler) {
+        const auth = buildScopedCommandAuth(msg, false, this.platformInstanceId)
+        await handler(msg, reply, auth)
+        return
+      }
+    }
+
+    if (this.messageHandler) {
+      await this.messageHandler(msg, reply)
+    }
   }
 
   async sendMessage(_platformInstanceId: string, target: DeferredDeliveryTarget, markdown: string): Promise<void> {

--- a/src/chat/kontur-talk/index.ts
+++ b/src/chat/kontur-talk/index.ts
@@ -176,6 +176,11 @@ export class KonturTalkChatProvider implements ChatProvider {
   }
 
   private async handleUpdate(update: KonturTalkUpdate): Promise<void> {
+    if (update.message_type !== 'm.text') {
+      log.debug({ message_type: update.message_type }, 'Skipping non-text message')
+      return
+    }
+
     const text = update.body ?? ''
     const mentioned = this.isMentioned(update.mentions)
 

--- a/src/chat/kontur-talk/index.ts
+++ b/src/chat/kontur-talk/index.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { logger } from '../../logger.js'
+import type {
+  ChatCapability,
+  ChatProvider,
+  ChatProviderConfigRequirement,
+  ChatProviderTraits,
+  CommandHandler,
+  ContextRendered,
+  ContextSnapshot,
+  DeferredDeliveryTarget,
+  IncomingMessage,
+  ReplyFn,
+  ThreadCapabilities,
+} from '../types.js'
+import { resolveKonturTalkConfig, type KonturTalkConstructorConfig } from './config.js'
+import { renderKonturTalkContext } from './context-renderer.js'
+import { konturTalkCapabilities, konturTalkConfigRequirements, konturTalkTraits } from './metadata.js'
+import type { KonturTalkUpdate } from './schema.js'
+import { KonturTalkGetUpdatesResponseSchema } from './schema.js'
+
+const BASE_URL = 'https://chat.ktalk.ru/_matrix/client/strangler/api/v1'
+
+const log = logger.child({ scope: 'chat:kontur-talk' })
+
+const delay = (ms: number): Promise<void> =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
+export class KonturTalkChatProvider implements ChatProvider {
+  readonly name = 'kontur-talk'
+  readonly threadCapabilities: ThreadCapabilities = {
+    supportsThreads: true,
+    canCreateThreads: true,
+    threadScope: 'message',
+  }
+  readonly capabilities: ReadonlySet<ChatCapability> = konturTalkCapabilities
+  readonly traits: ChatProviderTraits = konturTalkTraits
+  readonly configRequirements: readonly ChatProviderConfigRequirement[] = konturTalkConfigRequirements
+
+  private readonly jwtToken: string
+  private readonly platformInstanceId: string
+  private readonly commands = new Map<string, CommandHandler>()
+  private messageHandler: ((msg: IncomingMessage, reply: ReplyFn) => Promise<void>) | null = null
+  private botUserId: string | null = null
+  private running = false
+
+  constructor(...args: [] | [KonturTalkConstructorConfig]) {
+    const config = args[0] ?? {}
+    const resolved = resolveKonturTalkConfig(config)
+    this.jwtToken = resolved.jwtToken
+    this.platformInstanceId = resolved.platformInstanceId
+  }
+
+  getBotUserId(): string | null {
+    return this.botUserId
+  }
+
+  getPlatformInstanceId(): string {
+    return this.platformInstanceId
+  }
+
+  isRunning(): boolean {
+    return this.running
+  }
+
+  registerCommand(name: string, handler: CommandHandler): void {
+    this.commands.set(name, handler)
+  }
+
+  onMessage(handler: (msg: IncomingMessage, reply: ReplyFn) => Promise<void>): void {
+    this.messageHandler = handler
+  }
+
+  getMessageHandler(): ((msg: IncomingMessage, reply: ReplyFn) => Promise<void>) | null {
+    return this.messageHandler
+  }
+
+  private extractBotUserId(): string {
+    const parts = this.jwtToken.split('.')
+    if (parts.length < 2 || parts[1] === undefined) {
+      throw new Error('Invalid JWT token: missing payload')
+    }
+    const decoded = atob(parts[1])
+    const payload: unknown = JSON.parse(decoded)
+    if (typeof payload !== 'object' || payload === null) {
+      throw new Error('Invalid JWT token: invalid payload format')
+    }
+    const sub: unknown = Reflect.get(payload, 'sub')
+    if (typeof sub !== 'string' || sub.trim() === '') {
+      throw new Error('Invalid JWT token: missing sub claim')
+    }
+    return sub
+  }
+
+  private buildUrl(endpoint: string): string {
+    return `${BASE_URL}/bot/${this.jwtToken}${endpoint}`
+  }
+
+  async apiFetch(method: string, endpoint: string, body?: unknown): Promise<unknown> {
+    const url = this.buildUrl(endpoint)
+    const options: RequestInit = {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+    }
+    if (body !== undefined) {
+      options.body = JSON.stringify(body)
+    }
+    const response = await fetch(url, options)
+    if (!response.ok) {
+      const errorBody = await response.text()
+      throw new Error(`Kontur Talk API error ${response.status}: ${errorBody}`)
+    }
+    return response.json()
+  }
+
+  start(): Promise<void> {
+    this.botUserId = this.extractBotUserId()
+    this.running = true
+    log.info({ botUserId: this.botUserId }, 'Kontur Talk bot started')
+    this.schedulePoll()
+    return Promise.resolve()
+  }
+
+  stop(): Promise<void> {
+    this.running = false
+    log.info('Kontur Talk bot stopped')
+    return Promise.resolve()
+  }
+
+  private schedulePoll(): void {
+    if (!this.running) return
+    void this.pollOnce().then(() => {
+      this.schedulePoll()
+    })
+  }
+
+  private async pollOnce(): Promise<void> {
+    try {
+      const data = await this.apiFetch('GET', '/get_updates?timeout=30')
+      const parsed = KonturTalkGetUpdatesResponseSchema.safeParse(data)
+      if (!parsed.success) {
+        log.warn({ error: parsed.error }, 'Failed to parse get_updates response')
+        await delay(1000)
+        return
+      }
+      await this.processUpdates(parsed.data.updates)
+    } catch (e) {
+      if (!this.running) return
+      log.warn({ error: e instanceof Error ? e.message : String(e) }, 'Poll loop error')
+      await delay(5000)
+    }
+  }
+
+  private processUpdates(updates: readonly KonturTalkUpdate[]): Promise<void> {
+    return updates.reduce<Promise<void>>((prev, update) => {
+      if (update.user_id === this.botUserId) return prev
+      return prev.then(() => this.handleUpdate(update))
+    }, Promise.resolve())
+  }
+
+  private handleUpdate(_update: KonturTalkUpdate): Promise<void> {
+    // Stub — implemented in Task 5
+    void _update
+    return Promise.resolve()
+  }
+
+  async sendMessage(_platformInstanceId: string, target: DeferredDeliveryTarget, markdown: string): Promise<void> {
+    if (target.contextType === 'dm') {
+      log.warn('Kontur Talk does not support proactive DM delivery')
+      return
+    }
+    await this.apiFetch('POST', '/send_message', {
+      room_id: target.contextId,
+      message: markdown,
+      format: 'markdown',
+      thread_id: target.threadId ?? null,
+      mentions: [],
+    })
+  }
+
+  renderContext(snapshot: ContextSnapshot): ContextRendered {
+    return renderKonturTalkContext(snapshot)
+  }
+}

--- a/src/chat/kontur-talk/label-helpers.ts
+++ b/src/chat/kontur-talk/label-helpers.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+type ApiFetchFn = (method: string, path: string, body: unknown) => Promise<unknown>
+
+export function resolveKonturTalkUserLabel(_apiFetch: ApiFetchFn, userId: string): Promise<string | null> {
+  if (userId.trim() === '') return Promise.resolve(null)
+  return Promise.resolve(userId)
+}
+
+export function resolveKonturTalkGroupLabel(_apiFetch: ApiFetchFn, _groupId: string): Promise<string | null> {
+  return Promise.resolve(null)
+}

--- a/src/chat/kontur-talk/metadata.ts
+++ b/src/chat/kontur-talk/metadata.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { ChatCapability, ChatProviderConfigRequirement, ChatProviderTraits } from '../types.js'
+
+export const konturTalkCapabilities: ReadonlySet<ChatCapability> = new Set<ChatCapability>(['messages.reply-context'])
+
+export const konturTalkTraits: ChatProviderTraits = {
+  observedGroupMessages: 'all',
+  maxMessageLength: 4096,
+}
+
+export const konturTalkConfigRequirements: readonly ChatProviderConfigRequirement[] = [
+  { key: 'KONTUR_TALK_JWT_TOKEN', label: 'Kontur Talk JWT Token', required: true },
+]

--- a/src/chat/kontur-talk/reply-helpers.ts
+++ b/src/chat/kontur-talk/reply-helpers.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { ButtonReplyOptions, ReplyFn, ReplyOptions } from '../types.js'
+
+interface KonturTalkReplyHelpersParams {
+  roomId: string
+  threadId?: string
+  apiFetch: (method: string, path: string, body: unknown) => Promise<unknown>
+}
+
+export function createKonturTalkReplyFn(params: KonturTalkReplyHelpersParams): ReplyFn {
+  const { roomId, threadId, apiFetch } = params
+
+  const send = async (message: string, format: string, options?: ReplyOptions): Promise<void> => {
+    await apiFetch('POST', '/send_message', {
+      room_id: roomId,
+      message,
+      format,
+      thread_id: options?.threadId ?? threadId ?? null,
+      mentions: [],
+    })
+  }
+
+  return {
+    text: (content: string, options?: ReplyOptions) => send(content, 'plain', options),
+    formatted: (markdown: string, options?: ReplyOptions) => send(markdown, 'markdown', options),
+    typing: () => {
+      // no-op: Kontur Talk has no typing indicator API
+    },
+    buttons: (_content: string, _options: ButtonReplyOptions): Promise<void> => {
+      return Promise.reject(
+        new Error(
+          'Kontur Talk does not support interactive buttons. Use supportsInteractiveButtons() to check before calling reply.buttons().',
+        ),
+      )
+    },
+  }
+}

--- a/src/chat/kontur-talk/schema.ts
+++ b/src/chat/kontur-talk/schema.ts
@@ -39,19 +39,3 @@ export const KonturTalkGetUpdatesResponseSchema = z.object({
 export const KonturTalkSendMessageResponseSchema = z.object({
   event_id: z.string(),
 })
-
-export const KonturTalkErrorResponseSchema = z.object({
-  detail: z.union([
-    z.object({
-      errcode: z.string(),
-      error: z.string(),
-    }),
-    z.array(
-      z.object({
-        loc: z.array(z.union([z.string(), z.number()])),
-        msg: z.string(),
-        type: z.string(),
-      }),
-    ),
-  ]),
-})

--- a/src/chat/kontur-talk/schema.ts
+++ b/src/chat/kontur-talk/schema.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+const KonturTalkForwardFromSchema = z.object({
+  user_id: z.string(),
+  room_id: z.string(),
+})
+
+const KonturTalkMentionsSchema = z.union([z.array(z.string()), z.literal('all'), z.null()])
+
+export const KonturTalkUpdateSchema = z.object({
+  event_id: z.string(),
+  user_id: z.string(),
+  room_id: z.string(),
+  room_is_direct: z.boolean(),
+  type: z.string(),
+  timestamp: z.number(),
+  message_type: z.string(),
+  body: z.string().optional(),
+  formatted_body: z.string().nullable().optional(),
+  media_url: z.string().optional(),
+  call_room_name: z.string().optional(),
+  thread_id: z.string().nullable().optional(),
+  reply_id: z.string().nullable().optional(),
+  forward_from: KonturTalkForwardFromSchema.nullable().optional(),
+  mentions: KonturTalkMentionsSchema.optional(),
+})
+
+export type KonturTalkUpdate = z.infer<typeof KonturTalkUpdateSchema>
+
+export const KonturTalkGetUpdatesResponseSchema = z.object({
+  updates: z.array(KonturTalkUpdateSchema),
+})
+
+export const KonturTalkSendMessageResponseSchema = z.object({
+  event_id: z.string(),
+})
+
+export const KonturTalkErrorResponseSchema = z.object({
+  detail: z.union([
+    z.object({
+      errcode: z.string(),
+      error: z.string(),
+    }),
+    z.array(
+      z.object({
+        loc: z.array(z.union([z.string(), z.number()])),
+        msg: z.string(),
+        type: z.string(),
+      }),
+    ),
+  ]),
+})

--- a/src/chat/registry.ts
+++ b/src/chat/registry.ts
@@ -8,6 +8,8 @@ import type { InstanceConfig, PlatformInstanceType } from '../instances/types.js
 import { logger } from '../logger.js'
 import { DiscordChatProvider } from './discord/index.js'
 import { discordCapabilities, discordTraits } from './discord/metadata.js'
+import { KonturTalkChatProvider } from './kontur-talk/index.js'
+import { konturTalkCapabilities, konturTalkTraits } from './kontur-talk/metadata.js'
 import { MattermostChatProvider } from './mattermost/index.js'
 import { mattermostCapabilities, mattermostTraits } from './mattermost/metadata.js'
 import { TelegramChatProvider } from './telegram/index.js'
@@ -62,6 +64,15 @@ const platformDescriptors = [
     capabilities: discordCapabilities,
     traits: discordTraits,
   },
+  {
+    type: 'kontur-talk',
+    displayName: 'Kontur Talk',
+    source: 'builtin',
+    instanceConfigSchema: [{ key: 'jwtToken', label: 'JWT Token', required: true, sensitive: true, scope: 'instance' }],
+    contextConfigSchema: [],
+    capabilities: konturTalkCapabilities,
+    traits: konturTalkTraits,
+  },
 ] as const satisfies readonly ChatProviderDescriptor[]
 
 registerChatProvider(
@@ -80,6 +91,14 @@ registerChatProvider(
 registerChatProvider(
   'discord',
   (deps) => new DiscordChatProvider(undefined, deps.env['DISCORD_BOT_TOKEN'], deps.platformInstanceId),
+)
+registerChatProvider(
+  'kontur-talk',
+  (deps) =>
+    new KonturTalkChatProvider({
+      jwtToken: deps.env['KONTUR_TALK_JWT_TOKEN'],
+      platformInstanceId: deps.platformInstanceId,
+    }),
 )
 
 function registerChatProvider(name: string, factory: ChatProviderFactory): void {
@@ -103,6 +122,9 @@ const configToEnv = (type: PlatformInstanceType, config: InstanceConfig): Record
   if (type === 'telegram') return { TELEGRAM_BOT_TOKEN: config['token'] }
   if (type === 'mattermost') {
     return { MATTERMOST_URL: config['baseUrl'] ?? config['url'], MATTERMOST_BOT_TOKEN: config['token'] }
+  }
+  if (type === 'kontur-talk') {
+    return { KONTUR_TALK_JWT_TOKEN: config['jwtToken'] }
   }
   return { DISCORD_BOT_TOKEN: config['token'] }
 }

--- a/src/debug/admin-system.ts
+++ b/src/debug/admin-system.ts
@@ -7,7 +7,7 @@ import { logger } from '../logger.js'
 import { listRecentRequests } from '../usage/recent-requests.js'
 import { RecentRequestsResponseSchema } from './admin-schemas.js'
 
-const CHAT_PROVIDERS = ['telegram', 'mattermost', 'discord'] as const
+const CHAT_PROVIDERS = ['telegram', 'mattermost', 'discord', 'kontur-talk'] as const
 const TASK_PROVIDERS = ['kaneo', 'youtrack'] as const
 
 type AdminChatProvider = (typeof CHAT_PROVIDERS)[number] | 'unknown'

--- a/src/debug/instance-route-support.ts
+++ b/src/debug/instance-route-support.ts
@@ -21,7 +21,7 @@ export const instanceConfigSchema: z.ZodType<InstanceConfig> = z.record(z.string
 
 export const platformInstanceSchema = z.object({
   id: z.string().min(1),
-  type: z.enum(['telegram', 'mattermost', 'discord']),
+  type: z.enum(['telegram', 'mattermost', 'discord', 'kontur-talk']),
   config: instanceConfigSchema,
 })
 

--- a/src/env-validation.ts
+++ b/src/env-validation.ts
@@ -9,16 +9,22 @@ export function validateChatProviderEnv(
   chatProvider: string | undefined,
   env: Record<string, string | undefined>,
 ): ChatProviderValidationResult {
-  if (chatProvider !== 'telegram' && chatProvider !== 'mattermost' && chatProvider !== 'discord') {
+  if (
+    chatProvider !== 'telegram' &&
+    chatProvider !== 'mattermost' &&
+    chatProvider !== 'discord' &&
+    chatProvider !== 'kontur-talk'
+  ) {
     return {
       ok: false,
-      reason: 'CHAT_PROVIDER must be "telegram", "mattermost", or "discord"',
+      reason: 'CHAT_PROVIDER must be "telegram", "mattermost", "discord", or "kontur-talk"',
     }
   }
-  const requirements: Record<'telegram' | 'mattermost' | 'discord', readonly string[]> = {
+  const requirements: Record<'telegram' | 'mattermost' | 'discord' | 'kontur-talk', readonly string[]> = {
     telegram: ['TELEGRAM_BOT_TOKEN'],
     mattermost: ['MATTERMOST_URL', 'MATTERMOST_BOT_TOKEN'],
     discord: ['DISCORD_BOT_TOKEN'],
+    'kontur-talk': ['KONTUR_TALK_JWT_TOKEN'],
   }
   const required = requirements[chatProvider]
   const missing = required.filter((key) => (env[key]?.trim() ?? '') === '')

--- a/src/instances/bootstrap.ts
+++ b/src/instances/bootstrap.ts
@@ -19,6 +19,7 @@ const CHAT_ENV_REQUIREMENTS: Readonly<Record<PlatformInstanceType, readonly stri
   telegram: ['TELEGRAM_BOT_TOKEN'],
   mattermost: ['MATTERMOST_URL', 'MATTERMOST_BOT_TOKEN'],
   discord: ['DISCORD_BOT_TOKEN'],
+  'kontur-talk': ['KONTUR_TALK_JWT_TOKEN'],
 }
 
 const TASK_ENV_REQUIREMENTS: Readonly<Record<BuiltinTaskType, readonly string[]>> = {
@@ -38,7 +39,7 @@ const getTrimmedEnv = (name: string): string | undefined => {
 }
 
 const parsePlatformType = (value: string | undefined): PlatformInstanceType | null => {
-  if (value === 'telegram' || value === 'mattermost' || value === 'discord') return value
+  if (value === 'telegram' || value === 'mattermost' || value === 'discord' || value === 'kontur-talk') return value
   return null
 }
 
@@ -58,6 +59,8 @@ const buildPlatformConfig = (type: PlatformInstanceType): InstanceConfig => {
       }
     case 'discord':
       return { token: getTrimmedEnv('DISCORD_BOT_TOKEN') ?? '' }
+    case 'kontur-talk':
+      return { jwtToken: getTrimmedEnv('KONTUR_TALK_JWT_TOKEN') ?? '' }
     default:
       return unreachable(type)
   }

--- a/src/instances/platform-store.ts
+++ b/src/instances/platform-store.ts
@@ -13,7 +13,7 @@ import type { InstanceConfig, InstanceStatus, PlatformInstance, PlatformInstance
 
 const log = logger.child({ scope: 'instances:platform-store' })
 
-const PLATFORM_INSTANCE_TYPES: readonly PlatformInstanceType[] = ['telegram', 'mattermost', 'discord']
+const PLATFORM_INSTANCE_TYPES: readonly PlatformInstanceType[] = ['telegram', 'mattermost', 'discord', 'kontur-talk']
 const INSTANCE_STATUSES: readonly InstanceStatus[] = ['pending', 'active', 'stopped']
 
 export interface InsertPlatformInstanceInput {

--- a/src/instances/types.ts
+++ b/src/instances/types.ts
@@ -5,7 +5,7 @@
 
 export type InstanceConfig = Record<string, string>
 
-export type PlatformInstanceType = 'telegram' | 'mattermost' | 'discord'
+export type PlatformInstanceType = 'telegram' | 'mattermost' | 'discord' | 'kontur-talk'
 export type TaskInstanceType = string
 export type BuiltinTaskType = 'kaneo' | 'youtrack'
 export type InstanceStatus = 'pending' | 'active' | 'stopped'

--- a/tests/chat/kontur-talk/config.test.ts
+++ b/tests/chat/kontur-talk/config.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test'
+
+import { resolveKonturTalkConfig } from '../../../src/chat/kontur-talk/config.js'
+
+describe('resolveKonturTalkConfig', () => {
+  const origEnv = { ...process.env }
+
+  beforeEach(() => {
+    process.env['KONTUR_TALK_JWT_TOKEN'] = 'test-jwt-token'
+  })
+
+  afterEach(() => {
+    process.env = { ...origEnv }
+  })
+
+  test('resolves from env when no constructor config provided', () => {
+    const config = resolveKonturTalkConfig({})
+    expect(config.jwtToken).toBe('test-jwt-token')
+    expect(config.platformInstanceId).toBe('kontur-talk-default')
+  })
+
+  test('constructor config takes precedence over env', () => {
+    const config = resolveKonturTalkConfig({ jwtToken: 'explicit-token' })
+    expect(config.jwtToken).toBe('explicit-token')
+  })
+
+  test('throws when jwtToken is missing', () => {
+    delete process.env['KONTUR_TALK_JWT_TOKEN']
+    expect(() => resolveKonturTalkConfig({})).toThrow(/KONTUR_TALK_JWT_TOKEN/iu)
+  })
+
+  test('throws when jwtToken is whitespace', () => {
+    delete process.env['KONTUR_TALK_JWT_TOKEN']
+    expect(() => resolveKonturTalkConfig({ jwtToken: '  ' })).toThrow(/KONTUR_TALK_JWT_TOKEN/iu)
+  })
+
+  test('uses custom platformInstanceId when provided', () => {
+    const config = resolveKonturTalkConfig({ platformInstanceId: 'custom-id' })
+    expect(config.platformInstanceId).toBe('custom-id')
+  })
+})

--- a/tests/chat/kontur-talk/context-renderer.test.ts
+++ b/tests/chat/kontur-talk/context-renderer.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+import assert from 'node:assert/strict'
+
+import { renderKonturTalkContext } from '../../../src/chat/kontur-talk/context-renderer.js'
+import type { ContextSnapshot } from '../../../src/chat/types.js'
+
+const makeSnapshot = (overrides?: Partial<ContextSnapshot>): ContextSnapshot => ({
+  modelName: 'gpt-4',
+  totalTokens: 1000,
+  maxTokens: 8000,
+  approximate: false,
+  sections: [],
+  ...overrides,
+})
+
+describe('renderKonturTalkContext', () => {
+  test('returns formatted method', () => {
+    const result = renderKonturTalkContext(makeSnapshot())
+    expect(result.method).toBe('formatted')
+  })
+
+  test('includes model name and token count', () => {
+    const result = renderKonturTalkContext(makeSnapshot())
+    assert(result.method === 'formatted')
+    expect(result.content).toContain('gpt-4')
+    expect(result.content).toContain('1,000')
+  })
+
+  test('includes percentage when maxTokens is set', () => {
+    const result = renderKonturTalkContext(makeSnapshot({ totalTokens: 4000, maxTokens: 8000 }))
+    assert(result.method === 'formatted')
+    expect(result.content).toContain('50.0%')
+  })
+
+  test('handles null maxTokens', () => {
+    const result = renderKonturTalkContext(makeSnapshot({ maxTokens: null }))
+    assert(result.method === 'formatted')
+    expect(result.content).not.toContain('undefined')
+  })
+})

--- a/tests/chat/kontur-talk/index.test.ts
+++ b/tests/chat/kontur-talk/index.test.ts
@@ -6,7 +6,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
 import { KonturTalkChatProvider } from '../../../src/chat/kontur-talk/index.js'
-import type { DeferredDeliveryTarget } from '../../../src/chat/types.js'
+import type { DeferredDeliveryTarget, IncomingMessage } from '../../../src/chat/types.js'
 import { restoreFetch, setMockFetch } from '../../utils/test-helpers.js'
 
 // JWT token with sub="bot123" (base64-encoded payload: {"sub":"bot123","owner":"admin1","iat":1757061777})
@@ -259,5 +259,152 @@ describe('KonturTalkChatProvider', () => {
     await provider.stop()
 
     expect(callCount).toBeGreaterThanOrEqual(1)
+  })
+
+  describe('message handling', () => {
+    function makeUpdate(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+      return {
+        event_id: '$event',
+        user_id: '@alice:host',
+        room_id: '!room:host',
+        room_is_direct: false,
+        type: 'm.room.message',
+        timestamp: 1704067200000,
+        message_type: 'm.text',
+        body: 'test',
+        formatted_body: null,
+        thread_id: null,
+        reply_id: null,
+        forward_from: null,
+        mentions: ['bot123'],
+        ...overrides,
+      }
+    }
+
+    function mockFetchWithUpdates(updates: Record<string, unknown>[]): void {
+      let called = false
+      setMockFetch(() =>
+        delay(10).then(() => {
+          const result = called ? [] : updates
+          called = true
+          return new Response(JSON.stringify({ updates: result }), { status: 200 })
+        }),
+      )
+    }
+
+    test('handleUpdate dispatches text message to messageHandler', async () => {
+      const received: IncomingMessage[] = []
+      mockFetchWithUpdates([makeUpdate({ event_id: '$event1', body: 'Hello bot' })])
+      const provider = new KonturTalkChatProvider()
+      provider.onMessage((msg, _reply) => {
+        received.push(msg)
+        return Promise.resolve()
+      })
+      await provider.start()
+
+      await delay(200)
+      await provider.stop()
+
+      expect(received.length).toBe(1)
+      expect(received[0]?.text).toBe('Hello bot')
+      expect(received[0]?.contextType).toBe('group')
+      expect(received[0]?.isMentioned).toBe(true)
+    })
+
+    test('handleUpdate passes non-mentioned group messages with isMentioned=false', async () => {
+      const received: IncomingMessage[] = []
+      mockFetchWithUpdates([makeUpdate({ event_id: '$event2', body: 'Not mentioning bot', mentions: null })])
+      const provider = new KonturTalkChatProvider()
+      provider.onMessage((msg, _reply) => {
+        received.push(msg)
+        return Promise.resolve()
+      })
+      await provider.start()
+
+      await delay(200)
+      await provider.stop()
+
+      expect(received.length).toBe(1)
+      expect(received[0]?.isMentioned).toBe(false)
+    })
+
+    test('handleUpdate recognizes mentions="all"', async () => {
+      const received: IncomingMessage[] = []
+      mockFetchWithUpdates([makeUpdate({ event_id: '$event3', body: '@all check this', mentions: 'all' })])
+      const provider = new KonturTalkChatProvider()
+      provider.onMessage((msg, _reply) => {
+        received.push(msg)
+        return Promise.resolve()
+      })
+      await provider.start()
+
+      await delay(200)
+      await provider.stop()
+
+      expect(received.length).toBe(1)
+      expect(received[0]?.isMentioned).toBe(true)
+    })
+
+    test('handleUpdate dispatches to command handler', async () => {
+      const commandCalls: string[] = []
+      mockFetchWithUpdates([makeUpdate({ event_id: '$event4', body: '/help' })])
+      const provider = new KonturTalkChatProvider()
+      provider.registerCommand('help', () => {
+        commandCalls.push('help')
+        return Promise.resolve()
+      })
+      provider.onMessage(() => {
+        commandCalls.push('message')
+        return Promise.resolve()
+      })
+      await provider.start()
+
+      await delay(200)
+      await provider.stop()
+
+      expect(commandCalls).toEqual(['help'])
+    })
+
+    test('handleUpdate passes threadId to IncomingMessage', async () => {
+      let capturedThreadId: string | undefined
+      mockFetchWithUpdates([makeUpdate({ event_id: '$event5', body: 'In thread', thread_id: '$thread123' })])
+      const provider = new KonturTalkChatProvider()
+      provider.onMessage((msg, _reply) => {
+        capturedThreadId = msg.threadId
+        return Promise.resolve()
+      })
+      await provider.start()
+
+      await delay(200)
+      await provider.stop()
+
+      expect(capturedThreadId).toBe('$thread123')
+    })
+
+    test('handleUpdate treats DM messages as contextType=dm', async () => {
+      const received: IncomingMessage[] = []
+      mockFetchWithUpdates([
+        makeUpdate({
+          event_id: '$event6',
+          room_id: '!dmroom:host',
+          room_is_direct: true,
+          body: 'Private message',
+          mentions: null,
+        }),
+      ])
+      const provider = new KonturTalkChatProvider()
+      provider.onMessage((msg, _reply) => {
+        received.push(msg)
+        return Promise.resolve()
+      })
+      await provider.start()
+
+      await delay(200)
+      await provider.stop()
+
+      expect(received.length).toBe(1)
+      expect(received[0]?.contextType).toBe('dm')
+      expect(received[0]?.contextId).toBe('!dmroom:host')
+    })
   })
 })

--- a/tests/chat/kontur-talk/index.test.ts
+++ b/tests/chat/kontur-talk/index.test.ts
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { KonturTalkChatProvider } from '../../../src/chat/kontur-talk/index.js'
+import type { DeferredDeliveryTarget } from '../../../src/chat/types.js'
+import { restoreFetch, setMockFetch } from '../../utils/test-helpers.js'
+
+// JWT token with sub="bot123" (base64-encoded payload: {"sub":"bot123","owner":"admin1","iat":1757061777})
+const TEST_JWT = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJib3QxMjMiLCJvd25lciI6ImFkbWluMSIsImlhdCI6MTc1NzA2MTc3N30.test'
+
+const emptyUpdatesResponse = (): Promise<Response> =>
+  Promise.resolve(new Response(JSON.stringify({ updates: [] }), { status: 200 }))
+
+const sentResponse = (): Promise<Response> =>
+  Promise.resolve(new Response(JSON.stringify({ event_id: '$sent' }), { status: 200 }))
+
+const delay = (ms: number): Promise<void> =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
+const GROUP_TARGET: DeferredDeliveryTarget = {
+  contextId: '!room:host',
+  contextType: 'group',
+  threadId: null,
+  audience: 'shared',
+  mentionUserIds: [],
+  createdByUserId: 'user1',
+  createdByUsername: null,
+}
+
+const DM_TARGET: DeferredDeliveryTarget = {
+  contextId: '@user:host',
+  contextType: 'dm',
+  threadId: null,
+  audience: 'personal',
+  mentionUserIds: [],
+  createdByUserId: 'user1',
+  createdByUsername: null,
+}
+
+const THREAD_TARGET: DeferredDeliveryTarget = {
+  contextId: '!room:host',
+  contextType: 'group',
+  threadId: '$thread123',
+  audience: 'shared',
+  mentionUserIds: [],
+  createdByUserId: 'user1',
+  createdByUsername: null,
+}
+
+function parseBody(options: RequestInit | undefined): unknown {
+  const body = options?.body
+  if (body === undefined || body === null) return undefined
+  if (typeof body === 'string') return JSON.parse(body)
+  return undefined
+}
+
+function findObjectBody(bodies: unknown[]): object | undefined {
+  for (const b of bodies) {
+    if (typeof b === 'object' && b !== null && !Array.isArray(b)) {
+      return b
+    }
+  }
+  return undefined
+}
+
+describe('KonturTalkChatProvider', () => {
+  const origEnv = { ...process.env }
+
+  beforeEach(() => {
+    process.env['KONTUR_TALK_JWT_TOKEN'] = TEST_JWT
+  })
+
+  afterEach(() => {
+    process.env = { ...origEnv }
+    restoreFetch()
+  })
+
+  test('name is kontur-talk', () => {
+    const provider = new KonturTalkChatProvider()
+    expect(provider.name).toBe('kontur-talk')
+  })
+
+  test('capabilities include messages.reply-context', () => {
+    const provider = new KonturTalkChatProvider()
+    expect(provider.capabilities.has('messages.reply-context')).toBe(true)
+  })
+
+  test('capabilities do not include messages.buttons', () => {
+    const provider = new KonturTalkChatProvider()
+    expect(provider.capabilities.has('messages.buttons')).toBe(false)
+  })
+
+  test('traits observe all group messages', () => {
+    const provider = new KonturTalkChatProvider()
+    expect(provider.traits.observedGroupMessages).toBe('all')
+  })
+
+  test('traits max message length is 4096', () => {
+    const provider = new KonturTalkChatProvider()
+    expect(provider.traits.maxMessageLength).toBe(4096)
+  })
+
+  test('thread capabilities support threads', () => {
+    const provider = new KonturTalkChatProvider()
+    expect(provider.threadCapabilities.supportsThreads).toBe(true)
+    expect(provider.threadCapabilities.canCreateThreads).toBe(true)
+    expect(provider.threadCapabilities.threadScope).toBe('message')
+  })
+
+  test('config requirements include KONTUR_TALK_JWT_TOKEN', () => {
+    const provider = new KonturTalkChatProvider()
+    expect(provider.configRequirements).toEqual([
+      { key: 'KONTUR_TALK_JWT_TOKEN', label: 'Kontur Talk JWT Token', required: true },
+    ])
+  })
+
+  test('start() extracts botUserId from JWT', async () => {
+    setMockFetch(() => emptyUpdatesResponse())
+    const provider = new KonturTalkChatProvider()
+    await provider.start()
+    expect(provider.getBotUserId()).toBe('bot123')
+    await provider.stop()
+  })
+
+  test('stop() sets running to false', async () => {
+    setMockFetch(() => emptyUpdatesResponse())
+    const provider = new KonturTalkChatProvider()
+    await provider.start()
+    await provider.stop()
+    expect(provider.isRunning()).toBe(false)
+  })
+
+  test('sendMessage for group sends to API', async () => {
+    const capturedBodies: unknown[] = []
+    setMockFetch((_url: string, options?: RequestInit) => {
+      capturedBodies.push(parseBody(options))
+      return sentResponse()
+    })
+    const provider = new KonturTalkChatProvider()
+
+    await provider.sendMessage('kontur-talk-default', GROUP_TARGET, 'Hello group')
+
+    const body = findObjectBody(capturedBodies)
+    expect(body).toEqual({
+      room_id: '!room:host',
+      message: 'Hello group',
+      format: 'markdown',
+      thread_id: null,
+      mentions: [],
+    })
+  })
+
+  test('sendMessage for DM does not make API call', async () => {
+    let fetchCallCount = 0
+    setMockFetch(() => {
+      fetchCallCount++
+      return sentResponse()
+    })
+    const provider = new KonturTalkChatProvider()
+    const callsBefore = fetchCallCount
+
+    await provider.sendMessage('kontur-talk-default', DM_TARGET, 'Hello DM')
+
+    expect(fetchCallCount).toBe(callsBefore)
+  })
+
+  test('sendMessage passes threadId when present', async () => {
+    const capturedBodies: unknown[] = []
+    setMockFetch((_url: string, options?: RequestInit) => {
+      capturedBodies.push(parseBody(options))
+      return sentResponse()
+    })
+    const provider = new KonturTalkChatProvider()
+
+    await provider.sendMessage('kontur-talk-default', THREAD_TARGET, 'In thread')
+
+    const body = findObjectBody(capturedBodies)
+    expect(body).toHaveProperty('thread_id', '$thread123')
+  })
+
+  test('renderContext returns formatted context', () => {
+    const provider = new KonturTalkChatProvider()
+    const result = provider.renderContext({
+      modelName: 'gpt-4',
+      totalTokens: 1000,
+      maxTokens: 8000,
+      approximate: false,
+      sections: [],
+    })
+    expect(result.method).toBe('formatted')
+  })
+
+  test('registerCommand stores handler', () => {
+    const provider = new KonturTalkChatProvider()
+    provider.registerCommand('test', () => Promise.resolve())
+  })
+
+  test('onMessage stores handler', () => {
+    const provider = new KonturTalkChatProvider()
+    provider.onMessage(() => Promise.resolve())
+  })
+
+  test('pollLoop skips updates from bot itself', async () => {
+    const handledUpdates: Array<Record<string, unknown>> = []
+    let callCount = 0
+    setMockFetch(() => {
+      callCount++
+      return delay(10).then(
+        () =>
+          new Response(
+            JSON.stringify({
+              updates: [
+                {
+                  event_id: '$frombot',
+                  user_id: 'bot123',
+                  room_id: '!room:host',
+                  room_is_direct: false,
+                  type: 'm.room.message',
+                  timestamp: 1000,
+                  message_type: 'text',
+                  body: 'own message',
+                },
+              ],
+            }),
+            { status: 200 },
+          ),
+      )
+    })
+    const provider = new KonturTalkChatProvider()
+    provider.onMessage((msg) => {
+      handledUpdates.push({ text: msg.text })
+      return Promise.resolve()
+    })
+    await provider.start()
+
+    await delay(200)
+    await provider.stop()
+
+    expect(handledUpdates).toEqual([])
+    expect(callCount).toBeGreaterThanOrEqual(1)
+  })
+
+  test('pollLoop handles API errors gracefully', async () => {
+    let callCount = 0
+    setMockFetch(() => {
+      callCount++
+      return delay(10).then(() => new Response('server error', { status: 500 }))
+    })
+    const provider = new KonturTalkChatProvider()
+    await provider.start()
+
+    await delay(200)
+    await provider.stop()
+
+    expect(callCount).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/tests/chat/kontur-talk/index.test.ts
+++ b/tests/chat/kontur-talk/index.test.ts
@@ -381,6 +381,26 @@ describe('KonturTalkChatProvider', () => {
       expect(capturedThreadId).toBe('$thread123')
     })
 
+    test('handleUpdate skips non-text messages (e.g. m.image)', async () => {
+      const received: IncomingMessage[] = []
+      mockFetchWithUpdates([
+        makeUpdate({ event_id: '$img1', message_type: 'm.image', body: '' }),
+        makeUpdate({ event_id: '$text1', message_type: 'm.text', body: 'Hello' }),
+      ])
+      const provider = new KonturTalkChatProvider()
+      provider.onMessage((msg, _reply) => {
+        received.push(msg)
+        return Promise.resolve()
+      })
+      await provider.start()
+
+      await delay(200)
+      await provider.stop()
+
+      expect(received.length).toBe(1)
+      expect(received[0]?.text).toBe('Hello')
+    })
+
     test('handleUpdate treats DM messages as contextType=dm', async () => {
       const received: IncomingMessage[] = []
       mockFetchWithUpdates([

--- a/tests/chat/kontur-talk/label-helpers.test.ts
+++ b/tests/chat/kontur-talk/label-helpers.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { resolveKonturTalkUserLabel, resolveKonturTalkGroupLabel } from '../../../src/chat/kontur-talk/label-helpers.js'
+
+describe('resolveKonturTalkUserLabel', () => {
+  test('returns user_id as-is when no display name API', async () => {
+    const apiFetch = (): Promise<unknown> => Promise.resolve({})
+    const result = await resolveKonturTalkUserLabel(apiFetch, '@alice:host')
+    expect(result).toBe('@alice:host')
+  })
+
+  test('returns null for empty userId', async () => {
+    const apiFetch = (): Promise<unknown> => Promise.resolve({})
+    const result = await resolveKonturTalkUserLabel(apiFetch, '')
+    expect(result).toBeNull()
+  })
+})
+
+describe('resolveKonturTalkGroupLabel', () => {
+  test('returns null (no group info API)', async () => {
+    const apiFetch = (): Promise<unknown> => Promise.resolve({})
+    const result = await resolveKonturTalkGroupLabel(apiFetch, '!room:host')
+    expect(result).toBeNull()
+  })
+})

--- a/tests/chat/kontur-talk/metadata.test.ts
+++ b/tests/chat/kontur-talk/metadata.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  konturTalkCapabilities,
+  konturTalkTraits,
+  konturTalkConfigRequirements,
+} from '../../../src/chat/kontur-talk/metadata.js'
+
+describe('Kontur Talk metadata', () => {
+  test('capabilities include messages.reply-context', () => {
+    expect(konturTalkCapabilities.has('messages.reply-context')).toBe(true)
+  })
+
+  test('capabilities do not include messages.buttons', () => {
+    expect(konturTalkCapabilities.has('messages.buttons')).toBe(false)
+  })
+
+  test('capabilities do not include files.receive', () => {
+    expect(konturTalkCapabilities.has('files.receive')).toBe(false)
+  })
+
+  test('traits observe all group messages', () => {
+    expect(konturTalkTraits.observedGroupMessages).toBe('all')
+  })
+
+  test('traits max message length is 4096', () => {
+    expect(konturTalkTraits.maxMessageLength).toBe(4096)
+  })
+
+  test('config requirements include KONTUR_TALK_JWT_TOKEN', () => {
+    expect(konturTalkConfigRequirements).toEqual([
+      { key: 'KONTUR_TALK_JWT_TOKEN', label: 'Kontur Talk JWT Token', required: true },
+    ])
+  })
+})

--- a/tests/chat/kontur-talk/reply-helpers.test.ts
+++ b/tests/chat/kontur-talk/reply-helpers.test.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { createKonturTalkReplyFn } from '../../../src/chat/kontur-talk/reply-helpers.js'
+import type { ReplyFn } from '../../../src/chat/types.js'
+
+function makeReplyFn(): { reply: ReplyFn; posts: unknown[] } {
+  const posts: unknown[] = []
+  const apiFetch = (_method: string, _path: string, body: unknown): Promise<unknown> => {
+    posts.push(body)
+    return Promise.resolve({ event_id: '$newEvent' })
+  }
+  const reply = createKonturTalkReplyFn({
+    roomId: '!room:host',
+    threadId: undefined,
+    apiFetch,
+  })
+  return { reply, posts }
+}
+
+describe('createKonturTalkReplyFn', () => {
+  test('text() sends plain format message', async () => {
+    const { reply, posts } = makeReplyFn()
+    await reply.text('Hello')
+    expect(posts).toEqual([{ room_id: '!room:host', message: 'Hello', format: 'plain', thread_id: null, mentions: [] }])
+  })
+
+  test('formatted() sends markdown format message', async () => {
+    const { reply, posts } = makeReplyFn()
+    await reply.formatted('**bold**')
+    expect(posts).toEqual([
+      { room_id: '!room:host', message: '**bold**', format: 'markdown', thread_id: null, mentions: [] },
+    ])
+  })
+
+  test('text() passes thread_id when present', async () => {
+    const posts: unknown[] = []
+    const apiFetch = (_method: string, _path: string, body: unknown): Promise<unknown> => {
+      posts.push(body)
+      return Promise.resolve({ event_id: '$newEvent' })
+    }
+    const reply = createKonturTalkReplyFn({
+      roomId: '!room:host',
+      threadId: '$thread123',
+      apiFetch,
+    })
+    await reply.text('In thread')
+    expect(posts).toEqual([
+      { room_id: '!room:host', message: 'In thread', format: 'plain', thread_id: '$thread123', mentions: [] },
+    ])
+  })
+
+  test('text() uses option threadId over default', async () => {
+    const posts: unknown[] = []
+    const apiFetch = (_method: string, _path: string, body: unknown): Promise<unknown> => {
+      posts.push(body)
+      return Promise.resolve({ event_id: '$newEvent' })
+    }
+    const reply = createKonturTalkReplyFn({
+      roomId: '!room:host',
+      threadId: '$defaultThread',
+      apiFetch,
+    })
+    await reply.text('Override', { threadId: '$otherThread' })
+    expect(posts[0]).toEqual(expect.objectContaining({ thread_id: '$otherThread' }))
+  })
+
+  test('typing() is a no-op', () => {
+    const { reply } = makeReplyFn()
+    expect(() => reply.typing()).not.toThrow()
+  })
+
+  test('buttons() throws', async () => {
+    const { reply } = makeReplyFn()
+    await expect(reply.buttons('content', { buttons: [] })).rejects.toThrow(/does not support/iu)
+  })
+})

--- a/tests/chat/kontur-talk/schema.test.ts
+++ b/tests/chat/kontur-talk/schema.test.ts
@@ -5,11 +5,7 @@
 
 import { describe, expect, test } from 'bun:test'
 
-import {
-  KonturTalkUpdateSchema,
-  KonturTalkSendMessageResponseSchema,
-  KonturTalkErrorResponseSchema,
-} from '../../../src/chat/kontur-talk/schema.js'
+import { KonturTalkUpdateSchema, KonturTalkSendMessageResponseSchema } from '../../../src/chat/kontur-talk/schema.js'
 
 describe('Kontur Talk schemas', () => {
   describe('KonturTalkUpdateSchema', () => {
@@ -118,33 +114,6 @@ describe('Kontur Talk schemas', () => {
 
     test('rejects missing event_id', () => {
       const result = KonturTalkSendMessageResponseSchema.safeParse({})
-      expect(result.success).toBe(false)
-    })
-  })
-
-  describe('KonturTalkErrorResponseSchema', () => {
-    test('validates error with detail.errcode', () => {
-      const data = { detail: { errcode: 'M_UNKNOWN_TOKEN', error: 'Access token has expired' } }
-      const result = KonturTalkErrorResponseSchema.safeParse(data)
-      expect(result.success).toBe(true)
-    })
-
-    test('validates error with detail array (validation error)', () => {
-      const data = {
-        detail: [
-          {
-            loc: ['body', 'message'],
-            msg: 'ensure this value has at most 4096 characters',
-            type: 'value_error.any_str.max_length',
-          },
-        ],
-      }
-      const result = KonturTalkErrorResponseSchema.safeParse(data)
-      expect(result.success).toBe(true)
-    })
-    test('rejects detail that is neither errcode object nor validation array', () => {
-      const data = { detail: 'unexpected string' }
-      const result = KonturTalkErrorResponseSchema.safeParse(data)
       expect(result.success).toBe(false)
     })
   })

--- a/tests/chat/kontur-talk/schema.test.ts
+++ b/tests/chat/kontur-talk/schema.test.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  KonturTalkUpdateSchema,
+  KonturTalkSendMessageResponseSchema,
+  KonturTalkErrorResponseSchema,
+} from '../../../src/chat/kontur-talk/schema.js'
+
+describe('Kontur Talk schemas', () => {
+  describe('KonturTalkUpdateSchema', () => {
+    test('validates a text message update', () => {
+      const data = {
+        event_id: '$event123',
+        user_id: '@alice:host',
+        room_id: '!room:host',
+        room_is_direct: false,
+        type: 'm.room.message',
+        timestamp: 1704067200000,
+        message_type: 'm.text',
+        body: 'Hello, bot!',
+        formatted_body: null,
+        thread_id: null,
+        reply_id: null,
+        forward_from: null,
+        mentions: ['@bot:host'],
+      }
+      const result = KonturTalkUpdateSchema.safeParse(data)
+      expect(result.success).toBe(true)
+      expect(result.data?.user_id).toBe('@alice:host')
+      expect(result.data?.message_type).toBe('m.text')
+      expect(result.data?.body).toBe('Hello, bot!')
+      expect(result.data?.mentions).toEqual(['@bot:host'])
+    })
+
+    test('validates a media message update', () => {
+      const data = {
+        event_id: '$event789',
+        user_id: '@bob:host',
+        room_id: '!room:host',
+        room_is_direct: true,
+        type: 'm.room.message',
+        timestamp: 1704070800000,
+        message_type: 'm.image',
+        media_url: 'mxc://host/abcd1234',
+        thread_id: null,
+        reply_id: null,
+        forward_from: null,
+        mentions: null,
+      }
+      const result = KonturTalkUpdateSchema.safeParse(data)
+      expect(result.success).toBe(true)
+      expect(result.data?.user_id).toBe('@bob:host')
+      expect(result.data?.message_type).toBe('m.image')
+      expect(result.data?.media_url).toBe('mxc://host/abcd1234')
+      expect(result.data?.room_is_direct).toBe(true)
+    })
+
+    test('validates a message with thread_id', () => {
+      const data = {
+        event_id: '$event456',
+        user_id: '@alice:host',
+        room_id: '!room:host',
+        room_is_direct: false,
+        type: 'm.room.message',
+        timestamp: 1704067200000,
+        message_type: 'm.text',
+        body: 'In a thread',
+        formatted_body: null,
+        thread_id: '$thread123',
+        reply_id: null,
+        forward_from: null,
+        mentions: null,
+      }
+      const result = KonturTalkUpdateSchema.safeParse(data)
+      expect(result.success).toBe(true)
+      expect(result.data?.thread_id).toBe('$thread123')
+    })
+
+    test('validates a message with mentions set to "all"', () => {
+      const data = {
+        event_id: '$eventAll',
+        user_id: '@alice:host',
+        room_id: '!room:host',
+        room_is_direct: false,
+        type: 'm.room.message',
+        timestamp: 1704067200000,
+        message_type: 'm.text',
+        body: '@room hello',
+        formatted_body: null,
+        thread_id: null,
+        reply_id: null,
+        forward_from: null,
+        mentions: 'all',
+      }
+      const result = KonturTalkUpdateSchema.safeParse(data)
+      expect(result.success).toBe(true)
+      expect(result.data?.mentions).toBe('all')
+    })
+
+    test('rejects missing required fields', () => {
+      const data = { event_id: '$event123' }
+      const result = KonturTalkUpdateSchema.safeParse(data)
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('KonturTalkSendMessageResponseSchema', () => {
+    test('validates success response', () => {
+      const data = { event_id: '$newEvent789' }
+      const result = KonturTalkSendMessageResponseSchema.safeParse(data)
+      expect(result.success).toBe(true)
+    })
+
+    test('rejects missing event_id', () => {
+      const result = KonturTalkSendMessageResponseSchema.safeParse({})
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('KonturTalkErrorResponseSchema', () => {
+    test('validates error with detail.errcode', () => {
+      const data = { detail: { errcode: 'M_UNKNOWN_TOKEN', error: 'Access token has expired' } }
+      const result = KonturTalkErrorResponseSchema.safeParse(data)
+      expect(result.success).toBe(true)
+    })
+
+    test('validates error with detail array (validation error)', () => {
+      const data = {
+        detail: [
+          {
+            loc: ['body', 'message'],
+            msg: 'ensure this value has at most 4096 characters',
+            type: 'value_error.any_str.max_length',
+          },
+        ],
+      }
+      const result = KonturTalkErrorResponseSchema.safeParse(data)
+      expect(result.success).toBe(true)
+    })
+    test('rejects detail that is neither errcode object nor validation array', () => {
+      const data = { detail: 'unexpected string' }
+      const result = KonturTalkErrorResponseSchema.safeParse(data)
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/tests/chat/registry.test.ts
+++ b/tests/chat/registry.test.ts
@@ -108,11 +108,26 @@ describe('chat registry', () => {
     ).toThrow('Missing mattermost instance config')
   })
 
+  test('createChatProvider("kontur-talk") creates provider', () => {
+    process.env['KONTUR_TALK_JWT_TOKEN'] = 'test-token'
+    const provider = createChatProvider('kontur-talk', { env: process.env as Record<string, string | undefined> })
+    expect(provider.name).toBe('kontur-talk')
+  })
+
+  test('createChatProvider("kontur-talk") throws when JWT token is missing', () => {
+    expect(() => createChatProvider('kontur-talk', { env: {} })).toThrow()
+  })
+
   test('listPlatformProviderTypes exposes built-in descriptor metadata', () => {
     const descriptors = listPlatformProviderTypes()
     const mattermost = descriptors.find((descriptor) => descriptor.type === 'mattermost')
 
-    expect(descriptors.map((descriptor) => descriptor.type)).toEqual(['telegram', 'mattermost', 'discord'])
+    expect(descriptors.map((descriptor) => descriptor.type)).toEqual([
+      'telegram',
+      'mattermost',
+      'discord',
+      'kontur-talk',
+    ])
     expect(mattermost?.instanceConfigSchema.map((field) => field.key)).toEqual(['baseUrl', 'token'])
     expect(mattermost?.capabilities.has('users.resolve')).toBe(true)
     expect(mattermost?.traits.observedGroupMessages).toBe('all')

--- a/tests/client/admin/instance-fetcher-schemas.test.ts
+++ b/tests/client/admin/instance-fetcher-schemas.test.ts
@@ -122,6 +122,20 @@ describe('PlatformProviderTypeViewSchema', () => {
     expect(parsed.traits.maxMessageLength).toBe(16383)
   })
 
+  test('accepts kontur-talk type', () => {
+    const parsed = PlatformProviderTypeViewSchema.parse({
+      type: 'kontur-talk',
+      displayName: 'Kontur Talk',
+      instanceConfigSchema: [{ key: 'jwtToken', label: 'JWT Token', required: true, sensitive: true }],
+      contextConfigSchema: [],
+      capabilities: ['messages.reply-context'],
+      traits: { observedGroupMessages: 'all', maxMessageLength: 4096 },
+      source: 'builtin',
+    })
+
+    expect(parsed.type).toBe('kontur-talk')
+  })
+
   test('rejects legacy array traits', () => {
     const result = PlatformProviderTypeViewSchema.safeParse({
       type: 'mattermost',

--- a/tests/debug/instance-route-support.test.ts
+++ b/tests/debug/instance-route-support.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { platformInstanceSchema } from '../../src/debug/instance-route-support.js'
+
+describe('platformInstanceSchema', () => {
+  test('accepts kontur-talk type', () => {
+    const result = platformInstanceSchema.safeParse({
+      id: 'kontur-talk-default',
+      type: 'kontur-talk',
+      config: { jwtToken: 'test-token' },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('accepts telegram type', () => {
+    const result = platformInstanceSchema.safeParse({
+      id: 'telegram-default',
+      type: 'telegram',
+      config: { token: 'test-token' },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('rejects unknown type', () => {
+    const result = platformInstanceSchema.safeParse({
+      id: 'test-default',
+      type: 'unknown',
+      config: {},
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/tests/debug/platform-provider-type-routes.test.ts
+++ b/tests/debug/platform-provider-type-routes.test.ts
@@ -38,7 +38,7 @@ describe('handlePlatformProviderTypes', () => {
     expect(res?.status).toBe(200)
     const body = expectArray(await res?.json()).map((entry) => expectObject(entry))
 
-    expect(body.map((entry) => pick(entry, 'type'))).toEqual(['telegram', 'mattermost', 'discord'])
+    expect(body.map((entry) => pick(entry, 'type'))).toEqual(['telegram', 'mattermost', 'discord', 'kontur-talk'])
     expect(readSchemaKeys(expectObject(body.find((entry) => pick(entry, 'type') === 'mattermost')))).toEqual([
       'baseUrl',
       'token',


### PR DESCRIPTION
## Summary

Adds Kontur Talk (Толк.Чаты) as a fourth chat provider in papai. The bot communicates via the Kontur Talk Chat Bot API using long polling for receiving messages and REST for sending.

## What's included

- **Chat provider**: `KonturTalkChatProvider` implementing `ChatProvider` interface
- **Long polling**: `GET /get_updates` with 30s timeout for receiving messages
- **Text messages**: Send/receive with plain/html/markdown formats
- **Threads**: Full thread support via `thread_id`
- **Commands**: `/command` dispatch via registered handlers
- **Integration**: Registry, bootstrap, env validation, admin dashboard

## MVP limitations (Phase 2)

- No media upload/download (images, files, audio)
- No interactive buttons or callbacks
- No message delete/edit
- No typing indicators
- No proactive DM delivery (API limitation)
- Long polling only (no WebSocket)

## Design

- Design spec: `docs/superpowers/specs/2026-05-28-kontur-talk-chat-provider-design.md`
- Implementation plan: `docs/superpowers/plans/2026-05-28-kontur-talk-chat-provider.md`

## Testing

- 57+ tests across 7 test files
- All existing tests pass (no regressions)
- Lint, typecheck, format all clean

## Config

Single env var: `KONTUR_TALK_JWT_TOKEN` — JWT token from the Talk.Chats space settings UI.