### PR TITLE
feat(settings): AI output visibility settings UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Fix the underlying issue rather than bypassing linting or hook policy.
 
 **Dashboard (`DEBUG_SERVER=true`):** the dashboard requires a session cookie minted via the bot — DM `/dashboard` for a one-time sign-in link. `DASHBOARD_BASE_URL` (default `SETTINGS_PUBLIC_BASE_URL`, else `http://{DEBUG_HOSTNAME}:{DEBUG_PORT}`), `DASHBOARD_SESSION_TTL_SECONDS` (default `28800`), `DASHBOARD_CLAIM_TTL_SECONDS` (default `300`). See `docs/deployment/dashboard-access.md`.
 
-**Per-user runtime config keys** (managed in the settings UI): `timezone`; `mcp_endpoints` (JSON array of external MCP endpoints `{ id, url (https only), label?, headers?, enabled, toolFilter? }`, registered in `src/config-keys.ts`); Kaneo `plugin:task-provider-kaneo:provider:{credential,workspaceId}`; YouTrack `plugin:task-provider-youtrack:provider:token`.
+**Per-user runtime config keys** (managed in the settings UI): `timezone`; `mcp_endpoints` (JSON array of external MCP endpoints `{ id, url (https only), label?, headers?, enabled, toolFilter? }`, registered in `src/config-keys.ts`); Kaneo `plugin:task-provider-kaneo:provider:{credential,workspaceId}`; YouTrack `plugin:task-provider-youtrack:provider:token`; AI output visibility `ai_tool_visibility` / `ai_reasoning_visibility` (`on`/`off`, default `off`) and `ai_output_detail_level` (`sanitized`/`raw`, default `sanitized`) — surfaced as enum `ConfigField`s (`kind: 'ai-output'`) in the settings UI "AI output" section, read by `getAiOutputSettings` (`src/ai-output-settings.ts`).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The bot interprets natural-language requests, invokes capability-gated tools thr
 | **Recurring Tasks**  | Template schedules                              | Reusable recurring task automation                                   |
 | **Deferred Prompts** | One-shot, delayed, cron                         | Scheduled proactive assistance                                       |
 | **Instructions**     | Context-specific guidance                       | Per-chat custom instructions                                         |
+| **AI Output**        | Show tool calls / reasoning; sanitized or raw   | Per-context control of the execution detail the bot posts to chat    |
 | **Plugins**          | Trusted local extensions                        | Discover, approve, and enable first-party plugins per context        |
 | **MCP Servers**      | External tools via Model Context Protocol       | Merge tools from per-context or plugin-declared MCP servers          |
 

--- a/client/settings/SettingsApp.svelte
+++ b/client/settings/SettingsApp.svelte
@@ -15,6 +15,7 @@
   import { activeContext, settingsSession } from './session.svelte.js'
   import ProfileSection from './sections/ProfileSection.svelte'
   import TaskProviderSection from './sections/TaskProviderSection.svelte'
+  import AiOutputSection from './sections/AiOutputSection.svelte'
   import ToolsSection from './sections/ToolsSection.svelte'
   import ByokSection from './sections/ByokSection.svelte'
   import McpSection from './sections/McpSection.svelte'
@@ -44,6 +45,7 @@
           { id: 'profile', label: 'Profile' },
           { id: 'task-provider', label: 'Task provider' },
           { id: 'tools', label: 'Tools' },
+          { id: 'ai-output', label: 'AI output' },
           { id: 'byok', label: 'BYOK LLM' },
           { id: 'identity', label: 'Identity' },
           ...(isGroup
@@ -124,6 +126,7 @@
             <ProfileSection contextId={ctx} />
             <TaskProviderSection contextId={ctx} />
             <ToolsSection contextId={ctx} />
+            <AiOutputSection contextId={ctx} />
             <ByokSection contextId={ctx} />
             <IdentitySection contextId={ctx} />
             {#if isGroup}

--- a/client/settings/components/ConfigFieldRow.svelte
+++ b/client/settings/components/ConfigFieldRow.svelte
@@ -12,6 +12,7 @@
   import Btn from '../../shared/ui/Btn.svelte'
   import Input from '../../shared/ui/Input.svelte'
   import Secret from '../../shared/ui/Secret.svelte'
+  import SegmentedControl from '../../shared/ui/SegmentedControl.svelte'
 
   interface Props {
     contextId: string
@@ -26,6 +27,8 @@
   let draft = $state(field.sensitive ? '' : field.value)
   let error: string | null = $state(null)
   let saving = $state(false)
+  const isEnum = $derived(field.control === 'toggle' || field.control === 'select')
+  let current = $state(field.value)
 
   // An unset secret (no stored value) has nothing to mask, so open the editor
   // directly — otherwise there is no Replace button and no way to enter a first value.
@@ -38,6 +41,7 @@
     void field.key
     untrack(() => {
       draft = sensitive ? '' : value
+      current = value
       replacing = false
     })
   })
@@ -55,42 +59,75 @@
       saving = false
     }
   }
+
+  async function saveEnum(next: string): Promise<void> {
+    const previous = current
+    current = next
+    error = null
+    saving = true
+    try {
+      await patchConfig({ key: field.key, value: next, contextId })
+      onSaved()
+    } catch (err) {
+      current = previous
+      error = err instanceof Error ? err.message : String(err)
+    } finally {
+      saving = false
+    }
+  }
 </script>
 
