### PR TITLE
test(run-control): set up test DB for invoke-wiring suite

### DIFF
--- a/tests/run-control/invoke-wiring.test.ts
+++ b/tests/run-control/invoke-wiring.test.ts
@@ -15,7 +15,7 @@ import type { InvokeModelArgs, LlmOrchestratorDeps } from '../../src/llm-orchest
 import { defaultDeps } from '../../src/llm-orchestrator.js'
 import { runRegistry } from '../../src/run-control/registry.js'
 import { RunAbortedError } from '../../src/run-control/types.js'
-import { createMockReply, mockLogger } from '../utils/test-helpers.js'
+import { createMockReply, mockLogger, setupTestDb } from '../utils/test-helpers.js'
 
 type CapturedOpts = Parameters<LlmOrchestratorDeps['generateText']>[0]
 type GenerateResult = Awaited<ReturnType<LlmOrchestratorDeps['generateText']>>
@@ -92,8 +92,9 @@ function makeFinishEvent(toolName: string): OnToolCallFinishEvent {
 }
 
 describe('invokeModel run-control wiring', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     mockLogger()
+    await setupTestDb()
     runRegistry.clear()
     stepCountArgs.length = 0
   })


### PR DESCRIPTION
invokeModel resolves the system prompt via getToolPrefs -> getCachedConfig,
which queries the user_config table. The invoke-wiring suite never called
setupTestDb, so every test failed with "no such table: user_config".
Migrate an in-memory DB in beforeEach so the system-prompt read succeeds.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UABacqviL9ZGDrnyfwcKTx