### PR TITLE
fix(youtrack): preserve provider binding in apply_youtrack_command

### DIFF
--- a/docs/superpowers/plans/2026-06-16-memory-foundation.md
+++ b/docs/superpowers/plans/2026-06-16-memory-foundation.md
@@ -1,0 +1,1460 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Memory Foundation Implementation Plan (Plan 1 of 3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the storage + capture + embedding infrastructure for the cross-thread memory bridge: a provisional record tier, an idle-debounce capture pipeline that writes durable knowledge from even short threads, embeddings for semantic recall, and a scheduler backstop — all behind the `cross_thread_memory` flag (default OFF ⇒ reference-identical to today).
+
+**Architecture:** Extends the existing long-term memory subsystem (`src/long-term-memory/`) rather than adding a new table. `memory_records` gains a `thread_context_id` column and a `provisional` status; a new `memory_extraction_state` table tracks per-context activity/extraction watermarks. Capture runs the existing `extractMemoryPatch` extractor against a thread's history (debounced on idle, with a scheduler sweep backstop) and writes provisional, thread-tagged records with populated embeddings. The user-visible recall (`recall` tool, cascade, promotion) is built on this foundation in **Plan 2**.
+
+**Tech Stack:** Bun, TypeScript (strict, `.js` import paths), Drizzle ORM over `bun:sqlite`, Zod v4, Vercel AI SDK. Tests: `bun test --parallel` (`bun run test`), DI-first per `tests/CLAUDE.md`.
+
+**Scope note:** This plan is infrastructure. When the flag is ON it captures provisional records but does not yet surface them — Plan 2 (`recall` cascade + promotion) makes them user-visible. The acceptance test for "stop rediscovering" lives in Plan 2; Plan 1 is verified by unit/integration tests on each layer.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-16-cross-thread-memory-and-context-scope-design.md`
+
+---
+
+## File Structure
+
+| File                                          | Responsibility                                                                         | Change |
+| --------------------------------------------- | -------------------------------------------------------------------------------------- | ------ |
+| `src/db/migrations/056_provisional_memory.ts` | Add `thread_context_id`, create `memory_extraction_state`, add index                   | Create |
+| `src/db/index.ts`                             | Register migration 056                                                                 | Modify |
+| `src/db/long-term-memory-schema.ts`           | Drizzle: `threadContextId` column, `provisional` status, `memoryExtractionState` table | Modify |
+| `src/db/schema.ts`                            | Re-export `memoryExtractionState`                                                      | Modify |
+| `src/long-term-memory/types.ts`               | `provisional` status, `threadContextId`, `evidence.threads`                            | Modify |
+| `src/long-term-memory/store.ts`               | Persist/read `threadContextId`; `listProvisionalRecords`                               | Modify |
+| `src/tools/feature-flags.ts`                  | `crossThreadMemory` flag + `resolveCrossThreadMemoryFlag`                              | Modify |
+| `src/long-term-memory/semantic-search.ts`     | Cosine ranking over record embeddings                                                  | Create |
+| `src/long-term-memory/embedding-writer.ts`    | `saveMemoryRecordWithEmbedding` (save + fire-and-forget embed)                         | Create |
+| `src/long-term-memory/extraction-state.ts`    | `memory_extraction_state` read/write (watermarks)                                      | Create |
+| `src/long-term-memory/capture.ts`             | `runMemoryCapture` — extract → provisional records                                     | Create |
+| `src/long-term-memory/capture-debounce.ts`    | `armMemoryCapture` — per-context idle debounce                                         | Create |
+| `src/long-term-memory/capture-sweep.ts`       | `sweepDirtyContexts` — scheduler backstop                                              | Create |
+| `src/llm-history.ts`                          | Arm capture on each group-thread turn                                                  | Modify |
+| `src/scheduler-instance.ts`                   | Register the capture sweep                                                             | Modify |
+
+---
+
+## Task 1: Migration 056 + schema + types
+
+**Files:**
+
+- Create: `src/db/migrations/056_provisional_memory.ts`
+- Modify: `src/db/index.ts` (import + append to `MIGRATIONS`)
+- Modify: `src/db/long-term-memory-schema.ts`
+- Modify: `src/db/schema.ts`
+- Modify: `src/long-term-memory/types.ts`
+- Test: `tests/db/migration-056.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/db/migration-056.test.ts
+import { describe, expect, test } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { runMigrations } from '../../src/db/migrate.js'
+import { MIGRATIONS } from '../../src/db/index.js'
+
+const columnNames = (db: Database, table: string): string[] =>
+  db
+    .query<{ name: string }, []>(`PRAGMA table_info(${table})`)
+    .all()
+    .map((r) => r.name)
+
+const tableExists = (db: Database, table: string): boolean =>
+  db.query<{ name: string }, [string]>(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`).get(table) !==
+  null
+
+describe('migration 056', () => {
+  test('adds thread_context_id and memory_extraction_state', () => {
+    const db = new Database(':memory:')
+    runMigrations(db, MIGRATIONS)
+    expect(columnNames(db, 'memory_records')).toContain('thread_context_id')
+    expect(tableExists(db, 'memory_extraction_state')).toBe(true)
+    expect(columnNames(db, 'memory_extraction_state')).toEqual(
+      expect.arrayContaining([
+        'context_id',
+        'context_type',
+        'config_context_id',
+        'last_activity_at',
+        'last_extracted_at',
+        'last_history_len',
+      ]),
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/db/migration-056.test.ts`
+Expected: FAIL — `thread_context_id` not in column list / `memory_extraction_state` does not exist.
+
+- [ ] **Step 3: Create the migration**
+
+```typescript
+// src/db/migrations/056_provisional_memory.ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { Database } from 'bun:sqlite'
+
+import { logger } from '../../logger.js'
+import type { Migration } from '../migrate.js'
+
+const log = logger.child({ scope: 'migration:056' })
+
+const columnExists = (db: Database, table: string, column: string): boolean => {
+  const rows = db.query<{ name: string }, []>(`PRAGMA table_info(${table})`).all()
+  return rows.some((row) => row.name === column)
+}
+
+const up = (db: Database): void => {
+  if (!columnExists(db, 'memory_records', 'thread_context_id')) {
+    db.run(`ALTER TABLE memory_records ADD COLUMN thread_context_id TEXT`)
+  }
+  db.run(`CREATE INDEX IF NOT EXISTS idx_memory_records_thread
+    ON memory_records(scope_id, thread_context_id, status)`)
+  db.run(`CREATE TABLE IF NOT EXISTS memory_extraction_state (
+    context_id TEXT PRIMARY KEY,
+    context_type TEXT NOT NULL,
+    config_context_id TEXT NOT NULL,
+    last_activity_at TEXT NOT NULL,
+    last_extracted_at TEXT,
+    last_history_len INTEGER NOT NULL DEFAULT 0
+  )`)
+  log.info('migration 056: provisional memory tier + extraction-state added')
+}
+
+export const migration056ProvisionalMemory: Migration = {
+  id: '056_provisional_memory',
+  up,
+}
+
+export default migration056ProvisionalMemory
+```
+
+- [ ] **Step 4: Register the migration**
+
+In `src/db/index.ts`, add the import next to the other migration imports:
+
+```typescript
+import { migration056ProvisionalMemory } from './migrations/056_provisional_memory.js'
+```
+
+Append it as the **last** element of the `MIGRATIONS` array (after `migration055UserConfigKeyIndex`):
+
+```typescript
+  migration055UserConfigKeyIndex,
+  migration056ProvisionalMemory,
+]
+```
+
+- [ ] **Step 5: Update the Drizzle schema**
+
+In `src/db/long-term-memory-schema.ts`, add `provisional` to the status enum and the `threadContextId` column inside the `memoryRecords` definition (place `threadContextId` right after `status`):
+
+```typescript
+    status: text('status', { enum: ['active', 'stale', 'archived', 'contradicted', 'provisional'] }).notNull(),
+    threadContextId: text('thread_context_id'),
+```
+
+Append a new table + its row type at the end of the file:
+
+```typescript
+export const memoryExtractionState = sqliteTable('memory_extraction_state', {
+  contextId: text('context_id').primaryKey(),
+  contextType: text('context_type', { enum: ['dm', 'group'] }).notNull(),
+  configContextId: text('config_context_id').notNull(),
+  lastActivityAt: text('last_activity_at').notNull(),
+  lastExtractedAt: text('last_extracted_at'),
+  lastHistoryLen: integer('last_history_len').notNull().default(0),
+})
+
+export type MemoryExtractionStateRow = typeof memoryExtractionState.$inferSelect
+```
+
+- [ ] **Step 6: Re-export from `src/db/schema.ts`**
+
+Extend the existing long-term-memory re-export block:
+
+```typescript
+export {
+  memoryProfiles,
+  memoryRecords,
+  memoryExtractionState,
+  type MemoryProfileRow,
+  type MemoryRecordRow,
+  type MemoryExtractionStateRow,
+} from './long-term-memory-schema.js'
+```
+
+- [ ] **Step 7: Update domain types**
+
+In `src/long-term-memory/types.ts`:
+
+```typescript
+// widen the status enum
+export const MemoryStatusSchema = z.enum(['active', 'stale', 'archived', 'contradicted', 'provisional'])
+
+// add `threads` to MemoryEvidence
+export type MemoryEvidence = Readonly<{
+  messageIds?: readonly string[]
+  actorIds?: readonly string[]
+  timestamps?: readonly string[]
+  contextId?: string
+  threads?: readonly string[]
+}>
+
+// add threadContextId to MemoryRecord (after `evidence`)
+//   threadContextId?: string | null
+```
+
+Add `threadContextId?: string | null` to the `MemoryRecord` type body. `MemoryRecordInput` inherits it via `Omit<MemoryRecord, 'embedding'>`.
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `bun test tests/db/migration-056.test.ts`
+Expected: PASS.
+
+- [ ] **Step 9: Typecheck + commit**
+
+```bash
+bun typecheck
+git add src/db/migrations/056_provisional_memory.ts src/db/index.ts src/db/long-term-memory-schema.ts src/db/schema.ts src/long-term-memory/types.ts tests/db/migration-056.test.ts
+git commit -m "feat(memory): provisional record tier + extraction-state schema (056)"
+```
+
+---
+
+## Task 2: Store — persist `threadContextId` + `listProvisionalRecords`
+
+**Files:**
+
+- Modify: `src/long-term-memory/store.ts`
+- Test: `tests/long-term-memory/provisional-store.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/long-term-memory/provisional-store.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { setupTestDb } from '../utils/test-helpers.js'
+import { saveMemoryRecord, listProvisionalRecords } from '../../src/long-term-memory/store.js'
+import type { MemoryRecordInput } from '../../src/long-term-memory/types.js'
+
+const provisional = (overrides: Partial<MemoryRecordInput>): MemoryRecordInput => ({
+  id: 'mem-1',
+  scopeId: 'group-1',
+  scopeType: 'group',
+  kind: 'fact',
+  content: 'Deploys happen on Fridays.',
+  summary: null,
+  tags: [],
+  confidence: 0.5,
+  status: 'provisional',
+  source: 'background',
+  evidence: { threads: ['thread-a'], contextId: 'thread-a' },
+  threadContextId: 'thread-a',
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  lastSeenAt: '2026-06-11T00:00:00.000Z',
+  ...overrides,
+})
+
+describe('provisional record store', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('round-trips thread_context_id', () => {
+    saveMemoryRecord(provisional({ id: 'mem-1' }))
+    const rows = listProvisionalRecords({ scopeId: 'group-1', scopeType: 'group' })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.threadContextId).toBe('thread-a')
+    expect(rows[0]?.status).toBe('provisional')
+  })
+
+  test('filters by thread and excludes other statuses', () => {
+    saveMemoryRecord(provisional({ id: 'mem-1', threadContextId: 'thread-a' }))
+    saveMemoryRecord(provisional({ id: 'mem-2', threadContextId: 'thread-b' }))
+    saveMemoryRecord(provisional({ id: 'mem-3', status: 'active', threadContextId: null, evidence: {} }))
+    expect(
+      listProvisionalRecords({ scopeId: 'group-1', scopeType: 'group', threadContextId: 'thread-a' }),
+    ).toHaveLength(1)
+    expect(
+      listProvisionalRecords({ scopeId: 'group-1', scopeType: 'group', excludeThreadContextId: 'thread-a' }),
+    ).toHaveLength(1)
+    expect(listProvisionalRecords({ scopeId: 'group-1', scopeType: 'group' })).toHaveLength(2)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/long-term-memory/provisional-store.test.ts`
+Expected: FAIL — `listProvisionalRecords` not exported; `threadContextId` undefined on results.
+
+- [ ] **Step 3: Persist + read `threadContextId`**
+
+In `src/long-term-memory/store.ts`, add `threadContextId` to `rowToRecord` (after `evidence`):
+
+```typescript
+  threadContextId: row.threadContextId ?? null,
+```
+
+Add it to `inputToRecordValues` (after `evidence`):
+
+```typescript
+  threadContextId: input.threadContextId ?? null,
+```
+
+- [ ] **Step 4: Add `listProvisionalRecords`**
+
+Append to `src/long-term-memory/store.ts`:
+
+```typescript
+export type ListProvisionalFilter = MemoryScope &
+  Readonly<{ threadContextId?: string; excludeThreadContextId?: string; limit?: number }>
+
+export function listProvisionalRecords(filter: ListProvisionalFilter): readonly MemoryRecord[] {
+  const conditions: SQL[] = [
+    eq(memoryRecords.scopeId, filter.scopeId),
+    eq(memoryRecords.scopeType, filter.scopeType),
+    eq(memoryRecords.status, 'provisional'),
+  ]
+  if (filter.threadContextId !== undefined) {
+    conditions.push(eq(memoryRecords.threadContextId, filter.threadContextId))
+  }
+  if (filter.excludeThreadContextId !== undefined) {
+    conditions.push(ne(memoryRecords.threadContextId, filter.excludeThreadContextId))
+  }
+  return getDrizzleDb()
+    .select()
+    .from(memoryRecords)
+    .where(and(...conditions))
+    .orderBy(desc(memoryRecords.lastSeenAt))
+    .limit(filter.limit ?? DEFAULT_LIST_LIMIT)
+    .all()
+    .map(rowToRecord)
+}
+```
+
+Add `ne` to the `drizzle-orm` import on line 6: `import { and, desc, eq, inArray, ne, sql, type SQL } from 'drizzle-orm'`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bun test tests/long-term-memory/provisional-store.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/long-term-memory/store.ts tests/long-term-memory/provisional-store.test.ts
+git commit -m "feat(memory): persist thread_context_id + listProvisionalRecords"
+```
+
+---
+
+## Task 3: Feature flag `cross_thread_memory`
+
+**Files:**
+
+- Modify: `src/tools/feature-flags.ts`
+- Test: `tests/tools/feature-flags-cross-thread.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/tools/feature-flags-cross-thread.test.ts
+import { describe, expect, test } from 'bun:test'
+import { parseReductionFlagsJson } from '../../src/tools/feature-flags.js'
+
+describe('cross_thread_memory flag', () => {
+  test('off by default', () => {
+    expect(parseReductionFlagsJson(null).crossThreadMemory).toBe(false)
+    expect(parseReductionFlagsJson('{}').crossThreadMemory).toBe(false)
+  })
+  test('only literal true enables it', () => {
+    expect(parseReductionFlagsJson('{"cross_thread_memory":true}').crossThreadMemory).toBe(true)
+    expect(parseReductionFlagsJson('{"cross_thread_memory":"true"}').crossThreadMemory).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/tools/feature-flags-cross-thread.test.ts`
+Expected: FAIL — `crossThreadMemory` does not exist on the result type.
+
+- [ ] **Step 3: Add the flag**
+
+In `src/tools/feature-flags.ts`: add `crossThreadMemory: boolean` to the `ReductionFlags` interface, `crossThreadMemory: false` to `ALL_OFF`, this line inside the `parseReductionFlagsJson` returned object:
+
+```typescript
+      crossThreadMemory: parsed['cross_thread_memory'] === true,
+```
+
+Append a convenience resolver at the end of the file:
+
+```typescript
+/** True when the cross-thread memory bridge is enabled for this storage context. */
+export function resolveCrossThreadMemoryFlag(storageContextId: string): boolean {
+  return resolveReductionFlags(storageContextId).crossThreadMemory
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/tools/feature-flags-cross-thread.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/feature-flags.ts tests/tools/feature-flags-cross-thread.test.ts
+git commit -m "feat(memory): cross_thread_memory feature flag"
+```
+
+---
+
+## Task 4: Semantic search over record embeddings
+
+**Files:**
+
+- Create: `src/long-term-memory/semantic-search.ts`
+- Test: `tests/long-term-memory/semantic-search.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/long-term-memory/semantic-search.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { setupTestDb } from '../utils/test-helpers.js'
+import { saveMemoryRecord } from '../../src/long-term-memory/store.js'
+import { rankRecordsBySimilarity } from '../../src/long-term-memory/semantic-search.js'
+import type { MemoryRecordInput } from '../../src/long-term-memory/types.js'
+
+const rec = (id: string, embedding: Float32Array): MemoryRecordInput => ({
+  id,
+  scopeId: 'group-1',
+  scopeType: 'group',
+  kind: 'fact',
+  content: id,
+  summary: null,
+  tags: [],
+  confidence: 1,
+  status: 'active',
+  source: 'background',
+  evidence: {},
+  embedding,
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  lastSeenAt: '2026-06-11T00:00:00.000Z',
+})
+
+describe('rankRecordsBySimilarity', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('returns nearest record first, drops below threshold', () => {
+    saveMemoryRecord(rec('near', new Float32Array([1, 0, 0])))
+    saveMemoryRecord(rec('far', new Float32Array([0, 1, 0])))
+    const out = rankRecordsBySimilarity({ scopeId: 'group-1', scopeType: 'group' }, [1, 0, 0], {
+      threshold: 0.65,
+      limit: 10,
+    })
+    expect(out.map((r) => r.id)).toEqual(['near'])
+  })
+
+  test('empty when no embeddings stored', () => {
+    saveMemoryRecord({ ...rec('x', new Float32Array([1, 0, 0])), embedding: null })
+    expect(rankRecordsBySimilarity({ scopeId: 'group-1', scopeType: 'group' }, [1, 0, 0], {})).toHaveLength(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/long-term-memory/semantic-search.test.ts`
+Expected: FAIL — module `semantic-search.js` not found.
+
+- [ ] **Step 3: Implement the module**
+
+```typescript
+// src/long-term-memory/semantic-search.ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { and, eq, inArray, type SQL } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { memoryRecords, type MemoryRecordRow } from '../db/schema.js'
+import type { MemoryRecord, MemoryScope, MemoryStatus } from './types.js'
+import { listMemoryRecords } from './store.js'
+
+export type SimilarityOptions = Readonly<{
+  threshold?: number
+  limit?: number
+  statuses?: readonly MemoryStatus[]
+}>
+
+const DEFAULT_THRESHOLD = 0.65
+const DEFAULT_LIMIT = 10
+
+const toFloat32 = (embedding: MemoryRecordRow['embedding']): Float32Array | null => {
+  if (embedding === null) return null
+  if (embedding instanceof ArrayBuffer) return new Float32Array(embedding.slice(0))
+  if (ArrayBuffer.isView(embedding)) {
+    const copy = new Uint8Array(embedding.byteLength)
+    copy.set(new Uint8Array(embedding.buffer, embedding.byteOffset, embedding.byteLength))
+    return new Float32Array(copy.buffer)
+  }
+  return null
+}
+
+export const cosineSimilarity = (a: readonly number[], b: Float32Array): number => {
+  if (a.length !== b.length) return 0
+  let dot = 0
+  let normA = 0
+  let normB = 0
+  for (let i = 0; i < a.length; i += 1) {
+    const av = a[i] ?? 0
+    const bv = b[i] ?? 0
+    dot += av * bv
+    normA += av * av
+    normB += bv * bv
+  }
+  if (normA === 0 || normB === 0) return 0
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB))
+}
+
+/** Rank stored records in a scope against a query embedding by cosine similarity. */
+export function rankRecordsBySimilarity(
+  scope: MemoryScope,
+  queryEmbedding: readonly number[],
+  options: SimilarityOptions,
+): readonly MemoryRecord[] {
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD
+  const limit = options.limit ?? DEFAULT_LIMIT
+  const statuses = options.statuses ?? ['active']
+
+  const conditions: SQL[] = [eq(memoryRecords.scopeId, scope.scopeId), eq(memoryRecords.scopeType, scope.scopeType)]
+  conditions.push(inArray(memoryRecords.status, [...statuses]))
+
+  const rows = getDrizzleDb()
+    .select()
+    .from(memoryRecords)
+    .where(and(...conditions))
+    .all()
+  const scored = rows
+    .map((row) => ({ row, vec: toFloat32(row.embedding) }))
+    .filter((entry): entry is { row: MemoryRecordRow; vec: Float32Array } => entry.vec !== null)
+    .map((entry) => ({ id: entry.row.id, score: cosineSimilarity(queryEmbedding, entry.vec) }))
+    .filter((entry) => entry.score >= threshold)
+    .sort((left, right) => right.score - left.score)
+    .slice(0, limit)
+
+  if (scored.length === 0) return []
+  const byId = new Map(
+    listMemoryRecords({ scopeId: scope.scopeId, scopeType: scope.scopeType, limit: 1000 }).map((r) => [r.id, r]),
+  )
+  return scored.map((entry) => byId.get(entry.id)).filter((r): r is MemoryRecord => r !== undefined)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/long-term-memory/semantic-search.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/long-term-memory/semantic-search.ts tests/long-term-memory/semantic-search.test.ts
+git commit -m "feat(memory): cosine semantic ranking over record embeddings"
+```
+
+---
+
+## Task 5: Embedding-writing save wrapper
+
+**Files:**
+
+- Create: `src/long-term-memory/embedding-writer.ts`
+- Test: `tests/long-term-memory/embedding-writer.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/long-term-memory/embedding-writer.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { setupTestDb } from '../utils/test-helpers.js'
+import { listMemoryRecords } from '../../src/long-term-memory/store.js'
+import { saveMemoryRecordWithEmbedding } from '../../src/long-term-memory/embedding-writer.js'
+import type { MemoryRecordInput } from '../../src/long-term-memory/types.js'
+
+const input = (): MemoryRecordInput => ({
+  id: 'mem-1',
+  scopeId: 'group-1',
+  scopeType: 'group',
+  kind: 'fact',
+  content: 'X',
+  summary: null,
+  tags: [],
+  confidence: 1,
+  status: 'provisional',
+  source: 'background',
+  evidence: {},
+  threadContextId: 't',
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  lastSeenAt: '2026-06-11T00:00:00.000Z',
+})
+
+describe('saveMemoryRecordWithEmbedding', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('saves the row synchronously and applies the embedding when it resolves', async () => {
+    const saved = await saveMemoryRecordWithEmbedding(input(), 'cfg-1', {
+      getEmbedding: () => Promise.resolve([0.1, 0.2, 0.3]),
+    })
+    expect(saved.id).toBe('mem-1')
+    const [row] = listMemoryRecords({ scopeId: 'group-1', scopeType: 'group', limit: 10 })
+    expect(Array.from(row?.embedding ?? [])).toEqual(expect.arrayContaining([expect.any(Number)]))
+    expect(row?.embedding).not.toBeNull()
+  })
+
+  test('still saves the row when embedding is unavailable', async () => {
+    const saved = await saveMemoryRecordWithEmbedding(input(), 'cfg-1', { getEmbedding: () => Promise.resolve(null) })
+    expect(saved.id).toBe('mem-1')
+    const [row] = listMemoryRecords({ scopeId: 'group-1', scopeType: 'group', limit: 10 })
+    expect(row?.embedding ?? null).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/long-term-memory/embedding-writer.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the wrapper**
+
+```typescript
+// src/long-term-memory/embedding-writer.ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { eq } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { memoryRecords } from '../db/schema.js'
+import { getEmbeddingForContext } from '../embeddings.js'
+import { logger } from '../logger.js'
+import { saveMemoryRecord } from './store.js'
+import type { MemoryRecord, MemoryRecordInput } from './types.js'
+
+const log = logger.child({ scope: 'memory:embedding-writer' })
+
+export type EmbeddingWriterDeps = Readonly<{
+  getEmbedding: (text: string, configContextId: string) => Promise<number[] | null>
+}>
+
+const defaultDeps: EmbeddingWriterDeps = {
+  getEmbedding: (text, configContextId) =>
+    getEmbeddingForContext(text, configContextId, {
+      storageContextId: configContextId,
+      contextType: 'group',
+      chatUserId: configContextId,
+    }),
+}
+
+const persistEmbedding = (recordId: string, embedding: number[]): void => {
+  const buffer = Buffer.from(new Float32Array(embedding).buffer)
+  getDrizzleDb().update(memoryRecords).set({ embedding: buffer }).where(eq(memoryRecords.id, recordId)).run()
+}
+
+/**
+ * Save a record, then asynchronously compute + persist its embedding.
+ * Awaits embedding completion (so promotion clustering can rely on it) but never throws on embed failure.
+ */
+export async function saveMemoryRecordWithEmbedding(
+  input: MemoryRecordInput,
+  configContextId: string,
+  deps: EmbeddingWriterDeps = defaultDeps,
+): Promise<MemoryRecord> {
+  const saved = saveMemoryRecord(input)
+  try {
+    const embedding = await deps.getEmbedding(input.content, configContextId)
+    if (embedding !== null) persistEmbedding(saved.id, embedding)
+  } catch (error) {
+    log.warn(
+      { recordId: saved.id, error: error instanceof Error ? error.message : String(error) },
+      'Embedding failed; FTS fallback',
+    )
+  }
+  return saved
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/long-term-memory/embedding-writer.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/long-term-memory/embedding-writer.ts tests/long-term-memory/embedding-writer.test.ts
+git commit -m "feat(memory): save records with populated embeddings"
+```
+
+---
+
+## Task 6: Extraction-state watermark store
+
+**Files:**
+
+- Create: `src/long-term-memory/extraction-state.ts`
+- Test: `tests/long-term-memory/extraction-state.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/long-term-memory/extraction-state.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { setupTestDb } from '../utils/test-helpers.js'
+import { markActivity, markExtracted, listDirtyContexts } from '../../src/long-term-memory/extraction-state.js'
+
+describe('extraction-state watermarks', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('a context with newer activity than extraction is dirty once idle', () => {
+    markActivity(
+      { contextId: 'c1', contextType: 'group', configContextId: 'cfg1', historyLen: 4 },
+      '2026-06-16T10:00:00.000Z',
+    )
+    // never extracted -> dirty when the idle cutoff is after its activity
+    expect(listDirtyContexts('2026-06-16T10:10:00.000Z').map((c) => c.contextId)).toEqual(['c1'])
+    markExtracted('c1', 4, '2026-06-16T10:11:00.000Z')
+    expect(listDirtyContexts('2026-06-16T10:20:00.000Z')).toHaveLength(0)
+  })
+
+  test('not dirty while still active (within idle window)', () => {
+    markActivity(
+      { contextId: 'c1', contextType: 'group', configContextId: 'cfg1', historyLen: 4 },
+      '2026-06-16T10:09:50.000Z',
+    )
+    expect(listDirtyContexts('2026-06-16T10:10:00.000Z', 60_000)).toHaveLength(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/long-term-memory/extraction-state.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/long-term-memory/extraction-state.ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { and, eq, isNull, lte, or, sql } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { memoryExtractionState, type MemoryExtractionStateRow } from '../db/schema.js'
+import type { ContextType } from '../chat/types.js'
+
+export const DEFAULT_IDLE_MS = 600_000 // ~10 min — matches MEMORY_CAPTURE_DEBOUNCE_MS
+
+export type ActivityInput = Readonly<{
+  contextId: string
+  contextType: ContextType
+  configContextId: string
+  historyLen: number
+}>
+
+export function markActivity(input: ActivityInput, now: string): void {
+  getDrizzleDb()
+    .insert(memoryExtractionState)
+    .values({
+      contextId: input.contextId,
+      contextType: input.contextType,
+      configContextId: input.configContextId,
+      lastActivityAt: now,
+      lastHistoryLen: input.historyLen,
+    })
+    .onConflictDoUpdate({
+      target: memoryExtractionState.contextId,
+      set: {
+        contextType: input.contextType,
+        configContextId: input.configContextId,
+        lastActivityAt: now,
+        lastHistoryLen: input.historyLen,
+      },
+    })
+    .run()
+}
+
+export function markExtracted(contextId: string, historyLen: number, now: string): void {
+  getDrizzleDb()
+    .update(memoryExtractionState)
+    .set({ lastExtractedAt: now, lastHistoryLen: historyLen })
+    .where(eq(memoryExtractionState.contextId, contextId))
+    .run()
+}
+
+/** Contexts with unextracted activity that have been idle for at least `idleMs`. */
+export function listDirtyContexts(now: string, idleMs: number = DEFAULT_IDLE_MS): readonly MemoryExtractionStateRow[] {
+  const cutoff = new Date(new Date(now).getTime() - idleMs).toISOString()
+  return getDrizzleDb()
+    .select()
+    .from(memoryExtractionState)
+    .where(
+      and(
+        lte(memoryExtractionState.lastActivityAt, cutoff),
+        or(
+          isNull(memoryExtractionState.lastExtractedAt),
+          sql`${memoryExtractionState.lastActivityAt} > ${memoryExtractionState.lastExtractedAt}`,
+        ),
+      ),
+    )
+    .all()
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/long-term-memory/extraction-state.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/long-term-memory/extraction-state.ts tests/long-term-memory/extraction-state.test.ts
+git commit -m "feat(memory): extraction-state watermark store"
+```
+
+---
+
+## Task 7: Capture executor
+
+**Files:**
+
+- Create: `src/long-term-memory/capture.ts`
+- Test: `tests/long-term-memory/capture.test.ts`
+
+The executor runs the existing `extractMemoryPatch`, writes each extracted fact as a **provisional** group-scoped record tagged with the current thread, and updates the watermark. It is a no-op for DM contexts, when the flag is off, or when the group profile has capture disabled.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/long-term-memory/capture.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { setupTestDb } from '../utils/test-helpers.js'
+import { listProvisionalRecords } from '../../src/long-term-memory/store.js'
+import { runMemoryCapture } from '../../src/long-term-memory/capture.js'
+import type { MemoryPatch } from '../../src/long-term-memory/extractor.js'
+
+const patch: MemoryPatch = {
+  profile: null,
+  records: [
+    {
+      kind: 'fact',
+      content: 'Deploys happen on Fridays.',
+      summary: null,
+      tags: [],
+      confidence: 0.5,
+      source: 'background',
+      evidence: {},
+    },
+  ],
+  updates: [],
+}
+
+describe('runMemoryCapture', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('writes provisional records tagged with the current thread', async () => {
+    await runMemoryCapture(
+      {
+        storageContextId: 'group-1:thread:abc',
+        configContextId: 'group-1',
+        contextType: 'group',
+        history: [{ role: 'user', content: 'hi' }],
+      },
+      {
+        flagEnabled: () => true,
+        extractMemoryPatch: () => Promise.resolve(patch),
+        getEmbedding: () => Promise.resolve(null),
+        now: () => '2026-06-16T00:00:00.000Z',
+        randomUUID: () => 'mem-new',
+      },
+    )
+    const rows = listProvisionalRecords({ scopeId: 'group-1', scopeType: 'group' })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.threadContextId).toBe('group-1:thread:abc')
+    expect(rows[0]?.evidence.threads).toEqual(['group-1:thread:abc'])
+    expect(rows[0]?.scopeType).toBe('group')
+  })
+
+  test('no-op when the flag is off', async () => {
+    await runMemoryCapture(
+      {
+        storageContextId: 'group-1:thread:abc',
+        configContextId: 'group-1',
+        contextType: 'group',
+        history: [{ role: 'user', content: 'hi' }],
+      },
+      {
+        flagEnabled: () => false,
+        extractMemoryPatch: () => Promise.resolve(patch),
+        getEmbedding: () => Promise.resolve(null),
+        now: () => 'x',
+        randomUUID: () => 'y',
+      },
+    )
+    expect(listProvisionalRecords({ scopeId: 'group-1', scopeType: 'group' })).toHaveLength(0)
+  })
+
+  test('no-op for DM contexts', async () => {
+    await runMemoryCapture(
+      {
+        storageContextId: 'user-1',
+        configContextId: 'user-1',
+        contextType: 'dm',
+        history: [{ role: 'user', content: 'hi' }],
+      },
+      {
+        flagEnabled: () => true,
+        extractMemoryPatch: () => Promise.resolve(patch),
+        getEmbedding: () => Promise.resolve(null),
+        now: () => 'x',
+        randomUUID: () => 'y',
+      },
+    )
+    expect(listProvisionalRecords({ scopeId: 'user-1', scopeType: 'group' })).toHaveLength(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/long-term-memory/capture.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the executor**
+
+```typescript
+// src/long-term-memory/capture.ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { randomUUID } from 'node:crypto'
+
+import type { ModelMessage } from 'ai'
+
+import { hasThreadContextId } from '../chat/scoped-context.js'
+import type { ContextType } from '../chat/types.js'
+import { getEmbeddingForContext } from '../embeddings.js'
+import { resolveEffectiveLlmConfig } from '../llm-config-resolver.js'
+import { buildChatModel } from '../llm-model-builder.js'
+import { logger } from '../logger.js'
+import { resolveCrossThreadMemoryFlag } from '../tools/feature-flags.js'
+import { saveMemoryRecordWithEmbedding } from './embedding-writer.js'
+import { markExtracted } from './extraction-state.js'
+import { extractMemoryPatch, type MemoryPatch } from './extractor.js'
+import { resolveMemoryScope } from './scope.js'
+import { getMemoryProfile } from './store.js'
+import type { MemoryRecordInput } from './types.js'
+
+const log = logger.child({ scope: 'memory:capture' })
+
+const EMPTY_PATCH: MemoryPatch = { profile: null, records: [], updates: [] }
+
+export type RunMemoryCaptureInput = Readonly<{
+  storageContextId: string
+  configContextId: string
+  contextType: ContextType
+  history: readonly ModelMessage[]
+}>
+
+export type CaptureExtractInput = Readonly<{
+  history: readonly ModelMessage[]
+  profile: string
+  configContextId: string
+}>
+
+export type RunMemoryCaptureDeps = Readonly<{
+  flagEnabled: (storageContextId: string) => boolean
+  extractMemoryPatch: (input: CaptureExtractInput) => Promise<MemoryPatch>
+  getEmbedding: (text: string, configContextId: string) => Promise<number[] | null>
+  now: () => string
+  randomUUID: () => string
+}>
+
+// Production extractor: resolves BYOK-aware config, builds the small model exactly like runner.ts,
+// then calls the shared extractMemoryPatch. Returns an empty patch (no-op) when config is unavailable.
+const defaultExtract = (input: CaptureExtractInput): Promise<MemoryPatch> => {
+  const resolved = resolveEffectiveLlmConfig(input.configContextId)
+  if (!resolved.ok) {
+    log.warn(
+      { configContextId: input.configContextId, source: resolved.source, type: resolved.type },
+      'LLM config unavailable for capture',
+    )
+    return Promise.resolve(EMPTY_PATCH)
+  }
+  const model = buildChatModel(resolved.llmApiKey, resolved.llmBaseUrl, resolved.smallModel)
+  return extractMemoryPatch({ history: input.history, profile: input.profile, records: [], model })
+}
+
+const defaultDeps: RunMemoryCaptureDeps = {
+  flagEnabled: resolveCrossThreadMemoryFlag,
+  extractMemoryPatch: defaultExtract,
+  getEmbedding: (text, configContextId) =>
+    getEmbeddingForContext(text, configContextId, {
+      storageContextId: configContextId,
+      contextType: 'group',
+      chatUserId: configContextId,
+    }),
+  now: () => new Date().toISOString(),
+  randomUUID: () => randomUUID(),
+}
+
+export async function runMemoryCapture(
+  input: RunMemoryCaptureInput,
+  deps: RunMemoryCaptureDeps = defaultDeps,
+): Promise<void> {
+  if (!deps.flagEnabled(input.storageContextId)) return
+  if (input.contextType !== 'group' || !hasThreadContextId(input.storageContextId)) return
+
+  const scope = resolveMemoryScope({ storageContextId: input.storageContextId, contextType: input.contextType })
+  const profile = getMemoryProfile(scope)
+  if (profile?.enabled === false) return
+
+  let patch: MemoryPatch
+  try {
+    patch = await deps.extractMemoryPatch({
+      history: input.history,
+      profile: profile?.profile ?? '',
+      configContextId: input.configContextId,
+    })
+  } catch (error) {
+    log.warn(
+      { contextId: input.storageContextId, error: error instanceof Error ? error.message : String(error) },
+      'Capture extraction failed',
+    )
+    return
+  }
+
+  const now = deps.now()
+  for (const candidate of patch.records) {
+    const record: MemoryRecordInput = {
+      id: deps.randomUUID(),
+      scopeId: scope.scopeId,
+      scopeType: scope.scopeType,
+      kind: candidate.kind,
+      content: candidate.content,
+      summary: candidate.summary ?? null,
+      tags: candidate.tags,
+      confidence: candidate.confidence,
+      status: 'provisional',
+      source: 'background',
+      evidence: { ...candidate.evidence, threads: [input.storageContextId], contextId: input.storageContextId },
+      threadContextId: input.storageContextId,
+      createdAt: now,
+      updatedAt: now,
+      lastSeenAt: now,
+    }
+    await saveMemoryRecordWithEmbedding(record, input.configContextId, { getEmbedding: deps.getEmbedding })
+  }
+
+  markExtracted(input.storageContextId, input.history.length, now)
+  log.debug({ contextId: input.storageContextId, captured: patch.records.length }, 'Memory capture complete')
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/long-term-memory/capture.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/long-term-memory/capture.ts tests/long-term-memory/capture.test.ts
+git commit -m "feat(memory): provisional capture executor"
+```
+
+---
+
+## Task 8: Idle-debounce manager + turn-path wiring
+
+**Files:**
+
+- Create: `src/long-term-memory/capture-debounce.ts`
+- Modify: `src/llm-history.ts`
+- Test: `tests/long-term-memory/capture-debounce.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/long-term-memory/capture-debounce.test.ts
+import { describe, expect, test } from 'bun:test'
+import { armMemoryCapture } from '../../src/long-term-memory/capture-debounce.js'
+
+describe('armMemoryCapture', () => {
+  test('coalesces rapid arms into a single deferred capture', async () => {
+    let captures = 0
+    const timers = new Map<string, () => void>()
+    const deps = {
+      flagEnabled: () => true,
+      markActivity: () => undefined,
+      runCapture: () => {
+        captures += 1
+        return Promise.resolve()
+      },
+      schedule: (fn: () => void) => {
+        timers.set('t', fn)
+        return 't' as unknown as ReturnType<typeof setTimeout>
+      },
+      clear: () => timers.delete('t'),
+      debounceMs: 600_000,
+      now: () => '2026-06-16T00:00:00.000Z',
+    }
+    const input = { storageContextId: 'g:thread:a', configContextId: 'g', contextType: 'group' as const, history: [] }
+    armMemoryCapture(input, deps)
+    armMemoryCapture(input, deps)
+    expect(captures).toBe(0) // nothing fired yet
+    timers.get('t')?.() // simulate the debounce elapsing
+    await Promise.resolve()
+    expect(captures).toBe(1) // exactly one capture despite two arms
+  })
+
+  test('no-op when flag disabled', () => {
+    let activity = 0
+    armMemoryCapture(
+      { storageContextId: 'g:thread:a', configContextId: 'g', contextType: 'group', history: [] },
+      {
+        flagEnabled: () => false,
+        markActivity: () => {
+          activity += 1
+        },
+        runCapture: () => Promise.resolve(),
+        schedule: () => 0 as unknown as ReturnType<typeof setTimeout>,
+        clear: () => undefined,
+        debounceMs: 1,
+        now: () => 'x',
+      },
+    )
+    expect(activity).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/long-term-memory/capture-debounce.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the debounce manager**
+
+```typescript
+// src/long-term-memory/capture-debounce.ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { ModelMessage } from 'ai'
+
+import type { ContextType } from '../chat/types.js'
+import { logger } from '../logger.js'
+import { resolveCrossThreadMemoryFlag } from '../tools/feature-flags.js'
+import { runMemoryCapture, type RunMemoryCaptureInput } from './capture.js'
+import { markActivity } from './extraction-state.js'
+
+const log = logger.child({ scope: 'memory:capture-debounce' })
+
+export const MEMORY_CAPTURE_DEBOUNCE_MS = 600_000 // ~10 min
+
+export type ArmCaptureDeps = Readonly<{
+  flagEnabled: (storageContextId: string) => boolean
+  markActivity: (input: RunMemoryCaptureInput, historyLen: number, now: string) => void
+  runCapture: (input: RunMemoryCaptureInput) => Promise<void>
+  schedule: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
+  clear: (timer: ReturnType<typeof setTimeout>) => void
+  debounceMs: number
+  now: () => string
+}>
+
+const pending = new Map<string, ReturnType<typeof setTimeout>>()
+
+const defaultDeps: ArmCaptureDeps = {
+  flagEnabled: resolveCrossThreadMemoryFlag,
+  markActivity: (input, historyLen, now) =>
+    markActivity(
+      {
+        contextId: input.storageContextId,
+        contextType: input.contextType,
+        configContextId: input.configContextId,
+        historyLen,
+      },
+      now,
+    ),
+  runCapture: (input) => runMemoryCapture(input),
+  schedule: (fn, ms) => setTimeout(fn, ms),
+  clear: (timer) => clearTimeout(timer),
+  debounceMs: MEMORY_CAPTURE_DEBOUNCE_MS,
+  now: () => new Date().toISOString(),
+}
+
+/** Record activity and (re)arm a debounced capture for this context. Safe to call every turn. */
+export function armMemoryCapture(input: RunMemoryCaptureInput, deps: ArmCaptureDeps = defaultDeps): void {
+  if (!deps.flagEnabled(input.storageContextId)) return
+  if (input.contextType !== 'group') return
+
+  deps.markActivity(input, input.history.length, deps.now())
+
+  const existing = pending.get(input.storageContextId)
+  if (existing !== undefined) deps.clear(existing)
+
+  const timer = deps.schedule(() => {
+    pending.delete(input.storageContextId)
+    void deps.runCapture(input).catch((error) => {
+      log.warn(
+        { contextId: input.storageContextId, error: error instanceof Error ? error.message : String(error) },
+        'Debounced capture failed',
+      )
+    })
+  }, deps.debounceMs)
+  pending.set(input.storageContextId, timer)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/long-term-memory/capture-debounce.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into the turn path**
+
+In `src/llm-history.ts`, add the import:
+
+```typescript
+import { armMemoryCapture } from './long-term-memory/capture-debounce.js'
+```
+
+Immediately **after** the existing `if (shouldTriggerTrim(...)) { ... }` block (the one that calls `runMemoryExtractionInBackground`), add an unconditional arm (it self-gates on the flag + group context):
+
+```typescript
+armMemoryCapture({ storageContextId: contextId, configContextId: configId, contextType, history: combined })
+```
+
+- [ ] **Step 6: Run the memory suite + typecheck**
+
+Run: `bun test tests/long-term-memory/ && bun typecheck`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/long-term-memory/capture-debounce.ts src/llm-history.ts tests/long-term-memory/capture-debounce.test.ts
+git commit -m "feat(memory): idle-debounce capture armed from the turn path"
+```
+
+---
+
+## Task 9: Scheduler backstop sweep
+
+**Files:**
+
+- Create: `src/long-term-memory/capture-sweep.ts`
+- Modify: `src/scheduler-instance.ts`
+- Test: `tests/long-term-memory/capture-sweep.test.ts`
+
+The sweep recovers debounced captures lost to a restart: it finds idle, unextracted contexts, loads their history, and runs capture.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/long-term-memory/capture-sweep.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { setupTestDb } from '../utils/test-helpers.js'
+import { markActivity } from '../../src/long-term-memory/extraction-state.js'
+import { sweepDirtyContexts } from '../../src/long-term-memory/capture-sweep.js'
+
+describe('sweepDirtyContexts', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('runs capture for idle unextracted group contexts', async () => {
+    markActivity(
+      { contextId: 'g:thread:a', contextType: 'group', configContextId: 'g', historyLen: 3 },
+      '2026-06-16T10:00:00.000Z',
+    )
+    const captured: string[] = []
+    await sweepDirtyContexts('2026-06-16T10:20:00.000Z', {
+      idleMs: 600_000,
+      loadHistory: () => [{ role: 'user', content: 'hi' }],
+      runCapture: (input) => {
+        captured.push(input.storageContextId)
+        return Promise.resolve()
+      },
+    })
+    expect(captured).toEqual(['g:thread:a'])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/long-term-memory/capture-sweep.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the sweep**
+
+```typescript
+// src/long-term-memory/capture-sweep.ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { ModelMessage } from 'ai'
+
+import { getCachedHistory } from '../cache.js'
+import type { ContextType } from '../chat/types.js'
+import { logger } from '../logger.js'
+import { runMemoryCapture, type RunMemoryCaptureInput } from './capture.js'
+import { DEFAULT_IDLE_MS, listDirtyContexts } from './extraction-state.js'
+
+const log = logger.child({ scope: 'memory:capture-sweep' })
+
+export type SweepDeps = Readonly<{
+  idleMs: number
+  loadHistory: (storageContextId: string) => readonly ModelMessage[]
+  runCapture: (input: RunMemoryCaptureInput) => Promise<void>
+}>
+
+const defaultDeps: SweepDeps = {
+  idleMs: DEFAULT_IDLE_MS,
+  loadHistory: (storageContextId) => getCachedHistory(storageContextId),
+  runCapture: (input) => runMemoryCapture(input),
+}
+
+export async function sweepDirtyContexts(now: string, deps: SweepDeps = defaultDeps): Promise<void> {
+  const dirty = listDirtyContexts(now, deps.idleMs)
+  for (const row of dirty) {
+    const history = deps.loadHistory(row.contextId)
+    if (history.length === 0) continue
+    try {
+      await deps.runCapture({
+        storageContextId: row.contextId,
+        configContextId: row.configContextId,
+        contextType: row.contextType as ContextType,
+        history,
+      })
+    } catch (error) {
+      log.warn(
+        { contextId: row.contextId, error: error instanceof Error ? error.message : String(error) },
+        'Sweep capture failed',
+      )
+    }
+  }
+}
+```
+
+`getCachedHistory(userId: string): readonly ModelMessage[]` (`src/cache.ts:46`) returns messages directly — the same accessor `lookup_group_history` uses — so no mapping is needed.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/long-term-memory/capture-sweep.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Register the sweep**
+
+In `src/scheduler-instance.ts`, add the import:
+
+```typescript
+import { sweepDirtyContexts } from './long-term-memory/capture-sweep.js'
+```
+
+Register it next to `long-term-memory-maintenance` (the sweep self-gates per context via the flag inside `runMemoryCapture`):
+
+```typescript
+scheduler.register('memory-capture-sweep', {
+  interval: 5 * 60 * 1000, // every 5 minutes
+  handler: () => {
+    void sweepDirtyContexts(new Date().toISOString())
+  },
+  options: { immediate: false },
+})
+```
+
+- [ ] **Step 6: Run the full memory suite + typecheck**
+
+Run: `bun test tests/long-term-memory/ && bun typecheck`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/long-term-memory/capture-sweep.ts src/scheduler-instance.ts tests/long-term-memory/capture-sweep.test.ts
+git commit -m "feat(memory): scheduler backstop sweep for dirty contexts"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the whole server suite**
+
+Run: `bun run test`
+Expected: all suites pass (no regressions from the schema/flag/turn-path changes).
+
+- [ ] **Confirm flag-OFF parity**
+
+With `cross_thread_memory` unset, `armMemoryCapture`/`runMemoryCapture` early-return, no `memory_extraction_state` rows are written from real turns, and `search`/injection behavior is unchanged. Verify by grepping that every new entry point guards on `flagEnabled`/`resolveCrossThreadMemoryFlag` before any write.
+
+- [ ] **Run the staged-file checks**
+
+Run: `bun check`
+Expected: lint + typecheck + format pass on staged files.
+
+---
+
+## Handoff to Plan 2
+
+Plan 1 leaves provisional records accumulating (flag-gated) with populated embeddings, a watermark table, and a semantic-ranking + hybrid-ready library. **Plan 2 (Cascade & Promotion)** builds: the `recall` tool with the server-side 3-layer cascade (using `searchMemoryRecords` for FTS + `rankRecordsBySimilarity` for semantic), the cross-thread clustering + hybrid promotion engine (frequency gate `MEMORY_PROMOTION_MIN_THREADS = 3` + SMALL_MODEL confirm → flip provisional rows to `active`), the system-prompt preamble, and the "stop rediscovering" acceptance test.
+</content>

--- a/docs/superpowers/plans/2026-06-16-recall-cascade-and-promotion.md
+++ b/docs/superpowers/plans/2026-06-16-recall-cascade-and-promotion.md
@@ -1,0 +1,1275 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Recall Cascade & Promotion Implementation Plan (Plan 2 of 3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the provisional memory captured in Plan 1 user-visible and self-improving: a `recall` tool with a server-side 3-layer cascade (current-thread → group long-term → sibling-thread), and a hybrid promotion engine that elevates a provisional fact to durable group memory once it appears in ≥3 threads and a SMALL_MODEL confirms it is general.
+
+**Architecture:** Builds entirely on Plan 1 primitives (`listProvisionalRecords`, `rankRecordsBySimilarity`, `cosineSimilarity`, the `cross_thread_memory` flag, populated embeddings). The cascade composes FTS (`searchMemoryRecords`) and semantic ranking; promotion clusters provisional rows across threads by embedding similarity, counts distinct threads, asks a cheap SMALL_MODEL yes/no, then flips the kept row to `active` (in-place status transition) and archives duplicates. Promotion runs as a background side-effect of reaching cascade layer 3, plus a deterministic scheduler sweep backstop. All behind `cross_thread_memory` (default OFF ⇒ `recall` degrades to layer-2 keyword search, identical to today's `search_memory`).
+
+**Tech Stack:** Bun, TypeScript (strict, `.js` import paths), Drizzle ORM over `bun:sqlite`, Zod v4, Vercel AI SDK (`generateText`). Tests: `bun run test`, DI-first per `tests/CLAUDE.md`.
+
+**Depends on:** Plan 1 (`docs/superpowers/plans/2026-06-16-memory-foundation.md`) — must be merged first.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-16-cross-thread-memory-and-context-scope-design.md` §4.4–§4.7.
+
+---
+
+## Constants
+
+| Name                              | Value              | Where                                    |
+| --------------------------------- | ------------------ | ---------------------------------------- |
+| `MEMORY_PROMOTION_MIN_THREADS`    | 3                  | `src/long-term-memory/promotion.ts`      |
+| `RECALL_SIMILARITY_THRESHOLD` (τ) | 0.65               | `src/long-term-memory/recall-ranking.ts` |
+| `RECALL_DEFAULT_LIMIT`            | 8                  | `src/long-term-memory/recall-cascade.ts` |
+| `PROMOTION_REJECT_COOLDOWN_MS`    | 604800000 (7 days) | `src/long-term-memory/promotion.ts`      |
+
+---
+
+## File Structure
+
+| File                                              | Responsibility                                                 | Change |
+| ------------------------------------------------- | -------------------------------------------------------------- | ------ |
+| `src/long-term-memory/types.ts`                   | `evidence.promotionRejectedAt`                                 | Modify |
+| `src/long-term-memory/store.ts`                   | `promoteProvisionalToActive`, `markPromotionRejected`          | Modify |
+| `src/long-term-memory/recall-ranking.ts`          | Rank an in-memory record list by query (semantic/keyword)      | Create |
+| `src/long-term-memory/recall-cascade.ts`          | `runRecallCascade` — layers 1→2→3 + provenance                 | Create |
+| `src/long-term-memory/promotion.ts`               | `evaluatePromotion`, `confirmDurableFact`, cluster + threshold | Create |
+| `src/long-term-memory/promotion-sweep.ts`         | `sweepPromotions` — deterministic backstop                     | Create |
+| `src/tools/recall.ts`                             | `makeRecallMemoryTool`                                         | Create |
+| `src/tools/provider-independent-tools-builder.ts` | Register `recall` (normal mode, flag-gated)                    | Modify |
+| `src/system-prompt.ts`                            | `MEMORY_RECALL` fragment                                       | Modify |
+| `src/scheduler-instance.ts`                       | Register promotion sweep                                       | Modify |
+
+---
+
+## Task 1: Store mutations for promotion
+
+**Files:**
+
+- Modify: `src/long-term-memory/types.ts` (add `promotionRejectedAt` to `MemoryEvidence`)
+- Modify: `src/long-term-memory/store.ts`
+- Test: `tests/long-term-memory/promotion-store.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/long-term-memory/promotion-store.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { setupTestDb } from '../utils/test-helpers.js'
+import {
+  saveMemoryRecord,
+  listMemoryRecords,
+  promoteProvisionalToActive,
+  markPromotionRejected,
+} from '../../src/long-term-memory/store.js'
+import type { MemoryRecordInput } from '../../src/long-term-memory/types.js'
+
+const prov = (id: string, thread: string): MemoryRecordInput => ({
+  id,
+  scopeId: 'g',
+  scopeType: 'group',
+  kind: 'fact',
+  content: 'Deploys on Fridays.',
+  summary: null,
+  tags: [],
+  confidence: 0.5,
+  status: 'provisional',
+  source: 'background',
+  evidence: { threads: [thread] },
+  threadContextId: thread,
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  lastSeenAt: '2026-06-11T00:00:00.000Z',
+})
+
+describe('promotion store mutations', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('promoteProvisionalToActive flips status, clears thread, merges threads', () => {
+    saveMemoryRecord(prov('m1', 't-a'))
+    const out = promoteProvisionalToActive(
+      { scopeId: 'g', scopeType: 'group' },
+      'm1',
+      ['t-a', 't-b', 't-c'],
+      '2026-06-16T00:00:00.000Z',
+    )
+    expect(out?.status).toBe('active')
+    expect(out?.threadContextId).toBeNull()
+    expect(out?.evidence.threads).toEqual(['t-a', 't-b', 't-c'])
+    expect(listMemoryRecords({ scopeId: 'g', scopeType: 'group', status: 'active' })).toHaveLength(1)
+  })
+
+  test('markPromotionRejected records a cooldown timestamp in evidence', () => {
+    saveMemoryRecord(prov('m1', 't-a'))
+    markPromotionRejected({ scopeId: 'g', scopeType: 'group' }, 'm1', '2026-06-16T00:00:00.000Z')
+    const [row] = listMemoryRecords({ scopeId: 'g', scopeType: 'group', status: 'provisional' })
+    expect(row?.evidence.promotionRejectedAt).toBe('2026-06-16T00:00:00.000Z')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/long-term-memory/promotion-store.test.ts`
+Expected: FAIL — functions not exported.
+
+- [ ] **Step 3: Extend the evidence type**
+
+In `src/long-term-memory/types.ts`, add `promotionRejectedAt?: string` to `MemoryEvidence`:
+
+```typescript
+export type MemoryEvidence = Readonly<{
+  messageIds?: readonly string[]
+  actorIds?: readonly string[]
+  timestamps?: readonly string[]
+  contextId?: string
+  threads?: readonly string[]
+  promotionRejectedAt?: string
+}>
+```
+
+- [ ] **Step 4: Add the store functions**
+
+Append to `src/long-term-memory/store.ts` (`parseEvidence`, `rowToRecord`, `recordScopeCondition` are already in scope):
+
+```typescript
+export function promoteProvisionalToActive(
+  scope: MemoryScope,
+  recordId: string,
+  threads: readonly string[],
+  now: string,
+): MemoryRecord | null {
+  const existing = getDrizzleDb().select().from(memoryRecords).where(recordScopeCondition(scope, recordId)).get()
+  if (existing === undefined) return null
+  const prev = parseEvidence(existing.evidence)
+  const evidence: MemoryEvidence = { ...prev, threads: [...new Set(threads)], promotionRejectedAt: undefined }
+  const rows = getDrizzleDb()
+    .update(memoryRecords)
+    .set({
+      status: 'active',
+      threadContextId: null,
+      evidence: JSON.stringify(evidence),
+      updatedAt: now,
+      lastSeenAt: now,
+    })
+    .where(recordScopeCondition(scope, recordId))
+    .returning()
+    .all()
+  return rows[0] === undefined ? null : rowToRecord(rows[0])
+}
+
+export function markPromotionRejected(scope: MemoryScope, recordId: string, now: string): void {
+  const existing = getDrizzleDb().select().from(memoryRecords).where(recordScopeCondition(scope, recordId)).get()
+  if (existing === undefined) return
+  const evidence: MemoryEvidence = { ...parseEvidence(existing.evidence), promotionRejectedAt: now }
+  getDrizzleDb()
+    .update(memoryRecords)
+    .set({ evidence: JSON.stringify(evidence), updatedAt: now })
+    .where(recordScopeCondition(scope, recordId))
+    .run()
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bun test tests/long-term-memory/promotion-store.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/long-term-memory/types.ts src/long-term-memory/store.ts tests/long-term-memory/promotion-store.test.ts
+git commit -m "feat(memory): promotion store mutations (promote/reject)"
+```
+
+---
+
+## Task 2: In-memory record ranking
+
+**Files:**
+
+- Create: `src/long-term-memory/recall-ranking.ts`
+- Test: `tests/long-term-memory/recall-ranking.test.ts`
+
+Ranks a provided record list against a query — semantic when a query embedding is available, keyword (term overlap) otherwise. Used for the provisional layers (1 and 3) where candidates are already loaded.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/long-term-memory/recall-ranking.test.ts
+import { describe, expect, test } from 'bun:test'
+import { rankCandidatesByQuery } from '../../src/long-term-memory/recall-ranking.js'
+import type { MemoryRecord } from '../../src/long-term-memory/types.js'
+
+const rec = (id: string, content: string, embedding: Float32Array | null): MemoryRecord => ({
+  id,
+  scopeId: 'g',
+  scopeType: 'group',
+  kind: 'fact',
+  content,
+  summary: null,
+  tags: [],
+  confidence: 0.5,
+  status: 'provisional',
+  source: 'background',
+  evidence: {},
+  threadContextId: 't',
+  embedding,
+  createdAt: '',
+  updatedAt: '',
+  lastSeenAt: '',
+})
+
+describe('rankCandidatesByQuery', () => {
+  test('semantic mode ranks by cosine and drops below threshold', () => {
+    const out = rankCandidatesByQuery(
+      [rec('near', 'x', new Float32Array([1, 0, 0])), rec('far', 'y', new Float32Array([0, 1, 0]))],
+      'anything',
+      [1, 0, 0],
+      { threshold: 0.65, limit: 5 },
+    )
+    expect(out.map((r) => r.id)).toEqual(['near'])
+  })
+
+  test('keyword fallback when no query embedding', () => {
+    const out = rankCandidatesByQuery(
+      [rec('a', 'deploys happen on fridays', null), rec('b', 'lunch is at noon', null)],
+      'Friday deploys',
+      null,
+      { limit: 5 },
+    )
+    expect(out[0]?.id).toBe('a')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/long-term-memory/recall-ranking.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/long-term-memory/recall-ranking.ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { cosineSimilarity } from './semantic-search.js'
+import type { MemoryRecord } from './types.js'
+
+export const RECALL_SIMILARITY_THRESHOLD = 0.65
+
+export type RankOptions = Readonly<{ threshold?: number; limit?: number }>
+
+const tokenize = (text: string): string[] => text.toLowerCase().match(/[a-z0-9]+/gu) ?? []
+
+const keywordScore = (query: string, content: string): number => {
+  const q = new Set(tokenize(query))
+  if (q.size === 0) return 0
+  const tokens = tokenize(content)
+  let hits = 0
+  for (const token of tokens) if (q.has(token)) hits += 1
+  return hits / q.size
+}
+
+/** Rank an already-loaded record list against a query. Semantic when `queryEmbedding` is present, else keyword. */
+export function rankCandidatesByQuery(
+  records: readonly MemoryRecord[],
+  query: string,
+  queryEmbedding: readonly number[] | null,
+  options: RankOptions,
+): readonly MemoryRecord[] {
+  const threshold = options.threshold ?? RECALL_SIMILARITY_THRESHOLD
+  const limit = options.limit ?? 10
+
+  const scored =
+    queryEmbedding !== null
+      ? records
+          .map((record) => ({
+            record,
+            score: record.embedding ? cosineSimilarity(queryEmbedding, record.embedding) : 0,
+          }))
+          .filter((entry) => entry.score >= threshold)
+      : records
+          .map((record) => ({ record, score: keywordScore(query, record.content) }))
+          .filter((entry) => entry.score > 0)
+
+  return scored
+    .sort((left, right) => right.score - left.score)
+    .slice(0, limit)
+    .map((entry) => entry.record)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/long-term-memory/recall-ranking.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/long-term-memory/recall-ranking.ts tests/long-term-memory/recall-ranking.test.ts
+git commit -m "feat(memory): in-memory record ranking for recall layers"
+```
+
+---
+
+## Task 3: Promotion engine
+
+**Files:**
+
+- Create: `src/long-term-memory/promotion.ts`
+- Test: `tests/long-term-memory/promotion.test.ts`
+
+Clusters provisional records similar to a candidate, counts distinct threads, and — when ≥ `MEMORY_PROMOTION_MIN_THREADS` and not in cooldown — asks a SMALL_MODEL to confirm the fact is durable/general. On confirm it promotes the candidate and archives the duplicates; on reject it stamps a cooldown.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/long-term-memory/promotion.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { setupTestDb } from '../utils/test-helpers.js'
+import { saveMemoryRecord, listMemoryRecords } from '../../src/long-term-memory/store.js'
+import { evaluatePromotion } from '../../src/long-term-memory/promotion.js'
+import type { MemoryRecord, MemoryRecordInput } from '../../src/long-term-memory/types.js'
+
+const emb = new Float32Array([1, 0, 0])
+const prov = (id: string, thread: string): MemoryRecordInput => ({
+  id,
+  scopeId: 'g',
+  scopeType: 'group',
+  kind: 'fact',
+  content: 'Deploys on Fridays.',
+  summary: null,
+  tags: [],
+  confidence: 0.5,
+  status: 'provisional',
+  source: 'background',
+  evidence: { threads: [thread] },
+  threadContextId: thread,
+  embedding: emb,
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  lastSeenAt: '2026-06-11T00:00:00.000Z',
+})
+
+const load = (id: string): MemoryRecord => {
+  const found = listMemoryRecords({ scopeId: 'g', scopeType: 'group', status: 'provisional', limit: 50 }).find(
+    (r) => r.id === id,
+  )
+  if (found === undefined) throw new Error('missing')
+  return found
+}
+
+describe('evaluatePromotion', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('promotes when 3 distinct threads agree and confirm passes', async () => {
+    saveMemoryRecord(prov('m1', 't-a'))
+    saveMemoryRecord(prov('m2', 't-b'))
+    saveMemoryRecord(prov('m3', 't-c'))
+    const promoted = await evaluatePromotion({ scopeId: 'g', scopeType: 'group' }, load('m1'), {
+      confirmDurable: () => Promise.resolve(true),
+      now: () => '2026-06-16T00:00:00.000Z',
+    })
+    expect(promoted).toBe(true)
+    expect(listMemoryRecords({ scopeId: 'g', scopeType: 'group', status: 'active' })).toHaveLength(1)
+    expect(listMemoryRecords({ scopeId: 'g', scopeType: 'group', status: 'provisional' })).toHaveLength(0)
+  })
+
+  test('does not promote below the thread threshold', async () => {
+    saveMemoryRecord(prov('m1', 't-a'))
+    saveMemoryRecord(prov('m2', 't-b'))
+    const promoted = await evaluatePromotion({ scopeId: 'g', scopeType: 'group' }, load('m1'), {
+      confirmDurable: () => Promise.resolve(true),
+      now: () => '2026-06-16T00:00:00.000Z',
+    })
+    expect(promoted).toBe(false)
+    expect(listMemoryRecords({ scopeId: 'g', scopeType: 'group', status: 'active' })).toHaveLength(0)
+  })
+
+  test('records a cooldown when confirm rejects', async () => {
+    saveMemoryRecord(prov('m1', 't-a'))
+    saveMemoryRecord(prov('m2', 't-b'))
+    saveMemoryRecord(prov('m3', 't-c'))
+    const promoted = await evaluatePromotion({ scopeId: 'g', scopeType: 'group' }, load('m1'), {
+      confirmDurable: () => Promise.resolve(false),
+      now: () => '2026-06-16T00:00:00.000Z',
+    })
+    expect(promoted).toBe(false)
+    expect(load('m1').evidence.promotionRejectedAt).toBe('2026-06-16T00:00:00.000Z')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/long-term-memory/promotion.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/long-term-memory/promotion.ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { generateText } from 'ai'
+
+import { resolveEffectiveLlmConfig } from '../llm-config-resolver.js'
+import { buildChatModel } from '../llm-model-builder.js'
+import { logger } from '../logger.js'
+import { cosineSimilarity } from './semantic-search.js'
+import {
+  archiveMemoryRecord,
+  listProvisionalRecords,
+  markPromotionRejected,
+  promoteProvisionalToActive,
+} from './store.js'
+import type { MemoryRecord, MemoryScope } from './types.js'
+
+const log = logger.child({ scope: 'memory:promotion' })
+
+export const MEMORY_PROMOTION_MIN_THREADS = 3
+export const PROMOTION_REJECT_COOLDOWN_MS = 604_800_000 // 7 days
+const CLUSTER_SIMILARITY_THRESHOLD = 0.8
+
+export type EvaluatePromotionDeps = Readonly<{
+  confirmDurable: (content: string, configContextId: string) => Promise<boolean>
+  now: () => string
+}>
+
+const isInCooldown = (record: MemoryRecord, now: string): boolean => {
+  const rejected = record.evidence.promotionRejectedAt
+  if (rejected === undefined) return false
+  return new Date(now).getTime() - new Date(rejected).getTime() < PROMOTION_REJECT_COOLDOWN_MS
+}
+
+/** A provisional row is "the same fact" as the candidate when its embedding is highly similar, or (no embeddings) its content matches. */
+const clusterMembers = (candidate: MemoryRecord, all: readonly MemoryRecord[]): readonly MemoryRecord[] => {
+  const vec = candidate.embedding
+  return all.filter((other) => {
+    if (other.id === candidate.id) return true
+    if (vec && other.embedding)
+      return cosineSimilarity(Array.from(vec), other.embedding) >= CLUSTER_SIMILARITY_THRESHOLD
+    return other.content.trim().toLowerCase() === candidate.content.trim().toLowerCase()
+  })
+}
+
+/**
+ * Evaluate a provisional candidate for promotion to durable group memory.
+ * Returns true iff it was promoted. Pure side effects on the store; never throws.
+ */
+export async function evaluatePromotion(
+  scope: MemoryScope,
+  candidate: MemoryRecord,
+  deps: EvaluatePromotionDeps = defaultDeps,
+): Promise<boolean> {
+  const now = deps.now()
+  if (isInCooldown(candidate, now)) return false
+
+  const provisional = listProvisionalRecords({ scopeId: scope.scopeId, scopeType: scope.scopeType, limit: 500 })
+  const cluster = clusterMembers(candidate, provisional)
+  const threads = new Set<string>()
+  for (const member of cluster) {
+    if (member.threadContextId !== null && member.threadContextId !== undefined) threads.add(member.threadContextId)
+    for (const t of member.evidence.threads ?? []) threads.add(t)
+  }
+  if (threads.size < MEMORY_PROMOTION_MIN_THREADS) return false
+
+  let confirmed: boolean
+  try {
+    confirmed = await deps.confirmDurable(candidate.content, candidate.scopeId)
+  } catch (error) {
+    log.warn(
+      { recordId: candidate.id, error: error instanceof Error ? error.message : String(error) },
+      'Promotion confirm failed',
+    )
+    return false
+  }
+
+  if (!confirmed) {
+    markPromotionRejected(scope, candidate.id, now)
+    return false
+  }
+
+  promoteProvisionalToActive(scope, candidate.id, [...threads], now)
+  for (const member of cluster) {
+    if (member.id !== candidate.id) archiveMemoryRecord(scope, member.id, now)
+  }
+  log.info({ recordId: candidate.id, threadCount: threads.size }, 'Promoted provisional record to active')
+  return true
+}
+
+const CONFIRM_PROMPT = (content: string): string =>
+  `A fact has been observed independently in several separate group conversations. Decide whether it is a DURABLE, GENERAL fact about this group worth remembering long-term, versus thread-specific or transient noise. Answer with exactly "yes" or "no".\n\nFact: ${content}`
+
+const defaultConfirm = async (content: string, configContextId: string): Promise<boolean> => {
+  const resolved = resolveEffectiveLlmConfig(configContextId)
+  if (!resolved.ok) return false
+  const model = buildChatModel(resolved.llmApiKey, resolved.llmBaseUrl, resolved.smallModel)
+  const { text } = await generateText({ model, prompt: CONFIRM_PROMPT(content) })
+  return text.trim().toLowerCase().startsWith('yes')
+}
+
+const defaultDeps: EvaluatePromotionDeps = {
+  confirmDurable: defaultConfirm,
+  now: () => new Date().toISOString(),
+}
+```
+
+> **Note:** `candidate.scopeId` is the group context id, which is also the `configContextId` used for BYOK-aware model resolution in this scope (groups key config by the group id). Passing it to `confirmDurable` keeps the model resolution consistent with capture.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/long-term-memory/promotion.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/long-term-memory/promotion.ts tests/long-term-memory/promotion.test.ts
+git commit -m "feat(memory): hybrid promotion engine (threshold + LLM confirm)"
+```
+
+---
+
+## Task 4: Recall cascade
+
+**Files:**
+
+- Create: `src/long-term-memory/recall-cascade.ts`
+- Test: `tests/long-term-memory/recall-cascade.test.ts`
+
+Runs the 3-layer cascade and returns records tagged with provenance. Layers 1+2 always run; layer 3 runs only when 1+2 return fewer than the requested limit (the "if the agent reaches this point" gate). Layer-3 hits fire promotion in the background.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/long-term-memory/recall-cascade.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { setupTestDb } from '../utils/test-helpers.js'
+import { saveMemoryRecord } from '../../src/long-term-memory/store.js'
+import { runRecallCascade } from '../../src/long-term-memory/recall-cascade.js'
+import type { MemoryRecordInput } from '../../src/long-term-memory/types.js'
+
+const base = (over: Partial<MemoryRecordInput>): MemoryRecordInput => ({
+  id: 'x',
+  scopeId: 'g',
+  scopeType: 'group',
+  kind: 'fact',
+  content: 'deploys happen on fridays',
+  summary: null,
+  tags: [],
+  confidence: 0.5,
+  status: 'provisional',
+  source: 'background',
+  evidence: {},
+  threadContextId: 'g:thread:a',
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  lastSeenAt: '2026-06-11T00:00:00.000Z',
+  ...over,
+})
+
+describe('runRecallCascade (keyword mode, no embeddings)', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('layer 2 active group record is found and tagged group', async () => {
+    saveMemoryRecord(base({ id: 'a', status: 'active', threadContextId: null }))
+    const out = await runRecallCascade(
+      { storageContextId: 'g:thread:z', configContextId: 'g', contextType: 'group', query: 'friday deploys', limit: 8 },
+      { getEmbedding: () => Promise.resolve(null), schedulePromotion: () => undefined },
+    )
+    expect(out.records.map((r) => ({ id: r.id, p: r.provenance }))).toContainEqual({ id: 'a', p: 'group' })
+  })
+
+  test('reaches layer 3 for sibling-thread provisional and schedules promotion', async () => {
+    saveMemoryRecord(base({ id: 'b', status: 'provisional', threadContextId: 'g:thread:a' }))
+    const scheduled: string[] = []
+    const out = await runRecallCascade(
+      { storageContextId: 'g:thread:z', configContextId: 'g', contextType: 'group', query: 'friday deploys', limit: 8 },
+      { getEmbedding: () => Promise.resolve(null), schedulePromotion: (r) => scheduled.push(r.id) },
+    )
+    expect(out.records.some((r) => r.id === 'b' && r.provenance === 'other-thread')).toBe(true)
+    expect(scheduled).toContain('b')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/long-term-memory/recall-cascade.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/long-term-memory/recall-cascade.ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { ContextType } from '../chat/types.js'
+import { getEmbeddingForContext } from '../embeddings.js'
+import { evaluatePromotion } from './promotion.js'
+import { rankCandidatesByQuery } from './recall-ranking.js'
+import { resolveMemoryScope } from './scope.js'
+import { rankRecordsBySimilarity } from './semantic-search.js'
+import { listProvisionalRecords, searchMemoryRecords } from './store.js'
+import type { MemoryRecord, MemoryScope } from './types.js'
+
+export const RECALL_DEFAULT_LIMIT = 8
+
+export type RecallProvenance = 'current' | 'group' | 'other-thread'
+export type RecallHit = MemoryRecord & Readonly<{ provenance: RecallProvenance }>
+
+export type RunRecallCascadeInput = Readonly<{
+  storageContextId: string
+  configContextId: string
+  contextType: ContextType
+  query: string
+  limit?: number
+}>
+
+export type RunRecallCascadeDeps = Readonly<{
+  getEmbedding: (query: string, configContextId: string) => Promise<readonly number[] | null>
+  schedulePromotion: (record: MemoryRecord, scope: MemoryScope) => void
+}>
+
+const defaultDeps: RunRecallCascadeDeps = {
+  getEmbedding: (query, configContextId) =>
+    getEmbeddingForContext(query, configContextId, {
+      storageContextId: configContextId,
+      contextType: 'group',
+      chatUserId: configContextId,
+    }),
+  schedulePromotion: (record, scope) => {
+    void evaluatePromotion(scope, record)
+  },
+}
+
+const dedupe = (hits: readonly RecallHit[], limit: number): readonly RecallHit[] => {
+  const seen = new Set<string>()
+  const out: RecallHit[] = []
+  for (const hit of hits) {
+    if (seen.has(hit.id)) continue
+    seen.add(hit.id)
+    out.push(hit)
+    if (out.length >= limit) break
+  }
+  return out
+}
+
+const tag = (records: readonly MemoryRecord[], provenance: RecallProvenance): RecallHit[] =>
+  records.map((record) => ({ ...record, provenance }))
+
+const searchActiveHybrid = (
+  scope: MemoryScope,
+  query: string,
+  queryEmbedding: readonly number[] | null,
+  limit: number,
+): readonly MemoryRecord[] => {
+  const semantic =
+    queryEmbedding === null ? [] : rankRecordsBySimilarity(scope, queryEmbedding, { statuses: ['active'], limit })
+  const keyword = searchMemoryRecords({ ...scope, query, limit })
+  const merged: MemoryRecord[] = [...semantic]
+  const seen = new Set(semantic.map((r) => r.id))
+  for (const record of keyword) if (!seen.has(record.id)) merged.push(record)
+  return merged.slice(0, limit)
+}
+
+export async function runRecallCascade(
+  input: RunRecallCascadeInput,
+  deps: RunRecallCascadeDeps = defaultDeps,
+): Promise<{ records: readonly RecallHit[] }> {
+  const limit = input.limit ?? RECALL_DEFAULT_LIMIT
+  const scope = resolveMemoryScope({ storageContextId: input.storageContextId, contextType: input.contextType })
+  const queryEmbedding = await deps.getEmbedding(input.query, input.configContextId)
+
+  // DMs have no threads: layer 2 only.
+  if (input.contextType === 'dm') {
+    return { records: dedupe(tag(searchActiveHybrid(scope, input.query, queryEmbedding, limit), 'group'), limit) }
+  }
+
+  // Layer 1 — current-thread provisional.
+  const layer1 = rankCandidatesByQuery(
+    listProvisionalRecords({ ...scope, threadContextId: input.storageContextId, limit: 100 }),
+    input.query,
+    queryEmbedding,
+    { limit },
+  )
+  // Layer 2 — active group records.
+  const layer2 = searchActiveHybrid(scope, input.query, queryEmbedding, limit)
+
+  const combined: RecallHit[] = [...tag(layer1, 'current'), ...tag(layer2, 'group')]
+
+  // Layer 3 — sibling-thread provisional, only when 1+2 are insufficient.
+  if (dedupe(combined, limit).length < limit) {
+    const siblings = rankCandidatesByQuery(
+      listProvisionalRecords({ ...scope, excludeThreadContextId: input.storageContextId, limit: 200 }),
+      input.query,
+      queryEmbedding,
+      { limit },
+    )
+    for (const record of siblings) deps.schedulePromotion(record, scope)
+    combined.push(...tag(siblings, 'other-thread'))
+  }
+
+  return { records: dedupe(combined, limit) }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/long-term-memory/recall-cascade.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/long-term-memory/recall-cascade.ts tests/long-term-memory/recall-cascade.test.ts
+git commit -m "feat(memory): 3-layer recall cascade with provenance"
+```
+
+---
+
+## Task 5: `recall` tool + registration
+
+**Files:**
+
+- Create: `src/tools/recall.ts`
+- Modify: `src/tools/provider-independent-tools-builder.ts`
+- Test: `tests/tools/recall.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/tools/recall.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { setupTestDb, getToolExecutor } from '../utils/test-helpers.js'
+import { saveMemoryRecord } from '../../src/long-term-memory/store.js'
+import { makeRecallMemoryTool } from '../../src/tools/recall.js'
+import type { MemoryRecordInput } from '../../src/long-term-memory/types.js'
+
+const active = (id: string): MemoryRecordInput => ({
+  id,
+  scopeId: 'g',
+  scopeType: 'group',
+  kind: 'fact',
+  content: 'deploys happen on fridays',
+  summary: null,
+  tags: [],
+  confidence: 1,
+  status: 'active',
+  source: 'background',
+  evidence: {},
+  threadContextId: null,
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  lastSeenAt: '2026-06-11T00:00:00.000Z',
+})
+
+const isRecallResult = (v: unknown): v is { mode: string; records: Array<{ id: string; provenance: string }> } =>
+  typeof v === 'object' && v !== null && 'records' in v
+
+describe('recall tool', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('returns records with provenance and public shape', async () => {
+    saveMemoryRecord(active('a'))
+    const tool = makeRecallMemoryTool({ storageContextId: 'g:thread:z', contextType: 'group' })
+    const result = await getToolExecutor(tool)({ query: 'friday deploys' })
+    expect(isRecallResult(result)).toBe(true)
+    if (!isRecallResult(result)) throw new Error('shape')
+    expect(result.mode).toBe('recall')
+    expect(result.records[0]?.provenance).toBe('group')
+    expect(result.records[0]).not.toHaveProperty('embedding')
+    expect(result.records[0]).not.toHaveProperty('scopeId')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/tools/recall.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the tool**
+
+```typescript
+// src/tools/recall.ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { tool, type ToolSet } from 'ai'
+import { z } from 'zod'
+
+import type { ContextType } from '../chat/types.js'
+import { getConfigContextIdFromStorageContextId } from '../chat/scoped-context.js'
+import { logger } from '../logger.js'
+import { runRecallCascade, type RecallHit } from '../long-term-memory/recall-cascade.js'
+
+const log = logger.child({ scope: 'tool:recall' })
+
+export type RecallToolContext = Readonly<{
+  storageContextId: string
+  contextType: Extract<ContextType, 'dm' | 'group'>
+}>
+
+type PublicRecallRecord = Readonly<{
+  id: string
+  provenance: RecallHit['provenance']
+  kind: RecallHit['kind']
+  content: string
+  summary: string | null
+  tags: readonly string[]
+  confidence: number
+  status: RecallHit['status']
+  lastSeenAt: string
+}>
+
+const toPublic = (hit: RecallHit): PublicRecallRecord => ({
+  id: hit.id,
+  provenance: hit.provenance,
+  kind: hit.kind,
+  content: hit.content,
+  summary: hit.summary,
+  tags: hit.tags,
+  confidence: hit.confidence,
+  status: hit.status,
+  lastSeenAt: hit.lastSeenAt,
+})
+
+export function makeRecallMemoryTool(input: RecallToolContext): ToolSet[string] {
+  return tool({
+    description:
+      'Recall what is known across this conversation, the shared group memory, and other conversations, in priority order. Prefer this before re-asking the user or claiming no prior knowledge.',
+    inputSchema: z.object({
+      query: z.string().min(1).max(500).describe('What to recall'),
+      limit: z.number().int().min(1).max(20).optional().describe('Maximum records to return'),
+    }),
+    execute: async ({ query, limit }) => {
+      const configContextId = getConfigContextIdFromStorageContextId(input.storageContextId)
+      const { records } = await runRecallCascade({
+        storageContextId: input.storageContextId,
+        configContextId,
+        contextType: input.contextType,
+        query,
+        limit,
+      })
+      log.debug({ storageContextId: input.storageContextId, count: records.length }, 'recall via tool')
+      return { mode: 'recall', records: records.map(toPublic) }
+    },
+  })
+}
+```
+
+- [ ] **Step 4: Register the tool (normal mode, flag-gated)**
+
+In `src/tools/provider-independent-tools-builder.ts`, add the imports:
+
+```typescript
+import { makeRecallMemoryTool } from './recall.js'
+import { resolveCrossThreadMemoryFlag } from './feature-flags.js'
+```
+
+Replace the `addMemoryTools(tools, contextId, contextType)` call site context: keep `addMemoryTools` as-is, and **after** it, add a flag-gated recall registration inside `addProviderIndependentTools` (it needs `mode`):
+
+```typescript
+addMemoryTools(tools, contextId, contextType)
+if (
+  contextId !== undefined &&
+  contextType !== undefined &&
+  mode === 'normal' &&
+  resolveCrossThreadMemoryFlag(contextId)
+) {
+  tools['recall'] = makeRecallMemoryTool({ storageContextId: contextId, contextType })
+}
+```
+
+- [ ] **Step 5: Run test + typecheck**
+
+Run: `bun test tests/tools/recall.test.ts && bun typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tools/recall.ts src/tools/provider-independent-tools-builder.ts tests/tools/recall.test.ts
+git commit -m "feat(memory): recall tool wired into the cascade (normal mode, flag-gated)"
+```
+
+---
+
+## Task 6: System-prompt recall preamble
+
+**Files:**
+
+- Modify: `src/system-prompt.ts`
+- Test: `tests/system-prompt-recall.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/system-prompt-recall.test.ts
+import { describe, expect, test } from 'bun:test'
+import { buildSystemPrompt } from '../src/system-prompt.js'
+
+describe('recall preamble', () => {
+  test('present only when the recall tool is enabled', () => {
+    const withRecall = buildSystemPrompt('g:thread:a', new Set(['recall']), { contextType: 'group' })
+    const without = buildSystemPrompt('g:thread:a', new Set(['create_task']), { contextType: 'group' })
+    expect(withRecall.toLowerCase()).toContain('priority order')
+    expect(without.toLowerCase()).not.toContain('priority order')
+  })
+})
+```
+
+> **Implementer note:** match the call to the real exported entry point in `src/system-prompt.ts` (the function that takes `contextId`, the enabled-tool-name set, and `AssembleOptions`). If the public function name/signature differs from `buildSystemPrompt`, adjust the test invocation accordingly — the assertion (fragment present iff `recall` enabled) is what matters.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/system-prompt-recall.test.ts`
+Expected: FAIL — preamble text absent.
+
+- [ ] **Step 3: Add the fragment**
+
+In `src/system-prompt.ts`, add the constant near the other fragment strings:
+
+```typescript
+const MEMORY_RECALL = `MEMORY RECALL
+You can recall prior knowledge with the recall tool, which searches in priority order: this conversation, then shared group memory, then other conversations. Use it before re-asking the user or assuming nothing is known.`
+```
+
+Add an entry to the `FRAGMENTS` array (after the `MEMOS` entry):
+
+```typescript
+  { text: MEMORY_RECALL, requiredTools: ['recall'] },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/system-prompt-recall.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/system-prompt.ts tests/system-prompt-recall.test.ts
+git commit -m "feat(memory): recall priority preamble in the system prompt"
+```
+
+---
+
+## Task 7: Promotion sweep + acceptance + flag-off parity
+
+**Files:**
+
+- Create: `src/long-term-memory/promotion-sweep.ts`
+- Modify: `src/scheduler-instance.ts`
+- Test: `tests/long-term-memory/promotion-sweep.test.ts`
+- Test: `tests/long-term-memory/stop-rediscovering.acceptance.test.ts`
+
+- [ ] **Step 1: Write the failing sweep test**
+
+```typescript
+// tests/long-term-memory/promotion-sweep.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { setupTestDb } from '../utils/test-helpers.js'
+import { saveMemoryRecord, listMemoryRecords } from '../../src/long-term-memory/store.js'
+import { sweepPromotions } from '../../src/long-term-memory/promotion-sweep.js'
+import type { MemoryRecordInput } from '../../src/long-term-memory/types.js'
+
+const prov = (id: string, thread: string): MemoryRecordInput => ({
+  id,
+  scopeId: 'g',
+  scopeType: 'group',
+  kind: 'fact',
+  content: 'deploys on fridays',
+  summary: null,
+  tags: [],
+  confidence: 0.5,
+  status: 'provisional',
+  source: 'background',
+  evidence: { threads: [thread] },
+  threadContextId: thread,
+  createdAt: '2026-06-11T00:00:00.000Z',
+  updatedAt: '2026-06-11T00:00:00.000Z',
+  lastSeenAt: '2026-06-11T00:00:00.000Z',
+})
+
+describe('sweepPromotions', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+
+  test('evaluates every provisional record in each scope', async () => {
+    saveMemoryRecord(prov('m1', 't-a'))
+    saveMemoryRecord(prov('m2', 't-b'))
+    saveMemoryRecord(prov('m3', 't-c'))
+    const seen: string[] = []
+    await sweepPromotions({
+      evaluate: (_scope, candidate) => {
+        seen.push(candidate.id)
+        return Promise.resolve(true)
+      },
+      listScopes: () => [{ scopeId: 'g', scopeType: 'group' }],
+    })
+    expect(seen).toEqual(['m1', 'm2', 'm3'])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/long-term-memory/promotion-sweep.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the sweep**
+
+```typescript
+// src/long-term-memory/promotion-sweep.ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { and, eq } from 'drizzle-orm'
+
+import { getDrizzleDb } from '../db/drizzle.js'
+import { memoryRecords } from '../db/schema.js'
+import { logger } from '../logger.js'
+import { evaluatePromotion } from './promotion.js'
+import { listProvisionalRecords } from './store.js'
+import type { MemoryScope } from './types.js'
+
+const log = logger.child({ scope: 'memory:promotion-sweep' })
+
+export type SweepPromotionsDeps = Readonly<{
+  evaluate: (scope: MemoryScope, candidate: ReturnType<typeof listProvisionalRecords>[number]) => Promise<boolean>
+  listScopes: () => readonly MemoryScope[]
+}>
+
+const defaultListScopes = (): readonly MemoryScope[] => {
+  const rows = getDrizzleDb()
+    .selectDistinct({ scopeId: memoryRecords.scopeId, scopeType: memoryRecords.scopeType })
+    .from(memoryRecords)
+    .where(and(eq(memoryRecords.status, 'provisional'), eq(memoryRecords.scopeType, 'group')))
+    .all()
+  return rows.map((r) => ({ scopeId: r.scopeId, scopeType: r.scopeType }))
+}
+
+const defaultDeps: SweepPromotionsDeps = {
+  evaluate: (scope, candidate) => evaluatePromotion(scope, candidate),
+  listScopes: defaultListScopes,
+}
+
+/** Deterministic backstop: evaluate every provisional record for promotion, scope by scope. */
+export async function sweepPromotions(deps: SweepPromotionsDeps = defaultDeps): Promise<void> {
+  for (const scope of deps.listScopes()) {
+    const provisional = listProvisionalRecords({ ...scope, limit: 500 })
+    const evaluated = new Set<string>()
+    for (const candidate of provisional) {
+      if (evaluated.has(candidate.id)) continue
+      evaluated.add(candidate.id)
+      try {
+        await deps.evaluate(scope, candidate)
+      } catch (error) {
+        log.warn(
+          { recordId: candidate.id, error: error instanceof Error ? error.message : String(error) },
+          'Sweep promotion failed',
+        )
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Register the sweep**
+
+In `src/scheduler-instance.ts`, add the import and register next to the maintenance job:
+
+```typescript
+import { sweepPromotions } from './long-term-memory/promotion-sweep.js'
+```
+
+```typescript
+scheduler.register('memory-promotion-sweep', {
+  interval: 30 * 60 * 1000, // every 30 minutes
+  handler: () => {
+    void sweepPromotions()
+  },
+  options: { immediate: false },
+})
+```
+
+- [ ] **Step 5: Write the acceptance test ("stop rediscovering")**
+
+```typescript
+// tests/long-term-memory/stop-rediscovering.acceptance.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { setupTestDb, getToolExecutor } from '../utils/test-helpers.js'
+import { runMemoryCapture } from '../../src/long-term-memory/capture.js'
+import { sweepPromotions } from '../../src/long-term-memory/promotion-sweep.js'
+import { evaluatePromotion } from '../../src/long-term-memory/promotion.js'
+import { makeRecallMemoryTool } from '../../src/tools/recall.js'
+import { listMemoryRecords } from '../../src/long-term-memory/store.js'
+import type { MemoryPatch } from '../../src/long-term-memory/extractor.js'
+
+// Keyword recall is used (no embeddings), so the recall query must share tokens with the stored content.
+const fact = 'we deploy every friday'
+const patch: MemoryPatch = {
+  profile: null,
+  records: [
+    { kind: 'fact', content: fact, summary: null, tags: [], confidence: 0.5, source: 'background', evidence: {} },
+  ],
+  updates: [],
+}
+let uid = 0
+const captureDeps = {
+  flagEnabled: () => true,
+  extractMemoryPatch: () => Promise.resolve(patch),
+  getEmbedding: () => Promise.resolve(null),
+  now: () => '2026-06-16T00:00:00.000Z',
+  randomUUID: () => `mem-${(uid += 1)}`,
+}
+
+describe('acceptance: stop rediscovering across threads', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+    uid = 0
+  })
+
+  test('a fact captured in 3 short threads is promoted and recalled from a fresh thread', async () => {
+    for (const thread of ['g:thread:a', 'g:thread:b', 'g:thread:c']) {
+      await runMemoryCapture(
+        {
+          storageContextId: thread,
+          configContextId: 'g',
+          contextType: 'group',
+          history: [{ role: 'user', content: fact }],
+        },
+        captureDeps,
+      )
+    }
+    await sweepPromotions({
+      listScopes: () => [{ scopeId: 'g', scopeType: 'group' }],
+      evaluate: (scope, candidate) =>
+        evaluatePromotion(scope, candidate, {
+          confirmDurable: () => Promise.resolve(true),
+          now: () => '2026-06-16T01:00:00.000Z',
+        }),
+    })
+
+    expect(
+      listMemoryRecords({ scopeId: 'g', scopeType: 'group', status: 'active' }).some((r) => r.content === fact),
+    ).toBe(true)
+
+    const tool = makeRecallMemoryTool({ storageContextId: 'g:thread:z', contextType: 'group' })
+    const result = (await getToolExecutor(tool)({ query: 'friday deploy' })) as {
+      records: Array<{ content: string; provenance: string }>
+    }
+    expect(result.records.some((r) => r.content === fact && r.provenance === 'group')).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 6: Write the flag-off parity test**
+
+```typescript
+// tests/long-term-memory/flag-off-parity.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { setupTestDb } from '../utils/test-helpers.js'
+import { runMemoryCapture } from '../../src/long-term-memory/capture.js'
+import { listProvisionalRecords } from '../../src/long-term-memory/store.js'
+import type { MemoryPatch } from '../../src/long-term-memory/extractor.js'
+
+const patch: MemoryPatch = {
+  profile: null,
+  records: [
+    { kind: 'fact', content: 'x', summary: null, tags: [], confidence: 0.5, source: 'background', evidence: {} },
+  ],
+  updates: [],
+}
+
+describe('flag-off parity', () => {
+  beforeEach(async () => {
+    await setupTestDb()
+  })
+  test('no provisional rows are written when the flag is off', async () => {
+    await runMemoryCapture(
+      {
+        storageContextId: 'g:thread:a',
+        configContextId: 'g',
+        contextType: 'group',
+        history: [{ role: 'user', content: 'x' }],
+      },
+      {
+        flagEnabled: () => false,
+        extractMemoryPatch: () => Promise.resolve(patch),
+        getEmbedding: () => Promise.resolve(null),
+        now: () => 'n',
+        randomUUID: () => 'm',
+      },
+    )
+    expect(listProvisionalRecords({ scopeId: 'g', scopeType: 'group' })).toHaveLength(0)
+  })
+})
+```
+
+- [ ] **Step 7: Run the whole memory suite + typecheck**
+
+Run: `bun test tests/long-term-memory/ tests/tools/recall.test.ts tests/system-prompt-recall.test.ts && bun typecheck`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/long-term-memory/promotion-sweep.ts src/scheduler-instance.ts tests/long-term-memory/promotion-sweep.test.ts tests/long-term-memory/stop-rediscovering.acceptance.test.ts tests/long-term-memory/flag-off-parity.test.ts
+git commit -m "feat(memory): promotion sweep + acceptance + flag-off parity"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full server suite**
+
+Run: `bun run test`
+Expected: all suites pass.
+
+- [ ] **Confirm flag-OFF behavior**: with `cross_thread_memory` unset, `recall` is not registered (Task 5 gate), no promotion runs from recall, and `search_memory` keyword behavior is unchanged. The promotion/capture sweeps no-op because `runMemoryCapture` self-gates and there are no provisional rows to promote.
+
+- [ ] **Run staged checks**: `bun check` — lint + typecheck + format pass.
+
+---
+
+## Handoff to Plan 3
+
+Plans 1+2 deliver the full memory bridge behind `cross_thread_memory`. **Plan 3 (Scope Corrections & Declarative Registry)** is independent of the memory work: attachments group-discoverable on read, `web_rate_limit` per-user, and the single `ENTITY_SCOPES` source of truth with a consistency test that retires the misleading `threadScoped` flag.
+</content>

--- a/docs/superpowers/plans/2026-06-16-scope-corrections-and-registry.md
+++ b/docs/superpowers/plans/2026-06-16-scope-corrections-and-registry.md
@@ -1,0 +1,733 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Scope Corrections & Declarative Registry Implementation Plan (Plan 3 of 3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two scope mistakes — attachments are unreachable across sibling threads, and the web-fetch quota is pooled per-group instead of per-user — and replace the fragile, four-places-to-edit scope model with one declarative `ENTITY_SCOPES` registry guarded by a consistency test.
+
+**Architecture:** Attachments gain a denormalized `group_context_id` (the thread-stripped parent), populated at ingest and used to widen read queries for group contexts only (write/ingest stays thread-scoped). The web-fetch tool keys its quota on `chatUserId` instead of the group-stripped owner id. A new `src/chat/context-scope.ts` declares every context-owned entity's effective scope plus its raw column behavior; a unit test reconciles it against `CONTEXT_OWNED_COLUMNS.threadScoped`, making it impossible to mislabel an entity's scope again.
+
+**Tech Stack:** Bun, TypeScript (strict, `.js` import paths), Drizzle ORM over `bun:sqlite`, Zod v4. Tests: `bun run test`, DI-first per `tests/CLAUDE.md`.
+
+**Independent of Plans 1 & 2** — can land before, after, or in parallel. **Reference spec:** `docs/superpowers/specs/2026-06-16-cross-thread-memory-and-context-scope-design.md` §5–§6.
+
+---
+
+## File Structure
+
+| File                                                | Responsibility                                                                  | Change |
+| --------------------------------------------------- | ------------------------------------------------------------------------------- | ------ |
+| `src/db/migrations/057_attachment_group_context.ts` | Add `group_context_id` to `attachments` + `staged_files`                        | Create |
+| `src/db/index.ts`                                   | Register migration 057                                                          | Modify |
+| `src/db/attachments-schema.ts`                      | `groupContextId` column                                                         | Modify |
+| `src/db/staged-schema.ts`                           | `groupContextId` column                                                         | Modify |
+| `src/attachments/store.ts`                          | Populate `group_context_id` in `saveAttachment`                                 | Modify |
+| `src/attachments/staged.ts`                         | Populate `group_context_id` on staged insert; group-widened `searchStagedFiles` | Modify |
+| `src/attachments/workspace.ts`                      | Group-widened `listActiveAttachments`                                           | Modify |
+| `src/tools/workspace-files.ts`                      | Thread `groupContextId` into `list_files`                                       | Modify |
+| `src/tools/staged-tools.ts`                         | Thread `groupContextId` into `search_staged_files`                              | Modify |
+| `src/tools/provider-independent-tools-builder.ts`   | Compute group-read id (group ctx only); web-fetch actor = `chatUserId`          | Modify |
+| `src/chat/context-scope.ts`                         | `ENTITY_SCOPES`, `EffectiveScope`, `getScopeKey`                                | Create |
+| `tests/chat/context-scope-consistency.test.ts`      | Reconcile registry vs `CONTEXT_OWNED_COLUMNS`                                   | Create |
+
+---
+
+## Task 1: Migration 057 — `group_context_id` columns
+
+**Files:**
+
+- Create: `src/db/migrations/057_attachment_group_context.ts`
+- Modify: `src/db/index.ts`
+- Test: `tests/db/migration-057.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/db/migration-057.test.ts
+import { describe, expect, test } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { runMigrations } from '../../src/db/migrate.js'
+import { MIGRATIONS } from '../../src/db/index.js'
+
+const cols = (db: Database, table: string): string[] =>
+  db
+    .query<{ name: string }, []>(`PRAGMA table_info(${table})`)
+    .all()
+    .map((r) => r.name)
+
+describe('migration 057', () => {
+  test('adds group_context_id to attachments and staged_files', () => {
+    const db = new Database(':memory:')
+    runMigrations(db, MIGRATIONS)
+    expect(cols(db, 'attachments')).toContain('group_context_id')
+    expect(cols(db, 'staged_files')).toContain('group_context_id')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/db/migration-057.test.ts`
+Expected: FAIL — column absent.
+
+- [ ] **Step 3: Create the migration**
+
+```typescript
+// src/db/migrations/057_attachment_group_context.ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { Database } from 'bun:sqlite'
+
+import { logger } from '../../logger.js'
+import type { Migration } from '../migrate.js'
+
+const log = logger.child({ scope: 'migration:057' })
+
+const columnExists = (db: Database, table: string, column: string): boolean =>
+  db
+    .query<{ name: string }, []>(`PRAGMA table_info(${table})`)
+    .all()
+    .some((row) => row.name === column)
+
+const up = (db: Database): void => {
+  if (!columnExists(db, 'attachments', 'group_context_id')) {
+    db.run(`ALTER TABLE attachments ADD COLUMN group_context_id TEXT`)
+  }
+  if (!columnExists(db, 'staged_files', 'group_context_id')) {
+    db.run(`ALTER TABLE staged_files ADD COLUMN group_context_id TEXT`)
+  }
+  db.run(`CREATE INDEX IF NOT EXISTS idx_attachments_group ON attachments(group_context_id, is_active)`)
+  db.run(`CREATE INDEX IF NOT EXISTS idx_staged_group ON staged_files(group_context_id, status)`)
+  log.info('migration 057: attachment/staged group_context_id added')
+}
+
+export const migration057AttachmentGroupContext: Migration = { id: '057_attachment_group_context', up }
+
+export default migration057AttachmentGroupContext
+```
+
+- [ ] **Step 4: Register**
+
+In `src/db/index.ts`, import and append after `migration056ProvisionalMemory` (or after `migration055...` if Plan 1 is not merged — append as the last element regardless):
+
+```typescript
+import { migration057AttachmentGroupContext } from './migrations/057_attachment_group_context.js'
+```
+
+```typescript
+  migration057AttachmentGroupContext,
+]
+```
+
+- [ ] **Step 5: Run test + commit**
+
+Run: `bun test tests/db/migration-057.test.ts`
+Expected: PASS.
+
+```bash
+git add src/db/migrations/057_attachment_group_context.ts src/db/index.ts tests/db/migration-057.test.ts
+git commit -m "feat(attachments): group_context_id columns (057)"
+```
+
+---
+
+## Task 2: Drizzle schema columns
+
+**Files:**
+
+- Modify: `src/db/attachments-schema.ts`
+- Modify: `src/db/staged-schema.ts`
+- Test: `tests/db/attachment-group-context-schema.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/db/attachment-group-context-schema.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { attachments } from '../../src/db/attachments-schema.js'
+import { eq } from 'drizzle-orm'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('attachments.groupContextId', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('round-trips group_context_id', () => {
+    const db = getDrizzleDb()
+    db.insert(attachments)
+      .values({
+        attachmentId: 'a1',
+        contextId: 'g:thread:a',
+        groupContextId: 'g',
+        sourceProvider: 'telegram',
+        filename: 'f.txt',
+        checksum: 'c',
+        blobKey: 'b',
+        status: 'stored',
+        createdAt: '2026-06-16T00:00:00.000Z',
+      })
+      .run()
+    const row = db.select().from(attachments).where(eq(attachments.attachmentId, 'a1')).get()
+    expect(row?.groupContextId).toBe('g')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/db/attachment-group-context-schema.test.ts`
+Expected: FAIL — `groupContextId` not a known column.
+
+- [ ] **Step 3: Add the columns**
+
+In `src/db/attachments-schema.ts`, add inside the `attachments` column object (after `contextId`):
+
+```typescript
+    groupContextId: text('group_context_id'),
+```
+
+In `src/db/staged-schema.ts`, add inside the `stagedFiles` column object (after `contextId`):
+
+```typescript
+    groupContextId: text('group_context_id'),
+```
+
+- [ ] **Step 4: Run test + commit**
+
+Run: `bun test tests/db/attachment-group-context-schema.test.ts`
+Expected: PASS.
+
+```bash
+git add src/db/attachments-schema.ts src/db/staged-schema.ts tests/db/attachment-group-context-schema.test.ts
+git commit -m "feat(attachments): groupContextId in drizzle schema"
+```
+
+---
+
+## Task 3: Populate `group_context_id` at ingest
+
+**Files:**
+
+- Modify: `src/attachments/store.ts` (`saveAttachment`)
+- Modify: `src/attachments/staged.ts` (staged insert site)
+- Test: `tests/attachments/group-context-ingest.test.ts`
+
+Compute the group id at the lowest write point so all callers benefit without API changes: `group_context_id = getConfigContextIdFromStorageContextId(contextId)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/attachments/group-context-ingest.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { attachments } from '../../src/db/attachments-schema.js'
+import { eq } from 'drizzle-orm'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+import { saveAttachment } from '../../src/attachments/store.js'
+import { toScopedThreadContextId, toScopedContextId } from '../../src/chat/scoped-context.js'
+
+describe('saveAttachment populates group_context_id', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('stores the thread-stripped parent for a thread context', async () => {
+    const thread = toScopedThreadContextId({ platformInstanceId: 'pi', nativeContextId: 'grp', threadId: 't1' })
+    const parent = toScopedContextId({ platformInstanceId: 'pi', nativeContextId: 'grp' })
+    await saveAttachment({
+      contextId: thread,
+      sourceProvider: 'telegram',
+      filename: 'f.txt',
+      checksum: 'c',
+      blobKey: 'b',
+      status: 'stored',
+      size: 1,
+      mimeType: 'text/plain',
+    } as Parameters<typeof saveAttachment>[0])
+    const row = getDrizzleDb().select().from(attachments).where(eq(attachments.contextId, thread)).get()
+    expect(row?.groupContextId).toBe(parent)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/attachments/group-context-ingest.test.ts`
+Expected: FAIL — `groupContextId` is null.
+
+- [ ] **Step 3: Populate in `saveAttachment`**
+
+In `src/attachments/store.ts`, add the import:
+
+```typescript
+import { getConfigContextIdFromStorageContextId } from '../chat/scoped-context.js'
+```
+
+In the `.insert(attachments).values({...})` object, add (right after `contextId: input.contextId,`):
+
+```typescript
+      groupContextId: getConfigContextIdFromStorageContextId(input.contextId),
+```
+
+- [ ] **Step 4: Populate at the staged insert site**
+
+In `src/attachments/staged.ts`, locate the `.insert(stagedFiles).values({...})` call (grep `insert(stagedFiles)`), add the same import, and add to the values object after `contextId`:
+
+```typescript
+      groupContextId: getConfigContextIdFromStorageContextId(<the contextId variable used in this insert>),
+```
+
+- [ ] **Step 5: Run test + commit**
+
+Run: `bun test tests/attachments/group-context-ingest.test.ts`
+Expected: PASS.
+
+```bash
+git add src/attachments/store.ts src/attachments/staged.ts tests/attachments/group-context-ingest.test.ts
+git commit -m "feat(attachments): populate group_context_id at ingest"
+```
+
+---
+
+## Task 4: Group-discoverable reads (group contexts only)
+
+**Files:**
+
+- Modify: `src/attachments/workspace.ts` (`listActiveAttachments`)
+- Modify: `src/attachments/staged.ts` (`searchStagedFiles`)
+- Modify: `src/tools/workspace-files.ts`, `src/tools/staged-tools.ts`
+- Modify: `src/tools/provider-independent-tools-builder.ts`
+- Test: `tests/attachments/group-discovery-read.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/attachments/group-discovery-read.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { getDrizzleDb } from '../../src/db/drizzle.js'
+import { attachments } from '../../src/db/attachments-schema.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+import { listActiveAttachments } from '../../src/attachments/workspace.js'
+
+const seed = (attachmentId: string, contextId: string, groupContextId: string): void => {
+  getDrizzleDb()
+    .insert(attachments)
+    .values({
+      attachmentId,
+      contextId,
+      groupContextId,
+      sourceProvider: 'telegram',
+      filename: `${attachmentId}.txt`,
+      checksum: attachmentId,
+      blobKey: attachmentId,
+      status: 'stored',
+      isActive: 1,
+      createdAt: '2026-06-16T00:00:00.000Z',
+    })
+    .run()
+}
+
+describe('listActiveAttachments group discovery', () => {
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+  })
+
+  test('without groupContextId, only the exact thread is returned', () => {
+    seed('a', 'g:thread:1', 'g')
+    seed('b', 'g:thread:2', 'g')
+    expect(listActiveAttachments('g:thread:1').map((r) => r.attachmentId)).toEqual(['a'])
+  })
+
+  test('with groupContextId, sibling-thread attachments are included', () => {
+    seed('a', 'g:thread:1', 'g')
+    seed('b', 'g:thread:2', 'g')
+    seed('c', 'other', 'other')
+    const ids = listActiveAttachments('g:thread:1', { groupContextId: 'g' })
+      .map((r) => r.attachmentId)
+      .sort()
+    expect(ids).toEqual(['a', 'b'])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/attachments/group-discovery-read.test.ts`
+Expected: FAIL — `listActiveAttachments` takes one arg.
+
+- [ ] **Step 3: Widen the store reads**
+
+In `src/attachments/workspace.ts`, change `listActiveAttachments` to accept an optional group id and widen the `where`:
+
+```typescript
+import { and, eq, or } from 'drizzle-orm'
+
+export function listActiveAttachments(
+  contextId: string,
+  options?: Readonly<{ groupContextId?: string }>,
+): AttachmentRef[] {
+  const scopeCondition =
+    options?.groupContextId === undefined
+      ? eq(attachments.contextId, contextId)
+      : or(eq(attachments.contextId, contextId), eq(attachments.groupContextId, options.groupContextId))
+  return getDrizzleDb()
+    .select()
+    .from(attachments)
+    .where(and(scopeCondition, eq(attachments.isActive, 1)))
+    .all()
+    .filter((row) => row.clearedAt === null)
+  // ...existing mapping unchanged...
+}
+```
+
+In `src/attachments/staged.ts`, change `searchStagedFiles` to accept an optional group id and replace the `eq(stagedFiles.contextId, contextId)` clause with the same `or(...)` shape (preserving the existing `status` + `LIKE` conditions):
+
+```typescript
+export function searchStagedFiles(
+  contextId: string,
+  query: string,
+  options?: Readonly<{ groupContextId?: string; limit?: number }>,
+): StagedFileRef[] {
+  const scopeCondition =
+    options?.groupContextId === undefined
+      ? eq(stagedFiles.contextId, contextId)
+      : or(eq(stagedFiles.contextId, contextId), eq(stagedFiles.groupContextId, options.groupContextId))
+  // ...build the same and(scopeCondition, eq(status,'staged'), or(LIKE...)) query, limit unchanged...
+}
+```
+
+> Keep `resolveStagedFile` unchanged — it requires an exact `stagedId`, so group widening does not apply.
+
+- [ ] **Step 4: Thread the group id through the tool factories**
+
+In `src/tools/workspace-files.ts`, change `makeListFilesTool` to accept and forward the group id:
+
+```typescript
+export function makeListFilesTool(contextId: string, groupContextId?: string): ToolSet[string] {
+  // ...inside execute, replace listActiveAttachments(contextId) with:
+  //   listActiveAttachments(contextId, groupContextId === undefined ? undefined : { groupContextId })
+}
+```
+
+In `src/tools/staged-tools.ts`, change `makeSearchStagedFilesTool` similarly:
+
+```typescript
+export function makeSearchStagedFilesTool(contextId: string, groupContextId?: string): ToolSet[string] {
+  // ...inside execute, call searchStagedFiles(contextId, query, { groupContextId, limit })
+}
+```
+
+- [ ] **Step 5: Compute the group-read id (group contexts only) in the builder**
+
+In `src/tools/provider-independent-tools-builder.ts`, inside `addProviderIndependentTools`, after `const storageOwnerId = getStorageOwnerId(chatUserId, contextId)`, add:
+
+```typescript
+const groupReadContextId =
+  contextType === 'group' && contextId !== undefined ? getConfigContextIdFromStorageContextId(contextId) : undefined
+```
+
+Pass it where the file tools are constructed (the `isS3Configured()` block): `makeListFilesTool(contextId, groupReadContextId)` and `makeSearchStagedFilesTool(contextId, groupReadContextId)`. (`getConfigContextIdFromStorageContextId` is already imported in this file — see line 10 of the existing import block.)
+
+- [ ] **Step 6: Run test + typecheck + commit**
+
+Run: `bun test tests/attachments/group-discovery-read.test.ts && bun typecheck`
+Expected: PASS.
+
+```bash
+git add src/attachments/workspace.ts src/attachments/staged.ts src/tools/workspace-files.ts src/tools/staged-tools.ts src/tools/provider-independent-tools-builder.ts tests/attachments/group-discovery-read.test.ts
+git commit -m "feat(attachments): group-discoverable reads for group contexts"
+```
+
+---
+
+## Task 5: `web_rate_limit` → per-user
+
+**Files:**
+
+- Modify: `src/tools/provider-independent-tools-builder.ts` (web-fetch call site)
+- Modify: `tests/tools/web-fetch.test.ts` (existing actor assertion)
+- Test: `tests/web/rate-limit-per-user.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/web/rate-limit-per-user.test.ts
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('web fetch quota keys on the actor', () => {
+  let consumeWebFetchQuota: typeof import('../../src/web/rate-limit.js').consumeWebFetchQuota
+  beforeEach(async () => {
+    mockLogger()
+    await setupTestDb()
+    ;({ consumeWebFetchQuota } = await import('../../src/web/rate-limit.js'))
+  })
+
+  test('two threads of the same user share one quota; two users are independent', () => {
+    const t0 = Date.parse('2026-06-16T00:00:00.000Z')
+    const first = consumeWebFetchQuota('user-A', t0)
+    const second = consumeWebFetchQuota('user-A', t0 + 1000) // same actor id -> same bucket
+    expect(second.remaining).toBe(first.remaining - 1)
+    const other = consumeWebFetchQuota('user-B', t0 + 2000)
+    expect(other.remaining).toBe(first.remaining) // independent bucket
+  })
+})
+```
+
+> This test asserts the rate-limit primitive is per-actor-id (already true). The behavioral change is _which_ id the web-fetch tool passes; Step 3 makes that the real `chatUserId`. If `RateLimitResult` field names differ, adjust the assertions to the real shape (`remaining`/`retryAfterSec`).
+
+- [ ] **Step 2: Run test to verify it fails (or passes trivially), then change the actor**
+
+Run: `bun test tests/web/rate-limit-per-user.test.ts`
+Expected: PASS for the primitive. The meaningful change is the wiring below.
+
+- [ ] **Step 3: Pass `chatUserId` as the actor**
+
+In `src/tools/provider-independent-tools-builder.ts`, change the web-fetch registration from:
+
+```typescript
+if (contextId !== undefined) tools['web_fetch'] = makeWebFetchTool(contextId, storageOwnerId, contextType)
+```
+
+to:
+
+```typescript
+if (contextId !== undefined) tools['web_fetch'] = makeWebFetchTool(contextId, chatUserId, contextType)
+```
+
+- [ ] **Step 4: Update the existing web-fetch test**
+
+In `tests/tools/web-fetch.test.ts`, the assembled-tools test (~line 87, "uses scoped storage context as actor id…") currently expects `actorId === storageContextId`. Update it so the assembled `web_fetch` records `actorId === chatUserId` (the value passed to `buildTools(provider, '<chatUserId>', storageContextId, ...)`). Update the test name to "uses chatUserId as the web-fetch actor id". The direct-DI test (~line 36) already passes `'user-456'` as `actorUserId` and asserts it forwards — leave it, it still validates the forwarding contract.
+
+- [ ] **Step 5: Run tests + commit**
+
+Run: `bun test tests/tools/web-fetch.test.ts tests/web/rate-limit-per-user.test.ts`
+Expected: PASS.
+
+```bash
+git add src/tools/provider-independent-tools-builder.ts tests/tools/web-fetch.test.ts tests/web/rate-limit-per-user.test.ts
+git commit -m "fix(web): rate-limit web_fetch per user, not per group"
+```
+
+---
+
+## Task 6: Declarative `ENTITY_SCOPES` registry + consistency test
+
+**Files:**
+
+- Create: `src/chat/context-scope.ts`
+- Modify: `src/tools/provider-independent-tools-builder.ts` (`getStorageOwnerId` delegates to the registry helper)
+- Test: `tests/chat/context-scope.test.ts`
+- Test: `tests/chat/context-scope-consistency.test.ts`
+
+The registry declares, per context-owned entity, its **effective** scope (`thread | group | user | group+threadOverride`) and its **raw** column behaviour (`rawThreadScoped` — does the stored id carry a thread suffix before any promotion). `getScopeKey` resolves a write/read key from the effective scope; the consistency test reconciles `rawThreadScoped` against the existing `CONTEXT_OWNED_COLUMNS.threadScoped`, so the two can never silently diverge again.
+
+- [ ] **Step 1: Write the failing unit test**
+
+```typescript
+// tests/chat/context-scope.test.ts
+import { describe, expect, test } from 'bun:test'
+import { getScopeKey } from '../../src/chat/context-scope.js'
+
+const ctx = { storageContextId: 'pi:enc:ctx:grp:thread:enc', chatUserId: 'user-1', contextType: 'group' as const }
+
+describe('getScopeKey', () => {
+  test('thread scope returns the full storage id', () => {
+    expect(getScopeKey('thread', ctx)).toBe(ctx.storageContextId)
+  })
+  test('group scope strips the thread suffix', () => {
+    expect(getScopeKey('group', ctx)).toBe('pi:enc:ctx:grp')
+    expect(getScopeKey('group+threadOverride', ctx)).toBe('pi:enc:ctx:grp')
+  })
+  test('user scope returns the chat user id', () => {
+    expect(getScopeKey('user', ctx)).toBe('user-1')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/chat/context-scope.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the registry + resolver**
+
+```typescript
+// src/chat/context-scope.ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { getConfigContextIdFromStorageContextId } from './scoped-context.js'
+
+export type EffectiveScope = 'thread' | 'group' | 'group+threadOverride' | 'user'
+
+export type EntityScope = Readonly<{
+  table: string
+  column: string
+  /** Effective read/write semantics — what `getScopeKey` resolves. */
+  scope: EffectiveScope
+  /** Does the stored column carry a thread-scoped id at write time (pre-promotion)? Must match CONTEXT_OWNED_COLUMNS.threadScoped. */
+  rawThreadScoped: boolean
+}>
+
+export type ScopeKeyContext = Readonly<{
+  storageContextId: string
+  chatUserId: string
+  contextType: 'dm' | 'group'
+}>
+
+/** Resolve the read/write key for an effective scope. */
+export function getScopeKey(scope: EffectiveScope, ctx: ScopeKeyContext): string {
+  switch (scope) {
+    case 'thread':
+      return ctx.storageContextId
+    case 'group':
+    case 'group+threadOverride':
+      return getConfigContextIdFromStorageContextId(ctx.storageContextId)
+    case 'user':
+      return ctx.chatUserId
+  }
+}
+
+// Single source of truth for context-owned entity scoping.
+// `scope` is the effective behaviour; `rawThreadScoped` mirrors the migration-era column flag.
+export const ENTITY_SCOPES: readonly EntityScope[] = [
+  { table: 'conversation_history', column: 'user_id', scope: 'thread', rawThreadScoped: true },
+  { table: 'memory_summary', column: 'user_id', scope: 'thread', rawThreadScoped: true },
+  { table: 'memory_facts', column: 'user_id', scope: 'thread', rawThreadScoped: true },
+  { table: 'task_snapshots', column: 'user_id', scope: 'thread', rawThreadScoped: true },
+  { table: 'message_metadata', column: 'context_id', scope: 'thread', rawThreadScoped: true },
+  { table: 'attachments', column: 'context_id', scope: 'thread', rawThreadScoped: true },
+  { table: 'staged_files', column: 'context_id', scope: 'thread', rawThreadScoped: true },
+  { table: 'llm_usage_events', column: 'storage_context_id', scope: 'thread', rawThreadScoped: true },
+  { table: 'tool_call_events', column: 'storage_context_id', scope: 'thread', rawThreadScoped: true },
+  { table: 'scheduled_prompts', column: 'delivery_context_id', scope: 'thread', rawThreadScoped: true },
+  { table: 'alert_prompts', column: 'delivery_context_id', scope: 'thread', rawThreadScoped: true },
+  // Effectively per-user (identity is the person; quota guards the actor) though the raw column is thread-shaped.
+  { table: 'user_identity_mappings', column: 'context_id', scope: 'user', rawThreadScoped: true },
+  { table: 'web_rate_limit', column: 'actor_id', scope: 'user', rawThreadScoped: true },
+  // Group-shared via runtime strip + migration-046 promotion (raw column may still be thread-shaped historically).
+  { table: 'memos', column: 'user_id', scope: 'group', rawThreadScoped: true },
+  { table: 'recurring_tasks', column: 'user_id', scope: 'group', rawThreadScoped: true },
+  { table: 'user_instructions', column: 'context_id', scope: 'group+threadOverride', rawThreadScoped: true },
+  { table: 'scheduled_prompts', column: 'created_by_user_id', scope: 'group', rawThreadScoped: true },
+  { table: 'alert_prompts', column: 'created_by_user_id', scope: 'group', rawThreadScoped: true },
+  // Natively group-scoped (never thread-shaped).
+  { table: 'context_settings', column: 'context_id', scope: 'group', rawThreadScoped: false },
+  { table: 'user_config', column: 'user_id', scope: 'group', rawThreadScoped: false },
+  { table: 'authorized_groups', column: 'group_id', scope: 'group', rawThreadScoped: false },
+  { table: 'group_members', column: 'group_id', scope: 'group', rawThreadScoped: false },
+  { table: 'known_group_contexts', column: 'context_id', scope: 'group', rawThreadScoped: false },
+  { table: 'group_admin_observations', column: 'context_id', scope: 'group', rawThreadScoped: false },
+  { table: 'group_user_observations', column: 'context_id', scope: 'group', rawThreadScoped: false },
+  // Plugin state — promoted to parent (mig 046).
+  { table: 'plugin_context_state', column: 'context_id', scope: 'group', rawThreadScoped: true },
+  { table: 'plugin_kv', column: 'context_id', scope: 'group', rawThreadScoped: true },
+]
+```
+
+- [ ] **Step 4: Write the consistency test**
+
+```typescript
+// tests/chat/context-scope-consistency.test.ts
+import { describe, expect, test } from 'bun:test'
+import { ENTITY_SCOPES } from '../../src/chat/context-scope.js'
+import { CONTEXT_OWNED_COLUMNS } from '../../src/db/migrations/scoped-context-owned-columns.js'
+
+const key = (t: string, c: string): string => `${t}.${c}`
+
+describe('ENTITY_SCOPES reconciliation', () => {
+  test('rawThreadScoped matches CONTEXT_OWNED_COLUMNS.threadScoped for every shared (table,column)', () => {
+    const owned = new Map(CONTEXT_OWNED_COLUMNS.map((c) => [key(c.table, c.column), c.threadScoped]))
+    const mismatches: string[] = []
+    for (const entry of ENTITY_SCOPES) {
+      const flag = owned.get(key(entry.table, entry.column))
+      if (flag !== undefined && flag !== entry.rawThreadScoped) {
+        mismatches.push(
+          `${key(entry.table, entry.column)}: registry rawThreadScoped=${entry.rawThreadScoped} but CONTEXT_OWNED_COLUMNS=${flag}`,
+        )
+      }
+    }
+    expect(mismatches).toEqual([])
+  })
+
+  test('every effective-thread entity is rawThreadScoped (cannot group-collapse a thread-scoped entity)', () => {
+    const bad = ENTITY_SCOPES.filter((e) => e.scope === 'thread' && !e.rawThreadScoped).map((e) =>
+      key(e.table, e.column),
+    )
+    expect(bad).toEqual([])
+  })
+
+  test('every CONTEXT_OWNED_COLUMNS entry is declared in the registry', () => {
+    const declared = new Set(ENTITY_SCOPES.map((e) => key(e.table, e.column)))
+    const missing = CONTEXT_OWNED_COLUMNS.map((c) => key(c.table, c.column)).filter((k) => !declared.has(k))
+    expect(missing).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 5: Run both tests to verify behavior**
+
+Run: `bun test tests/chat/context-scope.test.ts tests/chat/context-scope-consistency.test.ts`
+Expected: the unit test PASSES; the consistency test PASSES only when every `rawThreadScoped` agrees with `CONTEXT_OWNED_COLUMNS` and every owned column is declared. If a mismatch/missing entry is reported, fix the `ENTITY_SCOPES` entry to match the real `threadScoped` value from `scoped-context-owned-columns.ts` (this is the test doing its job — reconcile, don't silence it).
+
+- [ ] **Step 6: Make the registry load-bearing**
+
+In `src/tools/provider-independent-tools-builder.ts`, reimplement `getStorageOwnerId` to resolve through the registry's group-strip (its three consumers — memos, recurring tasks, instructions — are all effective `group`), keeping the existing `undefined`/DM fallback:
+
+```typescript
+import { getScopeKey } from '../chat/context-scope.js'
+
+export function getStorageOwnerId(chatUserId: string | undefined, contextId: string | undefined): string | undefined {
+  if (contextId === undefined) return chatUserId
+  return getScopeKey('group', {
+    storageContextId: contextId,
+    chatUserId: chatUserId ?? contextId,
+    contextType: 'group',
+  })
+}
+```
+
+This is behavior-identical (`getScopeKey('group', …)` is exactly `getConfigContextIdFromStorageContextId(contextId)`) but routes the strip through the single source of truth.
+
+- [ ] **Step 7: Run the full suite + commit**
+
+Run: `bun run test && bun typecheck`
+Expected: PASS (the existing `getStorageOwnerId` callers are unchanged behaviorally).
+
+```bash
+git add src/chat/context-scope.ts src/tools/provider-independent-tools-builder.ts tests/chat/context-scope.test.ts tests/chat/context-scope-consistency.test.ts
+git commit -m "feat(scope): declarative ENTITY_SCOPES registry + consistency test"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full server suite**: `bun run test` — all suites pass.
+- [ ] **Manual scope sanity**: in a group thread, an attachment uploaded in thread A is now listable from thread B (`list_files`) but not from a different group; a DM is unaffected (no `groupContextId` widening since `contextType !== 'group'`).
+- [ ] **Run staged checks**: `bun check`.
+
+---
+
+## Notes / deferred
+
+- **Per-thread `user_instructions` override** (`group+threadOverride`) is declared in the registry but not yet implemented — base behavior stays group-shared. Implementing the override layer is a separate change.
+- **Full migration of all `getConfigContextIdFromStorageContextId` call sites to `getScopeKey`** is intentionally out of scope; Task 6 wires the one generic helper (`getStorageOwnerId`) and establishes the registry + enforcement so new code uses `getScopeKey` going forward.
+  </content>

--- a/docs/superpowers/specs/2026-06-15-youtrack-custom-fields-design.md
+++ b/docs/superpowers/specs/2026-06-15-youtrack-custom-fields-design.md
@@ -8,7 +8,7 @@ See LICENSE in the project root for details.
 # YouTrack custom-field reliability — design
 
 **Date:** 2026-06-15
-**Status:** Approved (pending implementation plan)
+**Status:** Implemented (2026-06-16) — see [As-built notes](#as-built-notes)
 **Area:** `plugins/task-provider-youtrack/`, `src/tools/`, `src/providers/`
 
 ## Problem
@@ -63,7 +63,9 @@ Four concrete defects:
 
 **Non-goals (v1)**
 
-- `update_task` generalization (the same engine can be applied later).
+- `update_task` generalization (the same engine can be applied later). _Delivered in the
+  2026-06-16 follow-up (`2026-06-16-youtrack-dedicated-fields-and-teaching-errors-design.md`),
+  commit `a68da9a1c` — create and update now share one schema-driven builder._
 - Group fields; fuzzy/synonym user resolution.
 - Two-phase create via the YouTrack `commands` API.
 
@@ -213,3 +215,24 @@ and cached. Existing `resolveStateBundle` usage is preserved.
   type rather than a silent wrong payload.
 - **Multi-value comma ambiguity:** values containing commas are rare for bundle elements;
   documented as a known limitation for v1.
+
+## As-built notes
+
+Implemented across `2026-06-16` (commits `35a933016`, `be3bec635`, `ffc43bce7`,
+`59f56a25a`, `a653a9776`, `74185162a`, `8fa540217`, `2f87c60bd`, `c8ad80309`). The shipped
+shape differs from the design sketch in a few naming/structure details; the behaviour matches.
+
+| Design sketch                                            | As-built                                                                                                                                                                                                                                                                      |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `field-engine.ts` `resolveCustomFieldValue()`            | Implemented as designed in `field-engine.ts` (`classifyFieldType` + `resolveCustomFieldValue`).                                                                                                                                                                               |
+| `bundle-cache.ts` (EDIT, generalize)                     | Bundle-element resolution split into `bundle-values.ts` (`makeBundleElementFetcher`, the per-`bundleId` cache) consumed by the field engine; `bundle-cache.ts` retains the legacy state cache.                                                                                |
+| `operations/describe.ts` (NEW)                           | Shipped as `operations/project-fields.ts` → `describeYouTrackProjectFields`.                                                                                                                                                                                                  |
+| provider `describeProjectFields(): ProjectFieldSchema[]` | `src/providers/types.ts` exposes `describeProjectFields?(projectId): Promise<ProjectFieldDescriptor[]>`; tool is `src/tools/describe-project.ts` (`makeDescribeProjectTool`, gated on the optional method).                                                                   |
+| `task-helpers.ts` builders                               | Required-detection (`validateRequiredCreateFields`) and the shared builder (`buildIssueCustomFields`) live in `task-helpers.ts`; the empty-admin-endpoint fallback derives the schema from a sample issue via `issue-derived-fields.ts` (`fetchProjectCustomFieldsViaIssue`). |
+
+**Subsequent work (2026-06-16 follow-up):** dedicated-param localization, name-level teaching
+errors, and `update_task` parity — see the follow-up design. After that follow-up, `create`
+and `update` share a single path: `buildIssueCustomFields(config, params, projectCustomFields,
+op)` over `collectFieldPairs` / `resolveFieldPair` (`create-field-helpers.ts`). The
+"Unsupported custom field for create/update: …" allowlist rejection described in the Problem
+section no longer exists in the code.

--- a/docs/superpowers/specs/2026-06-16-acp-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-16-acp-plugin-design.md
@@ -1,0 +1,265 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# ACP Agent Sessions — Design Spec
+
+- **Date:** 2026-06-16
+- **Status:** Approved (design); ready for implementation planning
+- **Scope:** A papai capability that lets a chat user drive sandboxed AI coding-agent sessions over the Agent Client Protocol (ACP) — configure agents/projects, start sessions (git fetch/checkout/worktree/branch), track progress in natural language, finish (commit/push/PR), and review open PRs.
+
+This spec spans **three deliverables across three repos**: a thin papai plugin + one papai-core endpoint (`papai`), a new TypeScript control service (`papai-acp-control`, new repo/service), and ACP support added to the existing Rust sandbox tool (`geofront`).
+
+---
+
+## 1. Problem & goals
+
+A user sends natural-language messages to papai ("start a session on repo X to do Y", "what's running?", "finish and open a PR", "review PR #123"). papai should translate those into **sandboxed coding-agent work**: an AI agent runs in an isolated container, edits a checked-out worktree, and the user supervises it from chat. The privileged operations (ACP client, git, forge, session state, permissions, secrets) must live in a trusted control plane; the untrusted, code-executing agent must be sandboxed and never hold forge/push secrets.
+
+### Required behaviours (from the request)
+
+1. **Configure agents/projects.**
+2. **Start session** — fetch/checkout, per-session worktree + branch.
+3. **Progress** — query current sessions in natural language (active / new / review / waiting-for-response).
+4. **Record progress + metadata telemetry.**
+5. **Finish session** — commit/push/create PR/output summary + review link.
+6. **Review open PR** — fetch/checkout, start a review session, create review comments.
+
+### Non-goals (v1)
+
+- Live token-by-token streaming of agent output into chat (background + milestone model instead).
+- Per-user forge identities (shared bot service account in v1).
+- Remote/k8s sandbox fleets (single-host geofront in v1; topology designed to evolve).
+- Dynamic mid-session egress-allowlist broadening (fixed per session at start).
+
+---
+
+## 2. Research findings that shaped the design
+
+These were verified against the codebases before designing (see decision log, §11).
+
+### papai plugin sandbox cannot host ACP
+
+The plugin runtime (`src/plugins/`) exposes exactly one outbound primitive — `providerRuntime.httpFetch()` (stateless HTTPS to allowlisted hosts). Verified absent: subprocess spawning (`child_process`/`Bun.spawn`), persistent stdio/WebSocket for plugins, local git, and a working `stdio` MCP transport (schema-reserved, hard-throws at runtime). ACP requires spawning an agent subprocess and holding a JSON-RPC-over-stdio channel with agent→client callbacks. **Therefore the ACP runtime cannot live inside the plugin sandbox** — it lives in an external service; the plugin is a thin HTTP client.
+
+### papai cannot proactively message users from a plugin
+
+Core _can_ send proactively — `ChatProvider.sendMessage(platformInstanceId, target, markdown)`, driven by the in-process scheduler, resolving the instance from the `context_settings` table (this is how deferred prompts and recurring tasks deliver). But **no plugin runtime context exposes any send/notify** (tool, command-proactive, or scheduled-job), and plugins cannot register HTTP routes. The only inbound send route today (`POST /settings/api/admin/announce`) broadcasts to all users. **Therefore the "background + milestone notifications" model requires one small papai-core addition: a targeted notify endpoint.**
+
+### geofront is a production sandbox, but has no external agent I/O
+
+geofront (Rust CLI) already does zero-trust Docker sandboxing: workspace container + egress-proxy container with a domain/CIDR allowlist enforced by in-namespace `iptables` (deny-by-default), `--cap-drop ALL`, `no-new-privileges`, non-root, host-cwd bind-mounted to `/home/dev/workspace`. Agent presets `codex`/`claude_code`/`other` (custom `entrypoint`), spawned via `docker exec`. **Gap:** the agent runs under `docker exec -it` with inherited terminal stdio — there is no way for an external ACP client to attach, no server/API, no stdin injection from outside, no sessions, no ACP awareness, no git (workspace = host cwd), no resource limits/timeouts. The clean seam to add ACP is the `RuntimeProvider::run_agent_session` boundary.
+
+### agent-sniff (evaluated, not used)
+
+agent-sniff (a Bun ACP bridge) was evaluated as the ACP client/transport. Because geofront becomes the sandbox and exposes a raw ACP stdio stream, the control service builds **directly on `@agentclientprotocol/sdk`** instead. agent-sniff is retained only as a _reference_ for chunk taxonomy and the DebugRecorder telemetry pattern — no code dependency.
+
+---
+
+## 3. Architecture
+
+Three tiers; the plugin is thin, the control service owns all operational work, geofront is the sandboxed ACP-exposing agent runtime.
+
+```
+papai bot ──httpFetch──► CONTROL SERVICE (host, trusted; TS/Bun — new)
+papai core ◄── /api/notify ── │  ACP client (@agentclientprotocol/sdk)
+                              │  session state machine + SQLite
+                              │  permission engine · notifier
+                              │  WorkspaceManager: git clone-cache + worktree + branch (host fs)
+                              │  Forge (GitHub + GitLab)  ·  holds ALL secrets
+                              │      │ per session: prepares worktree dir, writes geofront.toml,
+                              │      ▼ spawns `geofront workspace up --acp <sock>` (cwd = worktree)
+                              │   ACP client connects ◄── unix socket ──┐
+                              ▼                                          │
+                        GEOFRONT (Rust CLI + NEW acp-relay) ────────────┘
+                              ▼ docker exec (piped, no TTY)
+                        AGENT SANDBOX (geofront-managed Docker)
+                          claude-code-acp (kind="other")  ·  egress allowlist + iptables
+                          workspace bind-mount  ·  LLM creds via mounted config  ·  NO forge token
+```
+
+### Trust & secrets boundaries
+
+- **plugin ↔ control:** bearer token over `httpFetch`; the control base URL is admin-scoped so a LAN/HTTP control service is allowed by `providerAllowedHostsFromConfig`.
+- **control ↔ geofront:** local Unix socket on the trusted host (filesystem permissions); add a token only if geofront is later placed remotely.
+- **control → papai:** notify token to `POST /api/notify`.
+- **Secrets:** forge token + git push creds + LLM key live **only** on the control host. The LLM key reaches the sandbox via geofront's config-dir mount; **the forge token never enters the sandbox.** Git commit/push and all forge calls run host-side on the worktree the agent edited through the bind-mount.
+
+### Why this topology
+
+- Untrusted code execution is isolated in geofront's hardened container; the trusted control plane holds secrets and performs privileged git/forge actions.
+- geofront's raw-ACP-stdio relay means `session/request_permission`, `fs/*`, `terminal/*` all work natively over ACP (no broken HTTP permission path).
+- The agent-launch boundary is an interface, so single-host docker today can evolve to remote/k8s sandboxes later without reworking the control logic.
+
+---
+
+## 4. geofront changes (Rust)
+
+Net-new work, all at/under the `RuntimeProvider::run_agent_session` seam; tiers above it (config, plan, network, sandbox lifecycle) need zero changes.
+
+1. **Piped exec** — a non-TTY `docker exec` variant that captures the agent's stdin/stdout (today's path uses `-it` with inherited terminal).
+2. **Host-side ACP relay** — a Unix-socket (or TCP) listener that bridges raw bytes ↔ the agent's piped stdio. **Raw ndJSON passthrough**, _not_ re-framed into leliel's Postcard protocol, so an external ACP client speaks ACP straight through. The relay runs on the host; the container needs **no inbound exposure** (sandbox stays closed). The existing `leliel-host` process-streaming broker is the reference pattern.
+3. **`SessionMode::AcpBridge`** (or equivalent) + a CLI mode `geofront workspace up --acp <socket>` selecting this path instead of interactive/skipped.
+4. _(Optional, later)_ per-container CPU/memory limits and a session timeout (geofront sets none today; control-side timeouts cover v1).
+
+A new crate (e.g. `crates/acp-relay`) or an extension of `crates/leliel/host` hosts the relay; `crates/runtime-docker` gains the piped-exec method; `crates/cli` wires the new mode.
+
+---
+
+## 5. Control service (TypeScript / Bun — new)
+
+The bulk of the net-new work. Modules:
+
+### 5.1 Session state machine
+
+States: `queued → preparing → running ⇄ {waiting_permission, waiting_input} → finishing → done`; plus `failed`, `cancelled`. Review sessions use a `review` running-variant → `done`.
+
+- **`preparing`** = clone-cache fetch + worktree/branch + `geofront workspace up`.
+- **Milestone-emitting transitions** (→ `/api/notify`): `plan_ready` (first plan chunk), `waiting_permission`, `waiting_input` (turn ended; agent asks or idles), `failed`/`blocked`, `done` (with PR URL when finished), `review_posted`.
+- **NL filter map:** "active" → running/preparing · "waiting" → waiting_permission + waiting_input · "review" → review · "new" → queued · "done" → done/failed/cancelled.
+
+### 5.2 Permission engine
+
+- **Policy presets** per project/agent: `autonomous` (auto-allow fs/terminal _inside the worktree_; ask on out-of-worktree/destructive ops), `cautious` (ask on any write/command), `readonly` (deny writes). **push/PR are never agent actions** — only the control plane performs them, gated behind explicit `acp_finish_session`.
+- **Flow:** agent `session/request_permission` (over ACP) → engine evaluates policy → auto-allow/deny responds immediately; otherwise **park the ACP response promise**, persist a pending-permission record, set `waiting_permission`, emit a milestone. The user answers via `acp_answer_permission(allow_once | allow_always | deny)`, which resolves the parked promise; `allow_always` updates the session policy. An unanswered request hits a **TTL → auto-deny** + milestone.
+- **Egress** is geofront's hard allowlist (deny-by-default); out-of-allowlist attempts surface as agent tool errors. _Known limitation:_ the allowlist is fixed at `workspace up`; broadening mid-session requires a new session (or a later geofront enhancement).
+
+### 5.3 WorkspaceManager (git, host-side)
+
+- Per project: a cached bare clone under a managed root, fetched on session start.
+- Per session: `git worktree add` off the configured **base branch**, new branch `acp/<shortId>-<slug>`; that worktree dir is the cwd geofront bind-mounts into the sandbox.
+- **Finish:** control-side `git add -A && git commit` (author = bot account) → `git push` → Forge PR.
+- **Cleanup:** on done/cancel/timeout → `geofront workspace down` + `git worktree remove`; retain the worktree on failure for inspection (configurable).
+- **Review:** `git worktree add` detached at the PR head ref.
+
+### 5.4 geofront driver (per session)
+
+- Templates a `geofront.toml` (project workspace image; `agent.kind="other"`, `entrypoint=["claude-code-acp", …]`; egress allowlist = project hosts + LLM host + package registries) and runs `geofront workspace up --acp <unix-sock>` with `cwd = worktree`.
+- Connects the ACP SDK client to the socket once geofront signals ready (handshake: geofront announces socket-ready / control polls the socket).
+- **LLM creds** delivered into the sandbox via geofront's config-dir mount (a generated service-account config dir); **forge token never provided.**
+- Tracks the geofront child process + container; enforces per-turn / per-session **timeouts**; bounds concurrency with `p-limit`. **One geofront process per session** (geofront is one-shot by design; the control service is the multiplexer).
+
+### 5.5 Forge layer
+
+- `Forge` interface: `createPR`, `listPRs`, `getPR`, `getPRDiff`, `checkoutRef`, `createReviewComments`, `createReview`.
+- **GitHub** adapter (Octokit) and **GitLab** adapter (gitbeaker). Project config carries forge type + repo identifiers; creds = the **shared bot account** (admin-scoped control config).
+- **Review flow:** `getPR` + diff → worktree at PR head → geofront review session (agent prompted to review the diff, emitting structured findings `{ file, line, severity, comment }`) → control posts inline review comments + a summary review via the forge API.
+
+### 5.6 Telemetry
+
+- Control-owned **SQLite** is the source of truth: `sessions` (id, project, agent, contextId, status, branch, worktree, pr_url, base, timestamps), `milestones`, `permission_decisions`, `tool_calls` (name, arg-digest, status, duration), per-turn token/usage rollups, plan snapshots.
+- Optional **JSONL replay** of the raw ACP chunk stream per session (admin flag, off by default) for deep debugging — modelled on agent-sniff's DebugRecorder.
+- Natural-language queries read SQLite (no content leakage of repo internals beyond what the user already controls).
+
+### 5.7 Control REST API (the plugin contract)
+
+Bearer auth on all routes.
+
+| Method | Path                       | Purpose                                                                  |
+| ------ | -------------------------- | ------------------------------------------------------------------------ |
+| POST   | `/sessions`                | start a session `{ project, agent?, branch?, base?, prompt, contextId }` |
+| GET    | `/sessions?filter=`        | list sessions (filter ∈ active/new/waiting/review/done)                  |
+| GET    | `/sessions/:id`            | session status + metadata                                                |
+| POST   | `/sessions/:id/prompt`     | continue a session with a follow-up prompt                               |
+| POST   | `/sessions/:id/permission` | answer a parked permission `{ decision }`                                |
+| POST   | `/sessions/:id/finish`     | `{ action: commit \| push \| pr, title?, body? }`                        |
+| POST   | `/sessions/:id/cancel`     | cancel + cleanup                                                         |
+| POST   | `/reviews`                 | start a PR review `{ project, prNumber }`                                |
+| GET    | `/projects`                | list configured projects                                                 |
+| GET    | `/agents`                  | list configured agents                                                   |
+
+Milestones flow out via papai's `/api/notify` (no SSE-to-plugin required in v1).
+
+---
+
+## 6. papai changes
+
+### 6.1 `acp` plugin (`plugins/acp/`, thin)
+
+- **Permissions:** `http`, `commands`, `storage`.
+- **Admin config:** control base URL (declared in `providerAllowedHostsFromConfig` so a LAN/HTTP control service is reachable) + control bearer token (`sensitive`).
+- **Tools (the NL surface):** `acp_start_session`, `acp_list_sessions`, `acp_session_status`, `acp_send`, `acp_answer_permission`, `acp_finish_session`, `acp_review_pr`, `acp_cancel_session`, `acp_list_projects`, `acp_list_agents`. Each validates input with Zod and calls the control REST API via `providerRuntime.httpFetch()`.
+- **Prompt fragment:** teaches the NL→tool mapping and session vocabulary ("what's running?", "finish and open a PR", "review PR #123"), within the 2,000-char/fragment budget.
+- **`/acp` (DM) command:** returns a status/settings link.
+- **`plugin_kv`** (per context): maps `sessionId ↔ storageContextId` so list/status/answers are scoped to the originating chat context.
+
+### 6.2 Core notify endpoint (the one core change)
+
+- **`POST /api/notify { contextId, markdown, threadId? }`**, guarded by a **notify token** (new `system_config` key), reusing the deferred-prompt delivery path (`src/chat/delivery-routing.ts` → `ChatRouter.sendMessage`).
+- Routed **before** the `DEBUG_SERVER`/`DEBUG_TOKEN` gates as its own trust plane (authorization = the notify token, independent of `DEBUG_SERVER`).
+- The control service's Notifier calls it on each milestone using the session's stored `contextId`.
+
+---
+
+## 7. End-to-end flows
+
+1. **Configure** — admin defines projects (repo URL, base branch, default agent, workspace image, egress allowlist, forge type + repo IDs) and agents (entrypoint/image preset) in the control service; forge/bot creds set admin-side on the control plane. Users see them read-only via `acp_list_projects` / `acp_list_agents`.
+2. **Start** — `acp_start_session` → control: fetch (cached bare clone) → worktree+branch on host → `geofront workspace up --acp` (worktree bind-mounted) → ACP `initialize`/`session/new(cwd=/home/dev/workspace)`/`session/prompt`. Returns `sessionId` immediately; the turn runs in the background.
+3. **Progress** — `acp_list_sessions(filter)` / `acp_session_status` query the SQLite state machine; milestones push proactively via `/api/notify`.
+4. **Finish** — `acp_finish_session(action)` → host-side commit/push → Forge PR → returns title + summary + review URL; `done` milestone carries the link.
+5. **Review** — `acp_review_pr(project, prNumber)` → fetch + checkout PR head into a review worktree → geofront review session → agent emits findings → control posts inline review comments + summary.
+
+---
+
+## 8. Error handling
+
+- **geofront/container start fails** → `failed` + milestone (reason) + worktree cleanup.
+- **Agent crash / non-zero exit** → `failed`; partial work retained on the branch (unpushed); user may inspect/retry.
+- **ACP socket drop** → `interrupted`; attempt graceful `geofront workspace down`.
+- **Forge failure on finish** → stay `finishing`, error milestone, retryable (branch already pushed ⇒ idempotent PR create).
+- **Egress denial** → surfaced as an agent tool error; non-fatal; may become a permission ask.
+- **Timeout** (per-turn / per-session) → cancel + cleanup + milestone.
+- **Notify failure** → retry with backoff; logged; never crashes the session.
+- **Permission never answered** → TTL → auto-deny + milestone.
+
+---
+
+## 9. Testing strategy
+
+- **Control unit:** state-machine transitions, permission-policy decisions, branch naming, forge adapters (mocked HTTP), notify payloads.
+- **Control integration:** a stub ACP agent (a fake agent speaking ACP over a socket) + a stub geofront driver; exercise start → prompt → permission → finish.
+- **geofront (Rust):** unit tests for piped exec + relay byte-bridging; an e2e with a tiny ACP echo agent.
+- **papai plugin:** tool-schema validation, mocked `httpFetch`, kv mapping, prompt-fragment budget; DI-first per repo conventions (`tests/CLAUDE.md`).
+- **Optional gated e2e:** real geofront + claude-code-acp on a scratch repo → PR on a test forge.
+
+---
+
+## 10. Implementation decomposition (for writing-plans)
+
+Independent plans, buildable in this order; the agent-launch boundary is an interface so tiers integrate against stubs.
+
+1. **geofront ACP support** (Rust): piped exec + host ACP relay + `AcpBridge` mode + tests. Deliverable: `geofront workspace up --acp <sock>` exposes a raw ACP stream from a sandboxed `claude-code-acp`.
+2. **Control service core** (TS): ACP client on the SDK + session state machine + SQLite + geofront driver, validated against a stub agent, then against deliverable #1.
+3. **Control service WorkspaceManager + permission engine** (TS): git clone-cache/worktree/branch/finish + policy/escalation.
+4. **Control service Forge layer** (TS): GitHub + GitLab adapters + review flow.
+5. **Control REST API + Notifier** (TS): the plugin contract + milestone delivery.
+6. **papai core notify endpoint** + delivery-path reuse + token.
+7. **papai `acp` plugin**: tools, command, prompt fragment, config, kv.
+8. **End-to-end wiring + optional gated e2e.**
+
+---
+
+## 11. Decision log
+
+| #   | Decision                               | Choice                                                                                |
+| --- | -------------------------------------- | ------------------------------------------------------------------------------------- |
+| 1   | Where the privileged ACP runtime lives | Sidecar service + thin plugin (not in the plugin sandbox; not papai core)             |
+| 2   | Session interaction model              | Background + milestone notifications                                                  |
+| 3   | Mid-turn permission handling           | Policy presets + chat escalation; push/PR always gated                                |
+| 4   | Agent support                          | Generic launcher + presets (admin-defined)                                            |
+| 5   | Forge                                  | GitHub + GitLab (behind one `Forge` interface)                                        |
+| 6   | Credentials/identity                   | Shared bot service account; secrets on control plane only                             |
+| 7   | Integration topology                   | Control plane + sandbox that natively exposes ACP (Approach A), realised via geofront |
+| 8   | Sandbox runtime                        | geofront (Rust, Docker, egress-allowlist) + net-new ACP relay                         |
+| 9   | Control-side ACP client                | Build directly on `@agentclientprotocol/sdk`; agent-sniff dropped (reference only)    |
+
+## 12. Open limitations (accepted for v1)
+
+- Egress allowlist is fixed per session at `workspace up`; broadening requires a new session.
+- Single-host geofront (no remote/k8s fleet yet); topology designed to evolve (orchestrator tier).
+- geofront sets no per-container CPU/memory limits or session timeout; control-side timeouts cover v1.
+- Shared bot identity ⇒ no per-user forge attribution.
+- No live streaming of agent output into chat (by design).

--- a/docs/superpowers/specs/2026-06-16-cross-thread-memory-and-context-scope-design.md
+++ b/docs/superpowers/specs/2026-06-16-cross-thread-memory-and-context-scope-design.md
@@ -1,0 +1,290 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Cross-Thread Memory Bridge & Context-Scope Corrections — Design
+
+**Date:** 2026-06-16
+**Status:** Approved (design); ready for implementation planning
+**Author:** Brainstormed with Claude Code
+
+## 1. Problem
+
+In group chats, threads are isolated for the _live conversation_ (history, short-term
+memory), while durable assets and config are group-shared. That split is mostly correct, but
+it produces a real symptom: **the bot rediscovers the same small recurring details in every
+new thread**, unaware it already learned them elsewhere.
+
+The naive framing ("nothing moves short-term → long-term") is **inaccurate** and was corrected
+during design. The real architecture and the real gaps:
+
+- What the code calls "short-term memory" (`memory_facts`) is **not** an LLM fact store. It is
+  a structural entity-reference cache (task/project IDs, titles, URLs) extracted automatically
+  from tool results, never LLM-written, **not searchable by the LLM**, injected as a system
+  block, thread-isolated. (`src/memory.ts:49`, `src/memory.ts:132`)
+- The actual durable fact store is **long-term `memory_records`** — preferences/facts/decisions
+  with confidence/status/kinds — written by a background LLM extraction pass and the explicit
+  `remember_memory` tool, and **already group-shared** across threads via
+  `resolveMemoryScope` (`src/long-term-memory/scope.ts:15`). This is what `search_memory`
+  searches (`src/long-term-memory/store.ts:215`).
+
+So a bridge already exists, but rediscovery persists because of **three concrete gaps**:
+
+1. **Capture gap** — background extraction only fires when a conversation is long enough to
+   _trim_ (`shouldTriggerTrim`, `src/llm-history.ts:34`). Short threads never trim, so their
+   durable facts never reach long-term memory.
+2. **Recall gap** — long-term search is **FTS5 keyword-only**; the `embedding` column exists
+   but is **never populated** (dead code). Only 3 records are auto-injected per turn
+   (`src/long-term-memory/context.ts:8`). Paraphrased recall fails → rediscovery.
+3. **No cross-thread fallback / cascade** — nothing searches sibling threads' state; only
+   `lookup_group_history` exists, and it reads main-group _history_, not memory.
+
+Alongside the memory work, two scope choices are wrong/questionable and one DX hazard makes the
+whole scope model fragile (see §5–§6).
+
+## 2. Goals / Non-Goals
+
+**Goals**
+
+- Capture durable knowledge even from short threads.
+- Recall it semantically, group-wide, with an explicit priority cascade.
+- Promote per-thread provisional knowledge to durable group memory once it proves itself across
+  threads (frequency-gated, LLM-confirmed).
+- Correct the attachments and web-rate-limit scope mistakes.
+- Replace the fragile, smeared scope model with a single declarative source of truth.
+
+**Non-Goals**
+
+- Per-thread instruction overrides (registry leaves room; behavior unchanged — deferred).
+- Plugin-declared scope (deferred).
+- Cross-_group_ or cross-platform memory sharing (scope stays within a single group).
+- Reworking `memory_facts` (the entity-reference cache) — it stays as-is.
+
+## 3. Decisions (locked during brainstorming)
+
+| Decision               | Choice                                             |
+| ---------------------- | -------------------------------------------------- |
+| Promotion trigger      | Hybrid: frequency gates, SMALL_MODEL confirms      |
+| Spec scope             | Full memory overhaul + scope/DX corrections        |
+| Cascade surface        | One unified `recall` tool; server-side cascade     |
+| Capture trigger        | Decoupled debounce on idle (+ scheduler backstop)  |
+| Provisional data model | Reuse `memory_records` with a `provisional` status |
+
+## 4. Memory Bridge Design
+
+### 4.1 Data model (extend `memory_records`, one migration)
+
+Additive only; no new table.
+
+- `thread_context_id TEXT NULL` — origin thread for **provisional** rows; `NULL` = durable
+  group record.
+- `status` enum gains `'provisional'`. Existing reads filter `status='active'`, so they ignore
+  provisional rows automatically (minimal blast radius).
+- `evidence.threads: string[]` — distinct thread IDs a provisional fact has been seen in; this
+  is the promotion counter. (`evidence` is already a JSON column.)
+- `embedding BLOB` — now **populated** on every write (currently dead).
+
+A provisional row remains `scope_type='group'`, `scope_id=<group>`; it is thread-tagged and not
+yet trusted. The FTS5 virtual table `memory_records_fts` and its triggers already cover
+provisional rows (same table).
+
+### 4.2 Capture pipeline (idle-debounce — closes the capture gap)
+
+- Decouple extraction from trim. A per-context in-memory debounce
+  (`MEMORY_CAPTURE_DEBOUNCE_MS ≈ 600000`, i.e. ~10 min) re-arms on each turn; a max-turns
+  fallback forces a capture in busy threads. On fire, SMALL_MODEL extracts candidate facts from
+  history since a `last_extracted_at` watermark and writes them as **provisional** records.
+- A small `memory_extraction_state(context_id PK, last_extracted_at, last_message_seen)` table
+  holds the watermark.
+- **Semantic dedup/merge on write** (embedding cosine ≥ τ, FTS fallback) against existing
+  group records:
+  - matches an **active** record → bump `last_seen_at` only (reinforcement), no new row;
+  - matches a **provisional** record → add current thread to `evidence.threads`, bump
+    confidence/`last_seen_at`, optionally refine content;
+  - no match → insert a new provisional row (`thread_context_id = current`,
+    `evidence.threads = [current]`).
+- **Backstop:** a lightweight scheduler sweep (alongside the existing hourly maintenance)
+  extracts watermark-dirty threads, covering debounce loss on restart. Existing
+  trim-triggered extraction stays in place.
+
+### 4.3 Embeddings revival (closes the recall gap)
+
+- Populate `memory_records.embedding` on every write via
+  `getEmbeddingForContext(content, configContextId)` — BYOK-aware;
+  `configContextId = getConfigContextIdFromStorageContextId(storageContextId)`.
+- Search becomes **hybrid**: FTS5 candidate set ∪ vector top-k by cosine, merged/reranked
+  (mirrors the existing `search-memos.ts` semantic + keyword-fallback pattern).
+- **Degradation:** if `EMBEDDING_MODEL` is unset or an embedding is null → **FTS-only**, exactly
+  today's behavior. Recall and promotion clustering both fall back to FTS/normalized-text
+  matching. The cascade never breaks.
+
+### 4.4 The `recall` tool + server-side cascade
+
+- New `recall(query)` tool registered in `normal` mode. It **supersedes** `search_memory`,
+  which becomes a thin layer-2-only alias for backward compatibility.
+- Server walks the priority order:
+  1. **Layer 1 — current thread:** provisional rows for this thread + the auto-injected
+     current-thread block.
+  2. **Layer 2 — group long-term:** `active` group records. _Layers 1+2 always run (cheap,
+     indexed)._
+  3. **Layer 3 — sibling threads:** provisional rows from other threads — **only when the
+     top score of 1+2 is below τ** ("if the agent reaches this point").
+- Returns ranked hits, each tagged with **provenance** (`current` / `group` / `other-thread`),
+  so the agent knows when it is pulling cross-thread knowledge. Layer-3 hits feed the promotion
+  engine as a side effect.
+
+### 4.5 Promotion engine (hybrid: frequency gates, LLM confirms)
+
+- **Trigger points:** a capture-merge or a recall layer-3 hit that pushes
+  `evidence.threads.length ≥ MEMORY_PROMOTION_MIN_THREADS` (default **3**).
+- **Confirm:** a cheap SMALL*MODEL check — "is this a durable, general \_group* fact, not
+  thread-specific/transient noise?" → boolean (+ optional refined content/kind/confidence).
+- **On yes:** in a transaction, set `status='active'`, `thread_context_id=NULL`, merge
+  duplicate provisional rows, bump confidence; emit a `memory:promote` debug event (counts
+  only — no content).
+- **On no:** set a cooldown on the row (`evidence.promotionRejectedAt`) and raise its effective
+  threshold so it is not re-evaluated every turn.
+- **Concurrency:** in-flight guard per scope (reuse the `src/long-term-memory/runner.ts`
+  `inFlight` pattern). Promotion is a status flip in a single transaction (idempotent).
+
+### 4.6 Maintenance & bounds
+
+- Extend `runMemoryMaintenance` (`src/long-term-memory/maintenance.ts:45`): provisional rows
+  decay faster — evict unpromoted provisional rows after `MEMORY_PROVISIONAL_TTL_DAYS`
+  (default **30**); cap provisional rows per group to bound storage. Active-record decay is
+  unchanged.
+
+### 4.7 System prompt
+
+- Short addition (≤ a few lines, budget-aware): the agent has a `recall` tool that searches
+  memory in priority order (this conversation → shared group memory → other conversations);
+  prefer `recall` before re-asking the user or claiming no prior knowledge.
+
+### 4.8 Rollout / safety (memory bridge)
+
+- The entire bridge sits behind one per-context flag `cross_thread_memory` in the reserved
+  `tool_context_flags` config key (super-admin **Feature flags** section, **default OFF**),
+  consistent with `result_compaction` / `progressive_disclosure`.
+- **OFF ⇒ reference-identical to today:** no provisional capture, `recall` = layer-2 only, no
+  promotion. Embedding population may remain always-on (harmless).
+
+## 5. Scope Corrections
+
+### 5.1 Attachments → group-discoverable (read side only)
+
+- **Ingest unchanged:** `attachments.context_id` stays the thread-scoped `storageContextId`.
+- **Add `group_context_id TEXT NULL`**, populated at ingest =
+  `getConfigContextIdFromStorageContextId(context_id)`; migration backfills existing rows.
+- **Read tools** (`list_files`, `search_staged_files`, `resolve_staged_file`) resolve across
+  the group: `context_id = current OR group_context_id = <group>`, **group contexts only**
+  (DMs unaffected). Threads share one audience, so this removes cross-thread reuse friction
+  with no privacy change.
+
+### 5.2 `web_rate_limit` → per-user
+
+- Change `makeWebFetchTool` wiring (`src/tools/web-fetch.ts`, `provider-independent-tools-builder.ts:112`)
+  to pass `actorUserId = chatUserId` instead of the group-stripped `storageOwnerId`. The quota
+  then keys on the person, not the pooled group — one heavy user can't starve the group and the
+  limit actually bounds an actor. Plumbing already supports it
+  (`actorId = input.actorUserId ?? input.storageContextId`, `src/web/fetch-extract.ts:224`).
+  Window-based rows age out; no migration. Ships unflagged as a correction with its own test.
+
+## 6. Declarative Scope Source of Truth (DX)
+
+Effective scope is currently smeared across four hand-synced places — the registry
+`threadScoped` flag (`src/db/migrations/scoped-context-owned-columns.ts`), runtime strip
+helpers (`getStorageOwnerId`, `getConfigContextIdFromStorageContextId`), the migration-046
+backfill allowlist, and the `PARENT_SHARED_USER_CONFIG_KEYS` Set. This is what mislabeled
+`user_identity_mappings` (effectively **per-user**), `web_rate_limit` (effectively **per-group**),
+and `memos`/`recurring_tasks`/`user_instructions` (effectively **group**) relative to their raw
+`threadScoped:true` flags.
+
+- **One registry** — `src/chat/context-scope.ts` exporting `ENTITY_SCOPES`: each entity
+  (table+column, or config key) → effective scope ∈ `thread | group | user | group+threadOverride`.
+- **Derive everything from it:**
+  - `getScopeKey(entity, { storageContextId, chatUserId, contextType })` — the single
+    write/read key resolver, replacing scattered ad-hoc strips at runtime.
+  - The **already-shipped** migration 046 stays immutable (it has run in production). Its
+    constants (`DURABLE_CONTEXT_COLUMNS`, `PARENT_SHARED_USER_CONFIG_KEYS`) and
+    `CONTEXT_OWNED_COLUMNS.threadScoped` are **reconciled against** the registry by a
+    **consistency unit test** that fails if they disagree — a declared `group` entity can no
+    longer carry `threadScoped:true`, and any future entity is declared in the registry only.
+    New backfills (if needed) read from the registry.
+- **Behavior-preserving refactor** except where scope is intentionally changed (attachments read
+  = `group`, `web_rate_limit` = `user`), now stated explicitly in the registry.
+  `user_instructions` is registered as `group+threadOverride` to leave room for the deferred
+  per-thread override; base behavior stays `group`, unchanged.
+
+## 7. Data Flow (end to end)
+
+```
+turn in thread A ──► (debounce ~10m / idle) ──► SMALL_MODEL extract
+   ──► provisional memory_records (scope=group, thread=A, embedding set)
+        │ semantic dedup/merge vs existing group records
+        ▼
+turn in thread B (same fact) ──► merge ──► evidence.threads = {A,B}
+turn in thread C (same fact) ──► merge ──► evidence.threads = {A,B,C}  (≥3)
+        ▼
+promotion engine ──► SMALL_MODEL confirm ──► status=active, thread_context_id=NULL
+        ▼
+fresh thread D: recall("…") ──► Layer1 (miss) ──► Layer2 active hit (provenance=group)
+        └─ bot answers from shared memory; no rediscovery
+```
+
+## 8. Error Handling
+
+- Embedding failure → FTS fallback; never breaks recall, capture, or promotion.
+- Capture/extraction or promotion SMALL_MODEL failure → logged and swallowed; never breaks a
+  turn (matches the existing background-extraction posture); the row waits for the next round.
+- Debounce timer lost on restart → scheduler watermark sweep recovers it.
+- `EMBEDDING_MODEL` unset → whole system runs keyword-only, degraded but functional.
+
+## 9. Testing
+
+- **Acceptance ("stop rediscovering"):** establish a durable fact in short thread A →
+  idle-debounce capture writes provisional → repeat in B and C → `evidence.threads` reaches 3
+  → SMALL_MODEL confirms → promoted to `active` → fresh thread D's `recall` returns it tagged
+  `group`.
+- **Unit:** scope-registry consistency (vs `threadScoped`); `getScopeKey` per scope; cascade
+  ordering + layer-3 early-exit; promotion threshold + confirm/reject + cooldown; provisional
+  dedup/merge; embedding → FTS fallback; attachments group read; `web_rate_limit` per-user
+  keying.
+- **Flag-off parity:** `cross_thread_memory=OFF` is byte-identical to current behavior.
+- DI-first per `tests/CLAUDE.md`; isolation-clean (no cross-file shared state, no fixed-wall-clock
+  timing assertions — poll for conditions).
+
+## 10. Configuration Defaults
+
+| Key                                      | Default          | Meaning                                                          |
+| ---------------------------------------- | ---------------- | ---------------------------------------------------------------- |
+| `cross_thread_memory` (per-context flag) | OFF              | Master switch for the whole bridge                               |
+| `MEMORY_PROMOTION_MIN_THREADS`           | 3                | Distinct threads before a provisional fact is promotion-eligible |
+| `MEMORY_CAPTURE_DEBOUNCE_MS`             | 600000 (~10 min) | Idle debounce before capture fires                               |
+| `MEMORY_PROVISIONAL_TTL_DAYS`            | 30               | Eviction age for unpromoted provisional rows                     |
+| τ (recall layer-3 threshold, cosine)     | tuned in impl    | Below this, the cascade reaches layer 3                          |
+
+## 11. Deferred / Future Work
+
+- Per-thread `user_instructions` overrides (`group+threadOverride` already reserved).
+- Plugin-declared scope (thread vs group) for `plugin_kv` / `plugin_context_state`.
+- Promoting embeddings into `lookup_group_history`.
+
+## 12. Affected Code (orientation, not exhaustive)
+
+- `src/long-term-memory/` — `schema`/store, `scope.ts`, `runner.ts`, `extractor.ts`,
+  `maintenance.ts`, `context.ts` (new: cascade, promotion, provisional handling).
+- `src/db/long-term-memory-schema.ts` + new migration (columns, status, FTS unaffected).
+- `src/embeddings.ts` — now wired into memory-record writes/search.
+- `src/tools/memory.ts`, `src/tools/provider-independent-tools-builder.ts` — `recall` tool.
+- `src/system-prompt.ts` — recall preamble.
+- `src/tools/feature-flags.ts` — `cross_thread_memory` flag.
+- `src/scheduler-instance.ts` — capture backstop sweep.
+- Attachments store + `src/tools/workspace-files.ts` / `staged-tools.ts` — group read + new column.
+- `src/tools/web-fetch.ts` — per-user actor.
+- `src/chat/context-scope.ts` (new), `scoped-context-owned-columns.ts`, migration-046 derivation,
+  `provider-independent-tools-builder.ts` (`getStorageOwnerId` → `getScopeKey`).
+  </content>
+  </invoke>

--- a/docs/superpowers/specs/2026-06-16-youtrack-dedicated-fields-and-teaching-errors-design.md
+++ b/docs/superpowers/specs/2026-06-16-youtrack-dedicated-fields-and-teaching-errors-design.md
@@ -8,7 +8,7 @@ See LICENSE in the project root for details.
 # YouTrack dedicated-field localization & teaching errors — design
 
 **Date:** 2026-06-16
-**Status:** Approved (pending implementation plan)
+**Status:** Implemented (2026-06-16) — see [As-built notes](#as-built-notes)
 **Area:** `plugins/task-provider-youtrack/`
 **Follows:** `2026-06-15-youtrack-custom-fields-design.md` and the issue-derived schema fallback
 (`fix(youtrack): derive field schema from a sample issue when admin endpoint is empty`).
@@ -186,3 +186,26 @@ restriction so enum/state/user fields become settable on update.
   not repopulate `dueDate` (best-effort, already swallowed) — documented limitation.
 - **Homoglyph names** only matter on the name-tiebreak path; the common unique-type case never
   compares names.
+
+## As-built notes
+
+Implemented as designed (commits `e0036ba5c` dedicated-by-type resolution, `e73279f70`
+name-level teaching errors, `6d631c11a` shared `normalize` export, `a68da9a1c` create/update
+unification, `6b2394b31` lint, `522186624` final-review cleanup; merged in PR #158).
+
+- `dedicated-fields.ts` (`resolveDedicatedField`) and `field-name-error.ts`
+  (`unknownFieldError`) shipped as specified.
+- `create-field-helpers.ts` carries `collectFieldPairs` / `resolveFieldPair` (dedicated→by-type,
+  generic→by-name); `legacyDedicatedPayload` was deleted as planned.
+- `task-helpers.ts` exposes the shared `buildIssueCustomFields(config, params,
+projectCustomFields, op)`, called by both `createYouTrackTask` and `updateYouTrackTask`
+  (`operations/tasks.ts`, via `buildUpdateCustomFields`). Update routes generic and dedicated
+  fields through the field engine — the prior string/text-only restriction is gone, so
+  localized enum/state/user fields are settable on update.
+- The empty-admin-schema fallback derives fields from a sample issue
+  (`fetchProjectCustomFields(…, { deriveFromIssueWhenEmpty })`).
+
+**Deployment note:** This fix removes the `Unsupported custom field for update: …` rejection.
+Production logs emitting that string after the merge indicate a **stale build** — the running
+binary predates `a68da9a1c` and must be rebuilt/redeployed from current `master`. The string
+exists nowhere in the post-merge codebase.

--- a/src/tools/apply-youtrack-command.ts
+++ b/src/tools/apply-youtrack-command.ts
@@ -74,8 +74,7 @@ async function executeApplyYouTrackCommand(
   provider: Readonly<TaskProvider>,
   { query, taskIds, comment, silent, confidence }: z.infer<typeof applyYouTrackCommandInputSchema>,
 ): Promise<unknown> {
-  const applyCommand = provider.applyCommand
-  if (applyCommand === undefined) {
+  if (provider.applyCommand === undefined) {
     throw new Error('YouTrack command support is unavailable')
   }
 
@@ -95,7 +94,8 @@ async function executeApplyYouTrackCommand(
   }
 
   try {
-    const result: TaskCommandResult = await applyCommand({ query, taskIds, comment, silent })
+    // Call through the provider so class-method implementations keep their `this` binding.
+    const result: TaskCommandResult = await provider.applyCommand({ query, taskIds, comment, silent })
     log.info({ query, taskCount: taskIds.length }, 'YouTrack command applied via tool')
     return result
   } catch (error) {

--- a/tests/tools/apply-youtrack-command.test.ts
+++ b/tests/tools/apply-youtrack-command.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test'
 
 import { z } from 'zod'
 
+import type { TaskCommandResult } from '../../src/providers/types.js'
 import { isToolFailureResult } from '../../src/tool-failure.js'
 import { makeApplyYouTrackCommandTool } from '../../src/tools/apply-youtrack-command.js'
 import { wrapToolExecution } from '../../src/tools/wrap-tool-execution.js'
@@ -448,6 +449,32 @@ describe('apply_youtrack_command', () => {
       comment: 'On it',
       silent: undefined,
     })
+  })
+
+  test('preserves provider binding when applyCommand reads instance state', async () => {
+    // Regression: the real YouTrackProvider.applyCommand is a class method whose body reads
+    // `this.config`. The tool must invoke it on the provider, not detach it into a bare
+    // function — detaching loses `this` and throws "undefined is not an object (this.config)".
+    const provider = Object.assign(createMockProvider({ name: 'youtrack' as const }), {
+      config: { baseUrl: 'https://yt.example' },
+      applyCommand(params: {
+        query: string
+        taskIds: string[]
+        comment?: string
+        silent?: boolean
+      }): Promise<TaskCommandResult> {
+        return Promise.resolve({ query: params.query, taskIds: params.taskIds, comment: this.config.baseUrl })
+      },
+    })
+
+    const tool = makeApplyYouTrackCommandTool(provider)
+    const result = await getToolExecutor(tool)({
+      query: 'for me',
+      taskIds: ['TEST-1'],
+      confidence: 0.6,
+    })
+
+    expect(result).toEqual({ query: 'for me', taskIds: ['TEST-1'], comment: 'https://yt.example' })
   })
 
   test('allows exact single-user for commands without confirmation', async () => {


### PR DESCRIPTION
## Summary

Fixes two issues surfaced by production YouTrack logs.

### 1. `apply_youtrack_command` → `undefined is not an object (evaluating 'this.config')` (code fix)

`src/tools/apply-youtrack-command.ts` detached `provider.applyCommand` into a bare variable and called it unbound, losing `this`. `YouTrackProvider.applyCommand` is a class method whose body reads `this.config` (a base-class field), so the unbound call threw. Now calls through the provider — matching the documented tool idiom in `src/tools/CLAUDE.md`. It was the only tool detaching a provider method.

### 2. `update_task` → "Unsupported custom field for update: …" (already fixed; stale build)

This error string exists nowhere in current source — it was removed by `a68da9a1c` (*unify create/update on schema-driven field engine*), which routes update through the same field engine as create. The logged failures came from a build predating that merge. **Action: redeploy from `master`.** No code change here; documented in the spec as-built notes.

## Changes

- **`src/tools/apply-youtrack-command.ts`** — call `provider.applyCommand(...)` directly (keeps the `undefined` guard).
- **`tests/tools/apply-youtrack-command.test.ts`** — regression test with a `this`-dependent `applyCommand` reproducing the exact production error (existing tests used a plain `mock()` that never touched `this`).
- **`docs/superpowers/specs/2026-06-15-…`** & **`2026-06-16-…`** — marked Implemented with as-built notes (create/update unification, dedicated-field localization, teaching errors) and a deployment note on the stale-build error.

## Test plan

- [x] `apply-youtrack-command` suite — 25/25 pass (incl. new regression test, RED→GREEN verified)
- [x] `bun lint` (changed files) — 0 errors
- [x] `bun typecheck` — 0 errors
- [x] `bun run format:check` — clean