-<div class="settings-field" data-testid={`cfg-row-${field.key}`}>
-  <div class="settings-field__head">
-    <span class="t-label settings-field__label">{field.label}{field.required ? ' *' : ''}</span>
-    {#if field.sensitive && field.hasValue && !replacing}
-      <Secret value={maskSecret(field.value)} />
-      <Btn variant="secondary" size="sm" testid={`cfg-replace-${field.key}`} onClick={() => (replacing = true)}>
-        {#snippet children()}Replace{/snippet}
-      </Btn>
+{#if isEnum}
+  <div class="settings-field" data-testid={`cfg-row-${field.key}`}>
+    <div class="settings-field__head">
+      <span class="t-label settings-field__label">{field.label}</span>
+      <SegmentedControl
+        options={field.options ?? []}
+        value={current}
+        ariaLabel={field.label}
+        onChange={(v) => void saveEnum(v)}
+        testidPrefix={`cfg-seg-${field.key}`} />
+    </div>
+    {#if error !== null}
+      <p class="status-error">{error}</p>
     {/if}
   </div>
-
-  {#if editorOpen}
-    <div class="settings-field__editor">
-      <Input
-        type={field.sensitive ? 'password' : 'text'}
-        value={draft}
-        placeholder={field.sensitive ? 'enter a new value' : ''}
-        onInput={(v) => (draft = v)}
-        testid={`cfg-input-${field.key}`} />
-      <Btn variant="primary" size="sm" testid={`cfg-save-${field.key}`} disabled={saving} onClick={() => void save()}>
-        {#snippet children()}{saving ? 'Saving…' : 'Save'}{/snippet}
-      </Btn>
-      {#if field.sensitive && field.hasValue}
-        <Btn variant="ghost" size="sm" testid={`cfg-cancel-${field.key}`} onClick={() => { replacing = false; draft = '' }}>
-          {#snippet children()}Cancel{/snippet}
+{:else}
+  <div class="settings-field" data-testid={`cfg-row-${field.key}`}>
+    <div class="settings-field__head">
+      <span class="t-label settings-field__label">{field.label}{field.required ? ' *' : ''}</span>
+      {#if field.sensitive && field.hasValue && !replacing}
+        <Secret value={maskSecret(field.value)} />
+        <Btn variant="secondary" size="sm" testid={`cfg-replace-${field.key}`} onClick={() => (replacing = true)}>
+          {#snippet children()}Replace{/snippet}
         </Btn>
       {/if}
     </div>
-  {/if}
 
-  {#if error !== null}
-    <p class="status-error">{error}</p>
-  {/if}
-</div>
+    {#if editorOpen}
+      <div class="settings-field__editor">
+        <Input
+          type={field.sensitive ? 'password' : 'text'}
+          value={draft}
+          placeholder={field.sensitive ? 'enter a new value' : ''}
+          onInput={(v) => (draft = v)}
+          testid={`cfg-input-${field.key}`} />
+        <Btn variant="primary" size="sm" testid={`cfg-save-${field.key}`} disabled={saving} onClick={() => void save()}>
+          {#snippet children()}{saving ? 'Saving…' : 'Save'}{/snippet}
+        </Btn>
+        {#if field.sensitive && field.hasValue}
+          <Btn variant="ghost" size="sm" testid={`cfg-cancel-${field.key}`} onClick={() => { replacing = false; draft = '' }}>
+            {#snippet children()}Cancel{/snippet}
+          </Btn>
+        {/if}
+      </div>
+    {/if}
+
+    {#if error !== null}
+      <p class="status-error">{error}</p>
+    {/if}
+  </div>
+{/if}
 
 <style>
   .settings-field {

--- a/client/settings/components/ConfigFieldRow.svelte
+++ b/client/settings/components/ConfigFieldRow.svelte
@@ -61,6 +61,7 @@
   }
 
   async function saveEnum(next: string): Promise<void> {
+    if (saving) return
     const previous = current
     current = next
     error = null

--- a/client/settings/fetcher-schemas.ts
+++ b/client/settings/fetcher-schemas.ts
@@ -31,6 +31,8 @@ export const ConfigFieldSchema = z.object({
   required: z.boolean(),
   sensitive: z.boolean(),
   kind: z.string(),
+  control: z.enum(['text', 'toggle', 'select']).optional(),
+  options: z.array(z.object({ value: z.string(), label: z.string() })).optional(),
   hasValue: z.boolean(),
   value: z.string(),
 })

--- a/client/settings/sections/AiOutputSection.svelte
+++ b/client/settings/sections/AiOutputSection.svelte
@@ -72,7 +72,9 @@
       {#each visible as field (field.key)}
         <ConfigFieldRow {contextId} {field} onSaved={() => void load(contextId)} />
       {/each}
-      <p class="ai-output-hint">Raw detail shows unredacted tool inputs/outputs and reasoning in chat.</p>
+      {#if visible.some((field) => field.key === 'ai_output_detail_level')}
+        <p class="ai-output-hint">Raw detail shows unredacted tool inputs/outputs and reasoning in chat.</p>
+      {/if}
     </div>
   {/if}
 </section>

--- a/client/settings/sections/AiOutputSection.svelte
+++ b/client/settings/sections/AiOutputSection.svelte
@@ -1,0 +1,89 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+<!-- Copyright (c) 2026 Dmitriy Lazarev -->
+<!-- Use of this software is governed by the Business Source License 1.1. -->
+<!-- See LICENSE in the project root for details. -->
+
+<script lang="ts">
+  import ConfigFieldRow from '../components/ConfigFieldRow.svelte'
+  import type { ConfigField } from '../fetcher-schemas.js'
+  import { fetchConfig } from '../fetchers.js'
+  import EmptyState from '../../shared/ui/EmptyState.svelte'
+  import IconButton from '../../shared/ui/IconButton.svelte'
+  import PageHeader from '../../shared/ui/PageHeader.svelte'
+
+  interface Props {
+    contextId: string
+  }
+
+  let { contextId }: Props = $props()
+
+  let fields: ConfigField[] = $state([])
+  let error: string | null = $state(null)
+  let loading = $state(false)
+
+  // Unset keys come back as value: ''. Display the first option (the default) so the
+  // control is never rendered in an indeterminate state.
+  const visible = $derived(
+    fields
+      .filter((field) => field.kind === 'ai-output')
+      .map((field) => ({
+        ...field,
+        value: field.value === '' ? (field.options?.[0]?.value ?? '') : field.value,
+      })),
+  )
+
+  async function load(id: string): Promise<void> {
+    error = null
+    loading = true
+    try {
+      fields = (await fetchConfig(id)).fields
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err)
+    } finally {
+      loading = false
+    }
+  }
+
+  $effect(() => {
+    void load(contextId)
+  })
+</script>
+
+<section id="ai-output" class="settings-section">
+  <PageHeader eyebrow="Personal" title="AI output">
+    {#snippet action()}
+      <IconButton
+        label="Refresh"
+        glyph="⟳"
+        busy={loading}
+        onClick={() => void load(contextId)}
+        testid="ai-output-refresh" />
+    {/snippet}
+  </PageHeader>
+
+  {#if error !== null}
+    <p class="status-error">{error}</p>
+  {:else if loading}
+    <p class="placeholder">Loading…</p>
+  {:else if visible.length === 0}
+    <EmptyState title="No AI output settings" hint="This context has no editable AI output settings." />
+  {:else}
+    <div class="settings-field-list">
+      {#each visible as field (field.key)}
+        <ConfigFieldRow {contextId} {field} onSaved={() => void load(contextId)} />
+      {/each}
+      <p class="ai-output-hint">Raw detail shows unredacted tool inputs/outputs and reasoning in chat.</p>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .settings-field-list {
+    display: grid;
+    gap: 12px;
+  }
+  .ai-output-hint {
+    color: var(--fg2);
+    font-size: 12px;
+  }
+</style>

--- a/docs/adr/0144-ai-output-visibility.md
+++ b/docs/adr/0144-ai-output-visibility.md
@@ -145,11 +145,16 @@ Restrict raw detail level to bot administrators only.
 
 Key modules:
 
-| File                          | Role                                                                                           |
-| ----------------------------- | ---------------------------------------------------------------------------------------------- |
-| `src/ai-output-settings.ts`   | Setting keys, value unions, defaults, parsers, `getAiOutputSettings()`, `setAiOutputSetting()` |
-| `src/ai-progress-reporter.ts` | Buffered `AiProgressReporter`: tool start/finish, reasoning, sanitization, flush               |
-| `src/ai-output-config-ui.ts`  | `/config` section rendering, `cfg:ai:*` callback serialization/parsing, callback handling      |
+| File                          | Role                                                                                      |
+| ----------------------------- | ----------------------------------------------------------------------------------------- |
+| `src/ai-output-settings.ts`   | Setting keys, value unions, defaults, parsers, `getAiOutputSettings()` (read side)        |
+| `src/ai-progress-reporter.ts` | Buffered `AiProgressReporter`: tool start/finish, reasoning, sanitization, flush          |
+| `src/ai-output-config-ui.ts`  | `/config` section rendering, `cfg:ai:*` callback serialization/parsing, callback handling |
+
+The write path is the settings web UI: the **AI output** section
+(`client/settings/sections/AiOutputSection.svelte`) reads and writes the three
+keys through the generic config route (`/settings/api/config`), which validates
+enum values and persists them via `setConfigValue`.
 
 Integration points:
 

--- a/docs/superpowers/plans/2026-06-09-ai-output-settings-ui.md
+++ b/docs/superpowers/plans/2026-06-09-ai-output-settings-ui.md
@@ -1,0 +1,1135 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# AI Output Settings UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface the three existing AI-output keys (`ai_tool_visibility`, `ai_reasoning_visibility`, `ai_output_detail_level`) as editable controls in the settings web UI, in both personal and group contexts.
+
+**Architecture:** Approach A — extend the generic `ConfigField` pipeline to carry an optional enum control descriptor (`control` + `options`), register the three keys so the existing GET/PATCH config route accepts them, and render them through a new `AiOutputSection` using the existing `SegmentedControl` (save-on-change). No orchestrator or `getAiOutputSettings` change; the read side is already wired.
+
+**Tech Stack:** Bun + `bun:test`, TypeScript (strict, `.js` import paths), Zod v4, Svelte 5 (runes), happy-dom for client tests.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-ai-output-settings-ui-design.md`
+**Branch:** `feat/ai-output-settings-ui` (already created; the spec is committed there)
+
+---
+
+## Background the engineer must know
+
+- **Config storage.** Per-context settings live in the `user_config` table, fronted by an in-memory cache. `setConfigValue(contextId, key, value)` (`src/config.ts:64`) writes the cache immediately (DB syncs in background) and **throws if the key is not allow-listed** by `isAllowedDynamicConfigKey`. `getConfigValue` returns `null` for non-allow-listed keys. So the three keys MUST be added to `ALL_CONFIG_KEYS` or both read and write fail.
+- **The read side is done.** `getAiOutputSettings(contextId)` (`src/ai-output-settings.ts`) reads the three keys via `getCachedConfig` and the orchestrator consumes them. Once the write path stores values into the same cache, the bot picks them up with no further wiring.
+- **Defaults are not stored.** Absent keys resolve to `off`/`off`/`sanitized` via the parsers in `ai-output-settings.ts`. The GET route returns `value: ''` for an unset key; the new section maps an empty value to the first option (which is the default) for display.
+- **`required: false` is mandatory for these fields.** `getRequiredProviderConfigKeysForContext` (`src/config-keys.ts:103`) returns every field where `required && kind !== 'preference'`, and `llm-orchestrator-config.ts` treats those as "context not fully configured." A `required: true` ai-output field would wrongly block the bot. Keep them `required: false`.
+- **Enum values pass through unchanged.** `normalizeDynamicConfigValue`/`readDynamicConfigValue` only special-case `timezone`; `on`/`off`/`sanitized`/`raw` are stored and read verbatim.
+- **Test commands.**
+  - Server test (single file): `bun test <path>`
+  - Client test (single file): `bun --conditions=browser test --preload ./tests/client-setup.ts --path-ignore-patterns '' <path>`
+  - Typecheck: `bun run typecheck`
+- **TDD hook.** Every edit to a `src/`/`client/` implementation file runs a hook that requires the resolved test file to pass. Always write/extend the test first, watch it fail, then implement. Do not add `eslint-disable`/`@ts-ignore` — the hook blocks them.
+
+## File structure
+
+**Backend**
+
+- `src/types/config.ts` — extend `ConfigField` (add `control?`, `options?`, `kind: 'ai-output'`); add `AiOutputConfigKey` to `ConfigKey` + `ALL_CONFIG_KEYS`.
+- `src/config-keys.ts` — add `AI_OUTPUT_FIELDS`; append to every `getConfigFieldsForContext` return path.
+- `src/config-editor/validation.ts` — generic enum check when `field.options` is set.
+- `src/debug/settings/config-routes.ts` — forward `control`/`options` in the GET field mapping.
+
+**Frontend**
+
+- `client/settings/fetcher-schemas.ts` — add optional `control`/`options` to `ConfigFieldSchema`.
+- `client/settings/components/ConfigFieldRow.svelte` — render `SegmentedControl` for enum controls (save-on-change, revert-on-error); text/secret branch unchanged.
+- `client/settings/sections/AiOutputSection.svelte` — new section; filters `kind === 'ai-output'`, maps empty→default.
+- `client/settings/SettingsApp.svelte` — register the section + Personal sidebar item.
+
+**Docs**
+
+- `docs/adr/0144-ai-output-visibility.md` — correct the stale `setAiOutputSetting()` reference.
+
+**Tests touched:** `tests/types/config.test.ts`, `tests/config-editor/validation.test.ts`, `tests/config-keys.test.ts`, `tests/debug/settings/config-routes.test.ts`, `tests/client/settings/fetcher-schemas.test.ts`, `tests/client/settings/components/ConfigFieldRow.test.ts`, `tests/client/settings/sections/AiOutputSection.test.ts` (new), `tests/client/settings/SettingsApp.test.ts`.
+
+---
+
+## Task 1: Extend `ConfigField` and register the three keys
+
+**Files:**
+
+- Modify: `src/types/config.ts`
+- Test: `tests/types/config.test.ts`
+
+- [ ] **Step 1: Update the failing tests**
+
+In `tests/types/config.test.ts`, replace the `ALL_CONFIG_KEYS` assertion (currently `expect(ALL_CONFIG_KEYS).toEqual(['timezone', 'mcp_endpoints'])`) and add allow-list coverage:
+
+```ts
+describe('ALL_CONFIG_KEYS', () => {
+  test('ALL_CONFIG_KEYS contains the static preference and AI-output keys', () => {
+    expect(ALL_CONFIG_KEYS).toEqual([
+      'timezone',
+      'mcp_endpoints',
+      'ai_tool_visibility',
+      'ai_reasoning_visibility',
+      'ai_output_detail_level',
+    ])
+  })
+})
+```
+
+Then add, inside the `isAllowedDynamicConfigKey` describe block:
+
+```ts
+test('accepts the AI-output config keys', () => {
+  expect(isAllowedDynamicConfigKey('ai_tool_visibility')).toBe(true)
+  expect(isAllowedDynamicConfigKey('ai_reasoning_visibility')).toBe(true)
+  expect(isAllowedDynamicConfigKey('ai_output_detail_level')).toBe(true)
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test tests/types/config.test.ts`
+Expected: FAIL — `ALL_CONFIG_KEYS` does not yet contain the three keys.
+
+- [ ] **Step 3: Implement the type + key changes**
+
+In `src/types/config.ts`:
+
+Add the AI-output key type next to the other key types:
+
+```ts
+// AI output visibility config keys (always available)
+export type AiOutputConfigKey = 'ai_tool_visibility' | 'ai_reasoning_visibility' | 'ai_output_detail_level'
+```
+
+Extend the `ConfigKey` union:
+
+```ts
+export type ConfigKey = PreferenceConfigKey | McpConfigKey | AiOutputConfigKey
+```
+
+Extend `ALL_CONFIG_KEYS`:
+
+```ts
+export const ALL_CONFIG_KEYS: readonly ConfigKey[] = [
+  'timezone',
+  'mcp_endpoints',
+  'ai_tool_visibility',
+  'ai_reasoning_visibility',
+  'ai_output_detail_level',
+]
+```
+
+Extend the `ConfigField` type with the optional control descriptor and the new `kind`:
+
+```ts
+export type ConfigFieldOption = {
+  readonly value: string
+  readonly label: string
+}
+
+export type ConfigField = {
+  readonly key: string
+  readonly storageKey: string
+  readonly label: string
+  readonly required: boolean
+  readonly sensitive: boolean
+  readonly kind: 'preference' | 'provider-context' | 'plugin-context' | 'ai-output'
+  readonly control?: 'text' | 'toggle' | 'select'
+  readonly options?: readonly ConfigFieldOption[]
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun test tests/types/config.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/config.ts tests/types/config.test.ts
+git commit -m "feat(config): add AI-output keys and typed ConfigField controls"
+```
+
+---
+
+## Task 2: Enum validation in `validateConfigField`
+
+**Files:**
+
+- Modify: `src/config-editor/validation.ts`
+- Test: `tests/config-editor/validation.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/config-editor/validation.test.ts`, inside the `validateConfigField` describe block. Note the existing `field()` helper accepts `Partial<ConfigField>` overrides, so `control`/`options` flow through:
+
+```ts
+test('validates enum fields against their options', () => {
+  const enumField = field('ai_output_detail_level', {
+    kind: 'ai-output',
+    required: false,
+    control: 'select',
+    options: [
+      { value: 'sanitized', label: 'Sanitized' },
+      { value: 'raw', label: 'Raw' },
+    ],
+  })
+
+  expect(validateConfigField(enumField, 'raw').valid).toBe(true)
+  expect(validateConfigField(enumField, 'sanitized').valid).toBe(true)
+
+  const bad = validateConfigField(enumField, 'verbose')
+  expect(bad.valid).toBe(false)
+  expect(bad.error).toContain('must be one of')
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test tests/config-editor/validation.test.ts`
+Expected: FAIL — `'verbose'` currently validates as `{ valid: true }`.
+
+- [ ] **Step 3: Implement the enum check**
+
+In `src/config-editor/validation.ts`, replace the body of `validateConfigField`:
+
+```ts
+export function validateConfigField(field: ConfigField, value: string): ValidationResult {
+  if (field.required && value.trim().length === 0) {
+    return { valid: false, error: `${field.label} cannot be empty` }
+  }
+  if (field.storageKey === 'timezone') return validateTimezone(value)
+  if (field.options !== undefined && !field.options.some((option) => option.value === value)) {
+    const allowed = field.options.map((option) => option.value).join(', ')
+    return { valid: false, error: `${field.label} must be one of: ${allowed}` }
+  }
+  return { valid: true }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun test tests/config-editor/validation.test.ts`
+Expected: PASS (all existing tests still pass)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config-editor/validation.ts tests/config-editor/validation.test.ts
+git commit -m "feat(config): validate enum config fields against their options"
+```
+
+---
+
+## Task 3: Surface AI-output fields from `getConfigFieldsForContext`
+
+**Files:**
+
+- Modify: `src/config-keys.ts`
+- Test: `tests/config-keys.test.ts`
+
+- [ ] **Step 1: Update existing key assertions and add a field test**
+
+In `tests/config-keys.test.ts`, the AI-output keys now append to every `getConfigKeysForContext` result. Update the **six** exact-array assertions:
+
+Lines asserting `toEqual(['timezone', 'mcp_endpoints'])` (the unassigned, kaneo, missing, and stopped cases) become:
+
+```ts
+expect(getConfigKeysForContext('ctx-unassigned')).toEqual([
+  'timezone',
+  'mcp_endpoints',
+  'ai_tool_visibility',
+  'ai_reasoning_visibility',
+  'ai_output_detail_level',
+])
+```
+
+Apply the same five-element array to the `ctx-kaneo`, `ctx-missing`, and `ctx-stopped` assertions.
+
+The YouTrack assertion becomes:
+
+```ts
+expect(getConfigKeysForContext('ctx-yt')).toEqual([
+  'plugin:task-provider-youtrack:provider:token',
+  'timezone',
+  'mcp_endpoints',
+  'ai_tool_visibility',
+  'ai_reasoning_visibility',
+  'ai_output_detail_level',
+])
+```
+
+The demo-tracker assertion becomes:
+
+```ts
+expect(getConfigKeysForContext('ctx-demo')).toEqual([
+  'plugin:demo-plugin:provider:token',
+  'timezone',
+  'mcp_endpoints',
+  'ai_tool_visibility',
+  'ai_reasoning_visibility',
+  'ai_output_detail_level',
+])
+```
+
+(The `getAllConfig('ctx-yt')` test that expects `{ timezone: 'UTC' }` does **not** change — unset AI-output keys have no cached value and are skipped.)
+
+Then add a new test in the `getConfigFieldsForContext` describe block:
+
+```ts
+test('includes the three AI-output fields as enum controls in any context', () => {
+  const fields = getConfigFieldsForContext('ctx-any')
+  const byKey = new Map(fields.map((field) => [field.storageKey, field]))
+
+  const tool = byKey.get('ai_tool_visibility')
+  expect(tool?.kind).toBe('ai-output')
+  expect(tool?.required).toBe(false)
+  expect(tool?.control).toBe('toggle')
+  expect(tool?.options).toEqual([
+    { value: 'off', label: 'Off' },
+    { value: 'on', label: 'On' },
+  ])
+
+  expect(byKey.get('ai_reasoning_visibility')?.control).toBe('toggle')
+
+  const detail = byKey.get('ai_output_detail_level')
+  expect(detail?.control).toBe('select')
+  expect(detail?.options).toEqual([
+    { value: 'sanitized', label: 'Sanitized' },
+    { value: 'raw', label: 'Raw' },
+  ])
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test tests/config-keys.test.ts`
+Expected: FAIL — the new field test fails (fields absent) and the updated key assertions fail until implementation.
+
+- [ ] **Step 3: Implement `AI_OUTPUT_FIELDS`**
+
+In `src/config-keys.ts`, add the import for the key constants at the top:
+
+```ts
+import {
+  AI_OUTPUT_DETAIL_LEVEL_KEY,
+  AI_REASONING_VISIBILITY_KEY,
+  AI_TOOL_VISIBILITY_KEY,
+} from './ai-output-settings.js'
+```
+
+Add the constant next to `PREFERENCE_FIELDS`:
+
+```ts
+const AI_OUTPUT_FIELDS: readonly ConfigField[] = [
+  {
+    key: 'ai_tool_visibility',
+    storageKey: AI_TOOL_VISIBILITY_KEY,
+    label: 'Show tool calls',
+    required: false,
+    sensitive: false,
+    kind: 'ai-output',
+    control: 'toggle',
+    options: [
+      { value: 'off', label: 'Off' },
+      { value: 'on', label: 'On' },
+    ],
+  },
+  {
+    key: 'ai_reasoning_visibility',
+    storageKey: AI_REASONING_VISIBILITY_KEY,
+    label: 'Show reasoning',
+    required: false,
+    sensitive: false,
+    kind: 'ai-output',
+    control: 'toggle',
+    options: [
+      { value: 'off', label: 'Off' },
+      { value: 'on', label: 'On' },
+    ],
+  },
+  {
+    key: 'ai_output_detail_level',
+    storageKey: AI_OUTPUT_DETAIL_LEVEL_KEY,
+    label: 'Detail level',
+    required: false,
+    sensitive: false,
+    kind: 'ai-output',
+    control: 'select',
+    options: [
+      { value: 'sanitized', label: 'Sanitized' },
+      { value: 'raw', label: 'Raw' },
+    ],
+  },
+]
+```
+
+In `getConfigFieldsForContext`, append `...AI_OUTPUT_FIELDS` to **every** return statement. There are four early returns plus the final return; each currently ends with `...PREFERENCE_FIELDS]`. Change each to:
+
+```ts
+return [...pluginFields, ...PREFERENCE_FIELDS, ...AI_OUTPUT_FIELDS]
+```
+
+and the final one to:
+
+```ts
+return [...providerFields, ...pluginFields, ...PREFERENCE_FIELDS, ...AI_OUTPUT_FIELDS]
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun test tests/config-keys.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run the config consumer suites to confirm no other assertions broke**
+
+Run: `bun test tests/config.test.ts tests/llm-orchestrator-config.test.ts`
+Expected: PASS (AI-output fields are `required:false`, so required-key logic is unaffected)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config-keys.ts tests/config-keys.test.ts
+git commit -m "feat(config): surface AI-output fields from getConfigFieldsForContext"
+```
+
+---
+
+## Task 4: Forward `control`/`options` through the config GET route
+
+**Files:**
+
+- Modify: `src/debug/settings/config-routes.ts`
+- Test: `tests/debug/settings/config-routes.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/debug/settings/config-routes.test.ts`. Extend the local `GetResponseSchema` near the top of the file to capture the new optional fields:
+
+```ts
+const GetResponseSchema = z.object({
+  fields: z.array(
+    z.object({
+      key: z.string(),
+      sensitive: z.boolean(),
+      hasValue: z.boolean(),
+      value: z.string(),
+      control: z.string().optional(),
+      options: z.array(z.object({ value: z.string(), label: z.string() })).optional(),
+    }),
+  ),
+})
+```
+
+Then add a test inside the `settings config routes` describe block:
+
+```ts
+test('GET forwards control and options for AI-output fields', async () => {
+  const res = await handleConfigRoutes(
+    new Request('https://x/settings/api/config', {
+      headers: authHeaders(session),
+    }),
+    new URL('https://x/settings/api/config'),
+  )
+  expect(res.status).toBe(200)
+  const body = GetResponseSchema.parse(await res.json())
+  const detail = body.fields.find((f) => f.key === 'ai_output_detail_level')
+  assert(detail, 'expected ai_output_detail_level field in GET response')
+  expect(detail.control).toBe('select')
+  expect(detail.options).toEqual([
+    { value: 'sanitized', label: 'Sanitized' },
+    { value: 'raw', label: 'Raw' },
+  ])
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test tests/debug/settings/config-routes.test.ts`
+Expected: FAIL — `detail.control` is `undefined` (route does not forward it yet).
+
+- [ ] **Step 3: Implement the forwarding**
+
+In `src/debug/settings/config-routes.ts`, in `handleGet`, add the two properties to the mapped object (after `kind: field.kind,`):
+
+```ts
+return {
+  key: field.key,
+  storageKey: field.storageKey,
+  label: field.label,
+  required: field.required,
+  sensitive: field.sensitive,
+  kind: field.kind,
+  control: field.control,
+  options: field.options,
+  hasValue,
+  value: hasValue && field.sensitive ? maskSensitiveValue(raw) : (raw ?? ''),
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun test tests/debug/settings/config-routes.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run the parity suite (it compares config field shapes)**
+
+Run: `bun test tests/debug/settings/config-parity.test.ts`
+Expected: PASS — if it fails because it asserts an exact field-key set, update its expected shape to include `control`/`options` (optional) the same way, then re-run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/debug/settings/config-routes.ts tests/debug/settings/config-routes.test.ts
+git commit -m "feat(settings): forward control/options in config GET response"
+```
+
+---
+
+## Task 5: Extend the client `ConfigFieldSchema`
+
+**Files:**
+
+- Modify: `client/settings/fetcher-schemas.ts`
+- Test: `tests/client/settings/fetcher-schemas.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/client/settings/fetcher-schemas.test.ts`, inside the `fetcher-schemas` describe block:
+
+```ts
+test('ConfigResponseSchema parses enum control fields', () => {
+  const parsed = ConfigResponseSchema.parse({
+    contextId: 'user:1',
+    fields: [
+      {
+        key: 'ai_output_detail_level',
+        storageKey: 'ai_output_detail_level',
+        label: 'Detail level',
+        required: false,
+        sensitive: false,
+        kind: 'ai-output',
+        control: 'select',
+        options: [
+          { value: 'sanitized', label: 'Sanitized' },
+          { value: 'raw', label: 'Raw' },
+        ],
+        hasValue: false,
+        value: '',
+      },
+    ],
+  })
+  expect(parsed.fields[0]!.control).toBe('select')
+  expect(parsed.fields[0]!.options).toHaveLength(2)
+})
+```
+
+Confirm `ConfigResponseSchema` is already imported at the top of the test file (it is used by the existing `ConfigResponseSchema parses fields` test).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun --conditions=browser test --preload ./tests/client-setup.ts --path-ignore-patterns '' tests/client/settings/fetcher-schemas.test.ts`
+Expected: FAIL — `parsed.fields[0].control` is `undefined` because the schema strips unknown keys.
+
+- [ ] **Step 3: Implement the schema change**
+
+In `client/settings/fetcher-schemas.ts`, extend `ConfigFieldSchema`:
+
+```ts
+export const ConfigFieldSchema = z.object({
+  key: z.string(),
+  storageKey: z.string(),
+  label: z.string(),
+  required: z.boolean(),
+  sensitive: z.boolean(),
+  kind: z.string(),
+  control: z.enum(['text', 'toggle', 'select']).optional(),
+  options: z.array(z.object({ value: z.string(), label: z.string() })).optional(),
+  hasValue: z.boolean(),
+  value: z.string(),
+})
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun --conditions=browser test --preload ./tests/client-setup.ts --path-ignore-patterns '' tests/client/settings/fetcher-schemas.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/settings/fetcher-schemas.ts tests/client/settings/fetcher-schemas.test.ts
+git commit -m "feat(settings): parse control/options on client ConfigField schema"
+```
+
+---
+
+## Task 6: Render enum controls in `ConfigFieldRow`
+
+**Files:**
+
+- Modify: `client/settings/components/ConfigFieldRow.svelte`
+- Test: `tests/client/settings/components/ConfigFieldRow.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/client/settings/components/ConfigFieldRow.test.ts`, inside the `ConfigFieldRow` describe block:
+
+```ts
+test('an enum field renders a SegmentedControl and PATCHes on change', async () => {
+  setCsrfToken('c')
+  let body = ''
+  setMockFetch((_url, init) => {
+    body = bodyString(init)
+    return Promise.resolve(json({ ok: true, contextId: 'user:1' }))
+  })
+  let saved = false
+  const { component, target } = render({
+    contextId: 'user:1',
+    field: {
+      key: 'ai_tool_visibility',
+      storageKey: 'ai_tool_visibility',
+      label: 'Show tool calls',
+      required: false,
+      sensitive: false,
+      kind: 'ai-output',
+      control: 'toggle',
+      options: [
+        { value: 'off', label: 'Off' },
+        { value: 'on', label: 'On' },
+      ],
+      hasValue: false,
+      value: 'off',
+    },
+    onSaved: () => {
+      saved = true
+    },
+  })
+  flushSync()
+  target.querySelector<HTMLButtonElement>('[data-testid="cfg-seg-ai_tool_visibility-on"]')!.click()
+  await drain()
+  expect(body).toBe(
+    JSON.stringify({
+      key: 'ai_tool_visibility',
+      value: 'on',
+      contextId: 'user:1',
+    }),
+  )
+  expect(saved).toBe(true)
+  void unmount(component)
+})
+
+test('an enum field reverts to the previous value when the PATCH fails', async () => {
+  setCsrfToken('c')
+  setMockFetch(() => Promise.resolve(new Response('nope', { status: 500 })))
+  const { component, target } = render({
+    contextId: 'user:1',
+    field: {
+      key: 'ai_output_detail_level',
+      storageKey: 'ai_output_detail_level',
+      label: 'Detail level',
+      required: false,
+      sensitive: false,
+      kind: 'ai-output',
+      control: 'select',
+      options: [
+        { value: 'sanitized', label: 'Sanitized' },
+        { value: 'raw', label: 'Raw' },
+      ],
+      hasValue: false,
+      value: 'sanitized',
+    },
+    onSaved: () => undefined,
+  })
+  flushSync()
+  target.querySelector<HTMLButtonElement>('[data-testid="cfg-seg-ai_output_detail_level-raw"]')!.click()
+  await drain()
+  expect(target.querySelector('.status-error')).not.toBeNull()
+  const sanitizedBtn = target.querySelector<HTMLButtonElement>(
+    '[data-testid="cfg-seg-ai_output_detail_level-sanitized"]',
+  )!
+  expect(sanitizedBtn.getAttribute('aria-checked')).toBe('true')
+  void unmount(component)
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun --conditions=browser test --preload ./tests/client-setup.ts --path-ignore-patterns '' tests/client/settings/components/ConfigFieldRow.test.ts`
+Expected: FAIL — no `cfg-seg-*` elements exist yet.
+
+- [ ] **Step 3: Implement the enum branch**
+
+In `client/settings/components/ConfigFieldRow.svelte`, add the import:
+
+```svelte
+  import SegmentedControl from '../../shared/ui/SegmentedControl.svelte'
+```
+
+Add state after the existing `let saving = $state(false)`:
+
+```svelte
+  const isEnum = $derived(field.control === 'toggle' || field.control === 'select')
+  let current = $state(field.value)
+```
+
+Update the existing `$effect` so it also re-syncs `current`:
+
+```svelte
+  $effect(() => {
+    // Re-sync local edit state when the field prop changes (parent re-fetch / context switch).
+    const sensitive = field.sensitive
+    const value = field.value
+    void field.key
+    untrack(() => {
+      draft = sensitive ? '' : value
+      current = value
+      replacing = false
+    })
+  })
+```
+
+Add the enum save handler after the existing `save` function:
+
+```svelte
+  async function saveEnum(next: string): Promise<void> {
+    const previous = current
+    current = next
+    error = null
+    saving = true
+    try {
+      await patchConfig({ key: field.key, value: next, contextId })
+      onSaved()
+    } catch (err) {
+      current = previous
+      error = err instanceof Error ? err.message : String(err)
+    } finally {
+      saving = false
+    }
+  }
+```
+
+Wrap the markup so enum fields render the segmented control and everything else keeps the current behavior. Replace the existing single root `<div class="settings-field" ...>...</div>` with:
+
+```svelte
+{#if isEnum}
+  <div class="settings-field" data-testid={`cfg-row-${field.key}`}>
+    <div class="settings-field__head">
+      <span class="t-label settings-field__label">{field.label}</span>
+      <SegmentedControl
+        options={field.options ?? []}
+        value={current}
+        ariaLabel={field.label}
+        onChange={(v) => void saveEnum(v)}
+        testidPrefix={`cfg-seg-${field.key}`} />
+    </div>
+    {#if error !== null}
+      <p class="status-error">{error}</p>
+    {/if}
+  </div>
+{:else}
+  <div class="settings-field" data-testid={`cfg-row-${field.key}`}>
+    <!-- existing head + editor + error markup, unchanged -->
+  </div>
+{/if}
+```
+
+Keep the entire existing `<div class="settings-field">…</div>` body verbatim inside the `{:else}` branch — do not modify the text/secret editor.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun --conditions=browser test --preload ./tests/client-setup.ts --path-ignore-patterns '' tests/client/settings/components/ConfigFieldRow.test.ts`
+Expected: PASS (including all pre-existing text/secret tests — the `{:else}` branch is unchanged)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/settings/components/ConfigFieldRow.svelte tests/client/settings/components/ConfigFieldRow.test.ts
+git commit -m "feat(settings): render enum config controls via SegmentedControl"
+```
+
+---
+
+## Task 7: New `AiOutputSection`
+
+**Files:**
+
+- Create: `client/settings/sections/AiOutputSection.svelte`
+- Test: `tests/client/settings/sections/AiOutputSection.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/client/settings/sections/AiOutputSection.test.ts`:
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { flushSync, mount, unmount } from 'svelte'
+
+import AiOutputSection from '../../../../client/settings/sections/AiOutputSection.svelte'
+import { restoreFetch, setMockFetch } from '../../../utils/test-helpers.js'
+
+const json = (payload: unknown): Response =>
+  new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const drain = async (): Promise<void> => {
+  for (let i = 0; i < 10; i++) await Promise.resolve()
+  flushSync()
+}
+
+const configPayload = {
+  contextId: 'user:1',
+  fields: [
+    {
+      key: 'timezone',
+      storageKey: 'timezone',
+      label: 'Timezone',
+      required: true,
+      sensitive: false,
+      kind: 'preference',
+      hasValue: true,
+      value: 'UTC',
+    },
+    {
+      key: 'ai_tool_visibility',
+      storageKey: 'ai_tool_visibility',
+      label: 'Show tool calls',
+      required: false,
+      sensitive: false,
+      kind: 'ai-output',
+      control: 'toggle',
+      options: [
+        { value: 'off', label: 'Off' },
+        { value: 'on', label: 'On' },
+      ],
+      hasValue: false,
+      value: '',
+    },
+    {
+      key: 'ai_output_detail_level',
+      storageKey: 'ai_output_detail_level',
+      label: 'Detail level',
+      required: false,
+      sensitive: false,
+      kind: 'ai-output',
+      control: 'select',
+      options: [
+        { value: 'sanitized', label: 'Sanitized' },
+        { value: 'raw', label: 'Raw' },
+      ],
+      hasValue: false,
+      value: '',
+    },
+  ],
+}
+
+afterEach(() => {
+  restoreFetch()
+})
+
+describe('AiOutputSection', () => {
+  test('renders only ai-output fields and defaults an empty value to the first option', async () => {
+    setMockFetch(() => Promise.resolve(json(configPayload)))
+    document.body.innerHTML = '<div id="root"></div>'
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(AiOutputSection, {
+      target,
+      props: { contextId: 'user:1' },
+    })
+    await drain()
+
+    expect(target.querySelector('#ai-output')).not.toBeNull()
+    expect(target.querySelector('[data-testid="cfg-row-ai_tool_visibility"]')).not.toBeNull()
+    expect(target.querySelector('[data-testid="cfg-row-ai_output_detail_level"]')).not.toBeNull()
+    // preference fields are excluded
+    expect(target.querySelector('[data-testid="cfg-row-timezone"]')).toBeNull()
+
+    // empty value defaults to the first option (off / sanitized)
+    const offBtn = target.querySelector<HTMLButtonElement>('[data-testid="cfg-seg-ai_tool_visibility-off"]')!
+    expect(offBtn.getAttribute('aria-checked')).toBe('true')
+    const sanitizedBtn = target.querySelector<HTMLButtonElement>(
+      '[data-testid="cfg-seg-ai_output_detail_level-sanitized"]',
+    )!
+    expect(sanitizedBtn.getAttribute('aria-checked')).toBe('true')
+    void unmount(component)
+  })
+
+  test('shows an error message when the config fetch fails', async () => {
+    setMockFetch(() => Promise.resolve(new Response('Internal Server Error', { status: 500 })))
+    document.body.innerHTML = '<div id="root"></div>'
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(AiOutputSection, {
+      target,
+      props: { contextId: 'user:1' },
+    })
+    await drain()
+    expect(target.querySelector('.status-error')).not.toBeNull()
+    void unmount(component)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun --conditions=browser test --preload ./tests/client-setup.ts --path-ignore-patterns '' tests/client/settings/sections/AiOutputSection.test.ts`
+Expected: FAIL — the section file does not exist (import error).
+
+- [ ] **Step 3: Create the section**
+
+Create `client/settings/sections/AiOutputSection.svelte`:
+
+```svelte
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+<!-- Copyright (c) 2026 Dmitriy Lazarev -->
+<!-- Use of this software is governed by the Business Source License 1.1. -->
+<!-- See LICENSE in the project root for details. -->
+
+<script lang="ts">
+  import ConfigFieldRow from '../components/ConfigFieldRow.svelte'
+  import type { ConfigField } from '../fetcher-schemas.js'
+  import { fetchConfig } from '../fetchers.js'
+  import EmptyState from '../../shared/ui/EmptyState.svelte'
+  import IconButton from '../../shared/ui/IconButton.svelte'
+  import PageHeader from '../../shared/ui/PageHeader.svelte'
+
+  interface Props {
+    contextId: string
+  }
+
+  let { contextId }: Props = $props()
+
+  let fields: ConfigField[] = $state([])
+  let error: string | null = $state(null)
+  let loading = $state(false)
+
+  // Unset keys come back as value: ''. Display the first option (the default) so the
+  // control is never rendered in an indeterminate state.
+  const visible = $derived(
+    fields
+      .filter((field) => field.kind === 'ai-output')
+      .map((field) => ({
+        ...field,
+        value: field.value === '' ? (field.options?.[0]?.value ?? '') : field.value,
+      })),
+  )
+
+  async function load(id: string): Promise<void> {
+    error = null
+    loading = true
+    try {
+      fields = (await fetchConfig(id)).fields
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err)
+    } finally {
+      loading = false
+    }
+  }
+
+  $effect(() => {
+    void load(contextId)
+  })
+</script>
+
+<section id="ai-output" class="settings-section">
+  <PageHeader eyebrow="Personal" title="AI output">
+    {#snippet action()}
+      <IconButton
+        label="Refresh"
+        glyph="⟳"
+        busy={loading}
+        onClick={() => void load(contextId)}
+        testid="ai-output-refresh" />
+    {/snippet}
+  </PageHeader>
+
+  {#if error !== null}
+    <p class="status-error">{error}</p>
+  {:else if loading}
+    <p class="placeholder">Loading…</p>
+  {:else if visible.length === 0}
+    <EmptyState title="No AI output settings" hint="This context has no editable AI output settings." />
+  {:else}
+    <div class="settings-field-list">
+      {#each visible as field (field.key)}
+        <ConfigFieldRow {contextId} {field} onSaved={() => void load(contextId)} />
+      {/each}
+      <p class="ai-output-hint">Raw detail shows unredacted tool inputs/outputs and reasoning in chat.</p>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .settings-field-list {
+    display: grid;
+    gap: 12px;
+  }
+  .ai-output-hint {
+    color: var(--fg2);
+    font-size: 12px;
+  }
+</style>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun --conditions=browser test --preload ./tests/client-setup.ts --path-ignore-patterns '' tests/client/settings/sections/AiOutputSection.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/settings/sections/AiOutputSection.svelte tests/client/settings/sections/AiOutputSection.test.ts
+git commit -m "feat(settings): add AI output settings section"
+```
+
+---
+
+## Task 8: Register the section in `SettingsApp`
+
+**Files:**
+
+- Modify: `client/settings/SettingsApp.svelte`
+- Test: `tests/client/settings/SettingsApp.test.ts`
+
+- [ ] **Step 1: Update the failing test**
+
+In `tests/client/settings/SettingsApp.test.ts`, the test `renders the always-on user sections for a personal context` iterates a list of section ids. Add `'ai-output'`:
+
+```ts
+for (const id of ['profile', 'task-provider', 'tools', 'ai-output', 'byok', 'mcp', 'plugins', 'identity']) {
+  expect(document.querySelector(`#${id}`)).not.toBeNull()
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun --conditions=browser test --preload ./tests/client-setup.ts --path-ignore-patterns '' tests/client/settings/SettingsApp.test.ts`
+Expected: FAIL — `#ai-output` is not rendered yet.
+
+- [ ] **Step 3: Implement the registration**
+
+In `client/settings/SettingsApp.svelte`:
+
+Add the import next to the other section imports:
+
+```svelte
+  import AiOutputSection from './sections/AiOutputSection.svelte'
+```
+
+Add the sidebar item to the Personal group, immediately after the `tools` item:
+
+```svelte
+          { id: 'tools', label: 'Tools' },
+          { id: 'ai-output', label: 'AI output' },
+          { id: 'byok', label: 'BYOK LLM' },
+```
+
+Render the section in the first `settings-group`, immediately after `<ToolsSection contextId={ctx} />`:
+
+```svelte
+            <ToolsSection contextId={ctx} />
+            <AiOutputSection contextId={ctx} />
+            <ByokSection contextId={ctx} />
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun --conditions=browser test --preload ./tests/client-setup.ts --path-ignore-patterns '' tests/client/settings/SettingsApp.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/settings/SettingsApp.svelte tests/client/settings/SettingsApp.test.ts
+git commit -m "feat(settings): register AI output section in settings SPA"
+```
+
+---
+
+## Task 9: Update ADR-0144 and run full verification
+
+**Files:**
+
+- Modify: `docs/adr/0144-ai-output-visibility.md`
+
+- [ ] **Step 1: Correct the stale ADR**
+
+In `docs/adr/0144-ai-output-visibility.md`, update the file table row for `src/ai-output-settings.ts` to remove the non-existent `setAiOutputSetting()` reference, and add a short note that the write path is the settings-web-UI AI output section via the generic config route. Example replacement for that row:
+
+```markdown
+| `src/ai-output-settings.ts` | Setting keys, value unions, defaults, parsers, `getAiOutputSettings()` (read side) |
+```
+
+Add a sentence under the relevant section:
+
+```markdown
+The write path is the settings web UI: the **AI output** section
+(`client/settings/sections/AiOutputSection.svelte`) reads and writes the three
+keys through the generic config route (`/settings/api/config`), which validates
+enum values and persists them via `setConfigValue`.
+```
+
+- [ ] **Step 2: Run the full server test suite**
+
+Run: `bun test`
+Expected: PASS
+
+- [ ] **Step 3: Run the full client test suite**
+
+Run: `bun test:client`
+Expected: PASS
+
+- [ ] **Step 4: Typecheck and staged-file checks**
+
+Run: `bun run typecheck`
+Expected: no errors
+
+Run: `bun check`
+Expected: lint/format/license checks pass on staged files
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/adr/0144-ai-output-visibility.md
+git commit -m "docs(adr): correct AI-output write-path reference (settings UI)"
+```
+
+---
+
+## Manual verification (optional, recommended)
+
+1. Start the bot with the debug server: `bun start:debug` (requires `SETTINGS_PUBLIC_BASE_URL`).
+2. DM the bot `/config`, open the single-use link.
+3. In the **AI output** section, toggle **Show tool calls** to **On** and set **Detail level** to **Raw**.
+4. Send the bot a message that triggers a tool call; confirm an "AI execution details" message appears with raw tool input/output.
+5. Toggle back to **Off**; confirm only the main response is sent.
+6. Repeat in a managed-group context to confirm the section appears and applies group-wide.
+
+## Spec coverage check
+
+- Three independent controls (two toggles + select) → Tasks 3, 6, 7.
+- Personal + group editability → Task 3 (fields in every context) + Task 8 (Personal sidebar group renders for both).
+- Approach A typed `ConfigField` pipeline → Tasks 1, 4, 5, 6.
+- Enum validation + `422` defense-in-depth → Task 2 (validation) consumed by existing PATCH handler.
+- Empty-value → default display → Task 7.
+- Error revert on failed save → Task 6.
+- `raw` informational helper line → Task 7.
+- ADR-0144 staleness fix → Task 9.
+- Out of scope (no migration, no orchestrator change, no new endpoint, no preset, no raw gating) → respected; no tasks add them.
+  </content>

--- a/docs/superpowers/specs/2026-06-09-ai-output-settings-ui-design.md
+++ b/docs/superpowers/specs/2026-06-09-ai-output-settings-ui-design.md
@@ -1,0 +1,216 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Design: AI Output Settings UI
+
+**Date:** 2026-06-09
+**Status:** Approved (pending implementation plan)
+
+## Problem
+
+Three context-scoped settings control what the bot emits to chat beyond its main
+reply (the "AI execution details" message produced by `createAiProgressReporter`):
+
+| storageKey                | Type                | Default     | Effect                                 |
+| ------------------------- | ------------------- | ----------- | -------------------------------------- |
+| `ai_tool_visibility`      | `on` / `off`        | `off`       | Whether tool calls appear in chat      |
+| `ai_reasoning_visibility` | `on` / `off`        | `off`       | Whether reasoning appears in chat      |
+| `ai_output_detail_level`  | `sanitized` / `raw` | `sanitized` | How shown tools/reasoning are rendered |
+
+The **read** path is fully wired: `getAiOutputSettings(contextId)`
+(`src/ai-output-settings.ts`) reads the three keys via `getCachedConfig`, and the
+orchestrator consumes them through `createProgressReporterForContext`
+(`src/llm-orchestrator.ts`), resolving group threads to the parent group context
+via `resolveAiOutputSettingsContextId`.
+
+The **write** path was removed. It originally lived in the retired in-chat
+`/config` callback flow (`gsel:`/`cfg:`), deleted when configuration moved to the
+settings web UI — but an equivalent control was never rebuilt there. Today the
+keys are effectively read-only: they always resolve to their parser defaults, so
+the bot only ever sends its main response. The only way to change them is a direct
+DB write to `user_config`.
+
+ADR-0144 (`docs/adr/0144-ai-output-visibility.md`) is marked "Implemented" but
+references a `setAiOutputSetting()` that no longer exists in `src/`; it predates
+the chat-config removal and is stale. Updating it is part of this work.
+
+## Goal
+
+Add a settings-web-UI surface that lets a user read and change all three keys, in
+both personal and managed-group contexts, with no change to the orchestrator or to
+`getAiOutputSettings`.
+
+## Decisions (from brainstorming)
+
+- **Control model:** three independent controls — two on/off toggles (tools,
+  reasoning) plus a `sanitized`/`raw` selector. No backend semantics change. (Not
+  a single "verbosity" preset; that cannot express combinations such as
+  tools-on/reasoning-off.)
+- **Context scope:** editable in both personal and managed-group contexts (like the
+  Tools section). A group setting applies to everyone in the group; this matches how
+  the orchestrator already resolves settings to the parent group context. No special
+  gating of `raw` in groups.
+- **Implementation approach (Approach A):** extend the generic `ConfigField`
+  pipeline to support typed enum controls, then surface the three keys through it.
+  Chosen over a dedicated section + dedicated route (Approach B) and a dedicated
+  section reusing the config route (Approach C) because the pipeline is small and
+  well-contained, and an additive, backward-compatible extension lets the existing
+  GET/PATCH route, scope resolution, CSRF, and validation be reused without a new
+  endpoint.
+
+### Pipeline usage (Approach A blast radius)
+
+The settings `ConfigField` type (`src/types/config.ts`) — distinct from
+`ProviderConfigField`/`ChatProviderConfigField` — is used in 6 files:
+
+- Server: `config-keys.ts` (producer), `config-editor/validation.ts` (validator),
+  `debug/settings/config-routes.ts` (GET/PATCH `/settings/api/config`).
+- Client: `fetcher-schemas.ts` (Zod schema), `components/ConfigFieldRow.svelte`
+  (renderer).
+
+The generic `<ConfigFieldRow>` renders in exactly two sections: `ProfileSection`
+(filters `kind === 'preference'`) and `TaskProviderSection` (filters
+`kind === 'provider-context'`). Both currently render only text/secret inputs. The
+extension is additive: an absent `control` keeps the exact current text/secret
+behavior, so those two sections are unchanged at runtime.
+
+## Architecture & data flow
+
+```
+AiOutputSection.svelte ──fetchConfig──▶ GET /settings/api/config
+   renders kind==='ai-output' fields via ConfigFieldRow (SegmentedControl)
+   onChange ──patchConfig──▶ PATCH /settings/api/config
+       → validateConfigField (new enum check) → setConfigValue (user_config)
+   → getAiOutputSettings reads via getCachedConfig (already wired)
+```
+
+Making the three keys first-class `ConfigKey`s causes `isConfigKey` /
+`isAllowedDynamicConfigKey` to return true for them, which is what makes
+`getConfigKeysForContext` preload them into the cache that `getAiOutputSettings`
+reads. They are appended in `getConfigFieldsForContext` for every context, so they
+appear in both personal and group contexts.
+
+## Components & changes (file-by-file)
+
+### Backend
+
+1. **`src/types/config.ts`**
+   - Extend the `ConfigField` type with optional `control?: 'text' | 'toggle' |
+'select'` (absent ⇒ `text`, backward-compatible) and
+     `options?: readonly { value: string; label: string }[]`.
+   - Add `'ai-output'` to the `ConfigField['kind']` union.
+   - Add `AiOutputConfigKey = 'ai_tool_visibility' | 'ai_reasoning_visibility' |
+'ai_output_detail_level'` to the `ConfigKey` union and to `ALL_CONFIG_KEYS`
+     (makes `isConfigKey`/`isAllowedDynamicConfigKey` true for the three keys).
+
+2. **`src/config-keys.ts`**
+   - Add an `AI_OUTPUT_FIELDS: readonly ConfigField[]` constant: the three fields
+     with `kind: 'ai-output'`, the `control`/`options` from the table below,
+     `required: true`, `sensitive: false`.
+   - Append `AI_OUTPUT_FIELDS` to every return path of
+     `getConfigFieldsForContext` (alongside `PREFERENCE_FIELDS`), so the fields are
+     always available regardless of task-instance state.
+
+3. **`src/config-editor/validation.ts`**
+   - Generic rule in `validateConfigField`: if `field.options` is defined, the value
+     must equal one of the option values; reject otherwise with a clear message.
+     This covers both `toggle` and `select` controls. Existing `required` and
+     `timezone` rules are unchanged.
+
+4. **`src/debug/settings/config-routes.ts`** — small change. The GET handler
+   whitelists fields into an explicit response object (`key`, `storageKey`, `label`,
+   `required`, `sensitive`, `kind`, `hasValue`, `value`); add `control: field.control`
+   and `options: field.options` to that mapped object so the client receives them.
+   The PATCH handler is unchanged — it already looks the field up, validates via
+   `validateConfigField` (which now enforces enums), and writes via `setConfigValue`.
+
+### Frontend
+
+5. **`client/settings/fetcher-schemas.ts`**
+   - Add optional `control` (`z.enum(['text','toggle','select']).optional()`) and
+     `options` (`z.array(z.object({ value: z.string(), label: z.string() })).optional()`)
+     to `ConfigFieldSchema`.
+
+6. **`client/settings/components/ConfigFieldRow.svelte`**
+   - Branch on `field.control`:
+     - `undefined` / `'text'` → the current text/secret editor, verbatim (default
+       branch is the regression guard for Profile/TaskProvider).
+     - `'toggle'` / `'select'` → render a `SegmentedControl`
+       (`client/shared/ui/SegmentedControl.svelte`) whose `onChange` calls
+       `patchConfig` immediately (save-on-change; no Save button). On error, revert
+       the control to the last-known value and show the existing inline
+       `status-error`.
+
+7. **`client/settings/sections/AiOutputSection.svelte`** — new. Mirrors
+   `ProfileSection`: `fetchConfig(contextId)`, filter `kind === 'ai-output'`, render
+   each via `ConfigFieldRow`, re-fetch on save. `PageHeader` eyebrow "Personal",
+   title "AI output". Include a short helper line under the detail control noting
+   that `raw` shows unredacted tool inputs/outputs and reasoning (informational
+   only).
+
+8. **`client/settings/SettingsApp.svelte`** — import `AiOutputSection`, render it in
+   the Personal `settings-group` (after `ToolsSection`), and add a
+   `{ id: 'ai-output', label: 'AI output' }` item to the Personal sidebar group
+   (visible in personal and group contexts, like Profile/Tools).
+
+## Field definitions & defaults
+
+| storageKey                | Label           | control | options             | effective default |
+| ------------------------- | --------------- | ------- | ------------------- | ----------------- |
+| `ai_tool_visibility`      | Show tool calls | toggle  | `off` / `on`        | `off`             |
+| `ai_reasoning_visibility` | Show reasoning  | toggle  | `off` / `on`        | `off`             |
+| `ai_output_detail_level`  | Detail level    | select  | `sanitized` / `raw` | `sanitized`       |
+
+Defaults are **not** stored. They come from the existing parsers in
+`ai-output-settings.ts` when a key is absent. The UI displays the current effective
+value: the fetched value when present, otherwise the parser default. The GET
+response returns `value: ''` for an unset key; the section maps an empty value to
+the field's default option for display so a control is never rendered in an
+indeterminate state.
+
+## Error handling
+
+- Invalid enum value → `422` from `validateConfigField` (defense-in-depth; the UI
+  only ever submits valid option values).
+- Failed `patchConfig` → the control reverts to the last-known value and the inline
+  `status-error` is shown, matching `ConfigFieldRow`'s existing behavior.
+- Unreadable / absent stored values → fall back to parser defaults (read side is
+  already tolerant via `parseVisibility`/`parseDetailLevel`).
+
+## Testing
+
+Per the project TDD hook pipeline, each implementation file is written test-first.
+
+- `tests/config-editor/validation.test.ts` — enum acceptance and rejection for the
+  three new fields; unaffected behavior for text/timezone fields.
+- `tests/config-keys.test.ts` — `getConfigFieldsForContext` includes the three
+  `ai-output` fields in personal and group contexts; the keys are allowlisted by
+  `isAllowedDynamicConfigKey` and present in `getConfigKeysForContext`.
+- `tests/client/settings/ConfigFieldRow.test.ts` — `toggle`/`select` render a
+  `SegmentedControl` and call `patchConfig` on change; `text`/undefined still
+  renders the existing input (regression guard); error path reverts the control.
+- `tests/client/settings/AiOutputSection.test.ts` — fetch, filter to `ai-output`,
+  render three controls, save-on-change round-trip, empty-value→default display.
+- Existing `tests/ai-output-settings.test.ts` and `tests/ai-progress-reporter.test.ts`
+  cover the read/render side and are left intact.
+
+## Documentation
+
+- Update `docs/adr/0144-ai-output-visibility.md`: correct the stale
+  `setAiOutputSetting()` reference and record that the write path is now the
+  settings-web-UI AI output section via the generic config route.
+
+## Out of scope (YAGNI)
+
+- No orchestrator or `getAiOutputSettings` changes.
+- No `raw` gating or confirmation dialog (user opted against gating in groups).
+- No verbosity-preset model.
+- No DB migration — the three keys already exist and are parent-shared via
+  migration `046`.
+- No new `/settings/api/*` endpoint.
+  </content>
+  </invoke>

--- a/src/config-editor/validation.ts
+++ b/src/config-editor/validation.ts
@@ -33,7 +33,7 @@ export function validateConfigField(field: ConfigField, value: string): Validati
     return { valid: false, error: `${field.label} cannot be empty` }
   }
   if (field.storageKey === 'timezone') return validateTimezone(value)
-  if (field.options !== undefined && !field.options.some((option) => option.value === value)) {
+  if (field.options !== undefined && value !== '' && !field.options.some((option) => option.value === value)) {
     const allowed = field.options.map((option) => option.value).join(', ')
     return { valid: false, error: `${field.label} must be one of: ${allowed}` }
   }

--- a/src/config-editor/validation.ts
+++ b/src/config-editor/validation.ts
@@ -33,5 +33,9 @@ export function validateConfigField(field: ConfigField, value: string): Validati
     return { valid: false, error: `${field.label} cannot be empty` }
   }
   if (field.storageKey === 'timezone') return validateTimezone(value)
+  if (field.options !== undefined && !field.options.some((option) => option.value === value)) {
+    const allowed = field.options.map((option) => option.value).join(', ')
+    return { valid: false, error: `${field.label} must be one of: ${allowed}` }
+  }
   return { valid: true }
 }

--- a/src/config-keys.ts
+++ b/src/config-keys.ts
@@ -144,7 +144,7 @@ export function getConfigKeysForContext(contextId: string): readonly string[] {
 
 export function getRequiredProviderConfigKeysForContext(contextId: string): string[] {
   return getConfigFieldsForContext(contextId)
-    .filter((field) => field.required && field.kind !== 'preference')
+    .filter((field) => field.required && field.kind !== 'preference' && field.kind !== 'ai-output')
     .map((field) => field.storageKey)
 }
 

--- a/src/config-keys.ts
+++ b/src/config-keys.ts
@@ -3,18 +3,17 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import {
+  AI_OUTPUT_DETAIL_LEVEL_KEY,
+  AI_REASONING_VISIBILITY_KEY,
+  AI_TOOL_VISIBILITY_KEY,
+} from './ai-output-settings.js'
 import { getContextSettings } from './instances/context-store.js'
 import { getTaskInstance } from './instances/task-store.js'
 import { pluginRegistry } from './plugins/registry.js'
 import { getTaskProviderDescriptor, listTaskProviderTypes } from './providers/registry.js'
-import {
-  isAllowedDynamicConfigKey,
-  KANEO_PLUGIN_WORKSPACE_KEY,
-  type ConfigField,
-  type ConfigKey,
-} from './types/config.js'
+import { isAllowedDynamicConfigKey, KANEO_PLUGIN_WORKSPACE_KEY, type ConfigField } from './types/config.js'
 
-const PREFERENCE_KEYS: readonly ConfigKey[] = ['timezone', 'mcp_endpoints']
 const PREFERENCE_FIELDS: readonly ConfigField[] = [
   {
     key: 'timezone',
@@ -31,6 +30,48 @@ const PREFERENCE_FIELDS: readonly ConfigField[] = [
     required: false,
     sensitive: false,
     kind: 'preference',
+  },
+]
+
+const AI_OUTPUT_FIELDS: readonly ConfigField[] = [
+  {
+    key: 'ai_tool_visibility',
+    storageKey: AI_TOOL_VISIBILITY_KEY,
+    label: 'Show tool calls',
+    required: false,
+    sensitive: false,
+    kind: 'ai-output',
+    control: 'toggle',
+    options: [
+      { value: 'off', label: 'Off' },
+      { value: 'on', label: 'On' },
+    ],
+  },
+  {
+    key: 'ai_reasoning_visibility',
+    storageKey: AI_REASONING_VISIBILITY_KEY,
+    label: 'Show reasoning',
+    required: false,
+    sensitive: false,
+    kind: 'ai-output',
+    control: 'toggle',
+    options: [
+      { value: 'off', label: 'Off' },
+      { value: 'on', label: 'On' },
+    ],
+  },
+  {
+    key: 'ai_output_detail_level',
+    storageKey: AI_OUTPUT_DETAIL_LEVEL_KEY,
+    label: 'Detail level',
+    required: false,
+    sensitive: false,
+    kind: 'ai-output',
+    control: 'select',
+    options: [
+      { value: 'sanitized', label: 'Sanitized' },
+      { value: 'raw', label: 'Raw' },
+    ],
   },
 ]
 
@@ -69,13 +110,14 @@ function getPluginContextFields(): readonly ConfigField[] {
 export function getConfigFieldsForContext(contextId: string): readonly ConfigField[] {
   const pluginFields = getPluginContextFields()
   const settings = getContextSettings(contextId)
-  if (settings === null) return [...pluginFields, ...PREFERENCE_FIELDS]
+  if (settings === null) return [...pluginFields, ...PREFERENCE_FIELDS, ...AI_OUTPUT_FIELDS]
 
   const instance = getTaskInstance(settings.taskInstanceId)
-  if (instance === null || instance.status !== 'active') return [...pluginFields, ...PREFERENCE_FIELDS]
+  if (instance === null || instance.status !== 'active')
+    return [...pluginFields, ...PREFERENCE_FIELDS, ...AI_OUTPUT_FIELDS]
 
   const descriptor = getTaskProviderDescriptor(instance.type)
-  if (descriptor === undefined) return [...pluginFields, ...PREFERENCE_FIELDS]
+  if (descriptor === undefined) return [...pluginFields, ...PREFERENCE_FIELDS, ...AI_OUTPUT_FIELDS]
 
   const providerFields = descriptor.contextConfigSchema
     .map(
@@ -90,14 +132,14 @@ export function getConfigFieldsForContext(contextId: string): readonly ConfigFie
     )
     .filter((field) => field.storageKey !== KANEO_PLUGIN_WORKSPACE_KEY)
 
-  return [...providerFields, ...pluginFields, ...PREFERENCE_FIELDS]
+  return [...providerFields, ...pluginFields, ...PREFERENCE_FIELDS, ...AI_OUTPUT_FIELDS]
 }
 
 export function getConfigKeysForContext(contextId: string): readonly string[] {
   const keys = getConfigFieldsForContext(contextId)
     .map((field) => field.storageKey)
     .filter((key) => isAllowedDynamicConfigKey(key))
-  return keys.length === 0 ? PREFERENCE_KEYS : keys
+  return keys
 }
 
 export function getRequiredProviderConfigKeysForContext(contextId: string): string[] {

--- a/src/debug/settings/config-routes.ts
+++ b/src/debug/settings/config-routes.ts
@@ -35,6 +35,8 @@ function handleGet(req: Request, url: URL): Response {
       required: field.required,
       sensitive: field.sensitive,
       kind: field.kind,
+      control: field.control,
+      options: field.options,
       hasValue,
       value: hasValue && field.sensitive ? maskSensitiveValue(raw) : (raw ?? ''),
     }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -44,6 +44,7 @@ export type ConfigField = {
   readonly sensitive: boolean
   readonly kind: 'preference' | 'provider-context' | 'plugin-context' | 'ai-output'
   readonly control?: 'text' | 'toggle' | 'select'
+  // Only meaningful for 'toggle'/'select' controls; ignored for 'text'.
   readonly options?: readonly ConfigFieldOption[]
 }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -20,13 +20,21 @@ export type PreferenceConfigKey = 'timezone'
 // MCP endpoint config keys
 export type McpConfigKey = 'mcp_endpoints'
 
+// AI output visibility config keys (always available)
+export type AiOutputConfigKey = 'ai_tool_visibility' | 'ai_reasoning_visibility' | 'ai_output_detail_level'
+
 // Static per-user config keys. Provider-specific keys ('kaneo_apikey',
 // 'kaneo_workspace_id', 'youtrack_token', etc.) are no longer part of this
 // union; they are plugin-namespaced dynamic keys handled via
 // setConfigValue/getConfigValue + isAllowedDynamicConfigKey.
 // LLM credentials live in `system_config` (see `src/system-config.ts`)
 // and are owned by the bot admin, not per-user.
-export type ConfigKey = PreferenceConfigKey | McpConfigKey
+export type ConfigKey = PreferenceConfigKey | McpConfigKey | AiOutputConfigKey
+
+export type ConfigFieldOption = {
+  readonly value: string
+  readonly label: string
+}
 
 export type ConfigField = {
   readonly key: string
@@ -34,12 +42,20 @@ export type ConfigField = {
   readonly label: string
   readonly required: boolean
   readonly sensitive: boolean
-  readonly kind: 'preference' | 'provider-context' | 'plugin-context'
+  readonly kind: 'preference' | 'provider-context' | 'plugin-context' | 'ai-output'
+  readonly control?: 'text' | 'toggle' | 'select'
+  readonly options?: readonly ConfigFieldOption[]
 }
 
 // All valid static config keys (preference and MCP only; provider keys are
 // handled via the dynamic-config path).
-export const ALL_CONFIG_KEYS: readonly ConfigKey[] = ['timezone', 'mcp_endpoints']
+export const ALL_CONFIG_KEYS: readonly ConfigKey[] = [
+  'timezone',
+  'mcp_endpoints',
+  'ai_tool_visibility',
+  'ai_reasoning_visibility',
+  'ai_output_detail_level',
+]
 
 /**
  * Check if a string is a valid ConfigKey

--- a/tests/client/settings/SettingsApp.test.ts
+++ b/tests/client/settings/SettingsApp.test.ts
@@ -68,7 +68,7 @@ describe('SettingsApp', () => {
     seed({})
     const component = mountApp()
     await drain()
-    for (const id of ['profile', 'task-provider', 'tools', 'byok', 'mcp', 'plugins', 'identity']) {
+    for (const id of ['profile', 'task-provider', 'tools', 'ai-output', 'byok', 'mcp', 'plugins', 'identity']) {
       expect(document.querySelector(`#${id}`)).not.toBeNull()
     }
     expect(document.querySelector('#members')).toBeNull()

--- a/tests/client/settings/components/ConfigFieldRow.test.ts
+++ b/tests/client/settings/components/ConfigFieldRow.test.ts
@@ -268,4 +268,74 @@ describe('ConfigFieldRow', () => {
     expect(target.querySelector('[data-testid="cfg-input-kaneo_apikey"]')).toBeNull()
     void unmount(component)
   })
+
+  test('an enum field renders a SegmentedControl and PATCHes on change', async () => {
+    setCsrfToken('c')
+    let body = ''
+    setMockFetch((_url, init) => {
+      body = bodyString(init)
+      return Promise.resolve(json({ ok: true, contextId: 'user:1' }))
+    })
+    let saved = false
+    const { component, target } = render({
+      contextId: 'user:1',
+      field: {
+        key: 'ai_tool_visibility',
+        storageKey: 'ai_tool_visibility',
+        label: 'Show tool calls',
+        required: false,
+        sensitive: false,
+        kind: 'ai-output',
+        control: 'toggle',
+        options: [
+          { value: 'off', label: 'Off' },
+          { value: 'on', label: 'On' },
+        ],
+        hasValue: false,
+        value: 'off',
+      },
+      onSaved: () => {
+        saved = true
+      },
+    })
+    flushSync()
+    target.querySelector<HTMLButtonElement>('[data-testid="cfg-seg-ai_tool_visibility-on"]')!.click()
+    await drain()
+    expect(body).toBe(JSON.stringify({ key: 'ai_tool_visibility', value: 'on', contextId: 'user:1' }))
+    expect(saved).toBe(true)
+    void unmount(component)
+  })
+
+  test('an enum field reverts to the previous value when the PATCH fails', async () => {
+    setCsrfToken('c')
+    setMockFetch(() => Promise.resolve(new Response('nope', { status: 500 })))
+    const { component, target } = render({
+      contextId: 'user:1',
+      field: {
+        key: 'ai_output_detail_level',
+        storageKey: 'ai_output_detail_level',
+        label: 'Detail level',
+        required: false,
+        sensitive: false,
+        kind: 'ai-output',
+        control: 'select',
+        options: [
+          { value: 'sanitized', label: 'Sanitized' },
+          { value: 'raw', label: 'Raw' },
+        ],
+        hasValue: false,
+        value: 'sanitized',
+      },
+      onSaved: () => undefined,
+    })
+    flushSync()
+    target.querySelector<HTMLButtonElement>('[data-testid="cfg-seg-ai_output_detail_level-raw"]')!.click()
+    await drain()
+    expect(target.querySelector('.status-error')).not.toBeNull()
+    const sanitizedBtn = target.querySelector<HTMLButtonElement>(
+      '[data-testid="cfg-seg-ai_output_detail_level-sanitized"]',
+    )!
+    expect(sanitizedBtn.getAttribute('aria-checked')).toBe('true')
+    void unmount(component)
+  })
 })

--- a/tests/client/settings/components/ConfigFieldRow.test.ts
+++ b/tests/client/settings/components/ConfigFieldRow.test.ts
@@ -303,12 +303,15 @@ describe('ConfigFieldRow', () => {
     await drain()
     expect(body).toBe(JSON.stringify({ key: 'ai_tool_visibility', value: 'on', contextId: 'user:1' }))
     expect(saved).toBe(true)
+    const onBtn = target.querySelector<HTMLButtonElement>('[data-testid="cfg-seg-ai_tool_visibility-on"]')!
+    expect(onBtn.getAttribute('aria-checked')).toBe('true')
     void unmount(component)
   })
 
   test('an enum field reverts to the previous value when the PATCH fails', async () => {
     setCsrfToken('c')
     setMockFetch(() => Promise.resolve(new Response('nope', { status: 500 })))
+    let saved = false
     const { component, target } = render({
       contextId: 'user:1',
       field: {
@@ -326,7 +329,9 @@ describe('ConfigFieldRow', () => {
         hasValue: false,
         value: 'sanitized',
       },
-      onSaved: () => undefined,
+      onSaved: () => {
+        saved = true
+      },
     })
     flushSync()
     target.querySelector<HTMLButtonElement>('[data-testid="cfg-seg-ai_output_detail_level-raw"]')!.click()
@@ -336,6 +341,7 @@ describe('ConfigFieldRow', () => {
       '[data-testid="cfg-seg-ai_output_detail_level-sanitized"]',
     )!
     expect(sanitizedBtn.getAttribute('aria-checked')).toBe('true')
+    expect(saved).toBe(false)
     void unmount(component)
   })
 })

--- a/tests/client/settings/fetcher-schemas.test.ts
+++ b/tests/client/settings/fetcher-schemas.test.ts
@@ -49,6 +49,31 @@ describe('fetcher-schemas', () => {
     expect(parsed.fields[0]!.kind).toBe('preference')
   })
 
+  test('ConfigResponseSchema parses enum control fields', () => {
+    const parsed = ConfigResponseSchema.parse({
+      contextId: 'user:1',
+      fields: [
+        {
+          key: 'ai_output_detail_level',
+          storageKey: 'ai_output_detail_level',
+          label: 'Detail level',
+          required: false,
+          sensitive: false,
+          kind: 'ai-output',
+          control: 'select',
+          options: [
+            { value: 'sanitized', label: 'Sanitized' },
+            { value: 'raw', label: 'Raw' },
+          ],
+          hasValue: false,
+          value: '',
+        },
+      ],
+    })
+    expect(parsed.fields[0]!.control).toBe('select')
+    expect(parsed.fields[0]!.options).toHaveLength(2)
+  })
+
   test('ToolsResponseSchema parses domains and tool risk (three-state model)', () => {
     const parsed = ToolsResponseSchema.parse({
       contextId: 'user:1',

--- a/tests/client/settings/sections/AiOutputSection.test.ts
+++ b/tests/client/settings/sections/AiOutputSection.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { flushSync, mount, unmount } from 'svelte'
+
+import AiOutputSection from '../../../../client/settings/sections/AiOutputSection.svelte'
+import { restoreFetch, setMockFetch } from '../../../utils/test-helpers.js'
+
+const json = (payload: unknown): Response =>
+  new Response(JSON.stringify(payload), { status: 200, headers: { 'Content-Type': 'application/json' } })
+
+const drain = async (): Promise<void> => {
+  for (let i = 0; i < 10; i++) await Promise.resolve()
+  flushSync()
+}
+
+const configPayload = {
+  contextId: 'user:1',
+  fields: [
+    {
+      key: 'timezone',
+      storageKey: 'timezone',
+      label: 'Timezone',
+      required: true,
+      sensitive: false,
+      kind: 'preference',
+      hasValue: true,
+      value: 'UTC',
+    },
+    {
+      key: 'ai_tool_visibility',
+      storageKey: 'ai_tool_visibility',
+      label: 'Show tool calls',
+      required: false,
+      sensitive: false,
+      kind: 'ai-output',
+      control: 'toggle',
+      options: [
+        { value: 'off', label: 'Off' },
+        { value: 'on', label: 'On' },
+      ],
+      hasValue: false,
+      value: '',
+    },
+    {
+      key: 'ai_output_detail_level',
+      storageKey: 'ai_output_detail_level',
+      label: 'Detail level',
+      required: false,
+      sensitive: false,
+      kind: 'ai-output',
+      control: 'select',
+      options: [
+        { value: 'sanitized', label: 'Sanitized' },
+        { value: 'raw', label: 'Raw' },
+      ],
+      hasValue: false,
+      value: '',
+    },
+  ],
+}
+
+afterEach(() => {
+  restoreFetch()
+})
+
+describe('AiOutputSection', () => {
+  test('renders only ai-output fields and defaults an empty value to the first option', async () => {
+    setMockFetch(() => Promise.resolve(json(configPayload)))
+    document.body.innerHTML = '<div id="root"></div>'
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(AiOutputSection, { target, props: { contextId: 'user:1' } })
+    await drain()
+
+    expect(target.querySelector('#ai-output')).not.toBeNull()
+    expect(target.querySelector('[data-testid="cfg-row-ai_tool_visibility"]')).not.toBeNull()
+    expect(target.querySelector('[data-testid="cfg-row-ai_output_detail_level"]')).not.toBeNull()
+    // preference fields are excluded
+    expect(target.querySelector('[data-testid="cfg-row-timezone"]')).toBeNull()
+
+    // empty value defaults to the first option (off / sanitized)
+    const offBtn = target.querySelector<HTMLButtonElement>('[data-testid="cfg-seg-ai_tool_visibility-off"]')!
+    expect(offBtn.getAttribute('aria-checked')).toBe('true')
+    const sanitizedBtn = target.querySelector<HTMLButtonElement>(
+      '[data-testid="cfg-seg-ai_output_detail_level-sanitized"]',
+    )!
+    expect(sanitizedBtn.getAttribute('aria-checked')).toBe('true')
+    void unmount(component)
+  })
+
+  test('shows an error message when the config fetch fails', async () => {
+    setMockFetch(() => Promise.resolve(new Response('Internal Server Error', { status: 500 })))
+    document.body.innerHTML = '<div id="root"></div>'
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(AiOutputSection, { target, props: { contextId: 'user:1' } })
+    await drain()
+    expect(target.querySelector('.status-error')).not.toBeNull()
+    void unmount(component)
+  })
+})

--- a/tests/client/settings/sections/AiOutputSection.test.ts
+++ b/tests/client/settings/sections/AiOutputSection.test.ts
@@ -47,6 +47,21 @@ const configPayload = {
       value: '',
     },
     {
+      key: 'ai_reasoning_visibility',
+      storageKey: 'ai_reasoning_visibility',
+      label: 'Show reasoning',
+      required: false,
+      sensitive: false,
+      kind: 'ai-output',
+      control: 'toggle',
+      options: [
+        { value: 'off', label: 'Off' },
+        { value: 'on', label: 'On' },
+      ],
+      hasValue: false,
+      value: '',
+    },
+    {
       key: 'ai_output_detail_level',
       storageKey: 'ai_output_detail_level',
       label: 'Detail level',
@@ -79,6 +94,7 @@ describe('AiOutputSection', () => {
     expect(target.querySelector('#ai-output')).not.toBeNull()
     expect(target.querySelector('[data-testid="cfg-row-ai_tool_visibility"]')).not.toBeNull()
     expect(target.querySelector('[data-testid="cfg-row-ai_output_detail_level"]')).not.toBeNull()
+    expect(target.querySelector('[data-testid="cfg-row-ai_reasoning_visibility"]')).not.toBeNull()
     // preference fields are excluded
     expect(target.querySelector('[data-testid="cfg-row-timezone"]')).toBeNull()
 
@@ -99,6 +115,26 @@ describe('AiOutputSection', () => {
     const component = mount(AiOutputSection, { target, props: { contextId: 'user:1' } })
     await drain()
     expect(target.querySelector('.status-error')).not.toBeNull()
+    expect(target.querySelector('.ui-empty')).toBeNull()
+    void unmount(component)
+  })
+
+  test('renders the refresh control as an icon button', () => {
+    setMockFetch(() => Promise.resolve(json(configPayload)))
+    document.body.innerHTML = '<div id="root"></div>'
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(AiOutputSection, { target, props: { contextId: 'ctx' } })
+    expect(target.querySelector('[data-testid="ai-output-refresh"]')).not.toBeNull()
+    void unmount(component)
+  })
+
+  test('renders section header via PageHeader', async () => {
+    setMockFetch(() => Promise.resolve(json(configPayload)))
+    document.body.innerHTML = '<div id="root"></div>'
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(AiOutputSection, { target, props: { contextId: 'user:1' } })
+    await drain()
+    expect(target.querySelector('.ui-page-header__title')?.textContent).toContain('AI output')
     void unmount(component)
   })
 })

--- a/tests/config-editor/validation.test.ts
+++ b/tests/config-editor/validation.test.ts
@@ -20,6 +20,7 @@ const field = (storageKey: string, overrides?: Partial<ConfigField>): ConfigFiel
   required: overrides?.required ?? true,
   sensitive: overrides?.sensitive ?? false,
   kind: overrides?.kind ?? 'provider-context',
+  ...overrides,
 })
 
 describe('config-editor validation', () => {
@@ -44,6 +45,25 @@ describe('config-editor validation', () => {
 
       const result2 = validateConfigField(field('youtrack_token'), 'valid-token')
       expect(result2.valid).toBe(true)
+    })
+
+    test('validates enum fields against their options', () => {
+      const enumField = field('ai_output_detail_level', {
+        kind: 'ai-output',
+        required: false,
+        control: 'select',
+        options: [
+          { value: 'sanitized', label: 'Sanitized' },
+          { value: 'raw', label: 'Raw' },
+        ],
+      })
+
+      expect(validateConfigField(enumField, 'raw').valid).toBe(true)
+      expect(validateConfigField(enumField, 'sanitized').valid).toBe(true)
+
+      const bad = validateConfigField(enumField, 'verbose')
+      expect(bad.valid).toBe(false)
+      expect(bad.error).toContain('must be one of')
     })
 
     test('validates timezone - must be valid IANA or UTC offset', () => {

--- a/tests/config-editor/validation.test.ts
+++ b/tests/config-editor/validation.test.ts
@@ -64,6 +64,10 @@ describe('config-editor validation', () => {
       const bad = validateConfigField(enumField, 'verbose')
       expect(bad.valid).toBe(false)
       expect(bad.error).toContain('must be one of')
+      expect(bad.error).toContain('sanitized, raw')
+
+      // An optional enum field treats empty string as "unset" and accepts it.
+      expect(validateConfigField(enumField, '').valid).toBe(true)
     })
 
     test('validates timezone - must be valid IANA or UTC offset', () => {

--- a/tests/config-keys.test.ts
+++ b/tests/config-keys.test.ts
@@ -69,7 +69,13 @@ describe('getConfigKeysForContext', () => {
   })
 
   test('returns preferences only for an unassigned context', () => {
-    expect(getConfigKeysForContext('ctx-unassigned')).toEqual(['timezone', 'mcp_endpoints'])
+    expect(getConfigKeysForContext('ctx-unassigned')).toEqual([
+      'timezone',
+      'mcp_endpoints',
+      'ai_tool_visibility',
+      'ai_reasoning_visibility',
+      'ai_output_detail_level',
+    ])
   })
 
   test('returns preferences only for an active Kaneo assignment (kaneo is now plugin-contributed)', () => {
@@ -83,7 +89,13 @@ describe('getConfigKeysForContext', () => {
     })
     setContextSettings({ contextId: 'ctx-kaneo', taskInstanceId: 'kaneo-prod', platformInstanceId: 'telegram-default' })
 
-    expect(getConfigKeysForContext('ctx-kaneo')).toEqual(['timezone', 'mcp_endpoints'])
+    expect(getConfigKeysForContext('ctx-kaneo')).toEqual([
+      'timezone',
+      'mcp_endpoints',
+      'ai_tool_visibility',
+      'ai_reasoning_visibility',
+      'ai_output_detail_level',
+    ])
   })
 
   test('returns plugin-namespaced token key for an active YouTrack assignment (contributed)', () => {
@@ -96,6 +108,9 @@ describe('getConfigKeysForContext', () => {
       'plugin:task-provider-youtrack:provider:token',
       'timezone',
       'mcp_endpoints',
+      'ai_tool_visibility',
+      'ai_reasoning_visibility',
+      'ai_output_detail_level',
     ])
   })
 
@@ -104,7 +119,13 @@ describe('getConfigKeysForContext', () => {
     setContextSettings({ contextId: 'ctx-missing', taskInstanceId: 'missing', platformInstanceId: 'telegram-default' })
     getTestDb().delete(taskInstances).where(eq(taskInstances.id, 'missing')).run()
 
-    expect(getConfigKeysForContext('ctx-missing')).toEqual(['timezone', 'mcp_endpoints'])
+    expect(getConfigKeysForContext('ctx-missing')).toEqual([
+      'timezone',
+      'mcp_endpoints',
+      'ai_tool_visibility',
+      'ai_reasoning_visibility',
+      'ai_output_detail_level',
+    ])
   })
 
   test('returns preferences only when assigned instance is inactive', () => {
@@ -120,7 +141,13 @@ describe('getConfigKeysForContext', () => {
       platformInstanceId: 'telegram-default',
     })
 
-    expect(getConfigKeysForContext('ctx-stopped')).toEqual(['timezone', 'mcp_endpoints'])
+    expect(getConfigKeysForContext('ctx-stopped')).toEqual([
+      'timezone',
+      'mcp_endpoints',
+      'ai_tool_visibility',
+      'ai_reasoning_visibility',
+      'ai_output_detail_level',
+    ])
   })
 
   test('returns dynamic provider keys for an active contributed assignment', () => {
@@ -143,6 +170,9 @@ describe('getConfigKeysForContext', () => {
       'plugin:demo-plugin:provider:token',
       'timezone',
       'mcp_endpoints',
+      'ai_tool_visibility',
+      'ai_reasoning_visibility',
+      'ai_output_detail_level',
     ])
   })
 
@@ -235,6 +265,29 @@ describe('getConfigFieldsForContext', () => {
     expect(fields.map((field) => field.storageKey)).toContain('plugin:plugin-tracker:provider:custom_token')
     expect(fields.map((field) => field.storageKey)).not.toContain('plugin:plugin-tracker:provider:token')
     expect(fields.map((field) => field.storageKey)).not.toContain('custom_token')
+  })
+
+  test('includes the three AI-output fields as enum controls in any context', () => {
+    const fields = getConfigFieldsForContext('ctx-any')
+    const byKey = new Map(fields.map((field) => [field.storageKey, field]))
+
+    const tool = byKey.get('ai_tool_visibility')
+    expect(tool?.kind).toBe('ai-output')
+    expect(tool?.required).toBe(false)
+    expect(tool?.control).toBe('toggle')
+    expect(tool?.options).toEqual([
+      { value: 'off', label: 'Off' },
+      { value: 'on', label: 'On' },
+    ])
+
+    expect(byKey.get('ai_reasoning_visibility')?.control).toBe('toggle')
+
+    const detail = byKey.get('ai_output_detail_level')
+    expect(detail?.control).toBe('select')
+    expect(detail?.options).toEqual([
+      { value: 'sanitized', label: 'Sanitized' },
+      { value: 'raw', label: 'Raw' },
+    ])
   })
 
   test('provider context field label comes from the descriptor field, not a hardcoded map', () => {

--- a/tests/debug/settings/config-routes.test.ts
+++ b/tests/debug/settings/config-routes.test.ts
@@ -23,7 +23,16 @@ import { mockLogger, seedTestPlatformInstance, setupTestDb } from '../../utils/t
 import { authHeaders, establishSession, type SettingsSession } from './helpers.js'
 
 const GetResponseSchema = z.object({
-  fields: z.array(z.object({ key: z.string(), sensitive: z.boolean(), hasValue: z.boolean(), value: z.string() })),
+  fields: z.array(
+    z.object({
+      key: z.string(),
+      sensitive: z.boolean(),
+      hasValue: z.boolean(),
+      value: z.string(),
+      control: z.string().optional(),
+      options: z.array(z.object({ value: z.string(), label: z.string() })).optional(),
+    }),
+  ),
 })
 const PatchResponseSchema = z.object({ contextId: z.string() })
 const PatchUnchangedResponseSchema = z.object({ ok: z.literal(true), unchanged: z.literal(true) })
@@ -164,6 +173,22 @@ describe('settings config routes', () => {
     })
     const res = await handleConfigRoutes(req, new URL('https://x/settings/api/config'))
     expect(res.status).toBe(422)
+  })
+
+  test('GET forwards control and options for AI-output fields', async () => {
+    const res = await handleConfigRoutes(
+      new Request('https://x/settings/api/config', { headers: authHeaders(session) }),
+      new URL('https://x/settings/api/config'),
+    )
+    expect(res.status).toBe(200)
+    const body = GetResponseSchema.parse(await res.json())
+    const detail = body.fields.find((f) => f.key === 'ai_output_detail_level')
+    assert(detail, 'expected ai_output_detail_level field in GET response')
+    expect(detail.control).toBe('select')
+    expect(detail.options).toEqual([
+      { value: 'sanitized', label: 'Sanitized' },
+      { value: 'raw', label: 'Raw' },
+    ])
   })
 
   test('PATCH sensitive field with masked value echoed back returns unchanged=true without overwriting stored secret', async () => {

--- a/tests/debug/settings/config-routes.test.ts
+++ b/tests/debug/settings/config-routes.test.ts
@@ -102,6 +102,28 @@ describe('settings config routes', () => {
     expect(res.status).toBe(422)
   })
 
+  test('PATCH persists an AI-output enum field', async () => {
+    const req = new Request('https://x/settings/api/config', {
+      method: 'PATCH',
+      headers: { ...authHeaders(session, true), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: 'ai_tool_visibility', value: 'on' }),
+    })
+    const res = await handleConfigRoutes(req, new URL('https://x/settings/api/config'))
+    expect(res.status).toBe(200)
+    const body = PatchResponseSchema.parse(await res.json())
+    expect(getConfigValue(body.contextId, 'ai_tool_visibility')).toBe('on')
+  })
+
+  test('PATCH rejects an invalid AI-output enum value with 422', async () => {
+    const req = new Request('https://x/settings/api/config', {
+      method: 'PATCH',
+      headers: { ...authHeaders(session, true), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: 'ai_output_detail_level', value: 'verbose' }),
+    })
+    const res = await handleConfigRoutes(req, new URL('https://x/settings/api/config'))
+    expect(res.status).toBe(422)
+  })
+
   test('PATCH without CSRF is 403', async () => {
     const req = new Request('https://x/settings/api/config', {
       method: 'PATCH',

--- a/tests/types/config.test.ts
+++ b/tests/types/config.test.ts
@@ -34,6 +34,12 @@ describe('config types', () => {
       }
     })
 
+    test('returns true for the AI-output keys', () => {
+      for (const key of ['ai_tool_visibility', 'ai_reasoning_visibility', 'ai_output_detail_level'] as const) {
+        expect(isConfigKey(key)).toBe(true)
+      }
+    })
+
     test('isConfigKey rejects the legacy flat provider keys', () => {
       expect(isConfigKey('kaneo_apikey')).toBe(false)
       expect(isConfigKey('youtrack_token')).toBe(false)

--- a/tests/types/config.test.ts
+++ b/tests/types/config.test.ts
@@ -14,8 +14,14 @@ import { ALL_CONFIG_KEYS, isAllowedDynamicConfigKey, isConfigKey, type ConfigKey
 
 describe('config types', () => {
   describe('ALL_CONFIG_KEYS', () => {
-    test('ALL_CONFIG_KEYS contains only static (non-provider) keys', () => {
-      expect(ALL_CONFIG_KEYS).toEqual(['timezone', 'mcp_endpoints'])
+    test('ALL_CONFIG_KEYS contains the static preference and AI-output keys', () => {
+      expect(ALL_CONFIG_KEYS).toEqual([
+        'timezone',
+        'mcp_endpoints',
+        'ai_tool_visibility',
+        'ai_reasoning_visibility',
+        'ai_output_detail_level',
+      ])
     })
   })
 
@@ -66,6 +72,12 @@ describe('config types', () => {
     test('accepts static config keys', () => {
       expect(isAllowedDynamicConfigKey('timezone')).toBe(true)
       expect(isAllowedDynamicConfigKey('mcp_endpoints')).toBe(true)
+    })
+
+    test('accepts the AI-output config keys', () => {
+      expect(isAllowedDynamicConfigKey('ai_tool_visibility')).toBe(true)
+      expect(isAllowedDynamicConfigKey('ai_reasoning_visibility')).toBe(true)
+      expect(isAllowedDynamicConfigKey('ai_output_detail_level')).toBe(true)
     })
 
     test('rejects unknown keys', () => {


### PR DESCRIPTION
## Summary

Surfaces three previously **read-only / UI-orphaned** per-context config keys as editable controls in the settings web UI. The read side (`getAiOutputSettings`, consumed by the LLM orchestrator) already existed; before this change the keys could only be set via a direct DB write, so they always resolved to defaults and the bot only ever posted its main response.

A new **AI output** section (personal + group contexts) exposes three independent controls via the shared `SegmentedControl` (save-on-change):

| Key | Control | Default |
|---|---|---|
| `ai_tool_visibility` | toggle (on/off) | off |
| `ai_reasoning_visibility` | toggle (on/off) | off |
| `ai_output_detail_level` | select (sanitized/raw) | sanitized |

## Approach (A)

Extended the generic `ConfigField` pipeline with an optional enum control descriptor (`control` + `options`) and registered the three keys, so the existing GET/PATCH config route, scope resolution, CSRF, and validation are all reused — **no new endpoint**. The existing text/secret `ConfigFieldRow` rendering is untouched (enum fields take a new branch).

Flow: `getConfigFieldsForContext` → GET `/settings/api/config` (forwards `control`/`options`) → client Zod schema → `ConfigFieldRow` renders `SegmentedControl` → PATCH → `validateConfigField` (enum check) → `setConfigValue` → `getAiOutputSettings`.

## Notable details

- Fields are `required: false` and excluded from `getRequiredProviderConfigKeysForContext` so they never mark a context as "not fully configured" / block the bot.
- Optional enum fields accept empty (`''` = unset → parser default); section maps empty → first option for display.
- Removed now-dead `PREFERENCE_KEYS` fallback in `getConfigKeysForContext`.
- Save-on-change has an in-flight re-entrancy guard (prevents a revert race).
- Corrected stale ADR-0144 (`setAiOutputSetting()` no longer exists; documents the new write path).

## Testing

- Server: **6122 pass / 0 fail**; Client: **779 pass / 0 fail**; typecheck clean; `bun check` 4/4.
- New/updated tests: types/allowlist, enum validation (incl. empty + invalid), config-keys field surfacing, config-route GET forwarding + PATCH enum round-trip, client schema, `ConfigFieldRow` enum render/save/revert, `AiOutputSection`, `SettingsApp` registration.

## Docs

Spec + plan under `docs/superpowers/`; updated `CLAUDE.md` config-key inventory, README Features table, and ADR-0144.

Built via spec → plan → subagent-driven execution with per-task spec + code-quality review and a final whole-branch integration review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)