### PR TITLE
fix(youtrack): create/update tasks in localized & permission-restricted projects

### DIFF
--- a/docs/superpowers/plans/2026-06-16-youtrack-dedicated-fields-and-teaching-errors.md
+++ b/docs/superpowers/plans/2026-06-16-youtrack-dedicated-fields-and-teaching-errors.md
@@ -1,0 +1,892 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# YouTrack Dedicated-Field Localization & Teaching Errors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make YouTrack `create_task`/`update_task` set fields reliably in localized projects by resolving dedicated `status`/`assignee`/`priority` params to the real field by type, teaching the model the available field names on unknown-field errors, and bringing `update_task` to create-parity.
+
+**Architecture:** Every field (dedicated or generic) is resolved to a `ProjectCustomField` — dedicated by type (unique-or-fail with a canonical-name tiebreak), generic by name — then flows through the existing `resolveCustomFieldValue` field engine. The hard-coded `legacyDedicatedPayload` is deleted. A shared builder serves both create and update. Unknown-field errors list the available names.
+
+**Tech Stack:** Bun, TypeScript (strict, `.js` import paths), Zod v4, `bun:test`. Reference spec: `docs/superpowers/specs/2026-06-16-youtrack-dedicated-fields-and-teaching-errors-design.md`.
+
+---
+
+## Background / orientation (read first)
+
+Key existing pieces (all under `plugins/task-provider-youtrack/`):
+
+- `field-engine.ts` — `classifyFieldType(field)` returns `{ label, kind, multi, singleType?, multiType?, bundleSegment? }`. `label` is the base type string (`'state'`, `'enum'`, `'user'`, `'date'`, `'string'`, `'text'`, …); `kind` is the family (`'bundle'`, `'user'`, `'text'`, `'simple'`, `'date'`, `'period'`, `'unknown'`). `resolveCustomFieldValue(field, rawValue, { getBundleElements })` builds the `IssueCustomFieldPayload`. `capAllowedValues(values)` caps a list at 50. `normalize` (trim + lowercase) is currently **private**.
+- `create-field-helpers.ts` — `collectCreateFieldPairs(params)` produces `{name, value, dedicated}[]` mapping `status`→`'State'` etc.; `resolveCreateFieldPair` looks a pair up by name, else falls back to `legacyDedicatedPayload` (the hard-coded `{name:'State', $type:'StateIssueCustomField'}` payloads — the bug). This file is to be rewritten.
+- `task-helpers.ts` — `fetchProjectCustomFields(config, projectId, opts?)` (admin endpoint + opt-in issue-derived fallback), `validateRequiredCreateFields` (fetches schema, checks required, returns the `ProjectCustomField[]`), `buildCreateCustomFields` (create generic+dedicated → payloads), `markDedicatedParamFields` (marks `State`/`Priority`/… handled), `buildHandledFieldSet` (throws "Unknown custom field for create"), `buildWriteSafeCustomFields`/`buildWriteSafeCustomFieldPayload` (update path, string/text only), `buildProjectFieldsByName`.
+- `operations/tasks.ts` — `createYouTrackTask` (calls `validateRequiredCreateFields` then `buildCreateIssueBody`→`buildCreateCustomFields`), `updateYouTrackTask`→`buildUpdateCustomFields` (`buildCustomFields` dedicated + `buildWriteSafeCustomFields` generic).
+
+`ProjectCustomField` is `z.infer<typeof ProjectCustomFieldSchema>` (`schemas/bundle.ts`); `field` is optional, `field.name` is a `string` when present. `IssueCustomFieldPayload` is `{ name: string; $type: string; value: unknown }` (`field-engine.ts`).
+
+Run tests with `bun test <path>` (serial) — the suites here use `setMockFetch`. Full gate: `bun run lint`, `bunx tsc --noEmit -p tsconfig.json`, `bun test tests/plugins/task-provider-youtrack/`.
+
+---
+
+## Task 1: Export `normalize` from the field engine
+
+The dedicated resolver needs the same trim+lowercase normalization the engine uses. Promote it to an export. No behavior change.
+
+**Files:**
+
+- Modify: `plugins/task-provider-youtrack/field-engine.ts:117`
+
+- [ ] **Step 1: Export `normalize`**
+
+In `field-engine.ts`, change line 117 from:
+
+```typescript
+const normalize = (value: string): string => value.trim().toLocaleLowerCase()
+```
+
+to:
+
+```typescript
+export const normalize = (value: string): string => value.trim().toLocaleLowerCase()
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -i "field-engine" || echo "clean"`
+Expected: `clean`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/task-provider-youtrack/field-engine.ts
+git commit -m "refactor(youtrack): export normalize from field-engine for reuse"
+```
+
+---
+
+## Task 2: Teaching error for unknown field names (`field-name-error.ts`)
+
+Shared helper that builds an "Unknown custom field … Available fields: …" error listing the schema's field names (capped), used by create and update.
+
+**Files:**
+
+- Create: `plugins/task-provider-youtrack/field-name-error.ts`
+- Test: `tests/plugins/task-provider-youtrack/field-name-error.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/plugins/task-provider-youtrack/field-name-error.test.ts`:
+
+```typescript
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { unknownFieldError } from '../../../plugins/task-provider-youtrack/field-name-error.js'
+
+describe('unknownFieldError', () => {
+  test('lists available field names in message and details', () => {
+    const error = unknownFieldError('URL адеса', ['Cтaтус', 'Срочность'], 'create')
+    expect(error.message).toContain('URL адеса')
+    expect(error.message).toContain('Cтaтус')
+    expect(error.message).toContain('Срочность')
+    expect(error.message).toContain('create')
+    expect(error.appError.code).toBe('validation-failed')
+    expect(error.appError.field).toBe('customFields')
+    expect(error.appError.reason).toContain('Cтaтус')
+  })
+
+  test('caps the available list at 50 names', () => {
+    const names = Array.from({ length: 60 }, (_, i) => `Field${i}`)
+    const error = unknownFieldError('X', names, 'update')
+    expect(error.message).toContain('and 10 more')
+    expect(error.message).toContain('update')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/plugins/task-provider-youtrack/field-name-error.test.ts`
+Expected: FAIL — cannot find module `field-name-error.js`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `plugins/task-provider-youtrack/field-name-error.ts`:
+
+```typescript
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { providerError } from 'papai/plugin-types'
+
+import { YouTrackClassifiedError } from './classify-error.js'
+import { capAllowedValues } from './field-engine.js'
+
+/**
+ * Teaching error for an unrecognized custom-field name. Lists the project's available field
+ * names (capped) in both the message string (the channel the model reliably reads) and the
+ * structured details, so the model can self-correct in the same turn.
+ */
+export const unknownFieldError = (
+  name: string,
+  availableNames: readonly string[],
+  op: 'create' | 'update',
+): YouTrackClassifiedError => {
+  const listed = capAllowedValues([...availableNames]).join('; ')
+  const message = `Unknown custom field "${name}" for ${op}. Available fields: ${listed}`
+  return new YouTrackClassifiedError(message, providerError.validationFailed('customFields', message))
+}
+```
+
+Note: `capAllowedValues` renders the overflow tail as `…and N more` (so 60 names → "and 10 more").
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/plugins/task-provider-youtrack/field-name-error.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/task-provider-youtrack/field-name-error.ts tests/plugins/task-provider-youtrack/field-name-error.test.ts
+git commit -m "feat(youtrack): teaching error listing available field names"
+```
+
+---
+
+## Task 3: Dedicated-field resolver (`dedicated-fields.ts`)
+
+Resolve `status`/`assignee`/`priority`/`dueDate` to the actual `ProjectCustomField` by type, unique-or-fail, with a canonical-name tiebreak; `priority` requires a name match (enums are non-unique).
+
+**Files:**
+
+- Create: `plugins/task-provider-youtrack/dedicated-fields.ts`
+- Test: `tests/plugins/task-provider-youtrack/dedicated-fields.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/plugins/task-provider-youtrack/dedicated-fields.test.ts`:
+
+```typescript
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+import type { z } from 'zod'
+
+import { resolveDedicatedField } from '../../../plugins/task-provider-youtrack/dedicated-fields.js'
+import type { ProjectCustomFieldSchema } from '../../../plugins/task-provider-youtrack/schemas/bundle.js'
+
+type PCF = z.infer<typeof ProjectCustomFieldSchema>
+
+const field = (name: string, typeId: string, bundleType?: string): PCF =>
+  ({
+    $type: 'ProjectCustomField',
+    field: { name, fieldType: { id: typeId } },
+    ...(bundleType === undefined ? {} : { bundle: { id: 'b-1', $type: bundleType } }),
+  }) as PCF
+
+const STATE = field('Cтaтус', 'state[1]', 'StateBundle')
+const USER = field('Oтветствeнный', 'user[*]', 'UserBundle')
+const URGENCY = field('Срочность', 'enum[1]', 'EnumBundle')
+const TEAM = field('Командa', 'enum[*]', 'EnumBundle')
+
+describe('resolveDedicatedField', () => {
+  test('status resolves to the sole state-typed field regardless of localized name', () => {
+    const resolved = resolveDedicatedField('state', [STATE, USER, URGENCY, TEAM])
+    expect(resolved.field?.name).toBe('Cтaтус')
+  })
+
+  test('assignee resolves to the sole user-typed field', () => {
+    const resolved = resolveDedicatedField('user', [STATE, USER, URGENCY])
+    expect(resolved.field?.name).toBe('Oтветствeнный')
+  })
+
+  test('priority requires a canonical name match and rejects ambiguous enums', () => {
+    expect(() => resolveDedicatedField('priority', [URGENCY, TEAM])).toThrow(/priority/iu)
+  })
+
+  test('priority resolves an enum field literally named Priority', () => {
+    const priority = field('Priority', 'enum[1]', 'EnumBundle')
+    const resolved = resolveDedicatedField('priority', [priority, URGENCY, TEAM])
+    expect(resolved.field?.name).toBe('Priority')
+  })
+
+  test('two same-type fields disambiguate by canonical name (Assignee)', () => {
+    const assignee = field('Assignee', 'user[1]', 'UserBundle')
+    const reviewer = field('Reviewer', 'user[1]', 'UserBundle')
+    const resolved = resolveDedicatedField('user', [assignee, reviewer])
+    expect(resolved.field?.name).toBe('Assignee')
+  })
+
+  test('two same-type fields with no canonical name throw a teaching error', () => {
+    const a = field('Owner', 'user[1]', 'UserBundle')
+    const b = field('Watcher', 'user[1]', 'UserBundle')
+    expect(() => resolveDedicatedField('user', [a, b])).toThrow(/Owner|Watcher/u)
+  })
+
+  test('no field of the requested type throws a teaching error', () => {
+    expect(() => resolveDedicatedField('state', [USER, URGENCY])).toThrow(/state/iu)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/plugins/task-provider-youtrack/dedicated-fields.test.ts`
+Expected: FAIL — cannot find module `dedicated-fields.js`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `plugins/task-provider-youtrack/dedicated-fields.ts`:
+
+```typescript
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { providerError } from 'papai/plugin-types'
+import type { z } from 'zod'
+
+import { YouTrackClassifiedError } from './classify-error.js'
+import { capAllowedValues, classifyFieldType, normalize } from './field-engine.js'
+import type { ProjectCustomFieldSchema } from './schemas/bundle.js'
+
+type ProjectCustomField = z.infer<typeof ProjectCustomFieldSchema>
+
+export type DedicatedKind = 'state' | 'user' | 'priority' | 'date'
+
+const CANONICAL_NAMES: Record<DedicatedKind, readonly string[]> = {
+  state: ['state', 'статус'],
+  user: ['assignee', 'ответственный'],
+  priority: ['priority', 'приоритет'],
+  date: ['due date', 'дедлайн'],
+}
+
+const matchesType = (field: Readonly<ProjectCustomField>, kind: DedicatedKind): boolean => {
+  const c = classifyFieldType(field)
+  switch (kind) {
+    case 'state':
+      return c.label === 'state'
+    case 'priority':
+      return c.label === 'enum'
+    case 'user':
+      return c.kind === 'user'
+    case 'date':
+      return c.kind === 'date'
+  }
+}
+
+const matchesCanonicalName = (field: Readonly<ProjectCustomField>, names: readonly string[]): boolean => {
+  const name = field.field?.name
+  const localized = field.field?.localizedName ?? undefined
+  return (
+    (name !== undefined && names.includes(normalize(name))) ||
+    (localized !== undefined && localized !== null && names.includes(normalize(localized)))
+  )
+}
+
+const fieldName = (field: Readonly<ProjectCustomField>): string => field.field?.name ?? '(unnamed)'
+
+const dedicatedError = (kind: DedicatedKind, candidates: readonly ProjectCustomField[]): YouTrackClassifiedError => {
+  const names = capAllowedValues(candidates.map(fieldName)).join('; ')
+  const detail =
+    candidates.length === 0
+      ? `No ${kind}-type field exists in this project. Use describe_project to see the fields, then set the value via customFields by name.`
+      : `Multiple candidate fields for "${kind}" (${names}). Set the intended one explicitly via customFields by name.`
+  return new YouTrackClassifiedError(detail, providerError.validationFailed('customFields', detail))
+}
+
+/**
+ * Resolve a dedicated param (status/assignee/priority/dueDate) to the project's real field by
+ * type. Unique → use it. Ambiguous → disambiguate by canonical name; still ambiguous → teaching
+ * error. `priority` always requires a canonical name match because enum fields are non-unique.
+ */
+export const resolveDedicatedField = (
+  kind: DedicatedKind,
+  projectFields: readonly ProjectCustomField[],
+): ProjectCustomField => {
+  const candidates = projectFields.filter((f) => f.field?.name !== undefined && matchesType(f, kind))
+  if (kind !== 'priority' && candidates.length === 1) {
+    const only = candidates[0]
+    if (only !== undefined) return only
+  }
+  const named = candidates.filter((f) => matchesCanonicalName(f, CANONICAL_NAMES[kind]))
+  const pick = named[0]
+  if (named.length === 1 && pick !== undefined) return pick
+  throw dedicatedError(kind, candidates)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/plugins/task-provider-youtrack/dedicated-fields.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/task-provider-youtrack/dedicated-fields.ts tests/plugins/task-provider-youtrack/dedicated-fields.test.ts
+git commit -m "feat(youtrack): resolve dedicated params to real fields by type"
+```
+
+---
+
+## Task 4: Rewrite `create-field-helpers.ts` onto the resolver
+
+Replace name-tagged pairs + `legacyDedicatedPayload` with kind-tagged pairs resolved through `resolveDedicatedField` / by-name, all producing `{ field, value }` for the engine.
+
+**Files:**
+
+- Modify: `plugins/task-provider-youtrack/create-field-helpers.ts` (full rewrite)
+- Test: `tests/plugins/task-provider-youtrack/create-field-helpers.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/plugins/task-provider-youtrack/create-field-helpers.test.ts`:
+
+```typescript
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+import type { z } from 'zod'
+
+import { collectFieldPairs, resolveFieldPair } from '../../../plugins/task-provider-youtrack/create-field-helpers.js'
+import type { ProjectCustomFieldSchema } from '../../../plugins/task-provider-youtrack/schemas/bundle.js'
+
+type PCF = z.infer<typeof ProjectCustomFieldSchema> & {
+  field: { name: string }
+}
+
+const field = (name: string, typeId: string, bundleType?: string): PCF =>
+  ({
+    $type: 'ProjectCustomField',
+    field: { name, fieldType: { id: typeId } },
+    ...(bundleType === undefined ? {} : { bundle: { id: 'b-1', $type: bundleType } }),
+  }) as PCF
+
+const byName = (fields: PCF[]): Map<string, PCF> => new Map(fields.map((f) => [f.field.name, f]))
+
+describe('collectFieldPairs', () => {
+  test('tags dedicated params with a kind and generic fields by name', () => {
+    const pairs = collectFieldPairs({
+      status: 'Open',
+      customFields: [{ name: 'URL', value: 'http://x' }],
+    })
+    expect(pairs).toContainEqual({
+      source: 'dedicated',
+      kind: 'state',
+      value: 'Open',
+    })
+    expect(pairs).toContainEqual({
+      source: 'generic',
+      name: 'URL',
+      value: 'http://x',
+    })
+  })
+})
+
+describe('resolveFieldPair', () => {
+  test('dedicated status resolves to the localized state field', () => {
+    const state = field('Cтaтус', 'state[1]', 'StateBundle')
+    const resolved = resolveFieldPair({ source: 'dedicated', kind: 'state', value: 'Open' }, byName([state]), 'create')
+    expect(resolved.field.field?.name).toBe('Cтaтус')
+    expect(resolved.value).toBe('Open')
+  })
+
+  test('generic unknown field throws a teaching error listing available names', () => {
+    const state = field('Cтaтус', 'state[1]', 'StateBundle')
+    expect(() => resolveFieldPair({ source: 'generic', name: 'Nope', value: 'x' }, byName([state]), 'create')).toThrow(
+      /Cтaтус/u,
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/plugins/task-provider-youtrack/create-field-helpers.test.ts`
+Expected: FAIL — `collectFieldPairs`/`resolveFieldPair` not exported.
+
+- [ ] **Step 3: Rewrite the implementation**
+
+Replace the entire contents of `plugins/task-provider-youtrack/create-field-helpers.ts` with:
+
+```typescript
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { z } from 'zod'
+
+import { YOUTRACK_DUE_DATE_FIELD_NAME } from './constants.js'
+import type { DedicatedKind } from './dedicated-fields.js'
+import { resolveDedicatedField } from './dedicated-fields.js'
+import { unknownFieldError } from './field-name-error.js'
+import type { ProjectCustomFieldSchema } from './schemas/bundle.js'
+
+type ProjectCustomField = z.infer<typeof ProjectCustomFieldSchema>
+type NamedProjectCustomField = ProjectCustomField & {
+  readonly field: { readonly name: string }
+}
+
+export type FieldPair =
+  | { source: 'dedicated'; kind: DedicatedKind; value: string }
+  | { source: 'generic'; name: string; value: string }
+
+export type ResolvedFieldPair = { field: ProjectCustomField; value: string }
+
+type DedicatedParams = Readonly<{
+  status?: string
+  priority?: string
+  dueDate?: string
+  assignee?: string
+  customFields?: ReadonlyArray<{ name: string; value: string }>
+}>
+
+/** Collects dedicated params (tagged by field kind) and generic customFields into a flat list. */
+export const collectFieldPairs = (params: DedicatedParams): FieldPair[] => {
+  const pairs: FieldPair[] = []
+  if (params.status !== undefined) pairs.push({ source: 'dedicated', kind: 'state', value: params.status })
+  if (params.priority !== undefined)
+    pairs.push({
+      source: 'dedicated',
+      kind: 'priority',
+      value: params.priority,
+    })
+  if (params.assignee !== undefined) pairs.push({ source: 'dedicated', kind: 'user', value: params.assignee })
+  if (params.dueDate !== undefined) pairs.push({ source: 'dedicated', kind: 'date', value: params.dueDate })
+  for (const cf of params.customFields ?? []) pairs.push({ source: 'generic', name: cf.name, value: cf.value })
+  return pairs
+}
+
+/** Resolves a pair to a concrete project field: dedicated by type, generic by name. */
+export const resolveFieldPair = (
+  pair: Readonly<FieldPair>,
+  projectFieldsByName: ReadonlyMap<string, NamedProjectCustomField>,
+  op: 'create' | 'update',
+): ResolvedFieldPair => {
+  if (pair.source === 'generic') {
+    const field = projectFieldsByName.get(pair.name)
+    if (field === undefined) throw unknownFieldError(pair.name, [...projectFieldsByName.keys()], op)
+    return { field, value: pair.value }
+  }
+  const field = resolveDedicatedField(pair.kind, [...projectFieldsByName.values()])
+  return { field, value: pair.value }
+}
+
+export { YOUTRACK_DUE_DATE_FIELD_NAME }
+```
+
+(The `YOUTRACK_DUE_DATE_FIELD_NAME` re-export keeps any existing import path stable; remove it later if unused.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/plugins/task-provider-youtrack/create-field-helpers.test.ts`
+Expected: PASS (3 tests). Other suites will be red until Task 5 — that's expected.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/task-provider-youtrack/create-field-helpers.ts tests/plugins/task-provider-youtrack/create-field-helpers.test.ts
+git commit -m "refactor(youtrack): kind-tagged field pairs resolved via the engine"
+```
+
+---
+
+## Task 5: Unify create on the shared builder + widen fallback gating
+
+Add a shared `buildIssueCustomFields`, route create through it, make `markDedicatedParamFields` use resolved names, switch `buildHandledFieldSet` to the teaching error, and widen the create fallback gating to fire when any dedicated param is present.
+
+**Files:**
+
+- Modify: `plugins/task-provider-youtrack/task-helpers.ts`
+- Modify: `plugins/task-provider-youtrack/operations/tasks.ts`
+- Test: `tests/plugins/task-provider-youtrack/task-helpers.test.ts` (extend)
+
+- [ ] **Step 1: Add the shared builder and helpers to `task-helpers.ts`**
+
+In `task-helpers.ts`, update imports to use the new helpers:
+
+```typescript
+import { collectFieldPairs, resolveFieldPair } from './create-field-helpers.js'
+import { resolveDedicatedField } from './dedicated-fields.js'
+import { unknownFieldError } from './field-name-error.js'
+```
+
+(Remove the old `collectCreateFieldPairs`/`resolveCreateFieldPair` import.)
+
+Add the shared builder (place near `buildCreateCustomFields`):
+
+```typescript
+export const buildIssueCustomFields = async (
+  config: Readonly<YouTrackConfig>,
+  params: Readonly<{
+    status?: string
+    priority?: string
+    dueDate?: string
+    assignee?: string
+    customFields?: Array<{ name: string; value: string }>
+  }>,
+  projectCustomFields: readonly ProjectCustomField[],
+  op: 'create' | 'update',
+): Promise<IssueCustomFieldPayload[]> => {
+  const projectFieldsByName = buildProjectFieldsByName(projectCustomFields)
+  const getBundleElements = makeBundleElementFetcher(config)
+  const resolved = collectFieldPairs(params).map((pair) => resolveFieldPair(pair, projectFieldsByName, op))
+  return Promise.all(resolved.map((r) => resolveCustomFieldValue(r.field, r.value, { getBundleElements })))
+}
+```
+
+- [ ] **Step 2: Replace `markDedicatedParamFields` to use resolved names**
+
+In `task-helpers.ts`, replace the existing `markDedicatedParamFields` with:
+
+```typescript
+const markDedicatedParamFields = (
+  handledFields: Set<string>,
+  params: Readonly<{
+    status?: string
+    priority?: string
+    dueDate?: string
+    assignee?: string
+  }>,
+  projectFieldsByName: ReadonlyMap<string, ProjectCustomField & { readonly field: { readonly name: string } }>,
+): void => {
+  const fields = [...projectFieldsByName.values()]
+  for (const pair of collectFieldPairs(params)) {
+    if (pair.source !== 'dedicated') continue
+    try {
+      handledFields.add(resolveDedicatedField(pair.kind, fields).field?.name ?? '')
+    } catch {
+      // Unresolvable dedicated param surfaces as a teaching error when payloads are built.
+    }
+  }
+}
+```
+
+Update its call site in `validateRequiredCreateFields` to pass the by-name map (which it already builds):
+
+```typescript
+const projectFieldsByName = buildProjectFieldsByName(projectCustomFields)
+const handledFields = buildHandledFieldSet(projectFieldsByName, params.customFields)
+markDedicatedParamFields(handledFields, params, projectFieldsByName)
+```
+
+- [ ] **Step 3: Switch `buildHandledFieldSet` to the teaching error**
+
+In `task-helpers.ts`, in `buildHandledFieldSet`, replace the `throw new YouTrackClassifiedError('Unknown custom field for create: ...', ...)` block with:
+
+```typescript
+if (!projectFieldsByName.has(fieldName)) {
+  throw unknownFieldError(fieldName, [...projectFieldsByName.keys()], 'create')
+}
+```
+
+- [ ] **Step 4: Widen the create fallback gating**
+
+In `validateRequiredCreateFields`, change the `deriveFromIssueWhenEmpty` condition so dedicated params also trigger derivation:
+
+```typescript
+const needsSchema =
+  (params.customFields?.length ?? 0) > 0 ||
+  params.status !== undefined ||
+  params.priority !== undefined ||
+  params.assignee !== undefined ||
+  params.dueDate !== undefined
+const projectCustomFields = await fetchProjectCustomFields(config, projectId, {
+  deriveFromIssueWhenEmpty: needsSchema,
+  shortName: projectShortName,
+})
+```
+
+- [ ] **Step 5: Route create through the shared builder in `operations/tasks.ts`**
+
+In `operations/tasks.ts`, update the import (`buildCreateCustomFields` → `buildIssueCustomFields`) and in `buildCreateIssueBody` replace:
+
+```typescript
+const customFields = await buildCreateCustomFields(config, params, projectCustomFields)
+```
+
+with:
+
+```typescript
+const customFields = await buildIssueCustomFields(config, params, projectCustomFields, 'create')
+```
+
+- [ ] **Step 6: Delete the now-unused `buildCreateCustomFields`**
+
+Remove `buildCreateCustomFields` from `task-helpers.ts` (replaced by `buildIssueCustomFields`). Leave `buildCustomFields` for now (Task 6 removes it). Run `bunx tsc --noEmit -p tsconfig.json` and fix any unused-import errors it surfaces.
+
+- [ ] **Step 7: Add a create integration test for localized dedicated resolution**
+
+Append to `tests/plugins/task-provider-youtrack/task-helpers.test.ts` (uses the existing `queueResponses`/`createUniqueYouTrackConfig` helpers in that file):
+
+```typescript
+describe('buildIssueCustomFields', () => {
+  test('resolves a dedicated status to the localized state field via the engine', async () => {
+    const config = createUniqueYouTrackConfig()
+    const projectCustomFields = [
+      {
+        $type: 'StateProjectCustomField',
+        field: { name: 'Cтaтус', fieldType: { id: 'state[1]' } },
+        canBeEmpty: false,
+        bundle: { id: 'sb-1', $type: 'StateBundle' },
+      },
+    ] as const
+    // resolveCustomFieldValue fetches the state bundle values once.
+    queueResponses([[{ name: 'Не разобрана' }, { name: 'Open' }]])
+
+    const result = await buildIssueCustomFields(config, { status: 'Open' }, projectCustomFields, 'create')
+
+    expect(result).toContainEqual({
+      name: 'Cтaтус',
+      $type: 'StateIssueCustomField',
+      value: { name: 'Open' },
+    })
+  })
+})
+```
+
+Add `buildIssueCustomFields` to the imports at the top of that test file.
+
+- [ ] **Step 8: Run the focused tests**
+
+Run: `bun test tests/plugins/task-provider-youtrack/task-helpers.test.ts tests/plugins/task-provider-youtrack/create-field-helpers.test.ts`
+Expected: PASS. (The `operations/tasks.test.ts` mocks are fixed in Task 7.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add plugins/task-provider-youtrack/task-helpers.ts plugins/task-provider-youtrack/operations/tasks.ts tests/plugins/task-provider-youtrack/task-helpers.test.ts
+git commit -m "feat(youtrack): create routes dedicated params through the schema engine"
+```
+
+---
+
+## Task 6: Bring `update_task` to parity
+
+Route update's custom fields through the same shared builder and issue-derived fallback; delete the string/text-only path; use the teaching error for unknown update fields.
+
+**Files:**
+
+- Modify: `plugins/task-provider-youtrack/task-helpers.ts`
+- Modify: `plugins/task-provider-youtrack/operations/tasks.ts`
+- Test: `tests/plugins/task-provider-youtrack/operations/tasks.test.ts` (extend)
+
+- [ ] **Step 1: Write the failing update test**
+
+In `tests/plugins/task-provider-youtrack/operations/tasks.test.ts`, inside the `updateYouTrackTask` describe block, add a test that sets a previously-"Unsupported" enum field. Use a URL-routed mock so the enum bundle + issue POST are answered by path:
+
+```typescript
+test('sets an enum custom field on update via the field engine', async () => {
+  const projectFields = [
+    {
+      $type: 'EnumProjectCustomField',
+      field: { name: 'Срочность', fieldType: { id: 'enum[1]' } },
+      canBeEmpty: true,
+      bundle: { id: 'eb-1', $type: 'EnumBundle' },
+    },
+  ]
+  installFetchMock((url, init) => {
+    const path = new URL(url).pathname
+    const method = init.method ?? 'GET'
+    if (method === 'POST' && path.startsWith('/api/issues/')) return jsonOk(makeIssueResponse())
+    if (path.endsWith('/customFields') && path.startsWith('/api/admin/')) return jsonOk(projectFields)
+    if (path.includes('/bundles/enum/')) return jsonOk([{ name: 'Срочно' }, { name: 'Не срочно' }])
+    if (path.startsWith('/api/admin/projects/')) return jsonOk({ id: '0-1', shortName: 'TEST' })
+    return jsonOk(makeIssueResponse())
+  })
+
+  await updateYouTrackTask(config, 'TEST-1', {
+    projectId: '0-1',
+    customFields: [{ name: 'Срочность', value: 'Срочно' }],
+  })
+
+  const body = getFetchBodyAt(findIssuesUpdateCallIndex(fetchMock.mock.calls))
+  expect(body['customFields']).toContainEqual({
+    name: 'Срочность',
+    $type: 'SingleEnumIssueCustomField',
+    value: { name: 'Срочно' },
+  })
+})
+```
+
+Add a small path-aware finder near the other helpers in this file:
+
+```typescript
+const findIssuesUpdateCallIndex = (calls: unknown[]): number =>
+  calls.findIndex((call) => {
+    const parsed = FetchCallSchema.safeParse(call)
+    return (
+      parsed.success && /\/api\/issues\/.+/u.test(new URL(parsed.data[0]).pathname) && parsed.data[1].method === 'POST'
+    )
+  })
+```
+
+(`installFetchMock` already receives `(url, init)`; `jsonOk` and `makeIssueResponse` already exist in this file.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/plugins/task-provider-youtrack/operations/tasks.test.ts -t "sets an enum custom field on update"`
+Expected: FAIL — current update path rejects enum fields as "Unsupported custom field for update".
+
+- [ ] **Step 3: Rewrite `buildUpdateCustomFields` in `operations/tasks.ts`**
+
+Replace the body of `buildUpdateCustomFields` so it fetches the schema (with fallback) and uses the shared builder for all fields:
+
+```typescript
+const buildUpdateCustomFields = async (
+  config: Readonly<YouTrackConfig>,
+  taskId: string,
+  params: Readonly<{
+    status?: string
+    priority?: string
+    dueDate?: string
+    assignee?: string
+    projectId?: string
+    customFields?: Array<{ name: string; value: string }>
+  }>,
+): Promise<IssueCustomFieldPayload[]> => {
+  const projectId = params.projectId ?? (await fetchIssueProjectId(config, taskId))
+  const needsSchema =
+    (params.customFields?.length ?? 0) > 0 ||
+    params.status !== undefined ||
+    params.priority !== undefined ||
+    params.assignee !== undefined ||
+    params.dueDate !== undefined
+  if (!needsSchema) return []
+  const projectCustomFields = await fetchProjectCustomFields(config, projectId, { deriveFromIssueWhenEmpty: true })
+  return buildIssueCustomFields(config, params, projectCustomFields, 'update')
+}
+```
+
+Update imports in `operations/tasks.ts`: import `buildIssueCustomFields`, `fetchProjectCustomFields`, and `IssueCustomFieldPayload` (type from `../field-engine.js`); drop `buildWriteSafeCustomFields` and `buildCustomFields`.
+
+Update the two call sites in `updateYouTrackTask` that currently branch on `params.customFields` to simply:
+
+```typescript
+const customFields = await buildUpdateCustomFields(config, taskId, params)
+if (customFields.length > 0) body['customFields'] = customFields
+```
+
+- [ ] **Step 4: Delete dead update helpers in `task-helpers.ts`**
+
+Remove `buildCustomFields`, `buildWriteSafeCustomFields`, `buildWriteSafeCustomFieldPayload`, `buildCreateIssueCustomField`, `customFieldValidationError`, and the `NON_GENERIC_FIELD_NAMES` constant if now unused. Run `bunx tsc --noEmit -p tsconfig.json` and remove any imports it flags as unused (e.g. `parseDueDateValue` if no longer referenced).
+
+- [ ] **Step 5: Run the update test**
+
+Run: `bun test tests/plugins/task-provider-youtrack/operations/tasks.test.ts -t "sets an enum custom field on update"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/task-provider-youtrack/task-helpers.ts plugins/task-provider-youtrack/operations/tasks.ts tests/plugins/task-provider-youtrack/operations/tasks.test.ts
+git commit -m "feat(youtrack): update_task parity via shared field engine + fallback"
+```
+
+---
+
+## Task 7: Repair existing mocks for widened gating + full green
+
+Dedicated-param create tests with an empty admin schema now trigger the issue-derived fetch, and the POST shifts position; old-name update tests change. Make the create/update mocks URL-routed and fix positional assertions.
+
+**Files:**
+
+- Modify: `tests/plugins/task-provider-youtrack/operations/tasks.test.ts`
+- Modify: `tests/plugins/task-provider-youtrack/index.test.ts`
+
+- [ ] **Step 1: Find the failures**
+
+Run: `bun test tests/plugins/task-provider-youtrack/ 2>&1 | grep -E "\(fail\)"`
+Expected: a list of create/update tests (mostly those passing `status`/`priority`/`assignee` against an empty admin schema, plus any asserting the old hard-coded `State`/`Assignee` payloads).
+
+- [ ] **Step 2: Convert the shared create mocks to URL routing**
+
+In `tests/plugins/task-provider-youtrack/operations/tasks.test.ts`, change `mockCreateTaskResponse` (and the other empty-`customFields` create helpers it shares logic with) to route by path so the fallback's extra calls are answered. Pattern:
+
+```typescript
+const mockCreateTaskResponse = (
+  issueResponse: unknown,
+  projectResponse: unknown = { id: '0-1', shortName: 'TEST' },
+  customFieldsResponse: unknown = [],
+  sampleIssueResponse: unknown = [],
+): void => {
+  installFetchMock((url, init) => {
+    const path = new URL(url).pathname
+    const method = init.method ?? 'GET'
+    if (method === 'POST' && path === '/api/issues') return jsonOk(issueResponse)
+    if (path.endsWith('/customFields') && path.startsWith('/api/admin/')) return jsonOk(customFieldsResponse)
+    if (path === '/api/issues') return jsonOk(sampleIssueResponse) // issue-derived fallback fetch
+    if (path.startsWith('/api/admin/projects/')) return jsonOk(projectResponse)
+    return jsonOk(issueResponse)
+  })
+}
+```
+
+- [ ] **Step 3: Make POST assertions path-aware**
+
+Replace `getFetchBodyAt(2)` / `getFetchUrlAt(2)` / `getFetchMethodAt(2)` in create tests with a finder targeting the create POST. Add near the existing helpers:
+
+```typescript
+const findCreateCallIndex = (): number =>
+  fetchMock.mock.calls.findIndex((call) => {
+    const parsed = FetchCallSchema.safeParse(call)
+    return parsed.success && new URL(parsed.data[0]).pathname === '/api/issues' && parsed.data[1].method === 'POST'
+  })
+const getCreateBody = (): z.infer<typeof BodySchema> => getFetchBodyAt(findCreateCallIndex())
+```
+
+Update the affected assertions to use `getCreateBody()` (and `findCreateCallIndex()` for URL/method checks). For dedicated-param create tests that assert the sent custom field, update the expected payload from the old hard-coded `{ name: 'State', … }` to the schema-resolved field (provide the field in `customFieldsResponse` so the admin path is non-empty, OR provide it via `sampleIssueResponse` and assert the resolved name).
+
+- [ ] **Step 4: Fix `index.test.ts` create tests**
+
+In `tests/plugins/task-provider-youtrack/index.test.ts`, the `createTask` tests use `mockFetchSequence`. For the ones sending `priority`/`status`/`assignee`, either (a) add a non-empty admin `customFields` response containing the matching typed field so no fallback fires, or (b) switch them to a URL-routed `installFetchMock` like Step 2. Prefer (a) for minimal churn — e.g. for the priority test, return a `Priority` enum field from the customFields call and a bundle-values response. Update expected payloads to the engine shape (`SingleEnumIssueCustomField` with `value: { name: … }`).
+
+- [ ] **Step 5: Run the full plugin suite**
+
+Run: `bun test tests/plugins/task-provider-youtrack/`
+Expected: PASS, 0 fail.
+
+- [ ] **Step 6: Run the full gate**
+
+Run: `bun run lint && bunx tsc --noEmit -p tsconfig.json && bun test tests/plugins/ tests/tools/ tests/providers/`
+Expected: lint 0 errors; typecheck clean; all suites pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/plugins/task-provider-youtrack/operations/tasks.test.ts tests/plugins/task-provider-youtrack/index.test.ts
+git commit -m "test(youtrack): URL-route create/update mocks for widened fallback gating"
+```
+
+---
+
+## Self-review checklist (performed)
+
+- **Spec coverage:** A → Tasks 2 + (5 step 3, 6); B → Tasks 1, 3, 4, 5; update_task parity → Task 6; widened gating + test repair → Tasks 5, 6, 7. Canonical-name tiebreak → Task 3. Backward-compat English projects → Task 3 tests + Task 7 updates.
+- **Type consistency:** `FieldPair`/`ResolvedFieldPair`, `DedicatedKind`, `resolveDedicatedField`, `collectFieldPairs`, `resolveFieldPair`, `buildIssueCustomFields`, `unknownFieldError` are used with consistent signatures across tasks. `resolveCustomFieldValue` and `IssueCustomFieldPayload` are reused from `field-engine.ts` unchanged.
+- **No placeholders:** every code step contains complete code or an exact transformation of a named existing block.
+
+## Known limitations (from the spec)
+
+- Due-date enrichment stays keyed on the resolved field name; localized date fields may not repopulate `dueDate` (best-effort).
+- No fuzzy matching for generic field names; `priority` never auto-maps among multiple enums.

--- a/docs/superpowers/specs/2026-06-16-youtrack-dedicated-fields-and-teaching-errors-design.md
+++ b/docs/superpowers/specs/2026-06-16-youtrack-dedicated-fields-and-teaching-errors-design.md
@@ -1,0 +1,188 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# YouTrack dedicated-field localization & teaching errors — design
+
+**Date:** 2026-06-16
+**Status:** Approved (pending implementation plan)
+**Area:** `plugins/task-provider-youtrack/`
+**Follows:** `2026-06-15-youtrack-custom-fields-design.md` and the issue-derived schema fallback
+(`fix(youtrack): derive field schema from a sample issue when admin endpoint is empty`).
+
+## Problem
+
+With the issue-derived schema fallback in place, `create_task` now works in projects whose
+admin `customFields` endpoint is empty (non-admin token). Production logs for the localized
+"Аудиты ОБВС" project (`AUDIT`, `39-1118`) confirmed the create succeeds (`AUDIT-1403`), but
+only after **five** failed attempts. Every failure was a known, fixable rough edge:
+
+| Attempt | What the model sent                            | Error                                           |
+| ------- | ---------------------------------------------- | ----------------------------------------------- |
+| 1       | dedicated `status` (→ hard-coded `State`)      | `incompatible-issue-custom-field-name-State`    |
+| 2       | dedicated `assignee` (→ hard-coded `Assignee`) | `incompatible-issue-custom-field-name-Assignee` |
+| 3       | no required field                              | `400 empty_sd_urls` (workflow assert)           |
+| 4       | generic field, **truncated** localized name    | `Unknown custom field for create: URL адеса …`  |
+| 5       | exact localized name                           | ✅ created                                      |
+
+Two root causes:
+
+- **C1 — Dedicated params are hard-coded to English field names.** `collectCreateFieldPairs`
+  maps `status`/`priority`/`assignee` to `State`/`Priority`/`Assignee`, and
+  `legacyDedicatedPayload` emits a fixed `{name, $type}` payload when that English name is not
+  in the schema. In a localized project the real fields are `Cтaтус` / `Oтветствeнный` /
+  `Срочность`, so the dedicated params produce `incompatible-issue-custom-field-name-*` 500s.
+- **C2 — "Unknown custom field" errors do not teach.** When a generic field name does not match
+  the schema, the error names only the bad input — not the available field names. The model
+  truncated a long localized name twice and could not self-correct, because it was never shown
+  the exact options. This is the original design's D4 ("errors that teach"), still unimplemented
+  for field _names_.
+
+`update_task` is also still limited: it routes generic custom fields through a string/text-only
+path (`buildWriteSafeCustomFieldPayload` returns `undefined` for enum/state/user) and uses the
+admin-only schema fetch — so it cannot set localized enum/state fields at all.
+
+## Goals / non-goals
+
+**Goals**
+
+1. Dedicated `status`/`assignee`/`priority` params resolve to the project's actual field by
+   **type**, regardless of its (localized) name — deterministically, never guessing.
+2. Unknown-field errors **teach**: list the available field names so the model self-corrects in
+   the same turn.
+3. `update_task` reaches parity with `create_task`: any settable field type, plus the
+   issue-derived schema fallback.
+4. Backward compatibility for English-named projects is preserved.
+
+**Non-goals (v1)**
+
+- Fuzzy/synonym matching for _generic_ field names (only canonical-name tiebreaks for dedicated
+  params).
+- Group fields; multi-value comma-ambiguity (unchanged from the prior spec).
+- Re-keying due-date enrichment to a localized field name (stays best-effort).
+
+## Decisions (from brainstorming)
+
+- **Scope:** A (teaching errors) + B (dedicated-param localization) + `update_task`
+  generalization.
+- **Dedicated resolution:** by **type, unique-or-fail**, with a **canonical-name tiebreak** only
+  when more than one field of that type exists. Never guess among multiple candidates; emit a
+  teaching error instead.
+- **Approach:** unified schema-driven resolver shared by create and update — every field
+  (dedicated or generic) becomes a `ProjectCustomField` and flows through the existing
+  `resolveCustomFieldValue` engine. `legacyDedicatedPayload` is removed.
+
+## Architecture
+
+```
+plugins/task-provider-youtrack/
+  dedicated-fields.ts        NEW  resolveDedicatedField(kind, projectFields) → matches
+                                  status/assignee/priority/dueDate to the real field by TYPE
+                                  (unique, with canonical-name tiebreak); throws teaching error
+  field-name-error.ts        NEW  unknownFieldError(name, availableNames, op) — shared
+                                  "Unknown field X; available: …" teaching error (capped)
+  create-field-helpers.ts    EDIT collectCreateFieldPairs tags dedicated pairs with a `kind`
+                                  ('state'|'user'|'priority'|'date') instead of a hard-coded
+                                  English name; resolveFieldPair routes dedicated→by-type,
+                                  generic→by-name; legacyDedicatedPayload DELETED
+  task-helpers.ts            EDIT buildHandledFieldSet + buildWriteSafeCustomFieldPayload throw
+                                  the new teaching error; update routes through the field engine
+                                  (not string/text-only) + issue-derived fallback; dedicated
+                                  required-detection uses resolved names
+  operations/tasks.ts        EDIT createYouTrackTask + updateYouTrackTask share one
+                                  schema-driven custom-field builder (create/update parity)
+```
+
+**Core idea:** one resolution path. Dedicated params resolve to a `ProjectCustomField` by type;
+generic params resolve by name; both feed `resolveCustomFieldValue`. No hard-coded `$type`/name
+payloads remain.
+
+## Components
+
+### 1. `dedicated-fields.ts` — `resolveDedicatedField(kind, projectFields)`
+
+`kind ∈ { state, user, priority, date }`. Matching uses the field engine's classifier
+(`classifyFieldType`) plus a shared `normalize` (trim + casefold, compared against both `name`
+and `localizedName`):
+
+| Param      | kind     | Match rule                                                                                                                                |
+| ---------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `status`   | state    | type `state[*]`. Unique → use; if >1 → tiebreak by canonical {`State`,`Статус`}; else teaching error                                      |
+| `assignee` | user     | type `user[*]`. Unique → use; if >1 → tiebreak {`Assignee`,`Ответственный`}; else teaching error                                          |
+| `priority` | priority | enum is non-unique, so **require** a name match: enum field named {`Priority`,`Приоритет`}. Exactly 1 → use; 0/ambiguous → teaching error |
+| `dueDate`  | date     | type `date`/`date and time`. Unique → use; if >1 → tiebreak {`Due Date`,`Дедлайн`}; else teaching error. Value via `parseDueDateValue`    |
+
+Returns the matched `ProjectCustomField`; the caller routes it through `resolveCustomFieldValue`
+with the raw value. For `AUDIT`: `status`→`Cтaтус` (sole state field), `assignee`→`Oтветствeнный`
+(sole user field), `priority`→teaching error (no Priority-named enum) directing the model to set
+`Срочность` via `customFields`.
+
+### 2. `field-name-error.ts` — `unknownFieldError(name, availableNames, op)`
+
+Builds `Unknown custom field "<name>" for <create|update>. Available fields: A; B; C (…N more)`
+— names capped at 50 (reuse `capAllowedValues`), embedded in **both** the message string and the
+structured `details`. Returns a `YouTrackClassifiedError` with
+`providerError.validationFailed('customFields', …)`. Replaces the bare "Unknown custom field"
+throws in `buildHandledFieldSet`, `resolveFieldPair`, and `buildWriteSafeCustomFieldPayload`.
+
+### 3. Create/update parity (`tasks.ts`, `task-helpers.ts`)
+
+A single shared builder converts `params` (dedicated + generic) into `IssueCustomFieldPayload[]`
+via the engine. `legacyDedicatedPayload` is deleted. Update drops its string/text-only
+restriction so enum/state/user fields become settable on update.
+
+- **Fallback gating widens:** derive-from-issue-when-empty now fires when **any** field needs
+  setting (generic `customFields` _or_ a dedicated param present), since dedicated params now need
+  the schema to resolve. On admin-readable projects the admin endpoint is non-empty, so no
+  fallback fires.
+- `validateRequiredCreateFields` marks required fields satisfied by their **resolved** names
+  (via the same resolver), not the hard-coded `State`/`Priority`/`Assignee`.
+
+## Data flow (create, localized project)
+
+1. `createYouTrackTask` resolves project (`id`, `shortName`).
+2. Fetch schema: admin `customFields` → empty → issue-derived fallback (fires because fields need
+   setting). 8 fields, exact names.
+3. `validateRequiredCreateFields`: dedicated params resolved to real fields (`status`→`Cтaтус`)
+   and marked handled; required-check runs against resolved names.
+4. Shared builder: each pair → `ProjectCustomField` (dedicated by type, generic by name) →
+   `resolveCustomFieldValue` → payload (state/enum resolve bundle values; text/string pass through).
+5. `POST /api/issues`. Update follows the identical path via `POST /api/issues/{id}`.
+
+## Error handling
+
+- Unknown generic name → `unknownFieldError` (lists available fields).
+- Dedicated no-match/ambiguous → teaching error naming the type and candidates, steering to
+  `describe_project` + `customFields`.
+- Bad enum/state _value_ → existing field-engine error with `allowedValues`.
+- All via `YouTrackClassifiedError` + `providerError.*`, so `errorType`/`errorCode` keep flowing
+  through the tool-wrapper. Option lists are embedded in the message string and `details`, both
+  capped.
+
+## Testing (DI-first per `tests/CLAUDE.md`; mock `youtrackFetch` via `setMockFetch`)
+
+- `dedicated-fields.test.ts` — table-driven per kind: unique-type match; localized match
+  (`status`→`Cтaтус`); >1 same-type → name tiebreak; `priority` with no Priority-named enum →
+  teaching error; English-project regression (`status`→`State`, `assignee`→sole/`Assignee`-named
+  user field).
+- `field-name-error.test.ts` — message lists available names, capped, in message + details.
+- create integration — dedicated param against a localized schema sets the right field; unknown
+  generic name → teaching error with available list; English-project backward-compat unchanged.
+- update integration — previously-"Unsupported" enum/state now settable; issue-derived fallback on
+  update; dedicated param on update resolves by type.
+- Update existing create/update mocks for the widened fallback gating (dedicated params against an
+  empty admin schema now make an issue-derived fetch — the correct new call sequence).
+
+## Risks
+
+- **Backward compatibility (multiple same-type fields):** mitigated by the canonical-name
+  tiebreak; if still ambiguous, a teaching error (never a silent wrong write).
+- **Extra API call** for dedicated-only creates on permission-restricted projects (one issue
+  fetch); none on admin-readable projects.
+- **Due-date enrichment** stays keyed on the resolved field name; for localized date fields it may
+  not repopulate `dueDate` (best-effort, already swallowed) — documented limitation.
+- **Homoglyph names** only matter on the name-tiebreak path; the common unique-type case never
+  compares names.

--- a/plugins/task-provider-youtrack/create-field-helpers.ts
+++ b/plugins/task-provider-youtrack/create-field-helpers.ts
@@ -3,79 +3,52 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { providerError } from 'papai/plugin-types'
 import type { z } from 'zod'
 
-import { YouTrackClassifiedError } from './classify-error.js'
-import { YOUTRACK_DUE_DATE_FIELD_NAME } from './constants.js'
-import { parseDueDateValue } from './due-date.js'
-import type { IssueCustomFieldPayload } from './field-engine.js'
+import type { DedicatedKind } from './dedicated-fields.js'
+import { resolveDedicatedField } from './dedicated-fields.js'
+import { unknownFieldError } from './field-name-error.js'
 import type { ProjectCustomFieldSchema } from './schemas/bundle.js'
 
 type ProjectCustomField = z.infer<typeof ProjectCustomFieldSchema>
+type NamedProjectCustomField = ProjectCustomField & { readonly field: { readonly name: string } }
 
-type StandardCustomFieldPayload = {
-  name: string
-  $type: string
-  value: Record<string, string> | number
-}
+export type FieldPair =
+  | { source: 'dedicated'; kind: DedicatedKind; value: string }
+  | { source: 'generic'; name: string; value: string }
 
-export type ResolvedCreateFieldPayload =
-  | { kind: 'legacy'; payload: StandardCustomFieldPayload | IssueCustomFieldPayload }
-  | { kind: 'engine'; field: ProjectCustomField; value: string }
+export type ResolvedFieldPair = { field: ProjectCustomField; value: string }
 
-export const legacyDedicatedPayload = (
-  name: string,
-  value: string,
-): StandardCustomFieldPayload | IssueCustomFieldPayload | undefined => {
-  switch (name) {
-    case 'State':
-      return { name, $type: 'StateIssueCustomField', value: { name: value } }
-    case 'Priority':
-      return { name, $type: 'SingleEnumIssueCustomField', value: { name: value } }
-    case 'Assignee':
-      return { name, $type: 'SingleUserIssueCustomField', value: { login: value } }
-    case YOUTRACK_DUE_DATE_FIELD_NAME:
-      return { name, $type: 'DateIssueCustomField', value: parseDueDateValue(value) }
-    default:
-      return undefined
-  }
-}
+type DedicatedParams = Readonly<{
+  status?: string
+  priority?: string
+  dueDate?: string
+  assignee?: string
+  customFields?: ReadonlyArray<{ name: string; value: string }>
+}>
 
-type CreateFieldPair = { name: string; value: string; dedicated: boolean }
-
-export const collectCreateFieldPairs = (
-  params: Readonly<{
-    status?: string
-    priority?: string
-    dueDate?: string
-    assignee?: string
-    customFields?: Array<{ name: string; value: string }>
-  }>,
-): CreateFieldPair[] => {
-  const pairs: CreateFieldPair[] = []
-  if (params.status !== undefined) pairs.push({ name: 'State', value: params.status, dedicated: true })
-  if (params.priority !== undefined) pairs.push({ name: 'Priority', value: params.priority, dedicated: true })
-  if (params.assignee !== undefined) pairs.push({ name: 'Assignee', value: params.assignee, dedicated: true })
-  if (params.dueDate !== undefined)
-    pairs.push({ name: YOUTRACK_DUE_DATE_FIELD_NAME, value: params.dueDate, dedicated: true })
-  for (const cf of params.customFields ?? []) pairs.push({ name: cf.name, value: cf.value, dedicated: false })
+/** Collects dedicated params (tagged by field kind) and generic customFields into a flat list. */
+export const collectFieldPairs = (params: DedicatedParams): FieldPair[] => {
+  const pairs: FieldPair[] = []
+  if (params.status !== undefined) pairs.push({ source: 'dedicated', kind: 'state', value: params.status })
+  if (params.priority !== undefined) pairs.push({ source: 'dedicated', kind: 'priority', value: params.priority })
+  if (params.assignee !== undefined) pairs.push({ source: 'dedicated', kind: 'user', value: params.assignee })
+  if (params.dueDate !== undefined) pairs.push({ source: 'dedicated', kind: 'date', value: params.dueDate })
+  for (const cf of params.customFields ?? []) pairs.push({ source: 'generic', name: cf.name, value: cf.value })
   return pairs
 }
 
-export const resolveCreateFieldPair = (
-  pair: Readonly<CreateFieldPair>,
-  projectFieldsByName: ReadonlyMap<string, ProjectCustomField & { readonly field: { readonly name: string } }>,
-): ResolvedCreateFieldPayload => {
-  const field = projectFieldsByName.get(pair.name)
-  if (field !== undefined) return { kind: 'engine', field, value: pair.value }
-  const legacy = pair.dedicated ? legacyDedicatedPayload(pair.name, pair.value) : undefined
-  if (legacy !== undefined) return { kind: 'legacy', payload: legacy }
-  throw new YouTrackClassifiedError(
-    `Unknown custom field for create: ${pair.name}`,
-    providerError.validationFailed(
-      'customFields',
-      `${pair.name} is not a known project field for this YouTrack project`,
-    ),
-  )
+/** Resolves a pair to a concrete project field: dedicated by type, generic by name. */
+export const resolveFieldPair = (
+  pair: Readonly<FieldPair>,
+  projectFieldsByName: ReadonlyMap<string, NamedProjectCustomField>,
+  op: 'create' | 'update',
+): ResolvedFieldPair => {
+  if (pair.source === 'generic') {
+    const field = projectFieldsByName.get(pair.name)
+    if (field === undefined) throw unknownFieldError(pair.name, [...projectFieldsByName.keys()], op)
+    return { field, value: pair.value }
+  }
+  const field = resolveDedicatedField(pair.kind, [...projectFieldsByName.values()])
+  return { field, value: pair.value }
 }

--- a/plugins/task-provider-youtrack/dedicated-fields.ts
+++ b/plugins/task-provider-youtrack/dedicated-fields.ts
@@ -23,16 +23,10 @@ const CANONICAL_NAMES: Record<DedicatedKind, readonly string[]> = {
 
 const matchesType = (field: Readonly<ProjectCustomField>, kind: DedicatedKind): boolean => {
   const c = classifyFieldType(field)
-  switch (kind) {
-    case 'state':
-      return c.label === 'state'
-    case 'priority':
-      return c.label === 'enum'
-    case 'user':
-      return c.kind === 'user'
-    case 'date':
-      return c.kind === 'date'
-  }
+  if (kind === 'state') return c.label === 'state'
+  if (kind === 'priority') return c.label === 'enum'
+  if (kind === 'user') return c.kind === 'user'
+  return c.kind === 'date'
 }
 
 const matchesCanonicalName = (field: Readonly<ProjectCustomField>, names: readonly string[]): boolean => {

--- a/plugins/task-provider-youtrack/dedicated-fields.ts
+++ b/plugins/task-provider-youtrack/dedicated-fields.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { providerError } from 'papai/plugin-types'
+import type { z } from 'zod'
+
+import { YouTrackClassifiedError } from './classify-error.js'
+import { capAllowedValues, classifyFieldType, normalize } from './field-engine.js'
+import type { ProjectCustomFieldSchema } from './schemas/bundle.js'
+
+type ProjectCustomField = z.infer<typeof ProjectCustomFieldSchema>
+
+export type DedicatedKind = 'state' | 'user' | 'priority' | 'date'
+
+const CANONICAL_NAMES: Record<DedicatedKind, readonly string[]> = {
+  state: ['state', 'статус'],
+  user: ['assignee', 'ответственный'],
+  priority: ['priority', 'приоритет'],
+  date: ['due date', 'дедлайн'],
+}
+
+const matchesType = (field: Readonly<ProjectCustomField>, kind: DedicatedKind): boolean => {
+  const c = classifyFieldType(field)
+  switch (kind) {
+    case 'state':
+      return c.label === 'state'
+    case 'priority':
+      return c.label === 'enum'
+    case 'user':
+      return c.kind === 'user'
+    case 'date':
+      return c.kind === 'date'
+  }
+}
+
+const matchesCanonicalName = (field: Readonly<ProjectCustomField>, names: readonly string[]): boolean => {
+  const name = field.field?.name
+  const localized = field.field?.localizedName ?? undefined
+  return (
+    (name !== undefined && names.includes(normalize(name))) ||
+    (localized !== undefined && localized !== null && names.includes(normalize(localized)))
+  )
+}
+
+const fieldName = (field: Readonly<ProjectCustomField>): string => field.field?.name ?? '(unnamed)'
+
+const dedicatedError = (kind: DedicatedKind, candidates: readonly ProjectCustomField[]): YouTrackClassifiedError => {
+  const names = capAllowedValues(candidates.map(fieldName)).join('; ')
+  const detail =
+    candidates.length === 0
+      ? `No ${kind}-type field exists in this project. Use describe_project to see the fields, then set the value via customFields by name.`
+      : `Multiple candidate fields for "${kind}" (${names}). Set the intended one explicitly via customFields by name.`
+  return new YouTrackClassifiedError(detail, providerError.validationFailed('customFields', detail))
+}
+
+/**
+ * Resolve a dedicated param (status/assignee/priority/dueDate) to the project's real field by
+ * type. Unique → use it. Ambiguous → disambiguate by canonical name; still ambiguous → teaching
+ * error. `priority` always requires a canonical name match because enum fields are non-unique.
+ */
+export const resolveDedicatedField = (
+  kind: DedicatedKind,
+  projectFields: readonly ProjectCustomField[],
+): ProjectCustomField => {
+  const candidates = projectFields.filter((f) => f.field?.name !== undefined && matchesType(f, kind))
+  if (kind !== 'priority' && candidates.length === 1) {
+    const only = candidates[0]
+    if (only !== undefined) return only
+  }
+  const named = candidates.filter((f) => matchesCanonicalName(f, CANONICAL_NAMES[kind]))
+  const pick = named[0]
+  if (named.length === 1 && pick !== undefined) return pick
+  throw dedicatedError(kind, candidates)
+}

--- a/plugins/task-provider-youtrack/field-engine.ts
+++ b/plugins/task-provider-youtrack/field-engine.ts
@@ -185,7 +185,7 @@ export const resolveCustomFieldValue = async (
     case 'unknown':
       throw fieldError(
         name,
-        `Field "${name}" has an unsupported type (${field.field?.fieldType?.id ?? 'unknown'}) for create_task`,
+        `Field "${name}" has an unsupported type (${field.field?.fieldType?.id ?? 'unknown'}). Use describe_project to choose a settable field.`,
       )
   }
   throw new Error(`Unreachable: unhandled field kind`)

--- a/plugins/task-provider-youtrack/field-engine.ts
+++ b/plugins/task-provider-youtrack/field-engine.ts
@@ -114,7 +114,7 @@ export const capAllowedValues = (values: readonly string[]): string[] => {
 const fieldError = (fieldName: string, message: string): YouTrackClassifiedError =>
   new YouTrackClassifiedError(message, providerError.validationFailed(fieldName, message))
 
-const normalize = (value: string): string => value.trim().toLocaleLowerCase()
+export const normalize = (value: string): string => value.trim().toLocaleLowerCase()
 
 const splitMulti = (raw: string, multi: boolean): string[] =>
   multi

--- a/plugins/task-provider-youtrack/field-name-error.ts
+++ b/plugins/task-provider-youtrack/field-name-error.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { providerError } from 'papai/plugin-types'
+
+import { YouTrackClassifiedError } from './classify-error.js'
+import { capAllowedValues } from './field-engine.js'
+
+/**
+ * Teaching error for an unrecognized custom-field name. Lists the project's available field
+ * names (capped) in both the message string (the channel the model reliably reads) and the
+ * structured details, so the model can self-correct in the same turn.
+ */
+export const unknownFieldError = (
+  name: string,
+  availableNames: readonly string[],
+  op: 'create' | 'update',
+): YouTrackClassifiedError => {
+  const listed = capAllowedValues([...availableNames]).join('; ')
+  const message = `Unknown custom field "${name}" for ${op}. Available fields: ${listed}`
+  return new YouTrackClassifiedError(message, providerError.validationFailed('customFields', message))
+}

--- a/plugins/task-provider-youtrack/issue-derived-fields.ts
+++ b/plugins/task-provider-youtrack/issue-derived-fields.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+import { logger } from '../../src/logger.js'
+import type { YouTrackConfig } from './client.js'
+import { youtrackFetch } from './client.js'
+import { ProjectCustomFieldSchema } from './schemas/bundle.js'
+
+const log = logger.child({ scope: 'provider:youtrack:custom-fields' })
+
+type ProjectCustomField = z.infer<typeof ProjectCustomFieldSchema>
+
+// An issue's `projectCustomField` sub-entity carries the same field settings the admin
+// `/customFields` endpoint exposes (type, bundle, canBeEmpty, defaultValues), but is
+// readable by any user who can view the issue. This is the schema source for tokens that
+// lack project field-settings admin rights — where the admin endpoint answers 200 with [].
+const ISSUE_PROJECT_FIELD_FIELDS =
+  'customFields(projectCustomField(id,$type,canBeEmpty,isPublic,field(id,name,localizedName,$type,fieldType(id,presentation)),bundle(id,$type),defaultValues(name,localizedName)))'
+
+const IssueProjectFieldsSchema = z.array(
+  z.object({
+    customFields: z.array(z.object({ projectCustomField: ProjectCustomFieldSchema.nullish() })).optional(),
+  }),
+)
+
+const fetchProjectShortName = async (config: Readonly<YouTrackConfig>, projectId: string): Promise<string> => {
+  const projectRaw = await youtrackFetch(config, 'GET', `/api/admin/projects/${projectId}`, {
+    query: { fields: 'shortName' },
+  })
+  return z.object({ shortName: z.string() }).parse(projectRaw).shortName
+}
+
+/**
+ * Fallback schema source: read one issue from the project and lift each field's
+ * `projectCustomField` settings into the `ProjectCustomField` shape the field engine
+ * already understands. Returns an empty list when the project has no issues to sample.
+ * Pass `knownShortName` (when the caller already resolved it) to skip the project lookup.
+ */
+export const fetchProjectCustomFieldsViaIssue = async (
+  config: Readonly<YouTrackConfig>,
+  projectId: string,
+  knownShortName?: string,
+): Promise<ProjectCustomField[]> => {
+  const shortName = knownShortName ?? (await fetchProjectShortName(config, projectId))
+  const raw = await youtrackFetch(config, 'GET', '/api/issues', {
+    query: { query: `project: {${shortName}}`, $top: '1', fields: ISSUE_PROJECT_FIELD_FIELDS },
+  })
+  const issues = IssueProjectFieldsSchema.parse(raw)
+  const fields = (issues[0]?.customFields ?? [])
+    .map((entry) => entry.projectCustomField)
+    .filter((field): field is ProjectCustomField => field !== null && field !== undefined)
+  log.debug(
+    {
+      projectId,
+      shortName,
+      count: fields.length,
+      fieldNames: fields.map((f) => f.field?.name ?? '(unnamed)'),
+    },
+    'Derived project custom fields from sample issue',
+  )
+  return fields
+}

--- a/plugins/task-provider-youtrack/mappers.ts
+++ b/plugins/task-provider-youtrack/mappers.ts
@@ -249,5 +249,4 @@ export const mapComment = (c: z.infer<typeof CommentSchema>): Comment => ({
   reactions: c.reactions?.map(mapCommentReaction),
 })
 
-export { buildCreateIssueCustomField, buildCustomFields } from './task-helpers.js'
 export { mapActivity, mapAgile, mapSavedQuery, mapSprint } from './phase-five-mappers.js'

--- a/plugins/task-provider-youtrack/operations/project-fields.ts
+++ b/plugins/task-provider-youtrack/operations/project-fields.ts
@@ -43,7 +43,7 @@ export const describeYouTrackProjectFields = async (
 ): Promise<ProjectFieldDescriptor[]> => {
   log.debug({ projectId }, 'describeProjectFields')
   try {
-    const fields = await fetchProjectCustomFields(config, projectId)
+    const fields = await fetchProjectCustomFields(config, projectId, { deriveFromIssueWhenEmpty: true })
     const getBundleElements = makeBundleElementFetcher(config)
     const descriptors = await Promise.all(fields.map((field) => describeField(field, getBundleElements)))
     log.info({ projectId, count: descriptors.length }, 'Project fields described')

--- a/plugins/task-provider-youtrack/operations/tasks.ts
+++ b/plugins/task-provider-youtrack/operations/tasks.ts
@@ -39,6 +39,27 @@ type CreateTaskParams = {
 const fallbackDueDate = (dueDate: string | undefined): string | undefined =>
   dueDate === undefined ? undefined : dueDate.slice(0, 10)
 
+const buildCreateIssueBody = async (
+  config: Readonly<YouTrackConfig>,
+  project: Readonly<{ id: string }>,
+  params: Readonly<CreateTaskParams>,
+  projectCustomFields: Awaited<ReturnType<typeof validateRequiredCreateFields>>,
+): Promise<Record<string, unknown>> => {
+  const body: Record<string, unknown> = { project: { id: project.id }, summary: params.title }
+  if (params.description !== undefined) body['description'] = params.description
+  const customFields = await buildCreateCustomFields(config, params, projectCustomFields)
+  if (customFields.length > 0) body['customFields'] = customFields
+  log.debug(
+    {
+      projectId: project.id,
+      projectFieldCount: projectCustomFields.length,
+      sentCustomFields: customFields.map((f) => ({ name: f.name, $type: f.$type })),
+    },
+    'Submitting createTask POST /api/issues',
+  )
+  return body
+}
+
 const fetchIssueProjectId = async (config: Readonly<YouTrackConfig>, taskId: string): Promise<string> => {
   const issueRaw = await youtrackFetch(config, 'GET', `/api/issues/${taskId}`, {
     query: { fields: 'project(id)' },
@@ -81,15 +102,7 @@ export async function createYouTrackTask(config: YouTrackConfig, params: CreateT
     })
     const project = z.object({ id: z.string(), shortName: z.string() }).parse(projectRaw)
     const projectCustomFields = await validateRequiredCreateFields(config, project.id, project.shortName, params)
-
-    const body: Record<string, unknown> = {
-      project: { id: project.id },
-      summary: params.title,
-    }
-    if (params.description !== undefined) body['description'] = params.description
-
-    const customFields = await buildCreateCustomFields(config, params, projectCustomFields)
-    if (customFields.length > 0) body['customFields'] = customFields
+    const body = await buildCreateIssueBody(config, project, params, projectCustomFields)
 
     const raw = await youtrackFetch(config, 'POST', '/api/issues', {
       body,

--- a/plugins/task-provider-youtrack/operations/tasks.ts
+++ b/plugins/task-provider-youtrack/operations/tasks.ts
@@ -11,14 +11,14 @@ import { classifyYouTrackError } from '../classify-error.js'
 import type { YouTrackConfig } from '../client.js'
 import { youtrackFetch } from '../client.js'
 import { ISSUE_FIELDS, ISSUE_LIST_FIELDS, YOUTRACK_INLINE_LIST_CUSTOM_FIELDS } from '../constants.js'
+import type { IssueCustomFieldPayload } from '../field-engine.js'
 import { mapIssueToListItem, mapIssueToSearchResult, mapIssueToTask } from '../mappers.js'
 import { IssueListSchema, IssueSchema } from '../schemas/issue.js'
 import {
-  buildCreateCustomFields,
-  buildCustomFields,
+  buildIssueCustomFields,
   buildYouTrackQuery,
-  buildWriteSafeCustomFields,
   enrichTaskWithDueDate,
+  fetchProjectCustomFields,
   validateRequiredCreateFields,
 } from '../task-helpers.js'
 import { fetchTasksWithPagination } from './task-list-fetch.js'
@@ -47,7 +47,7 @@ const buildCreateIssueBody = async (
 ): Promise<Record<string, unknown>> => {
   const body: Record<string, unknown> = { project: { id: project.id }, summary: params.title }
   if (params.description !== undefined) body['description'] = params.description
-  const customFields = await buildCreateCustomFields(config, params, projectCustomFields)
+  const customFields = await buildIssueCustomFields(config, params, projectCustomFields, 'create')
   if (customFields.length > 0) body['customFields'] = customFields
   log.debug(
     {
@@ -79,12 +79,17 @@ const buildUpdateCustomFields = async (
     projectId?: string
     customFields?: Array<{ name: string; value: string }>
   }>,
-): Promise<
-  Array<ReturnType<typeof buildCustomFields>[number] | Awaited<ReturnType<typeof buildWriteSafeCustomFields>>[number]>
-> => {
+): Promise<IssueCustomFieldPayload[]> => {
+  const needsSchema =
+    (params.customFields?.length ?? 0) > 0 ||
+    params.status !== undefined ||
+    params.priority !== undefined ||
+    params.assignee !== undefined ||
+    params.dueDate !== undefined
+  if (!needsSchema) return []
   const projectId = params.projectId ?? (await fetchIssueProjectId(config, taskId))
-  const projectCustomFields = await buildWriteSafeCustomFields(config, projectId, params.customFields)
-  return [...buildCustomFields(params), ...projectCustomFields]
+  const projectCustomFields = await fetchProjectCustomFields(config, projectId, { deriveFromIssueWhenEmpty: true })
+  return buildIssueCustomFields(config, params, projectCustomFields, 'update')
 }
 
 export async function createYouTrackTask(config: YouTrackConfig, params: CreateTaskParams): Promise<Task> {
@@ -161,13 +166,8 @@ export async function updateYouTrackTask(
     if (params.description !== undefined) body['description'] = params.description
     if (params.projectId !== undefined) body['project'] = { id: params.projectId }
 
-    if (params.customFields !== undefined && params.customFields.length > 0) {
-      const customFields = await buildUpdateCustomFields(config, taskId, params)
-      if (customFields.length > 0) body['customFields'] = customFields
-    } else {
-      const customFields = buildCustomFields(params)
-      if (customFields.length > 0) body['customFields'] = customFields
-    }
+    const customFields = await buildUpdateCustomFields(config, taskId, params)
+    if (customFields.length > 0) body['customFields'] = customFields
 
     const raw = await youtrackFetch(config, 'POST', `/api/issues/${taskId}`, {
       body,

--- a/plugins/task-provider-youtrack/query-builder.ts
+++ b/plugins/task-provider-youtrack/query-builder.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { ListTasksParams } from 'papai/plugin-types'
+
+/** Builds a YouTrack issue-search query string from normalized list params. */
+export const buildYouTrackQuery = (params: Readonly<ListTasksParams> | undefined, projectShortName: string): string => {
+  const queryParts: string[] = [`project: {${projectShortName}}`]
+  if (params?.status !== undefined) queryParts.push(`State: {${params.status}}`)
+  if (params?.priority !== undefined) queryParts.push(`Priority: {${params.priority}}`)
+  if (params?.assigneeId !== undefined) queryParts.push(`Assignee: {${params.assigneeId}}`)
+  if (params?.dueAfter !== undefined && params.dueBefore !== undefined) {
+    queryParts.push(`Due date: >${params.dueAfter}`)
+    queryParts.push(`Due date: <${params.dueBefore}`)
+  } else if (params?.dueAfter !== undefined) {
+    queryParts.push(`Due date: >${params.dueAfter}`)
+  } else if (params?.dueBefore !== undefined) {
+    queryParts.push(`Due date: <${params.dueBefore}`)
+  }
+  if (params?.sortBy !== undefined) {
+    const sortField = params.sortBy === 'createdAt' ? 'created' : params.sortBy
+    queryParts.push(`sort by: ${sortField} ${params.sortOrder ?? 'asc'}`)
+  }
+  return queryParts.join(' ')
+}

--- a/plugins/task-provider-youtrack/schemas/bundle.ts
+++ b/plugins/task-provider-youtrack/schemas/bundle.ts
@@ -30,7 +30,7 @@ export const ProjectCustomFieldSchema = z.object({
     .object({
       id: z.string().optional(),
       name: z.string(),
-      localizedName: z.string().optional(),
+      localizedName: z.string().nullish(),
       $type: z.string().optional(),
       fieldType: z
         .object({

--- a/plugins/task-provider-youtrack/task-helpers.ts
+++ b/plugins/task-provider-youtrack/task-helpers.ts
@@ -3,10 +3,11 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import type { ListTasksParams, Task } from 'papai/plugin-types'
+import type { Task } from 'papai/plugin-types'
 import { providerError } from 'papai/plugin-types'
 import type { z } from 'zod'
 
+import { logger } from '../../src/logger.js'
 import { makeBundleElementFetcher } from './bundle-values.js'
 import { YouTrackClassifiedError } from './classify-error.js'
 import type { YouTrackConfig } from './client.js'
@@ -17,7 +18,10 @@ import { DueDateCustomFieldSchema, mapYouTrackDueDateValue, parseDueDateValue } 
 import { classifyFieldType, formatAllowed, resolveCustomFieldValue } from './field-engine.js'
 import type { IssueCustomFieldPayload } from './field-engine.js'
 import { paginate } from './helpers.js'
+import { fetchProjectCustomFieldsViaIssue } from './issue-derived-fields.js'
 import { ProjectCustomFieldListSchema, ProjectCustomFieldSchema } from './schemas/bundle.js'
+
+const log = logger.child({ scope: 'provider:youtrack:custom-fields' })
 
 type ProjectCustomField = z.infer<typeof ProjectCustomFieldSchema>
 
@@ -45,11 +49,26 @@ const isTextProjectField = (field: ProjectCustomField): boolean => field.$type =
 export const fetchProjectCustomFields = async (
   config: Readonly<YouTrackConfig>,
   projectId: string,
+  opts?: Readonly<{ deriveFromIssueWhenEmpty?: boolean; shortName?: string }>,
 ): Promise<ProjectCustomField[]> => {
   const raw = await youtrackFetch(config, 'GET', `/api/admin/projects/${projectId}/customFields`, {
     query: { fields: PROJECT_CUSTOM_FIELD_FIELDS },
   })
-  return ProjectCustomFieldListSchema.parse(raw)
+  const fields = ProjectCustomFieldListSchema.parse(raw)
+  if (fields.length > 0 || opts?.deriveFromIssueWhenEmpty !== true) {
+    log.debug(
+      { projectId, count: fields.length, fieldNames: fields.map((f) => f.field?.name ?? '(unnamed)'), source: 'admin' },
+      'Fetched project custom fields',
+    )
+    return fields
+  }
+  // The admin endpoint answers 200 with [] when the token cannot read project field-settings.
+  // Derive the schema from a sample issue, which exposes the same settings to any issue reader.
+  log.warn(
+    { projectId },
+    'Admin customFields endpoint returned empty; deriving schema from a sample issue (token likely lacks field-settings read permission)',
+  )
+  return fetchProjectCustomFieldsViaIssue(config, projectId, opts.shortName)
 }
 const buildProjectFieldsByName = (
   projectCustomFields: readonly ProjectCustomField[],
@@ -172,7 +191,13 @@ export const validateRequiredCreateFields = async (
     customFields?: Array<{ name: string; value: string }>
   }>,
 ): Promise<ProjectCustomField[]> => {
-  const projectCustomFields = await fetchProjectCustomFields(config, projectId)
+  // Named generic custom fields can only be resolved against the project schema. When the token
+  // cannot read field-settings (admin endpoint empty), derive the schema from a sample issue so
+  // those fields are recognized instead of rejected as "unknown".
+  const projectCustomFields = await fetchProjectCustomFields(config, projectId, {
+    deriveFromIssueWhenEmpty: (params.customFields?.length ?? 0) > 0,
+    shortName: projectShortName,
+  })
   const handledFields = buildHandledFieldSet(buildProjectFieldsByName(projectCustomFields), params.customFields)
   markDedicatedParamFields(handledFields, params)
   const requiredFields = projectCustomFields.filter(
@@ -254,25 +279,7 @@ export const buildWriteSafeCustomFields = async (
   const projectFieldsByName = buildProjectFieldsByName(await fetchProjectCustomFields(config, projectId))
   return customFields.map((input) => buildWriteSafeCustomFieldPayload(projectFieldsByName, input))
 }
-export const buildYouTrackQuery = (params: Readonly<ListTasksParams> | undefined, projectShortName: string): string => {
-  const queryParts: string[] = [`project: {${projectShortName}}`]
-  if (params?.status !== undefined) queryParts.push(`State: {${params.status}}`)
-  if (params?.priority !== undefined) queryParts.push(`Priority: {${params.priority}}`)
-  if (params?.assigneeId !== undefined) queryParts.push(`Assignee: {${params.assigneeId}}`)
-  if (params?.dueAfter !== undefined && params.dueBefore !== undefined) {
-    queryParts.push(`Due date: >${params.dueAfter}`)
-    queryParts.push(`Due date: <${params.dueBefore}`)
-  } else if (params?.dueAfter !== undefined) {
-    queryParts.push(`Due date: >${params.dueAfter}`)
-  } else if (params?.dueBefore !== undefined) {
-    queryParts.push(`Due date: <${params.dueBefore}`)
-  }
-  if (params?.sortBy !== undefined) {
-    const sortField = params.sortBy === 'createdAt' ? 'created' : params.sortBy
-    queryParts.push(`sort by: ${sortField} ${params.sortOrder ?? 'asc'}`)
-  }
-  return queryParts.join(' ')
-}
+export { buildYouTrackQuery } from './query-builder.js'
 export const enrichTaskWithDueDate = async (config: Readonly<YouTrackConfig>, task: Readonly<Task>): Promise<Task> => {
   try {
     const customFields = await paginate(

--- a/plugins/task-provider-youtrack/task-helpers.ts
+++ b/plugins/task-provider-youtrack/task-helpers.ts
@@ -114,7 +114,8 @@ const markDedicatedParamFields = (
   for (const pair of collectFieldPairs(params)) {
     if (pair.source !== 'dedicated') continue
     try {
-      handledFields.add(resolveDedicatedField(pair.kind, fields).field?.name ?? '')
+      const name = resolveDedicatedField(pair.kind, fields).field?.name
+      if (name !== undefined) handledFields.add(name)
     } catch {
       // Unresolvable dedicated param surfaces as a teaching error when payloads are built.
     }

--- a/plugins/task-provider-youtrack/task-helpers.ts
+++ b/plugins/task-provider-youtrack/task-helpers.ts
@@ -13,10 +13,12 @@ import { YouTrackClassifiedError } from './classify-error.js'
 import type { YouTrackConfig } from './client.js'
 import { youtrackFetch } from './client.js'
 import { PROJECT_CUSTOM_FIELD_FIELDS, YOUTRACK_DUE_DATE_FIELD_NAME } from './constants.js'
-import { collectCreateFieldPairs, resolveCreateFieldPair } from './create-field-helpers.js'
-import { DueDateCustomFieldSchema, mapYouTrackDueDateValue, parseDueDateValue } from './due-date.js'
+import { collectFieldPairs, resolveFieldPair } from './create-field-helpers.js'
+import { resolveDedicatedField } from './dedicated-fields.js'
+import { DueDateCustomFieldSchema, mapYouTrackDueDateValue } from './due-date.js'
 import { classifyFieldType, formatAllowed, resolveCustomFieldValue } from './field-engine.js'
 import type { IssueCustomFieldPayload } from './field-engine.js'
+import { unknownFieldError } from './field-name-error.js'
 import { paginate } from './helpers.js'
 import { fetchProjectCustomFieldsViaIssue } from './issue-derived-fields.js'
 import { ProjectCustomFieldListSchema, ProjectCustomFieldSchema } from './schemas/bundle.js'
@@ -24,28 +26,16 @@ import { ProjectCustomFieldListSchema, ProjectCustomFieldSchema } from './schema
 const log = logger.child({ scope: 'provider:youtrack:custom-fields' })
 
 type ProjectCustomField = z.infer<typeof ProjectCustomFieldSchema>
+type NamedProjectCustomField = ProjectCustomField & { readonly field: { readonly name: string } }
 
-type CreateIssueCustomFieldPayload = {
-  name: string
-  $type: 'SimpleIssueCustomField' | 'TextIssueCustomField'
-  value: string | { text: string }
-}
+type CustomFieldParams = Readonly<{
+  status?: string
+  priority?: string
+  dueDate?: string
+  assignee?: string
+  customFields?: Array<{ name: string; value: string }>
+}>
 
-type StandardCustomFieldPayload = {
-  name: string
-  $type: string
-  value: Record<string, string> | number
-}
-const NON_GENERIC_FIELD_NAMES = new Set(['State', 'Priority', 'Assignee', YOUTRACK_DUE_DATE_FIELD_NAME])
-const normalizeCustomFieldType = (value: string | undefined): string | undefined => value?.trim().toLowerCase()
-
-const isStringSimpleProjectField = (field: ProjectCustomField): boolean => {
-  if (field.$type !== 'SimpleProjectCustomField') return false
-  const fieldTypeId = normalizeCustomFieldType(field.field?.fieldType?.id)
-  const presentation = normalizeCustomFieldType(field.field?.fieldType?.presentation)
-  return fieldTypeId === 'string' || presentation === 'string'
-}
-const isTextProjectField = (field: ProjectCustomField): boolean => field.$type === 'TextProjectCustomField'
 export const fetchProjectCustomFields = async (
   config: Readonly<YouTrackConfig>,
   projectId: string,
@@ -70,86 +60,30 @@ export const fetchProjectCustomFields = async (
   )
   return fetchProjectCustomFieldsViaIssue(config, projectId, opts.shortName)
 }
+
 const buildProjectFieldsByName = (
   projectCustomFields: readonly ProjectCustomField[],
-): Map<string, ProjectCustomField & { readonly field: { readonly name: string } }> =>
+): Map<string, NamedProjectCustomField> =>
   new Map(
     projectCustomFields
-      .filter(
-        (field): field is ProjectCustomField & { readonly field: { readonly name: string } } =>
-          field.field?.name !== undefined,
-      )
+      .filter((field): field is NamedProjectCustomField => field.field?.name !== undefined)
       .map((field) => [field.field.name, field] as const),
   )
+
 const buildHandledFieldSet = (
-  projectFieldsByName: ReadonlyMap<string, ProjectCustomField & { readonly field: { readonly name: string } }>,
+  projectFieldsByName: ReadonlyMap<string, NamedProjectCustomField>,
   customFields: ReadonlyArray<{ name: string; value: string }> | undefined,
 ): Set<string> => {
   const handledFields = new Set<string>()
   for (const fieldName of new Set((customFields ?? []).map((field) => field.name))) {
     if (!projectFieldsByName.has(fieldName)) {
-      throw new YouTrackClassifiedError(
-        `Unknown custom field for create: ${fieldName}`,
-        providerError.validationFailed(
-          'customFields',
-          `${fieldName} is not a known project field for this YouTrack project`,
-        ),
-      )
+      throw unknownFieldError(fieldName, [...projectFieldsByName.keys()], 'create')
     }
     handledFields.add(fieldName)
   }
   return handledFields
 }
-export const buildCustomFields = (
-  params: Readonly<{
-    status?: string
-    priority?: string
-    dueDate?: string
-    assignee?: string
-    customFields?: Array<{ name: string; value: string }>
-  }>,
-): StandardCustomFieldPayload[] => {
-  const fields: StandardCustomFieldPayload[] = []
-  if (params.priority !== undefined) {
-    fields.push({
-      name: 'Priority',
-      $type: 'SingleEnumIssueCustomField',
-      value: { name: params.priority },
-    })
-  }
-  if (params.status !== undefined) {
-    fields.push({ name: 'State', $type: 'StateIssueCustomField', value: { name: params.status } })
-  }
-  if (params.dueDate !== undefined) {
-    fields.push({
-      name: YOUTRACK_DUE_DATE_FIELD_NAME,
-      $type: 'DateIssueCustomField',
-      value: parseDueDateValue(params.dueDate),
-    })
-  }
-  if (params.assignee !== undefined) {
-    fields.push({
-      name: 'Assignee',
-      $type: 'SingleUserIssueCustomField',
-      value: { login: params.assignee },
-    })
-  }
-  return fields
-}
-export const buildCreateIssueCustomField = (
-  field: ProjectCustomField,
-  value: string,
-): CreateIssueCustomFieldPayload | undefined => {
-  const name = field.field?.name
-  if (name === undefined) return undefined
-  if (isTextProjectField(field)) {
-    return { name, $type: 'TextIssueCustomField', value: { text: value } }
-  }
-  if (isStringSimpleProjectField(field)) {
-    return { name, $type: 'SimpleIssueCustomField', value }
-  }
-  return undefined
-}
+
 type RequiredFieldDescriptor = { name: string; label: string }
 
 const describeRequiredField = async (
@@ -169,37 +103,47 @@ const describeRequiredField = async (
   }
 }
 
+// Marks the project fields satisfied by dedicated params, resolving each to its real (possibly
+// localized) field name so required-detection does not re-flag a field the caller already set.
 const markDedicatedParamFields = (
   handledFields: Set<string>,
-  params: Readonly<{ status?: string; priority?: string; dueDate?: string; assignee?: string }>,
+  params: CustomFieldParams,
+  projectFieldsByName: ReadonlyMap<string, NamedProjectCustomField>,
 ): void => {
-  if (params.status !== undefined) handledFields.add('State')
-  if (params.priority !== undefined) handledFields.add('Priority')
-  if (params.assignee !== undefined) handledFields.add('Assignee')
-  if (params.dueDate !== undefined) handledFields.add(YOUTRACK_DUE_DATE_FIELD_NAME)
+  const fields = [...projectFieldsByName.values()]
+  for (const pair of collectFieldPairs(params)) {
+    if (pair.source !== 'dedicated') continue
+    try {
+      handledFields.add(resolveDedicatedField(pair.kind, fields).field?.name ?? '')
+    } catch {
+      // Unresolvable dedicated param surfaces as a teaching error when payloads are built.
+    }
+  }
 }
+
+const dedicatedParamPresent = (params: CustomFieldParams): boolean =>
+  params.status !== undefined ||
+  params.priority !== undefined ||
+  params.assignee !== undefined ||
+  params.dueDate !== undefined
 
 export const validateRequiredCreateFields = async (
   config: Readonly<YouTrackConfig>,
   projectId: string,
   projectShortName: string,
-  params: Readonly<{
-    status?: string
-    priority?: string
-    dueDate?: string
-    assignee?: string
-    customFields?: Array<{ name: string; value: string }>
-  }>,
+  params: CustomFieldParams,
 ): Promise<ProjectCustomField[]> => {
-  // Named generic custom fields can only be resolved against the project schema. When the token
-  // cannot read field-settings (admin endpoint empty), derive the schema from a sample issue so
-  // those fields are recognized instead of rejected as "unknown".
+  // Named generic fields and dedicated params both need the project schema to resolve. When the
+  // token cannot read field-settings (admin endpoint empty), derive the schema from a sample issue
+  // so fields are recognized instead of rejected as "unknown".
+  const needsSchema = (params.customFields?.length ?? 0) > 0 || dedicatedParamPresent(params)
   const projectCustomFields = await fetchProjectCustomFields(config, projectId, {
-    deriveFromIssueWhenEmpty: (params.customFields?.length ?? 0) > 0,
+    deriveFromIssueWhenEmpty: needsSchema,
     shortName: projectShortName,
   })
-  const handledFields = buildHandledFieldSet(buildProjectFieldsByName(projectCustomFields), params.customFields)
-  markDedicatedParamFields(handledFields, params)
+  const projectFieldsByName = buildProjectFieldsByName(projectCustomFields)
+  const handledFields = buildHandledFieldSet(projectFieldsByName, params.customFields)
+  markDedicatedParamFields(handledFields, params, projectFieldsByName)
   const requiredFields = projectCustomFields.filter(
     (field) =>
       field.canBeEmpty === false &&
@@ -219,67 +163,26 @@ export const validateRequiredCreateFields = async (
     ),
   )
 }
-export const buildCreateCustomFields = async (
+
+// Shared custom-field builder for create and update: every field — dedicated (resolved by type)
+// or generic (resolved by name) — flows through the field engine.
+export const buildIssueCustomFields = async (
   config: Readonly<YouTrackConfig>,
-  params: Readonly<{
-    status?: string
-    priority?: string
-    dueDate?: string
-    assignee?: string
-    customFields?: Array<{ name: string; value: string }>
-  }>,
+  params: CustomFieldParams,
   projectCustomFields: readonly ProjectCustomField[],
-): Promise<Array<StandardCustomFieldPayload | IssueCustomFieldPayload>> => {
+  op: 'create' | 'update',
+): Promise<IssueCustomFieldPayload[]> => {
   const projectFieldsByName = buildProjectFieldsByName(projectCustomFields)
   const getBundleElements = makeBundleElementFetcher(config)
-  const resolved = collectCreateFieldPairs(params).map((pair) => resolveCreateFieldPair(pair, projectFieldsByName))
+  const resolved = collectFieldPairs(params).map((pair) => resolveFieldPair(pair, projectFieldsByName, op))
   const payloads = await Promise.all(
-    resolved.map((r) =>
-      r.kind === 'legacy'
-        ? Promise.resolve(r.payload)
-        : resolveCustomFieldValue(r.field, r.value, { getBundleElements }),
-    ),
+    resolved.map((r) => resolveCustomFieldValue(r.field, r.value, { getBundleElements })),
   )
   return payloads
 }
-const buildWriteSafeCustomFieldPayload = (
-  projectFieldsByName: ReadonlyMap<string, ProjectCustomField & { readonly field: { readonly name: string } }>,
-  input: Readonly<{ name: string; value: string }>,
-): CreateIssueCustomFieldPayload => {
-  const projectField = projectFieldsByName.get(input.name)
-  if (projectField === undefined) {
-    throw customFieldValidationError(
-      `Unknown custom field for update: ${input.name}`,
-      `${input.name} is not a known project field for this YouTrack project`,
-    )
-  }
-  if (NON_GENERIC_FIELD_NAMES.has(input.name)) {
-    throw customFieldValidationError(
-      `Use the dedicated field for ${input.name}`,
-      `Use the dedicated tool field for ${input.name}`,
-    )
-  }
-  const payload = buildCreateIssueCustomField(projectField, input.value)
-  if (payload === undefined) {
-    throw customFieldValidationError(
-      `Unsupported custom field for update: ${input.name}`,
-      `${input.name} only supports simple string/text writes in update_task`,
-    )
-  }
-  return payload
-}
-const customFieldValidationError = (reason: string, message: string): YouTrackClassifiedError =>
-  new YouTrackClassifiedError(reason, providerError.validationFailed('customFields', message))
-export const buildWriteSafeCustomFields = async (
-  config: Readonly<YouTrackConfig>,
-  projectId: string,
-  customFields: ReadonlyArray<{ name: string; value: string }> | undefined,
-): Promise<CreateIssueCustomFieldPayload[]> => {
-  if (customFields === undefined || customFields.length === 0) return []
-  const projectFieldsByName = buildProjectFieldsByName(await fetchProjectCustomFields(config, projectId))
-  return customFields.map((input) => buildWriteSafeCustomFieldPayload(projectFieldsByName, input))
-}
+
 export { buildYouTrackQuery } from './query-builder.js'
+
 export const enrichTaskWithDueDate = async (config: Readonly<YouTrackConfig>, task: Readonly<Task>): Promise<Task> => {
   try {
     const customFields = await paginate(
@@ -295,5 +198,6 @@ export const enrichTaskWithDueDate = async (config: Readonly<YouTrackConfig>, ta
     return { ...task }
   }
 }
+
 export { mapYouTrackDueDateValue } from './due-date.js'
 export { mapReadOnlyCustomFields } from './custom-field-values.js'

--- a/tests/plugins/task-provider-youtrack/create-field-helpers.test.ts
+++ b/tests/plugins/task-provider-youtrack/create-field-helpers.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import type { z } from 'zod'
+
+import { collectFieldPairs, resolveFieldPair } from '../../../plugins/task-provider-youtrack/create-field-helpers.js'
+import type { ProjectCustomFieldSchema } from '../../../plugins/task-provider-youtrack/schemas/bundle.js'
+
+type PCF = z.infer<typeof ProjectCustomFieldSchema> & { field: { name: string } }
+
+const field = (name: string, typeId: string, bundleType?: string): PCF =>
+  ({
+    $type: 'ProjectCustomField',
+    field: { name, fieldType: { id: typeId } },
+    ...(bundleType === undefined ? {} : { bundle: { id: 'b-1', $type: bundleType } }),
+  }) as PCF
+
+const byName = (fields: PCF[]): Map<string, PCF> => new Map(fields.map((f) => [f.field.name, f]))
+
+describe('collectFieldPairs', () => {
+  test('tags dedicated params with a kind and generic fields by name', () => {
+    const pairs = collectFieldPairs({ status: 'Open', customFields: [{ name: 'URL', value: 'http://x' }] })
+    expect(pairs).toContainEqual({ source: 'dedicated', kind: 'state', value: 'Open' })
+    expect(pairs).toContainEqual({ source: 'generic', name: 'URL', value: 'http://x' })
+  })
+})
+
+describe('resolveFieldPair', () => {
+  test('dedicated status resolves to the localized state field', () => {
+    const state = field('Cтaтус', 'state[1]', 'StateBundle')
+    const resolved = resolveFieldPair({ source: 'dedicated', kind: 'state', value: 'Open' }, byName([state]), 'create')
+    expect(resolved.field.field?.name).toBe('Cтaтус')
+    expect(resolved.value).toBe('Open')
+  })
+
+  test('generic unknown field throws a teaching error listing available names', () => {
+    const state = field('Cтaтус', 'state[1]', 'StateBundle')
+    expect(() => resolveFieldPair({ source: 'generic', name: 'Nope', value: 'x' }, byName([state]), 'create')).toThrow(
+      /Cтaтус/u,
+    )
+  })
+})

--- a/tests/plugins/task-provider-youtrack/dedicated-fields.test.ts
+++ b/tests/plugins/task-provider-youtrack/dedicated-fields.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import type { z } from 'zod'
+
+import { resolveDedicatedField } from '../../../plugins/task-provider-youtrack/dedicated-fields.js'
+import type { ProjectCustomFieldSchema } from '../../../plugins/task-provider-youtrack/schemas/bundle.js'
+
+type PCF = z.infer<typeof ProjectCustomFieldSchema>
+
+const field = (name: string, typeId: string, bundleType?: string): PCF =>
+  ({
+    $type: 'ProjectCustomField',
+    field: { name, fieldType: { id: typeId } },
+    ...(bundleType === undefined ? {} : { bundle: { id: 'b-1', $type: bundleType } }),
+  }) as PCF
+
+const STATE = field('Cтaтус', 'state[1]', 'StateBundle')
+const USER = field('Oтветствeнный', 'user[*]', 'UserBundle')
+const URGENCY = field('Срочность', 'enum[1]', 'EnumBundle')
+const TEAM = field('Командa', 'enum[*]', 'EnumBundle')
+
+describe('resolveDedicatedField', () => {
+  test('status resolves to the sole state-typed field regardless of localized name', () => {
+    const resolved = resolveDedicatedField('state', [STATE, USER, URGENCY, TEAM])
+    expect(resolved.field?.name).toBe('Cтaтус')
+  })
+
+  test('assignee resolves to the sole user-typed field', () => {
+    const resolved = resolveDedicatedField('user', [STATE, USER, URGENCY])
+    expect(resolved.field?.name).toBe('Oтветствeнный')
+  })
+
+  test('priority requires a canonical name match and rejects ambiguous enums', () => {
+    expect(() => resolveDedicatedField('priority', [URGENCY, TEAM])).toThrow(/priority/iu)
+  })
+
+  test('priority resolves an enum field literally named Priority', () => {
+    const priority = field('Priority', 'enum[1]', 'EnumBundle')
+    const resolved = resolveDedicatedField('priority', [priority, URGENCY, TEAM])
+    expect(resolved.field?.name).toBe('Priority')
+  })
+
+  test('two same-type fields disambiguate by canonical name (Assignee)', () => {
+    const assignee = field('Assignee', 'user[1]', 'UserBundle')
+    const reviewer = field('Reviewer', 'user[1]', 'UserBundle')
+    const resolved = resolveDedicatedField('user', [assignee, reviewer])
+    expect(resolved.field?.name).toBe('Assignee')
+  })
+
+  test('two same-type fields with no canonical name throw a teaching error', () => {
+    const a = field('Owner', 'user[1]', 'UserBundle')
+    const b = field('Watcher', 'user[1]', 'UserBundle')
+    expect(() => resolveDedicatedField('user', [a, b])).toThrow(/Owner|Watcher/u)
+  })
+
+  test('no field of the requested type throws a teaching error', () => {
+    expect(() => resolveDedicatedField('state', [USER, URGENCY])).toThrow(/state/iu)
+  })
+})

--- a/tests/plugins/task-provider-youtrack/field-name-error.test.ts
+++ b/tests/plugins/task-provider-youtrack/field-name-error.test.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { unknownFieldError } from '../../../plugins/task-provider-youtrack/field-name-error.js'
+
+describe('unknownFieldError', () => {
+  test('lists available field names in message and details', () => {
+    const error = unknownFieldError('URL адеса', ['Cтaтус', 'Срочность'], 'create')
+    expect(error.message).toContain('URL адеса')
+    expect(error.message).toContain('Cтaтус')
+    expect(error.message).toContain('Срочность')
+    expect(error.message).toContain('create')
+    expect(error.appError.code).toBe('validation-failed')
+    expect(error.appError).toHaveProperty('field', 'customFields')
+    expect(error.appError).toHaveProperty('reason', expect.stringContaining('Cтaтус'))
+  })
+
+  test('caps the available list at 50 names', () => {
+    const names = Array.from({ length: 60 }, (_, i) => `Field${i}`)
+    const error = unknownFieldError('X', names, 'update')
+    expect(error.message).toContain('and 10 more')
+    expect(error.message).toContain('update')
+  })
+})

--- a/tests/plugins/task-provider-youtrack/index.test.ts
+++ b/tests/plugins/task-provider-youtrack/index.test.ts
@@ -58,6 +58,56 @@ const mockFetchSequence = (responses: Array<{ data: unknown; status?: number }>)
   })
 }
 
+type RoutedFetchHandler = (url: string, init: RequestInit) => Promise<Response>
+
+const installRoutedFetchMock = (handler: RoutedFetchHandler): void => {
+  const m = mock<RoutedFetchHandler>(handler)
+  fetchMock = m
+  setMockFetch((url, init) => m(url, init))
+}
+
+const jsonOk = (data: unknown): Promise<Response> =>
+  Promise.resolve(new Response(JSON.stringify(data), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+
+const createTaskWithPriorityAndStatusIssueData = {
+  id: '2-2',
+  idReadable: 'TEST-2',
+  summary: 'Task with fields',
+  project: { id: '0-1', shortName: 'TEST' },
+  created: 1700000000000,
+  updated: 1700000000000,
+  customFields: [],
+  tags: [],
+  links: [],
+}
+
+const mockCreateTaskWithPriorityAndStatus = (): void => {
+  const stateFieldSchema = {
+    $type: 'StateProjectCustomField',
+    field: { name: 'State', fieldType: { id: 'state[1]' } },
+    bundle: { id: 'idx-sb1', $type: 'StateBundle' },
+    canBeEmpty: false,
+  }
+  const priorityFieldSchema = {
+    $type: 'EnumProjectCustomField',
+    field: { name: 'Priority', fieldType: { id: 'enum[1]' } },
+    bundle: { id: 'idx-eb1', $type: 'EnumBundle' },
+    canBeEmpty: false,
+  }
+  installRoutedFetchMock((url, init) => {
+    const p = new URL(url).pathname
+    const method = init.method ?? 'GET'
+    if (p === '/api/admin/projects/0-1' && method === 'GET') return jsonOk({ id: '0-1', shortName: 'TEST' })
+    if (p === '/api/admin/projects/0-1/customFields') return jsonOk([stateFieldSchema, priorityFieldSchema])
+    if (p === '/api/admin/customFieldSettings/bundles/state/idx-sb1/values')
+      return jsonOk([{ name: 'Open' }, { name: 'In Progress' }])
+    if (p === '/api/admin/customFieldSettings/bundles/enum/idx-eb1/values')
+      return jsonOk([{ name: 'Critical' }, { name: 'Normal' }])
+    if (p === '/api/issues' && method === 'POST') return jsonOk(createTaskWithPriorityAndStatusIssueData)
+    return jsonOk([])
+  })
+}
+
 /** Schema for a mock fetch call tuple: [url, init] */
 const FetchCallSchema = z.tuple([
   z.string(),
@@ -319,28 +369,7 @@ describe('YouTrackProvider', () => {
     })
 
     test('sends custom fields for priority and status', async () => {
-      mockFetchSequence([
-        // First: project lookup
-        { data: { id: '0-1', shortName: 'TEST' } },
-        // Second: project custom fields lookup
-        { data: [] },
-        // Third: issue creation response
-        {
-          data: {
-            id: '2-2',
-            idReadable: 'TEST-2',
-            summary: 'Task with fields',
-            project: { id: '0-1', shortName: 'TEST' },
-            created: 1700000000000,
-            updated: 1700000000000,
-            customFields: [],
-            tags: [],
-            links: [],
-          },
-        },
-        // Fourth: enrichTaskWithDueDate fetches issue custom fields
-        { data: [] },
-      ])
+      mockCreateTaskWithPriorityAndStatus()
 
       await provider.createTask({
         projectId: '0-1',
@@ -349,15 +378,10 @@ describe('YouTrackProvider', () => {
         status: 'In Progress',
       })
 
-      // Get the third call (issue creation - first two are GET project and GET custom fields)
       assert(fetchMock !== undefined)
       const calls = fetchMock.mock.calls
       const createCallIndex = findIssuesCreateCallIndex(calls)
       expect(createCallIndex).toBeGreaterThanOrEqual(0)
-      const createCall = calls[createCallIndex]
-      const parsed = FetchCallSchema.safeParse(createCall)
-      expect(parsed.success).toBe(true)
-      assert(parsed.success)
 
       const rawBody: unknown = getFetchBodyAt(createCallIndex)
       const customFields = parseCustomFields(rawBody)

--- a/tests/plugins/task-provider-youtrack/issue-derived-fields.test.ts
+++ b/tests/plugins/task-provider-youtrack/issue-derived-fields.test.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { fetchProjectCustomFieldsViaIssue } from '../../../plugins/task-provider-youtrack/issue-derived-fields.js'
+import { fetchProjectCustomFields } from '../../../plugins/task-provider-youtrack/task-helpers.js'
+import { mockLogger, restoreFetch, setMockFetch } from '../../utils/test-helpers.js'
+import { createUniqueYouTrackConfig } from './fetch-mock-utils.js'
+
+// Mirrors the real (localized, homoglyph-polluted) AUDIT project schema reached through an
+// issue, where the admin /customFields endpoint returns [] for a non-admin token.
+const SAMPLE_ISSUE = {
+  $type: 'Issue',
+  customFields: [
+    {
+      name: 'Cтaтус',
+      $type: 'StateIssueCustomField',
+      projectCustomField: {
+        $type: 'StateProjectCustomField',
+        canBeEmpty: false,
+        bundle: { id: '72-976', $type: 'StateBundle' },
+        field: {
+          name: 'Cтaтус',
+          localizedName: null,
+          $type: 'CustomField',
+          fieldType: { id: 'state[1]', presentation: 'state[1]' },
+        },
+      },
+    },
+    {
+      name: 'URL адеса где будет размещаться приложение. Одна строчка - один URL',
+      $type: 'TextIssueCustomField',
+      projectCustomField: {
+        $type: 'TextProjectCustomField',
+        canBeEmpty: true,
+        field: {
+          name: 'URL адеса где будет размещаться приложение. Одна строчка - один URL',
+          $type: 'CustomField',
+          fieldType: { id: 'text', presentation: 'text' },
+        },
+      },
+    },
+  ],
+}
+
+const nameOf = (field: { field?: { name?: string } | null }): string => field.field?.name ?? ''
+
+const queueResponses = (responses: readonly unknown[]): void => {
+  let i = 0
+  setMockFetch(() => {
+    const body = responses[Math.min(i, responses.length - 1)]
+    i += 1
+    return Promise.resolve(
+      new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+  })
+}
+
+describe('fetchProjectCustomFieldsViaIssue', () => {
+  beforeEach(() => mockLogger())
+  afterEach(() => restoreFetch())
+
+  test('lifts projectCustomField settings from a sample issue into ProjectCustomField shape', async () => {
+    const config = createUniqueYouTrackConfig()
+    // 1) project shortName lookup, 2) sample issue
+    queueResponses([{ shortName: 'AUDIT' }, [SAMPLE_ISSUE]])
+
+    const fields = await fetchProjectCustomFieldsViaIssue(config, '39-1118')
+
+    expect(fields).toHaveLength(2)
+    const state = fields.find((f) => f.field?.name === 'Cтaтус')
+    expect(state?.$type).toBe('StateProjectCustomField')
+    expect(state?.canBeEmpty).toBe(false)
+    expect(state?.bundle?.id).toBe('72-976')
+    expect(state?.field?.fieldType?.id).toBe('state[1]')
+    const url = fields.find((f) => nameOf(f).startsWith('URL'))
+    expect(url?.$type).toBe('TextProjectCustomField')
+  })
+
+  test('returns an empty list when the project has no issues to sample', async () => {
+    const config = createUniqueYouTrackConfig()
+    queueResponses([{ shortName: 'EMPTY' }, []])
+
+    const fields = await fetchProjectCustomFieldsViaIssue(config, '0-9')
+
+    expect(fields).toEqual([])
+  })
+})
+
+describe('fetchProjectCustomFields admin→issue fallback', () => {
+  beforeEach(() => mockLogger())
+  afterEach(() => restoreFetch())
+
+  test('returns admin fields directly when the admin endpoint is populated', async () => {
+    const config = createUniqueYouTrackConfig()
+    const adminFields = [
+      { $type: 'TextProjectCustomField', field: { name: 'Notes', fieldType: { id: 'text' } }, canBeEmpty: true },
+    ]
+    // Only the admin endpoint should be hit (the sample-fetch responses below stay unused).
+    queueResponses([adminFields, { shortName: 'NOPE' }, [SAMPLE_ISSUE]])
+
+    const fields = await fetchProjectCustomFields(config, '39-1', { deriveFromIssueWhenEmpty: true })
+
+    expect(fields).toHaveLength(1)
+    expect(fields[0]?.field?.name).toBe('Notes')
+  })
+
+  test('does not derive when the flag is off, even if the admin endpoint returns []', async () => {
+    const config = createUniqueYouTrackConfig()
+    queueResponses([[]])
+
+    const fields = await fetchProjectCustomFields(config, '39-1118')
+
+    expect(fields).toEqual([])
+  })
+
+  test('falls back to the issue-derived schema when the admin endpoint returns []', async () => {
+    const config = createUniqueYouTrackConfig()
+    // 1) admin customFields → [], 2) project shortName, 3) sample issue
+    queueResponses([[], { shortName: 'AUDIT' }, [SAMPLE_ISSUE]])
+
+    const fields = await fetchProjectCustomFields(config, '39-1118', { deriveFromIssueWhenEmpty: true })
+
+    expect(fields.map((f) => f.field?.name)).toContain('Cтaтус')
+    expect(fields.some((f) => nameOf(f).startsWith('URL'))).toBe(true)
+  })
+})

--- a/tests/plugins/task-provider-youtrack/mappers.test.ts
+++ b/tests/plugins/task-provider-youtrack/mappers.test.ts
@@ -8,12 +8,10 @@ import { describe, expect, test } from 'bun:test'
 import type { z } from 'zod'
 
 import {
-  buildCreateIssueCustomField,
   mapIssueToTask,
   mapIssueToListItem,
   mapIssueToSearchResult,
   mapComment,
-  buildCustomFields,
 } from '../../../plugins/task-provider-youtrack/mappers.js'
 
 describe('mapIssueToTask', () => {
@@ -625,141 +623,5 @@ describe('mapComment', () => {
         createdAt: undefined,
       },
     ])
-  })
-
-  test('returns empty array when no fields', () => {
-    const result = buildCustomFields({})
-    expect(result).toHaveLength(0)
-  })
-
-  test('ignores create-only custom fields without project metadata', () => {
-    const result = buildCustomFields({
-      customFields: [
-        { name: 'URL адеса где будет размещаться приложени', value: 'stream://myapp' },
-        { name: 'Environment', value: 'production' },
-      ],
-    })
-    expect(result).toEqual([])
-  })
-
-  test('builds create-time custom field payload for supported simple string project fields', () => {
-    expect(
-      buildCreateIssueCustomField(
-        {
-          id: '82-12',
-          $type: 'SimpleProjectCustomField',
-          field: {
-            id: '58-4',
-            name: 'Requester email',
-            $type: 'CustomField',
-            fieldType: { id: 'string', presentation: 'string' },
-          },
-          canBeEmpty: true,
-          isPublic: true,
-        },
-        'test@example.com',
-      ),
-    ).toEqual({
-      name: 'Requester email',
-      $type: 'SimpleIssueCustomField',
-      value: 'test@example.com',
-    })
-  })
-
-  test('builds create-time custom field payload for supported text project fields', () => {
-    expect(
-      buildCreateIssueCustomField(
-        {
-          id: '82-13',
-          $type: 'TextProjectCustomField',
-          field: {
-            id: '58-5',
-            name: 'Environment details',
-            $type: 'CustomField',
-            fieldType: { id: 'text', presentation: 'text' },
-          },
-          canBeEmpty: true,
-          isPublic: true,
-        },
-        'Needs staging parity',
-      ),
-    ).toEqual({
-      name: 'Environment details',
-      $type: 'TextIssueCustomField',
-      value: { text: 'Needs staging parity' },
-    })
-  })
-
-  test('returns undefined for unsupported create-time project custom fields', () => {
-    expect(
-      buildCreateIssueCustomField(
-        {
-          id: '82-14',
-          $type: 'EnumProjectCustomField',
-          field: {
-            id: '58-6',
-            name: 'Type',
-            $type: 'CustomField',
-            fieldType: { id: 'enum[1]', presentation: 'enum[1]' },
-          },
-          canBeEmpty: true,
-          isPublic: true,
-        },
-        'Bug',
-      ),
-    ).toBeUndefined()
-  })
-
-  test('combines standard and custom fields', () => {
-    const result = buildCustomFields({
-      priority: 'High',
-      customFields: [{ name: 'URL', value: 'stream://test' }],
-    })
-    expect(result).toHaveLength(1)
-    expect(result[0]).toEqual({
-      name: 'Priority',
-      $type: 'SingleEnumIssueCustomField',
-      value: { name: 'High' },
-    })
-  })
-
-  test('encodes due date as midday UTC for date-only custom field', () => {
-    const result = buildCustomFields({ dueDate: '2026-03-25' })
-
-    expect(result).toEqual([
-      {
-        name: 'Due Date',
-        $type: 'DateIssueCustomField',
-        value: Date.parse('2026-03-25T12:00:00.000Z'),
-      },
-    ])
-  })
-
-  test('preserves calendar date from iso datetime input with offset', () => {
-    const result = buildCustomFields({ dueDate: '2026-03-25T00:30:00+02:00' })
-
-    expect(result).toEqual([
-      {
-        name: 'Due Date',
-        $type: 'DateIssueCustomField',
-        value: Date.parse('2026-03-25T12:00:00.000Z'),
-      },
-    ])
-  })
-
-  test('rejects malformed due date input', () => {
-    expect(() => buildCustomFields({ dueDate: 'not-a-date' })).toThrow('Invalid dueDate')
-  })
-
-  test('rejects impossible date-only input', () => {
-    expect(() => buildCustomFields({ dueDate: '2026-02-30' })).toThrow('Invalid dueDate')
-  })
-
-  test('rejects ambiguous non-iso datetime input', () => {
-    expect(() => buildCustomFields({ dueDate: '03/25/2026 17:00' })).toThrow('Invalid dueDate')
-  })
-
-  test('does not reject custom field values without metadata', () => {
-    expect(() => buildCustomFields({ customFields: [{ name: 'Type', value: 'Bug' }] })).not.toThrow()
   })
 })

--- a/tests/plugins/task-provider-youtrack/operations/tasks.test.ts
+++ b/tests/plugins/task-provider-youtrack/operations/tasks.test.ts
@@ -154,13 +154,152 @@ const jsonOk = (data: unknown): Promise<Response> =>
 const jsonError = (status: number, data: unknown): Promise<Response> =>
   Promise.resolve(new Response(JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } }))
 
-/** project=1, customFields=2, issue=3, followup=4 */
+const ASSIGNEE_FIELD_SCHEMA = {
+  $type: 'UserProjectCustomField',
+  field: { name: 'Assignee', fieldType: { id: 'user[1]' } },
+  canBeEmpty: true,
+}
+const DUE_DATE_FIELD_SCHEMA = {
+  $type: 'DateProjectCustomField',
+  field: { name: 'Due Date', fieldType: { id: 'date' } },
+  canBeEmpty: true,
+}
+
+const findPostCallIndex = (calls: unknown[]): number =>
+  calls.findIndex((call) => {
+    const parsed = FetchCallSchema.safeParse(call)
+    if (!parsed.success) return false
+    const [url, init] = parsed.data
+    return new URL(url).pathname === '/api/issues' && (init.method ?? 'GET') === 'POST'
+  })
+
+const findUpdatePostCallIndex = (calls: unknown[]): number =>
+  calls.findIndex((call) => {
+    const parsed = FetchCallSchema.safeParse(call)
+    if (!parsed.success) return false
+    const [url, init] = parsed.data
+    return new URL(url).pathname === '/api/issues/TEST-1' && (init.method ?? 'GET') === 'POST'
+  })
+
+type RoutedFetchHandler = (url: string, init: RequestInit) => Promise<Response>
+
+const installRoutedFetchMock = (handler: RoutedFetchHandler): void => {
+  const m = mock<RoutedFetchHandler>(handler)
+  fetchMock = m
+  setMockFetch((url, init) => m(url, init))
+}
+
+/** create priority+status: project=1, schema=2, state-bundle=3, enum-bundle=4, POST=5, enrichment=6+ */
+const mockCreateWithPriorityAndStatus = (): void => {
+  const stateSchema = {
+    $type: 'StateProjectCustomField',
+    field: { name: 'State', fieldType: { id: 'state[1]' } },
+    bundle: { id: 'sb-cr1', $type: 'StateBundle' },
+    canBeEmpty: false,
+  }
+  const prioritySchema = {
+    $type: 'EnumProjectCustomField',
+    field: { name: 'Priority', fieldType: { id: 'enum[1]' } },
+    bundle: { id: 'eb-cr1', $type: 'EnumBundle' },
+    canBeEmpty: false,
+  }
+  installRoutedFetchMock((url, init) => {
+    const p = new URL(url).pathname
+    const method = init.method ?? 'GET'
+    if (p === '/api/admin/projects/0-1' && method === 'GET') return jsonOk({ id: '0-1', shortName: 'TEST' })
+    if (p === '/api/admin/projects/0-1/customFields') return jsonOk([stateSchema, prioritySchema])
+    if (p === '/api/admin/customFieldSettings/bundles/state/sb-cr1/values')
+      return jsonOk([{ name: 'Open' }, { name: 'In Progress' }])
+    if (p === '/api/admin/customFieldSettings/bundles/enum/eb-cr1/values')
+      return jsonOk([{ name: 'Critical' }, { name: 'Normal' }])
+    if (p === '/api/issues' && method === 'POST') return jsonOk(makeIssueResponse())
+    return jsonOk([])
+  })
+}
+
+/** create assignee: project=1, schema (Assignee field)=2, POST=3, enrichment=4+ */
+const mockCreateWithAssigneeField = (): void => {
+  installRoutedFetchMock((url, init) => {
+    const p = new URL(url).pathname
+    const method = init.method ?? 'GET'
+    if (p === '/api/admin/projects/0-1' && method === 'GET') return jsonOk({ id: '0-1', shortName: 'TEST' })
+    if (p === '/api/admin/projects/0-1/customFields') return jsonOk([ASSIGNEE_FIELD_SCHEMA])
+    if (p === '/api/issues' && method === 'POST') return jsonOk(makeIssueResponse())
+    return jsonOk([])
+  })
+}
+
+/** create dueDate: project=1, schema (Due Date field)=2, POST=3, enrichment=4+ */
+const mockCreateWithDueDateField = (): void => {
+  installRoutedFetchMock((url, init) => {
+    const p = new URL(url).pathname
+    const method = init.method ?? 'GET'
+    if (p === '/api/admin/projects/0-1' && method === 'GET') return jsonOk({ id: '0-1', shortName: 'TEST' })
+    if (p === '/api/admin/projects/0-1/customFields') return jsonOk([DUE_DATE_FIELD_SCHEMA])
+    if (p === '/api/issues' && method === 'POST') return jsonOk(makeIssueResponse())
+    return jsonOk([])
+  })
+}
+
+/** update status+priority+assignee: project(id)=1, schema=2, bundles=3-4, POST=5 */
+const mockUpdateWithStatusPriorityAssignee = (): void => {
+  const stateSchema = {
+    $type: 'StateProjectCustomField',
+    field: { name: 'State', fieldType: { id: 'state[1]' } },
+    bundle: { id: 'sb-upd1', $type: 'StateBundle' },
+    canBeEmpty: false,
+  }
+  const prioritySchema = {
+    $type: 'EnumProjectCustomField',
+    field: { name: 'Priority', fieldType: { id: 'enum[1]' } },
+    bundle: { id: 'eb-upd1', $type: 'EnumBundle' },
+    canBeEmpty: false,
+  }
+  installRoutedFetchMock((url, init) => {
+    const p = new URL(url).pathname
+    const method = init.method ?? 'GET'
+    if (p === '/api/issues/TEST-1' && method === 'GET') return jsonOk({ project: { id: '0-1' } })
+    if (p === '/api/admin/projects/0-1/customFields')
+      return jsonOk([stateSchema, prioritySchema, ASSIGNEE_FIELD_SCHEMA])
+    if (p === '/api/admin/customFieldSettings/bundles/state/sb-upd1/values')
+      return jsonOk([{ name: 'Open' }, { name: 'Done' }])
+    if (p === '/api/admin/customFieldSettings/bundles/enum/eb-upd1/values')
+      return jsonOk([{ name: 'Normal' }, { name: 'Major' }])
+    if (p === '/api/issues/TEST-1' && method === 'POST') return jsonOk(makeIssueResponse())
+    return jsonOk([])
+  })
+}
+
+/** update dueDate: project(id)=1, schema (Due Date field)=2, POST=3, enrichment=4+ */
+const mockUpdateWithDueDateField = (): void => {
+  installRoutedFetchMock((url, init) => {
+    const p = new URL(url).pathname
+    const method = init.method ?? 'GET'
+    if (p === '/api/issues/TEST-1' && method === 'GET') return jsonOk({ project: { id: '0-1' } })
+    if (p === '/api/admin/projects/0-1/customFields') return jsonOk([DUE_DATE_FIELD_SCHEMA])
+    if (p === '/api/issues/TEST-1' && method === 'POST') return jsonOk(makeIssueResponse())
+    return jsonOk([])
+  })
+}
+
+/** update malformed dueDate: project(id)=1, schema (Due Date field)=2, then throws before POST */
+const mockUpdateWithMalformedDueDateField = (): void => {
+  installRoutedFetchMock((url, init) => {
+    const p = new URL(url).pathname
+    const method = init.method ?? 'GET'
+    if (p === '/api/issues/TEST-1' && method === 'GET') return jsonOk({ project: { id: '0-1' } })
+    if (p === '/api/admin/projects/0-1/customFields') return jsonOk([DUE_DATE_FIELD_SCHEMA])
+    return jsonOk([])
+  })
+}
+
+/** project=1, customFields (Due Date schema)=2, issue=3, followup=4 */
 const mockCreateWithFollowup = (issueResponse: unknown, followupResponse: Response): void => {
   let callCount = 0
   installFetchMock(() => {
     callCount++
     if (callCount === 1) return jsonOk({ id: '0-1', shortName: 'TEST' })
-    if (callCount === 2) return jsonOk([])
+    if (callCount === 2) return jsonOk([DUE_DATE_FIELD_SCHEMA])
     if (callCount === 3) return jsonOk(issueResponse)
     return Promise.resolve(followupResponse)
   })
@@ -221,13 +360,13 @@ const mockCreateWithRequiredDateField = (): void => {
   })
 }
 
-/** project=1, customFields (malformed dueDate)=rest */
+/** project=1, customFields (Due Date schema)=rest */
 const mockCreateWithMalformedDueDate = (): void => {
   let callCount = 0
   installFetchMock(() => {
     callCount++
     if (callCount === 1) return jsonOk({ id: '0-1', shortName: 'TEST' })
-    return jsonOk([])
+    return jsonOk([DUE_DATE_FIELD_SCHEMA])
   })
 }
 
@@ -457,88 +596,42 @@ const mockUpdateWithCustomFields = (): void => {
   })
 }
 
-/** updateYouTrackTask: current issue lookup (unknown field)=1, custom fields=2 */
+/** updateYouTrackTask: current issue lookup (unknown field)=1, custom fields (known env field)=2 */
 const mockUpdateWithUnknownField = (): void => {
   let callCount = 0
   installFetchMock(() => {
     callCount++
     if (callCount === 1) return jsonOk({ project: { id: '0-1' } })
-    return jsonOk([])
-  })
-}
-
-/** updateYouTrackTask: current issue lookup (unsupported field)=1, custom fields=2 */
-const mockUpdateWithUnsupportedField = (): void => {
-  let callCount = 0
-  installFetchMock(() => {
-    callCount++
-    if (callCount === 1) return jsonOk({ project: { id: '0-1' } })
     return jsonOk([
       {
-        id: 'pcf-3',
-        $type: 'EnumProjectCustomField',
-        field: { name: 'Type', fieldType: { id: 'enum[1]', presentation: 'enum[1]' } },
+        $type: 'SimpleProjectCustomField',
+        field: { name: 'Environment', fieldType: { id: 'string' } },
         canBeEmpty: true,
       },
     ])
   })
 }
 
-/** updateYouTrackTask dedicated field rejection: current issue lookup=1, custom fields=2 */
-const mockUpdateDedicatedFieldLookup = (fieldName: string): void => {
-  const fieldTypeMap: Record<string, { $type: string; fieldType: { id: string; presentation: string } }> = {
-    Assignee: {
-      $type: 'UserProjectCustomField',
-      fieldType: { id: 'user[1]', presentation: 'user[1]' },
-    },
-    'Due Date': {
-      $type: 'DateProjectCustomField',
-      fieldType: { id: 'date', presentation: 'date' },
-    },
-    State: {
-      $type: 'SimpleProjectCustomField',
-      fieldType: { id: 'string', presentation: 'string' },
-    },
-    Priority: {
-      $type: 'SimpleProjectCustomField',
-      fieldType: { id: 'string', presentation: 'string' },
-    },
-  }
-  const fieldMeta = fieldTypeMap[fieldName] ?? {
-    $type: 'SimpleProjectCustomField',
-    fieldType: { id: 'string', presentation: 'string' },
-  }
-  let callCount = 0
-  installFetchMock(() => {
-    callCount++
-    if (callCount === 1) return jsonOk({ project: { id: '0-1' } })
-    return jsonOk([
-      {
-        id: `pcf-${fieldName}`,
-        $type: fieldMeta.$type,
-        field: { name: fieldName, fieldType: fieldMeta.fieldType },
-        canBeEmpty: true,
-      },
-    ])
-  })
-}
-
-/** updateYouTrackTask: update with dueDate=1 (returns issue), enrichment=2 */
+/** updateYouTrackTask: project(id)=1, customFields (Due Date schema)=2, update=3, enrichment=4 */
 const mockUpdateWithDueDateEnrichment = (dueDateEnrichmentResponse: Response): void => {
   let callCount = 0
   installFetchMock(() => {
     callCount++
-    if (callCount === 1) return jsonOk(makeIssueResponse())
+    if (callCount === 1) return jsonOk({ project: { id: '0-1' } })
+    if (callCount === 2) return jsonOk([DUE_DATE_FIELD_SCHEMA])
+    if (callCount === 3) return jsonOk(makeIssueResponse())
     return Promise.resolve(dueDateEnrichmentResponse)
   })
 }
 
-/** updateYouTrackTask: update with dueDate=1 (returns issue), enrichment fails=2 */
+/** updateYouTrackTask: project(id)=1, customFields (Due Date schema)=2, update=3, enrichment fails=4 */
 const mockUpdateWithFailedEnrichment = (): void => {
   let callCount = 0
   installFetchMock(() => {
     callCount++
-    if (callCount === 1) return jsonOk(makeIssueResponse())
+    if (callCount === 1) return jsonOk({ project: { id: '0-1' } })
+    if (callCount === 2) return jsonOk([DUE_DATE_FIELD_SCHEMA])
+    if (callCount === 3) return jsonOk(makeIssueResponse())
     return jsonError(500, { error: 'custom field lookup failed' })
   })
 }
@@ -746,7 +839,7 @@ describe('createYouTrackTask', () => {
   })
 
   test('sends custom fields for priority and status', async () => {
-    mockCreateTaskResponse(makeIssueResponse())
+    mockCreateWithPriorityAndStatus()
 
     await createYouTrackTask(config, {
       projectId: '0-1',
@@ -755,7 +848,8 @@ describe('createYouTrackTask', () => {
       status: 'In Progress',
     })
 
-    const body = getFetchBodyAt(2)
+    const postIdx = findPostCallIndex(fetchMock.mock.calls)
+    const body = getFetchBodyAt(postIdx)
     expect(body['customFields']).toContainEqual({
       name: 'Priority',
       $type: 'SingleEnumIssueCustomField',
@@ -769,7 +863,7 @@ describe('createYouTrackTask', () => {
   })
 
   test('sends assignee custom field when provided', async () => {
-    mockCreateTaskResponse(makeIssueResponse())
+    mockCreateWithAssigneeField()
 
     await createYouTrackTask(config, {
       projectId: '0-1',
@@ -777,7 +871,8 @@ describe('createYouTrackTask', () => {
       assignee: 'john.doe',
     })
 
-    const body = getFetchBodyAt(2)
+    const postIdx = findPostCallIndex(fetchMock.mock.calls)
+    const body = getFetchBodyAt(postIdx)
     expect(body['customFields']).toContainEqual({
       name: 'Assignee',
       $type: 'SingleUserIssueCustomField',
@@ -786,7 +881,7 @@ describe('createYouTrackTask', () => {
   })
 
   test('sends due date custom field when provided', async () => {
-    mockCreateTaskResponse(makeIssueResponse())
+    mockCreateWithDueDateField()
 
     await createYouTrackTask(config, {
       projectId: '0-1',
@@ -794,7 +889,8 @@ describe('createYouTrackTask', () => {
       dueDate: '2026-03-25',
     })
 
-    const body = getFetchBodyAt(2)
+    const postIdx = findPostCallIndex(fetchMock.mock.calls)
+    const body = getFetchBodyAt(postIdx)
     expect(body['customFields']).toContainEqual({
       name: 'Due Date',
       $type: 'DateIssueCustomField',
@@ -831,7 +927,7 @@ describe('createYouTrackTask', () => {
   })
 
   test('canonicalizes datetime input to date-only value when creating', async () => {
-    mockCreateTaskResponse(makeIssueResponse())
+    mockCreateWithDueDateField()
 
     await createYouTrackTask(config, {
       projectId: '0-1',
@@ -839,7 +935,8 @@ describe('createYouTrackTask', () => {
       dueDate: '2026-03-25T23:45:00.000Z',
     })
 
-    const body = getFetchBodyAt(2)
+    const postIdx = findPostCallIndex(fetchMock.mock.calls)
+    const body = getFetchBodyAt(postIdx)
     expect(body['customFields']).toContainEqual({
       name: 'Due Date',
       $type: 'DateIssueCustomField',
@@ -1418,7 +1515,7 @@ describe('updateYouTrackTask', () => {
   })
 
   test('sends custom fields for status, priority, and assignee', async () => {
-    mockFetchResponse(makeIssueResponse())
+    mockUpdateWithStatusPriorityAssignee()
 
     await updateYouTrackTask(config, 'TEST-1', {
       status: 'Done',
@@ -1426,20 +1523,22 @@ describe('updateYouTrackTask', () => {
       assignee: 'john',
     })
 
-    const body = getFetchBodyAt(0)
+    const postIdx = findUpdatePostCallIndex(fetchMock.mock.calls)
+    const body = getFetchBodyAt(postIdx)
     expect(body['customFields']).toContainEqual(expect.objectContaining({ name: 'Priority', value: { name: 'Major' } }))
     expect(body['customFields']).toContainEqual(expect.objectContaining({ name: 'State', value: { name: 'Done' } }))
     expect(body['customFields']).toContainEqual(expect.objectContaining({ name: 'Assignee', value: { login: 'john' } }))
   })
 
   test('sends due date custom field when provided', async () => {
-    mockFetchResponse(makeIssueResponse())
+    mockUpdateWithDueDateField()
 
     await updateYouTrackTask(config, 'TEST-1', {
       dueDate: '2026-03-25',
     })
 
-    const body = getFetchBodyAt(0)
+    const postIdx = findUpdatePostCallIndex(fetchMock.mock.calls)
+    const body = getFetchBodyAt(postIdx)
     expect(body['customFields']).toContainEqual({
       name: 'Due Date',
       $type: 'DateIssueCustomField',
@@ -1472,56 +1571,19 @@ describe('updateYouTrackTask', () => {
   test('rejects unknown custom field names on update before sending the write request', async () => {
     mockUpdateWithUnknownField()
 
-    await expect(
-      updateYouTrackTask(config, 'TEST-1', {
+    try {
+      await updateYouTrackTask(config, 'TEST-1', {
         customFields: [{ name: 'Unknown field', value: 'value' }],
-      }),
-    ).rejects.toMatchObject({
-      appError: {
-        code: 'validation-failed',
-        field: 'customFields',
-      },
-    })
-
-    expect(fetchMock.mock.calls).toHaveLength(2)
-  })
-
-  test('rejects unsupported project custom field types on update before sending the write request', async () => {
-    mockUpdateWithUnsupportedField()
-
-    await expect(
-      updateYouTrackTask(config, 'TEST-1', {
-        customFields: [{ name: 'Type', value: 'Bug' }],
-      }),
-    ).rejects.toMatchObject({
-      appError: {
-        code: 'validation-failed',
-        field: 'customFields',
-      },
-    })
-
-    expect(fetchMock.mock.calls).toHaveLength(2)
-  })
-
-  test('rejects writes to dedicated fields through customFields on update', async () => {
-    const dedicatedFields = ['State', 'Priority', 'Assignee', 'Due Date'] as const
-
-    for (const fieldName of dedicatedFields) {
-      mockUpdateDedicatedFieldLookup(fieldName)
-
-      await expect(
-        updateYouTrackTask(config, 'TEST-1', {
-          customFields: [{ name: fieldName, value: 'value' }],
-        }),
-      ).rejects.toMatchObject({
-        appError: {
-          code: 'validation-failed',
-          field: 'customFields',
-        },
       })
-
-      expect(fetchMock.mock.calls).toHaveLength(2)
+      expect.unreachable('Should have thrown')
+    } catch (error) {
+      expect(error).toMatchObject({ appError: { code: 'validation-failed', field: 'customFields' } })
+      assert(error instanceof YouTrackClassifiedError)
+      expect(error.appError).toHaveProperty('field', 'customFields')
+      expect(error.appError).toHaveProperty('reason', expect.stringContaining('Unknown field'))
     }
+
+    expect(fetchMock.mock.calls).toHaveLength(2)
   })
 
   test('validates custom fields against the destination project when moving an issue', async () => {
@@ -1566,13 +1628,14 @@ describe('updateYouTrackTask', () => {
   })
 
   test('canonicalizes datetime input to date-only value when updating', async () => {
-    mockFetchResponse(makeIssueResponse())
+    mockUpdateWithDueDateField()
 
     await updateYouTrackTask(config, 'TEST-1', {
       dueDate: '2026-03-25T23:45:00.000Z',
     })
 
-    const body = getFetchBodyAt(0)
+    const postIdx = findUpdatePostCallIndex(fetchMock.mock.calls)
+    const body = getFetchBodyAt(postIdx)
     expect(body['customFields']).toContainEqual({
       name: 'Due Date',
       $type: 'DateIssueCustomField',
@@ -1581,13 +1644,13 @@ describe('updateYouTrackTask', () => {
   })
 
   test('rejects malformed due date before sending update request', async () => {
-    mockFetchResponse(makeIssueResponse())
+    mockUpdateWithMalformedDueDateField()
 
     await expect(updateYouTrackTask(config, 'TEST-1', { dueDate: 'not-a-date' })).rejects.toMatchObject({
       appError: { code: 'validation-failed', field: 'dueDate' },
     })
 
-    expect(fetchMock.mock.calls).toHaveLength(0)
+    expect(fetchMock.mock.calls).toHaveLength(2)
   })
 
   test('does not send fields when they are not provided', async () => {

--- a/tests/plugins/task-provider-youtrack/operations/tasks.test.ts
+++ b/tests/plugins/task-provider-youtrack/operations/tasks.test.ts
@@ -229,6 +229,25 @@ const mockCreateWithAssigneeField = (): void => {
   })
 }
 
+/** create with a localized project whose only enum is "Срочность" (no Priority-named field). */
+const mockCreateWithLocalizedEnumOnly = (): void => {
+  installRoutedFetchMock((url, init) => {
+    const p = new URL(url).pathname
+    const method = init.method ?? 'GET'
+    if (p === '/api/admin/projects/0-1' && method === 'GET') return jsonOk({ id: '0-1', shortName: 'AUDIT' })
+    if (p === '/api/admin/projects/0-1/customFields')
+      return jsonOk([
+        {
+          $type: 'EnumProjectCustomField',
+          field: { name: 'Срочность', fieldType: { id: 'enum[1]' } },
+          bundle: { id: 'eb-x', $type: 'EnumBundle' },
+          canBeEmpty: true,
+        },
+      ])
+    return jsonOk([])
+  })
+}
+
 /** create dueDate: project=1, schema (Due Date field)=2, POST=3, enrichment=4+ */
 const mockCreateWithDueDateField = (): void => {
   installRoutedFetchMock((url, init) => {
@@ -1221,6 +1240,23 @@ describe('createYouTrackTask', () => {
     // project lookup + admin customFields ([]) + issue-derived schema probe (also empty here),
     // after which the named field is confirmed unknown.
     expect(fetchMock.mock.calls).toHaveLength(3)
+  })
+
+  test('rejects a dedicated priority when the project has no Priority-named enum', async () => {
+    // The motivating AUDIT scenario: a localized project whose only enum is "Срочность" — there is
+    // no field named Priority/Приоритет, so priority must not silently pick an arbitrary enum.
+    mockCreateWithLocalizedEnumOnly()
+
+    try {
+      await createYouTrackTask(config, { projectId: '0-1', title: 'Test task', priority: 'Срочно' })
+      throw new Error('Expected createYouTrackTask to reject')
+    } catch (error) {
+      assert(error instanceof YouTrackClassifiedError)
+      expect(error.appError.code).toBe('validation-failed')
+      assert(error.appError.code === 'validation-failed')
+      expect(error.appError.field).toBe('customFields')
+      expect(error.appError.reason).toMatch(/priority/iu)
+    }
   })
 
   test('rejects a required enum custom field that has no resolvable bundle', async () => {

--- a/tests/plugins/task-provider-youtrack/operations/tasks.test.ts
+++ b/tests/plugins/task-provider-youtrack/operations/tasks.test.ts
@@ -1121,7 +1121,9 @@ describe('createYouTrackTask', () => {
       expect(error.appError.reason).toContain('Unknown field')
     }
 
-    expect(fetchMock.mock.calls).toHaveLength(2)
+    // project lookup + admin customFields ([]) + issue-derived schema probe (also empty here),
+    // after which the named field is confirmed unknown.
+    expect(fetchMock.mock.calls).toHaveLength(3)
   })
 
   test('rejects a required enum custom field that has no resolvable bundle', async () => {

--- a/tests/plugins/task-provider-youtrack/task-helpers.test.ts
+++ b/tests/plugins/task-provider-youtrack/task-helpers.test.ts
@@ -6,7 +6,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
 import {
-  buildCreateCustomFields,
+  buildIssueCustomFields,
   buildYouTrackQuery,
   mapYouTrackDueDateValue,
   validateRequiredCreateFields,
@@ -90,7 +90,7 @@ describe('task-helpers', () => {
     )
   })
 
-  test('adds supported create-time custom fields alongside standard fields', async () => {
+  test('builds a generic text custom field through the field engine', async () => {
     const config = createUniqueYouTrackConfig()
     const projectCustomFields = [
       {
@@ -107,25 +107,37 @@ describe('task-helpers', () => {
       },
     ] as const
 
-    // Priority not in project schema → legacy fallback; Environment details is TextProjectCustomField → engine
-    const result = await buildCreateCustomFields(
+    const result = await buildIssueCustomFields(
       config,
-      {
-        priority: 'High',
-        customFields: [{ name: 'Environment details', value: 'Needs staging parity' }],
-      },
+      { customFields: [{ name: 'Environment details', value: 'Needs staging parity' }] },
       projectCustomFields,
+      'create',
     )
 
-    expect(result).toContainEqual({
-      name: 'Priority',
-      $type: 'SingleEnumIssueCustomField',
-      value: { name: 'High' },
-    })
     expect(result).toContainEqual({
       name: 'Environment details',
       $type: 'TextIssueCustomField',
       value: { text: 'Needs staging parity' },
     })
+  })
+})
+
+describe('buildIssueCustomFields', () => {
+  test('resolves a dedicated status to the localized state field via the engine', async () => {
+    const config = createUniqueYouTrackConfig()
+    const projectCustomFields = [
+      {
+        $type: 'StateProjectCustomField',
+        field: { name: 'Cтaтус', fieldType: { id: 'state[1]' } },
+        canBeEmpty: false,
+        bundle: { id: 'sb-1', $type: 'StateBundle' },
+      },
+    ] as const
+    // resolveCustomFieldValue fetches the state bundle values once.
+    queueResponses([[{ name: 'Не разобрана' }, { name: 'Open' }]])
+
+    const result = await buildIssueCustomFields(config, { status: 'Open' }, projectCustomFields, 'create')
+
+    expect(result).toContainEqual({ name: 'Cтaтус', $type: 'StateIssueCustomField', value: { name: 'Open' } })
   })
 })


### PR DESCRIPTION
## Summary

Fixes YouTrack `create_task`/`update_task` failing in projects where the bot's token cannot read field settings and/or where fields are localized (e.g. the AUDIT project, whose fields are `Cтaтус`/`Oтветствeнный`/`Срочность`).

- **Issue-derived schema fallback** — when `GET /api/admin/projects/{id}/customFields` returns `[]` (token lacks project field-settings admin rights), derive the project field schema from a sample issue's `projectCustomField` sub-entity, which any issue reader can access. Opt-in, default off, so admin-readable projects are unchanged. Also accept `field.localizedName: null`.
- **Dedicated-param localization** — `status`/`assignee`/`priority`/`dueDate` now resolve to the project's real field **by type** (unique-or-fail with a canonical-name tiebreak; `priority` requires a name match since enums are non-unique) and flow through the field engine, instead of hard-coding English `State`/`Assignee`/`Priority` names. Removes `legacyDedicatedPayload`.
- **Teaching errors** — an unknown custom-field name now raises an error listing the available field names so the model self-corrects in the same turn.
- **`update_task` parity** — updates now set any field type via the field engine (not just string/text) and use the same issue-derived fallback.
- Backward compatible for English-named projects.

Design: `docs/superpowers/specs/2026-06-16-youtrack-dedicated-fields-and-teaching-errors-design.md`
Plan: `docs/superpowers/plans/2026-06-16-youtrack-dedicated-fields-and-teaching-errors.md`

## Test Plan

- [x] `bun check:full` — 12/12 (lint, typecheck, format, license, knip, server tests, client tests, duplicates, review-loop suite)
- [x] New unit + integration tests: issue-derived schema, `resolveDedicatedField` (localized/tiebreak/priority-rejection), `unknownFieldError`, create/update engine payloads, dedicated priority rejected on a localized project
- [x] Production-verified end-to-end: AUDIT-1403 created against the real restricted+localized project