### PR TITLE
Harden background long-term memory extraction

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
         "dependency-cruiser": "^17.4.3",
         "drizzle-kit": "^0.31.10",
         "happy-dom": "^20.8.9",
-        "jscpd": "^4.2.2",
+        "jscpd": "^5.0.7",
         "knip": "^6.14.1",
         "msw": "^2",
         "msw-storybook-addon": "^2.0.7",
@@ -151,8 +151,6 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
     "@discordjs/builders": ["@discordjs/builders@1.14.1", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.40", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ=="],
 
@@ -286,16 +284,6 @@
 
     "@js-temporal/polyfill": ["@js-temporal/polyfill@0.5.1", "", { "dependencies": { "jsbi": "^4.3.0" } }, "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ=="],
 
-    "@jscpd/badge-reporter": ["@jscpd/badge-reporter@4.2.2", "", { "dependencies": { "badgen": "^3.2.3", "colors": "^1.4.0", "fs-extra": "^11.2.0" } }, "sha512-03ngWGBtvdL6dRC7+Q/4FdoUozN4KBHpaJ1SjGnPaMuPoEmcGDdw7W/+HfhPWSwpzam3lfTM2yBsGhrG2g3LqQ=="],
-
-    "@jscpd/core": ["@jscpd/core@4.2.2", "", { "dependencies": { "eventemitter3": "^5.0.1" } }, "sha512-YheyoZAVIeZXyQ5mE1lZ+no8Rs8bo02PXnTfW6PN9QrPUOlRsuJ0br5F3T/H6GU8S2DUP5gUJPOp1Lz7oxN+aA=="],
-
-    "@jscpd/finder": ["@jscpd/finder@4.2.2", "", { "dependencies": { "@jscpd/core": "4.2.2", "@jscpd/tokenizer": "4.2.2", "blamer": "^1.0.6", "bytes": "^3.1.2", "cli-table3": "^0.6.5", "colors": "^1.4.0", "fast-glob": "^3.3.2", "fs-extra": "^11.2.0", "markdown-table": "^2.0.0", "pug": "^3.0.3" } }, "sha512-HGsvprcIVTjSU3x8+Ofb5mKq2gRYYZ8Cd1O00w97x8GWUub5sHLGOdvlP4Bw19FVoZzBz+1pjnF5dDvzEoj4rg=="],
-
-    "@jscpd/html-reporter": ["@jscpd/html-reporter@4.2.2", "", { "dependencies": { "colors": "1.4.0", "fs-extra": "^11.2.0", "pug": "^3.0.3" } }, "sha512-pw+spkYfgWNiDH9bURB0jWzGlfbpQjc8gUe3c726qzPSgMUe9QB3fBA44e9iAJP/o0jtizgUd4MZHyWRbVAw1w=="],
-
-    "@jscpd/tokenizer": ["@jscpd/tokenizer@4.2.2", "", { "dependencies": { "@jscpd/core": "4.2.2", "spark-md5": "^3.0.2" } }, "sha512-haV7OWM2xzQ3I7tWgNTAOcR+kkFr0lYxkdnTOSd5Pve4QGx1Jk7kwk9gotqpXTd6AauaPnBdfHPxeZrUY21QYA=="],
-
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
@@ -315,12 +303,6 @@
     "@mswjs/interceptors": ["@mswjs/interceptors@0.41.9", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
-
-    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
-
-    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
-
-    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@open-draft/deferred-promise": ["@open-draft/deferred-promise@3.0.0", "", {}, "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA=="],
 
@@ -620,8 +602,6 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
-    "@types/sarif": ["@types/sarif@2.1.7", "", {}, "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ=="],
-
     "@types/set-cookie-parser": ["@types/set-cookie-parser@2.4.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw=="],
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
@@ -694,10 +674,6 @@
 
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
-    "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
-
-    "assert-never": ["assert-never@1.4.0", "", {}, "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA=="],
-
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
@@ -708,25 +684,17 @@
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
-    "babel-walk": ["babel-walk@3.0.0-canary-5", "", { "dependencies": { "@babel/types": "^7.9.6" } }, "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw=="],
-
-    "badgen": ["badgen@3.2.3", "", {}, "sha512-svDuwkc63E/z0ky3drpUppB83s/nlgDciH9m+STwwQoWyq7yCgew1qEfJ+9axkKdNq7MskByptWUN9j1PGMwFA=="],
-
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.20", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ=="],
 
     "better-opn": ["better-opn@3.0.2", "", { "dependencies": { "open": "^8.0.4" } }, "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ=="],
 
-    "blamer": ["blamer@1.0.7", "", { "dependencies": { "execa": "^4.0.0", "which": "^2.0.2" } }, "sha512-GbBStl/EVlSWkiJQBZps3H1iARBrC7vt++Jb/TTmCNu/jZ04VW7tSN1nScbFXBUy1AN+jzeL7Zep9sbQxLhXKA=="],
-
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
-
-    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
@@ -746,13 +714,9 @@
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "character-parser": ["character-parser@2.2.0", "", { "dependencies": { "is-regex": "^1.0.3" } }, "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw=="],
-
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
-
-    "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
 
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
@@ -764,11 +728,7 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "colors": ["colors@1.4.0", "", {}, "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="],
-
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
-    "constantinople": ["constantinople@4.0.1", "", { "dependencies": { "@babel/parser": "^7.6.0", "@babel/types": "^7.6.1" } }, "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -781,6 +741,18 @@
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cpd-darwin-arm64": ["cpd-darwin-arm64@5.0.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yfqUd+y1lqCp0Oso462SxYmaLhnkZRumhvZB+Noz/jg4+AvQDZcsVnb7gbjr7Wu3+Te8Jz41mZs+ka2XDJ257g=="],
+
+    "cpd-darwin-x64": ["cpd-darwin-x64@5.0.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-RFT71RYdfuejaRY5K0jxEg/hIb/lDX7DK3+Y8SvQixrQi4Epo5EMhtiechCYlIcuDkbq4b2htpldipqssEcc/g=="],
+
+    "cpd-linux-arm64-gnu": ["cpd-linux-arm64-gnu@5.0.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-SBkIVIgH+oqsPJCh89PzOA8EJ0URF97FP9JgGgQrYogfQ3AmNyjJIGpgTClj9IyTb5jTomJVpwa75FYqERXVIQ=="],
+
+    "cpd-linux-x64-gnu": ["cpd-linux-x64-gnu@5.0.7", "", { "os": "linux", "cpu": "x64" }, "sha512-UE+BGxcJSYJPNGD01vPZcIFNFKOc3lgMGpe717JppCCSjyjXd8fKO3FXDePcy3MRTZymC67i2rg6IZkLVsmBWQ=="],
+
+    "cpd-linux-x64-musl": ["cpd-linux-x64-musl@5.0.7", "", { "os": "linux", "cpu": "x64" }, "sha512-1Lv5BXw5AHTb5x5quL813UryKmbzJAJ2uG2lonnanEarWA+j/D0jKNJjY7k3+rnKaeAugiMltmeF6Rf9PAFSIw=="],
+
+    "cpd-windows-x64-msvc": ["cpd-windows-x64-msvc@5.0.7", "", { "os": "win32", "cpu": "x64" }, "sha512-rISkx5Vfl9Chl6kIuOJrf03pDtV4xBGqPaXcS32RE5t65JlAO+AEt0uVpjMWDPm9SKS6onyBKHdRoQkiluqW/Q=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -828,8 +800,6 @@
 
     "discord.js": ["discord.js@14.26.4", "", { "dependencies": { "@discordjs/builders": "^1.14.1", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.1", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.40", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA=="],
 
-    "doctypes": ["doctypes@1.1.0", "", {}, "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ=="],
-
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
@@ -855,8 +825,6 @@
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
-
-    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.22.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww=="],
 
@@ -890,8 +858,6 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
-    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
-
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
@@ -906,8 +872,6 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
-
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
@@ -916,15 +880,11 @@
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
-    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
-
     "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
-
-    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -935,8 +895,6 @@
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
-
-    "fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -956,8 +914,6 @@
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
-    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
     "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
@@ -973,8 +929,6 @@
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
-
-    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
@@ -1010,19 +964,11 @@
 
     "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
-    "is-expression": ["is-expression@4.0.0", "", { "dependencies": { "acorn": "^7.1.1", "object-assign": "^4.1.1" } }, "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A=="],
-
-    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
-
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-installed-globally": ["is-installed-globally@1.0.0", "", { "dependencies": { "global-directory": "^4.0.1", "is-path-inside": "^4.0.0" } }, "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ=="],
 
     "is-node-process": ["is-node-process@1.2.0", "", {}, "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="],
-
-    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-path-inside": ["is-path-inside@4.0.0", "", {}, "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="],
 
@@ -1031,8 +977,6 @@
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
-
-    "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
     "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
@@ -1048,15 +992,11 @@
 
     "js-md4": ["js-md4@0.3.2", "", {}, "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA=="],
 
-    "js-stringify": ["js-stringify@1.0.2", "", {}, "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g=="],
-
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "jsbi": ["jsbi@4.3.2", "", {}, "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew=="],
 
-    "jscpd": ["jscpd@4.2.2", "", { "dependencies": { "@jscpd/badge-reporter": "4.2.2", "@jscpd/core": "4.2.2", "@jscpd/finder": "4.2.2", "@jscpd/html-reporter": "4.2.2", "@jscpd/tokenizer": "4.2.2", "colors": "^1.4.0", "commander": "^5.0.0", "fs-extra": "^11.2.0", "jscpd-sarif-reporter": "4.2.2" }, "bin": { "jscpd": "bin/jscpd" } }, "sha512-zmoSXtG5Dsgo3QHhnsA06okqnKu3DlYBeAuD7MRnNQoNiL13UgBBh28pEEhe0tyR4yqYXk4Q3GAFoHx5cY+oDw=="],
-
-    "jscpd-sarif-reporter": ["jscpd-sarif-reporter@4.2.2", "", { "dependencies": { "colors": "^1.4.0", "fs-extra": "^11.2.0", "node-sarif-builder": "^3.4.0" } }, "sha512-qpLhFZ6pVJcIjvEcUVRxnsrQuTbRY7bBnAgzXY9th0mL1uYhb1ii+SkMcBrBchH23vFfZu/9EG4lIxLCGfEpCQ=="],
+    "jscpd": ["jscpd@5.0.7", "", { "optionalDependencies": { "cpd-darwin-arm64": "5.0.7", "cpd-darwin-x64": "5.0.7", "cpd-linux-arm64-gnu": "5.0.7", "cpd-linux-x64-gnu": "5.0.7", "cpd-linux-x64-musl": "5.0.7", "cpd-windows-x64-msvc": "5.0.7" }, "bin": { "jscpd": "run-jscpd.js", "cpd": "run-jscpd.js" } }, "sha512-V2YemuWeT7qOF6TeNG1zkKavamuDJJQppdHOQjG8dR2bzWNEJacaPgi/ALQPTlNbtXoL/rsQGhPQC8ASN+WzMQ=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -1069,10 +1009,6 @@
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
-
-    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
-
-    "jstransformer": ["jstransformer@1.0.0", "", { "dependencies": { "is-promise": "^2.0.0", "promise": "^7.0.1" } }, "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
@@ -1100,8 +1036,6 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
-    "markdown-table": ["markdown-table@2.0.0", "", { "dependencies": { "repeat-string": "^1.0.0" } }, "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A=="],
-
     "marked": ["marked@18.0.3", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
@@ -1112,17 +1046,9 @@
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
-    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
-
-    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
-
-    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
-
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
-    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
@@ -1164,8 +1090,6 @@
 
     "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
-    "node-sarif-builder": ["node-sarif-builder@3.4.0", "", { "dependencies": { "@types/sarif": "^2.1.7", "fs-extra": "^11.1.1" } }, "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg=="],
-
     "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
@@ -1179,8 +1103,6 @@
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
-
-    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
@@ -1232,43 +1154,13 @@
 
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
-    "promise": ["promise@7.3.1", "", { "dependencies": { "asap": "~2.0.3" } }, "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="],
-
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
-    "pug": ["pug@3.0.4", "", { "dependencies": { "pug-code-gen": "^3.0.4", "pug-filters": "^4.0.0", "pug-lexer": "^5.0.1", "pug-linker": "^4.0.0", "pug-load": "^3.0.0", "pug-parser": "^6.0.0", "pug-runtime": "^3.0.1", "pug-strip-comments": "^2.0.0" } }, "sha512-kFfq5mMzrS7+wrl5pLJzZEzemx34OQ0w4SARfhy/3yxTlhbstsudDwJzhf1hP02yHzbjoVMSXUj/Sz6RNfMyXg=="],
-
-    "pug-attrs": ["pug-attrs@3.0.0", "", { "dependencies": { "constantinople": "^4.0.1", "js-stringify": "^1.0.2", "pug-runtime": "^3.0.0" } }, "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA=="],
-
-    "pug-code-gen": ["pug-code-gen@3.0.4", "", { "dependencies": { "constantinople": "^4.0.1", "doctypes": "^1.1.0", "js-stringify": "^1.0.2", "pug-attrs": "^3.0.0", "pug-error": "^2.1.0", "pug-runtime": "^3.0.1", "void-elements": "^3.1.0", "with": "^7.0.0" } }, "sha512-6okWYIKdasTyXICyEtvobmTZAVX57JkzgzIi4iRJlin8kmhG+Xry2dsus+Mun/nGCn6F2U49haHI5mkELXB14g=="],
-
-    "pug-error": ["pug-error@2.1.0", "", {}, "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg=="],
-
-    "pug-filters": ["pug-filters@4.0.0", "", { "dependencies": { "constantinople": "^4.0.1", "jstransformer": "1.0.0", "pug-error": "^2.0.0", "pug-walk": "^2.0.0", "resolve": "^1.15.1" } }, "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A=="],
-
-    "pug-lexer": ["pug-lexer@5.0.1", "", { "dependencies": { "character-parser": "^2.2.0", "is-expression": "^4.0.0", "pug-error": "^2.0.0" } }, "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w=="],
-
-    "pug-linker": ["pug-linker@4.0.0", "", { "dependencies": { "pug-error": "^2.0.0", "pug-walk": "^2.0.0" } }, "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw=="],
-
-    "pug-load": ["pug-load@3.0.0", "", { "dependencies": { "object-assign": "^4.1.1", "pug-walk": "^2.0.0" } }, "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ=="],
-
-    "pug-parser": ["pug-parser@6.0.0", "", { "dependencies": { "pug-error": "^2.0.0", "token-stream": "1.0.0" } }, "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw=="],
-
-    "pug-runtime": ["pug-runtime@3.0.1", "", {}, "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg=="],
-
-    "pug-strip-comments": ["pug-strip-comments@2.0.0", "", { "dependencies": { "pug-error": "^2.0.0" } }, "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ=="],
-
-    "pug-walk": ["pug-walk@2.0.0", "", {}, "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ=="],
-
-    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
-
     "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
-
-    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
@@ -1288,8 +1180,6 @@
 
     "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
 
-    "repeat-string": ["repeat-string@1.6.1", "", {}, "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="],
-
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
@@ -1300,8 +1190,6 @@
 
     "rettime": ["rettime@0.11.11", "", {}, "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ=="],
 
-    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
-
     "review-loop": ["review-loop@workspace:review-loop"],
 
     "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
@@ -1309,8 +1197,6 @@
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "rrule-temporal": ["rrule-temporal@1.5.3", "", { "dependencies": { "@js-temporal/polyfill": "^0.5.1" } }, "sha512-qALnXyu4MKNUeykkkO0r6Xxl5or3rM8Cf6ibKIe/29sgmq3tGm1oNq4G1Ddp8Ku3mnKmvC3+3yFAJ3OgOu6OJw=="],
-
-    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
@@ -1357,8 +1243,6 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
-
-    "spark-md5": ["spark-md5@3.0.2", "", {}, "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
@@ -1412,11 +1296,7 @@
 
     "tldts-core": ["tldts-core@7.0.32", "", {}, "sha512-GbSw6chU2HsHIB/NAyBJYxXQKpcqhtgY6bvWi90OarpbuMia+Z4Gw5BYiW4hJo1DzQ/6k9coba7FU/ijcgVLLw=="],
 
-    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
-
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
-
-    "token-stream": ["token-stream@1.0.0", "", {}, "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg=="],
 
     "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
 
@@ -1464,8 +1344,6 @@
 
     "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
-    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
     "unpdf": ["unpdf@1.6.2", "", { "peerDependencies": { "@napi-rs/canvas": "^0.1.69" }, "optionalPeers": ["@napi-rs/canvas"] }, "sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
@@ -1484,8 +1362,6 @@
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
-    "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
-
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "watskeburt": ["watskeburt@5.0.3", "", { "bin": { "watskeburt": "dist/run-cli.js" } }, "sha512-g9CXukMjazlJJVQ3OHzXsnG25KFYgSgKMIyoJrD8ggr0DbS9UNF7OzIqWmmKKBMedkxj3T01uqEaGnn+y7QhMA=="],
@@ -1501,8 +1377,6 @@
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
-
-    "with": ["with@7.0.2", "", { "dependencies": { "@babel/parser": "^7.9.6", "@babel/types": "^7.9.6", "assert-never": "^1.2.1", "babel-walk": "3.0.0-canary-5" } }, "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -1560,8 +1434,6 @@
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
-    "blamer/execa": ["execa@4.1.0", "", { "dependencies": { "cross-spawn": "^7.0.0", "get-stream": "^5.0.0", "human-signals": "^1.1.1", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.0", "onetime": "^5.1.0", "signal-exit": "^3.0.2", "strip-final-newline": "^2.0.0" } }, "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA=="],
-
     "defuddle/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "dependency-cruiser/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
@@ -1573,14 +1445,6 @@
     "global-directory/ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
 
     "happy-dom/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
-
-    "is-expression/acorn": ["acorn@7.4.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="],
-
-    "jscpd/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
-
-    "jstransformer/is-promise": ["is-promise@2.2.2", "", {}, "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="],
-
-    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "mutation-server-protocol/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -1657,18 +1521,6 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
-
-    "blamer/execa/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
-
-    "blamer/execa/human-signals": ["human-signals@1.1.1", "", {}, "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="],
-
-    "blamer/execa/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
-
-    "blamer/execa/npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
-
-    "blamer/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
-    "blamer/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 

--- a/client/settings/SettingsApp.svelte
+++ b/client/settings/SettingsApp.svelte
@@ -14,6 +14,7 @@
   import { useScrollSpy } from './scrollspy.js'
   import { activeContext, settingsSession } from './session.svelte.js'
   import ProfileSection from './sections/ProfileSection.svelte'
+  import MemorySection from './sections/MemorySection.svelte'
   import TaskProviderSection from './sections/TaskProviderSection.svelte'
   import AiOutputSection from './sections/AiOutputSection.svelte'
   import ToolsSection from './sections/ToolsSection.svelte'
@@ -43,6 +44,7 @@
         kicker: 'Personal',
         items: [
           { id: 'profile', label: 'Profile' },
+          { id: 'memory', label: 'Memory' },
           { id: 'task-provider', label: 'Task provider' },
           { id: 'tools', label: 'Tools' },
           { id: 'ai-output', label: 'AI output' },
@@ -124,6 +126,7 @@
         <main class="settings-grid__main">
           <div class="settings-group">
             <ProfileSection contextId={ctx} />
+            <MemorySection contextId={ctx} />
             <TaskProviderSection contextId={ctx} />
             <ToolsSection contextId={ctx} />
             <AiOutputSection contextId={ctx} />

--- a/client/settings/fetcher-schemas.ts
+++ b/client/settings/fetcher-schemas.ts
@@ -24,17 +24,19 @@ export type BootstrapData = z.infer<typeof BootstrapSchema>
 
 // --- Config ---
 
-export const ConfigFieldSchema = z.object({
+const StoredConfigValueSchema = z.object({
   key: z.string(),
-  storageKey: z.string(),
   label: z.string(),
   required: z.boolean(),
   sensitive: z.boolean(),
+  hasValue: z.boolean(),
+  value: z.string(),
+})
+export const ConfigFieldSchema = StoredConfigValueSchema.extend({
+  storageKey: z.string(),
   kind: z.string(),
   control: z.enum(['text', 'toggle', 'select']).optional(),
   options: z.array(z.object({ value: z.string(), label: z.string() })).optional(),
-  hasValue: z.boolean(),
-  value: z.string(),
 })
 export type ConfigField = z.infer<typeof ConfigFieldSchema>
 
@@ -43,14 +45,7 @@ export type ConfigResponse = z.infer<typeof ConfigResponseSchema>
 
 // --- BYOK ---
 
-export const ByokFieldSchema = z.object({
-  key: z.string(),
-  label: z.string(),
-  required: z.boolean(),
-  sensitive: z.boolean(),
-  hasValue: z.boolean(),
-  value: z.string(),
-})
+export const ByokFieldSchema = StoredConfigValueSchema
 export const ByokResponseSchema = z.object({
   enabled: z.boolean(),
   complete: z.boolean(),
@@ -98,6 +93,29 @@ export type ToolsResponse = z.infer<typeof ToolsResponseSchema>
 export type ToolDomainView = z.infer<typeof ToolDomainSchema>
 export type ToolEntry = z.infer<typeof ToolEntrySchema>
 
+export const MemoryRecordSchema = z.object({
+  id: z.string(),
+  kind: z.string(),
+  content: z.string(),
+  summary: z.string().nullable(),
+  tags: z.array(z.string()),
+  confidence: z.number(),
+  status: z.string(),
+  source: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  lastSeenAt: z.string(),
+})
+export const MemoryResponseSchema = z.object({
+  contextId: z.string(),
+  scopeType: z.enum(['personal', 'group']),
+  enabled: z.boolean(),
+  profile: z.string(),
+  records: z.array(MemoryRecordSchema),
+})
+export type MemoryRecordView = z.infer<typeof MemoryRecordSchema>
+export type MemoryResponse = z.infer<typeof MemoryResponseSchema>
+
 // --- MCP ---
 
 export const McpEndpointSchema = z.object({
@@ -126,13 +144,7 @@ export const PluginEligibilitySchema = z.union([
 ])
 export type PluginEligibility = z.infer<typeof PluginEligibilitySchema>
 
-export const PluginConfigFieldSchema = z.object({
-  key: z.string(),
-  label: z.string(),
-  required: z.boolean(),
-  sensitive: z.boolean(),
-  hasValue: z.boolean(),
-})
+export const PluginConfigFieldSchema = StoredConfigValueSchema.omit({ value: true })
 export const PluginEntrySchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -188,11 +200,7 @@ export const GroupTaskInstanceResponseSchema = z.object({
 })
 export type GroupTaskInstanceResponse = z.infer<typeof GroupTaskInstanceResponseSchema>
 
-export const ContextTaskInstanceResponseSchema = z.object({
-  contextId: z.string(),
-  taskInstanceId: z.string().nullable(),
-  available: z.array(TaskInstanceOptionSchema),
-})
+export const ContextTaskInstanceResponseSchema = GroupTaskInstanceResponseSchema
 export type ContextTaskInstanceResponse = z.infer<typeof ContextTaskInstanceResponseSchema>
 
 // --- Admin (lenient: store-shaped rows rendered generically) ---
@@ -206,12 +214,7 @@ export const AdminInstanceRowSchema = z
     createdAt: z.union([z.string(), z.number()]).nullable().optional(),
   })
   .loose()
-const InstanceDecodeFailureSchema = z.object({
-  table: z.string(),
-  id: z.string(),
-  type: z.string(),
-  error: z.string(),
-})
+const InstanceDecodeFailureSchema = z.object({ table: z.string(), id: z.string(), type: z.string(), error: z.string() })
 export const AdminInstancesResponseSchema = z.object({
   instances: z.array(AdminInstanceRowSchema),
   unreadable: z.array(InstanceDecodeFailureSchema).optional(),
@@ -220,12 +223,8 @@ export type AdminInstanceDecodeFailure = z.infer<typeof InstanceDecodeFailureSch
 export type AdminInstanceRow = z.infer<typeof AdminInstanceRowSchema>
 export type AdminInstancesResponse = z.infer<typeof AdminInstancesResponseSchema>
 
-export const ProviderTypeFieldSchema = z.object({
-  key: z.string(),
+export const ProviderTypeFieldSchema = StoredConfigValueSchema.omit({ hasValue: true, value: true }).extend({
   storageKey: z.string().optional(),
-  label: z.string(),
-  required: z.boolean(),
-  sensitive: z.boolean(),
 })
 export const ProviderTypeSchema = z
   .object({

--- a/client/settings/fetchers.ts
+++ b/client/settings/fetchers.ts
@@ -12,6 +12,7 @@ import {
   GroupMembersResponseSchema,
   GroupTaskInstanceResponseSchema,
   IdentityResponseSchema,
+  MemoryResponseSchema,
   McpResponseSchema,
   PluginsResponseSchema,
   ProvisionResultSchema,
@@ -23,6 +24,7 @@ import {
   type GroupMembersResponse,
   type GroupTaskInstanceResponse,
   type IdentityResponse,
+  type MemoryResponse,
   type McpEndpoint,
   type McpResponse,
   type PluginsResponse,
@@ -129,6 +131,30 @@ export const setToolPermission = (
     | { kind: 'domain'; domain: string; permission: 'allow' | 'ask' | 'deny'; contextId: string }
     | { kind: 'tool'; tool: string; permission: 'allow' | 'ask' | 'deny'; contextId: string },
 ): Promise<ToolsResponse> => writeJson('/settings/api/tools/toggle', 'POST', input, (b) => ToolsResponseSchema.parse(b))
+
+// --- Memory ---
+
+export const fetchMemory = (contextId: string): Promise<MemoryResponse> =>
+  getJson(`/settings/api/memory?${ctxQuery(contextId)}`, (b) => MemoryResponseSchema.parse(b))
+
+export const updateMemoryProfile = (input: { contextId: string; profile: string }): Promise<unknown> =>
+  writeJson('/settings/api/memory/profile', 'PATCH', input, (b) => b)
+
+export const setMemoryCapture = (input: { contextId: string; enabled: boolean }): Promise<unknown> =>
+  writeJson('/settings/api/memory/capture', 'PATCH', input, (b) => b)
+
+export const clearMemory = (input: { contextId: string }): Promise<unknown> =>
+  writeJson('/settings/api/memory/clear', 'POST', input, (b) => b)
+
+export const archiveMemoryRecord = (contextId: string, id: string): Promise<unknown> =>
+  settingsFetch(`/settings/api/memory/records/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    body: JSON.stringify({ contextId }),
+  }).then(async (res) => {
+    const body = await readBody(res)
+    requireOk(res, body)
+    return body
+  })
 
 // --- MCP ---
 

--- a/client/settings/sections/MemorySection.svelte
+++ b/client/settings/sections/MemorySection.svelte
@@ -244,12 +244,12 @@
 
   <Confirm
     open={pendingClear}
-    title="Clear all memory records"
+    title="Clear memory for this context"
     danger
     confirmLabel="Clear memory"
     onCancel={() => (pendingClear = false)}
     onConfirm={() => { pendingClear = false; void clearRecords() }}>
-    {#snippet body()}<p>Clear all memory records for this context? This cannot be undone.</p>{/snippet}
+    {#snippet body()}<p>Clear the memory profile and all memory records for this context? This cannot be undone.</p>{/snippet}
   </Confirm>
 </section>
 

--- a/client/settings/sections/MemorySection.svelte
+++ b/client/settings/sections/MemorySection.svelte
@@ -1,0 +1,312 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+<!-- Copyright (c) 2026 Dmitriy Lazarev -->
+<!-- Use of this software is governed by the Business Source License 1.1. -->
+<!-- See LICENSE in the project root for details. -->
+
+<script lang="ts">
+  import Btn from '../../shared/ui/Btn.svelte'
+  import EmptyState from '../../shared/ui/EmptyState.svelte'
+  import Field from '../../shared/ui/Field.svelte'
+  import Input from '../../shared/ui/Input.svelte'
+  import PageHeader from '../../shared/ui/PageHeader.svelte'
+  import Pill from '../../shared/ui/Pill.svelte'
+  import { statusTone } from '../../shared/ui/status-tone.js'
+
+  import type { MemoryRecordView, MemoryResponse } from '../fetcher-schemas.js'
+  import {
+    archiveMemoryRecord,
+    clearMemory,
+    fetchMemory,
+    setMemoryCapture,
+    updateMemoryProfile,
+  } from '../fetchers.js'
+
+  interface Props {
+    contextId: string
+  }
+
+  let { contextId }: Props = $props()
+
+  let memory: MemoryResponse | null = $state(null)
+  let profileDraft = $state('')
+  let error: string | null = $state(null)
+  let status: string | null = $state(null)
+  let loading = $state(false)
+  let savingProfile = $state(false)
+  let mutating = $state(false)
+  let initialLoad = $state(true)
+
+  const activeRecords = $derived(memory?.records.filter((record) => record.status === 'active') ?? [])
+
+  function messageFrom(err: unknown): string {
+    return err instanceof Error ? err.message : String(err)
+  }
+
+  function applyMemory(next: MemoryResponse): void {
+    memory = next
+    profileDraft = next.profile
+  }
+
+  function shortDate(value: string): string {
+    return value.length >= 10 ? value.slice(0, 10) : value
+  }
+
+  function recordText(record: MemoryRecordView): string {
+    return record.summary ?? record.content
+  }
+
+  async function load(id: string): Promise<void> {
+    error = null
+    status = null
+    loading = true
+    try {
+      applyMemory(await fetchMemory(id))
+      initialLoad = false
+    } catch (err) {
+      memory = null
+      error = messageFrom(err)
+      initialLoad = false
+    } finally {
+      loading = false
+    }
+  }
+
+  async function toggleCapture(): Promise<void> {
+    if (memory === null) return
+    error = null
+    status = null
+    mutating = true
+    try {
+      await setMemoryCapture({ contextId, enabled: !memory.enabled })
+      await load(contextId)
+    } catch (err) {
+      error = messageFrom(err)
+    } finally {
+      mutating = false
+    }
+  }
+
+  async function saveProfile(): Promise<void> {
+    error = null
+    status = null
+    savingProfile = true
+    try {
+      await updateMemoryProfile({ contextId, profile: profileDraft })
+      await load(contextId)
+      status = 'Saved.'
+    } catch (err) {
+      error = messageFrom(err)
+    } finally {
+      savingProfile = false
+    }
+  }
+
+  async function clearRecords(): Promise<void> {
+    error = null
+    status = null
+    mutating = true
+    try {
+      await clearMemory({ contextId })
+      await load(contextId)
+    } catch (err) {
+      error = messageFrom(err)
+    } finally {
+      mutating = false
+    }
+  }
+
+  async function archiveRecord(id: string): Promise<void> {
+    error = null
+    status = null
+    mutating = true
+    try {
+      await archiveMemoryRecord(contextId, id)
+      await load(contextId)
+    } catch (err) {
+      error = messageFrom(err)
+    } finally {
+      mutating = false
+    }
+  }
+
+  $effect(() => {
+    initialLoad = true
+    void load(contextId)
+  })
+</script>
+
+<section id="memory" class="settings-section">
+  <PageHeader eyebrow={memory?.scopeType === 'group' ? 'Group' : 'Personal'} title="Memory">
+    {#snippet action()}
+      <Btn
+        variant={memory?.enabled ? 'outline' : 'primary'}
+        size="sm"
+        disabled={memory === null || loading || mutating}
+        testid="memory-capture-toggle"
+        onClick={() => void toggleCapture()}>
+        {#snippet children()}{memory?.enabled ? 'Disable capture' : 'Enable capture'}{/snippet}
+      </Btn>
+    {/snippet}
+  </PageHeader>
+
+  {#if error !== null}<p class="status-error">{error}</p>{/if}
+  {#if status !== null}<p class="status-success">{status}</p>{/if}
+
+  {#if initialLoad && loading}
+    <p class="placeholder">Loading…</p>
+  {:else if memory !== null}
+    <div class="settings-memory">
+      <div class="settings-memory__profile">
+        <Field label="Pinned profile">
+          <Input
+            value={profileDraft}
+            multiline={true}
+            rows={5}
+            onInput={(value) => (profileDraft = value)}
+            testid="memory-profile" />
+        </Field>
+        <div class="settings-memory__profile-actions">
+          <Btn
+            variant="primary"
+            size="sm"
+            disabled={savingProfile}
+            testid="memory-profile-save"
+            onClick={() => void saveProfile()}>
+            {#snippet children()}{savingProfile ? 'Saving…' : 'Save profile'}{/snippet}
+          </Btn>
+          <Btn variant="danger" size="sm" disabled={mutating} testid="memory-clear" onClick={() => void clearRecords()}>
+            {#snippet children()}Clear memory{/snippet}
+          </Btn>
+        </div>
+      </div>
+
+      {#if activeRecords.length === 0}
+        <div data-testid="memory-empty">
+          <EmptyState title="No active memory records" hint="Captured memory records for this context will appear here." />
+        </div>
+      {:else}
+        <ul class="settings-memory__records">
+          {#each activeRecords as record (record.id)}
+            <li class="settings-memory__record">
+              <div class="settings-memory__record-main">
+                <div class="settings-memory__record-head">
+                  <Pill tone="info">{#snippet children()}{record.kind}{/snippet}</Pill>
+                  <Pill tone={statusTone(record.status)}>{#snippet children()}{record.status}{/snippet}</Pill>
+                  <span class="settings-memory__source">{record.source}</span>
+                  <span class="settings-memory__seen">last {shortDate(record.lastSeenAt)}</span>
+                </div>
+                <p class="settings-memory__text">{recordText(record)}</p>
+                {#if record.tags.length > 0}
+                  <div class="settings-memory__tags">
+                    {#each record.tags as tag (tag)}
+                      <span class="settings-memory__tag">{tag}</span>
+                    {/each}
+                  </div>
+                {/if}
+              </div>
+              <Btn
+                variant="ghost"
+                size="sm"
+                disabled={mutating}
+                testid={`memory-archive-${record.id}`}
+                onClick={() => void archiveRecord(record.id)}>
+                {#snippet children()}Archive{/snippet}
+              </Btn>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .settings-memory {
+    display: grid;
+    gap: 14px;
+  }
+
+  .settings-memory__profile {
+    display: grid;
+    gap: 10px;
+    padding: 12px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+  }
+
+  .settings-memory__profile-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .settings-memory__records {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 8px;
+  }
+
+  .settings-memory__record {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px;
+    align-items: start;
+    min-height: 76px;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+  }
+
+  .settings-memory__record-main {
+    min-width: 0;
+    display: grid;
+    gap: 7px;
+  }
+
+  .settings-memory__record-head,
+  .settings-memory__tags {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .settings-memory__source,
+  .settings-memory__seen,
+  .settings-memory__tag {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--fg3);
+  }
+
+  .settings-memory__seen {
+    color: var(--fg4);
+  }
+
+  .settings-memory__text {
+    margin: 0;
+    color: var(--fg);
+    font-size: 12px;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
+  }
+
+  .settings-memory__tag {
+    padding: 1px 6px;
+    border: 1px solid var(--hair);
+    color: var(--fg4);
+  }
+
+  @media (max-width: 640px) {
+    .settings-memory__record {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/client/settings/sections/MemorySection.svelte
+++ b/client/settings/sections/MemorySection.svelte
@@ -4,6 +4,9 @@
 <!-- See LICENSE in the project root for details. -->
 
 <script lang="ts">
+  import { untrack } from 'svelte'
+
+  import Confirm from '../../shared/Confirm.svelte'
   import Btn from '../../shared/ui/Btn.svelte'
   import EmptyState from '../../shared/ui/EmptyState.svelte'
   import Field from '../../shared/ui/Field.svelte'
@@ -35,8 +38,11 @@
   let savingProfile = $state(false)
   let mutating = $state(false)
   let initialLoad = $state(true)
+  let loadedContextId: string | null = $state(null)
+  let pendingClear = $state(false)
 
-  const activeRecords = $derived(memory?.records.filter((record) => record.status === 'active') ?? [])
+  const currentMemory = $derived(loadedContextId === contextId ? memory : null)
+  const activeRecords = $derived(currentMemory?.records.filter((record) => record.status === 'active') ?? [])
 
   function messageFrom(err: unknown): string {
     return err instanceof Error ? err.message : String(err)
@@ -45,6 +51,14 @@
   function applyMemory(next: MemoryResponse): void {
     memory = next
     profileDraft = next.profile
+    loadedContextId = next.contextId
+  }
+
+  function clearContextState(): void {
+    memory = null
+    profileDraft = ''
+    loadedContextId = null
+    pendingClear = false
   }
 
   function shortDate(value: string): string {
@@ -55,29 +69,36 @@
     return record.summary ?? record.content
   }
 
-  async function load(id: string): Promise<void> {
+  async function load(id: string): Promise<boolean> {
     error = null
     status = null
+    if (id !== loadedContextId) clearContextState()
     loading = true
     try {
-      applyMemory(await fetchMemory(id))
+      const next = await fetchMemory(id)
+      if (id !== contextId) return false
+      applyMemory(next)
       initialLoad = false
+      return true
     } catch (err) {
-      memory = null
-      error = messageFrom(err)
-      initialLoad = false
+      if (id === contextId) {
+        clearContextState()
+        error = messageFrom(err)
+        initialLoad = false
+      }
+      return false
     } finally {
-      loading = false
+      if (id === contextId) loading = false
     }
   }
 
   async function toggleCapture(): Promise<void> {
-    if (memory === null) return
+    if (currentMemory === null) return
     error = null
     status = null
     mutating = true
     try {
-      await setMemoryCapture({ contextId, enabled: !memory.enabled })
+      await setMemoryCapture({ contextId, enabled: !currentMemory.enabled })
       await load(contextId)
     } catch (err) {
       error = messageFrom(err)
@@ -92,8 +113,7 @@
     savingProfile = true
     try {
       await updateMemoryProfile({ contextId, profile: profileDraft })
-      await load(contextId)
-      status = 'Saved.'
+      if (await load(contextId)) status = 'Saved.'
     } catch (err) {
       error = messageFrom(err)
     } finally {
@@ -130,21 +150,24 @@
   }
 
   $effect(() => {
-    initialLoad = true
-    void load(contextId)
+    const id = contextId
+    untrack(() => {
+      initialLoad = true
+      void load(id)
+    })
   })
 </script>
 
 <section id="memory" class="settings-section">
-  <PageHeader eyebrow={memory?.scopeType === 'group' ? 'Group' : 'Personal'} title="Memory">
+  <PageHeader eyebrow={currentMemory?.scopeType === 'group' ? 'Group' : 'Personal'} title="Memory">
     {#snippet action()}
       <Btn
-        variant={memory?.enabled ? 'outline' : 'primary'}
+        variant={currentMemory?.enabled ? 'outline' : 'primary'}
         size="sm"
-        disabled={memory === null || loading || mutating}
+        disabled={currentMemory === null || loading || mutating}
         testid="memory-capture-toggle"
         onClick={() => void toggleCapture()}>
-        {#snippet children()}{memory?.enabled ? 'Disable capture' : 'Enable capture'}{/snippet}
+        {#snippet children()}{currentMemory?.enabled ? 'Disable capture' : 'Enable capture'}{/snippet}
       </Btn>
     {/snippet}
   </PageHeader>
@@ -154,7 +177,7 @@
 
   {#if initialLoad && loading}
     <p class="placeholder">Loading…</p>
-  {:else if memory !== null}
+  {:else if currentMemory !== null}
     <div class="settings-memory">
       <div class="settings-memory__profile">
         <Field label="Pinned profile">
@@ -174,7 +197,7 @@
             onClick={() => void saveProfile()}>
             {#snippet children()}{savingProfile ? 'Saving…' : 'Save profile'}{/snippet}
           </Btn>
-          <Btn variant="danger" size="sm" disabled={mutating} testid="memory-clear" onClick={() => void clearRecords()}>
+          <Btn variant="danger" size="sm" disabled={mutating} testid="memory-clear" onClick={() => (pendingClear = true)}>
             {#snippet children()}Clear memory{/snippet}
           </Btn>
         </div>
@@ -218,6 +241,16 @@
       {/if}
     </div>
   {/if}
+
+  <Confirm
+    open={pendingClear}
+    title="Clear all memory records"
+    danger
+    confirmLabel="Clear memory"
+    onCancel={() => (pendingClear = false)}
+    onConfirm={() => { pendingClear = false; void clearRecords() }}>
+    {#snippet body()}<p>Clear all memory records for this context? This cannot be undone.</p>{/snippet}
+  </Confirm>
 </section>
 
 <style>

--- a/docs/superpowers/plans/2026-06-11-long-term-memory.md
+++ b/docs/superpowers/plans/2026-06-11-long-term-memory.md
@@ -32,6 +32,7 @@ Create:
 - `src/tools/memory.ts` — `search_memory`, `remember_memory`, `forget_memory`, and `list_memory` tool factories.
 - `src/debug/settings/memory-routes.ts` — settings API for profile/records/toggle/clear operations.
 - `client/settings/sections/MemorySection.svelte` — settings UI section for profile and records.
+- `src/db/long-term-memory-schema.ts` — Drizzle schema definitions for long-term memory tables.
 
 Modify:
 
@@ -69,6 +70,7 @@ Tests:
 - Create: `src/db/migrations/053_long_term_memory.ts`
 - Modify: `src/db/index.ts`
 - Modify: `src/db/schema.ts`
+- Create: `src/db/long-term-memory-schema.ts`
 - Test: `tests/db/migrations/053_long_term_memory.test.ts`
 
 - [ ] **Step 1: Write the failing migration test**
@@ -250,9 +252,16 @@ Add `migration053LongTermMemory` immediately after `migration052ByokLlmCredentia
 
 - [ ] **Step 5: Add Drizzle schema exports**
 
-Modify `src/db/schema.ts` near the existing memory tables:
+Create `src/db/long-term-memory-schema.ts` to keep `src/db/schema.ts` under the repo's max-lines rule:
 
 ```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { blob, index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
 export const memoryProfiles = sqliteTable(
   'memory_profiles',
   {
@@ -309,7 +318,16 @@ export type MemoryProfileRow = typeof memoryProfiles.$inferSelect
 export type MemoryRecordRow = typeof memoryRecords.$inferSelect
 ```
 
-Add `real` and `integer` to the existing `drizzle-orm/sqlite-core` import if they are not already imported.
+Modify `src/db/schema.ts` to re-export that module near the other schema re-exports:
+
+```ts
+export {
+  memoryProfiles,
+  memoryRecords,
+  type MemoryProfileRow,
+  type MemoryRecordRow,
+} from './long-term-memory-schema.js'
+```
 
 - [ ] **Step 6: Verify and commit**
 
@@ -325,7 +343,7 @@ Expected: PASS.
 Commit:
 
 ```bash
-git add src/db/migrations/053_long_term_memory.ts src/db/index.ts src/db/schema.ts tests/db/migrations/053_long_term_memory.test.ts
+git add src/db/migrations/053_long_term_memory.ts src/db/index.ts src/db/schema.ts src/db/long-term-memory-schema.ts tests/db/migrations/053_long_term_memory.test.ts
 git commit -m "feat(memory): add long-term memory schema"
 ```
 

--- a/docs/superpowers/plans/2026-06-11-long-term-memory.md
+++ b/docs/superpowers/plans/2026-06-11-long-term-memory.md
@@ -1,0 +1,1863 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Long-Term Memory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build default-on hybrid long-term memory with pinned profiles, searchable memory records, background capture, bounded context injection, agent tools, and settings controls for personal and group scopes.
+
+**Architecture:** Add a focused `src/long-term-memory/` module with scope normalization, storage, retrieval, context rendering, extraction, and maintenance. Long-term group memory normalizes thread-scoped contexts to the parent group context, while short-term history remains unchanged. Runtime integration happens through `conversation.ts`, `llm-history.ts`, provider-independent tools, and settings routes.
+
+**Tech Stack:** Bun, TypeScript, Drizzle SQLite schema, SQLite FTS5, Vercel AI SDK `generateText`/tools, Zod v4, Svelte settings UI, existing scheduler and settings auth.
+
+---
+
+## File Structure
+
+Create:
+
+- `src/db/migrations/053_long_term_memory.ts` — SQLite tables, indexes, FTS5 virtual table, and triggers.
+- `src/long-term-memory/types.ts` — public domain types and Zod schemas for records, profiles, patches, filters, and tool inputs.
+- `src/long-term-memory/scope.ts` — normalized personal/group memory scope resolution.
+- `src/long-term-memory/store.ts` — profile and record CRUD, FTS search, status transitions, and clear operations.
+- `src/long-term-memory/context.ts` — bounded trust-labelled memory block builder.
+- `src/long-term-memory/extractor.ts` — prompt construction, model response parsing, and patch validation.
+- `src/long-term-memory/runner.ts` — background extraction runner with per-scope in-flight guard.
+- `src/long-term-memory/maintenance.ts` — staleness and expiry transitions.
+- `src/tools/memory.ts` — `search_memory`, `remember_memory`, `forget_memory`, and `list_memory` tool factories.
+- `src/debug/settings/memory-routes.ts` — settings API for profile/records/toggle/clear operations.
+- `client/settings/sections/MemorySection.svelte` — settings UI section for profile and records.
+
+Modify:
+
+- `src/db/index.ts` — register migration `053_long_term_memory`.
+- `src/db/schema.ts` — export `memoryProfiles` and `memoryRecords`.
+- `src/conversation.ts` — load long-term memory context alongside existing summary/facts.
+- `src/llm-history.ts` — trigger background memory extraction after assistant history append.
+- `src/tools/provider-independent-tools-builder.ts` — add memory tools for normal turns.
+- `src/tools/tool-metadata.ts` — add `memory` domain and metadata for new tools.
+- `src/debug/settings-api-router.ts` — route `/settings/api/memory`.
+- `client/settings/SettingsApp.svelte` — add Memory section to the sidebar and page body.
+- `client/settings/fetcher-schemas.ts` and `client/settings/fetchers.ts` — add memory response schemas and fetchers.
+- `src/scheduler-instance.ts` — register a memory maintenance task.
+
+Tests:
+
+- `tests/db/migrations/053_long_term_memory.test.ts`
+- `tests/long-term-memory/scope.test.ts`
+- `tests/long-term-memory/store.test.ts`
+- `tests/long-term-memory/context.test.ts`
+- `tests/long-term-memory/extractor.test.ts`
+- `tests/long-term-memory/runner.test.ts`
+- `tests/long-term-memory/maintenance.test.ts`
+- `tests/tools/memory.test.ts`
+- `tests/debug/settings-memory-routes.test.ts`
+- `tests/client/settings/MemorySection.test.ts`
+- Extend `tests/conversation.test.ts`, `tests/llm-history.test.ts`, `tests/tools/tools-builder.test.ts`, and `tests/tools/tool-metadata.test.ts` if those files exist; otherwise add focused cases to the nearest existing test file in that area.
+
+---
+
+### Task 1: Database Schema And Migration
+
+**Files:**
+
+- Create: `src/db/migrations/053_long_term_memory.ts`
+- Modify: `src/db/index.ts`
+- Modify: `src/db/schema.ts`
+- Test: `tests/db/migrations/053_long_term_memory.test.ts`
+
+- [ ] **Step 1: Write the failing migration test**
+
+Create `tests/db/migrations/053_long_term_memory.test.ts`:
+
+```ts
+import { Database } from 'bun:sqlite'
+import { describe, expect, test } from 'bun:test'
+
+import { migration053LongTermMemory } from '../../../src/db/migrations/053_long_term_memory.js'
+
+const tableNames = (db: Database): string[] =>
+  db
+    .query<{ name: string }, []>(`SELECT name FROM sqlite_master WHERE type IN ('table', 'index', 'trigger')`)
+    .all()
+    .map((r) => r.name)
+
+describe('migration053LongTermMemory', () => {
+  test('creates long-term memory profile and record storage', () => {
+    const db = new Database(':memory:')
+    migration053LongTermMemory.up(db)
+
+    const names = tableNames(db)
+    expect(names).toContain('memory_profiles')
+    expect(names).toContain('memory_records')
+    expect(names).toContain('memory_records_fts')
+    expect(names).toContain('idx_memory_profiles_scope')
+    expect(names).toContain('idx_memory_records_scope_status_seen')
+    expect(names).toContain('idx_memory_records_scope_kind_status')
+    expect(names).toContain('memory_records_ai')
+    expect(names).toContain('memory_records_au')
+    expect(names).toContain('memory_records_ad')
+  })
+
+  test('keeps FTS rows in sync with memory records', () => {
+    const db = new Database(':memory:')
+    migration053LongTermMemory.up(db)
+
+    db.run(
+      `INSERT INTO memory_records
+        (id, scope_id, scope_type, kind, content, summary, tags, confidence, status, source, evidence, created_at, updated_at, last_seen_at)
+       VALUES
+        ('mem-1', 'scope-1', 'personal', 'preference', 'User prefers concise replies', 'Concise replies', '["style"]', 0.9, 'active', 'explicit', '{}', '2026-06-11T00:00:00.000Z', '2026-06-11T00:00:00.000Z', '2026-06-11T00:00:00.000Z')`,
+    )
+
+    const found = db
+      .query<{ id: string }, []>(
+        `SELECT m.id
+         FROM memory_records m
+         JOIN memory_records_fts f ON m.rowid = f.rowid
+         WHERE f.memory_records_fts MATCH 'concise'`,
+      )
+      .all()
+    expect(found).toEqual([{ id: 'mem-1' }])
+  })
+})
+```
+
+- [ ] **Step 2: Run the migration test and verify it fails**
+
+Run:
+
+```bash
+bun test tests/db/migrations/053_long_term_memory.test.ts
+```
+
+Expected: FAIL because `src/db/migrations/053_long_term_memory.ts` does not exist.
+
+- [ ] **Step 3: Add the migration**
+
+Create `src/db/migrations/053_long_term_memory.ts`:
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { Database } from 'bun:sqlite'
+
+import { logger } from '../../logger.js'
+import type { Migration } from '../migrate.js'
+
+const log = logger.child({ scope: 'migration:053' })
+
+const createProfiles = (db: Database): void => {
+  db.run(`
+    CREATE TABLE memory_profiles (
+      scope_id   TEXT NOT NULL PRIMARY KEY,
+      scope_type TEXT NOT NULL CHECK (scope_type IN ('personal', 'group')),
+      profile    TEXT NOT NULL DEFAULT '',
+      enabled    INTEGER NOT NULL DEFAULT 1,
+      version    INTEGER NOT NULL DEFAULT 1,
+      updated_at TEXT NOT NULL
+    )
+  `)
+  db.run(`CREATE INDEX idx_memory_profiles_scope ON memory_profiles(scope_type, scope_id)`)
+}
+
+const createRecords = (db: Database): void => {
+  db.run(`
+    CREATE TABLE memory_records (
+      id            TEXT PRIMARY KEY,
+      scope_id      TEXT NOT NULL,
+      scope_type    TEXT NOT NULL CHECK (scope_type IN ('personal', 'group')),
+      kind          TEXT NOT NULL CHECK (kind IN ('preference', 'fact', 'decision', 'project_context', 'person_context', 'procedure', 'episode', 'reference')),
+      content       TEXT NOT NULL,
+      summary       TEXT,
+      tags          TEXT NOT NULL DEFAULT '[]',
+      confidence    REAL NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
+      status        TEXT NOT NULL CHECK (status IN ('active', 'stale', 'archived', 'contradicted')),
+      source        TEXT NOT NULL CHECK (source IN ('background', 'explicit', 'tool_result', 'admin_edit')),
+      evidence      TEXT NOT NULL DEFAULT '{}',
+      created_at    TEXT NOT NULL,
+      updated_at    TEXT NOT NULL,
+      last_seen_at  TEXT NOT NULL,
+      valid_from    TEXT,
+      valid_until   TEXT,
+      expires_at    TEXT,
+      embedding     BLOB
+    )
+  `)
+  db.run(`CREATE INDEX idx_memory_records_scope_status_seen ON memory_records(scope_id, status, last_seen_at DESC)`)
+  db.run(`CREATE INDEX idx_memory_records_scope_kind_status ON memory_records(scope_id, kind, status)`)
+}
+
+const createFts = (db: Database): void => {
+  db.run(`
+    CREATE VIRTUAL TABLE memory_records_fts
+      USING fts5(content, summary, tags, content='memory_records', content_rowid='rowid')
+  `)
+  db.run(`
+    CREATE TRIGGER memory_records_ai AFTER INSERT ON memory_records BEGIN
+      INSERT INTO memory_records_fts(rowid, content, summary, tags)
+      VALUES (new.rowid, new.content, new.summary, new.tags);
+    END
+  `)
+  db.run(`
+    CREATE TRIGGER memory_records_au AFTER UPDATE ON memory_records BEGIN
+      INSERT INTO memory_records_fts(memory_records_fts, rowid, content, summary, tags)
+      VALUES ('delete', old.rowid, old.content, old.summary, old.tags);
+      INSERT INTO memory_records_fts(rowid, content, summary, tags)
+      VALUES (new.rowid, new.content, new.summary, new.tags);
+    END
+  `)
+  db.run(`
+    CREATE TRIGGER memory_records_ad AFTER DELETE ON memory_records BEGIN
+      INSERT INTO memory_records_fts(memory_records_fts, rowid, content, summary, tags)
+      VALUES ('delete', old.rowid, old.content, old.summary, old.tags);
+    END
+  `)
+}
+
+const up = (db: Database): void => {
+  createProfiles(db)
+  createRecords(db)
+  createFts(db)
+  log.info('migration 053: long-term memory tables created')
+}
+
+export const migration053LongTermMemory: Migration = {
+  id: '053_long_term_memory',
+  up,
+}
+
+export default migration053LongTermMemory
+```
+
+- [ ] **Step 4: Register the migration**
+
+Modify `src/db/index.ts`:
+
+```ts
+import { migration053LongTermMemory } from './migrations/053_long_term_memory.js'
+```
+
+Add `migration053LongTermMemory` immediately after `migration052ByokLlmCredentials` in the exported migrations array.
+
+- [ ] **Step 5: Add Drizzle schema exports**
+
+Modify `src/db/schema.ts` near the existing memory tables:
+
+```ts
+export const memoryProfiles = sqliteTable(
+  'memory_profiles',
+  {
+    scopeId: text('scope_id').primaryKey(),
+    scopeType: text('scope_type', { enum: ['personal', 'group'] }).notNull(),
+    profile: text('profile').notNull().default(''),
+    enabled: integer('enabled').notNull().default(1),
+    version: integer('version').notNull().default(1),
+    updatedAt: text('updated_at').notNull(),
+  },
+  (table) => [index('idx_memory_profiles_scope').on(table.scopeType, table.scopeId)],
+)
+
+export const memoryRecords = sqliteTable(
+  'memory_records',
+  {
+    id: text('id').primaryKey(),
+    scopeId: text('scope_id').notNull(),
+    scopeType: text('scope_type', { enum: ['personal', 'group'] }).notNull(),
+    kind: text('kind', {
+      enum: [
+        'preference',
+        'fact',
+        'decision',
+        'project_context',
+        'person_context',
+        'procedure',
+        'episode',
+        'reference',
+      ],
+    }).notNull(),
+    content: text('content').notNull(),
+    summary: text('summary'),
+    tags: text('tags').notNull().default('[]'),
+    confidence: real('confidence').notNull(),
+    status: text('status', { enum: ['active', 'stale', 'archived', 'contradicted'] }).notNull(),
+    source: text('source', { enum: ['background', 'explicit', 'tool_result', 'admin_edit'] }).notNull(),
+    evidence: text('evidence').notNull().default('{}'),
+    createdAt: text('created_at').notNull(),
+    updatedAt: text('updated_at').notNull(),
+    lastSeenAt: text('last_seen_at').notNull(),
+    validFrom: text('valid_from'),
+    validUntil: text('valid_until'),
+    expiresAt: text('expires_at'),
+    embedding: blob('embedding'),
+  },
+  (table) => [
+    index('idx_memory_records_scope_status_seen').on(table.scopeId, table.status, table.lastSeenAt),
+    index('idx_memory_records_scope_kind_status').on(table.scopeId, table.kind, table.status),
+  ],
+)
+
+export type MemoryProfileRow = typeof memoryProfiles.$inferSelect
+export type MemoryRecordRow = typeof memoryRecords.$inferSelect
+```
+
+Add `real` and `integer` to the existing `drizzle-orm/sqlite-core` import if they are not already imported.
+
+- [ ] **Step 6: Verify and commit**
+
+Run:
+
+```bash
+bun test tests/db/migrations/053_long_term_memory.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/db/migrations/053_long_term_memory.ts src/db/index.ts src/db/schema.ts tests/db/migrations/053_long_term_memory.test.ts
+git commit -m "feat(memory): add long-term memory schema"
+```
+
+---
+
+### Task 2: Memory Scope Normalization
+
+**Files:**
+
+- Create: `src/long-term-memory/types.ts`
+- Create: `src/long-term-memory/scope.ts`
+- Test: `tests/long-term-memory/scope.test.ts`
+
+- [ ] **Step 1: Write scope tests**
+
+Create `tests/long-term-memory/scope.test.ts`:
+
+```ts
+import { describe, expect, test } from 'bun:test'
+
+import { toScopedContextId, toScopedThreadContextId } from '../../src/chat/scoped-context.js'
+import { resolveMemoryScope } from '../../src/long-term-memory/scope.js'
+
+describe('resolveMemoryScope', () => {
+  test('uses personal scope for DMs', () => {
+    expect(resolveMemoryScope({ storageContextId: 'user-1', contextType: 'dm' })).toEqual({
+      scopeId: 'user-1',
+      scopeType: 'personal',
+    })
+  })
+
+  test('rolls scoped Telegram or Mattermost thread contexts up to parent group', () => {
+    const parent = toScopedContextId({ platformInstanceId: 'telegram-main', nativeContextId: '-1001' })
+    const thread = toScopedThreadContextId({
+      platformInstanceId: 'telegram-main',
+      nativeContextId: '-1001',
+      threadId: '42',
+    })
+
+    expect(resolveMemoryScope({ storageContextId: thread, contextType: 'group' })).toEqual({
+      scopeId: parent,
+      scopeType: 'group',
+    })
+  })
+
+  test('rolls legacy colon thread contexts up to the first segment', () => {
+    expect(resolveMemoryScope({ storageContextId: 'group-1:thread-2', contextType: 'group' })).toEqual({
+      scopeId: 'group-1',
+      scopeType: 'group',
+    })
+  })
+
+  test('keeps non-thread group contexts as group scope', () => {
+    expect(resolveMemoryScope({ storageContextId: 'discord-channel-1', contextType: 'group' })).toEqual({
+      scopeId: 'discord-channel-1',
+      scopeType: 'group',
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run scope tests and verify failure**
+
+Run:
+
+```bash
+bun test tests/long-term-memory/scope.test.ts
+```
+
+Expected: FAIL because `src/long-term-memory/scope.ts` does not exist.
+
+- [ ] **Step 3: Add domain types**
+
+Create `src/long-term-memory/types.ts`:
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+export const MemoryScopeTypeSchema = z.enum(['personal', 'group'])
+export type MemoryScopeType = z.infer<typeof MemoryScopeTypeSchema>
+
+export type MemoryScope = Readonly<{
+  scopeId: string
+  scopeType: MemoryScopeType
+}>
+
+export const MemoryKindSchema = z.enum([
+  'preference',
+  'fact',
+  'decision',
+  'project_context',
+  'person_context',
+  'procedure',
+  'episode',
+  'reference',
+])
+export type MemoryKind = z.infer<typeof MemoryKindSchema>
+
+export const MemoryStatusSchema = z.enum(['active', 'stale', 'archived', 'contradicted'])
+export type MemoryStatus = z.infer<typeof MemoryStatusSchema>
+
+export const MemorySourceSchema = z.enum(['background', 'explicit', 'tool_result', 'admin_edit'])
+export type MemorySource = z.infer<typeof MemorySourceSchema>
+```
+
+- [ ] **Step 4: Implement scope normalization**
+
+Create `src/long-term-memory/scope.ts`:
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { getConfigContextIdFromStorageContextId } from '../chat/scoped-context.js'
+import type { ContextType } from '../chat/types.js'
+import type { MemoryScope } from './types.js'
+
+export type ResolveMemoryScopeInput = Readonly<{
+  storageContextId: string
+  contextType: ContextType
+}>
+
+export function resolveMemoryScope(input: ResolveMemoryScopeInput): MemoryScope {
+  if (input.contextType === 'dm') {
+    return { scopeId: input.storageContextId, scopeType: 'personal' }
+  }
+  return {
+    scopeId: getConfigContextIdFromStorageContextId(input.storageContextId),
+    scopeType: 'group',
+  }
+}
+```
+
+- [ ] **Step 5: Verify and commit**
+
+Run:
+
+```bash
+bun test tests/long-term-memory/scope.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/long-term-memory/types.ts src/long-term-memory/scope.ts tests/long-term-memory/scope.test.ts
+git commit -m "feat(memory): normalize long-term memory scopes"
+```
+
+---
+
+### Task 3: Profile And Record Store
+
+**Files:**
+
+- Modify: `src/long-term-memory/types.ts`
+- Create: `src/long-term-memory/store.ts`
+- Test: `tests/long-term-memory/store.test.ts`
+
+- [ ] **Step 1: Write store tests**
+
+Create `tests/long-term-memory/store.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { setupTestDb } from '../utils/db.js'
+import {
+  archiveMemoryRecord,
+  clearMemoryScope,
+  getMemoryProfile,
+  listMemoryRecords,
+  saveMemoryProfile,
+  saveMemoryRecord,
+  searchMemoryRecords,
+} from '../../src/long-term-memory/store.js'
+
+describe('long-term memory store', () => {
+  beforeEach(() => {
+    setupTestDb()
+  })
+
+  test('saves and loads a profile for one scope', () => {
+    saveMemoryProfile(
+      { scopeId: 'user-1', scopeType: 'personal' },
+      '## Communication\n- Concise replies',
+      '2026-06-11T00:00:00.000Z',
+    )
+
+    expect(getMemoryProfile({ scopeId: 'user-1', scopeType: 'personal' })).toEqual({
+      scopeId: 'user-1',
+      scopeType: 'personal',
+      profile: '## Communication\n- Concise replies',
+      enabled: true,
+      version: 1,
+      updatedAt: '2026-06-11T00:00:00.000Z',
+    })
+  })
+
+  test('stores records and lists only requested scope/status', () => {
+    saveMemoryRecord({
+      id: 'mem-1',
+      scopeId: 'group-1',
+      scopeType: 'group',
+      kind: 'decision',
+      content: 'The group decided to release on Fridays.',
+      summary: 'Friday releases',
+      tags: ['release'],
+      confidence: 0.9,
+      status: 'active',
+      source: 'background',
+      evidence: { messageIds: ['m1'] },
+      createdAt: '2026-06-11T00:00:00.000Z',
+      updatedAt: '2026-06-11T00:00:00.000Z',
+      lastSeenAt: '2026-06-11T00:00:00.000Z',
+    })
+
+    expect(listMemoryRecords({ scopeId: 'group-1', status: 'active' }).map((r) => r.id)).toEqual(['mem-1'])
+    expect(listMemoryRecords({ scopeId: 'user-1', status: 'active' })).toEqual([])
+  })
+
+  test('searches active records with FTS', () => {
+    saveMemoryRecord({
+      id: 'mem-2',
+      scopeId: 'user-1',
+      scopeType: 'personal',
+      kind: 'preference',
+      content: 'User prefers concise implementation plans.',
+      summary: 'Concise plans',
+      tags: ['style'],
+      confidence: 1,
+      status: 'active',
+      source: 'explicit',
+      evidence: {},
+      createdAt: '2026-06-11T00:00:00.000Z',
+      updatedAt: '2026-06-11T00:00:00.000Z',
+      lastSeenAt: '2026-06-11T00:00:00.000Z',
+    })
+
+    expect(searchMemoryRecords({ scopeId: 'user-1', query: 'concise', includeStale: false }).map((r) => r.id)).toEqual([
+      'mem-2',
+    ])
+  })
+
+  test('archives a record and clears a scope', () => {
+    saveMemoryRecord({
+      id: 'mem-3',
+      scopeId: 'user-1',
+      scopeType: 'personal',
+      kind: 'reference',
+      content: 'User shared a reusable setup link.',
+      summary: null,
+      tags: [],
+      confidence: 0.7,
+      status: 'active',
+      source: 'explicit',
+      evidence: {},
+      createdAt: '2026-06-11T00:00:00.000Z',
+      updatedAt: '2026-06-11T00:00:00.000Z',
+      lastSeenAt: '2026-06-11T00:00:00.000Z',
+    })
+
+    expect(archiveMemoryRecord('user-1', 'mem-3', '2026-06-12T00:00:00.000Z')).toBe(true)
+    expect(listMemoryRecords({ scopeId: 'user-1', status: 'active' })).toEqual([])
+    expect(clearMemoryScope({ scopeId: 'user-1', scopeType: 'personal' })).toEqual({
+      recordsDeleted: 1,
+      profileDeleted: 0,
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run store tests and verify failure**
+
+Run:
+
+```bash
+bun test tests/long-term-memory/store.test.ts
+```
+
+Expected: FAIL because `src/long-term-memory/store.ts` does not exist.
+
+- [ ] **Step 3: Extend types**
+
+Add to `src/long-term-memory/types.ts`:
+
+```ts
+export type MemoryProfile = MemoryScope &
+  Readonly<{
+    profile: string
+    enabled: boolean
+    version: number
+    updatedAt: string
+  }>
+
+export type MemoryEvidence = Readonly<{
+  messageIds?: readonly string[]
+  actorIds?: readonly string[]
+  timestamps?: readonly string[]
+  contextId?: string
+}>
+
+export type MemoryRecord = MemoryScope &
+  Readonly<{
+    id: string
+    kind: MemoryKind
+    content: string
+    summary: string | null
+    tags: readonly string[]
+    confidence: number
+    status: MemoryStatus
+    source: MemorySource
+    evidence: MemoryEvidence
+    createdAt: string
+    updatedAt: string
+    lastSeenAt: string
+    validFrom?: string | null
+    validUntil?: string | null
+    expiresAt?: string | null
+    embedding?: Float32Array | null
+  }>
+
+export type MemoryRecordInput = Omit<MemoryRecord, 'embedding'> & Readonly<{ embedding?: Float32Array | null }>
+```
+
+- [ ] **Step 4: Implement store helpers**
+
+Create `src/long-term-memory/store.ts` with these exported functions:
+
+```ts
+export function getMemoryProfile(scope: MemoryScope): MemoryProfile | null
+export function saveMemoryProfile(scope: MemoryScope, profile: string, now: string): MemoryProfile
+export function setMemoryCaptureEnabled(scope: MemoryScope, enabled: boolean, now: string): MemoryProfile
+export function saveMemoryRecord(input: MemoryRecordInput): MemoryRecord
+export function listMemoryRecords(filter: ListMemoryRecordsFilter): readonly MemoryRecord[]
+export function searchMemoryRecords(filter: SearchMemoryRecordsFilter): readonly MemoryRecord[]
+export function archiveMemoryRecord(scopeId: string, recordId: string, now: string): boolean
+export function clearMemoryScope(scope: MemoryScope): { profileDeleted: number; recordsDeleted: number }
+```
+
+Use the same JSON parsing style as `src/memos.ts`:
+
+```ts
+const parseTags = (json: string): readonly string[] => {
+  const parsed: unknown = JSON.parse(json)
+  return Array.isArray(parsed) ? parsed.filter((tag): tag is string => typeof tag === 'string') : []
+}
+
+const parseEvidence = (json: string): MemoryEvidence => {
+  const parsed: unknown = JSON.parse(json)
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+  return parsed as MemoryEvidence
+}
+```
+
+Use FTS query sanitization from `src/memos.ts`:
+
+```ts
+const sanitizeFtsQuery = (query: string): string => `"${query.replace(/"/gu, '""')}"`
+```
+
+For `searchMemoryRecords`, filter by `scope_id`, include `active` records by default, and include `stale` only when `includeStale` is true.
+
+- [ ] **Step 5: Verify and commit**
+
+Run:
+
+```bash
+bun test tests/long-term-memory/store.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/long-term-memory/types.ts src/long-term-memory/store.ts tests/long-term-memory/store.test.ts
+git commit -m "feat(memory): add long-term memory store"
+```
+
+---
+
+### Task 4: Bounded Context Injection
+
+**Files:**
+
+- Create: `src/long-term-memory/context.ts`
+- Modify: `src/conversation.ts`
+- Test: `tests/long-term-memory/context.test.ts`
+- Test: `tests/conversation.test.ts`
+
+- [ ] **Step 1: Write context builder tests**
+
+Create `tests/long-term-memory/context.test.ts`:
+
+```ts
+import { describe, expect, test } from 'bun:test'
+
+import { buildLongTermMemoryContextMessage } from '../../src/long-term-memory/context.js'
+import type { MemoryRecord } from '../../src/long-term-memory/types.js'
+
+const record = (id: string, content: string, status: 'active' | 'stale' = 'active'): MemoryRecord => ({
+  id,
+  scopeId: 'user-1',
+  scopeType: 'personal',
+  kind: 'preference',
+  content,
+  summary: content,
+  tags: [],
+  confidence: 0.9,
+  status,
+  source: 'background',
+  evidence: {},
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  lastSeenAt: '2026-06-11T00:00:00.000Z',
+})
+
+describe('buildLongTermMemoryContextMessage', () => {
+  test('returns null when profile and records are empty', () => {
+    expect(buildLongTermMemoryContextMessage({ profile: null, records: [] })).toBeNull()
+  })
+
+  test('renders trust-labelled profile and at most three records', () => {
+    const message = buildLongTermMemoryContextMessage({
+      profile: '## Communication\n- User prefers concise replies.',
+      records: [record('1', 'One'), record('2', 'Two'), record('3', 'Three'), record('4', 'Four')],
+    })
+
+    expect(message?.role).toBe('system')
+    expect(message?.content).toContain('<long_term_memory trust="profile_and_retrieved_low">')
+    expect(message?.content).toContain('<profile>')
+    expect(message?.content).toContain('User prefers concise replies')
+    expect(message?.content).toContain('id="1"')
+    expect(message?.content).toContain('id="3"')
+    expect(message?.content).not.toContain('id="4"')
+  })
+
+  test('marks stale records in the rendered block', () => {
+    const message = buildLongTermMemoryContextMessage({
+      profile: null,
+      records: [record('stale-1', 'Old fact', 'stale')],
+    })
+    expect(message?.content).toContain('status="stale"')
+  })
+})
+```
+
+- [ ] **Step 2: Write conversation integration test**
+
+Extend `tests/conversation.test.ts` with a case that seeds a profile and an active record, then calls `buildMessagesWithMemory('user-1', [])` and asserts that the first system message contains both `<long_term_memory` and the existing `<memory trust="compacted_low">` only when both layers are present.
+
+Use this assertion shape:
+
+```ts
+expect(result.messages[0]?.role).toBe('system')
+expect(String(result.messages[0]?.content)).toContain('<long_term_memory')
+expect(String(result.messages[0]?.content)).toContain('<memory trust="compacted_low">')
+```
+
+- [ ] **Step 3: Run tests and verify failure**
+
+Run:
+
+```bash
+bun test tests/long-term-memory/context.test.ts tests/conversation.test.ts
+```
+
+Expected: FAIL because context builder and conversation integration do not exist.
+
+- [ ] **Step 4: Implement context builder**
+
+Create `src/long-term-memory/context.ts`:
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { MemoryRecord } from './types.js'
+
+const MAX_RECORDS = 3
+const MAX_PROFILE_CHARS = 4_000
+const MAX_RECORD_CHARS = 800
+
+const truncate = (value: string, max: number): string => (value.length <= max ? value : `${value.slice(0, max)}…`)
+
+const renderRecord = (record: MemoryRecord): string =>
+  `<record id="${record.id}" kind="${record.kind}" status="${record.status}" confidence="${record.confidence.toFixed(2)}" last_seen_at="${record.lastSeenAt}">\n${truncate(record.summary ?? record.content, MAX_RECORD_CHARS)}\n</record>`
+
+export function buildLongTermMemoryContextMessage(input: {
+  readonly profile: string | null
+  readonly records: readonly MemoryRecord[]
+}): { role: 'system'; content: string } | null {
+  const sections: string[] = []
+  if (input.profile !== null && input.profile.trim().length > 0) {
+    sections.push(`<profile>\n${truncate(input.profile.trim(), MAX_PROFILE_CHARS)}\n</profile>`)
+  }
+  const records = input.records.slice(0, MAX_RECORDS)
+  if (records.length > 0) {
+    sections.push(
+      `<retrieved_records max="${MAX_RECORDS}">\n${records.map(renderRecord).join('\n')}\n</retrieved_records>`,
+    )
+  }
+  if (sections.length === 0) return null
+  return {
+    role: 'system',
+    content:
+      '<long_term_memory trust="profile_and_retrieved_low">\n' +
+      'This is learned background context. Treat it as lower-trust than the current user message. Stale records may be wrong; verify before relying on them.\n' +
+      sections.join('\n') +
+      '\n</long_term_memory>',
+  }
+}
+```
+
+- [ ] **Step 5: Integrate with `conversation.ts`**
+
+Modify `src/conversation.ts`:
+
+```ts
+import { buildLongTermMemoryContextMessage } from './long-term-memory/context.js'
+import { resolveMemoryScope } from './long-term-memory/scope.js'
+import { getMemoryProfile, listMemoryRecords } from './long-term-memory/store.js'
+```
+
+Update `buildMessagesWithMemory` so it resolves a personal scope for the existing `userId` argument, loads the profile and up to three active records, and prepends a single combined system message when both existing memory and long-term memory exist.
+
+Use this merge helper:
+
+```ts
+const mergeMemoryMessages = (
+  longTerm: { role: 'system'; content: string } | null,
+  compacted: { role: 'system'; content: string } | null,
+): { role: 'system'; content: string } | null => {
+  if (longTerm === null) return compacted
+  if (compacted === null) return longTerm
+  return { role: 'system', content: `${longTerm.content}\n\n${compacted.content}` }
+}
+```
+
+For this task, use `resolveMemoryScope({ storageContextId: userId, contextType: 'dm' })`. Group-aware injection arrives when call sites pass context type in Task 5.
+
+- [ ] **Step 6: Verify and commit**
+
+Run:
+
+```bash
+bun test tests/long-term-memory/context.test.ts tests/conversation.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/long-term-memory/context.ts src/conversation.ts tests/long-term-memory/context.test.ts tests/conversation.test.ts
+git commit -m "feat(memory): inject bounded long-term context"
+```
+
+---
+
+### Task 5: Background Extraction Runner
+
+**Files:**
+
+- Create: `src/long-term-memory/extractor.ts`
+- Create: `src/long-term-memory/runner.ts`
+- Modify: `src/llm-history.ts`
+- Modify: `src/conversation.ts`
+- Test: `tests/long-term-memory/extractor.test.ts`
+- Test: `tests/long-term-memory/runner.test.ts`
+- Test: `tests/llm-history.test.ts`
+
+- [ ] **Step 1: Write extractor tests**
+
+Create `tests/long-term-memory/extractor.test.ts`:
+
+```ts
+import { describe, expect, test } from 'bun:test'
+
+import { parseMemoryPatch } from '../../src/long-term-memory/extractor.js'
+
+describe('parseMemoryPatch', () => {
+  test('parses valid JSON patch', () => {
+    const patch = parseMemoryPatch(
+      `{"profile":"## Style\\n- Concise","records":[{"kind":"preference","content":"User prefers concise replies","summary":"Concise replies","tags":["style"],"confidence":0.9,"source":"background","evidence":{"messageIds":["m1"]}}],"updates":[]}`,
+    )
+
+    expect(patch.profile).toContain('Concise')
+    expect(patch.records).toHaveLength(1)
+    expect(patch.records[0]?.kind).toBe('preference')
+  })
+
+  test('rejects malformed model output', () => {
+    expect(() => parseMemoryPatch('not json')).toThrow(/invalid memory patch/u)
+  })
+
+  test('rejects out-of-range confidence', () => {
+    expect(() =>
+      parseMemoryPatch(
+        `{"profile":null,"records":[{"kind":"fact","content":"x","summary":null,"tags":[],"confidence":2,"source":"background","evidence":{}}],"updates":[]}`,
+      ),
+    ).toThrow(/invalid memory patch/u)
+  })
+})
+```
+
+- [ ] **Step 2: Write runner tests**
+
+Create `tests/long-term-memory/runner.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { setupTestDb } from '../utils/db.js'
+import { getMemoryProfile, listMemoryRecords } from '../../src/long-term-memory/store.js'
+import { runMemoryExtractionInBackground } from '../../src/long-term-memory/runner.js'
+
+describe('runMemoryExtractionInBackground', () => {
+  beforeEach(() => {
+    setupTestDb()
+  })
+
+  test('applies a model patch to the normalized scope', async () => {
+    await runMemoryExtractionInBackground({
+      storageContextId: 'user-1',
+      contextType: 'dm',
+      configContextId: 'user-1',
+      history: [{ role: 'user', content: 'Remember I prefer concise replies.' }],
+      deps: {
+        resolveLlmConfig: () => ({ ok: false, source: 'global', type: 'missing', missing: [] }),
+        generatePatch: async () => ({
+          profile: '## Communication\n- User prefers concise replies.',
+          records: [
+            {
+              kind: 'preference',
+              content: 'User prefers concise replies.',
+              summary: 'Concise replies',
+              tags: ['style'],
+              confidence: 1,
+              source: 'background',
+              evidence: { messageIds: [] },
+            },
+          ],
+          updates: [],
+        }),
+        now: () => '2026-06-11T00:00:00.000Z',
+      },
+    })
+
+    expect(getMemoryProfile({ scopeId: 'user-1', scopeType: 'personal' })?.profile).toContain('Concise')
+    expect(listMemoryRecords({ scopeId: 'user-1', status: 'active' })).toHaveLength(1)
+  })
+})
+```
+
+- [ ] **Step 3: Run tests and verify failure**
+
+Run:
+
+```bash
+bun test tests/long-term-memory/extractor.test.ts tests/long-term-memory/runner.test.ts
+```
+
+Expected: FAIL because extractor and runner do not exist.
+
+- [ ] **Step 4: Implement extractor parser and prompt**
+
+Create `src/long-term-memory/extractor.ts` with:
+
+```ts
+export const MemoryPatchSchema = z.object({
+  profile: z.string().nullable(),
+  records: z.array(
+    z.object({
+      kind: MemoryKindSchema,
+      content: z.string().min(3).max(2_000),
+      summary: z.string().max(300).nullable(),
+      tags: z.array(z.string().min(1).max(40)).max(10),
+      confidence: z.number().min(0).max(1),
+      source: MemorySourceSchema,
+      evidence: z.object({
+        messageIds: z.array(z.string()).optional(),
+        actorIds: z.array(z.string()).optional(),
+        timestamps: z.array(z.string()).optional(),
+        contextId: z.string().optional(),
+      }),
+      expiresAt: z.string().nullable().optional(),
+      validFrom: z.string().nullable().optional(),
+      validUntil: z.string().nullable().optional(),
+    }),
+  ),
+  updates: z.array(
+    z.object({
+      id: z.string(),
+      status: MemoryStatusSchema.optional(),
+      content: z.string().min(3).max(2_000).optional(),
+      confidence: z.number().min(0).max(1).optional(),
+    }),
+  ),
+})
+
+export type MemoryPatch = z.infer<typeof MemoryPatchSchema>
+
+export function parseMemoryPatch(text: string): MemoryPatch {
+  const match = text.match(/\{[\s\S]*\}/u)
+  if (match === null) throw new Error('invalid memory patch: no JSON object')
+  try {
+    const parsed = JSON.parse(match[0]) as unknown
+    const result = MemoryPatchSchema.safeParse(parsed)
+    if (!result.success) throw new Error(result.error.message)
+    return result.data
+  } catch (error) {
+    throw new Error(`invalid memory patch: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+```
+
+Also export `extractMemoryPatch(...)` that calls `generateText` with a prompt instructing the model to return only the JSON shape above, skip secrets/private sensitive data, and be conservative.
+
+- [ ] **Step 5: Implement runner**
+
+Create `src/long-term-memory/runner.ts` with:
+
+```ts
+const inFlight = new Set<string>()
+
+export async function runMemoryExtractionInBackground(input: RunMemoryExtractionInput): Promise<void> {
+  const scope = resolveMemoryScope({ storageContextId: input.storageContextId, contextType: input.contextType })
+  if (inFlight.has(scope.scopeId)) return
+  inFlight.add(scope.scopeId)
+  try {
+    await performMemoryExtraction(input, scope)
+  } catch (error) {
+    log.warn(
+      { scopeId: scope.scopeId, error: error instanceof Error ? error.message : String(error) },
+      'Long-term memory extraction failed',
+    )
+  } finally {
+    inFlight.delete(scope.scopeId)
+  }
+}
+```
+
+`performMemoryExtraction` should:
+
+1. Return early when the profile exists and `enabled === false`.
+2. Load current profile and active records.
+3. Generate or accept a patch through injected deps.
+4. Save profile when `patch.profile !== null`.
+5. Insert patch records with generated UUIDs, `status: 'active'`, and `now`.
+6. Apply update status/content/confidence to existing records in the same scope.
+7. Log only counts and scope IDs, never profile or record content.
+
+- [ ] **Step 6: Trigger runner after assistant history append**
+
+Modify `src/llm-history.ts` so `appendAssistantHistory` accepts `contextType` and invokes memory extraction when trim triggers:
+
+```ts
+if (shouldTriggerTrim(combined, mainModel)) {
+  void runTrimInBackground(contextId, combined, undefined, configId)
+  void runMemoryExtractionInBackground({
+    storageContextId: contextId,
+    contextType,
+    configContextId: configId,
+    history: combined,
+  })
+}
+```
+
+Modify the call in `src/llm-orchestrator.ts` to pass `contextType`.
+
+- [ ] **Step 7: Verify and commit**
+
+Run:
+
+```bash
+bun test tests/long-term-memory/extractor.test.ts tests/long-term-memory/runner.test.ts tests/llm-history.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/long-term-memory/extractor.ts src/long-term-memory/runner.ts src/llm-history.ts src/llm-orchestrator.ts tests/long-term-memory/extractor.test.ts tests/long-term-memory/runner.test.ts tests/llm-history.test.ts
+git commit -m "feat(memory): capture long-term memory in background"
+```
+
+---
+
+### Task 6: Agent Memory Tools
+
+**Files:**
+
+- Create: `src/tools/memory.ts`
+- Modify: `src/tools/provider-independent-tools-builder.ts`
+- Modify: `src/tools/tool-metadata.ts`
+- Test: `tests/tools/memory.test.ts`
+- Test: `tests/tools/tools-builder.test.ts`
+
+- [ ] **Step 1: Write tool tests**
+
+Create `tests/tools/memory.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { setupTestDb } from '../utils/db.js'
+import { makeListMemoryTool, makeRememberMemoryTool, makeSearchMemoryTool } from '../../src/tools/memory.js'
+
+describe('memory tools', () => {
+  beforeEach(() => {
+    setupTestDb()
+  })
+
+  test('remember_memory writes explicit memory to the current scope', async () => {
+    const tool = makeRememberMemoryTool({ storageContextId: 'user-1', contextType: 'dm' })
+    const result = await tool.execute!({ content: 'User prefers concise replies.', kind: 'preference' }, {} as never)
+    expect(result).toMatchObject({ status: 'saved', kind: 'preference' })
+  })
+
+  test('search_memory returns scoped matches', async () => {
+    const remember = makeRememberMemoryTool({ storageContextId: 'user-1', contextType: 'dm' })
+    await remember.execute!({ content: 'User prefers concise replies.', kind: 'preference' }, {} as never)
+
+    const search = makeSearchMemoryTool({ storageContextId: 'user-1', contextType: 'dm' })
+    const result = await search.execute!({ query: 'concise', include_stale: false }, {} as never)
+    expect(result).toMatchObject({ mode: 'keyword' })
+    expect(result.records).toHaveLength(1)
+  })
+
+  test('list_memory omits archived records by default', async () => {
+    const list = makeListMemoryTool({ storageContextId: 'user-1', contextType: 'dm' })
+    const result = await list.execute!({}, {} as never)
+    expect(result).toEqual({ records: [] })
+  })
+})
+```
+
+- [ ] **Step 2: Run tool tests and verify failure**
+
+Run:
+
+```bash
+bun test tests/tools/memory.test.ts
+```
+
+Expected: FAIL because `src/tools/memory.ts` does not exist.
+
+- [ ] **Step 3: Implement tool factories**
+
+Create `src/tools/memory.ts` with four exported factories:
+
+```ts
+export function makeSearchMemoryTool(input: MemoryToolContext): ToolSet[string]
+export function makeRememberMemoryTool(input: MemoryToolContext): ToolSet[string]
+export function makeForgetMemoryTool(input: MemoryToolContext): ToolSet[string]
+export function makeListMemoryTool(input: MemoryToolContext): ToolSet[string]
+```
+
+Use schemas:
+
+```ts
+const MemoryToolContextSchema = z.object({
+  storageContextId: z.string(),
+  contextType: z.enum(['dm', 'group']),
+})
+
+const RememberSchema = z.object({
+  content: z.string().min(3).max(2_000),
+  kind: MemoryKindSchema,
+  tags: z.array(z.string()).default([]),
+  expiry: z.string().optional(),
+})
+```
+
+Tool behavior:
+
+- `remember_memory`: save an `explicit` active record in `resolveMemoryScope(input)`.
+- `search_memory`: FTS search current scope; `include_stale` defaults false.
+- `list_memory`: list current scope by optional `kind` and optional `status`, default `active`.
+- `forget_memory`: archive by `memory_id` when provided; otherwise search by query and archive the best exact or first result. Return `{ status: 'forgotten' | 'not_found' }`.
+
+- [ ] **Step 4: Add tools to provider-independent builder**
+
+Modify `src/tools/provider-independent-tools-builder.ts`:
+
+```ts
+import { makeForgetMemoryTool, makeListMemoryTool, makeRememberMemoryTool, makeSearchMemoryTool } from './memory.js'
+
+function addMemoryTools(tools: ToolSet, contextId: string | undefined, contextType: ContextType | undefined): void {
+  if (contextId === undefined || contextType === undefined) return
+  tools['search_memory'] = makeSearchMemoryTool({ storageContextId: contextId, contextType })
+  tools['remember_memory'] = makeRememberMemoryTool({ storageContextId: contextId, contextType })
+  tools['forget_memory'] = makeForgetMemoryTool({ storageContextId: contextId, contextType })
+  tools['list_memory'] = makeListMemoryTool({ storageContextId: contextId, contextType })
+}
+```
+
+Call `addMemoryTools(tools, contextId, contextType)` after memo tools.
+
+- [ ] **Step 5: Add tool metadata**
+
+Modify `src/tools/tool-metadata.ts`:
+
+```ts
+export type ToolDomain /* existing union */ = 'memory'
+```
+
+Add:
+
+```ts
+search_memory: read('memory'),
+list_memory: read('memory'),
+remember_memory: write('memory', 'create'),
+forget_memory: destructive('memory'),
+```
+
+- [ ] **Step 6: Verify and commit**
+
+Run:
+
+```bash
+bun test tests/tools/memory.test.ts tests/tools/tools-builder.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/tools/memory.ts src/tools/provider-independent-tools-builder.ts src/tools/tool-metadata.ts tests/tools/memory.test.ts tests/tools/tools-builder.test.ts
+git commit -m "feat(memory): expose long-term memory tools"
+```
+
+---
+
+### Task 7: Settings API Controls
+
+**Files:**
+
+- Create: `src/debug/settings/memory-routes.ts`
+- Modify: `src/debug/settings-api-router.ts`
+- Test: `tests/debug/settings-memory-routes.test.ts`
+
+- [ ] **Step 1: Write settings route tests**
+
+Create `tests/debug/settings-memory-routes.test.ts` following the existing settings route auth pattern. Cover:
+
+```ts
+test('GET /settings/api/memory returns profile and active records for authorized personal scope', async () => {
+  // arrange authenticated settings session
+  // seed profile and one record
+  // fetch /settings/api/memory?contextId=<personal>
+  // assert { contextId, scopeType, profile, enabled, records }
+})
+
+test('PATCH /settings/api/memory/profile updates the profile with CSRF', async () => {
+  // send { contextId, profile: "## Communication\n- Concise" }
+  // assert profile persisted with source not logged
+})
+
+test('DELETE /settings/api/memory/records/:id archives only records in the authorized scope', async () => {
+  // seed two scopes, delete one record, assert other scope unchanged
+})
+
+test('POST /settings/api/memory/clear clears authorized scope', async () => {
+  // seed profile + record, call clear, assert both absent
+})
+```
+
+Use concrete request paths:
+
+- `GET /settings/api/memory?contextId=...`
+- `PATCH /settings/api/memory/profile`
+- `DELETE /settings/api/memory/records/:id`
+- `POST /settings/api/memory/clear`
+- `PATCH /settings/api/memory/capture`
+
+- [ ] **Step 2: Run route tests and verify failure**
+
+Run:
+
+```bash
+bun test tests/debug/settings-memory-routes.test.ts
+```
+
+Expected: FAIL because memory routes are not implemented.
+
+- [ ] **Step 3: Implement routes**
+
+Create `src/debug/settings/memory-routes.ts`:
+
+```ts
+const ProfilePatchSchema = z.object({
+  contextId: z.string().optional(),
+  profile: z.string().max(20_000),
+})
+
+const CapturePatchSchema = z.object({
+  contextId: z.string().optional(),
+  enabled: z.boolean(),
+})
+
+export function handleMemoryRoutes(req: Request, url: URL): Promise<Response> {
+  if (url.pathname === '/settings/api/memory' && req.method === 'GET') return Promise.resolve(handleGet(req, url))
+  if (url.pathname === '/settings/api/memory/profile' && req.method === 'PATCH') return handleProfilePatch(req)
+  if (url.pathname === '/settings/api/memory/capture' && req.method === 'PATCH') return handleCapturePatch(req)
+  if (url.pathname === '/settings/api/memory/clear' && req.method === 'POST') return handleClear(req)
+  if (url.pathname.startsWith('/settings/api/memory/records/') && req.method === 'DELETE')
+    return handleRecordDelete(req, url)
+  return Promise.resolve(settingsJson(404, { error: 'not found' }))
+}
+```
+
+Each write handler must:
+
+1. `authenticate(req)`.
+2. `requireCsrf(req, auth.authed)`.
+3. `parseJsonBody(req)` when a body is needed.
+4. `resolveContextScope(principal, 'write', body.contextId)`.
+5. Convert to memory scope with `{ scopeId: scope.scope.contextId, scopeType: scope.scope.kind }`.
+6. Call store functions.
+7. Log only scope ID, action, and counts.
+
+- [ ] **Step 4: Register settings route**
+
+Modify `src/debug/settings-api-router.ts`:
+
+```ts
+import { handleMemoryRoutes } from './settings/memory-routes.js'
+```
+
+Before the group route fallback, add:
+
+```ts
+if (url.pathname === '/settings/api/memory' || url.pathname.startsWith('/settings/api/memory/')) {
+  return handleMemoryRoutes(req, url)
+}
+```
+
+- [ ] **Step 5: Verify and commit**
+
+Run:
+
+```bash
+bun test tests/debug/settings-memory-routes.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/debug/settings/memory-routes.ts src/debug/settings-api-router.ts tests/debug/settings-memory-routes.test.ts
+git commit -m "feat(memory): add settings API controls"
+```
+
+---
+
+### Task 8: Settings UI Memory Section
+
+**Files:**
+
+- Modify: `client/settings/fetcher-schemas.ts`
+- Modify: `client/settings/fetchers.ts`
+- Create: `client/settings/sections/MemorySection.svelte`
+- Modify: `client/settings/SettingsApp.svelte`
+- Test: `tests/client/settings/MemorySection.test.ts`
+
+- [ ] **Step 1: Write client test**
+
+Create `tests/client/settings/MemorySection.test.ts`:
+
+```ts
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, render, screen, waitFor } from '@testing-library/svelte'
+
+import MemorySection from '../../../client/settings/sections/MemorySection.svelte'
+
+describe('MemorySection', () => {
+  afterEach(() => cleanup())
+
+  test('loads and renders memory profile and records', async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = Object.assign(
+      async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.startsWith('/settings/api/memory')) {
+          return Response.json({
+            contextId: 'user-1',
+            scopeType: 'personal',
+            enabled: true,
+            profile: '## Communication\n- Concise replies',
+            records: [
+              {
+                id: 'mem-1',
+                kind: 'preference',
+                content: 'User prefers concise replies.',
+                summary: 'Concise replies',
+                tags: ['style'],
+                confidence: 1,
+                status: 'active',
+                source: 'explicit',
+                createdAt: '2026-06-11T00:00:00.000Z',
+                updatedAt: '2026-06-11T00:00:00.000Z',
+                lastSeenAt: '2026-06-11T00:00:00.000Z',
+              },
+            ],
+          })
+        }
+        return new Response('not found', { status: 404 })
+      },
+      { preconnect: originalFetch.preconnect },
+    ) as typeof fetch
+
+    try {
+      render(MemorySection, { contextId: 'user-1' })
+      await waitFor(() => expect(screen.getByText('Memory')).toBeTruthy())
+      expect(screen.getByText(/Concise replies/u)).toBeTruthy()
+      expect(screen.getByText('preference')).toBeTruthy()
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run client test and verify failure**
+
+Run:
+
+```bash
+bun test:client tests/client/settings/MemorySection.test.ts
+```
+
+Expected: FAIL because `MemorySection.svelte` does not exist.
+
+- [ ] **Step 3: Add fetch schemas and fetchers**
+
+Modify `client/settings/fetcher-schemas.ts`:
+
+```ts
+export const MemoryRecordSchema = z.object({
+  id: z.string(),
+  kind: z.string(),
+  content: z.string(),
+  summary: z.string().nullable(),
+  tags: z.array(z.string()),
+  confidence: z.number(),
+  status: z.string(),
+  source: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  lastSeenAt: z.string(),
+})
+
+export const MemoryResponseSchema = z.object({
+  contextId: z.string(),
+  scopeType: z.enum(['personal', 'group']),
+  enabled: z.boolean(),
+  profile: z.string(),
+  records: z.array(MemoryRecordSchema),
+})
+
+export type MemoryResponse = z.infer<typeof MemoryResponseSchema>
+export type MemoryRecordView = z.infer<typeof MemoryRecordSchema>
+```
+
+Modify `client/settings/fetchers.ts`:
+
+```ts
+export const fetchMemory = (contextId: string): Promise<MemoryResponse> =>
+  getJson(`/settings/api/memory?${ctxQuery(contextId)}`, (b) => MemoryResponseSchema.parse(b))
+
+export const updateMemoryProfile = (input: { contextId: string; profile: string }): Promise<unknown> =>
+  writeJson('/settings/api/memory/profile', 'PATCH', input, (b) => b)
+
+export const setMemoryCapture = (input: { contextId: string; enabled: boolean }): Promise<unknown> =>
+  writeJson('/settings/api/memory/capture', 'PATCH', input, (b) => b)
+
+export const clearMemory = (input: { contextId: string }): Promise<unknown> =>
+  writeJson('/settings/api/memory/clear', 'POST', input, (b) => b)
+
+export const archiveMemoryRecord = (contextId: string, id: string): Promise<unknown> =>
+  settingsFetch(`/settings/api/memory/records/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json', 'X-Settings-CSRF': csrfToken },
+    body: JSON.stringify({ contextId }),
+  }).then(async (res) => {
+    if (!res.ok) throw new Error(await res.text())
+    return res.json()
+  })
+```
+
+- [ ] **Step 4: Implement UI section**
+
+Create `client/settings/sections/MemorySection.svelte` with:
+
+```svelte
+<script lang="ts">
+  import Btn from '../../shared/ui/Btn.svelte'
+  import EmptyState from '../../shared/ui/EmptyState.svelte'
+  import PageHeader from '../../shared/ui/PageHeader.svelte'
+  import Pill from '../../shared/ui/Pill.svelte'
+  import { clearMemory, fetchMemory, setMemoryCapture, updateMemoryProfile } from '../fetchers.js'
+  import type { MemoryRecordView } from '../fetcher-schemas.js'
+
+  interface Props { contextId: string }
+  let { contextId }: Props = $props()
+
+  let profile = $state('')
+  let enabled = $state(true)
+  let records: MemoryRecordView[] = $state([])
+  let loading = $state(false)
+  let error: string | null = $state(null)
+
+  async function load(id: string): Promise<void> {
+    loading = true
+    error = null
+    try {
+      const data = await fetchMemory(id)
+      profile = data.profile
+      enabled = data.enabled
+      records = data.records
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err)
+    } finally {
+      loading = false
+    }
+  }
+
+  async function saveProfile(): Promise<void> {
+    await updateMemoryProfile({ contextId, profile })
+    await load(contextId)
+  }
+
+  async function toggleCapture(): Promise<void> {
+    await setMemoryCapture({ contextId, enabled: !enabled })
+    await load(contextId)
+  }
+
+  async function onClear(): Promise<void> {
+    await clearMemory({ contextId })
+    await load(contextId)
+  }
+
+  $effect(() => { void load(contextId) })
+</script>
+
+<section id="memory" class="settings-section">
+  <PageHeader eyebrow="Context" title="Memory">
+    {#snippet action()}
+      <Btn variant="ghost" size="sm" onClick={() => void toggleCapture()}>
+        {#snippet children()}{enabled ? 'Disable capture' : 'Enable capture'}{/snippet}
+      </Btn>
+    {/snippet}
+  </PageHeader>
+
+  {#if error !== null}<p class="status-error">{error}</p>{/if}
+
+  <label class="settings-label" for="memory-profile">Pinned profile</label>
+  <textarea id="memory-profile" class="settings-textarea" bind:value={profile} rows="8" />
+  <div class="settings-actions">
+    <Btn size="sm" onClick={() => void saveProfile()}>{#snippet children()}Save profile{/snippet}</Btn>
+    <Btn variant="danger" size="sm" onClick={() => void onClear()}>{#snippet children()}Clear memory{/snippet}</Btn>
+  </div>
+
+  {#if records.length === 0 && !loading}
+    <EmptyState title="No memory records" hint="Learned records will appear here after conversations or explicit saves." />
+  {:else}
+    <div class="settings-memory-records">
+      {#each records as record (record.id)}
+        <article class="settings-memory-record">
+          <div><Pill tone="accent">{#snippet children()}{record.kind}{/snippet}</Pill> <Pill tone="mute">{#snippet children()}{record.status}{/snippet}</Pill></div>
+          <p>{record.summary ?? record.content}</p>
+          <small>{record.source} · {record.lastSeenAt}</small>
+        </article>
+      {/each}
+    </div>
+  {/if}
+</section>
+```
+
+Add CSS in the same file for `.settings-memory-records`, `.settings-memory-record`, `.settings-textarea`, and `.settings-actions` using existing settings colors and spacing.
+
+- [ ] **Step 5: Add section to Settings app**
+
+Modify `client/settings/SettingsApp.svelte`:
+
+```ts
+import MemorySection from './sections/MemorySection.svelte'
+```
+
+Add `{ id: 'memory', label: 'Memory' }` after Profile in the Personal group, and render:
+
+```svelte
+<MemorySection contextId={ctx} />
+```
+
+after `<ProfileSection contextId={ctx} />`.
+
+- [ ] **Step 6: Verify and commit**
+
+Run:
+
+```bash
+bun test:client tests/client/settings/MemorySection.test.ts
+bun test:client
+bun run typecheck
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add client/settings/fetcher-schemas.ts client/settings/fetchers.ts client/settings/sections/MemorySection.svelte client/settings/SettingsApp.svelte tests/client/settings/MemorySection.test.ts
+git commit -m "feat(memory): add settings memory controls"
+```
+
+---
+
+### Task 9: Decay Maintenance And Final Verification
+
+**Files:**
+
+- Create: `src/long-term-memory/maintenance.ts`
+- Modify: `src/scheduler-instance.ts`
+- Test: `tests/long-term-memory/maintenance.test.ts`
+
+- [ ] **Step 1: Write maintenance tests**
+
+Create `tests/long-term-memory/maintenance.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { setupTestDb } from '../utils/db.js'
+import { runMemoryMaintenance } from '../../src/long-term-memory/maintenance.js'
+import { listMemoryRecords, saveMemoryRecord } from '../../src/long-term-memory/store.js'
+
+describe('runMemoryMaintenance', () => {
+  beforeEach(() => setupTestDb())
+
+  test('marks old decisions stale and archives expired records', () => {
+    saveMemoryRecord({
+      id: 'old-decision',
+      scopeId: 'group-1',
+      scopeType: 'group',
+      kind: 'decision',
+      content: 'Release on Fridays.',
+      summary: 'Friday release',
+      tags: [],
+      confidence: 0.9,
+      status: 'active',
+      source: 'background',
+      evidence: {},
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      lastSeenAt: '2026-01-01T00:00:00.000Z',
+    })
+    saveMemoryRecord({
+      id: 'expired-reference',
+      scopeId: 'group-1',
+      scopeType: 'group',
+      kind: 'reference',
+      content: 'Temporary link.',
+      summary: null,
+      tags: [],
+      confidence: 0.7,
+      status: 'active',
+      source: 'explicit',
+      evidence: {},
+      createdAt: '2026-06-01T00:00:00.000Z',
+      updatedAt: '2026-06-01T00:00:00.000Z',
+      lastSeenAt: '2026-06-01T00:00:00.000Z',
+      expiresAt: '2026-06-10T00:00:00.000Z',
+    })
+
+    expect(runMemoryMaintenance('2026-06-11T00:00:00.000Z')).toEqual({ staleMarked: 1, archived: 1 })
+    expect(listMemoryRecords({ scopeId: 'group-1', status: 'stale' }).map((r) => r.id)).toEqual(['old-decision'])
+    expect(listMemoryRecords({ scopeId: 'group-1', status: 'archived' }).map((r) => r.id)).toEqual([
+      'expired-reference',
+    ])
+  })
+})
+```
+
+- [ ] **Step 2: Run maintenance tests and verify failure**
+
+Run:
+
+```bash
+bun test tests/long-term-memory/maintenance.test.ts
+```
+
+Expected: FAIL because maintenance does not exist.
+
+- [ ] **Step 3: Implement maintenance**
+
+Create `src/long-term-memory/maintenance.ts`:
+
+```ts
+const STALE_DAYS_BY_KIND: Record<MemoryKind, number> = {
+  preference: 180,
+  procedure: 180,
+  decision: 90,
+  project_context: 90,
+  person_context: 90,
+  episode: 45,
+  reference: 45,
+  fact: 90,
+}
+
+const dayMs = 24 * 60 * 60 * 1000
+const cutoff = (nowMs: number, days: number): string => new Date(nowMs - days * dayMs).toISOString()
+
+export function runMemoryMaintenance(nowIso: string = new Date().toISOString()): {
+  staleMarked: number
+  archived: number
+} {
+  const db = getDrizzleDb().$client
+  const nowMs = Date.parse(nowIso)
+  let staleMarked = 0
+  for (const [kind, days] of Object.entries(STALE_DAYS_BY_KIND) as [MemoryKind, number][]) {
+    const result = db
+      .prepare(
+        `UPDATE memory_records SET status = 'stale', updated_at = ? WHERE kind = ? AND status = 'active' AND source != 'explicit' AND last_seen_at <= ?`,
+      )
+      .run(nowIso, kind, cutoff(nowMs, days))
+    staleMarked += result.changes
+  }
+  const archived = db
+    .prepare(
+      `UPDATE memory_records SET status = 'archived', updated_at = ? WHERE status != 'archived' AND expires_at IS NOT NULL AND expires_at <= ?`,
+    )
+    .run(nowIso, nowIso).changes
+  log.info({ staleMarked, archived }, 'Long-term memory maintenance complete')
+  return { staleMarked, archived }
+}
+```
+
+- [ ] **Step 4: Register scheduler task**
+
+Modify `src/scheduler-instance.ts`:
+
+```ts
+import { runMemoryMaintenance } from './long-term-memory/maintenance.js'
+```
+
+Register:
+
+```ts
+scheduler.register('long-term-memory-maintenance', {
+  interval: 60 * 60 * 1000,
+  handler: () => {
+    runMemoryMaintenance()
+  },
+})
+```
+
+Follow the surrounding task registration style exactly.
+
+- [ ] **Step 5: Final verification**
+
+Run focused tests:
+
+```bash
+bun test tests/long-term-memory
+bun test tests/tools/memory.test.ts
+bun test tests/debug/settings-memory-routes.test.ts
+bun test:client tests/client/settings/MemorySection.test.ts
+```
+
+Run broader checks:
+
+```bash
+bun run test
+bun test:client
+bun run typecheck
+bun run format:check
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/long-term-memory/maintenance.ts src/scheduler-instance.ts tests/long-term-memory/maintenance.test.ts
+git commit -m "feat(memory): retire stale long-term memories"
+```
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+- Background capture: Task 5.
+- Personal and group memory: Tasks 2, 3, 5, 6, 7, 8.
+- Group memory shared across threads: Task 2 and Task 5.
+- Bounded context: Task 4.
+- Agent retrieval tools: Task 6.
+- Timestamps, confidence, evidence, status, decay: Tasks 1, 3, 5, 9.
+- User/admin controls: Tasks 7 and 8.
+- SQLite/settings/tool-permission fit: Tasks 1, 6, 7, 8.
+
+Placeholder scan:
+
+- No placeholder markers or open-ended steps.
+- Every task has concrete files, tests, commands, and expected outcomes.
+
+Type consistency:
+
+- Scope types use `personal | group`.
+- Record kinds/status/source values match the design spec and migration checks.
+- Tool names match the planned metadata and builder integration.

--- a/docs/superpowers/specs/2026-06-11-long-term-memory-design.md
+++ b/docs/superpowers/specs/2026-06-11-long-term-memory-design.md
@@ -1,0 +1,313 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Long-Term Memory Design
+
+**Date:** 2026-06-11
+**Status:** Approved for implementation planning
+
+## Problem
+
+papai already has useful memory primitives, but they are not a complete long-term memory system:
+
+| Layer                                   | Current behavior                                                           | Gap                                                    |
+| --------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Conversation history + `memory_summary` | Stores recent turns and a compacted low-trust summary                      | Mostly short-term narrative context                    |
+| `memory_facts`                          | Stores recently accessed task/project entities with staleness and eviction | Entity pointers only, not learned knowledge            |
+| `memos`                                 | Explicit user notes with FTS5 and optional embeddings                      | User/tool initiated, not automatic background learning |
+| `user_instructions`                     | Explicit durable instructions                                              | Not implicit preferences, decisions, or shared context |
+
+The missing capability is a default-on, controllable long-term memory layer that learns durable personal and group context in the background, keeps that context organized, makes it easy for agents to retrieve, and prevents stale memories from polluting every turn.
+
+## Goals
+
+- Capture durable memory in the background after conversations without delaying replies.
+- Support both personal memory and group memory.
+- Share long-term group memory across threads inside the same group chat.
+- Keep default prompt context small and trust-labelled.
+- Make deeper memory easy to retrieve through tools.
+- Track timestamps, confidence, evidence pointers, status, and decay metadata.
+- Provide clear controls to view, correct, delete, clear, and disable memory.
+- Fit papai's existing SQLite, settings UI, tool permission, and context-scoping model.
+
+## Non-Goals
+
+- Do not adopt an external memory platform for the first implementation.
+- Do not build a full temporal knowledge graph in this phase.
+- Do not share private personal memory into groups by default.
+- Do not store raw message text as evidence for generated memories.
+- Do not replace existing memos, instructions, summary, or entity memory in the first pass.
+
+## Research Summary
+
+The selected architecture follows a hybrid pattern common across current agent-memory systems:
+
+- **mem0-style layered memory:** memory is scoped by user/session-like identifiers and retrieved by metadata rather than injected wholesale.
+- **LangMem-style memory managers:** separates semantic, episodic, and procedural memory, with application-owned schemas and background extraction.
+- **Letta-style core + archival memory:** small always-visible core memory plus larger searchable archival memory.
+- **Zep-style temporal facts:** memories benefit from validity and expiration timestamps, but a full graph engine is not necessary for papai's next step.
+- **Anthropic context-engineering guidance:** keep default context bounded and use just-in-time retrieval for deeper knowledge.
+
+References:
+
+- mem0 memory types: <https://docs.mem0.ai/core-concepts/memory-types>
+- LangMem concepts: <https://langchain-ai.github.io/langmem/concepts/conceptual_guide/>
+- Letta memory blocks: <https://docs.letta.com/guides/core-concepts/memory/memory-blocks>
+- Letta archival memory: <https://docs.letta.com/guides/core-concepts/memory/archival-memory/>
+- Zep concepts: <https://help.getzep.com/concepts>
+- Zep facts: <https://help.getzep.com/facts>
+- Anthropic context engineering: <https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents>
+
+## Chosen Approach
+
+Use a **hybrid profile + memory records** design.
+
+Each memory scope has:
+
+1. **Pinned profile** — a small, always-injected projection of the most important stable context.
+2. **Memory records** — individual typed, timestamped, searchable long-term memories that are recalled by tools or a bounded relevance pass.
+
+This gives agents immediate access to high-signal context while keeping detailed memory out of the prompt until it is relevant.
+
+Rejected alternatives:
+
+- **Pinned profile only:** too likely to either grow noisy or lose important detail.
+- **Temporal graph memory:** powerful, but overbuilt for the first version and expensive to design correctly.
+
+## Scope Model
+
+Long-term memory uses normalized memory scopes, not raw conversation context IDs in every case.
+
+| Conversation                | Long-term memory scope           |
+| --------------------------- | -------------------------------- |
+| Personal DM                 | The personal user/context scope  |
+| Telegram group thread/topic | The parent group chat scope      |
+| Mattermost group thread     | The parent group chat scope      |
+| Discord group/channel       | The existing group/channel scope |
+
+Telegram and Mattermost may keep thread-scoped short-term conversation history, but long-term group memory intentionally rolls up to the parent group chat. A decision learned in one thread should be available in another thread in the same group.
+
+No cross-scope recall happens implicitly:
+
+- A group turn does not read private personal memory.
+- A personal DM turn does not read group memory.
+- Future cross-scope recall would require explicit design and user-visible controls.
+
+## Data Model
+
+### `memory_profiles`
+
+One pinned profile per normalized memory scope.
+
+Fields:
+
+- `scope_id`: normalized personal or parent-group memory scope.
+- `scope_type`: `personal` or `group`.
+- `profile`: small markdown or structured text block.
+- `updated_at`: ISO timestamp.
+- `version`: integer for future optimistic updates or profile regeneration tracking.
+
+The profile is not the source of truth. It is a compact projection synthesized from active records plus recent conversation.
+
+### `memory_records`
+
+Individual searchable long-term memories.
+
+Fields:
+
+- `id`: UUID.
+- `scope_id`: normalized memory scope.
+- `scope_type`: `personal` or `group`.
+- `kind`: one of `preference`, `fact`, `decision`, `project_context`, `person_context`, `procedure`, `episode`, `reference`.
+- `content`: concise natural-language memory.
+- `summary`: optional one-line display and retrieval text.
+- `tags`: JSON array.
+- `confidence`: number from `0.0` to `1.0`.
+- `status`: `active`, `stale`, `archived`, or `contradicted`.
+- `source`: `background`, `explicit`, `tool_result`, or `admin_edit`.
+- `evidence`: compact JSON containing message IDs, timestamps, actor IDs, and source context where available.
+- `created_at`, `updated_at`, `last_seen_at`: ISO timestamps.
+- `valid_from`, `valid_until`: optional validity window.
+- `expires_at`: optional hard expiration timestamp.
+- `embedding`: optional blob, following the existing memo embedding pattern.
+
+Indexes:
+
+- `(scope_id, status, last_seen_at)`
+- `(scope_id, kind, status)`
+- FTS5 over `content`, `summary`, and serialized tags.
+- Optional embedding lookup by current `scope_id`, with in-app cosine similarity.
+
+SQLite + FTS5 + in-app cosine is sufficient for the initial scale. A vector database or graph database should be reconsidered only if memory volume grows beyond the current memo-search assumptions or cross-scope semantic retrieval becomes a product requirement.
+
+## Decay And Retirement
+
+Records gradually lose authority before they disappear.
+
+Default staleness windows:
+
+| Kind              | Stale after unseen |
+| ----------------- | ------------------ |
+| `preference`      | 180 days           |
+| `procedure`       | 180 days           |
+| `decision`        | 90 days            |
+| `project_context` | 90 days            |
+| `person_context`  | 90 days            |
+| `episode`         | 45 days            |
+| `reference`       | 45 days            |
+| `fact`            | 90 days            |
+
+Explicit memories do not auto-expire unless the user sets an expiry or deletes them.
+
+Maintenance should run periodically and:
+
+- mark records stale after their kind-specific window;
+- archive records whose `expires_at` has passed;
+- leave explicit memories alone unless expired or deleted;
+- regenerate pinned profiles from active records when profile drift is likely.
+
+Hard deletion is only for explicit user/admin deletion or full clear operations.
+
+## Background Capture
+
+Memory capture runs after the assistant has replied and never blocks the user-facing response.
+
+The extractor receives:
+
+- recent conversation window;
+- current pinned profile;
+- a small set of relevant existing records;
+- normalized memory scope metadata;
+- current date/time;
+- author and message metadata where available.
+
+It returns a structured patch:
+
+- profile rewrite or unchanged;
+- new records;
+- updates to existing records;
+- records to mark stale, contradicted, or archived;
+- confidence and evidence metadata.
+
+Extraction should be conservative:
+
+- Personal memory captures stable user identity, expertise, preferences, communication style, recurring defaults, and long-running personal context.
+- Group memory captures shared decisions, project context, group conventions, recurring references, and collaboration norms.
+- It should skip transient chatter, one-off trivia, secrets, credentials, sensitive private details, and unverified gossip.
+
+The runner should have an in-flight guard per normalized memory scope, similar to `runTrimInBackground`, so back-to-back turns do not race profile rewrites and record updates.
+
+## Retrieval
+
+Retrieval has two paths.
+
+### Default Context Injection
+
+Each turn gets a bounded memory block when memory exists:
+
+- pinned profile;
+- up to three fresh, high-confidence records relevant to the current turn;
+- trust and staleness guidance.
+
+The block must be labelled as compacted, possibly stale background context. The current user message always outranks memory when they conflict.
+
+### Agent Tools
+
+Expose memory tools through the existing tool permission system:
+
+- `search_memory(query, scope?, kind?, include_stale?)`
+- `remember_memory(content, kind, scope?, expiry?)`
+- `forget_memory(memory_id | query, scope?)`
+- `list_memory(kind?, status?, scope?)`
+
+Defaults:
+
+- In DMs, memory tools operate on personal memory.
+- In groups, memory tools operate on the parent group memory scope.
+- Cross-scope access is not implicit.
+
+Explicit requests like "remember this" or "forget that" should write immediately through hot-path tools. Implicit learning remains background-only.
+
+## Controls
+
+Memory is default-on for personal and group scopes, so controls are mandatory.
+
+Personal settings:
+
+- view profile;
+- search/list records;
+- inspect kind, status, source, confidence, and timestamps;
+- edit, archive, delete individual records;
+- clear all personal memory;
+- disable capture.
+
+Group settings for authorized group admins:
+
+- same controls for group memory;
+- changes apply to the parent group memory scope shared across threads.
+
+Chat-facing controls:
+
+- "what do you remember about me/us?";
+- "forget X";
+- "do not remember this";
+- explicit remember/save flows.
+
+Every displayed memory should show whether it came from background capture, explicit save, tool result, or admin edit.
+
+## Safety
+
+- Profile and memory record content must never be logged.
+- Evidence stores pointers and metadata, not full raw message text.
+- Secrets, credentials, sensitive private health/financial details, and one-off gossip are not captured.
+- Prompt-injection-shaped memory content is rendered as data, not instructions.
+- Stale records are labelled and should be verified before use.
+- Background extractor failures are logged and swallowed.
+- Group memory writes to the parent group memory scope and never imports private DM memory by default.
+- Settings and tool access must respect the existing authorization and tool-permission model.
+
+## Testing
+
+Core tests:
+
+- scope normalization: Telegram and Mattermost threads write long-term memory to the parent group scope;
+- personal/group isolation;
+- background extraction does not block replies;
+- in-flight guard prevents concurrent background memory writes for one scope;
+- profile injection stays bounded;
+- relevant-record injection respects limit, scope, status, and staleness;
+- `search_memory` respects scope, kind, status, and stale flags;
+- `remember_memory` writes immediately;
+- `forget_memory` marks records archived or deleted according to the requested action;
+- maintenance marks records stale and archives expired records;
+- prompt-injection-shaped memory content remains data;
+- settings/admin controls mutate only authorized scopes.
+
+Existing areas likely to receive tests:
+
+- `tests/conversation.test.ts`
+- `tests/memory*.test.ts`
+- `tests/tools/*memory*.test.ts`
+- `tests/db/migrations/*memory*.test.ts`
+- `tests/settings/*` or matching settings-route tests
+- group context tests covering parent group scope normalization
+
+## Implementation Notes
+
+The implementation plan should decide exact module boundaries, but the design expects these units:
+
+- scope normalization helper for long-term memory scope IDs;
+- profile store;
+- record store with FTS and optional embeddings;
+- background extraction runner;
+- memory patch parser/validator;
+- bounded context builder;
+- memory tools;
+- settings routes and UI controls;
+- scheduled maintenance pass.
+
+The first implementation should keep the graph door open by preserving evidence, timestamps, validity windows, and record kinds, but it should not build graph traversal or relationship storage yet.

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "dependency-cruiser": "^17.4.3",
     "drizzle-kit": "^0.31.10",
     "happy-dom": "^20.8.9",
-    "jscpd": "^4.2.2",
+    "jscpd": "^5.0.7",
     "knip": "^6.14.1",
     "msw": "^2",
     "msw-storybook-addon": "^2.0.7",

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -67,13 +67,18 @@ function resolveRegisterDeps(rest: readonly [ContextCommandDeps] | readonly []):
   return defaultDeps
 }
 
-function buildMemoryMessageText(contextId: string, history: readonly ModelMessage[]): string | null {
-  const { memoryMsg } = buildMessagesWithMemory(contextId, history)
+function buildMemoryMessageText(
+  contextId: string,
+  history: readonly ModelMessage[],
+  contextType: 'dm' | 'group',
+): string | null {
+  const { memoryMsg } = buildMessagesWithMemory(contextId, history, contextType)
   return memoryMsg === null ? null : memoryMsg.content
 }
 
 async function buildCollectorDeps(
   storageContextId: string,
+  contextType: 'dm' | 'group',
   provider: TaskProvider | null,
   resolvedToolSurface: ResolvedContextToolSurface,
   deps: ContextCommandDeps,
@@ -99,7 +104,7 @@ async function buildCollectorDeps(
     buildInstructionsBlock: () => buildInstructionsBlock(storageContextId),
     getProviderAddendum: () => (provider === null ? '' : provider.getPromptAddendum()),
     getHistory: () => loadHistory(storageContextId),
-    getMemoryMessage: () => buildMemoryMessageText(storageContextId, loadHistory(storageContextId)),
+    getMemoryMessage: () => buildMemoryMessageText(storageContextId, loadHistory(storageContextId), contextType),
     getSummary: () => loadSummary(storageContextId),
     getFacts: () => loadFacts(storageContextId),
     getActiveToolDefinitions: (): Record<string, unknown> => deps.resolveActiveToolDefinitions(resolvedToolSurface),
@@ -153,11 +158,12 @@ function renderContextForMessage(
 
 async function buildContextSnapshot(
   storageContextId: string,
+  contextType: 'dm' | 'group',
   provider: TaskProvider | null,
   resolvedToolSurface: ResolvedContextToolSurface,
   deps: ContextCommandDeps,
 ): Promise<ContextSnapshot> {
-  const collectorDeps = await buildCollectorDeps(storageContextId, provider, resolvedToolSurface, deps)
+  const collectorDeps = await buildCollectorDeps(storageContextId, contextType, provider, resolvedToolSurface, deps)
   return deps.collectContext(storageContextId, collectorDeps)
 }
 
@@ -195,7 +201,7 @@ async function handleContextCommand(
   )
   let snapshot: ContextSnapshot
   try {
-    snapshot = await buildContextSnapshot(auth.storageContextId, provider, resolvedToolSurface, deps)
+    snapshot = await buildContextSnapshot(auth.storageContextId, msg.contextType, provider, resolvedToolSurface, deps)
   } catch (error) {
     log.warn(
       {

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -10,6 +10,9 @@ import { getCachedHistory, setCachedHistory } from './cache.js'
 import { emitUser } from './debug/event-bus.js'
 import { resolveEffectiveLlmConfig } from './llm-config-resolver.js'
 import { logger } from './logger.js'
+import { buildLongTermMemoryContextMessage } from './long-term-memory/context.js'
+import { resolveMemoryScope } from './long-term-memory/scope.js'
+import { getMemoryProfile, listMemoryRecords } from './long-term-memory/store.js'
 import { buildMemoryContextMessage, loadFacts, loadSummary, saveSummary, trimWithMemoryModel } from './memory.js'
 import { estimateMessagesTokens, resolveMaxTokens } from './model-context.js'
 
@@ -60,7 +63,21 @@ const logTrimConfigFailure = (
 export const buildMessagesWithMemory = (userId: string, history: readonly ModelMessage[]): MessagesWithMemory => {
   const summary = loadSummary(userId)
   const facts = loadFacts(userId)
-  const memoryMsg = buildMemoryContextMessage(summary, facts)
+  const compactedMemoryMsg = buildMemoryContextMessage(summary, facts)
+  const scope = resolveMemoryScope({ storageContextId: userId, contextType: 'dm' })
+  const profile = getMemoryProfile(scope)?.profile ?? null
+  const records = listMemoryRecords({ ...scope, status: 'active' })
+  const longTermMemoryMsg = buildLongTermMemoryContextMessage({ profile, records })
+  const memoryMessages = [compactedMemoryMsg, longTermMemoryMsg].filter(
+    (message): message is { role: 'system'; content: string } => message !== null,
+  )
+  const memoryMsg =
+    memoryMessages.length === 0
+      ? null
+      : {
+          role: 'system' as const,
+          content: memoryMessages.map((message) => message.content).join('\n'),
+        }
   return { messages: memoryMsg === null ? [...history] : [memoryMsg, ...history], memoryMsg }
 }
 

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -66,7 +66,7 @@ export const buildMessagesWithMemory = (userId: string, history: readonly ModelM
   const compactedMemoryMsg = buildMemoryContextMessage(summary, facts)
   const scope = resolveMemoryScope({ storageContextId: userId, contextType: 'dm' })
   const profile = getMemoryProfile(scope)?.profile ?? null
-  const records = listMemoryRecords({ ...scope, status: 'active' })
+  const records = listMemoryRecords({ ...scope, status: 'active', limit: 3 })
   const longTermMemoryMsg = buildLongTermMemoryContextMessage({ profile, records })
   const memoryMessages = [compactedMemoryMsg, longTermMemoryMsg].filter(
     (message): message is { role: 'system'; content: string } => message !== null,

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -60,11 +60,15 @@ const logTrimConfigFailure = (
   )
 }
 
-export const buildMessagesWithMemory = (userId: string, history: readonly ModelMessage[]): MessagesWithMemory => {
+export const buildMessagesWithMemory = (
+  userId: string,
+  history: readonly ModelMessage[],
+  contextType: 'dm' | 'group' = 'dm',
+): MessagesWithMemory => {
   const summary = loadSummary(userId)
   const facts = loadFacts(userId)
   const compactedMemoryMsg = buildMemoryContextMessage(summary, facts)
-  const scope = resolveMemoryScope({ storageContextId: userId, contextType: 'dm' })
+  const scope = resolveMemoryScope({ storageContextId: userId, contextType })
   const profile = getMemoryProfile(scope)?.profile ?? null
   const records = listMemoryRecords({ ...scope, status: 'active', limit: 3 })
   const longTermMemoryMsg = buildLongTermMemoryContextMessage({ profile, records })

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -63,6 +63,7 @@ import { migration049NamespaceYoutrackConfig } from './migrations/049_namespace_
 import { migration050SettingsAuth } from './migrations/050_settings_auth.js'
 import { migration051LegacyContextIdBackfill } from './migrations/051_legacy_context_id_backfill.js'
 import { migration052ByokLlmCredentials } from './migrations/052_byok_llm_credentials.js'
+import { migration053LongTermMemory } from './migrations/053_long_term_memory.js'
 
 const getDbPath = (): string => {
   const dbPath = process.env['DB_PATH']
@@ -150,6 +151,7 @@ export const MIGRATIONS: readonly Migration[] = [
   migration050SettingsAuth,
   migration051LegacyContextIdBackfill,
   migration052ByokLlmCredentials,
+  migration053LongTermMemory,
 ]
 
 export const initDb = (): void => {

--- a/src/db/long-term-memory-schema.ts
+++ b/src/db/long-term-memory-schema.ts
@@ -3,6 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import { desc } from 'drizzle-orm'
 import { blob, index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 export const memoryProfiles = sqliteTable(
@@ -11,7 +12,7 @@ export const memoryProfiles = sqliteTable(
     scopeId: text('scope_id').primaryKey(),
     scopeType: text('scope_type', { enum: ['personal', 'group'] }).notNull(),
     profile: text('profile').notNull().default(''),
-    enabled: integer('enabled').notNull().default(1),
+    enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
     version: integer('version').notNull().default(1),
     updatedAt: text('updated_at').notNull(),
   },
@@ -52,7 +53,7 @@ export const memoryRecords = sqliteTable(
     embedding: blob('embedding'),
   },
   (table) => [
-    index('idx_memory_records_scope_status_seen').on(table.scopeId, table.status, table.lastSeenAt),
+    index('idx_memory_records_scope_status_seen').on(table.scopeId, table.status, desc(table.lastSeenAt)),
     index('idx_memory_records_scope_kind_status').on(table.scopeId, table.kind, table.status),
   ],
 )

--- a/src/db/long-term-memory-schema.ts
+++ b/src/db/long-term-memory-schema.ts
@@ -4,19 +4,22 @@
 // See LICENSE in the project root for details.
 
 import { desc } from 'drizzle-orm'
-import { blob, index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { blob, index, integer, primaryKey, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 export const memoryProfiles = sqliteTable(
   'memory_profiles',
   {
-    scopeId: text('scope_id').primaryKey(),
+    scopeId: text('scope_id').notNull(),
     scopeType: text('scope_type', { enum: ['personal', 'group'] }).notNull(),
     profile: text('profile').notNull().default(''),
     enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
     version: integer('version').notNull().default(1),
     updatedAt: text('updated_at').notNull(),
   },
-  (table) => [index('idx_memory_profiles_scope').on(table.scopeType, table.scopeId)],
+  (table) => [
+    primaryKey({ columns: [table.scopeType, table.scopeId] }),
+    index('idx_memory_profiles_scope').on(table.scopeType, table.scopeId),
+  ],
 )
 
 export const memoryRecords = sqliteTable(

--- a/src/db/long-term-memory-schema.ts
+++ b/src/db/long-term-memory-schema.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { blob, index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+export const memoryProfiles = sqliteTable(
+  'memory_profiles',
+  {
+    scopeId: text('scope_id').primaryKey(),
+    scopeType: text('scope_type', { enum: ['personal', 'group'] }).notNull(),
+    profile: text('profile').notNull().default(''),
+    enabled: integer('enabled').notNull().default(1),
+    version: integer('version').notNull().default(1),
+    updatedAt: text('updated_at').notNull(),
+  },
+  (table) => [index('idx_memory_profiles_scope').on(table.scopeType, table.scopeId)],
+)
+
+export const memoryRecords = sqliteTable(
+  'memory_records',
+  {
+    id: text('id').primaryKey(),
+    scopeId: text('scope_id').notNull(),
+    scopeType: text('scope_type', { enum: ['personal', 'group'] }).notNull(),
+    kind: text('kind', {
+      enum: [
+        'preference',
+        'fact',
+        'decision',
+        'project_context',
+        'person_context',
+        'procedure',
+        'episode',
+        'reference',
+      ],
+    }).notNull(),
+    content: text('content').notNull(),
+    summary: text('summary'),
+    tags: text('tags').notNull().default('[]'),
+    confidence: real('confidence').notNull(),
+    status: text('status', { enum: ['active', 'stale', 'archived', 'contradicted'] }).notNull(),
+    source: text('source', { enum: ['background', 'explicit', 'tool_result', 'admin_edit'] }).notNull(),
+    evidence: text('evidence').notNull().default('{}'),
+    createdAt: text('created_at').notNull(),
+    updatedAt: text('updated_at').notNull(),
+    lastSeenAt: text('last_seen_at').notNull(),
+    validFrom: text('valid_from'),
+    validUntil: text('valid_until'),
+    expiresAt: text('expires_at'),
+    embedding: blob('embedding'),
+  },
+  (table) => [
+    index('idx_memory_records_scope_status_seen').on(table.scopeId, table.status, table.lastSeenAt),
+    index('idx_memory_records_scope_kind_status').on(table.scopeId, table.kind, table.status),
+  ],
+)
+
+export type MemoryProfileRow = typeof memoryProfiles.$inferSelect
+export type MemoryRecordRow = typeof memoryRecords.$inferSelect

--- a/src/db/migrations/053_long_term_memory.ts
+++ b/src/db/migrations/053_long_term_memory.ts
@@ -16,7 +16,7 @@ const createProfiles = (db: Database): void => {
       scope_id   TEXT NOT NULL PRIMARY KEY,
       scope_type TEXT NOT NULL CHECK (scope_type IN ('personal', 'group')),
       profile    TEXT NOT NULL DEFAULT '',
-      enabled    INTEGER NOT NULL DEFAULT 1,
+      enabled    INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
       version    INTEGER NOT NULL DEFAULT 1,
       updated_at TEXT NOT NULL
     )

--- a/src/db/migrations/053_long_term_memory.ts
+++ b/src/db/migrations/053_long_term_memory.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { Database } from 'bun:sqlite'
+
+import { logger } from '../../logger.js'
+import type { Migration } from '../migrate.js'
+
+const log = logger.child({ scope: 'migration:053' })
+
+const createProfiles = (db: Database): void => {
+  db.run(`
+    CREATE TABLE memory_profiles (
+      scope_id   TEXT NOT NULL PRIMARY KEY,
+      scope_type TEXT NOT NULL CHECK (scope_type IN ('personal', 'group')),
+      profile    TEXT NOT NULL DEFAULT '',
+      enabled    INTEGER NOT NULL DEFAULT 1,
+      version    INTEGER NOT NULL DEFAULT 1,
+      updated_at TEXT NOT NULL
+    )
+  `)
+  db.run(`CREATE INDEX idx_memory_profiles_scope ON memory_profiles(scope_type, scope_id)`)
+}
+
+const createRecords = (db: Database): void => {
+  db.run(`
+    CREATE TABLE memory_records (
+      id            TEXT PRIMARY KEY,
+      scope_id      TEXT NOT NULL,
+      scope_type    TEXT NOT NULL CHECK (scope_type IN ('personal', 'group')),
+      kind          TEXT NOT NULL CHECK (kind IN ('preference', 'fact', 'decision', 'project_context', 'person_context', 'procedure', 'episode', 'reference')),
+      content       TEXT NOT NULL,
+      summary       TEXT,
+      tags          TEXT NOT NULL DEFAULT '[]',
+      confidence    REAL NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
+      status        TEXT NOT NULL CHECK (status IN ('active', 'stale', 'archived', 'contradicted')),
+      source        TEXT NOT NULL CHECK (source IN ('background', 'explicit', 'tool_result', 'admin_edit')),
+      evidence      TEXT NOT NULL DEFAULT '{}',
+      created_at    TEXT NOT NULL,
+      updated_at    TEXT NOT NULL,
+      last_seen_at  TEXT NOT NULL,
+      valid_from    TEXT,
+      valid_until   TEXT,
+      expires_at    TEXT,
+      embedding     BLOB
+    )
+  `)
+  db.run(`CREATE INDEX idx_memory_records_scope_status_seen ON memory_records(scope_id, status, last_seen_at DESC)`)
+  db.run(`CREATE INDEX idx_memory_records_scope_kind_status ON memory_records(scope_id, kind, status)`)
+}
+
+const createFts = (db: Database): void => {
+  db.run(`
+    CREATE VIRTUAL TABLE memory_records_fts
+      USING fts5(content, summary, tags, content='memory_records', content_rowid='rowid')
+  `)
+  db.run(`
+    CREATE TRIGGER memory_records_ai AFTER INSERT ON memory_records BEGIN
+      INSERT INTO memory_records_fts(rowid, content, summary, tags)
+      VALUES (new.rowid, new.content, new.summary, new.tags);
+    END
+  `)
+  db.run(`
+    CREATE TRIGGER memory_records_au AFTER UPDATE ON memory_records BEGIN
+      INSERT INTO memory_records_fts(memory_records_fts, rowid, content, summary, tags)
+      VALUES ('delete', old.rowid, old.content, old.summary, old.tags);
+      INSERT INTO memory_records_fts(rowid, content, summary, tags)
+      VALUES (new.rowid, new.content, new.summary, new.tags);
+    END
+  `)
+  db.run(`
+    CREATE TRIGGER memory_records_ad AFTER DELETE ON memory_records BEGIN
+      INSERT INTO memory_records_fts(memory_records_fts, rowid, content, summary, tags)
+      VALUES ('delete', old.rowid, old.content, old.summary, old.tags);
+    END
+  `)
+}
+
+const up = (db: Database): void => {
+  createProfiles(db)
+  createRecords(db)
+  createFts(db)
+  log.info('migration 053: long-term memory tables created')
+}
+
+export const migration053LongTermMemory: Migration = {
+  id: '053_long_term_memory',
+  up,
+}
+
+export default migration053LongTermMemory

--- a/src/db/migrations/053_long_term_memory.ts
+++ b/src/db/migrations/053_long_term_memory.ts
@@ -13,12 +13,13 @@ const log = logger.child({ scope: 'migration:053' })
 const createProfiles = (db: Database): void => {
   db.run(`
     CREATE TABLE memory_profiles (
-      scope_id   TEXT NOT NULL PRIMARY KEY,
+      scope_id   TEXT NOT NULL,
       scope_type TEXT NOT NULL CHECK (scope_type IN ('personal', 'group')),
       profile    TEXT NOT NULL DEFAULT '',
       enabled    INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
       version    INTEGER NOT NULL DEFAULT 1,
-      updated_at TEXT NOT NULL
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (scope_type, scope_id)
     )
   `)
   db.run(`CREATE INDEX idx_memory_profiles_scope ON memory_profiles(scope_type, scope_id)`)

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -69,6 +69,12 @@ export const memoryFacts = sqliteTable(
     index('idx_memory_facts_user_lastseen').on(table.userId, table.lastSeen),
   ],
 )
+export {
+  memoryProfiles,
+  memoryRecords,
+  type MemoryProfileRow,
+  type MemoryRecordRow,
+} from './long-term-memory-schema.js'
 export const versionAnnouncements = sqliteTable('version_announcements', {
   version: text('version').primaryKey(),
   announcedAt: text('announced_at').notNull(),

--- a/src/debug/settings-api-router.ts
+++ b/src/debug/settings-api-router.ts
@@ -14,6 +14,7 @@ import { handleContextTaskInstanceRoutes } from './settings/context-task-instanc
 import { handleGroupRoutes } from './settings/group-routes.js'
 import { handleIdentityRoutes } from './settings/identity-routes.js'
 import { handleMcpRoutes } from './settings/mcp-routes.js'
+import { handleMemoryRoutes } from './settings/memory-routes.js'
 import { handlePluginsRoutes } from './settings/plugins-routes.js'
 import { handleProvisionKaneo } from './settings/provision-routes.js'
 import { handleToolsRoutes } from './settings/tools-routes.js'
@@ -57,6 +58,9 @@ export function routeSettingsApi(req: Request, url: URL): Promise<Response | nul
     return handleToolsRoutes(req, url, url.pathname)
   }
   if (url.pathname === '/settings/api/mcp') return handleMcpRoutes(req, url)
+  if (url.pathname === '/settings/api/memory' || url.pathname.startsWith('/settings/api/memory/')) {
+    return handleMemoryRoutes(req, url)
+  }
   if (url.pathname.startsWith('/settings/api/plugins')) return handlePluginsRoutes(req, url, url.pathname)
   if (url.pathname === '/settings/api/identity') return handleIdentityRoutes(req, url)
   if (url.pathname.startsWith('/settings/api/group/')) return handleGroupRoutes(req, url, url.pathname)

--- a/src/debug/settings/memory-routes.ts
+++ b/src/debug/settings/memory-routes.ts
@@ -72,6 +72,14 @@ function parseOptionalJsonBody(req: Request): Promise<ParsedBody> {
   return parseJsonBody(req)
 }
 
+function decodeRecordId(rawRecordId: string): string | null {
+  try {
+    return decodeURIComponent(rawRecordId)
+  } catch {
+    return null
+  }
+}
+
 function handleGet(req: Request, url: URL): Response {
   const auth = authenticate(req)
   if (!auth.ok) return auth.response
@@ -159,6 +167,9 @@ async function handleRecordDelete(req: Request, recordId: string): Promise<Respo
   const csrf = requireCsrf(req, auth.authed)
   if (csrf !== null) return csrf
 
+  const decodedRecordId = decodeRecordId(recordId)
+  if (decodedRecordId === null) return settingsJson(400, { error: 'invalid record id' })
+
   const parsed = await parseOptionalJsonBody(req)
   if (!parsed.ok) return parsed.response
   const body = ContextBodySchema.safeParse(parsed.value)
@@ -168,7 +179,7 @@ async function handleRecordDelete(req: Request, recordId: string): Promise<Respo
   if (!scope.ok) return scope.response
 
   const memoryScope = toMemoryScope(scope.scope)
-  const archived = archiveMemoryRecord(memoryScope, recordId, new Date().toISOString())
+  const archived = archiveMemoryRecord(memoryScope, decodedRecordId, new Date().toISOString())
   const status = archived ? 'archived' : 'not_found'
   log.info(
     { scopeId: memoryScope.scopeId, scopeType: memoryScope.scopeType, action: 'record.archive', status },
@@ -232,7 +243,7 @@ export function handleMemoryRoutes(req: Request, url: URL): Promise<Response> {
 
   const recordId = url.pathname.match(/^\/settings\/api\/memory\/records\/([^/]+)$/u)?.[1]
   if (recordId !== undefined) {
-    if (req.method === 'DELETE') return handleRecordDelete(req, decodeURIComponent(recordId))
+    if (req.method === 'DELETE') return handleRecordDelete(req, recordId)
     return Promise.resolve(settingsJson(405, { error: 'method not allowed' }))
   }
 

--- a/src/debug/settings/memory-routes.ts
+++ b/src/debug/settings/memory-routes.ts
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+import { logger } from '../../logger.js'
+import {
+  archiveMemoryRecord,
+  clearMemoryScope,
+  getMemoryProfile,
+  listMemoryRecords,
+  saveMemoryProfile,
+  setMemoryCaptureEnabled,
+} from '../../long-term-memory/store.js'
+import type { MemoryRecord, MemoryScope } from '../../long-term-memory/types.js'
+import {
+  authenticate,
+  parseJsonBody,
+  requireCsrf,
+  resolveContextScope,
+  settingsJson,
+  type ParsedBody,
+} from './respond.js'
+
+const log = logger.child({ scope: 'debug-server:settings-memory' })
+const MAX_PROFILE_LENGTH = 20_000
+const RECORD_LIST_LIMIT = 100
+
+const ProfilePatchBodySchema = z.object({
+  contextId: z.string().optional(),
+  profile: z.string().max(MAX_PROFILE_LENGTH),
+})
+
+const CapturePatchBodySchema = z.object({
+  contextId: z.string().optional(),
+  enabled: z.boolean(),
+})
+
+const ContextBodySchema = z.object({
+  contextId: z.string().optional(),
+})
+
+const toMemoryScope = (scope: { readonly contextId: string; readonly kind: 'personal' | 'group' }): MemoryScope => ({
+  scopeId: scope.contextId,
+  scopeType: scope.kind,
+})
+
+const recordView = (record: MemoryRecord): Omit<MemoryRecord, 'embedding'> => ({
+  id: record.id,
+  scopeId: record.scopeId,
+  scopeType: record.scopeType,
+  kind: record.kind,
+  content: record.content,
+  summary: record.summary,
+  tags: record.tags,
+  confidence: record.confidence,
+  status: record.status,
+  source: record.source,
+  evidence: record.evidence,
+  createdAt: record.createdAt,
+  updatedAt: record.updatedAt,
+  lastSeenAt: record.lastSeenAt,
+  validFrom: record.validFrom,
+  validUntil: record.validUntil,
+  expiresAt: record.expiresAt,
+})
+
+function parseOptionalJsonBody(req: Request): Promise<ParsedBody> {
+  if (req.headers.get('Content-Type') === null) return Promise.resolve({ ok: true, value: {} })
+  return parseJsonBody(req)
+}
+
+function handleGet(req: Request, url: URL): Response {
+  const auth = authenticate(req)
+  if (!auth.ok) return auth.response
+
+  const scope = resolveContextScope(auth.authed.principal, 'read', url.searchParams.get('contextId') ?? undefined)
+  if (!scope.ok) return scope.response
+
+  const memoryScope = toMemoryScope(scope.scope)
+  const profile = getMemoryProfile(memoryScope)
+  const records = listMemoryRecords({ ...memoryScope, status: 'active', limit: RECORD_LIST_LIMIT }).map(recordView)
+
+  return settingsJson(200, {
+    contextId: memoryScope.scopeId,
+    scopeType: memoryScope.scopeType,
+    enabled: profile?.enabled ?? true,
+    profile: profile?.profile ?? '',
+    records,
+  })
+}
+
+async function handleProfilePatch(req: Request): Promise<Response> {
+  const auth = authenticate(req)
+  if (!auth.ok) return auth.response
+  const csrf = requireCsrf(req, auth.authed)
+  if (csrf !== null) return csrf
+
+  const parsed = await parseJsonBody(req)
+  if (!parsed.ok) return parsed.response
+  const body = ProfilePatchBodySchema.safeParse(parsed.value)
+  if (!body.success) return settingsJson(422, { error: 'invalid request' })
+
+  const scope = resolveContextScope(auth.authed.principal, 'write', body.data.contextId)
+  if (!scope.ok) return scope.response
+
+  const memoryScope = toMemoryScope(scope.scope)
+  const profile = saveMemoryProfile(memoryScope, body.data.profile, new Date().toISOString())
+  log.info(
+    { scopeId: memoryScope.scopeId, scopeType: memoryScope.scopeType, action: 'profile.update' },
+    'Settings memory profile updated',
+  )
+  return settingsJson(200, {
+    ok: true,
+    contextId: memoryScope.scopeId,
+    scopeType: memoryScope.scopeType,
+    profile: profile.profile,
+  })
+}
+
+async function handleCapturePatch(req: Request): Promise<Response> {
+  const auth = authenticate(req)
+  if (!auth.ok) return auth.response
+  const csrf = requireCsrf(req, auth.authed)
+  if (csrf !== null) return csrf
+
+  const parsed = await parseJsonBody(req)
+  if (!parsed.ok) return parsed.response
+  const body = CapturePatchBodySchema.safeParse(parsed.value)
+  if (!body.success) return settingsJson(422, { error: 'invalid request' })
+
+  const scope = resolveContextScope(auth.authed.principal, 'write', body.data.contextId)
+  if (!scope.ok) return scope.response
+
+  const memoryScope = toMemoryScope(scope.scope)
+  const profile = setMemoryCaptureEnabled(memoryScope, body.data.enabled, new Date().toISOString())
+  log.info(
+    {
+      scopeId: memoryScope.scopeId,
+      scopeType: memoryScope.scopeType,
+      action: 'capture.update',
+      enabled: profile.enabled,
+    },
+    'Settings memory capture updated',
+  )
+  return settingsJson(200, {
+    ok: true,
+    contextId: memoryScope.scopeId,
+    scopeType: memoryScope.scopeType,
+    enabled: profile.enabled,
+  })
+}
+
+async function handleRecordDelete(req: Request, recordId: string): Promise<Response> {
+  const auth = authenticate(req)
+  if (!auth.ok) return auth.response
+  const csrf = requireCsrf(req, auth.authed)
+  if (csrf !== null) return csrf
+
+  const parsed = await parseOptionalJsonBody(req)
+  if (!parsed.ok) return parsed.response
+  const body = ContextBodySchema.safeParse(parsed.value)
+  if (!body.success) return settingsJson(422, { error: 'invalid request' })
+
+  const scope = resolveContextScope(auth.authed.principal, 'write', body.data.contextId)
+  if (!scope.ok) return scope.response
+
+  const memoryScope = toMemoryScope(scope.scope)
+  const archived = archiveMemoryRecord(memoryScope, recordId, new Date().toISOString())
+  const status = archived ? 'archived' : 'not_found'
+  log.info(
+    { scopeId: memoryScope.scopeId, scopeType: memoryScope.scopeType, action: 'record.archive', status },
+    'Settings memory record archive requested',
+  )
+  return settingsJson(200, { ok: true, status })
+}
+
+async function handleClear(req: Request): Promise<Response> {
+  const auth = authenticate(req)
+  if (!auth.ok) return auth.response
+  const csrf = requireCsrf(req, auth.authed)
+  if (csrf !== null) return csrf
+
+  const parsed = await parseJsonBody(req)
+  if (!parsed.ok) return parsed.response
+  const body = ContextBodySchema.safeParse(parsed.value)
+  if (!body.success) return settingsJson(422, { error: 'invalid request' })
+
+  const scope = resolveContextScope(auth.authed.principal, 'write', body.data.contextId)
+  if (!scope.ok) return scope.response
+
+  const memoryScope = toMemoryScope(scope.scope)
+  const counts = clearMemoryScope(memoryScope)
+  log.info(
+    {
+      scopeId: memoryScope.scopeId,
+      scopeType: memoryScope.scopeType,
+      action: 'scope.clear',
+      profileDeleted: counts.profileDeleted,
+      recordsDeleted: counts.recordsDeleted,
+    },
+    'Settings memory scope cleared',
+  )
+  return settingsJson(200, {
+    ok: true,
+    contextId: memoryScope.scopeId,
+    scopeType: memoryScope.scopeType,
+    profileDeleted: counts.profileDeleted,
+    recordsDeleted: counts.recordsDeleted,
+  })
+}
+
+export function handleMemoryRoutes(req: Request, url: URL): Promise<Response> {
+  if (url.pathname === '/settings/api/memory') {
+    if (req.method === 'GET') return Promise.resolve(handleGet(req, url))
+    return Promise.resolve(settingsJson(405, { error: 'method not allowed' }))
+  }
+  if (url.pathname === '/settings/api/memory/profile') {
+    if (req.method === 'PATCH') return handleProfilePatch(req)
+    return Promise.resolve(settingsJson(405, { error: 'method not allowed' }))
+  }
+  if (url.pathname === '/settings/api/memory/capture') {
+    if (req.method === 'PATCH') return handleCapturePatch(req)
+    return Promise.resolve(settingsJson(405, { error: 'method not allowed' }))
+  }
+  if (url.pathname === '/settings/api/memory/clear') {
+    if (req.method === 'POST') return handleClear(req)
+    return Promise.resolve(settingsJson(405, { error: 'method not allowed' }))
+  }
+
+  const recordId = url.pathname.match(/^\/settings\/api\/memory\/records\/([^/]+)$/u)?.[1]
+  if (recordId !== undefined) {
+    if (req.method === 'DELETE') return handleRecordDelete(req, decodeURIComponent(recordId))
+    return Promise.resolve(settingsJson(405, { error: 'method not allowed' }))
+  }
+
+  return Promise.resolve(settingsJson(404, { error: 'not found' }))
+}

--- a/src/deferred-prompts/proactive-llm-full.ts
+++ b/src/deferred-prompts/proactive-llm-full.ts
@@ -41,11 +41,12 @@ export function buildFullMessages(
   prompt: string,
   matchedTasksSummary: string | undefined,
   metadata: ExecutionMetadata,
+  contextType: 'dm' | 'group' = 'dm',
 ): { messages: ModelMessage[]; systemPrompt: string } {
   const timezone = timezoneOrUtc(getConfig(createdByUserId, 'timezone'))
   const trigger = buildProactiveTrigger(type, prompt, timezone, matchedTasksSummary)
   const history = getCachedHistory(storageContextId)
-  const { messages: messagesWithMemory } = buildMessagesWithMemory(storageContextId, history)
+  const { messages: messagesWithMemory } = buildMessagesWithMemory(storageContextId, history, contextType)
   return {
     messages: [
       ...messagesWithMemory,

--- a/src/deferred-prompts/proactive-llm-helpers.ts
+++ b/src/deferred-prompts/proactive-llm-helpers.ts
@@ -6,11 +6,13 @@
 import type { ModelMessage } from 'ai'
 
 import type { DeferredDeliveryTarget } from '../chat/types.js'
-import { runTrimInBackground, shouldTriggerTrim } from '../conversation.js'
+import { buildMessagesWithMemory, runTrimInBackground, shouldTriggerTrim } from '../conversation.js'
 import { appendHistory } from '../history.js'
 import { logger } from '../logger.js'
 import { extractFactToolCalls, extractFactToolResults } from '../memory-tool-steps.js'
 import { extractFactsFromSdkResults, upsertFact } from '../memory.js'
+import type { TaskProvider } from '../providers/types.js'
+import { buildProviderlessSystemPrompt, buildSystemPrompt } from '../system-prompt.js'
 import type { ExecutionMetadata } from './types.js'
 
 const log = logger.child({ scope: 'deferred:proactive-llm-helpers' })
@@ -32,6 +34,8 @@ type DeferredExecutionContextLike = Readonly<{
   createdByUserId: string
   deliveryTarget: DeferredDeliveryTarget
 }>
+
+export type BuildProviderFn = (contextId: string) => Promise<TaskProvider | null> | TaskProvider | null
 
 const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -83,6 +87,52 @@ export function buildMetadataMessages(m: ExecutionMetadata): ModelMessage[] {
 }
 
 export const wrapPrompt = (prompt: string): string => `===DEFERRED_TASK===\n${prompt}\n===END_DEFERRED_TASK===`
+
+export const buildContextMessages = (
+  storageContextId: string,
+  contextType: 'dm' | 'group',
+  history: readonly ModelMessage[],
+  metadata: ExecutionMetadata,
+  prompt: string,
+): ModelMessage[] => {
+  const { messages: messagesWithMemory } = buildMessagesWithMemory(storageContextId, history, contextType)
+  return [...messagesWithMemory, ...buildMetadataMessages(metadata), { role: 'user', content: wrapPrompt(prompt) }]
+}
+
+export const persistContextResponse = (
+  storageContextId: string,
+  configContextId: string,
+  history: readonly ModelMessage[],
+  mainModel: string,
+  assistantMessages: ModelMessage[],
+): void => {
+  if (assistantMessages.length === 0) return
+  appendHistory(storageContextId, assistantMessages)
+  const updatedHistory = [...history, ...assistantMessages]
+  if (shouldTriggerTrim(updatedHistory, mainModel))
+    void runTrimInBackground(storageContextId, updatedHistory, undefined, configContextId)
+}
+
+export const buildFullSystemPrompt = (
+  provider: TaskProvider | null,
+  storageContextId: string,
+  enabledToolNames: ReadonlySet<string>,
+): string =>
+  provider === null
+    ? buildProviderlessSystemPrompt(storageContextId, enabledToolNames, { askPermissionAvailable: false })
+    : buildSystemPrompt(provider, storageContextId, enabledToolNames, { askPermissionAvailable: false })
+
+export async function resolveFullProvider(
+  buildProviderFn: BuildProviderFn,
+  userId: string,
+  storageContextId: string,
+  configContextId: string,
+): Promise<TaskProvider | null> {
+  const provider = await buildProviderFn(configContextId)
+  if (provider !== null) return provider
+  log.warn({ userId, storageContextId, configContextId }, 'Could not build task provider for deferred prompt')
+  return null
+}
 
 type LlmResult = { response: { messages: ModelMessage[] }; text: string; toolCalls: unknown[] | undefined }
 

--- a/src/deferred-prompts/proactive-llm-helpers.ts
+++ b/src/deferred-prompts/proactive-llm-helpers.ts
@@ -5,10 +5,12 @@
 
 import type { ModelMessage } from 'ai'
 
+import { getCachedHistory } from '../cache.js'
 import type { DeferredDeliveryTarget } from '../chat/types.js'
 import { buildMessagesWithMemory, runTrimInBackground, shouldTriggerTrim } from '../conversation.js'
 import { appendHistory } from '../history.js'
 import { logger } from '../logger.js'
+import { runMemoryExtractionInBackground } from '../long-term-memory/runner.js'
 import { extractFactToolCalls, extractFactToolResults } from '../memory-tool-steps.js'
 import { extractFactsFromSdkResults, upsertFact } from '../memory.js'
 import type { TaskProvider } from '../providers/types.js'
@@ -99,9 +101,29 @@ export const buildContextMessages = (
   return [...messagesWithMemory, ...buildMetadataMessages(metadata), { role: 'user', content: wrapPrompt(prompt) }]
 }
 
+export const persistLightweightResponse = (
+  creatorId: string,
+  storageContextId: string,
+  configContextId: string,
+  mainModel: string,
+  assistantMessages: readonly ModelMessage[],
+): void => {
+  if (assistantMessages.length === 0) return
+  const history = getCachedHistory(storageContextId)
+  appendHistory(storageContextId, assistantMessages)
+  log.debug(
+    { userId: creatorId, storageContextId, count: assistantMessages.length },
+    'Lightweight response appended to history',
+  )
+  const updatedHistory = [...history, ...assistantMessages]
+  if (shouldTriggerTrim(updatedHistory, mainModel))
+    void runTrimInBackground(storageContextId, updatedHistory, undefined, configContextId)
+}
+
 export const persistContextResponse = (
   storageContextId: string,
   configContextId: string,
+  contextType: 'dm' | 'group',
   history: readonly ModelMessage[],
   mainModel: string,
   assistantMessages: ModelMessage[],
@@ -109,8 +131,15 @@ export const persistContextResponse = (
   if (assistantMessages.length === 0) return
   appendHistory(storageContextId, assistantMessages)
   const updatedHistory = [...history, ...assistantMessages]
-  if (shouldTriggerTrim(updatedHistory, mainModel))
+  if (shouldTriggerTrim(updatedHistory, mainModel)) {
     void runTrimInBackground(storageContextId, updatedHistory, undefined, configContextId)
+    void runMemoryExtractionInBackground({
+      storageContextId,
+      configContextId,
+      contextType,
+      history: updatedHistory,
+    })
+  }
 }
 
 export const buildFullSystemPrompt = (
@@ -140,6 +169,7 @@ export function persistProactiveResults(
   creatorId: string,
   storageContextId: string,
   configContextId: string,
+  contextType: 'dm' | 'group',
   result: LlmResult,
   history: readonly ModelMessage[],
   mainModel: string,
@@ -156,8 +186,15 @@ export function persistProactiveResults(
   if (msgs.length > 0) {
     appendHistory(storageContextId, msgs)
     const updated = [...history, ...msgs]
-    if (shouldTriggerTrim(updated, mainModel))
+    if (shouldTriggerTrim(updated, mainModel)) {
       void runTrimInBackground(storageContextId, updated, undefined, configContextId)
+      void runMemoryExtractionInBackground({
+        storageContextId,
+        configContextId,
+        contextType,
+        history: updated,
+      })
+    }
   }
   log.debug({ userId: creatorId, toolCalls: toolCallCount(result) }, 'Proactive LLM response received')
 }

--- a/src/deferred-prompts/proactive-llm.ts
+++ b/src/deferred-prompts/proactive-llm.ts
@@ -9,8 +9,6 @@ import { generateText, stepCountIs, type ModelMessage } from 'ai'
 import { getCachedHistory } from '../cache.js'
 import { getConfigContextIdFromStorageContextId } from '../chat/scoped-context.js'
 import type { DeferredDeliveryTarget } from '../chat/types.js'
-import { runTrimInBackground, shouldTriggerTrim } from '../conversation.js'
-import { appendHistory } from '../history.js'
 import { resolveEffectiveLlmConfig } from '../llm-config-resolver.js'
 import { logger } from '../logger.js'
 import { makeGetCurrentTimeTool } from '../tools/get-current-time.js'
@@ -23,6 +21,7 @@ import {
   getStorageContextId,
   modelIdForLightweight,
   persistContextResponse,
+  persistLightweightResponse,
   persistProactiveResults,
   resultTextOrDone,
   resolveFullProvider,
@@ -132,17 +131,7 @@ async function invokeLightweight(
   })
 
   const assistantMessages = result.response.messages
-  if (assistantMessages.length > 0) {
-    const history = getCachedHistory(storageContextId)
-    appendHistory(storageContextId, assistantMessages)
-    log.debug(
-      { userId: createdByUserId, storageContextId, count: assistantMessages.length },
-      'Lightweight response appended to history',
-    )
-    const updatedHistory = [...history, ...assistantMessages]
-    if (shouldTriggerTrim(updatedHistory, config.mainModel))
-      void runTrimInBackground(storageContextId, updatedHistory, undefined, configContextId)
-  }
+  persistLightweightResponse(createdByUserId, storageContextId, configContextId, config.mainModel, assistantMessages)
   return resultTextOrDone(result.text)
 }
 
@@ -181,7 +170,14 @@ async function invokeWithContext(
     timeout: 1_200_000,
   })
 
-  persistContextResponse(storageContextId, configContextId, history, config.mainModel, result.response.messages)
+  persistContextResponse(
+    storageContextId,
+    configContextId,
+    deliveryTarget.contextType,
+    history,
+    config.mainModel,
+    result.response.messages,
+  )
   return resultTextOrDone(result.text)
 }
 
@@ -241,12 +237,14 @@ async function runFullGeneration(
     stopWhen: deps.stepCountIs(25),
     timeout: 1_200_000,
   })
+  const previousHistory = getCachedHistory(prepared.storageContextId)
   persistProactiveResults(
     createdByUserId,
     prepared.storageContextId,
     configContextId,
+    execCtx.deliveryTarget.contextType,
     result,
-    getCachedHistory(prepared.storageContextId),
+    previousHistory,
     config.mainModel,
   )
   return resultTextOrDone(result.text)

--- a/src/deferred-prompts/proactive-llm.ts
+++ b/src/deferred-prompts/proactive-llm.ts
@@ -9,21 +9,24 @@ import { generateText, stepCountIs, type ModelMessage } from 'ai'
 import { getCachedHistory } from '../cache.js'
 import { getConfigContextIdFromStorageContextId } from '../chat/scoped-context.js'
 import type { DeferredDeliveryTarget } from '../chat/types.js'
-import { buildMessagesWithMemory, runTrimInBackground, shouldTriggerTrim } from '../conversation.js'
+import { runTrimInBackground, shouldTriggerTrim } from '../conversation.js'
 import { appendHistory } from '../history.js'
 import { resolveEffectiveLlmConfig } from '../llm-config-resolver.js'
 import { logger } from '../logger.js'
-import type { TaskProvider } from '../providers/types.js'
-import { buildProviderlessSystemPrompt, buildSystemPrompt } from '../system-prompt.js'
 import { makeGetCurrentTimeTool } from '../tools/get-current-time.js'
 import { buildFullMessages, buildFullToolSet } from './proactive-llm-full.js'
 import {
+  buildContextMessages,
+  buildFullSystemPrompt,
   buildMetadataMessages,
   buildMinimalSystemPrompt,
   getStorageContextId,
   modelIdForLightweight,
+  persistContextResponse,
   persistProactiveResults,
   resultTextOrDone,
+  resolveFullProvider,
+  type BuildProviderFn,
   type ProactiveLlmDispatchArgs,
   wrapPrompt,
 } from './proactive-llm-helpers.js'
@@ -31,7 +34,6 @@ import type { ExecutionMetadata } from './types.js'
 
 const log = logger.child({ scope: 'deferred:proactive-llm' })
 
-/** Execution context for a deferred prompt: who created it and where to deliver. */
 export type DeferredExecutionContext = {
   createdByUserId: string
   deliveryTarget: DeferredDeliveryTarget
@@ -55,11 +57,15 @@ const defaultProactiveLlmDeps: ProactiveLlmDeps = {
   stepCountIs: (...args) => stepCountIs(...args),
   buildModel: (config, modelId) => createOpenAICompatible({ name: 'openai-compatible', ...config })(modelId),
 }
-
-export type BuildProviderFn = (contextId: string) => Promise<TaskProvider | null> | TaskProvider | null
-
 type LlmConfig = { apiKey: string; baseURL: string; mainModel: string; smallModel: string }
 type DispatchExecutionArgs = ProactiveLlmDispatchArgs<ProactiveLlmDeps, BuildProviderFn>
+export type { BuildProviderFn }
+type FullGenerationInput = Readonly<{
+  storageContextId: string
+  tools: Awaited<ReturnType<typeof buildFullToolSet>>['tools']
+  systemPrompt: string
+  messages: ModelMessage[]
+}>
 
 function getLlmConfig(configContextId: string): LlmConfig | string {
   const resolved = resolveEffectiveLlmConfig(configContextId)
@@ -156,12 +162,7 @@ async function invokeWithContext(
 
   const model = deps.buildModel(config, config.mainModel)
   const history = getCachedHistory(storageContextId)
-  const { messages: messagesWithMemory } = buildMessagesWithMemory(storageContextId, history)
-  const messages: ModelMessage[] = [
-    ...messagesWithMemory,
-    ...buildMetadataMessages(metadata),
-    { role: 'user', content: wrapPrompt(prompt) },
-  ]
+  const messages = buildContextMessages(storageContextId, deliveryTarget.contextType, history, metadata, prompt)
 
   log.debug(
     {
@@ -180,26 +181,38 @@ async function invokeWithContext(
     timeout: 1_200_000,
   })
 
-  const assistantMessages = result.response.messages
-  if (assistantMessages.length > 0) {
-    appendHistory(storageContextId, assistantMessages)
-    const updatedHistory = [...history, ...assistantMessages]
-    if (shouldTriggerTrim(updatedHistory, config.mainModel))
-      void runTrimInBackground(storageContextId, updatedHistory, undefined, configContextId)
-  }
+  persistContextResponse(storageContextId, configContextId, history, config.mainModel, result.response.messages)
   return resultTextOrDone(result.text)
 }
 
-async function resolveFullProvider(
-  buildProviderFn: BuildProviderFn,
-  userId: string,
-  storageContextId: string,
-  configContextId: string,
-): Promise<TaskProvider | null> {
-  const provider = await buildProviderFn(configContextId)
-  if (provider !== null) return provider
-  log.warn({ userId, storageContextId, configContextId }, 'Could not build task provider for deferred prompt')
-  return null
+async function prepareFullGenerationInput(
+  execCtx: DeferredExecutionContext,
+  type: 'scheduled' | 'alert',
+  prompt: string,
+  metadata: ExecutionMetadata,
+  matchedTasksSummary: string | undefined,
+  provider: Awaited<ReturnType<BuildProviderFn>>,
+): Promise<FullGenerationInput> {
+  const { createdByUserId, deliveryTarget } = execCtx
+  const storageContextId = getStorageContextId(deliveryTarget)
+  const { tools, enabledToolNames } = await buildFullToolSet(
+    provider,
+    createdByUserId,
+    storageContextId,
+    deliveryTarget.contextType,
+    prompt,
+  )
+  const systemPrompt = buildFullSystemPrompt(provider, storageContextId, enabledToolNames)
+  const { messages } = buildFullMessages(
+    createdByUserId,
+    storageContextId,
+    type,
+    prompt,
+    matchedTasksSummary,
+    metadata,
+    deliveryTarget.contextType,
+  )
+  return { storageContextId, tools, systemPrompt, messages }
 }
 
 async function runFullGeneration(
@@ -213,39 +226,27 @@ async function runFullGeneration(
   provider: Awaited<ReturnType<BuildProviderFn>>,
   deps: ProactiveLlmDeps,
 ): Promise<string> {
-  const { createdByUserId, deliveryTarget } = execCtx
-  const storageContextId = getStorageContextId(deliveryTarget)
+  const { createdByUserId } = execCtx
   const model = deps.buildModel(config, config.mainModel)
-  const { tools, enabledToolNames } = await buildFullToolSet(
-    provider,
-    createdByUserId,
-    storageContextId,
-    deliveryTarget.contextType,
-    prompt,
-  )
-  const systemPrompt =
-    provider === null
-      ? buildProviderlessSystemPrompt(storageContextId, enabledToolNames, { askPermissionAvailable: false })
-      : buildSystemPrompt(provider, storageContextId, enabledToolNames, { askPermissionAvailable: false })
-  const { messages } = buildFullMessages(createdByUserId, storageContextId, type, prompt, matchedTasksSummary, metadata)
+  const prepared = await prepareFullGenerationInput(execCtx, type, prompt, metadata, matchedTasksSummary, provider)
   log.debug(
-    { userId: createdByUserId, mainModel: config.mainModel, historyLength: messages.length, mode: 'full' },
+    { userId: createdByUserId, mainModel: config.mainModel, historyLength: prepared.messages.length, mode: 'full' },
     'generateText',
   )
   const result = await deps.generateText({
     model,
-    system: systemPrompt,
-    messages,
-    tools,
+    system: prepared.systemPrompt,
+    messages: prepared.messages,
+    tools: prepared.tools,
     stopWhen: deps.stepCountIs(25),
     timeout: 1_200_000,
   })
   persistProactiveResults(
     createdByUserId,
-    storageContextId,
+    prepared.storageContextId,
     configContextId,
     result,
-    getCachedHistory(storageContextId),
+    getCachedHistory(prepared.storageContextId),
     config.mainModel,
   )
   return resultTextOrDone(result.text)

--- a/src/llm-history.ts
+++ b/src/llm-history.ts
@@ -8,6 +8,7 @@ import type { ModelMessage } from 'ai'
 import { runTrimInBackground, shouldTriggerTrim } from './conversation.js'
 import { appendHistory } from './history.js'
 import { logger } from './logger.js'
+import { runMemoryExtractionInBackground } from './long-term-memory/runner.js'
 
 const log = logger.child({ scope: 'llm-history' })
 
@@ -21,6 +22,7 @@ export const appendAssistantHistory = (
   mainModel: string,
   history: readonly ModelMessage[],
   assistantMessages: ModelMessage[],
+  contextType: 'dm' | 'group' = 'dm',
 ): void => {
   if (assistantMessages.length > 0) {
     appendHistory(contextId, assistantMessages)
@@ -29,5 +31,30 @@ export const appendAssistantHistory = (
   const combined = [...history, ...assistantMessages]
   if (shouldTriggerTrim(combined, mainModel)) {
     void runTrimInBackground(contextId, combined, undefined, configId)
+    void runMemoryExtractionInBackground({
+      storageContextId: contextId,
+      contextType,
+      configContextId: configId,
+      history: combined,
+    })
   }
+}
+
+export const appendAssistantTurnHistory = (
+  contextId: string,
+  configId: string,
+  mainModel: string,
+  baseHistory: readonly ModelMessage[],
+  historyMessage: ModelMessage,
+  assistantMessages: ModelMessage[],
+  contextType: 'dm' | 'group',
+): void => {
+  appendAssistantHistory(
+    contextId,
+    configId,
+    mainModel,
+    [...baseHistory, historyMessage],
+    assistantMessages,
+    contextType,
+  )
 }

--- a/src/llm-orchestrator-tools.ts
+++ b/src/llm-orchestrator-tools.ts
@@ -128,7 +128,7 @@ export const prepareLlmInvocation = async (
     'Prepared tool set for LLM invocation',
   )
   const timezone = resolveTimezone(configId)
-  const { messages: messagesWithMemory, memoryMsg } = buildMessagesWithMemory(contextId, history)
+  const { messages: messagesWithMemory, memoryMsg } = buildMessagesWithMemory(contextId, history, contextType)
   const validatedMessages = validateToolResults(messagesWithMemory)
   log.debug(
     { contextId, historyLength: history.length, hasMemory: memoryMsg !== null, timezone },

--- a/src/llm-orchestrator.ts
+++ b/src/llm-orchestrator.ts
@@ -15,7 +15,7 @@ import { appendHistory } from './history.js'
 import { getIdentityMapping } from './identity/mapping.js'
 import { attemptAutoLink } from './identity/resolver.js'
 import { resolveEffectiveLlmConfig, type EffectiveLlmConfig } from './llm-config-resolver.js'
-import { appendAssistantHistory } from './llm-history.js'
+import { appendAssistantTurnHistory } from './llm-history.js'
 import { buildUserTurnMessages } from './llm-orchestrator-attachments.js'
 import { checkRequiredProviderConfig, resolveConfigId } from './llm-orchestrator-config.js'
 import { invokeModelWithTyping } from './llm-orchestrator-invoke.js'
@@ -252,30 +252,30 @@ export const processMessage = async (
   const resolvedLlm = await resolveLlmForTurn(reply, contextId, configId)
   if (resolvedLlm === null) return
   const turn = await buildHistory(contextId, chatUserId, resolvedLlm.mainModel, userText, newAttachmentIds)
+  const invocationSource = { reply, contextId, chatUserId, username, userText, contextType }
   appendHistory(contextId, [turn.historyMessage])
   const startedAt = Date.now()
   try {
     const result = await callLlm({
-      reply,
-      contextId,
-      chatUserId,
-      username,
+      ...invocationSource,
       history: [...turn.baseHistory, turn.modelMessage],
-      userText,
-      contextType,
       deps,
       configId,
       resolvedLlm,
       turnId: resolvedTurnId,
     })
-    const priorHistory = [...turn.baseHistory, turn.historyMessage]
-    appendAssistantHistory(contextId, configId, resolvedLlm.mainModel, priorHistory, result.response.messages)
+    appendAssistantTurnHistory(
+      contextId,
+      configId,
+      resolvedLlm.mainModel,
+      turn.baseHistory,
+      turn.historyMessage,
+      result.response.messages,
+      contextType,
+    )
   } catch (error) {
     await handleLlmTurnError({
-      reply,
-      contextId,
-      chatUserId,
-      contextType,
+      ...invocationSource,
       mainModel: resolvedLlm.mainModel,
       startedAt,
       baseHistory: turn.baseHistory,

--- a/src/long-term-memory/context.ts
+++ b/src/long-term-memory/context.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { MemoryRecord } from './types.js'
+
+const MAX_PROFILE_CHARS = 1_200
+const MAX_RECORD_CHARS = 600
+const RENDER_LIMIT = 3
+
+const TRUST_GUIDANCE =
+  'The learned memory below is lower-trust than the current user message. If the user contradicts it, believe the user; stale records may be wrong.'
+
+export type LongTermMemoryContextInput = Readonly<{
+  profile: string | null
+  records: readonly MemoryRecord[]
+}>
+
+const truncate = (value: string, maxChars: number): string =>
+  value.length > maxChars ? `${value.slice(0, maxChars)}... [truncated]` : value
+
+const escapeText = (value: string): string =>
+  value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+
+const escapeAttribute = (value: string): string => escapeText(value).replaceAll('"', '&quot;').replaceAll("'", '&apos;')
+
+const recordText = (record: MemoryRecord): string => {
+  const candidate = record.summary !== null && record.summary.trim().length > 0 ? record.summary : record.content
+  return escapeText(truncate(candidate, MAX_RECORD_CHARS))
+}
+
+const renderRecord = (record: MemoryRecord): string =>
+  `<record id="${escapeAttribute(record.id)}" kind="${escapeAttribute(record.kind)}" status="${escapeAttribute(
+    record.status,
+  )}" confidence="${escapeAttribute(String(record.confidence))}" last_seen_at="${escapeAttribute(
+    record.lastSeenAt,
+  )}">${recordText(record)}</record>`
+
+const profileSection = (profile: string | null): string | null => {
+  const trimmed = profile?.trim()
+  if (trimmed === undefined || trimmed.length === 0) return null
+  return `<profile>\n${escapeText(truncate(trimmed, MAX_PROFILE_CHARS))}\n</profile>`
+}
+
+const recordsSection = (records: readonly MemoryRecord[]): string | null => {
+  const rendered = records.slice(0, RENDER_LIMIT).map(renderRecord)
+  if (rendered.length === 0) return null
+  return `<retrieved_records max="${RENDER_LIMIT}">\n${rendered.join('\n')}\n</retrieved_records>`
+}
+
+export function buildLongTermMemoryContextMessage(
+  input: LongTermMemoryContextInput,
+): { role: 'system'; content: string } | null {
+  const sections = [profileSection(input.profile), recordsSection(input.records)].filter(
+    (section): section is string => section !== null,
+  )
+
+  if (sections.length === 0) return null
+
+  return {
+    role: 'system',
+    content: `<long_term_memory trust="profile_and_retrieved_low">\n${TRUST_GUIDANCE}\n${sections.join(
+      '\n',
+    )}\n</long_term_memory>`,
+  }
+}

--- a/src/long-term-memory/extractor.ts
+++ b/src/long-term-memory/extractor.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { generateText, type LanguageModel, type ModelMessage } from 'ai'
+import { z } from 'zod'
+
+import { serializeHistoryForTrimPrompt } from '../memory.js'
+import {
+  MemoryKindSchema,
+  MemorySourceSchema,
+  MemoryStatusSchema,
+  type MemoryRecord,
+  type MemoryEvidence,
+} from './types.js'
+
+const MemoryEvidenceSchema: z.ZodType<MemoryEvidence> = z
+  .object({
+    messageIds: z.array(z.string()).optional(),
+    actorIds: z.array(z.string()).optional(),
+    timestamps: z.array(z.string()).optional(),
+    contextId: z.string().optional(),
+  })
+  .readonly()
+
+const MemoryPatchRecordSchema = z.object({
+  kind: MemoryKindSchema,
+  content: z.string().min(1),
+  summary: z.string().nullable(),
+  tags: z.array(z.string()),
+  confidence: z.number().min(0).max(1),
+  source: MemorySourceSchema,
+  evidence: MemoryEvidenceSchema,
+  expiresAt: z.string().optional(),
+  validFrom: z.string().optional(),
+  validUntil: z.string().optional(),
+})
+
+const MemoryPatchUpdateSchema = z.object({
+  id: z.string().min(1),
+  status: MemoryStatusSchema.optional(),
+  content: z.string().min(1).optional(),
+  confidence: z.number().min(0).max(1).optional(),
+})
+
+export const MemoryPatchSchema = z.object({
+  profile: z.string().nullable(),
+  records: z.array(MemoryPatchRecordSchema),
+  updates: z.array(MemoryPatchUpdateSchema),
+})
+
+export type MemoryPatch = z.infer<typeof MemoryPatchSchema>
+
+export type ExtractMemoryPatchInput = Readonly<{
+  history: readonly ModelMessage[]
+  profile: string | null
+  records: readonly MemoryRecord[]
+  model: LanguageModel
+}>
+
+export type ExtractMemoryPatchDeps = Readonly<{
+  generateText: typeof generateText
+}>
+
+const defaultDeps: ExtractMemoryPatchDeps = {
+  generateText: (...args) => generateText(...args),
+}
+
+const jsonObjectFromText = (text: string): string => {
+  const start = text.indexOf('{')
+  if (start === -1) throw new Error('no JSON object found')
+
+  const initialState = {
+    depth: 0,
+    inString: false,
+    escaped: false,
+    end: -1,
+  }
+  const result = Array.from(text.slice(start)).reduce((state, char, offset) => {
+    if (state.end !== -1) return state
+    if (state.escaped) return { ...state, escaped: false }
+    if (char === '\\' && state.inString) return { ...state, escaped: true }
+    if (char === '"') return { ...state, inString: !state.inString }
+    if (state.inString) return state
+    if (char === '{') return { ...state, depth: state.depth + 1 }
+    if (char !== '}') return state
+    const depth = state.depth - 1
+    return depth === 0 ? { ...state, depth, end: start + offset + 1 } : { ...state, depth }
+  }, initialState)
+
+  if (result.end === -1) throw new Error('unterminated JSON object')
+  return text.slice(start, result.end)
+}
+
+export function parseMemoryPatch(text: string): MemoryPatch {
+  try {
+    const raw = JSON.parse(jsonObjectFromText(text)) as unknown
+    return MemoryPatchSchema.parse(raw)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`invalid memory patch: ${message}`, { cause: error })
+  }
+}
+
+const recordsForPrompt = (records: readonly MemoryRecord[]): string =>
+  JSON.stringify(
+    records.map((record) => ({
+      id: record.id,
+      kind: record.kind,
+      summary: record.summary,
+      tags: record.tags,
+      confidence: record.confidence,
+      status: record.status,
+      lastSeenAt: record.lastSeenAt,
+    })),
+  )
+
+const EXTRACTION_PROMPT = `You are papai's long-term memory extractor.
+
+Return ONLY a raw JSON object with this exact shape:
+{"profile": string|null, "records": [{"kind": "...", "content": "...", "summary": string|null, "tags": string[], "confidence": 0.0, "source": "background", "evidence": {}}], "updates": [{"id": "...", "status": "active|stale|archived|contradicted", "content": "...", "confidence": 0.0}]}
+
+Rules:
+- Capture only durable user or group preferences, stable facts, decisions, procedures, project context, person context, episodes, and references.
+- Avoid over-capturing routine chat, transient requests, guesses, secrets, credentials, tokens, private sensitive data, or anything the user would not reasonably expect to be remembered.
+- Preserve timestamps, message ids, actors, and context ids in evidence when present in the conversation.
+- Use "background" as the source for new records inferred from this conversation.
+- Use updates only for existing record ids listed below, and never invent ids.
+- If nothing should change, return {"profile":null,"records":[],"updates":[]}.
+
+Current profile:
+{PROFILE}
+
+Existing active records:
+{RECORDS}
+
+Conversation:
+{HISTORY}`
+
+export async function extractMemoryPatch(
+  input: ExtractMemoryPatchInput,
+  deps: ExtractMemoryPatchDeps = defaultDeps,
+): Promise<MemoryPatch> {
+  const prompt = EXTRACTION_PROMPT.replace('{PROFILE}', input.profile ?? '(none)')
+    .replace('{RECORDS}', recordsForPrompt(input.records))
+    .replace('{HISTORY}', serializeHistoryForTrimPrompt(input.history))
+  const result = await deps.generateText({
+    model: input.model,
+    prompt,
+    timeout: 1_200_000,
+  })
+  return parseMemoryPatch(result.text)
+}

--- a/src/long-term-memory/extractor.ts
+++ b/src/long-term-memory/extractor.ts
@@ -7,47 +7,54 @@ import { generateText, type LanguageModel, type ModelMessage } from 'ai'
 import { z } from 'zod'
 
 import { serializeHistoryForTrimPrompt } from '../memory.js'
-import {
-  MemoryKindSchema,
-  MemorySourceSchema,
-  MemoryStatusSchema,
-  type MemoryRecord,
-  type MemoryEvidence,
-} from './types.js'
+import { MemoryKindSchema, MemoryStatusSchema, type MemoryRecord, type MemoryEvidence } from './types.js'
+
+const MAX_PROFILE_LENGTH = 4_000
+const MAX_RECORDS_PER_PATCH = 20
+const MAX_UPDATES_PER_PATCH = 50
+const MAX_CONTENT_LENGTH = 2_000
+const MAX_SUMMARY_LENGTH = 240
+const MAX_TAGS_PER_RECORD = 12
+const MAX_TAG_LENGTH = 48
+const MAX_EVIDENCE_VALUES = 20
+const MAX_EVIDENCE_VALUE_LENGTH = 512
+
+const IsoTimestampSchema = z.iso.datetime().transform((value) => new Date(value).toISOString())
+const EvidenceValueSchema = z.string().min(1).max(MAX_EVIDENCE_VALUE_LENGTH)
 
 const MemoryEvidenceSchema: z.ZodType<MemoryEvidence> = z
   .object({
-    messageIds: z.array(z.string()).optional(),
-    actorIds: z.array(z.string()).optional(),
-    timestamps: z.array(z.string()).optional(),
-    contextId: z.string().optional(),
+    messageIds: z.array(EvidenceValueSchema).max(MAX_EVIDENCE_VALUES).optional(),
+    actorIds: z.array(EvidenceValueSchema).max(MAX_EVIDENCE_VALUES).optional(),
+    timestamps: z.array(IsoTimestampSchema).max(MAX_EVIDENCE_VALUES).optional(),
+    contextId: EvidenceValueSchema.optional(),
   })
   .readonly()
 
 const MemoryPatchRecordSchema = z.object({
   kind: MemoryKindSchema,
-  content: z.string().min(1),
-  summary: z.string().nullable(),
-  tags: z.array(z.string()),
+  content: z.string().min(1).max(MAX_CONTENT_LENGTH),
+  summary: z.string().min(1).max(MAX_SUMMARY_LENGTH).nullable(),
+  tags: z.array(z.string().min(1).max(MAX_TAG_LENGTH)).max(MAX_TAGS_PER_RECORD),
   confidence: z.number().min(0).max(1),
-  source: MemorySourceSchema,
+  source: z.literal('background'),
   evidence: MemoryEvidenceSchema,
-  expiresAt: z.string().optional(),
-  validFrom: z.string().optional(),
-  validUntil: z.string().optional(),
+  expiresAt: IsoTimestampSchema.optional(),
+  validFrom: IsoTimestampSchema.optional(),
+  validUntil: IsoTimestampSchema.optional(),
 })
 
 const MemoryPatchUpdateSchema = z.object({
-  id: z.string().min(1),
+  id: z.string().min(1).max(256),
   status: MemoryStatusSchema.optional(),
-  content: z.string().min(1).optional(),
+  content: z.string().min(1).max(MAX_CONTENT_LENGTH).optional(),
   confidence: z.number().min(0).max(1).optional(),
 })
 
 export const MemoryPatchSchema = z.object({
-  profile: z.string().nullable(),
-  records: z.array(MemoryPatchRecordSchema),
-  updates: z.array(MemoryPatchUpdateSchema),
+  profile: z.string().min(1).max(MAX_PROFILE_LENGTH).nullable(),
+  records: z.array(MemoryPatchRecordSchema).max(MAX_RECORDS_PER_PATCH),
+  updates: z.array(MemoryPatchUpdateSchema).max(MAX_UPDATES_PER_PATCH),
 })
 
 export type MemoryPatch = z.infer<typeof MemoryPatchSchema>

--- a/src/long-term-memory/maintenance.ts
+++ b/src/long-term-memory/maintenance.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { and, eq, isNotNull, lte, ne, or, type SQL } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { memoryRecords } from '../db/schema.js'
+import { logger } from '../logger.js'
+import type { MemoryKind } from './types.js'
+
+const log = logger.child({ scope: 'long-term-memory-maintenance' })
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+const STALE_CUTOFFS = [
+  ['preference', 180],
+  ['procedure', 180],
+  ['decision', 90],
+  ['project_context', 90],
+  ['person_context', 90],
+  ['episode', 45],
+  ['reference', 45],
+  ['fact', 90],
+] as const satisfies readonly (readonly [MemoryKind, number])[]
+
+const cutoffIso = (now: Date, days: number): string => new Date(now.getTime() - days * DAY_MS).toISOString()
+
+const staleKindCondition = (now: Date): SQL | undefined =>
+  or(
+    ...STALE_CUTOFFS.map(([kind, days]) =>
+      and(eq(memoryRecords.kind, kind), lte(memoryRecords.lastSeenAt, cutoffIso(now, days))),
+    ),
+  )
+
+const parseMaintenanceTime = (nowIso: string): Date => {
+  const now = new Date(nowIso)
+  if (Number.isNaN(now.getTime())) {
+    throw new Error(`Invalid memory maintenance timestamp: ${nowIso}`)
+  }
+  return now
+}
+
+export function runMemoryMaintenance(nowIso = new Date().toISOString()): { staleMarked: number; archived: number } {
+  const now = parseMaintenanceTime(nowIso)
+  const db = getDrizzleDb()
+
+  const archivedRows = db
+    .update(memoryRecords)
+    .set({ status: 'archived', updatedAt: nowIso })
+    .where(
+      and(
+        ne(memoryRecords.status, 'archived'),
+        isNotNull(memoryRecords.expiresAt),
+        lte(memoryRecords.expiresAt, nowIso),
+      ),
+    )
+    .returning({ id: memoryRecords.id })
+    .all()
+
+  const staleRows = db
+    .update(memoryRecords)
+    .set({ status: 'stale', updatedAt: nowIso })
+    .where(and(eq(memoryRecords.status, 'active'), ne(memoryRecords.source, 'explicit'), staleKindCondition(now)))
+    .returning({ id: memoryRecords.id })
+    .all()
+
+  const result = { staleMarked: staleRows.length, archived: archivedRows.length }
+  log.info(result, 'Long-term memory maintenance complete')
+  return result
+}

--- a/src/long-term-memory/runner.ts
+++ b/src/long-term-memory/runner.ts
@@ -89,6 +89,13 @@ const inFlight = new Set<string>()
 
 const scopeKey = (scope: MemoryScope): string => `${scope.scopeType}:${scope.scopeId}`
 
+const canonicalIsoOrNull = (value: string | undefined): string | null => {
+  if (value === undefined) return null
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return null
+  return parsed.toISOString()
+}
+
 const logConfigFailure = (
   input: RunMemoryExtractionInput,
   scope: MemoryScope,
@@ -121,14 +128,14 @@ const insertRecords = (scope: MemoryScope, patch: MemoryPatch, deps: RunMemoryEx
       tags: record.tags,
       confidence: record.confidence,
       status: 'active',
-      source: record.source,
+      source: 'background',
       evidence: record.evidence,
       createdAt: now,
       updatedAt: now,
       lastSeenAt: now,
-      validFrom: record.validFrom ?? null,
-      validUntil: record.validUntil ?? null,
-      expiresAt: record.expiresAt ?? null,
+      validFrom: canonicalIsoOrNull(record.validFrom),
+      validUntil: canonicalIsoOrNull(record.validUntil),
+      expiresAt: canonicalIsoOrNull(record.expiresAt),
     })
     return count + 1
   }, 0)

--- a/src/long-term-memory/runner.ts
+++ b/src/long-term-memory/runner.ts
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { randomUUID } from 'node:crypto'
+
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import type { LanguageModel, ModelMessage } from 'ai'
+
+import type { ContextType } from '../chat/types.js'
+import { resolveEffectiveLlmConfig, type EffectiveLlmConfig } from '../llm-config-resolver.js'
+import { logger } from '../logger.js'
+import { fetchWithoutTimeout } from '../utils/fetch.js'
+import { extractMemoryPatch, type MemoryPatch } from './extractor.js'
+import { resolveMemoryScope } from './scope.js'
+import {
+  getMemoryProfile,
+  listMemoryRecords,
+  saveMemoryProfile,
+  saveMemoryRecord,
+  updateMemoryRecord,
+} from './store.js'
+import type { MemoryRecord, MemoryScope } from './types.js'
+
+const log = logger.child({ scope: 'long-term-memory:runner' })
+
+type ResolvedConfig = Extract<ReturnType<typeof resolveEffectiveLlmConfig>, EffectiveLlmConfig>
+
+export type RunMemoryExtractionInput = Readonly<{
+  storageContextId: string
+  configContextId: string
+  contextType: ContextType
+  history: readonly ModelMessage[]
+  deps?: Partial<RunMemoryExtractionDeps>
+}>
+
+export type RunMemoryExtractionDeps = Readonly<{
+  extractMemoryPatch: (input: ExtractMemoryPatchRunInput) => Promise<MemoryPatch>
+  resolveLlmConfig: (configContextId: string) => ReturnType<typeof resolveEffectiveLlmConfig>
+  buildModel: (config: ResolvedConfig) => LanguageModel
+  now: () => string
+  randomUUID: () => string
+}>
+
+export type ExtractMemoryPatchRunInput = Readonly<{
+  storageContextId: string
+  configContextId: string
+  contextType: ContextType
+  scope: MemoryScope
+  history: readonly ModelMessage[]
+  profile: string | null
+  records: readonly MemoryRecord[]
+  model: LanguageModel | null
+}>
+
+const buildModel = (config: ResolvedConfig): LanguageModel =>
+  createOpenAICompatible({
+    name: 'openai-compatible',
+    apiKey: config.llmApiKey,
+    baseURL: config.llmBaseUrl,
+    fetch: fetchWithoutTimeout,
+  })(config.smallModel)
+
+const defaultDeps: RunMemoryExtractionDeps = {
+  extractMemoryPatch: (input) => {
+    if (input.model === null) {
+      throw new Error('memory extraction model is required')
+    }
+    return extractMemoryPatch({
+      history: input.history,
+      profile: input.profile,
+      records: input.records,
+      model: input.model,
+    })
+  },
+  resolveLlmConfig: (configContextId) => resolveEffectiveLlmConfig(configContextId),
+  buildModel,
+  now: () => new Date().toISOString(),
+  randomUUID: () => randomUUID(),
+}
+
+const resolveDeps = (deps: Partial<RunMemoryExtractionDeps> | undefined): RunMemoryExtractionDeps => ({
+  ...defaultDeps,
+  ...deps,
+})
+
+const inFlight = new Set<string>()
+
+const scopeKey = (scope: MemoryScope): string => `${scope.scopeType}:${scope.scopeId}`
+
+const logConfigFailure = (
+  input: RunMemoryExtractionInput,
+  scope: MemoryScope,
+  resolved: Exclude<ReturnType<typeof resolveEffectiveLlmConfig>, { readonly ok: true }>,
+): void => {
+  log.warn(
+    {
+      storageContextId: input.storageContextId,
+      configContextId: input.configContextId,
+      scopeId: scope.scopeId,
+      scopeType: scope.scopeType,
+      source: resolved.source,
+      type: resolved.type,
+      missing: resolved.type === 'missing' ? resolved.missing : undefined,
+      error: resolved.type === 'error' ? resolved.error : undefined,
+    },
+    'LLM config not available for long-term memory extraction',
+  )
+}
+
+const insertRecords = (scope: MemoryScope, patch: MemoryPatch, deps: RunMemoryExtractionDeps): number => {
+  const now = deps.now()
+  return patch.records.reduce((count, record) => {
+    saveMemoryRecord({
+      id: deps.randomUUID(),
+      ...scope,
+      kind: record.kind,
+      content: record.content,
+      summary: record.summary,
+      tags: record.tags,
+      confidence: record.confidence,
+      status: 'active',
+      source: record.source,
+      evidence: record.evidence,
+      createdAt: now,
+      updatedAt: now,
+      lastSeenAt: now,
+      validFrom: record.validFrom ?? null,
+      validUntil: record.validUntil ?? null,
+      expiresAt: record.expiresAt ?? null,
+    })
+    return count + 1
+  }, 0)
+}
+
+const applyUpdates = (scope: MemoryScope, patch: MemoryPatch, now: string): number =>
+  patch.updates.reduce((count, update) => {
+    const updated = updateMemoryRecord(scope, update.id, update, now)
+    return updated === null ? count : count + 1
+  }, 0)
+
+const shouldResolveModel = (input: RunMemoryExtractionInput): boolean =>
+  input.deps?.extractMemoryPatch === undefined || input.deps.buildModel !== undefined
+
+const resolveModel = (
+  input: RunMemoryExtractionInput,
+  scope: MemoryScope,
+  deps: RunMemoryExtractionDeps,
+): LanguageModel | null => {
+  if (!shouldResolveModel(input)) return null
+  const resolvedConfig = deps.resolveLlmConfig(input.configContextId)
+  if (!resolvedConfig.ok) {
+    logConfigFailure(input, scope, resolvedConfig)
+    return null
+  }
+  return deps.buildModel(resolvedConfig)
+}
+
+const performExtraction = async (
+  input: RunMemoryExtractionInput,
+  scope: MemoryScope,
+  deps: RunMemoryExtractionDeps,
+): Promise<void> => {
+  const profile = getMemoryProfile(scope)
+  if (profile?.enabled === false) {
+    log.debug({ scopeId: scope.scopeId, scopeType: scope.scopeType }, 'Long-term memory capture disabled; skipping')
+    return
+  }
+
+  const records = listMemoryRecords({ ...scope, status: 'active' })
+  const model = resolveModel(input, scope, deps)
+  if (model === null && shouldResolveModel(input)) {
+    return
+  }
+
+  const patch = await deps.extractMemoryPatch({
+    storageContextId: input.storageContextId,
+    configContextId: input.configContextId,
+    contextType: input.contextType,
+    scope,
+    history: input.history,
+    profile: profile?.profile ?? null,
+    records,
+    model,
+  })
+
+  const now = deps.now()
+  if (patch.profile !== null) {
+    saveMemoryProfile(scope, patch.profile, now)
+  }
+  const inserted = insertRecords(scope, patch, deps)
+  const updated = applyUpdates(scope, patch, now)
+
+  log.info(
+    {
+      storageContextId: input.storageContextId,
+      configContextId: input.configContextId,
+      scopeId: scope.scopeId,
+      scopeType: scope.scopeType,
+      inserted,
+      updated,
+      profileUpdated: patch.profile !== null,
+    },
+    'Long-term memory extraction complete',
+  )
+}
+
+export async function runMemoryExtractionInBackground(input: RunMemoryExtractionInput): Promise<void> {
+  const scope = resolveMemoryScope({ storageContextId: input.storageContextId, contextType: input.contextType })
+  const key = scopeKey(scope)
+  if (inFlight.has(key)) {
+    log.debug({ scopeId: scope.scopeId, scopeType: scope.scopeType }, 'Long-term memory extraction already in flight')
+    return
+  }
+  inFlight.add(key)
+  try {
+    await performExtraction(input, scope, resolveDeps(input.deps))
+  } catch (error) {
+    log.warn(
+      {
+        storageContextId: input.storageContextId,
+        configContextId: input.configContextId,
+        scopeId: scope.scopeId,
+        scopeType: scope.scopeType,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'Long-term memory extraction failed in background',
+    )
+  } finally {
+    inFlight.delete(key)
+  }
+}

--- a/src/long-term-memory/scope.ts
+++ b/src/long-term-memory/scope.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { getMainContextIdFromThreadContextId } from '../chat/scoped-context.js'
+import type { ContextType } from '../chat/types.js'
+import type { MemoryScope } from './types.js'
+
+export type ResolveMemoryScopeInput = Readonly<{
+  storageContextId: string
+  contextType: ContextType
+}>
+
+export function resolveMemoryScope(input: ResolveMemoryScopeInput): MemoryScope {
+  if (input.contextType === 'dm') {
+    return { scopeId: input.storageContextId, scopeType: 'personal' }
+  }
+  return {
+    scopeId: getMainContextIdFromThreadContextId(input.storageContextId),
+    scopeType: 'group',
+  }
+}

--- a/src/long-term-memory/store.ts
+++ b/src/long-term-memory/store.ts
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { and, desc, eq, inArray, sql, type SQL } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { memoryProfiles, memoryRecords, type MemoryProfileRow, type MemoryRecordRow } from '../db/schema.js'
+import type {
+  MemoryEvidence,
+  MemoryKind,
+  MemoryProfile,
+  MemoryRecord,
+  MemoryRecordInput,
+  MemoryScope,
+  MemoryStatus,
+} from './types.js'
+
+export type ListMemoryRecordsFilter = Readonly<{
+  scopeId: string
+  status?: MemoryStatus
+  kind?: MemoryKind
+  limit?: number
+}>
+
+export type SearchMemoryRecordsFilter = Readonly<{
+  scopeId: string
+  query: string
+  includeStale?: boolean
+  kind?: MemoryKind
+  limit?: number
+}>
+
+const DEFAULT_LIST_LIMIT = 50
+const DEFAULT_SEARCH_LIMIT = 10
+
+type MemoryRecordValues = typeof memoryRecords.$inferInsert
+
+const parseTags = (json: string): readonly string[] => {
+  const parsed: unknown = JSON.parse(json)
+  return Array.isArray(parsed) ? parsed.filter((tag): tag is string => typeof tag === 'string') : []
+}
+
+const parseEvidence = (json: string): MemoryEvidence => {
+  const parsed: unknown = JSON.parse(json)
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+  return parsed as MemoryEvidence
+}
+
+const sanitizeFtsQuery = (query: string): string => `"${query.replace(/"/gu, '""')}"`
+
+const serializeEmbedding = (embedding: Float32Array | null | undefined): Buffer | null =>
+  embedding === null || embedding === undefined
+    ? null
+    : Buffer.from(embedding.buffer, embedding.byteOffset, embedding.byteLength)
+
+const copyViewBuffer = (view: ArrayBufferView): ArrayBuffer => {
+  const copy = new Uint8Array(view.byteLength)
+  copy.set(new Uint8Array(view.buffer, view.byteOffset, view.byteLength))
+  return copy.buffer
+}
+
+const deserializeEmbedding = (embedding: MemoryRecordRow['embedding']): Float32Array | null => {
+  if (embedding === null) return null
+  if (embedding instanceof ArrayBuffer) return new Float32Array(embedding.slice(0))
+  if (ArrayBuffer.isView(embedding)) return new Float32Array(copyViewBuffer(embedding))
+  return null
+}
+
+const rowToProfile = (row: MemoryProfileRow): MemoryProfile => ({
+  scopeId: row.scopeId,
+  scopeType: row.scopeType,
+  profile: row.profile,
+  enabled: row.enabled,
+  version: row.version,
+  updatedAt: row.updatedAt,
+})
+
+const rowToRecord = (row: MemoryRecordRow): MemoryRecord => ({
+  id: row.id,
+  scopeId: row.scopeId,
+  scopeType: row.scopeType,
+  kind: row.kind,
+  content: row.content,
+  summary: row.summary,
+  tags: parseTags(row.tags),
+  confidence: row.confidence,
+  status: row.status,
+  source: row.source,
+  evidence: parseEvidence(row.evidence),
+  createdAt: row.createdAt,
+  updatedAt: row.updatedAt,
+  lastSeenAt: row.lastSeenAt,
+  validFrom: row.validFrom,
+  validUntil: row.validUntil,
+  expiresAt: row.expiresAt,
+  embedding: deserializeEmbedding(row.embedding),
+})
+
+const inputToRecordValues = (input: MemoryRecordInput): MemoryRecordValues => ({
+  id: input.id,
+  scopeId: input.scopeId,
+  scopeType: input.scopeType,
+  kind: input.kind,
+  content: input.content,
+  summary: input.summary,
+  tags: JSON.stringify(input.tags),
+  confidence: input.confidence,
+  status: input.status,
+  source: input.source,
+  evidence: JSON.stringify(input.evidence),
+  createdAt: input.createdAt,
+  updatedAt: input.updatedAt,
+  lastSeenAt: input.lastSeenAt,
+  validFrom: input.validFrom ?? null,
+  validUntil: input.validUntil ?? null,
+  expiresAt: input.expiresAt ?? null,
+  embedding: serializeEmbedding(input.embedding),
+})
+
+const loadProfile = (scopeId: string): MemoryProfile => {
+  const row = getDrizzleDb().select().from(memoryProfiles).where(eq(memoryProfiles.scopeId, scopeId)).get()
+  if (row === undefined) {
+    throw new Error(`Memory profile not found after save: ${scopeId}`)
+  }
+  return rowToProfile(row)
+}
+
+const loadRecord = (recordId: string): MemoryRecord => {
+  const row = getDrizzleDb().select().from(memoryRecords).where(eq(memoryRecords.id, recordId)).get()
+  if (row === undefined) {
+    throw new Error(`Memory record not found after save: ${recordId}`)
+  }
+  return rowToRecord(row)
+}
+
+export function getMemoryProfile(scope: MemoryScope): MemoryProfile | null {
+  const row = getDrizzleDb()
+    .select()
+    .from(memoryProfiles)
+    .where(and(eq(memoryProfiles.scopeId, scope.scopeId), eq(memoryProfiles.scopeType, scope.scopeType)))
+    .get()
+  return row === undefined ? null : rowToProfile(row)
+}
+
+export function saveMemoryProfile(scope: MemoryScope, profile: string, now: string): MemoryProfile {
+  getDrizzleDb()
+    .insert(memoryProfiles)
+    .values({ scopeId: scope.scopeId, scopeType: scope.scopeType, profile, enabled: true, version: 1, updatedAt: now })
+    .onConflictDoUpdate({
+      target: memoryProfiles.scopeId,
+      set: {
+        scopeType: scope.scopeType,
+        profile,
+        version: sql`${memoryProfiles.version} + 1`,
+        updatedAt: now,
+      },
+    })
+    .run()
+  return loadProfile(scope.scopeId)
+}
+
+export function setMemoryCaptureEnabled(scope: MemoryScope, enabled: boolean, now: string): MemoryProfile {
+  getDrizzleDb()
+    .insert(memoryProfiles)
+    .values({ scopeId: scope.scopeId, scopeType: scope.scopeType, profile: '', enabled, version: 1, updatedAt: now })
+    .onConflictDoUpdate({
+      target: memoryProfiles.scopeId,
+      set: {
+        scopeType: scope.scopeType,
+        enabled,
+        version: sql`${memoryProfiles.version} + 1`,
+        updatedAt: now,
+      },
+    })
+    .run()
+  return loadProfile(scope.scopeId)
+}
+
+export function saveMemoryRecord(input: MemoryRecordInput): MemoryRecord {
+  const values = inputToRecordValues(input)
+
+  getDrizzleDb()
+    .insert(memoryRecords)
+    .values(values)
+    .onConflictDoUpdate({
+      target: memoryRecords.id,
+      set: values,
+    })
+    .run()
+  return loadRecord(input.id)
+}
+
+export function listMemoryRecords(filter: ListMemoryRecordsFilter): readonly MemoryRecord[] {
+  const conditions: SQL[] = [eq(memoryRecords.scopeId, filter.scopeId)]
+  if (filter.status !== undefined) conditions.push(eq(memoryRecords.status, filter.status))
+  if (filter.kind !== undefined) conditions.push(eq(memoryRecords.kind, filter.kind))
+
+  return getDrizzleDb()
+    .select()
+    .from(memoryRecords)
+    .where(and(...conditions))
+    .orderBy(desc(memoryRecords.lastSeenAt))
+    .limit(filter.limit ?? DEFAULT_LIST_LIMIT)
+    .all()
+    .map(rowToRecord)
+}
+
+export function searchMemoryRecords(filter: SearchMemoryRecordsFilter): readonly MemoryRecord[] {
+  const safeQuery = sanitizeFtsQuery(filter.query)
+  const statusFilter =
+    filter.includeStale === true
+      ? inArray(memoryRecords.status, ['active', 'stale'])
+      : eq(memoryRecords.status, 'active')
+  const conditions: SQL[] = [
+    eq(memoryRecords.scopeId, filter.scopeId),
+    statusFilter,
+    sql`${memoryRecords.id} IN (
+      SELECT m.id
+      FROM memory_records m
+      INNER JOIN memory_records_fts f ON m.rowid = f.rowid
+      WHERE f.memory_records_fts MATCH ${safeQuery}
+        AND m.scope_id = ${filter.scopeId}
+    )`,
+  ]
+  if (filter.kind !== undefined) conditions.push(eq(memoryRecords.kind, filter.kind))
+
+  return getDrizzleDb()
+    .select()
+    .from(memoryRecords)
+    .where(and(...conditions))
+    .orderBy(desc(memoryRecords.lastSeenAt))
+    .limit(filter.limit ?? DEFAULT_SEARCH_LIMIT)
+    .all()
+    .map(rowToRecord)
+}
+
+export function archiveMemoryRecord(scopeId: string, recordId: string, now: string): boolean {
+  const rows = getDrizzleDb()
+    .update(memoryRecords)
+    .set({ status: 'archived', updatedAt: now })
+    .where(and(eq(memoryRecords.scopeId, scopeId), eq(memoryRecords.id, recordId)))
+    .returning({ id: memoryRecords.id })
+    .all()
+  return rows.length > 0
+}
+
+export function clearMemoryScope(scope: MemoryScope): { profileDeleted: number; recordsDeleted: number } {
+  const db = getDrizzleDb()
+  const deletedRecords = db
+    .delete(memoryRecords)
+    .where(and(eq(memoryRecords.scopeId, scope.scopeId), eq(memoryRecords.scopeType, scope.scopeType)))
+    .returning({ id: memoryRecords.id })
+    .all()
+  const deletedProfiles = db
+    .delete(memoryProfiles)
+    .where(and(eq(memoryProfiles.scopeId, scope.scopeId), eq(memoryProfiles.scopeType, scope.scopeType)))
+    .returning({ scopeId: memoryProfiles.scopeId })
+    .all()
+
+  return { profileDeleted: deletedProfiles.length, recordsDeleted: deletedRecords.length }
+}

--- a/src/long-term-memory/store.ts
+++ b/src/long-term-memory/store.ts
@@ -18,19 +18,19 @@ import type {
 } from './types.js'
 
 export type ListMemoryRecordsFilter = Readonly<{
-  scopeId: string
   status?: MemoryStatus
   kind?: MemoryKind
   limit?: number
-}>
+}> &
+  MemoryScope
 
 export type SearchMemoryRecordsFilter = Readonly<{
-  scopeId: string
   query: string
   includeStale?: boolean
   kind?: MemoryKind
   limit?: number
-}>
+}> &
+  MemoryScope
 
 const DEFAULT_LIST_LIMIT = 50
 const DEFAULT_SEARCH_LIMIT = 10
@@ -38,14 +38,22 @@ const DEFAULT_SEARCH_LIMIT = 10
 type MemoryRecordValues = typeof memoryRecords.$inferInsert
 
 const parseTags = (json: string): readonly string[] => {
-  const parsed: unknown = JSON.parse(json)
-  return Array.isArray(parsed) ? parsed.filter((tag): tag is string => typeof tag === 'string') : []
+  try {
+    const parsed: unknown = JSON.parse(json)
+    return Array.isArray(parsed) ? parsed.filter((tag): tag is string => typeof tag === 'string') : []
+  } catch {
+    return []
+  }
 }
 
 const parseEvidence = (json: string): MemoryEvidence => {
-  const parsed: unknown = JSON.parse(json)
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
-  return parsed as MemoryEvidence
+  try {
+    const parsed: unknown = JSON.parse(json)
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    return parsed as MemoryEvidence
+  } catch {
+    return {}
+  }
 }
 
 const sanitizeFtsQuery = (query: string): string => `"${query.replace(/"/gu, '""')}"`
@@ -193,7 +201,7 @@ export function saveMemoryRecord(input: MemoryRecordInput): MemoryRecord {
 }
 
 export function listMemoryRecords(filter: ListMemoryRecordsFilter): readonly MemoryRecord[] {
-  const conditions: SQL[] = [eq(memoryRecords.scopeId, filter.scopeId)]
+  const conditions: SQL[] = [eq(memoryRecords.scopeId, filter.scopeId), eq(memoryRecords.scopeType, filter.scopeType)]
   if (filter.status !== undefined) conditions.push(eq(memoryRecords.status, filter.status))
   if (filter.kind !== undefined) conditions.push(eq(memoryRecords.kind, filter.kind))
 
@@ -215,6 +223,7 @@ export function searchMemoryRecords(filter: SearchMemoryRecordsFilter): readonly
       : eq(memoryRecords.status, 'active')
   const conditions: SQL[] = [
     eq(memoryRecords.scopeId, filter.scopeId),
+    eq(memoryRecords.scopeType, filter.scopeType),
     statusFilter,
     sql`${memoryRecords.id} IN (
       SELECT m.id
@@ -222,6 +231,7 @@ export function searchMemoryRecords(filter: SearchMemoryRecordsFilter): readonly
       INNER JOIN memory_records_fts f ON m.rowid = f.rowid
       WHERE f.memory_records_fts MATCH ${safeQuery}
         AND m.scope_id = ${filter.scopeId}
+        AND m.scope_type = ${filter.scopeType}
     )`,
   ]
   if (filter.kind !== undefined) conditions.push(eq(memoryRecords.kind, filter.kind))
@@ -236,11 +246,17 @@ export function searchMemoryRecords(filter: SearchMemoryRecordsFilter): readonly
     .map(rowToRecord)
 }
 
-export function archiveMemoryRecord(scopeId: string, recordId: string, now: string): boolean {
+export function archiveMemoryRecord(scope: MemoryScope, recordId: string, now: string): boolean {
   const rows = getDrizzleDb()
     .update(memoryRecords)
     .set({ status: 'archived', updatedAt: now })
-    .where(and(eq(memoryRecords.scopeId, scopeId), eq(memoryRecords.id, recordId)))
+    .where(
+      and(
+        eq(memoryRecords.scopeId, scope.scopeId),
+        eq(memoryRecords.scopeType, scope.scopeType),
+        eq(memoryRecords.id, recordId),
+      ),
+    )
     .returning({ id: memoryRecords.id })
     .all()
   return rows.length > 0

--- a/src/long-term-memory/store.ts
+++ b/src/long-term-memory/store.ts
@@ -127,10 +127,13 @@ const inputToRecordValues = (input: MemoryRecordInput): MemoryRecordValues => ({
   embedding: serializeEmbedding(input.embedding),
 })
 
-const loadProfile = (scopeId: string): MemoryProfile => {
-  const row = getDrizzleDb().select().from(memoryProfiles).where(eq(memoryProfiles.scopeId, scopeId)).get()
+const profileScopeCondition = (scope: MemoryScope): SQL | undefined =>
+  and(eq(memoryProfiles.scopeId, scope.scopeId), eq(memoryProfiles.scopeType, scope.scopeType))
+
+const loadProfile = (scope: MemoryScope): MemoryProfile => {
+  const row = getDrizzleDb().select().from(memoryProfiles).where(profileScopeCondition(scope)).get()
   if (row === undefined) {
-    throw new Error(`Memory profile not found after save: ${scopeId}`)
+    throw new Error(`Memory profile not found after save: ${scope.scopeType}:${scope.scopeId}`)
   }
   return rowToProfile(row)
 }
@@ -144,11 +147,7 @@ const loadRecord = (recordId: string): MemoryRecord => {
 }
 
 export function getMemoryProfile(scope: MemoryScope): MemoryProfile | null {
-  const row = getDrizzleDb()
-    .select()
-    .from(memoryProfiles)
-    .where(and(eq(memoryProfiles.scopeId, scope.scopeId), eq(memoryProfiles.scopeType, scope.scopeType)))
-    .get()
+  const row = getDrizzleDb().select().from(memoryProfiles).where(profileScopeCondition(scope)).get()
   return row === undefined ? null : rowToProfile(row)
 }
 
@@ -157,16 +156,15 @@ export function saveMemoryProfile(scope: MemoryScope, profile: string, now: stri
     .insert(memoryProfiles)
     .values({ scopeId: scope.scopeId, scopeType: scope.scopeType, profile, enabled: true, version: 1, updatedAt: now })
     .onConflictDoUpdate({
-      target: memoryProfiles.scopeId,
+      target: [memoryProfiles.scopeType, memoryProfiles.scopeId],
       set: {
-        scopeType: scope.scopeType,
         profile,
         version: sql`${memoryProfiles.version} + 1`,
         updatedAt: now,
       },
     })
     .run()
-  return loadProfile(scope.scopeId)
+  return loadProfile(scope)
 }
 
 export function setMemoryCaptureEnabled(scope: MemoryScope, enabled: boolean, now: string): MemoryProfile {
@@ -174,16 +172,15 @@ export function setMemoryCaptureEnabled(scope: MemoryScope, enabled: boolean, no
     .insert(memoryProfiles)
     .values({ scopeId: scope.scopeId, scopeType: scope.scopeType, profile: '', enabled, version: 1, updatedAt: now })
     .onConflictDoUpdate({
-      target: memoryProfiles.scopeId,
+      target: [memoryProfiles.scopeType, memoryProfiles.scopeId],
       set: {
-        scopeType: scope.scopeType,
         enabled,
         version: sql`${memoryProfiles.version} + 1`,
         updatedAt: now,
       },
     })
     .run()
-  return loadProfile(scope.scopeId)
+  return loadProfile(scope)
 }
 
 export function saveMemoryRecord(input: MemoryRecordInput): MemoryRecord {
@@ -293,7 +290,7 @@ export function clearMemoryScope(scope: MemoryScope): { profileDeleted: number; 
     .all()
   const deletedProfiles = db
     .delete(memoryProfiles)
-    .where(and(eq(memoryProfiles.scopeId, scope.scopeId), eq(memoryProfiles.scopeType, scope.scopeType)))
+    .where(profileScopeCondition(scope))
     .returning({ scopeId: memoryProfiles.scopeId })
     .all()
   return { profileDeleted: deletedProfiles.length, recordsDeleted: deletedRecords.length }

--- a/src/long-term-memory/store.ts
+++ b/src/long-term-memory/store.ts
@@ -246,20 +246,42 @@ export function searchMemoryRecords(filter: SearchMemoryRecordsFilter): readonly
     .map(rowToRecord)
 }
 
+const recordScopeCondition = (scope: MemoryScope, recordId: string): SQL | undefined =>
+  and(
+    eq(memoryRecords.scopeId, scope.scopeId),
+    eq(memoryRecords.scopeType, scope.scopeType),
+    eq(memoryRecords.id, recordId),
+  )
+
 export function archiveMemoryRecord(scope: MemoryScope, recordId: string, now: string): boolean {
   const rows = getDrizzleDb()
     .update(memoryRecords)
     .set({ status: 'archived', updatedAt: now })
-    .where(
-      and(
-        eq(memoryRecords.scopeId, scope.scopeId),
-        eq(memoryRecords.scopeType, scope.scopeType),
-        eq(memoryRecords.id, recordId),
-      ),
-    )
+    .where(recordScopeCondition(scope, recordId))
     .returning({ id: memoryRecords.id })
     .all()
   return rows.length > 0
+}
+
+export function updateMemoryRecord(
+  scope: MemoryScope,
+  recordId: string,
+  patch: Readonly<{ status?: MemoryStatus; content?: string; confidence?: number }>,
+  now: string,
+): MemoryRecord | null {
+  const rows = getDrizzleDb()
+    .update(memoryRecords)
+    .set({
+      ...(patch.status === undefined ? {} : { status: patch.status }),
+      ...(patch.content === undefined ? {} : { content: patch.content }),
+      ...(patch.confidence === undefined ? {} : { confidence: patch.confidence }),
+      updatedAt: now,
+      lastSeenAt: now,
+    } satisfies Partial<MemoryRecordValues>)
+    .where(recordScopeCondition(scope, recordId))
+    .returning()
+    .all()
+  return rows[0] === undefined ? null : rowToRecord(rows[0])
 }
 
 export function clearMemoryScope(scope: MemoryScope): { profileDeleted: number; recordsDeleted: number } {
@@ -274,6 +296,5 @@ export function clearMemoryScope(scope: MemoryScope): { profileDeleted: number; 
     .where(and(eq(memoryProfiles.scopeId, scope.scopeId), eq(memoryProfiles.scopeType, scope.scopeType)))
     .returning({ scopeId: memoryProfiles.scopeId })
     .all()
-
   return { profileDeleted: deletedProfiles.length, recordsDeleted: deletedRecords.length }
 }

--- a/src/long-term-memory/types.ts
+++ b/src/long-term-memory/types.ts
@@ -30,3 +30,40 @@ export type MemoryStatus = z.infer<typeof MemoryStatusSchema>
 
 export const MemorySourceSchema = z.enum(['background', 'explicit', 'tool_result', 'admin_edit'])
 export type MemorySource = z.infer<typeof MemorySourceSchema>
+
+export type MemoryProfile = MemoryScope &
+  Readonly<{
+    profile: string
+    enabled: boolean
+    version: number
+    updatedAt: string
+  }>
+
+export type MemoryEvidence = Readonly<{
+  messageIds?: readonly string[]
+  actorIds?: readonly string[]
+  timestamps?: readonly string[]
+  contextId?: string
+}>
+
+export type MemoryRecord = MemoryScope &
+  Readonly<{
+    id: string
+    kind: MemoryKind
+    content: string
+    summary: string | null
+    tags: readonly string[]
+    confidence: number
+    status: MemoryStatus
+    source: MemorySource
+    evidence: MemoryEvidence
+    createdAt: string
+    updatedAt: string
+    lastSeenAt: string
+    validFrom?: string | null
+    validUntil?: string | null
+    expiresAt?: string | null
+    embedding?: Float32Array | null
+  }>
+
+export type MemoryRecordInput = Omit<MemoryRecord, 'embedding'> & Readonly<{ embedding?: Float32Array | null }>

--- a/src/long-term-memory/types.ts
+++ b/src/long-term-memory/types.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+export const MemoryScopeTypeSchema = z.enum(['personal', 'group'])
+export type MemoryScopeType = z.infer<typeof MemoryScopeTypeSchema>
+
+export type MemoryScope = Readonly<{
+  scopeId: string
+  scopeType: MemoryScopeType
+}>
+
+export const MemoryKindSchema = z.enum([
+  'preference',
+  'fact',
+  'decision',
+  'project_context',
+  'person_context',
+  'procedure',
+  'episode',
+  'reference',
+])
+export type MemoryKind = z.infer<typeof MemoryKindSchema>
+
+export const MemoryStatusSchema = z.enum(['active', 'stale', 'archived', 'contradicted'])
+export type MemoryStatus = z.infer<typeof MemoryStatusSchema>
+
+export const MemorySourceSchema = z.enum(['background', 'explicit', 'tool_result', 'admin_edit'])
+export type MemorySource = z.infer<typeof MemorySourceSchema>

--- a/src/scheduler-instance.ts
+++ b/src/scheduler-instance.ts
@@ -11,6 +11,7 @@
 import { purgeExpiredStagedFiles } from './attachments/staged.js'
 import { cleanupExpiredCaches } from './cache.js'
 import { logger } from './logger.js'
+import { runMemoryMaintenance } from './long-term-memory/maintenance.js'
 import { sweepExpiredMessages } from './message-cache/cache.js'
 import { cleanupExpiredMessages } from './message-cache/persistence.js'
 import { cleanupExpiredQueues } from './message-queue/index.js'
@@ -57,6 +58,14 @@ scheduler.register('staged-files-purge', {
   interval: 60 * 60 * 1000,
   handler: () => {
     purgeExpiredStagedFiles()
+  },
+  options: { immediate: true },
+})
+
+scheduler.register('long-term-memory-maintenance', {
+  interval: 60 * 60 * 1000,
+  handler: () => {
+    runMemoryMaintenance()
   },
   options: { immediate: true },
 })

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { randomUUID } from 'node:crypto'
+
+import { tool, type ToolSet } from 'ai'
+import { z } from 'zod'
+
+import type { ContextType } from '../chat/types.js'
+import { logger } from '../logger.js'
+import { resolveMemoryScope } from '../long-term-memory/scope.js'
+import {
+  archiveMemoryRecord,
+  listMemoryRecords,
+  saveMemoryRecord,
+  searchMemoryRecords,
+} from '../long-term-memory/store.js'
+import { MemoryKindSchema, MemoryStatusSchema, type MemoryRecord, type MemoryScope } from '../long-term-memory/types.js'
+
+const log = logger.child({ scope: 'tool:memory' })
+
+export type MemoryToolContext = Readonly<{
+  storageContextId: string
+  contextType: Extract<ContextType, 'dm' | 'group'>
+}>
+
+const tagsSchema = z
+  .array(z.string().min(1).max(80))
+  .default([])
+  .describe('Optional short tags for grouping the memory')
+
+const optionalKindSchema = MemoryKindSchema.optional().describe('Optional memory kind filter')
+
+const limitSchema = z.number().int().min(1).max(50).optional().describe('Maximum number of memory records to return')
+
+type PublicMemoryRecord = Readonly<{
+  id: string
+  kind: MemoryRecord['kind']
+  content: string
+  summary: string | null
+  tags: readonly string[]
+  confidence: number
+  status: MemoryRecord['status']
+  source: MemoryRecord['source']
+  createdAt: string
+  updatedAt: string
+  lastSeenAt: string
+  expiresAt?: string | null
+}>
+
+const toPublicRecord = (record: MemoryRecord): PublicMemoryRecord => ({
+  id: record.id,
+  kind: record.kind,
+  content: record.content,
+  summary: record.summary,
+  tags: record.tags,
+  confidence: record.confidence,
+  status: record.status,
+  source: record.source,
+  createdAt: record.createdAt,
+  updatedAt: record.updatedAt,
+  lastSeenAt: record.lastSeenAt,
+  expiresAt: record.expiresAt,
+})
+
+const memoryScope = (context: MemoryToolContext): MemoryScope =>
+  resolveMemoryScope({ storageContextId: context.storageContextId, contextType: context.contextType })
+
+const nowIso = (): string => new Date().toISOString()
+
+const sameText = (left: string, right: string): boolean =>
+  left.trim().toLocaleLowerCase() === right.trim().toLocaleLowerCase()
+
+export function makeRememberMemoryTool(input: MemoryToolContext): ToolSet[string] {
+  return tool({
+    description:
+      'Store explicit long-term memory for the current user or group. Use only when the user asks to remember durable information.',
+    inputSchema: z.object({
+      content: z.string().min(3).max(2000).describe('Durable memory content to store'),
+      kind: MemoryKindSchema.describe('Category that best describes the memory'),
+      tags: tagsSchema.optional(),
+      expiresAt: z.iso.datetime().optional().describe('Optional ISO timestamp when this memory should expire'),
+    }),
+    execute: ({ content, kind, tags, expiresAt }) => {
+      const scope = memoryScope(input)
+      const now = nowIso()
+      const record = saveMemoryRecord({
+        id: randomUUID(),
+        ...scope,
+        kind,
+        content,
+        summary: null,
+        tags: tags ?? [],
+        confidence: 1,
+        status: 'active',
+        source: 'explicit',
+        evidence: { contextId: input.storageContextId },
+        createdAt: now,
+        updatedAt: now,
+        lastSeenAt: now,
+        expiresAt: expiresAt ?? null,
+      })
+      log.info(
+        { scopeId: scope.scopeId, scopeType: scope.scopeType, memoryId: record.id, kind },
+        'Memory saved via tool',
+      )
+      return { status: 'saved', id: record.id, kind: record.kind }
+    },
+  })
+}
+
+export function makeSearchMemoryTool(input: MemoryToolContext): ToolSet[string] {
+  return tool({
+    description: 'Search long-term memory in the current user or group scope by keyword.',
+    inputSchema: z.object({
+      query: z.string().min(1).max(500).describe('Keyword query to search for in memory records'),
+      include_stale: z.boolean().optional().describe('Include stale memories in addition to active memories'),
+      kind: optionalKindSchema,
+      limit: limitSchema,
+    }),
+    execute: ({ query, include_stale: includeStale, kind, limit }) => {
+      const scope = memoryScope(input)
+      const records = searchMemoryRecords({ ...scope, query, includeStale: includeStale ?? false, kind, limit }).map(
+        toPublicRecord,
+      )
+      log.debug(
+        { scopeId: scope.scopeId, scopeType: scope.scopeType, includeStale, kind, limit, count: records.length },
+        'Memory searched via tool',
+      )
+      return { mode: 'keyword', records }
+    },
+  })
+}
+
+export function makeListMemoryTool(input: MemoryToolContext): ToolSet[string] {
+  return tool({
+    description: 'List long-term memory records in the current user or group scope.',
+    inputSchema: z.object({
+      kind: optionalKindSchema,
+      status: MemoryStatusSchema.optional().describe('Memory status to list; defaults to active'),
+      limit: limitSchema,
+    }),
+    execute: ({ kind, status, limit }) => {
+      const scope = memoryScope(input)
+      const resolvedStatus = status ?? 'active'
+      const records = listMemoryRecords({ ...scope, kind, status: resolvedStatus, limit }).map(toPublicRecord)
+      log.debug(
+        {
+          scopeId: scope.scopeId,
+          scopeType: scope.scopeType,
+          kind,
+          status: resolvedStatus,
+          limit,
+          count: records.length,
+        },
+        'Memory listed via tool',
+      )
+      return { records }
+    },
+  })
+}
+
+export function makeForgetMemoryTool(input: MemoryToolContext): ToolSet[string] {
+  return tool({
+    description: 'Archive one long-term memory in the current user or group scope by memory ID or keyword query.',
+    inputSchema: z.object({
+      memory_id: z.string().optional().describe('Exact memory record ID to archive'),
+      query: z.string().min(1).max(500).optional().describe('Keyword query used when memory_id is not available'),
+    }),
+    execute: ({ memory_id: memoryId, query }) => {
+      const scope = memoryScope(input)
+      const now = nowIso()
+      if (memoryId !== undefined) {
+        const archived = archiveMemoryRecord(scope, memoryId, now)
+        log.info(
+          { scopeId: scope.scopeId, scopeType: scope.scopeType, memoryId, archived },
+          'Memory archive by ID requested via tool',
+        )
+        return archived ? { status: 'forgotten', id: memoryId } : { status: 'not_found' }
+      }
+      if (query === undefined) return { status: 'not_found' }
+
+      const matches = searchMemoryRecords({ ...scope, query, includeStale: true })
+      const match = matches.find((record) => sameText(record.content, query)) ?? matches[0]
+      if (match === undefined) {
+        log.info({ scopeId: scope.scopeId, scopeType: scope.scopeType }, 'Memory archive by query found no match')
+        return { status: 'not_found' }
+      }
+
+      const archived = archiveMemoryRecord(scope, match.id, now)
+      log.info(
+        { scopeId: scope.scopeId, scopeType: scope.scopeType, memoryId: match.id, archived },
+        'Memory archive by query requested via tool',
+      )
+      return archived ? { status: 'forgotten', id: match.id } : { status: 'not_found' }
+    },
+  })
+}

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -27,7 +27,8 @@ export type MemoryToolContext = Readonly<{
 }>
 
 const tagsSchema = z
-  .array(z.string().min(1).max(80))
+  .array(z.string().min(1).max(40))
+  .max(10)
   .default([])
   .describe('Optional short tags for grouping the memory')
 
@@ -166,7 +167,7 @@ export function makeForgetMemoryTool(input: MemoryToolContext): ToolSet[string] 
   return tool({
     description: 'Archive one long-term memory in the current user or group scope by memory ID or keyword query.',
     inputSchema: z.object({
-      memory_id: z.string().optional().describe('Exact memory record ID to archive'),
+      memory_id: z.string().max(128).optional().describe('Exact memory record ID to archive'),
       query: z.string().min(1).max(500).optional().describe('Keyword query used when memory_id is not available'),
     }),
     execute: ({ memory_id: memoryId, query }) => {

--- a/src/tools/provider-independent-tools-builder.ts
+++ b/src/tools/provider-independent-tools-builder.ts
@@ -18,6 +18,7 @@ import { makeDeleteInstructionTool, makeListInstructionsTool, makeSaveInstructio
 import { makeListMemosTool } from './list-memos.js'
 import { makeListRecurringTasksTool } from './list-recurring-tasks.js'
 import { makeLookupGroupHistoryTool } from './lookup-group-history.js'
+import { makeForgetMemoryTool, makeListMemoryTool, makeRememberMemoryTool, makeSearchMemoryTool } from './memory.js'
 import { makePauseRecurringTaskTool } from './pause-recurring-task.js'
 import { makeUpdateRecurringTaskTool } from './recurring-tools.js'
 import { makeResumeRecurringTaskTool } from './resume-recurring-task.js'
@@ -40,6 +41,14 @@ function addMemoTools(tools: ToolSet, userId: string | undefined): void {
   tools['search_memos'] = makeSearchMemosTool(userId)
   tools['list_memos'] = makeListMemosTool(userId)
   tools['archive_memos'] = makeArchiveMemosTool(userId)
+}
+
+function addMemoryTools(tools: ToolSet, contextId: string | undefined, contextType: ContextType | undefined): void {
+  if (contextId === undefined || contextType === undefined) return
+  tools['search_memory'] = makeSearchMemoryTool({ storageContextId: contextId, contextType })
+  tools['remember_memory'] = makeRememberMemoryTool({ storageContextId: contextId, contextType })
+  tools['forget_memory'] = makeForgetMemoryTool({ storageContextId: contextId, contextType })
+  tools['list_memory'] = makeListMemoryTool({ storageContextId: contextId, contextType })
 }
 
 function addRecurringTools(tools: ToolSet, userId: string | undefined): void {
@@ -91,6 +100,7 @@ export function addProviderIndependentTools(tools: ToolSet, options: AddProvider
   }
   addRecurringTools(tools, storageOwnerId)
   addMemoTools(tools, storageOwnerId)
+  addMemoryTools(tools, contextId, contextType)
   addInstructionTools(tools, storageOwnerId)
   addLookupGroupHistoryTool(tools, chatUserId, contextId)
   if (contextId !== undefined) tools['web_fetch'] = makeWebFetchTool(contextId, storageOwnerId, contextType)

--- a/src/tools/tool-metadata.ts
+++ b/src/tools/tool-metadata.ts
@@ -24,6 +24,7 @@ export const TOOL_DOMAINS = [
   'time',
   'mcp',
   'plugin',
+  'memory',
 ] as const
 
 export type ToolDomain = (typeof TOOL_DOMAINS)[number]
@@ -138,6 +139,11 @@ export const TOOL_METADATA: Readonly<Record<string, ToolClassification>> = {
   list_memos: read('memo'),
   archive_memos: write('memo', 'update'),
   promote_memo: write('memo', 'create'),
+
+  search_memory: read('memory'),
+  list_memory: read('memory'),
+  remember_memory: write('memory', 'create'),
+  forget_memory: destructive('memory'),
 
   create_recurring_task: write('recurring', 'create'),
   list_recurring_tasks: read('recurring'),

--- a/tests/client/settings/sections/MemorySection.test.ts
+++ b/tests/client/settings/sections/MemorySection.test.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { flushSync, mount, unmount } from 'svelte'
+
+import { setCsrfToken } from '../../../../client/settings/fetchers.js'
+import MemorySection from '../../../../client/settings/sections/MemorySection.svelte'
+import { restoreFetch, setMockFetch } from '../../../utils/test-helpers.js'
+
+const json = (payload: unknown, status = 200): Response =>
+  new Response(JSON.stringify(payload), { status, headers: { 'Content-Type': 'application/json' } })
+
+const drain = async (): Promise<void> => {
+  for (let i = 0; i < 10; i++) await Promise.resolve()
+  flushSync()
+}
+
+interface CapturedCall {
+  url: string
+  method: string
+  body: unknown
+}
+
+const readRequestBody = (init: RequestInit): unknown => {
+  if (typeof init.body !== 'string') return undefined
+  return JSON.parse(init.body)
+}
+
+const captureCall = (calls: CapturedCall[], url: string, init: RequestInit): void => {
+  calls.push({ url, method: init.method ?? 'GET', body: readRequestBody(init) })
+}
+
+const memoryPayload = {
+  contextId: 'user:1',
+  scopeType: 'personal',
+  enabled: true,
+  profile: 'Pinned profile facts for this context.',
+  records: [
+    {
+      id: 'rec/alpha',
+      kind: 'preference',
+      content: 'The user prefers short status updates and compact settings screens.',
+      summary: 'Prefers compact status updates.',
+      tags: ['ui', 'style'],
+      confidence: 0.91,
+      status: 'active',
+      source: 'conversation',
+      createdAt: '2026-06-01T10:00:00.000Z',
+      updatedAt: '2026-06-02T10:00:00.000Z',
+      lastSeenAt: '2026-06-03T10:00:00.000Z',
+    },
+    {
+      id: 'rec-beta',
+      kind: 'fact',
+      content: 'Fallback record body should render when no summary is available.',
+      summary: null,
+      tags: [],
+      confidence: 0.73,
+      status: 'active',
+      source: 'manual',
+      createdAt: '2026-06-04T10:00:00.000Z',
+      updatedAt: '2026-06-05T10:00:00.000Z',
+      lastSeenAt: '2026-06-06T10:00:00.000Z',
+    },
+  ],
+}
+
+const emptyMemoryPayload = {
+  contextId: 'user:1',
+  scopeType: 'personal',
+  enabled: false,
+  profile: '',
+  records: [],
+}
+
+afterEach(() => {
+  restoreFetch()
+  setCsrfToken('')
+})
+
+describe('MemorySection', () => {
+  test('loads and renders the profile and records', async () => {
+    setMockFetch(() => Promise.resolve(json(memoryPayload)))
+    document.body.innerHTML = '<div id="root"></div>'
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(MemorySection, { target, props: { contextId: 'user:1' } })
+
+    await drain()
+
+    expect(target.querySelector('.ui-page-header__title')?.textContent).toContain('Memory')
+    expect(target.querySelector<HTMLTextAreaElement>('[data-testid="memory-profile"]')!.value).toBe(
+      'Pinned profile facts for this context.',
+    )
+    expect(target.textContent).toContain('Prefers compact status updates.')
+    expect(target.textContent).toContain('Fallback record body should render')
+    expect(target.textContent).toContain('conversation')
+    expect(target.textContent).toContain('2026-06-03')
+    expect(target.querySelector('[data-testid="memory-empty"]')).toBeNull()
+    void unmount(component)
+  })
+
+  test('capture toggle sends the next enabled state and reloads', async () => {
+    setCsrfToken('c')
+    const calls: CapturedCall[] = []
+    setMockFetch((url, init) => {
+      captureCall(calls, url, init)
+      return Promise.resolve(json(memoryPayload))
+    })
+    document.body.innerHTML = '<div id="root"></div>'
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(MemorySection, { target, props: { contextId: 'user:1' } })
+    await drain()
+
+    target.querySelector<HTMLButtonElement>('[data-testid="memory-capture-toggle"]')!.click()
+    await drain()
+
+    const write = calls.find((call) => call.url === '/settings/api/memory/capture')
+    expect(write?.method).toBe('PATCH')
+    expect(write?.body).toEqual({ contextId: 'user:1', enabled: false })
+    expect(calls.filter((call) => call.url.startsWith('/settings/api/memory?')).length).toBe(2)
+    void unmount(component)
+  })
+
+  test('save profile sends PATCH with contextId and profile', async () => {
+    setCsrfToken('c')
+    const calls: CapturedCall[] = []
+    setMockFetch((url, init) => {
+      captureCall(calls, url, init)
+      return Promise.resolve(json(memoryPayload))
+    })
+    document.body.innerHTML = '<div id="root"></div>'
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(MemorySection, { target, props: { contextId: 'user:1' } })
+    await drain()
+
+    const input = target.querySelector<HTMLTextAreaElement>('[data-testid="memory-profile"]')!
+    input.value = 'Updated pinned profile.'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    target.querySelector<HTMLButtonElement>('[data-testid="memory-profile-save"]')!.click()
+    await drain()
+
+    const write = calls.find((call) => call.url === '/settings/api/memory/profile')
+    expect(write?.body).toEqual({ contextId: 'user:1', profile: 'Updated pinned profile.' })
+    void unmount(component)
+  })
+
+  test('archive record sends DELETE to encoded record path with body contextId and reloads', async () => {
+    setCsrfToken('c')
+    const calls: CapturedCall[] = []
+    setMockFetch((url, init) => {
+      captureCall(calls, url, init)
+      return Promise.resolve(json(memoryPayload))
+    })
+    document.body.innerHTML = '<div id="root"></div>'
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(MemorySection, { target, props: { contextId: 'user:1' } })
+    await drain()
+
+    target.querySelector<HTMLButtonElement>('[data-testid="memory-archive-rec/alpha"]')!.click()
+    await drain()
+
+    const write = calls.find((call) => call.url === '/settings/api/memory/records/rec%2Falpha')
+    expect(write?.method).toBe('DELETE')
+    expect(write?.body).toEqual({ contextId: 'user:1' })
+    expect(calls.filter((call) => call.url.startsWith('/settings/api/memory?')).length).toBe(2)
+    void unmount(component)
+  })
+
+  test('clear sends POST and reloads', async () => {
+    setCsrfToken('c')
+    const calls: CapturedCall[] = []
+    setMockFetch((url, init) => {
+      captureCall(calls, url, init)
+      return Promise.resolve(json(emptyMemoryPayload))
+    })
+    document.body.innerHTML = '<div id="root"></div>'
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(MemorySection, { target, props: { contextId: 'user:1' } })
+    await drain()
+
+    target.querySelector<HTMLButtonElement>('[data-testid="memory-clear"]')!.click()
+    await drain()
+
+    const write = calls.find((call) => call.url === '/settings/api/memory/clear')
+    expect(write?.method).toBe('POST')
+    expect(write?.body).toEqual({ contextId: 'user:1' })
+    expect(calls.filter((call) => call.url.startsWith('/settings/api/memory?')).length).toBe(2)
+    void unmount(component)
+  })
+
+  test('renders an empty state when there are no records', async () => {
+    setMockFetch(() => Promise.resolve(json(emptyMemoryPayload)))
+    document.body.innerHTML = '<div id="root"></div>'
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(MemorySection, { target, props: { contextId: 'user:1' } })
+    await drain()
+    expect(target.querySelector('[data-testid="memory-empty"]')).not.toBeNull()
+    void unmount(component)
+  })
+
+  test('shows an error state when fetch fails', async () => {
+    setMockFetch(() => Promise.resolve(new Response('Internal Server Error', { status: 500 })))
+    document.body.innerHTML = '<div id="root"></div>'
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(MemorySection, { target, props: { contextId: 'user:1' } })
+    await drain()
+    expect(target.querySelector('.status-error')).not.toBeNull()
+    expect(target.querySelector('[data-testid="memory-profile"]')).toBeNull()
+    void unmount(component)
+  })
+})

--- a/tests/client/settings/sections/MemorySection.test.ts
+++ b/tests/client/settings/sections/MemorySection.test.ts
@@ -295,7 +295,8 @@ describe('MemorySection', () => {
     await drain()
 
     expect(calls.find((call) => call.url === '/settings/api/memory/clear')).toBeUndefined()
-    expect(target.textContent).toContain('Clear all memory records')
+    expect(target.textContent).toContain('Clear memory for this context')
+    expect(target.textContent).toContain('memory profile and all memory records')
 
     const confirmButtons = Array.from(target.querySelectorAll<HTMLButtonElement>('button')).filter((button) =>
       button.textContent?.includes('Clear memory'),

--- a/tests/client/settings/sections/MemorySection.test.ts
+++ b/tests/client/settings/sections/MemorySection.test.ts
@@ -9,6 +9,8 @@ import { flushSync, mount, unmount } from 'svelte'
 
 import { setCsrfToken } from '../../../../client/settings/fetchers.js'
 import MemorySection from '../../../../client/settings/sections/MemorySection.svelte'
+import { settingsSession } from '../../../../client/settings/session.svelte.js'
+import SettingsApp from '../../../../client/settings/SettingsApp.svelte'
 import { restoreFetch, setMockFetch } from '../../../utils/test-helpers.js'
 
 const json = (payload: unknown, status = 200): Response =>
@@ -77,9 +79,96 @@ const emptyMemoryPayload = {
   records: [],
 }
 
+const userAMemoryPayload = {
+  ...memoryPayload,
+  contextId: 'user:a',
+  profile: 'Profile from context A.',
+  records: [{ ...memoryPayload.records[0], id: 'rec-a', summary: 'Record from context A.' }],
+}
+
+const userBMemoryPayload = {
+  ...memoryPayload,
+  contextId: 'user:b',
+  profile: 'Profile from context B.',
+  records: [{ ...memoryPayload.records[0], id: 'rec-b', summary: 'Record from context B.' }],
+}
+
+interface PendingMemoryState {
+  resolveUserA: ((response: Response) => void) | null
+}
+
+const resetSession = (): void => {
+  settingsSession.status = 'loading'
+  settingsSession.display = ''
+  settingsSession.isBotAdmin = false
+  settingsSession.isSuperAdmin = false
+  settingsSession.contexts = []
+  settingsSession.activeContextId = ''
+}
+
+const seedTwoContextSession = (): void => {
+  settingsSession.status = 'ready'
+  settingsSession.display = 'alice'
+  settingsSession.isBotAdmin = false
+  settingsSession.isSuperAdmin = false
+  settingsSession.contexts = [
+    { kind: 'personal', contextId: 'user:a', label: 'Context A' },
+    { kind: 'personal', contextId: 'user:b', label: 'Context B' },
+  ]
+  settingsSession.activeContextId = 'user:a'
+}
+
+const jsonForSettingsEndpoint = (url: string): Response => {
+  const parsed = new URL(url, 'https://settings.invalid')
+  const contextId = parsed.searchParams.get('contextId') ?? 'user:a'
+  if (parsed.pathname.endsWith('/settings/api/config')) return json({ contextId, fields: [] })
+  if (parsed.pathname.endsWith('/settings/api/context/task-instance'))
+    return json({ contextId, taskInstanceId: null, available: [] })
+  if (parsed.pathname.endsWith('/settings/api/tools')) return json({ contextId, domains: [] })
+  if (parsed.pathname.endsWith('/settings/api/byok'))
+    return json({ contextId, enabled: false, complete: false, missing: [], fields: [] })
+  if (parsed.pathname.endsWith('/settings/api/identity'))
+    return json({ contextId, providerName: 'provider', mapping: null })
+  if (parsed.pathname.endsWith('/settings/api/mcp')) return json({ contextId, endpoints: [] })
+  if (parsed.pathname.endsWith('/settings/api/plugins')) return json({ contextId, plugins: [] })
+  return json({})
+}
+
+const routeSettingsWithMemory =
+  (memory: (contextId: string) => Promise<Response>): ((url: string, init: RequestInit) => Promise<Response>) =>
+  (url): Promise<Response> => {
+    const parsed = new URL(url, 'https://settings.invalid')
+    if (parsed.pathname.endsWith('/settings/api/memory')) return memory(parsed.searchParams.get('contextId') ?? '')
+    return Promise.resolve(jsonForSettingsEndpoint(url))
+  }
+
+const pendingUserAMemory =
+  (state: PendingMemoryState) =>
+  (contextId: string): Promise<Response> => {
+    if (contextId === 'user:a') {
+      return new Promise<Response>((resolve) => {
+        state.resolveUserA = resolve
+      })
+    }
+    return Promise.resolve(json(userBMemoryPayload))
+  }
+
+const routeProfilePatchThenReloadFailure = (): ((url: string, init: RequestInit) => Promise<Response>) => {
+  let memoryFetchCount = 0
+  return (url): Promise<Response> => {
+    if (url.startsWith('/settings/api/memory?')) {
+      memoryFetchCount += 1
+      if (memoryFetchCount === 1) return Promise.resolve(json(memoryPayload))
+      return Promise.resolve(new Response('reload failed', { status: 500 }))
+    }
+    return Promise.resolve(json({ ok: true }))
+  }
+}
+
 afterEach(() => {
   restoreFetch()
   setCsrfToken('')
+  resetSession()
 })
 
 describe('MemorySection', () => {
@@ -148,6 +237,26 @@ describe('MemorySection', () => {
     void unmount(component)
   })
 
+  test('does not show success when profile reload fails after PATCH', async () => {
+    setCsrfToken('c')
+    setMockFetch(routeProfilePatchThenReloadFailure())
+    document.body.innerHTML = '<div id="root"></div>'
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(MemorySection, { target, props: { contextId: 'user:1' } })
+    await drain()
+
+    const input = target.querySelector<HTMLTextAreaElement>('[data-testid="memory-profile"]')!
+    input.value = 'Updated pinned profile.'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    target.querySelector<HTMLButtonElement>('[data-testid="memory-profile-save"]')!.click()
+    await drain()
+    await drain()
+
+    expect(target.querySelector('.status-error')).not.toBeNull()
+    expect(target.querySelector('.status-success')).toBeNull()
+    void unmount(component)
+  })
+
   test('archive record sends DELETE to encoded record path with body contextId and reloads', async () => {
     setCsrfToken('c')
     const calls: CapturedCall[] = []
@@ -170,7 +279,7 @@ describe('MemorySection', () => {
     void unmount(component)
   })
 
-  test('clear sends POST and reloads', async () => {
+  test('clear memory requires confirmation before POST and reloads after confirmation', async () => {
     setCsrfToken('c')
     const calls: CapturedCall[] = []
     setMockFetch((url, init) => {
@@ -185,10 +294,51 @@ describe('MemorySection', () => {
     target.querySelector<HTMLButtonElement>('[data-testid="memory-clear"]')!.click()
     await drain()
 
+    expect(calls.find((call) => call.url === '/settings/api/memory/clear')).toBeUndefined()
+    expect(target.textContent).toContain('Clear all memory records')
+
+    const confirmButtons = Array.from(target.querySelectorAll<HTMLButtonElement>('button')).filter((button) =>
+      button.textContent?.includes('Clear memory'),
+    )
+    const confirmButton = confirmButtons.at(-1)
+    expect(confirmButton).not.toBeUndefined()
+    confirmButton!.click()
+    await drain()
+
     const write = calls.find((call) => call.url === '/settings/api/memory/clear')
     expect(write?.method).toBe('POST')
     expect(write?.body).toEqual({ contextId: 'user:1' })
     expect(calls.filter((call) => call.url.startsWith('/settings/api/memory?')).length).toBe(2)
+    void unmount(component)
+  })
+
+  test('stale slower load for old context does not overwrite newer context state', async () => {
+    const pending: PendingMemoryState = { resolveUserA: null }
+    setMockFetch(routeSettingsWithMemory(pendingUserAMemory(pending)))
+    seedTwoContextSession()
+    document.body.innerHTML = '<div id="root"></div>'
+    history.replaceState(null, '', '/settings')
+    const target = document.querySelector<HTMLElement>('#root')!
+    const component = mount(SettingsApp, { target })
+
+    await drain()
+    settingsSession.activeContextId = 'user:b'
+    await drain()
+    expect(target.querySelector<HTMLTextAreaElement>('[data-testid="memory-profile"]')!.value).toBe(
+      'Profile from context B.',
+    )
+    expect(target.textContent).toContain('Record from context B.')
+
+    const resolveUserA = pending.resolveUserA
+    expect(resolveUserA).not.toBeNull()
+    resolveUserA!(json(userAMemoryPayload))
+    await drain()
+
+    expect(target.querySelector<HTMLTextAreaElement>('[data-testid="memory-profile"]')!.value).toBe(
+      'Profile from context B.',
+    )
+    expect(target.textContent).toContain('Record from context B.')
+    expect(target.textContent).not.toContain('Record from context A.')
     void unmount(component)
   })
 

--- a/tests/commands/context.test.ts
+++ b/tests/commands/context.test.ts
@@ -15,6 +15,7 @@ import {
   safeBuildProvider,
 } from '../../src/commands/context-tool-resolution.js'
 import type { ContextCommandDeps } from '../../src/commands/context.js'
+import { saveMemoryProfile } from '../../src/long-term-memory/store.js'
 import type { TaskProvider } from '../../src/providers/types.js'
 import { buildProviderlessSystemPrompt } from '../../src/system-prompt.js'
 import { makeTools } from '../../src/tools/index.js'
@@ -124,6 +125,11 @@ function createSequentialLiveToolSet(results: readonly (ToolSet | null)[]): () =
   }
 }
 
+function requireMemoryMessage(value: string | null): string {
+  if (value === null) throw new Error('expected memory message')
+  return value
+}
+
 describe('registerContextCommand', () => {
   beforeEach(async () => {
     mockLogger()
@@ -200,6 +206,49 @@ describe('registerContextCommand', () => {
     expect(activeToolDefinitions).not.toBeNull()
     expect(activeToolDefinitions).toHaveProperty('set_my_identity')
     expect(activeToolDefinitions).toHaveProperty('clear_my_identity')
+  })
+
+  test('uses group long-term memory in context command memory section', async () => {
+    const commands = new Map<string, CommandHandler>()
+    const chat = createFormattedContextChat(commands, null)
+    let memoryMessage: string | null = null
+    saveMemoryProfile(
+      { scopeId: 'group-ctx', scopeType: 'group' },
+      '## Group memory\n- Group planning happens in the roadmap thread',
+      '2026-06-12T00:00:00.000Z',
+    )
+    saveMemoryProfile(
+      { scopeId: 'group-ctx', scopeType: 'personal' },
+      '## Personal memory\n- This personal profile should not be shown',
+      '2026-06-12T00:00:00.000Z',
+    )
+    const handler = await registerContextHandler(
+      commands,
+      chat,
+      snapshotDeps({
+        collectContext: (_contextId, collectorDeps): ContextSnapshot => {
+          memoryMessage = collectorDeps.getMemoryMessage()
+          return {
+            modelName: 'gpt-4o',
+            sections: [],
+            totalTokens: 0,
+            maxTokens: 128_000,
+            approximate: false,
+          }
+        },
+      }),
+    )
+    const { reply } = createMockReply()
+
+    await handler(
+      createGroupMessage('actor-user', '/context', false, 'group-ctx'),
+      reply,
+      createAuth('group-ctx', { isGroupAdmin: true }),
+    )
+
+    const capturedMemoryMessage = requireMemoryMessage(memoryMessage)
+    expect(capturedMemoryMessage).toContain('Group planning happens in the roadmap thread')
+    expect(capturedMemoryMessage).not.toContain('This personal profile should not be shown')
   })
 
   test('uses injected provider construction instead of the hardwired provider factory', async () => {

--- a/tests/conversation.test.ts
+++ b/tests/conversation.test.ts
@@ -11,6 +11,7 @@ import { enableByokForContext, updateByokLlmConfig } from '../src/byok-llm/store
 import * as cacheModule from '../src/cache.js'
 import { shouldTriggerTrim, buildMessagesWithMemory, runTrimInBackground } from '../src/conversation.js'
 import { logger } from '../src/logger.js'
+import * as longTermMemoryStore from '../src/long-term-memory/store.js'
 import { saveMemoryProfile, saveMemoryRecord } from '../src/long-term-memory/store.js'
 import type { MemoryRecordInput } from '../src/long-term-memory/types.js'
 import * as systemConfigModule from '../src/system-config.js'
@@ -268,6 +269,23 @@ describe('buildMessagesWithMemory', () => {
     expect(systemMsg.content).toContain('Prefer concise answers')
     expect(result.memoryMsg).not.toBeNull()
     expect(result.messages[0]).toEqual(result.memoryMsg!)
+  })
+
+  test('loads at most three active long-term memory records', () => {
+    const listMemoryRecordsSpy = spyOn(longTermMemoryStore, 'listMemoryRecords')
+
+    try {
+      buildMessagesWithMemory('user-1', [])
+
+      expect(listMemoryRecordsSpy).toHaveBeenCalledWith({
+        scopeId: 'user-1',
+        scopeType: 'personal',
+        status: 'active',
+        limit: 3,
+      })
+    } finally {
+      listMemoryRecordsSpy.mockRestore()
+    }
   })
 
   test('does not mutate original history array', () => {

--- a/tests/conversation.test.ts
+++ b/tests/conversation.test.ts
@@ -9,6 +9,7 @@ import type { ModelMessage } from 'ai'
 
 import { enableByokForContext, updateByokLlmConfig } from '../src/byok-llm/store.js'
 import * as cacheModule from '../src/cache.js'
+import { toScopedContextId, toScopedThreadContextId } from '../src/chat/scoped-context.js'
 import { shouldTriggerTrim, buildMessagesWithMemory, runTrimInBackground } from '../src/conversation.js'
 import { logger } from '../src/logger.js'
 import * as longTermMemoryStore from '../src/long-term-memory/store.js'
@@ -286,6 +287,35 @@ describe('buildMessagesWithMemory', () => {
     } finally {
       listMemoryRecordsSpy.mockRestore()
     }
+  })
+
+  test('loads long-term memory from parent group scope for thread contexts', () => {
+    const parent = toScopedContextId({ platformInstanceId: 'telegram-main', nativeContextId: '-1001' })
+    const thread = toScopedThreadContextId({
+      platformInstanceId: 'telegram-main',
+      nativeContextId: '-1001',
+      threadId: '42',
+    })
+    saveMemoryProfile(
+      { scopeId: parent, scopeType: 'group' },
+      '## Group memory\n- Release notes go out on Fridays',
+      '2026-06-12T00:00:00.000Z',
+    )
+    saveMemoryRecord(
+      memoryRecordInput({
+        id: 'mem-group-thread',
+        scopeId: parent,
+        scopeType: 'group',
+        kind: 'procedure',
+        content: 'Release notes go out on Fridays.',
+        summary: 'Friday release notes',
+      }),
+    )
+
+    const result = buildMessagesWithMemory(thread, [], 'group')
+
+    expect(result.memoryMsg?.content).toContain('Release notes go out on Fridays')
+    expect(result.memoryMsg?.content).toContain('Friday release notes')
   })
 
   test('does not mutate original history array', () => {

--- a/tests/conversation.test.ts
+++ b/tests/conversation.test.ts
@@ -11,6 +11,8 @@ import { enableByokForContext, updateByokLlmConfig } from '../src/byok-llm/store
 import * as cacheModule from '../src/cache.js'
 import { shouldTriggerTrim, buildMessagesWithMemory, runTrimInBackground } from '../src/conversation.js'
 import { logger } from '../src/logger.js'
+import { saveMemoryProfile, saveMemoryRecord } from '../src/long-term-memory/store.js'
+import type { MemoryRecordInput } from '../src/long-term-memory/types.js'
 import * as systemConfigModule from '../src/system-config.js'
 import { flushMicrotasks, resetSystemConfigCacheForTesting, setupTestDb } from './utils/test-helpers.js'
 
@@ -41,6 +43,24 @@ const defaultGenerateTextImpl = (): Promise<GenerateTextResult> =>
   Promise.resolve({
     text: JSON.stringify({ keep_indices: [0, 1], summary: 'Updated summary text' }),
   })
+
+const memoryRecordInput = (overrides: Partial<MemoryRecordInput>): MemoryRecordInput => ({
+  id: 'mem-1',
+  scopeId: 'user-1',
+  scopeType: 'personal',
+  kind: 'preference',
+  content: 'User prefers concise implementation plans.',
+  summary: 'Concise plans',
+  tags: ['style'],
+  confidence: 0.9,
+  status: 'active',
+  source: 'explicit',
+  evidence: {},
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  lastSeenAt: '2026-06-12T00:00:00.000Z',
+  ...overrides,
+})
 
 describe('shouldTriggerTrim', () => {
   const makeMessages = (count: number, userEvery = 2): ModelMessage[] =>
@@ -146,7 +166,8 @@ describe('buildMessagesWithMemory', () => {
   let getCachedSummarySpy: ReturnType<typeof spyOn<typeof cacheModule, 'getCachedSummary'>>
   let getCachedFactsSpy: ReturnType<typeof spyOn<typeof cacheModule, 'getCachedFacts'>>
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await setupTestDb()
     mockSummaries.clear()
     mockFacts.clear()
     getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null)
@@ -217,6 +238,36 @@ describe('buildMessagesWithMemory', () => {
     expect(systemMsg.role).toBe('system')
     expect(systemMsg.content).toContain('User worked on mobile app project')
     expect(systemMsg.content).toContain('#42')
+  })
+
+  test('prepends one system message containing compacted and long-term memory when both are present', () => {
+    const history: ModelMessage[] = []
+    const summary = 'User worked on mobile app project'
+    getCachedSummarySpy.mockReturnValue(summary)
+    saveMemoryProfile(
+      { scopeId: 'user-1', scopeType: 'personal' },
+      '## Communication\n- Prefer concise answers',
+      '2026-06-12T00:00:00.000Z',
+    )
+    saveMemoryRecord(
+      memoryRecordInput({
+        id: 'mem-direct',
+        content: 'User prefers direct status reports.',
+        summary: 'Direct status reports',
+      }),
+    )
+
+    const result = buildMessagesWithMemory('user-1', history)
+
+    expect(result.messages).toHaveLength(1)
+    const systemMsg = result.messages[0]!
+    expect(systemMsg.role).toBe('system')
+    expect(systemMsg.content).toContain('<memory trust="compacted_low">')
+    expect(systemMsg.content).toContain('<long_term_memory trust="profile_and_retrieved_low">')
+    expect(systemMsg.content).toContain(summary)
+    expect(systemMsg.content).toContain('Prefer concise answers')
+    expect(result.memoryMsg).not.toBeNull()
+    expect(result.messages[0]).toEqual(result.memoryMsg!)
   })
 
   test('does not mutate original history array', () => {
@@ -609,7 +660,8 @@ describe('Story 5: Summary injected into context', () => {
   let getCachedSummarySpy: ReturnType<typeof spyOn<typeof cacheModule, 'getCachedSummary'>>
   let getCachedFactsSpy: ReturnType<typeof spyOn<typeof cacheModule, 'getCachedFacts'>>
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await setupTestDb()
     mockSummaries.clear()
     mockFacts.clear()
     getCachedSummarySpy = spyOn(cacheModule, 'getCachedSummary').mockReturnValue(null)

--- a/tests/db/migration-registration.test.ts
+++ b/tests/db/migration-registration.test.ts
@@ -23,8 +23,8 @@ describe('MIGRATIONS list', () => {
     expect(ids).toContain('051_legacy_context_id_backfill')
   })
 
-  test('052_byok_llm_credentials is the last migration', () => {
+  test('053_long_term_memory is the last migration', () => {
     const lastMigration = requireDefined(MIGRATIONS.at(-1))
-    expect(lastMigration.id).toBe('052_byok_llm_credentials')
+    expect(lastMigration.id).toBe('053_long_term_memory')
   })
 })

--- a/tests/db/migrations/053_long_term_memory.test.ts
+++ b/tests/db/migrations/053_long_term_memory.test.ts
@@ -14,6 +14,16 @@ const tableNames = (db: Database): string[] =>
     .all()
     .map((r) => r.name)
 
+const searchMemory = (db: Database, query: string): { id: string }[] =>
+  db
+    .query<{ id: string }, [string]>(
+      `SELECT m.id
+       FROM memory_records m
+       JOIN memory_records_fts f ON m.rowid = f.rowid
+       WHERE f.memory_records_fts MATCH ?`,
+    )
+    .all(query)
+
 describe('migration053LongTermMemory', () => {
   test('creates long-term memory profile and record storage', () => {
     const db = new Database(':memory:')
@@ -31,6 +41,18 @@ describe('migration053LongTermMemory', () => {
     expect(names).toContain('memory_records_ad')
   })
 
+  test('rejects non-boolean memory profile enabled values', () => {
+    const db = new Database(':memory:')
+    migration053LongTermMemory.up(db)
+
+    expect(() =>
+      db.run(
+        `INSERT INTO memory_profiles (scope_id, scope_type, profile, enabled, updated_at)
+         VALUES ('scope-1', 'personal', '', 2, '2026-06-11T00:00:00.000Z')`,
+      ),
+    ).toThrow()
+  })
+
   test('keeps FTS rows in sync with memory records', () => {
     const db = new Database(':memory:')
     migration053LongTermMemory.up(db)
@@ -42,14 +64,19 @@ describe('migration053LongTermMemory', () => {
         ('mem-1', 'scope-1', 'personal', 'preference', 'User prefers concise replies', 'Concise replies', '["style"]', 0.9, 'active', 'explicit', '{}', '2026-06-11T00:00:00.000Z', '2026-06-11T00:00:00.000Z', '2026-06-11T00:00:00.000Z')`,
     )
 
-    const found = db
-      .query<{ id: string }, []>(
-        `SELECT m.id
-         FROM memory_records m
-         JOIN memory_records_fts f ON m.rowid = f.rowid
-         WHERE f.memory_records_fts MATCH 'concise'`,
-      )
-      .all()
-    expect(found).toEqual([{ id: 'mem-1' }])
+    expect(searchMemory(db, 'concise')).toEqual([{ id: 'mem-1' }])
+
+    db.run(
+      `UPDATE memory_records
+       SET content = 'User prefers detailed replies', summary = 'Detailed replies'
+       WHERE id = 'mem-1'`,
+    )
+
+    expect(searchMemory(db, 'concise')).toEqual([])
+    expect(searchMemory(db, 'detailed')).toEqual([{ id: 'mem-1' }])
+
+    db.run(`DELETE FROM memory_records WHERE id = 'mem-1'`)
+
+    expect(searchMemory(db, 'detailed')).toEqual([])
   })
 })

--- a/tests/db/migrations/053_long_term_memory.test.ts
+++ b/tests/db/migrations/053_long_term_memory.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { Database } from 'bun:sqlite'
+import { describe, expect, test } from 'bun:test'
+
+import { migration053LongTermMemory } from '../../../src/db/migrations/053_long_term_memory.js'
+
+const tableNames = (db: Database): string[] =>
+  db
+    .query<{ name: string }, []>(`SELECT name FROM sqlite_master WHERE type IN ('table', 'index', 'trigger')`)
+    .all()
+    .map((r) => r.name)
+
+describe('migration053LongTermMemory', () => {
+  test('creates long-term memory profile and record storage', () => {
+    const db = new Database(':memory:')
+    migration053LongTermMemory.up(db)
+
+    const names = tableNames(db)
+    expect(names).toContain('memory_profiles')
+    expect(names).toContain('memory_records')
+    expect(names).toContain('memory_records_fts')
+    expect(names).toContain('idx_memory_profiles_scope')
+    expect(names).toContain('idx_memory_records_scope_status_seen')
+    expect(names).toContain('idx_memory_records_scope_kind_status')
+    expect(names).toContain('memory_records_ai')
+    expect(names).toContain('memory_records_au')
+    expect(names).toContain('memory_records_ad')
+  })
+
+  test('keeps FTS rows in sync with memory records', () => {
+    const db = new Database(':memory:')
+    migration053LongTermMemory.up(db)
+
+    db.run(
+      `INSERT INTO memory_records
+        (id, scope_id, scope_type, kind, content, summary, tags, confidence, status, source, evidence, created_at, updated_at, last_seen_at)
+       VALUES
+        ('mem-1', 'scope-1', 'personal', 'preference', 'User prefers concise replies', 'Concise replies', '["style"]', 0.9, 'active', 'explicit', '{}', '2026-06-11T00:00:00.000Z', '2026-06-11T00:00:00.000Z', '2026-06-11T00:00:00.000Z')`,
+    )
+
+    const found = db
+      .query<{ id: string }, []>(
+        `SELECT m.id
+         FROM memory_records m
+         JOIN memory_records_fts f ON m.rowid = f.rowid
+         WHERE f.memory_records_fts MATCH 'concise'`,
+      )
+      .all()
+    expect(found).toEqual([{ id: 'mem-1' }])
+  })
+})

--- a/tests/db/migrations/053_long_term_memory.test.ts
+++ b/tests/db/migrations/053_long_term_memory.test.ts
@@ -53,6 +53,34 @@ describe('migration053LongTermMemory', () => {
     ).toThrow()
   })
 
+  test('allows personal and group memory profiles with the same scope id', () => {
+    const db = new Database(':memory:')
+    migration053LongTermMemory.up(db)
+
+    db.run(
+      `INSERT INTO memory_profiles (scope_id, scope_type, profile, enabled, updated_at)
+       VALUES ('shared-scope', 'personal', 'Personal profile', 1, '2026-06-11T00:00:00.000Z')`,
+    )
+    db.run(
+      `INSERT INTO memory_profiles (scope_id, scope_type, profile, enabled, updated_at)
+       VALUES ('shared-scope', 'group', 'Group profile', 1, '2026-06-11T00:00:00.000Z')`,
+    )
+
+    expect(
+      db
+        .query<{ scopeType: string; profile: string }, []>(
+          `SELECT scope_type AS scopeType, profile
+           FROM memory_profiles
+           WHERE scope_id = 'shared-scope'
+           ORDER BY scope_type`,
+        )
+        .all(),
+    ).toEqual([
+      { scopeType: 'group', profile: 'Group profile' },
+      { scopeType: 'personal', profile: 'Personal profile' },
+    ])
+  })
+
   test('keeps FTS rows in sync with memory records', () => {
     const db = new Database(':memory:')
     migration053LongTermMemory.up(db)

--- a/tests/debug/settings/memory-routes.test.ts
+++ b/tests/debug/settings/memory-routes.test.ts
@@ -173,6 +173,34 @@ describe('settings memory routes', () => {
     expect(getMemoryProfile(personalScope)?.profile).toBe('## Preferences\n- Remember task context')
   })
 
+  test('PATCH profile rejects oversized profile text', async () => {
+    const res = await handleMemoryRoutes(
+      request('/settings/api/memory/profile', session, {
+        method: 'PATCH',
+        csrf: true,
+        body: { profile: 'x'.repeat(20_001) },
+      }),
+      new URL('https://x/settings/api/memory/profile'),
+    )
+
+    expect(res.status).toBe(422)
+    expect(getMemoryProfile(personalScope)).toBeNull()
+  })
+
+  test('PATCH capture returns controlled JSON error for malformed JSON', async () => {
+    const res = await handleMemoryRoutes(
+      new Request('https://x/settings/api/memory/capture', {
+        method: 'PATCH',
+        headers: { ...authHeaders(session, true), 'Content-Type': 'application/json' },
+        body: 'not-json',
+      }),
+      new URL('https://x/settings/api/memory/capture'),
+    )
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: 'invalid JSON body' })
+  })
+
   test('PATCH capture toggles enabled', async () => {
     const res = await handleMemoryRoutes(
       request('/settings/api/memory/capture', session, {
@@ -211,6 +239,29 @@ describe('settings memory routes', () => {
     expect(
       listMemoryRecords({ scopeId: personalContextId, scopeType: 'group', status: 'active' }).map((r) => r.id),
     ).toEqual(['group-record'])
+  })
+
+  test('DELETE malformed encoded record id returns controlled JSON error', async () => {
+    const url = new URL('https://x/settings/api/memory/records/%E0%A4%A')
+    let thrown: unknown
+    let res: Response | undefined
+
+    try {
+      res = await handleMemoryRoutes(
+        new Request(url, {
+          method: 'DELETE',
+          headers: { ...authHeaders(session, true), 'Content-Type': 'application/json' },
+          body: '{}',
+        }),
+        url,
+      )
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeUndefined()
+    expect(res?.status).toBe(400)
+    await expect(res?.json()).resolves.toEqual({ error: 'invalid record id' })
   })
 
   test('POST clear clears only authorized scope', async () => {

--- a/tests/debug/settings/memory-routes.test.ts
+++ b/tests/debug/settings/memory-routes.test.ts
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { z } from 'zod'
+
+import { toScopedContextId } from '../../../src/chat/scoped-context.js'
+import { routeSettingsApi } from '../../../src/debug/settings-api-router.js'
+import { handleMemoryRoutes } from '../../../src/debug/settings/memory-routes.js'
+import {
+  getMemoryProfile,
+  listMemoryRecords,
+  saveMemoryProfile,
+  saveMemoryRecord,
+} from '../../../src/long-term-memory/store.js'
+import type { MemoryRecordInput, MemoryScope } from '../../../src/long-term-memory/types.js'
+import { addUser } from '../../../src/users.js'
+import { mockLogger, seedTestPlatformInstance, setupTestDb } from '../../utils/test-helpers.js'
+import { authHeaders, establishSession, type SettingsSession } from './helpers.js'
+
+const MemoryRecordViewSchema = z.object({
+  id: z.string(),
+  scopeId: z.string(),
+  scopeType: z.enum(['personal', 'group']),
+  kind: z.string(),
+  content: z.string(),
+  status: z.string(),
+})
+
+const GetMemoryResponseSchema = z.object({
+  contextId: z.string(),
+  scopeType: z.enum(['personal', 'group']),
+  enabled: z.boolean(),
+  profile: z.string(),
+  records: z.array(MemoryRecordViewSchema),
+})
+
+const ProfilePatchResponseSchema = z.object({
+  ok: z.literal(true),
+  contextId: z.string(),
+  scopeType: z.enum(['personal', 'group']),
+  profile: z.string(),
+})
+
+const CapturePatchResponseSchema = z.object({
+  ok: z.literal(true),
+  contextId: z.string(),
+  scopeType: z.enum(['personal', 'group']),
+  enabled: z.boolean(),
+})
+
+const DeleteRecordResponseSchema = z.object({
+  ok: z.literal(true),
+  status: z.enum(['archived', 'not_found']),
+})
+
+const ClearResponseSchema = z.object({
+  ok: z.literal(true),
+  contextId: z.string(),
+  scopeType: z.enum(['personal', 'group']),
+  profileDeleted: z.number(),
+  recordsDeleted: z.number(),
+})
+
+const PLATFORM_INSTANCE_ID = 'pi-1'
+const USER_ID = 'u-1'
+
+const memoryRecordInput = (overrides: Partial<MemoryRecordInput>): MemoryRecordInput => ({
+  id: 'mem-1',
+  scopeId: 'unused-context',
+  scopeType: 'personal',
+  kind: 'preference',
+  content: 'User prefers concise implementation plans.',
+  summary: 'Concise plans',
+  tags: ['style'],
+  confidence: 1,
+  status: 'active',
+  source: 'explicit',
+  evidence: {},
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  lastSeenAt: '2026-06-11T00:00:00.000Z',
+  ...overrides,
+})
+
+function request(
+  path: string,
+  session: SettingsSession,
+  options: Readonly<{ method?: string; csrf?: boolean; body?: unknown }> = {},
+): Request {
+  return new Request(`https://x${path}`, {
+    method: options.method,
+    headers: {
+      ...authHeaders(session, options.csrf === true),
+      ...(options.body === undefined ? {} : { 'Content-Type': 'application/json' }),
+    },
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  })
+}
+
+describe('settings memory routes', () => {
+  let session: SettingsSession
+  let personalContextId: string
+  let personalScope: MemoryScope
+
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+    seedTestPlatformInstance({ id: PLATFORM_INSTANCE_ID })
+    addUser({ userId: USER_ID, platformInstanceId: PLATFORM_INSTANCE_ID, addedBy: 'admin', username: undefined })
+    session = await establishSession({ platformInstanceId: PLATFORM_INSTANCE_ID, platformUserId: USER_ID })
+    personalContextId = toScopedContextId({ platformInstanceId: PLATFORM_INSTANCE_ID, nativeContextId: USER_ID })
+    personalScope = { scopeId: personalContextId, scopeType: 'personal' }
+  })
+
+  test('GET returns profile and active records for authorized personal scope', async () => {
+    saveMemoryProfile(personalScope, '## Preferences\n- Keep answers concise', '2026-06-11T00:00:00.000Z')
+    saveMemoryRecord(memoryRecordInput({ id: 'active-1', scopeId: personalContextId, status: 'active' }))
+    saveMemoryRecord(memoryRecordInput({ id: 'archived-1', scopeId: personalContextId, status: 'archived' }))
+
+    const url = new URL('https://x/settings/api/memory')
+    const res = await handleMemoryRoutes(request('/settings/api/memory', session), url)
+
+    expect(res.status).toBe(200)
+    const body = GetMemoryResponseSchema.parse(await res.json())
+    expect(body.contextId).toBe(personalContextId)
+    expect(body.scopeType).toBe('personal')
+    expect(body.enabled).toBe(true)
+    expect(body.profile).toBe('## Preferences\n- Keep answers concise')
+    expect(body.records.map((record) => record.id)).toEqual(['active-1'])
+  })
+
+  test('GET defaults profile to empty and capture enabled when no profile row exists', async () => {
+    const routed = await routeSettingsApi(
+      request('/settings/api/memory', session),
+      new URL('https://x/settings/api/memory'),
+    )
+
+    expect(routed?.status).toBe(200)
+    const body = GetMemoryResponseSchema.parse(await routed?.json())
+    expect(body.contextId).toBe(personalContextId)
+    expect(body.profile).toBe('')
+    expect(body.enabled).toBe(true)
+    expect(body.records).toEqual([])
+  })
+
+  test('PATCH profile updates profile with CSRF and rejects without CSRF', async () => {
+    const missingCsrf = await handleMemoryRoutes(
+      request('/settings/api/memory/profile', session, {
+        method: 'PATCH',
+        body: { profile: '## Preferences\n- Remember task context' },
+      }),
+      new URL('https://x/settings/api/memory/profile'),
+    )
+    expect(missingCsrf.status).toBe(403)
+
+    const res = await handleMemoryRoutes(
+      request('/settings/api/memory/profile', session, {
+        method: 'PATCH',
+        csrf: true,
+        body: { profile: '## Preferences\n- Remember task context' },
+      }),
+      new URL('https://x/settings/api/memory/profile'),
+    )
+
+    expect(res.status).toBe(200)
+    const body = ProfilePatchResponseSchema.parse(await res.json())
+    expect(body.contextId).toBe(personalContextId)
+    expect(body.profile).toBe('## Preferences\n- Remember task context')
+    expect(getMemoryProfile(personalScope)?.profile).toBe('## Preferences\n- Remember task context')
+  })
+
+  test('PATCH capture toggles enabled', async () => {
+    const res = await handleMemoryRoutes(
+      request('/settings/api/memory/capture', session, {
+        method: 'PATCH',
+        csrf: true,
+        body: { enabled: false },
+      }),
+      new URL('https://x/settings/api/memory/capture'),
+    )
+
+    expect(res.status).toBe(200)
+    const body = CapturePatchResponseSchema.parse(await res.json())
+    expect(body.contextId).toBe(personalContextId)
+    expect(body.enabled).toBe(false)
+    expect(getMemoryProfile(personalScope)?.enabled).toBe(false)
+  })
+
+  test('DELETE archives only records in authorized full scope', async () => {
+    saveMemoryRecord(memoryRecordInput({ id: 'personal-record', scopeId: personalContextId, scopeType: 'personal' }))
+    saveMemoryRecord(
+      memoryRecordInput({ id: 'group-record', scopeId: personalContextId, scopeType: 'group', kind: 'decision' }),
+    )
+
+    const res = await handleMemoryRoutes(
+      request('/settings/api/memory/records/personal-record', session, {
+        method: 'DELETE',
+        csrf: true,
+        body: {},
+      }),
+      new URL('https://x/settings/api/memory/records/personal-record'),
+    )
+
+    expect(res.status).toBe(200)
+    expect(DeleteRecordResponseSchema.parse(await res.json()).status).toBe('archived')
+    expect(listMemoryRecords({ scopeId: personalContextId, scopeType: 'personal', status: 'active' })).toEqual([])
+    expect(
+      listMemoryRecords({ scopeId: personalContextId, scopeType: 'group', status: 'active' }).map((r) => r.id),
+    ).toEqual(['group-record'])
+  })
+
+  test('POST clear clears only authorized scope', async () => {
+    saveMemoryProfile(personalScope, 'Personal profile', '2026-06-11T00:00:00.000Z')
+    saveMemoryProfile({ scopeId: personalContextId, scopeType: 'group' }, 'Group profile', '2026-06-11T00:00:00.000Z')
+    saveMemoryRecord(memoryRecordInput({ id: 'personal-record', scopeId: personalContextId, scopeType: 'personal' }))
+    saveMemoryRecord(
+      memoryRecordInput({ id: 'group-record', scopeId: personalContextId, scopeType: 'group', kind: 'decision' }),
+    )
+
+    const res = await handleMemoryRoutes(
+      request('/settings/api/memory/clear', session, {
+        method: 'POST',
+        csrf: true,
+        body: {},
+      }),
+      new URL('https://x/settings/api/memory/clear'),
+    )
+
+    expect(res.status).toBe(200)
+    const body = ClearResponseSchema.parse(await res.json())
+    expect(body.profileDeleted).toBe(1)
+    expect(body.recordsDeleted).toBe(1)
+    expect(getMemoryProfile(personalScope)).toBeNull()
+    expect(getMemoryProfile({ scopeId: personalContextId, scopeType: 'group' })?.profile).toBe('Group profile')
+    expect(
+      listMemoryRecords({ scopeId: personalContextId, scopeType: 'group', status: 'active' }).map((r) => r.id),
+    ).toEqual(['group-record'])
+  })
+
+  test('GET returns 401 when unauthenticated', async () => {
+    const url = new URL('https://x/settings/api/memory')
+    const res = await handleMemoryRoutes(new Request(url), url)
+    expect(res.status).toBe(401)
+  })
+
+  test("GET rejects another user's personal context", async () => {
+    addUser({ userId: 'u-2', platformInstanceId: PLATFORM_INSTANCE_ID, addedBy: 'admin', username: undefined })
+    const victimContextId = toScopedContextId({ platformInstanceId: PLATFORM_INSTANCE_ID, nativeContextId: 'u-2' })
+    const url = new URL(`https://x/settings/api/memory?contextId=${encodeURIComponent(victimContextId)}`)
+
+    const res = await handleMemoryRoutes(new Request(url, { headers: authHeaders(session) }), url)
+
+    expect(res.status).toBe(403)
+  })
+})

--- a/tests/deferred-prompts/proactive-llm-full.test.ts
+++ b/tests/deferred-prompts/proactive-llm-full.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test'
 import type { ToolSet } from 'ai'
 
 import { userCachesForTesting } from '../../src/cache.js'
+import { saveMemoryProfile } from '../../src/long-term-memory/store.js'
 import { createMockProvider } from '../tools/mock-provider.js'
 import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
 
@@ -28,7 +29,10 @@ void mock.module('../../src/mcp/index.js', () => ({
   convertMcpToolsToToolSet: mock(() => ({})),
 }))
 
-const { buildFullToolSet } = await import('../../src/deferred-prompts/proactive-llm-full.js')
+const { buildFullMessages, buildFullToolSet } = await import('../../src/deferred-prompts/proactive-llm-full.js')
+
+const includesMessageText = (messages: readonly { content: unknown }[], text: string): boolean =>
+  messages.some((message) => typeof message.content === 'string' && message.content.includes(text))
 
 beforeEach(async () => {
   void mock.module('../../src/mcp/user-endpoints.js', () => ({
@@ -70,5 +74,33 @@ describe('buildFullToolSet async', () => {
 
     expect(Object.keys(reminder.tools).toSorted()).toEqual(Object.keys(neutral.tools).toSorted())
     expect(reminder.enabledToolNames).toEqual(neutral.enabledToolNames)
+  })
+})
+
+describe('buildFullMessages', () => {
+  test('uses group long-term memory for group thread contexts', () => {
+    saveMemoryProfile(
+      { scopeId: 'group-1', scopeType: 'group' },
+      '## Group memory\n- Group release notes ship on Fridays',
+      '2026-06-12T00:00:00.000Z',
+    )
+    saveMemoryProfile(
+      { scopeId: 'group-1:thread-2', scopeType: 'personal' },
+      '## Personal memory\n- This personal thread memory should not be injected',
+      '2026-06-12T00:00:00.000Z',
+    )
+
+    const { messages } = buildFullMessages(
+      'user-1',
+      'group-1:thread-2',
+      'scheduled',
+      'Summarize releases',
+      undefined,
+      { mode: 'full', delivery_brief: 'Release digest', context_snapshot: null },
+      'group',
+    )
+
+    expect(includesMessageText(messages, 'Group release notes ship on Fridays')).toBe(true)
+    expect(includesMessageText(messages, 'This personal thread memory should not be injected')).toBe(false)
   })
 })

--- a/tests/deferred-prompts/proactive-llm-helpers.test.ts
+++ b/tests/deferred-prompts/proactive-llm-helpers.test.ts
@@ -3,20 +3,27 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, spyOn, test } from 'bun:test'
+
+import type { ModelMessage } from 'ai'
 
 import type { DeferredDeliveryTarget } from '../../src/chat/types.js'
+import * as conversationModule from '../../src/conversation.js'
 import {
   buildMetadataMessages,
   buildMinimalSystemPrompt,
   getStorageContextId,
   modelIdForLightweight,
+  persistContextResponse,
+  persistProactiveResults,
   resultTextOrDone,
   timezoneOrUtc,
   toolCallCount,
   wrapPrompt,
 } from '../../src/deferred-prompts/proactive-llm-helpers.js'
 import type { ExecutionMetadata } from '../../src/deferred-prompts/types.js'
+import * as historyModule from '../../src/history.js'
+import * as memoryRunnerModule from '../../src/long-term-memory/runner.js'
 
 const dmTarget: DeferredDeliveryTarget = {
   contextId: 'user-1',
@@ -29,6 +36,18 @@ const dmTarget: DeferredDeliveryTarget = {
 }
 
 describe('proactive-llm-helpers', () => {
+  const spies: Array<{ mockRestore: () => void }> = []
+
+  afterEach(() => {
+    for (const spy of spies) spy.mockRestore()
+    spies.length = 0
+  })
+
+  const track = <T extends { mockRestore: () => void }>(spy: T): T => {
+    spies.push(spy)
+    return spy
+  }
+
   test('uses thread-scoped storage context for group threads', () => {
     expect(
       getStorageContextId({
@@ -73,5 +92,61 @@ describe('proactive-llm-helpers', () => {
       { role: 'system', content: '[CONTEXT FROM CREATION TIME]\nSnapshot' },
     ])
     expect(wrapPrompt('drink water')).toBe('===DEFERRED_TASK===\ndrink water\n===END_DEFERRED_TASK===')
+  })
+
+  test('context-mode persistence triggers long-term extraction when trimming', () => {
+    const extractionCalls: unknown[][] = []
+    track(spyOn(historyModule, 'appendHistory').mockImplementation(() => undefined))
+    track(spyOn(conversationModule, 'shouldTriggerTrim').mockReturnValue(true))
+    track(spyOn(conversationModule, 'runTrimInBackground').mockResolvedValue(undefined))
+    track(
+      spyOn(memoryRunnerModule, 'runMemoryExtractionInBackground').mockImplementation((...args: unknown[]) => {
+        extractionCalls.push(args)
+        return Promise.resolve()
+      }),
+    )
+    const history: ModelMessage[] = [{ role: 'user', content: 'Remember the release cadence.' }]
+    const assistantMessages: ModelMessage[] = [{ role: 'assistant', content: 'Captured.' }]
+
+    persistContextResponse('ctx:thread', 'cfg', 'group', history, 'gpt-main', assistantMessages)
+
+    expect(extractionCalls[0]?.[0]).toEqual({
+      storageContextId: 'ctx:thread',
+      configContextId: 'cfg',
+      contextType: 'group',
+      history: [...history, ...assistantMessages],
+    })
+  })
+
+  test('full-mode persistence triggers long-term extraction when trimming', () => {
+    const extractionCalls: unknown[][] = []
+    track(spyOn(historyModule, 'appendHistory').mockImplementation(() => undefined))
+    track(spyOn(conversationModule, 'shouldTriggerTrim').mockReturnValue(true))
+    track(spyOn(conversationModule, 'runTrimInBackground').mockResolvedValue(undefined))
+    track(
+      spyOn(memoryRunnerModule, 'runMemoryExtractionInBackground').mockImplementation((...args: unknown[]) => {
+        extractionCalls.push(args)
+        return Promise.resolve()
+      }),
+    )
+    const history: ModelMessage[] = [{ role: 'user', content: 'Ship notes every Friday.' }]
+    const assistantMessages: ModelMessage[] = [{ role: 'assistant', content: 'Done.' }]
+
+    persistProactiveResults(
+      'creator',
+      'ctx',
+      'cfg',
+      'dm',
+      { response: { messages: assistantMessages }, text: 'Done.', toolCalls: [] },
+      history,
+      'gpt-main',
+    )
+
+    expect(extractionCalls[0]?.[0]).toEqual({
+      storageContextId: 'ctx',
+      configContextId: 'cfg',
+      contextType: 'dm',
+      history: [...history, ...assistantMessages],
+    })
   })
 })

--- a/tests/deferred-prompts/proactive-llm.test.ts
+++ b/tests/deferred-prompts/proactive-llm.test.ts
@@ -19,6 +19,7 @@ import type { DeferredExecutionContext } from '../../src/deferred-prompts/proact
 import type { ExecutionMetadata } from '../../src/deferred-prompts/types.js'
 import { appendHistory } from '../../src/history.js'
 import { loadHistory } from '../../src/history.js'
+import { saveMemoryProfile } from '../../src/long-term-memory/store.js'
 import { loadFacts } from '../../src/memory.js'
 import { setSystemConfig } from '../../src/system-config.js'
 import { setToolPrefs } from '../../src/tools/tool-preferences.js'
@@ -266,6 +267,26 @@ describe('dispatchExecution', () => {
       expect(messageIncludesText(messages, 'history message')).toBe(true)
     })
 
+    test('uses group long-term memory for group thread delivery context', async () => {
+      setupUserConfig()
+      saveMemoryProfile(
+        { scopeId: '-1001', scopeType: 'group' },
+        '## Group memory\n- Group standups happen at 10:00',
+        '2026-06-12T00:00:00.000Z',
+      )
+      saveMemoryProfile(
+        { scopeId: '-1001:42', scopeType: 'personal' },
+        '## Personal memory\n- This personal thread scope should not be injected',
+        '2026-06-12T00:00:00.000Z',
+      )
+
+      await dispatchExecution(makeGroupThreadExecCtx(), 'scheduled', 'standup reminder', metadata, () => null)
+
+      const messages = generateTextCalls[0]!.messages
+      expect(messageIncludesText(messages, 'Group standups happen at 10:00')).toBe(true)
+      expect(messageIncludesText(messages, 'This personal thread scope should not be injected')).toBe(false)
+    })
+
     test('includes get_current_time tool only', async () => {
       setupUserConfig()
       await dispatchExecution(makeExecCtx(), 'scheduled', 'standup reminder', metadata, () => null)
@@ -350,6 +371,27 @@ describe('dispatchExecution', () => {
       await dispatchExecution(makeExecCtx(), 'scheduled', 'check overdue', metadata, () => provider)
       const messages = generateTextCalls[0]!.messages
       expect(messageIncludesText(messages, 'full mode history')).toBe(true)
+    })
+
+    test('full mode uses group long-term memory for group thread delivery context', async () => {
+      setupUserConfig()
+      const provider = createMockProvider()
+      saveMemoryProfile(
+        { scopeId: '-1001', scopeType: 'group' },
+        '## Group memory\n- Group escalations use the incident queue',
+        '2026-06-12T00:00:00.000Z',
+      )
+      saveMemoryProfile(
+        { scopeId: '-1001:42', scopeType: 'personal' },
+        '## Personal memory\n- This personal thread profile should not be injected',
+        '2026-06-12T00:00:00.000Z',
+      )
+
+      await dispatchExecution(makeGroupThreadExecCtx(), 'scheduled', 'check overdue', metadata, () => provider)
+
+      const messages = generateTextCalls[0]!.messages
+      expect(messageIncludesText(messages, 'Group escalations use the incident queue')).toBe(true)
+      expect(messageIncludesText(messages, 'This personal thread profile should not be injected')).toBe(false)
     })
 
     test('falls back to providerless full execution when provider cannot be built', async () => {

--- a/tests/deferred-prompts/proactive-llm.test.ts
+++ b/tests/deferred-prompts/proactive-llm.test.ts
@@ -531,6 +531,13 @@ describe('dispatchExecution', () => {
           steps: undefined,
           response: { messages: [] },
         }),
+        Promise.resolve({
+          text: JSON.stringify({ profile: null, records: [], updates: [] }),
+          toolCalls: [],
+          toolResults: [],
+          steps: undefined,
+          response: { messages: [] },
+        }),
       ]
       let callIndex = 0
       generateTextImpl = (args: GenerateTextCall): Promise<GenerateTextResult> => {
@@ -563,6 +570,7 @@ describe('dispatchExecution', () => {
 
       expect(buildModelCalls).toEqual([
         { apiKey: 'sk-byok-full-trim', baseURL: 'https://byok-full-trim.invalid/v1', modelId: 'byok-full-main' },
+        { apiKey: 'sk-byok-full-trim', baseURL: 'https://byok-full-trim.invalid/v1', modelId: 'byok-full-small' },
         { apiKey: 'sk-byok-full-trim', baseURL: 'https://byok-full-trim.invalid/v1', modelId: 'byok-full-small' },
       ])
     })

--- a/tests/llm-history.test.ts
+++ b/tests/llm-history.test.ts
@@ -10,6 +10,7 @@ import type { ModelMessage } from 'ai'
 import * as conversationModule from '../src/conversation.js'
 import * as historyModule from '../src/history.js'
 import { appendAssistantHistory } from '../src/llm-history.js'
+import * as memoryRunnerModule from '../src/long-term-memory/runner.js'
 import { mockLogger } from './utils/test-helpers.js'
 
 type SpyInstance = { mockRestore: () => void }
@@ -27,10 +28,11 @@ describe('appendAssistantHistory', () => {
     return spy
   }
 
-  const setup = (): { appendCalls: ModelMessage[][]; trimCalls: unknown[][] } => {
+  const setup = (): { appendCalls: ModelMessage[][]; trimCalls: unknown[][]; extractionCalls: unknown[][] } => {
     mockLogger()
     const appendCalls: ModelMessage[][] = []
     const trimCalls: unknown[][] = []
+    const extractionCalls: unknown[][] = []
     track(
       spyOn(historyModule, 'appendHistory').mockImplementation((_id: string, msgs: readonly ModelMessage[]) => {
         appendCalls.push([...msgs])
@@ -42,11 +44,17 @@ describe('appendAssistantHistory', () => {
         return Promise.resolve()
       }),
     )
-    return { appendCalls, trimCalls }
+    track(
+      spyOn(memoryRunnerModule, 'runMemoryExtractionInBackground').mockImplementation((...args: unknown[]) => {
+        extractionCalls.push(args)
+        return Promise.resolve()
+      }),
+    )
+    return { appendCalls, trimCalls, extractionCalls }
   }
 
   test('appends assistant messages and does not trim a short history', () => {
-    const { appendCalls, trimCalls } = setup()
+    const { appendCalls, trimCalls, extractionCalls } = setup()
     track(spyOn(conversationModule, 'shouldTriggerTrim').mockReturnValue(false))
 
     appendAssistantHistory(
@@ -59,23 +67,27 @@ describe('appendAssistantHistory', () => {
 
     expect(appendCalls).toHaveLength(1)
     expect(trimCalls).toHaveLength(0)
+    expect(extractionCalls).toHaveLength(0)
   })
 
-  test('triggers a background trim when the threshold is crossed', () => {
-    const { trimCalls } = setup()
+  test('triggers background trim and memory extraction when the threshold is crossed', () => {
+    const { trimCalls, extractionCalls } = setup()
     track(spyOn(conversationModule, 'shouldTriggerTrim').mockReturnValue(true))
+    const history: ModelMessage[] = [{ role: 'user', content: 'hi' }]
+    const assistantMessages: ModelMessage[] = [{ role: 'assistant', content: 'hello' }]
 
-    appendAssistantHistory(
-      'ctx',
-      'cfg',
-      'gpt-4o',
-      [{ role: 'user', content: 'hi' }],
-      [{ role: 'assistant', content: 'hello' }],
-    )
+    appendAssistantHistory('ctx', 'cfg', 'gpt-4o', history, assistantMessages, 'group')
 
     expect(trimCalls).toHaveLength(1)
     expect(trimCalls[0]![0]).toBe('ctx')
     expect(trimCalls[0]![3]).toBe('cfg')
+    expect(extractionCalls).toHaveLength(1)
+    expect(extractionCalls[0]![0]).toEqual({
+      storageContextId: 'ctx',
+      configContextId: 'cfg',
+      contextType: 'group',
+      history: [...history, ...assistantMessages],
+    })
   })
 
   test('passes the model name through to the trim decision', () => {

--- a/tests/llm-orchestrator-tools.test.ts
+++ b/tests/llm-orchestrator-tools.test.ts
@@ -19,6 +19,7 @@ import type { ToolSet } from 'ai'
 import type { StagedFileDownloadFn } from '../src/attachments/types.js'
 import { userCachesForTesting } from '../src/cache.js'
 import type { LlmInvocationOptions } from '../src/llm-orchestrator-tools.js'
+import { saveMemoryProfile } from '../src/long-term-memory/store.js'
 import type { TaskProvider } from '../src/providers/types.js'
 import { makeGetCurrentTimeTool } from '../src/tools/get-current-time.js'
 import type { MakeToolsOptions } from '../src/tools/types.js'
@@ -245,5 +246,36 @@ describe('llm-orchestrator-tools / prepareLlmInvocation enabledToolNames', () =>
     expect(buildToolDescriptorsSpy).toHaveBeenCalledTimes(0)
     expect(result.enabledToolNames.has('save_memo')).toBe(true)
     expect(result.enabledToolNames.has('get_current_time')).toBe(true)
+  })
+
+  test('injects group long-term memory using group scope', async () => {
+    saveMemoryProfile(
+      { scopeId: 'ctx-group-memory', scopeType: 'group' },
+      '## Group memory\n- The group ships release notes on Fridays',
+      '2026-06-12T00:00:00.000Z',
+    )
+    saveMemoryProfile(
+      { scopeId: 'ctx-group-memory', scopeType: 'personal' },
+      '## Personal memory\n- This should not be injected for group turns',
+      '2026-06-12T00:00:00.000Z',
+    )
+
+    const result = await prepareLlmInvocation({
+      contextId: 'ctx-group-memory',
+      configId: 'ctx-group-memory',
+      chatUserId: 'user-pr',
+      username: null,
+      contextType: 'group',
+      provider,
+      history: [{ role: 'user', content: 'What is our release note cadence?' }],
+      userText: 'What is our release note cadence?',
+      stagedDownloadFn: NO_STAGED_DOWNLOAD,
+      askPermission: undefined,
+    })
+
+    const systemMessage = result.validatedMessages[0]
+    expect(systemMessage?.role).toBe('system')
+    expect(systemMessage?.content).toContain('The group ships release notes on Fridays')
+    expect(systemMessage?.content).not.toContain('This should not be injected for group turns')
   })
 })

--- a/tests/long-term-memory/context.test.ts
+++ b/tests/long-term-memory/context.test.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { buildLongTermMemoryContextMessage } from '../../src/long-term-memory/context.js'
+import type { MemoryRecord } from '../../src/long-term-memory/types.js'
+
+const record = (overrides: Partial<MemoryRecord> = {}): MemoryRecord => ({
+  id: 'mem-1',
+  scopeId: 'user-1',
+  scopeType: 'personal',
+  kind: 'preference',
+  content: 'User prefers concise implementation plans.',
+  summary: 'Concise plans',
+  tags: ['style'],
+  confidence: 0.9,
+  status: 'active',
+  source: 'explicit',
+  evidence: {},
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  lastSeenAt: '2026-06-12T00:00:00.000Z',
+  ...overrides,
+})
+
+describe('buildLongTermMemoryContextMessage', () => {
+  test('returns null when profile and records are empty', () => {
+    expect(buildLongTermMemoryContextMessage({ profile: null, records: [] })).toBeNull()
+    expect(buildLongTermMemoryContextMessage({ profile: '', records: [] })).toBeNull()
+    expect(buildLongTermMemoryContextMessage({ profile: '   ', records: [] })).toBeNull()
+  })
+
+  test('wraps profile in a bounded low-trust block', () => {
+    const result = buildLongTermMemoryContextMessage({
+      profile: '## Communication\n- Prefer direct answers',
+      records: [],
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.role).toBe('system')
+    expect(result!.content).toContain('<long_term_memory trust="profile_and_retrieved_low">')
+    expect(result!.content).toContain('lower-trust than the current user message')
+    expect(result!.content).toContain('stale records may be wrong')
+    expect(result!.content).toContain('<profile>')
+    expect(result!.content).toContain('Prefer direct answers')
+  })
+
+  test('renders at most three retrieved records with attributes', () => {
+    const records = [
+      record({ id: 'mem-0', kind: 'preference', confidence: 0.5, lastSeenAt: '2026-06-10T00:00:00.000Z' }),
+      record({ id: 'mem-1', kind: 'decision', confidence: 0.6, lastSeenAt: '2026-06-11T00:00:00.000Z' }),
+      record({ id: 'mem-2', kind: 'preference', confidence: 0.7, lastSeenAt: '2026-06-12T00:00:00.000Z' }),
+      record({ id: 'mem-3', kind: 'preference', confidence: 0.8, lastSeenAt: '2026-06-13T00:00:00.000Z' }),
+      record({ id: 'mem-4', kind: 'preference', confidence: 0.9, lastSeenAt: '2026-06-14T00:00:00.000Z' }),
+    ]
+
+    const result = buildLongTermMemoryContextMessage({ profile: null, records })
+    const recordLines = result!.content.split('\n').filter((line) => line.trim().startsWith('<record '))
+
+    expect(result!.content).toContain('<retrieved_records max="3">')
+    expect(recordLines).toHaveLength(3)
+    expect(result!.content).toContain('id="mem-0"')
+    expect(result!.content).toContain('kind="decision"')
+    expect(result!.content).toContain('confidence="0.6"')
+    expect(result!.content).toContain('last_seen_at="2026-06-11T00:00:00.000Z"')
+    expect(result!.content).not.toContain('mem-4')
+  })
+
+  test('renders stale status and falls back to content when summary is absent', () => {
+    const result = buildLongTermMemoryContextMessage({
+      profile: null,
+      records: [
+        record({
+          id: 'mem-stale',
+          status: 'stale',
+          summary: null,
+          content: 'The old deployment checklist referenced staging v1.',
+        }),
+      ],
+    })
+
+    expect(result!.content).toContain('status="stale"')
+    expect(result!.content).toContain('The old deployment checklist referenced staging v1.')
+  })
+
+  test('escapes XML-ish attributes and content', () => {
+    const result = buildLongTermMemoryContextMessage({
+      profile: 'Use <profile> & check "quotes"',
+      records: [
+        record({
+          id: 'mem"1<&',
+          kind: 'reference',
+          summary: null,
+          content: 'Use <unsafe> & "quoted" content',
+        }),
+      ],
+    })
+
+    expect(result!.content).toContain('id="mem&quot;1&lt;&amp;"')
+    expect(result!.content).toContain('Use &lt;profile&gt; &amp; check "quotes"')
+    expect(result!.content).toContain('Use &lt;unsafe&gt; &amp; "quoted" content')
+    expect(result!.content).not.toContain('<unsafe>')
+  })
+
+  test('truncates profile and record text to keep injected context bounded', () => {
+    const result = buildLongTermMemoryContextMessage({
+      profile: `profile ${'x'.repeat(5_000)}`,
+      records: [
+        record({
+          summary: `${'record '.repeat(1_000)}tail`,
+        }),
+      ],
+    })
+
+    expect(result!.content).toContain('[truncated]')
+    expect(result!.content).not.toContain('tail')
+    expect(result!.content.length).toBeLessThan(5_000)
+  })
+})

--- a/tests/long-term-memory/extractor.test.ts
+++ b/tests/long-term-memory/extractor.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { parseMemoryPatch } from '../../src/long-term-memory/extractor.js'
+
+describe('parseMemoryPatch', () => {
+  test('parses a valid JSON patch', () => {
+    const patch = parseMemoryPatch(
+      JSON.stringify({
+        profile: '## Work style\n- Prefers concise status updates',
+        records: [
+          {
+            kind: 'preference',
+            content: 'User prefers concise status updates.',
+            summary: 'Concise status updates',
+            tags: ['communication'],
+            confidence: 0.9,
+            source: 'background',
+            evidence: {
+              messageIds: ['m-1'],
+              timestamps: ['2026-06-12T00:00:00.000Z'],
+              contextId: 'ctx-1',
+            },
+          },
+        ],
+        updates: [{ id: 'mem-1', status: 'stale', confidence: 0.4 }],
+      }),
+    )
+
+    expect(patch.profile).toContain('Prefers concise')
+    expect(patch.records[0]?.kind).toBe('preference')
+    expect(patch.records[0]?.expiresAt).toBeUndefined()
+    expect(patch.updates).toEqual([{ id: 'mem-1', status: 'stale', confidence: 0.4 }])
+  })
+
+  test('extracts a JSON object surrounded by non-JSON text', () => {
+    const patch = parseMemoryPatch('Here is the patch:\n{"profile":null,"records":[],"updates":[]}\nNo other changes.')
+
+    expect(patch).toEqual({ profile: null, records: [], updates: [] })
+  })
+
+  test('rejects malformed output with a memory patch error', () => {
+    expect(() => parseMemoryPatch('not json')).toThrow(/^invalid memory patch:/u)
+  })
+
+  test('rejects confidence outside the valid range', () => {
+    expect(() =>
+      parseMemoryPatch(
+        JSON.stringify({
+          profile: null,
+          records: [
+            {
+              kind: 'fact',
+              content: 'A remembered fact.',
+              summary: null,
+              tags: [],
+              confidence: 1.2,
+              source: 'background',
+              evidence: {},
+            },
+          ],
+          updates: [],
+        }),
+      ),
+    ).toThrow(/^invalid memory patch:/u)
+  })
+})

--- a/tests/long-term-memory/extractor.test.ts
+++ b/tests/long-term-memory/extractor.test.ts
@@ -33,6 +33,7 @@ describe('parseMemoryPatch', () => {
 
     expect(patch.profile).toContain('Prefers concise')
     expect(patch.records[0]?.kind).toBe('preference')
+    expect(patch.records[0]?.evidence.timestamps).toEqual(['2026-06-12T00:00:00.000Z'])
     expect(patch.records[0]?.expiresAt).toBeUndefined()
     expect(patch.updates).toEqual([{ id: 'mem-1', status: 'stale', confidence: 0.4 }])
   })
@@ -61,6 +62,81 @@ describe('parseMemoryPatch', () => {
               confidence: 1.2,
               source: 'background',
               evidence: {},
+            },
+          ],
+          updates: [],
+        }),
+      ),
+    ).toThrow(/^invalid memory patch:/u)
+  })
+
+  test('rejects privileged sources from model output', () => {
+    expect(() =>
+      parseMemoryPatch(
+        JSON.stringify({
+          profile: null,
+          records: [
+            {
+              kind: 'fact',
+              content: 'A remembered fact.',
+              summary: null,
+              tags: [],
+              confidence: 0.8,
+              source: 'explicit',
+              evidence: {},
+            },
+          ],
+          updates: [],
+        }),
+      ),
+    ).toThrow(/^invalid memory patch:/u)
+  })
+
+  test('rejects oversized model output before persistence', () => {
+    expect(() =>
+      parseMemoryPatch(
+        JSON.stringify({
+          profile: 'x'.repeat(4_001),
+          records: [],
+          updates: [],
+        }),
+      ),
+    ).toThrow(/^invalid memory patch:/u)
+
+    expect(() =>
+      parseMemoryPatch(
+        JSON.stringify({
+          profile: null,
+          records: Array.from({ length: 21 }, () => ({
+            kind: 'fact',
+            content: 'A remembered fact.',
+            summary: null,
+            tags: [],
+            confidence: 0.8,
+            source: 'background',
+            evidence: {},
+          })),
+          updates: [],
+        }),
+      ),
+    ).toThrow(/^invalid memory patch:/u)
+  })
+
+  test('rejects non-ISO expiration timestamps', () => {
+    expect(() =>
+      parseMemoryPatch(
+        JSON.stringify({
+          profile: null,
+          records: [
+            {
+              kind: 'fact',
+              content: 'A remembered fact.',
+              summary: null,
+              tags: [],
+              confidence: 0.8,
+              source: 'background',
+              evidence: {},
+              expiresAt: 'tomorrow',
             },
           ],
           updates: [],

--- a/tests/long-term-memory/maintenance.test.ts
+++ b/tests/long-term-memory/maintenance.test.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { runMemoryMaintenance } from '../../src/long-term-memory/maintenance.js'
+import { listMemoryRecords, saveMemoryRecord } from '../../src/long-term-memory/store.js'
+import type { MemoryRecord, MemoryRecordInput, MemoryScope } from '../../src/long-term-memory/types.js'
+import { setupTestDb } from '../utils/test-helpers.js'
+
+const NOW = '2026-06-12T00:00:00.000Z'
+const OLD_DECISION = '2026-02-01T00:00:00.000Z'
+const RECENT = '2026-06-01T00:00:00.000Z'
+const EXPIRED = '2026-06-11T23:59:59.000Z'
+const PERSONAL_SCOPE: MemoryScope = { scopeId: 'user-memory', scopeType: 'personal' }
+const GROUP_SCOPE: MemoryScope = { scopeId: 'group-memory', scopeType: 'group' }
+
+const memoryRecordInput = (overrides: Partial<MemoryRecordInput>): MemoryRecordInput => ({
+  id: 'mem-default',
+  scopeId: PERSONAL_SCOPE.scopeId,
+  scopeType: PERSONAL_SCOPE.scopeType,
+  kind: 'decision',
+  content: 'The team chose the lightweight implementation path.',
+  summary: 'Lightweight path',
+  tags: [],
+  confidence: 0.8,
+  status: 'active',
+  source: 'background',
+  evidence: {},
+  createdAt: RECENT,
+  updatedAt: RECENT,
+  lastSeenAt: RECENT,
+  ...overrides,
+})
+
+const recordById = (scope: MemoryScope, status: MemoryRecordInput['status'], id: string): MemoryRecord | null =>
+  listMemoryRecords({ ...scope, status, limit: 20 }).find((record) => record.id === id) ?? null
+
+describe('long-term memory maintenance', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('marks old non-explicit active decisions stale and archives expired references', () => {
+    saveMemoryRecord(
+      memoryRecordInput({
+        id: 'old-decision',
+        lastSeenAt: OLD_DECISION,
+        createdAt: OLD_DECISION,
+        updatedAt: OLD_DECISION,
+      }),
+    )
+    saveMemoryRecord(
+      memoryRecordInput({
+        id: 'expired-reference',
+        kind: 'reference',
+        lastSeenAt: RECENT,
+        expiresAt: EXPIRED,
+      }),
+    )
+
+    expect(runMemoryMaintenance(NOW)).toEqual({ staleMarked: 1, archived: 1 })
+
+    expect(recordById(PERSONAL_SCOPE, 'stale', 'old-decision')).toMatchObject({
+      id: 'old-decision',
+      updatedAt: NOW,
+    })
+    expect(recordById(PERSONAL_SCOPE, 'archived', 'expired-reference')).toMatchObject({
+      id: 'expired-reference',
+      updatedAt: NOW,
+    })
+  })
+
+  test('keeps old explicit records active', () => {
+    saveMemoryRecord(
+      memoryRecordInput({
+        id: 'explicit-old',
+        source: 'explicit',
+        lastSeenAt: OLD_DECISION,
+        createdAt: OLD_DECISION,
+        updatedAt: OLD_DECISION,
+      }),
+    )
+
+    expect(runMemoryMaintenance(NOW)).toEqual({ staleMarked: 0, archived: 0 })
+    expect(recordById(PERSONAL_SCOPE, 'active', 'explicit-old')).toMatchObject({
+      id: 'explicit-old',
+      updatedAt: OLD_DECISION,
+    })
+  })
+
+  test('keeps recent active records active', () => {
+    saveMemoryRecord(memoryRecordInput({ id: 'recent-decision' }))
+
+    expect(runMemoryMaintenance(NOW)).toEqual({ staleMarked: 0, archived: 0 })
+    expect(recordById(PERSONAL_SCOPE, 'active', 'recent-decision')).toMatchObject({
+      id: 'recent-decision',
+      updatedAt: RECENT,
+    })
+  })
+
+  test('does not count already archived expired records again', () => {
+    saveMemoryRecord(
+      memoryRecordInput({
+        id: 'archived-expired',
+        scopeId: GROUP_SCOPE.scopeId,
+        scopeType: GROUP_SCOPE.scopeType,
+        kind: 'reference',
+        status: 'archived',
+        expiresAt: EXPIRED,
+      }),
+    )
+
+    expect(runMemoryMaintenance(NOW)).toEqual({ staleMarked: 0, archived: 0 })
+    expect(recordById(GROUP_SCOPE, 'archived', 'archived-expired')).toMatchObject({
+      id: 'archived-expired',
+      updatedAt: RECENT,
+    })
+  })
+
+  test('rejects invalid maintenance timestamps', () => {
+    expect(() => runMemoryMaintenance('not-a-date')).toThrow('Invalid memory maintenance timestamp')
+  })
+})

--- a/tests/long-term-memory/runner.test.ts
+++ b/tests/long-term-memory/runner.test.ts
@@ -98,6 +98,42 @@ describe('runMemoryExtractionInBackground', () => {
     expect(updated?.confidence).toBe(0.7)
   })
 
+  test('stores background source and canonical timestamps for extracted records', async () => {
+    const extractedPatch: MemoryPatch = {
+      profile: null,
+      records: [
+        {
+          kind: 'fact',
+          content: 'Release notes expire after launch.',
+          summary: null,
+          tags: [],
+          confidence: 0.8,
+          source: 'background',
+          evidence: {},
+          expiresAt: '2026-06-13T00:00:00Z',
+          validFrom: 'not-a-date',
+        },
+      ],
+      updates: [],
+    }
+    await runMemoryExtractionInBackground({
+      storageContextId: 'ctx-1',
+      configContextId: 'cfg-1',
+      contextType: 'dm',
+      history,
+      deps: {
+        extractMemoryPatch: () => Promise.resolve(extractedPatch),
+        now: () => '2026-06-12T00:00:00.000Z',
+        randomUUID: () => 'mem-sanitized',
+      },
+    })
+
+    const [record] = listMemoryRecords({ scopeId: 'ctx-1', scopeType: 'personal' })
+    expect(record?.source).toBe('background')
+    expect(record?.expiresAt).toBe('2026-06-13T00:00:00.000Z')
+    expect(record?.validFrom).toBeNull()
+  })
+
   test('respects disabled profile and skips extraction', async () => {
     setMemoryCaptureEnabled({ scopeId: 'ctx-disabled', scopeType: 'personal' }, false, '2026-06-12T00:00:00.000Z')
     let calls = 0

--- a/tests/long-term-memory/runner.test.ts
+++ b/tests/long-term-memory/runner.test.ts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import type { ModelMessage } from 'ai'
+
+import { toScopedContextId, toScopedThreadContextId } from '../../src/chat/scoped-context.js'
+import type { MemoryPatch } from '../../src/long-term-memory/extractor.js'
+import { runMemoryExtractionInBackground } from '../../src/long-term-memory/runner.js'
+import {
+  getMemoryProfile,
+  listMemoryRecords,
+  saveMemoryRecord,
+  setMemoryCaptureEnabled,
+} from '../../src/long-term-memory/store.js'
+import type { MemoryRecordInput } from '../../src/long-term-memory/types.js'
+import { setupTestDb } from '../utils/test-helpers.js'
+
+const history: readonly ModelMessage[] = [
+  { role: 'user', content: 'Please remember that release notes go out on Fridays.' },
+  { role: 'assistant', content: 'Noted.' },
+]
+
+const memoryRecordInput = (overrides: Partial<MemoryRecordInput>): MemoryRecordInput => ({
+  id: 'mem-existing',
+  scopeId: 'ctx-1',
+  scopeType: 'personal',
+  kind: 'fact',
+  content: 'Old release note process.',
+  summary: 'Old release notes',
+  tags: ['release'],
+  confidence: 0.5,
+  status: 'active',
+  source: 'background',
+  evidence: {},
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  lastSeenAt: '2026-06-11T00:00:00.000Z',
+  ...overrides,
+})
+
+const patch: MemoryPatch = {
+  profile: '## Team memory\n- Release notes go out on Fridays',
+  records: [
+    {
+      kind: 'procedure',
+      content: 'Release notes go out on Fridays.',
+      summary: 'Friday release notes',
+      tags: ['release'],
+      confidence: 0.88,
+      source: 'background',
+      evidence: {
+        messageIds: ['m-1'],
+        timestamps: ['2026-06-12T00:00:00.000Z'],
+        contextId: 'ctx-1',
+      },
+    },
+  ],
+  updates: [{ id: 'mem-existing', status: 'stale', content: 'Updated release note process.', confidence: 0.7 }],
+}
+
+describe('runMemoryExtractionInBackground', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('applies generated patch to normalized scope', async () => {
+    saveMemoryRecord(memoryRecordInput({ id: 'mem-existing', scopeId: 'ctx-1', scopeType: 'personal' }))
+
+    await runMemoryExtractionInBackground({
+      storageContextId: 'ctx-1',
+      configContextId: 'cfg-1',
+      contextType: 'dm',
+      history,
+      deps: {
+        extractMemoryPatch: () => Promise.resolve(patch),
+        now: () => '2026-06-12T00:00:00.000Z',
+        randomUUID: () => 'mem-new',
+      },
+    })
+
+    expect(getMemoryProfile({ scopeId: 'ctx-1', scopeType: 'personal' })?.profile).toBe(
+      '## Team memory\n- Release notes go out on Fridays',
+    )
+    expect(
+      listMemoryRecords({ scopeId: 'ctx-1', scopeType: 'personal' })
+        .map((record) => record.id)
+        .sort(),
+    ).toEqual(['mem-existing', 'mem-new'])
+    const updated = listMemoryRecords({ scopeId: 'ctx-1', scopeType: 'personal' }).find(
+      (record) => record.id === 'mem-existing',
+    )
+    expect(updated?.status).toBe('stale')
+    expect(updated?.content).toBe('Updated release note process.')
+    expect(updated?.confidence).toBe(0.7)
+  })
+
+  test('respects disabled profile and skips extraction', async () => {
+    setMemoryCaptureEnabled({ scopeId: 'ctx-disabled', scopeType: 'personal' }, false, '2026-06-12T00:00:00.000Z')
+    let calls = 0
+
+    await runMemoryExtractionInBackground({
+      storageContextId: 'ctx-disabled',
+      configContextId: 'cfg-1',
+      contextType: 'dm',
+      history,
+      deps: {
+        extractMemoryPatch: () => {
+          calls += 1
+          return Promise.resolve(patch)
+        },
+      },
+    })
+
+    expect(calls).toBe(0)
+    expect(listMemoryRecords({ scopeId: 'ctx-disabled', scopeType: 'personal' })).toEqual([])
+  })
+
+  test('in-flight guard prevents duplicate concurrent extraction for same normalized scope', async () => {
+    let releaseFirst: (value: MemoryPatch) => void = () => {}
+    const firstPatch = new Promise<MemoryPatch>((resolve) => {
+      releaseFirst = resolve
+    })
+    let calls = 0
+
+    const first = runMemoryExtractionInBackground({
+      storageContextId: 'same-scope',
+      configContextId: 'cfg-1',
+      contextType: 'dm',
+      history,
+      deps: {
+        extractMemoryPatch: () => {
+          calls += 1
+          return firstPatch
+        },
+        randomUUID: () => `mem-${calls}`,
+      },
+    })
+    const second = runMemoryExtractionInBackground({
+      storageContextId: 'same-scope',
+      configContextId: 'cfg-1',
+      contextType: 'dm',
+      history,
+      deps: {
+        extractMemoryPatch: () => {
+          calls += 1
+          return Promise.resolve({ profile: null, records: [], updates: [] })
+        },
+      },
+    })
+
+    await second
+    expect(calls).toBe(1)
+    releaseFirst({ profile: null, records: [], updates: [] })
+    await first
+  })
+
+  test('group thread context resolves to parent group scope', async () => {
+    const parent = toScopedContextId({ platformInstanceId: 'telegram-main', nativeContextId: '-1001' })
+    const thread = toScopedThreadContextId({
+      platformInstanceId: 'telegram-main',
+      nativeContextId: '-1001',
+      threadId: '42',
+    })
+
+    await runMemoryExtractionInBackground({
+      storageContextId: thread,
+      configContextId: parent,
+      contextType: 'group',
+      history,
+      deps: {
+        extractMemoryPatch: () => Promise.resolve(patch),
+        now: () => '2026-06-12T00:00:00.000Z',
+        randomUUID: () => 'mem-group',
+      },
+    })
+
+    expect(getMemoryProfile({ scopeId: parent, scopeType: 'group' })?.profile).toBe(
+      '## Team memory\n- Release notes go out on Fridays',
+    )
+    expect(listMemoryRecords({ scopeId: parent, scopeType: 'group' }).map((record) => record.id)).toEqual(['mem-group'])
+    expect(listMemoryRecords({ scopeId: thread, scopeType: 'group' })).toEqual([])
+  })
+})

--- a/tests/long-term-memory/scope.test.ts
+++ b/tests/long-term-memory/scope.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { toScopedContextId, toScopedThreadContextId } from '../../src/chat/scoped-context.js'
+import { resolveMemoryScope } from '../../src/long-term-memory/scope.js'
+
+describe('resolveMemoryScope', () => {
+  test('uses personal scope for DMs', () => {
+    expect(resolveMemoryScope({ storageContextId: 'user-1', contextType: 'dm' })).toEqual({
+      scopeId: 'user-1',
+      scopeType: 'personal',
+    })
+  })
+
+  test('rolls scoped Telegram or Mattermost thread contexts up to parent group', () => {
+    const parent = toScopedContextId({ platformInstanceId: 'telegram-main', nativeContextId: '-1001' })
+    const thread = toScopedThreadContextId({
+      platformInstanceId: 'telegram-main',
+      nativeContextId: '-1001',
+      threadId: '42',
+    })
+
+    expect(resolveMemoryScope({ storageContextId: thread, contextType: 'group' })).toEqual({
+      scopeId: parent,
+      scopeType: 'group',
+    })
+  })
+
+  test('rolls legacy colon thread contexts up to the first segment', () => {
+    expect(resolveMemoryScope({ storageContextId: 'group-1:thread-2', contextType: 'group' })).toEqual({
+      scopeId: 'group-1',
+      scopeType: 'group',
+    })
+  })
+
+  test('keeps non-thread group contexts as group scope', () => {
+    expect(resolveMemoryScope({ storageContextId: 'discord-channel-1', contextType: 'group' })).toEqual({
+      scopeId: 'discord-channel-1',
+      scopeType: 'group',
+    })
+  })
+})

--- a/tests/long-term-memory/store.test.ts
+++ b/tests/long-term-memory/store.test.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import {
+  archiveMemoryRecord,
+  clearMemoryScope,
+  getMemoryProfile,
+  listMemoryRecords,
+  saveMemoryProfile,
+  saveMemoryRecord,
+  searchMemoryRecords,
+} from '../../src/long-term-memory/store.js'
+import { setupTestDb } from '../utils/test-helpers.js'
+
+describe('long-term memory store', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('saves and loads a profile for one scope', () => {
+    saveMemoryProfile(
+      { scopeId: 'user-1', scopeType: 'personal' },
+      '## Communication\n- Concise replies',
+      '2026-06-11T00:00:00.000Z',
+    )
+
+    expect(getMemoryProfile({ scopeId: 'user-1', scopeType: 'personal' })).toEqual({
+      scopeId: 'user-1',
+      scopeType: 'personal',
+      profile: '## Communication\n- Concise replies',
+      enabled: true,
+      version: 1,
+      updatedAt: '2026-06-11T00:00:00.000Z',
+    })
+  })
+
+  test('stores records and lists only requested scope/status', () => {
+    saveMemoryRecord({
+      id: 'mem-1',
+      scopeId: 'group-1',
+      scopeType: 'group',
+      kind: 'decision',
+      content: 'The group decided to release on Fridays.',
+      summary: 'Friday releases',
+      tags: ['release'],
+      confidence: 0.9,
+      status: 'active',
+      source: 'background',
+      evidence: { messageIds: ['m1'] },
+      createdAt: '2026-06-11T00:00:00.000Z',
+      updatedAt: '2026-06-11T00:00:00.000Z',
+      lastSeenAt: '2026-06-11T00:00:00.000Z',
+    })
+
+    expect(listMemoryRecords({ scopeId: 'group-1', status: 'active' }).map((r) => r.id)).toEqual(['mem-1'])
+    expect(listMemoryRecords({ scopeId: 'user-1', status: 'active' })).toEqual([])
+  })
+
+  test('searches active records with FTS', () => {
+    saveMemoryRecord({
+      id: 'mem-2',
+      scopeId: 'user-1',
+      scopeType: 'personal',
+      kind: 'preference',
+      content: 'User prefers concise implementation plans.',
+      summary: 'Concise plans',
+      tags: ['style'],
+      confidence: 1,
+      status: 'active',
+      source: 'explicit',
+      evidence: {},
+      createdAt: '2026-06-11T00:00:00.000Z',
+      updatedAt: '2026-06-11T00:00:00.000Z',
+      lastSeenAt: '2026-06-11T00:00:00.000Z',
+    })
+
+    expect(searchMemoryRecords({ scopeId: 'user-1', query: 'concise', includeStale: false }).map((r) => r.id)).toEqual([
+      'mem-2',
+    ])
+  })
+
+  test('archives a record and clears a scope', () => {
+    saveMemoryRecord({
+      id: 'mem-3',
+      scopeId: 'user-1',
+      scopeType: 'personal',
+      kind: 'reference',
+      content: 'User shared a reusable setup link.',
+      summary: null,
+      tags: [],
+      confidence: 0.7,
+      status: 'active',
+      source: 'explicit',
+      evidence: {},
+      createdAt: '2026-06-11T00:00:00.000Z',
+      updatedAt: '2026-06-11T00:00:00.000Z',
+      lastSeenAt: '2026-06-11T00:00:00.000Z',
+    })
+
+    expect(archiveMemoryRecord('user-1', 'mem-3', '2026-06-12T00:00:00.000Z')).toBe(true)
+    expect(listMemoryRecords({ scopeId: 'user-1', status: 'active' })).toEqual([])
+    expect(clearMemoryScope({ scopeId: 'user-1', scopeType: 'personal' })).toEqual({
+      recordsDeleted: 1,
+      profileDeleted: 0,
+    })
+  })
+})

--- a/tests/long-term-memory/store.test.ts
+++ b/tests/long-term-memory/store.test.ts
@@ -61,6 +61,18 @@ describe('long-term memory store', () => {
     })
   })
 
+  test('keeps memory profiles isolated by full scope identity', () => {
+    saveMemoryProfile(
+      { scopeId: 'shared-profile', scopeType: 'personal' },
+      'Personal profile',
+      '2026-06-11T00:00:00.000Z',
+    )
+    saveMemoryProfile({ scopeId: 'shared-profile', scopeType: 'group' }, 'Group profile', '2026-06-12T00:00:00.000Z')
+
+    expect(getMemoryProfile({ scopeId: 'shared-profile', scopeType: 'personal' })?.profile).toBe('Personal profile')
+    expect(getMemoryProfile({ scopeId: 'shared-profile', scopeType: 'group' })?.profile).toBe('Group profile')
+  })
+
   test('stores records and lists only requested scope/status', () => {
     saveMemoryRecord(
       memoryRecordInput({

--- a/tests/long-term-memory/store.test.ts
+++ b/tests/long-term-memory/store.test.ts
@@ -5,6 +5,10 @@
 
 import { beforeEach, describe, expect, test } from 'bun:test'
 
+import { eq } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { memoryRecords } from '../../src/db/schema.js'
 import {
   archiveMemoryRecord,
   clearMemoryScope,
@@ -14,7 +18,26 @@ import {
   saveMemoryRecord,
   searchMemoryRecords,
 } from '../../src/long-term-memory/store.js'
+import type { MemoryRecordInput } from '../../src/long-term-memory/types.js'
 import { setupTestDb } from '../utils/test-helpers.js'
+
+const memoryRecordInput = (overrides: Partial<MemoryRecordInput>): MemoryRecordInput => ({
+  id: 'mem-1',
+  scopeId: 'user-1',
+  scopeType: 'personal',
+  kind: 'preference',
+  content: 'User prefers concise implementation plans.',
+  summary: 'Concise plans',
+  tags: ['style'],
+  confidence: 1,
+  status: 'active',
+  source: 'explicit',
+  evidence: {},
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  lastSeenAt: '2026-06-11T00:00:00.000Z',
+  ...overrides,
+})
 
 describe('long-term memory store', () => {
   beforeEach(async () => {
@@ -39,73 +62,138 @@ describe('long-term memory store', () => {
   })
 
   test('stores records and lists only requested scope/status', () => {
-    saveMemoryRecord({
-      id: 'mem-1',
-      scopeId: 'group-1',
-      scopeType: 'group',
-      kind: 'decision',
-      content: 'The group decided to release on Fridays.',
-      summary: 'Friday releases',
-      tags: ['release'],
-      confidence: 0.9,
-      status: 'active',
-      source: 'background',
-      evidence: { messageIds: ['m1'] },
-      createdAt: '2026-06-11T00:00:00.000Z',
-      updatedAt: '2026-06-11T00:00:00.000Z',
-      lastSeenAt: '2026-06-11T00:00:00.000Z',
-    })
+    saveMemoryRecord(
+      memoryRecordInput({
+        id: 'mem-1',
+        scopeId: 'group-1',
+        scopeType: 'group',
+        kind: 'decision',
+        content: 'The group decided to release on Fridays.',
+        summary: 'Friday releases',
+        tags: ['release'],
+        confidence: 0.9,
+        status: 'active',
+        source: 'background',
+        evidence: { messageIds: ['m1'] },
+        createdAt: '2026-06-11T00:00:00.000Z',
+        updatedAt: '2026-06-11T00:00:00.000Z',
+        lastSeenAt: '2026-06-11T00:00:00.000Z',
+      }),
+    )
 
-    expect(listMemoryRecords({ scopeId: 'group-1', status: 'active' }).map((r) => r.id)).toEqual(['mem-1'])
-    expect(listMemoryRecords({ scopeId: 'user-1', status: 'active' })).toEqual([])
+    expect(listMemoryRecords({ scopeId: 'group-1', scopeType: 'group', status: 'active' }).map((r) => r.id)).toEqual([
+      'mem-1',
+    ])
+    expect(listMemoryRecords({ scopeId: 'user-1', scopeType: 'personal', status: 'active' })).toEqual([])
   })
 
   test('searches active records with FTS', () => {
-    saveMemoryRecord({
-      id: 'mem-2',
-      scopeId: 'user-1',
-      scopeType: 'personal',
-      kind: 'preference',
-      content: 'User prefers concise implementation plans.',
-      summary: 'Concise plans',
-      tags: ['style'],
-      confidence: 1,
-      status: 'active',
-      source: 'explicit',
-      evidence: {},
-      createdAt: '2026-06-11T00:00:00.000Z',
-      updatedAt: '2026-06-11T00:00:00.000Z',
-      lastSeenAt: '2026-06-11T00:00:00.000Z',
-    })
+    saveMemoryRecord(
+      memoryRecordInput({
+        id: 'mem-2',
+        scopeId: 'user-1',
+        scopeType: 'personal',
+        kind: 'preference',
+        content: 'User prefers concise implementation plans.',
+        summary: 'Concise plans',
+        tags: ['style'],
+        confidence: 1,
+        status: 'active',
+        source: 'explicit',
+        evidence: {},
+        createdAt: '2026-06-11T00:00:00.000Z',
+        updatedAt: '2026-06-11T00:00:00.000Z',
+        lastSeenAt: '2026-06-11T00:00:00.000Z',
+      }),
+    )
 
-    expect(searchMemoryRecords({ scopeId: 'user-1', query: 'concise', includeStale: false }).map((r) => r.id)).toEqual([
-      'mem-2',
-    ])
+    expect(
+      searchMemoryRecords({ scopeId: 'user-1', scopeType: 'personal', query: 'concise', includeStale: false }).map(
+        (r) => r.id,
+      ),
+    ).toEqual(['mem-2'])
   })
 
   test('archives a record and clears a scope', () => {
-    saveMemoryRecord({
-      id: 'mem-3',
-      scopeId: 'user-1',
-      scopeType: 'personal',
-      kind: 'reference',
-      content: 'User shared a reusable setup link.',
-      summary: null,
-      tags: [],
-      confidence: 0.7,
-      status: 'active',
-      source: 'explicit',
-      evidence: {},
-      createdAt: '2026-06-11T00:00:00.000Z',
-      updatedAt: '2026-06-11T00:00:00.000Z',
-      lastSeenAt: '2026-06-11T00:00:00.000Z',
-    })
+    saveMemoryRecord(
+      memoryRecordInput({
+        id: 'mem-3',
+        scopeId: 'user-1',
+        scopeType: 'personal',
+        kind: 'reference',
+        content: 'User shared a reusable setup link.',
+        summary: null,
+        tags: [],
+        confidence: 0.7,
+        status: 'active',
+        source: 'explicit',
+        evidence: {},
+        createdAt: '2026-06-11T00:00:00.000Z',
+        updatedAt: '2026-06-11T00:00:00.000Z',
+        lastSeenAt: '2026-06-11T00:00:00.000Z',
+      }),
+    )
 
-    expect(archiveMemoryRecord('user-1', 'mem-3', '2026-06-12T00:00:00.000Z')).toBe(true)
-    expect(listMemoryRecords({ scopeId: 'user-1', status: 'active' })).toEqual([])
+    expect(archiveMemoryRecord({ scopeId: 'user-1', scopeType: 'personal' }, 'mem-3', '2026-06-12T00:00:00.000Z')).toBe(
+      true,
+    )
+    expect(listMemoryRecords({ scopeId: 'user-1', scopeType: 'personal', status: 'active' })).toEqual([])
     expect(clearMemoryScope({ scopeId: 'user-1', scopeType: 'personal' })).toEqual({
       recordsDeleted: 1,
       profileDeleted: 0,
     })
+  })
+
+  test('keeps list and search isolated by scope type when scope ids match', () => {
+    saveMemoryRecord(
+      memoryRecordInput({
+        id: 'mem-personal',
+        scopeId: 'shared-1',
+        scopeType: 'personal',
+        content: 'Shared identifier personal concise preference.',
+      }),
+    )
+    saveMemoryRecord(
+      memoryRecordInput({
+        id: 'mem-group',
+        scopeId: 'shared-1',
+        scopeType: 'group',
+        content: 'Shared identifier group concise decision.',
+        kind: 'decision',
+      }),
+    )
+
+    expect(listMemoryRecords({ scopeId: 'shared-1', scopeType: 'personal' }).map((r) => r.id)).toEqual(['mem-personal'])
+    expect(searchMemoryRecords({ scopeId: 'shared-1', scopeType: 'group', query: 'concise' }).map((r) => r.id)).toEqual(
+      ['mem-group'],
+    )
+  })
+
+  test('archives records only in the requested scope type', () => {
+    saveMemoryRecord(memoryRecordInput({ id: 'mem-personal', scopeId: 'shared-2', scopeType: 'personal' }))
+    saveMemoryRecord(memoryRecordInput({ id: 'mem-group', scopeId: 'shared-2', scopeType: 'group' }))
+
+    expect(
+      archiveMemoryRecord({ scopeId: 'shared-2', scopeType: 'personal' }, 'mem-personal', '2026-06-12T00:00:00.000Z'),
+    ).toBe(true)
+
+    expect(listMemoryRecords({ scopeId: 'shared-2', scopeType: 'personal', status: 'active' })).toEqual([])
+    expect(listMemoryRecords({ scopeId: 'shared-2', scopeType: 'group', status: 'active' }).map((r) => r.id)).toEqual([
+      'mem-group',
+    ])
+  })
+
+  test('degrades malformed tags and evidence without throwing', () => {
+    saveMemoryRecord(memoryRecordInput({ id: 'mem-bad-json' }))
+    getDrizzleDb()
+      .update(memoryRecords)
+      .set({ tags: 'not-json', evidence: 'not-json' })
+      .where(eq(memoryRecords.id, 'mem-bad-json'))
+      .run()
+
+    const records = listMemoryRecords({ scopeId: 'user-1', scopeType: 'personal' })
+
+    expect(records[0]?.tags).toEqual([])
+    expect(records[0]?.evidence).toEqual({})
   })
 })

--- a/tests/tools/memory.test.ts
+++ b/tests/tools/memory.test.ts
@@ -14,7 +14,7 @@ import {
   makeRememberMemoryTool,
   makeSearchMemoryTool,
 } from '../../src/tools/memory.js'
-import { getToolExecutor, setupTestDb } from '../utils/test-helpers.js'
+import { getToolExecutor, schemaValidates, setupTestDb } from '../utils/test-helpers.js'
 
 const memoryRecordInput = (overrides: Partial<MemoryRecordInput>): MemoryRecordInput => ({
   id: 'mem-existing',
@@ -85,6 +85,23 @@ describe('memory tools', () => {
     })
   })
 
+  test('remember_memory rejects too many tags and oversized tag strings', () => {
+    const tool = makeRememberMemoryTool({ storageContextId: 'user-1', contextType: 'dm' })
+    const baseInput = {
+      content: 'User prefers release summaries grouped by customer impact.',
+      kind: 'preference',
+    }
+
+    expect(
+      schemaValidates(tool, { ...baseInput, tags: Array.from({ length: 10 }, (_, index) => `tag-${index}`) }),
+    ).toBe(true)
+    expect(
+      schemaValidates(tool, { ...baseInput, tags: Array.from({ length: 11 }, (_, index) => `tag-${index}`) }),
+    ).toBe(false)
+    expect(schemaValidates(tool, { ...baseInput, tags: ['a'.repeat(40)] })).toBe(true)
+    expect(schemaValidates(tool, { ...baseInput, tags: ['a'.repeat(41)] })).toBe(false)
+  })
+
   test('search_memory returns active scoped keyword matches', async () => {
     saveMemoryRecord(
       memoryRecordInput({ id: 'mem-user-match', scopeId: 'user-1', content: 'Use concise release notes.' }),
@@ -128,6 +145,13 @@ describe('memory tools', () => {
     expect(
       listMemoryRecords({ scopeId: 'user-1', scopeType: 'personal', status: 'archived' }).map((r) => r.id),
     ).toEqual(['mem-target'])
+  })
+
+  test('forget_memory rejects oversized memory ids', () => {
+    const tool = makeForgetMemoryTool({ storageContextId: 'user-1', contextType: 'dm' })
+
+    expect(schemaValidates(tool, { memory_id: 'a'.repeat(128) })).toBe(true)
+    expect(schemaValidates(tool, { memory_id: 'a'.repeat(129) })).toBe(false)
   })
 
   test('forget_memory archives a query match only in the current scope', async () => {

--- a/tests/tools/memory.test.ts
+++ b/tests/tools/memory.test.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { toScopedContextId, toScopedThreadContextId } from '../../src/chat/scoped-context.js'
+import { listMemoryRecords, saveMemoryRecord } from '../../src/long-term-memory/store.js'
+import type { MemoryRecordInput } from '../../src/long-term-memory/types.js'
+import {
+  makeForgetMemoryTool,
+  makeListMemoryTool,
+  makeRememberMemoryTool,
+  makeSearchMemoryTool,
+} from '../../src/tools/memory.js'
+import { getToolExecutor, setupTestDb } from '../utils/test-helpers.js'
+
+const memoryRecordInput = (overrides: Partial<MemoryRecordInput>): MemoryRecordInput => ({
+  id: 'mem-existing',
+  scopeId: 'user-1',
+  scopeType: 'personal',
+  kind: 'fact',
+  content: 'The release checklist includes a customer announcement.',
+  summary: null,
+  tags: ['release'],
+  confidence: 1,
+  status: 'active',
+  source: 'explicit',
+  evidence: {},
+  createdAt: '2026-06-12T00:00:00.000Z',
+  updatedAt: '2026-06-12T00:00:00.000Z',
+  lastSeenAt: '2026-06-12T00:00:00.000Z',
+  ...overrides,
+})
+
+type MemoryRecordsResult = Readonly<{
+  records: readonly Readonly<{ id: string; content: string; kind: string; status: string }>[]
+}>
+
+type SavedMemoryResult = Readonly<{
+  status: 'saved'
+  id: string
+  kind: string
+}>
+
+function assertMemoryRecordsResult(value: unknown): asserts value is MemoryRecordsResult {
+  if (typeof value !== 'object' || value === null || !('records' in value)) {
+    throw new Error('Expected memory records result')
+  }
+}
+
+function assertSavedMemoryResult(value: unknown): asserts value is SavedMemoryResult {
+  if (typeof value !== 'object' || value === null || !('id' in value)) {
+    throw new Error('Expected saved memory result')
+  }
+}
+
+describe('memory tools', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('remember_memory writes an explicit active memory without echoing content', async () => {
+    const tool = makeRememberMemoryTool({ storageContextId: 'user-1', contextType: 'dm' })
+
+    const result = await getToolExecutor(tool)({
+      content: 'User prefers release summaries grouped by customer impact.',
+      kind: 'preference',
+      tags: ['release', 'writing'],
+    })
+
+    assertSavedMemoryResult(result)
+    expect(result).toMatchObject({ status: 'saved', kind: 'preference' })
+    expect(result.id.length).toBeGreaterThan(0)
+    expect('content' in result).toBe(false)
+    const records = listMemoryRecords({ scopeId: 'user-1', scopeType: 'personal', status: 'active' })
+    expect(records).toHaveLength(1)
+    expect(records[0]).toMatchObject({
+      kind: 'preference',
+      content: 'User prefers release summaries grouped by customer impact.',
+      tags: ['release', 'writing'],
+      source: 'explicit',
+      status: 'active',
+    })
+  })
+
+  test('search_memory returns active scoped keyword matches', async () => {
+    saveMemoryRecord(
+      memoryRecordInput({ id: 'mem-user-match', scopeId: 'user-1', content: 'Use concise release notes.' }),
+    )
+    saveMemoryRecord(
+      memoryRecordInput({ id: 'mem-other-scope', scopeId: 'user-2', content: 'Use concise release notes.' }),
+    )
+    saveMemoryRecord(
+      memoryRecordInput({ id: 'mem-stale', scopeId: 'user-1', content: 'Concise old notes.', status: 'stale' }),
+    )
+    const tool = makeSearchMemoryTool({ storageContextId: 'user-1', contextType: 'dm' })
+
+    const result = await getToolExecutor(tool)({ query: 'concise' })
+
+    expect(result).toMatchObject({ mode: 'keyword' })
+    assertMemoryRecordsResult(result)
+    expect(result.records.map((record) => record.id)).toEqual(['mem-user-match'])
+  })
+
+  test('list_memory omits archived records by default', async () => {
+    saveMemoryRecord(memoryRecordInput({ id: 'mem-active', scopeId: 'user-1', content: 'Active memory' }))
+    saveMemoryRecord(
+      memoryRecordInput({ id: 'mem-archived', scopeId: 'user-1', content: 'Archived memory', status: 'archived' }),
+    )
+    const tool = makeListMemoryTool({ storageContextId: 'user-1', contextType: 'dm' })
+
+    const result = await getToolExecutor(tool)({})
+
+    assertMemoryRecordsResult(result)
+    expect(result.records.map((record) => record.id)).toEqual(['mem-active'])
+  })
+
+  test('forget_memory archives a memory by id in the current scope', async () => {
+    saveMemoryRecord(memoryRecordInput({ id: 'mem-target', scopeId: 'user-1' }))
+    const tool = makeForgetMemoryTool({ storageContextId: 'user-1', contextType: 'dm' })
+
+    const result = await getToolExecutor(tool)({ memory_id: 'mem-target' })
+
+    expect(result).toEqual({ status: 'forgotten', id: 'mem-target' })
+    expect(listMemoryRecords({ scopeId: 'user-1', scopeType: 'personal', status: 'active' })).toEqual([])
+    expect(
+      listMemoryRecords({ scopeId: 'user-1', scopeType: 'personal', status: 'archived' }).map((r) => r.id),
+    ).toEqual(['mem-target'])
+  })
+
+  test('forget_memory archives a query match only in the current scope', async () => {
+    saveMemoryRecord(memoryRecordInput({ id: 'mem-personal', scopeId: 'shared', scopeType: 'personal' }))
+    saveMemoryRecord(memoryRecordInput({ id: 'mem-group', scopeId: 'shared', scopeType: 'group' }))
+    const tool = makeForgetMemoryTool({ storageContextId: 'shared', contextType: 'dm' })
+
+    const result = await getToolExecutor(tool)({ query: 'release checklist' })
+
+    expect(result).toEqual({ status: 'forgotten', id: 'mem-personal' })
+    expect(listMemoryRecords({ scopeId: 'shared', scopeType: 'personal', status: 'active' })).toEqual([])
+    expect(listMemoryRecords({ scopeId: 'shared', scopeType: 'group', status: 'active' }).map((r) => r.id)).toEqual([
+      'mem-group',
+    ])
+  })
+
+  test('group thread context writes and searches parent group memory scope', async () => {
+    const parentContextId = toScopedContextId({ platformInstanceId: 'telegram-main', nativeContextId: '-1001' })
+    const threadContextId = toScopedThreadContextId({
+      platformInstanceId: 'telegram-main',
+      nativeContextId: '-1001',
+      threadId: '42',
+    })
+    const context = { storageContextId: threadContextId, contextType: 'group' as const }
+
+    await getToolExecutor(makeRememberMemoryTool(context))({
+      content: 'The group release captain is Dana.',
+      kind: 'person_context',
+      tags: ['release'],
+    })
+    const search = await getToolExecutor(makeSearchMemoryTool(context))({ query: 'Dana' })
+
+    assertMemoryRecordsResult(search)
+    expect(search.records.map((record) => record.content)).toEqual(['The group release captain is Dana.'])
+    expect(
+      listMemoryRecords({ scopeId: parentContextId, scopeType: 'group', status: 'active' }).map((r) => r.content),
+    ).toEqual(['The group release captain is Dana.'])
+    expect(listMemoryRecords({ scopeId: threadContextId, scopeType: 'group', status: 'active' })).toEqual([])
+  })
+})

--- a/tests/tools/tool-metadata.test.ts
+++ b/tests/tools/tool-metadata.test.ts
@@ -71,4 +71,27 @@ describe('tool metadata', () => {
       })
     }
   })
+
+  test('classifies memory tools by read/write/destructive risk', () => {
+    expect(getToolMetadata('search_memory')).toEqual({
+      domain: 'memory',
+      operation: 'read',
+      risk: 'read',
+    })
+    expect(getToolMetadata('list_memory')).toEqual({
+      domain: 'memory',
+      operation: 'read',
+      risk: 'read',
+    })
+    expect(getToolMetadata('remember_memory')).toEqual({
+      domain: 'memory',
+      operation: 'create',
+      risk: 'write',
+    })
+    expect(getToolMetadata('forget_memory')).toEqual({
+      domain: 'memory',
+      operation: 'delete',
+      risk: 'destructive',
+    })
+  })
 })

--- a/tests/tools/tools-builder.test.ts
+++ b/tests/tools/tools-builder.test.ts
@@ -15,6 +15,7 @@ import type { IncomingFile } from '../../src/chat/types.js'
 import { createAlertPrompt, listAlertPrompts } from '../../src/deferred-prompts/alerts.js'
 import { getIdentityMapping } from '../../src/identity/mapping.js'
 import { listInstructions } from '../../src/instructions.js'
+import { listMemoryRecords } from '../../src/long-term-memory/store.js'
 import { listMemos } from '../../src/memos.js'
 import { contributionRegistry } from '../../src/plugins/contributions.js'
 import { pluginRegistry, setPluginEnabledForContext } from '../../src/plugins/registry.js'
@@ -139,6 +140,10 @@ describe('buildTools', () => {
     const tools = buildTools(provider, 'user-123', threadContextId, 'normal', 'group', 'alice')
 
     await getToolExecutor(tools['save_memo'])({ content: 'shared group memo' })
+    await getToolExecutor(tools['remember_memory'])({
+      content: 'The group remembers release notes are reviewed in the main channel.',
+      kind: 'procedure',
+    })
     await getToolExecutor(tools['save_instruction'])({ text: 'Prefer concise replies' })
     await getToolExecutor(tools['create_recurring_task'])({
       title: 'Shared recurring task',
@@ -154,6 +159,10 @@ describe('buildTools', () => {
     expect(parentContextId).not.toBe(threadContextId)
     expect(listMemos(parentContextId).map((memo) => memo.content)).toContain('shared group memo')
     expect(listMemos(threadContextId).map((memo) => memo.content)).not.toContain('shared group memo')
+    expect(
+      listMemoryRecords({ scopeId: parentContextId, scopeType: 'group', status: 'active' }).map((r) => r.content),
+    ).toContain('The group remembers release notes are reviewed in the main channel.')
+    expect(listMemoryRecords({ scopeId: threadContextId, scopeType: 'group', status: 'active' })).toEqual([])
     expect(listInstructions(parentContextId).map((instruction) => instruction.text)).toContain('Prefer concise replies')
     expect(listInstructions(threadContextId).map((instruction) => instruction.text)).not.toContain(
       'Prefer concise replies',
@@ -431,16 +440,41 @@ describe('buildTools', () => {
     expect(tools).not.toHaveProperty('list_memos')
     expect(tools).not.toHaveProperty('create_recurring_task')
     expect(tools).not.toHaveProperty('save_instruction')
+    expect(tools).not.toHaveProperty('remember_memory')
+  })
+
+  it('exposes memory tools when storage context and context type are available', () => {
+    const provider = createMockProvider()
+    const tools = buildTools(provider, 'user-123', 'user-123', 'normal', 'dm')
+
+    expect(tools).toHaveProperty('search_memory')
+    expect(tools).toHaveProperty('remember_memory')
+    expect(tools).toHaveProperty('forget_memory')
+    expect(tools).toHaveProperty('list_memory')
+  })
+
+  it('does not expose memory tools without context type', () => {
+    const provider = createMockProvider()
+    const tools = buildTools(provider, 'user-123', 'user-123', 'normal')
+
+    expect(tools).not.toHaveProperty('search_memory')
+    expect(tools).not.toHaveProperty('remember_memory')
+    expect(tools).not.toHaveProperty('forget_memory')
+    expect(tools).not.toHaveProperty('list_memory')
   })
 
   it('builds only provider-independent tools for providerless invocation', () => {
-    const tools = buildProviderlessTools('user-123', 'group-456:thread-1', 'normal')
+    const tools = buildProviderlessTools('user-123', 'group-456:thread-1', 'normal', 'group')
 
     expect(tools).toHaveProperty('get_current_time')
     expect(tools).toHaveProperty('save_memo')
     expect(tools).toHaveProperty('search_memos')
     expect(tools).toHaveProperty('list_memos')
     expect(tools).toHaveProperty('archive_memos')
+    expect(tools).toHaveProperty('search_memory')
+    expect(tools).toHaveProperty('remember_memory')
+    expect(tools).toHaveProperty('forget_memory')
+    expect(tools).toHaveProperty('list_memory')
     expect(tools).toHaveProperty('create_recurring_task')
     expect(tools).toHaveProperty('list_recurring_tasks')
     expect(tools).toHaveProperty('save_instruction')


### PR DESCRIPTION
## Summary
- Tighten background memory extraction with bounded schemas, ISO timestamp validation, and forced `background` provenance
- Trigger long-term extraction from proactive trim paths so scheduled and alert conversations are captured too
- Clarify the settings clear-memory dialog and add regressions for the new behavior

## Testing
- `bun test` (full server suite) passed
- `bun test:client` passed
- `bun run typecheck` passed
- `bun run format:check` passed