### PR TITLE
fix(attachments): scope prompt manifest to current-message attachments only

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -177,7 +177,9 @@ async function handleMessage(
   maybeSeedContextAssignment(auth, msg.platformInstanceId)
   const voiceStagedIds = msg.contextType === 'group' ? findVoiceStagedIds(auth.storageContextId, msg.messageId) : []
   const { newAttachmentIds, activeAttachments } = await resolveMessageAttachments(chat, msg, auth.storageContextId)
-  const steerText = buildPromptWithReplyContext(msg, activeAttachments, auth.storageContextId)
+  const newAttachmentIdSet = new Set(newAttachmentIds)
+  const messageAttachments = activeAttachments.filter((ref) => newAttachmentIdSet.has(ref.attachmentId))
+  const steerText = buildPromptWithReplyContext(msg, messageAttachments, auth.storageContextId)
 
   const activeRun = runRegistry.get(auth.storageContextId)
   if (activeRun !== undefined) {

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -1928,18 +1928,27 @@ describe('Attachment workspace integration (setupBot)', () => {
   const RELAY_ADMIN = 'relay-admin'
   let capturedStorageId: string | null = null
   let attachmentIdsAtProcessingTime: readonly string[] = []
+  let lastProcessedText: string
   let getMessageHandler: () => ((msg: IncomingMessage, reply: ReplyFn) => Promise<void>) | null
 
   beforeEach(async () => {
     capturedStorageId = null
     attachmentIdsAtProcessingTime = []
+    lastProcessedText = ''
     mockLogger()
     await setupTestDb()
     seedCommonTestPlatformInstances()
 
     const botDeps = withSynchronousQueue({
-      processMessage: (_reply: ReplyFn, storageContextId: string, _chatUserId: string): Promise<void> => {
+      processMessage: (
+        _reply: ReplyFn,
+        storageContextId: string,
+        _chatUserId: string,
+        _username: string | null,
+        userText: string,
+      ): Promise<void> => {
         capturedStorageId = storageContextId
+        lastProcessedText = userText
         attachmentIdsAtProcessingTime = listActiveAttachments(storageContextId).map((ref) => ref.attachmentId)
         return Promise.resolve()
       },
@@ -1985,6 +1994,53 @@ describe('Attachment workspace integration (setupBot)', () => {
     await getMessageHandler()!(msg, reply)
 
     expect(listActiveAttachments('unauth-user')).toEqual([])
+  })
+
+  test('text-only follow-up does not carry prior attachments in the prompt manifest', async () => {
+    addUser('relay-user3', RELAY_ADMIN)
+    setupUserConfig('relay-user3')
+    const { reply } = createMockReply()
+
+    const fileMsg: IncomingMessage = {
+      ...createDmMessage('relay-user3'),
+      files: [makeFile({ filename: 'first.pdf' })],
+    }
+    await getMessageHandler()!(fileMsg, reply)
+    expect(attachmentIdsAtProcessingTime).toHaveLength(1)
+    const firstAttachmentId = attachmentIdsAtProcessingTime[0]!
+    assert.ok(firstAttachmentId !== undefined)
+    expect(lastProcessedText).toContain('Available attachments')
+    expect(lastProcessedText).toContain(firstAttachmentId)
+
+    const textMsg: IncomingMessage = { ...createDmMessage('relay-user3'), text: 'what was that about?' }
+    await getMessageHandler()!(textMsg, reply)
+
+    expect(lastProcessedText).not.toContain('Available attachments')
+    expect(lastProcessedText).not.toContain(firstAttachmentId)
+    expect(lastProcessedText).toBe('what was that about?')
+  })
+
+  test('forwarded attachment stays bound to its own message, not a later text message', async () => {
+    addUser('relay-user4', RELAY_ADMIN)
+    setupUserConfig('relay-user4')
+    const { reply } = createMockReply()
+
+    const forwardedMsg: IncomingMessage = {
+      ...createDmMessage('relay-user4'),
+      files: [makeFile({ filename: 'forwarded.png', mimeType: 'image/png', forwardedFrom: 'Alice' })],
+    }
+    await getMessageHandler()!(forwardedMsg, reply)
+    expect(attachmentIdsAtProcessingTime).toHaveLength(1)
+    const forwardedAttachmentId = attachmentIdsAtProcessingTime[0]!
+    assert.ok(forwardedAttachmentId !== undefined)
+    expect(lastProcessedText).toContain(forwardedAttachmentId)
+
+    const textMsg: IncomingMessage = { ...createDmMessage('relay-user4'), text: 'thanks' }
+    await getMessageHandler()!(textMsg, reply)
+
+    expect(lastProcessedText).not.toContain('Available attachments')
+    expect(lastProcessedText).not.toContain(forwardedAttachmentId)
+    expect(lastProcessedText).toBe('thanks')
   })
 })
 


### PR DESCRIPTION
## Problem

All previously-sent files (photos, voice notes, screenshots, etc.) were attached to **every** new message's prompt as `[Available attachments]`, even when the user just sent plain text. Sending 9 files at the start of a conversation meant every subsequent message carried all 9 attachments' metadata.

**Symptoms:**
- Context bloat — every LLM prompt carried KB of irrelevant attachment metadata.
- Token waste — the model processed unrelated attachments every turn.
- Spurious mentions — the bot referenced stale transcriptions in unrelated replies.

## Root cause

`src/bot.ts:180` passed `activeAttachments` — the **entire** set of non-cleared attachments in the workspace (accumulated across the whole conversation) — to `buildPromptWithReplyContext`, which built a manifest of all of them.

This had a compounding effect: that manifest text (full of `att_*` IDs) became the `userText` fed to `buildUserTurnMessages`, where `selectAttachmentsForTurn` regex-matches every `att_*` token in the text — so it also defeated the *correct* per-turn filtering and pulled all historical attachments in as multimodal content parts too.

## Fix

Filter the manifest to only the current message's new attachments via `newAttachmentIds`:

```ts
const newAttachmentIdSet = new Set(newAttachmentIds)
const messageAttachments = activeAttachments.filter((ref) => newAttachmentIdSet.has(ref.attachmentId))
const steerText = buildPromptWithReplyContext(msg, messageAttachments, auth.storageContextId)
```

Text-only follow-ups now carry no manifest, and only genuinely new files appear. The existing `selectAttachmentsForTurn` (new + explicitly-mentioned-by-ID) logic in the orchestrator still works correctly since old IDs no longer leak into the text.

## Tests

Added two regression tests in `tests/bot.test.ts` (Attachment workspace integration):
- **text-only follow-up** — send a file, then a text message; assert the follow-up has no manifest and no prior attachment ID.
- **forwarded attachment** — a `forwardedFrom` attachment stays bound to its own message and does not leak into a later text message.

## Verification

- `bun test tests/bot.test.ts` — 72/72 pass
- `bun test tests/reply-context.test.ts tests/attachments/resolver.test.ts tests/llm-orchestrator-attachments.test.ts tests/bot-attachments.test.ts` — all pass
- `tsgo --noEmit` — clean
- `oxlint` — clean
- Pre-commit hooks (lint, typecheck, format, license) — all passed