### PR TITLE
fix(context): count disclosed tool surface in /context, not full catalog

### DIFF
--- a/src/commands/context-collector.ts
+++ b/src/commands/context-collector.ts
@@ -26,7 +26,7 @@ export interface ContextCollectorDeps {
   getSummary: () => string | null
   getFacts: () => readonly Fact[]
   getActiveToolDefinitions: () => Record<string, unknown>
-  getProviderName: () => string
+  getDisclosedToolDefinitions: () => Record<string, unknown>
   countTokens: (text: string) => number
 }
 
@@ -153,14 +153,18 @@ const buildHistorySection = (deps: ContextCollectorDeps, counter: SafeCounter): 
 }
 
 const buildToolsSection = (deps: ContextCollectorDeps, counter: SafeCounter): ContextSection => {
-  const tools = deps.getActiveToolDefinitions()
-  const count = Object.keys(tools).length
-  const providerName = deps.getProviderName()
-  const tokens = counter.count(serializeTools(tools))
+  // Progressive disclosure only exposes the always-on/meta tools at a turn's first step; the
+  // rest of the catalog is discoverable via search_tools but its schemas only enter context
+  // when load_tool pulls them in. Count the disclosed surface (what actually costs tokens now)
+  // and report the full catalog size as available context.
+  const disclosed = deps.getDisclosedToolDefinitions()
+  const activeCount = Object.keys(disclosed).length
+  const availableCount = Object.keys(deps.getActiveToolDefinitions()).length
+  const tokens = counter.count(serializeTools(disclosed))
   return {
     label: 'Tools',
     tokens,
-    detail: `${String(count)} active, gated by ${providerName}`,
+    detail: `${String(activeCount)} active · ${String(availableCount)} available (progressive disclosure)`,
   }
 }
 

--- a/src/commands/context-tool-resolution.ts
+++ b/src/commands/context-tool-resolution.ts
@@ -9,6 +9,9 @@ import { getCachedTools } from '../cache.js'
 import { logger } from '../logger.js'
 import { defaultTaskProviderResolver } from '../providers/resolver.js'
 import type { TaskProvider } from '../providers/types.js'
+import { ALWAYS_ON_TOOL_NAMES } from '../tools/disclosure/core.js'
+import { LexicalToolRetriever } from '../tools/disclosure/tool-retriever.js'
+import { maybeApplyDisclosure } from '../tools/disclosure/wire.js'
 import { applyToolPreferences, buildProviderlessToolDescriptors, makeTools } from '../tools/index.js'
 
 const log = logger.child({ scope: 'commands:context-tool-resolution' })
@@ -38,6 +41,51 @@ export async function safeBuildProvider(contextId: string): Promise<TaskProvider
 
 export function resolveActiveToolDefinitions(resolvedToolSurface: ResolvedContextToolSurface): Record<string, unknown> {
   return resolvedToolSurface.definitions
+}
+
+/**
+ * Context id used only to build the disclosure preview. No real turn is running, so nothing
+ * is emitted against it — search_tools/load_tool are constructed for their schemas alone and
+ * never executed here.
+ */
+const DISCLOSURE_PREVIEW_CONTEXT_ID = 'context-view'
+
+/**
+ * Narrow the full tool catalog to the surface a live turn's first step actually exposes to
+ * the model under progressive disclosure: the always-on core tools plus the injected
+ * `search_tools`/`load_tool` meta tools (with their real schemas). This mirrors
+ * `maybeApplyDisclosure` + `DisclosureSession.activeToolNames()` in the orchestrator path so
+ * the `/context` view counts what a fresh turn loads (~4 tools), not the entire catalog whose
+ * schemas only enter context on demand via `load_tool`.
+ */
+export function resolveDisclosedToolDefinitions(
+  resolvedToolSurface: ResolvedContextToolSurface,
+): Record<string, unknown> {
+  const catalog = resolvedToolSurface.definitions
+  try {
+    const catalogToolSet: ToolSet = isToolSet(catalog) ? catalog : {}
+    const { tools: disclosed, disclosure } = maybeApplyDisclosure(
+      catalogToolSet,
+      DISCLOSURE_PREVIEW_CONTEXT_ID,
+      new LexicalToolRetriever(),
+    )
+    const active = new Set(disclosure.activeToolNames())
+    const definitions: Record<string, unknown> = {}
+    for (const [name, definition] of Object.entries(disclosed)) {
+      if (active.has(name)) definitions[name] = definition
+    }
+    return definitions
+  } catch (error) {
+    log.warn(
+      { error: error instanceof Error ? error.message : String(error) },
+      'Failed to compute disclosed tool surface; falling back to always-on catalog tools',
+    )
+    const definitions: Record<string, unknown> = {}
+    for (const [name, definition] of Object.entries(catalog)) {
+      if (ALWAYS_ON_TOOL_NAMES.has(name)) definitions[name] = definition
+    }
+    return definitions
+  }
 }
 
 export function buildInvocationToolSet(

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -25,6 +25,7 @@ import {
   buildInvocationToolSet,
   resolveActiveToolDefinitions,
   resolveContextToolSurface,
+  resolveDisclosedToolDefinitions,
   safeBuildProvider,
   type BuildLiveToolSet,
   type ResolvedContextToolSurface,
@@ -37,6 +38,7 @@ export interface ContextCommandDeps {
   buildProvider: (contextId: string) => Promise<TaskProvider | null> | TaskProvider | null
   buildLiveToolSet: BuildLiveToolSet
   resolveActiveToolDefinitions: (resolvedToolSurface: ResolvedContextToolSurface) => Record<string, unknown>
+  resolveDisclosedToolDefinitions: (resolvedToolSurface: ResolvedContextToolSurface) => Record<string, unknown>
   resolveToolSurface: (
     storageContextId: string,
     actorUserId: string,
@@ -52,6 +54,7 @@ const defaultDeps: ContextCommandDeps = {
   buildProvider: safeBuildProvider,
   buildLiveToolSet: buildInvocationToolSet,
   resolveActiveToolDefinitions,
+  resolveDisclosedToolDefinitions,
   resolveToolSurface: resolveContextToolSurface,
 }
 function resolveModelName(modelName: string | null | undefined): string {
@@ -88,7 +91,6 @@ async function buildCollectorDeps(
   const resolvedModelName = resolveModelName(modelName)
   const encoding = resolveEncodingName(resolvedModelName)
   const resolvedEncoding = resolveEncoding(encoding)
-  const providerName = provider === null ? 'none' : provider.name
 
   await prepareDefaultCountTokens(resolvedEncoding)
 
@@ -109,7 +111,8 @@ async function buildCollectorDeps(
     getSummary: () => loadSummary(storageContextId),
     getFacts: () => loadFacts(storageContextId),
     getActiveToolDefinitions: (): Record<string, unknown> => deps.resolveActiveToolDefinitions(resolvedToolSurface),
-    getProviderName: () => providerName,
+    getDisclosedToolDefinitions: (): Record<string, unknown> =>
+      deps.resolveDisclosedToolDefinitions(resolvedToolSurface),
     countTokens: (text: string): number => defaultCountTokens(text, resolvedEncoding),
   }
 }

--- a/tests/chat/fixtures/context-snapshot.ts
+++ b/tests/chat/fixtures/context-snapshot.ts
@@ -29,6 +29,6 @@ export const standardContextSnapshot: ContextSnapshot = {
       ],
     },
     { label: 'Conversation history', tokens: 2_400, detail: '34 messages' },
-    { label: 'Tools', tokens: 3_200, detail: '18 active, gated by kaneo' },
+    { label: 'Tools', tokens: 3_200, detail: '4 active · 18 available (progressive disclosure)' },
   ],
 }

--- a/tests/commands/context-collector.test.ts
+++ b/tests/commands/context-collector.test.ts
@@ -38,7 +38,7 @@ function makeDeps(overrides: Partial<ContextCollectorDeps> | null): ContextColle
       last_seen: string
     }[] => [],
     getActiveToolDefinitions: (): Record<string, unknown> => ({}),
-    getProviderName: (): string => 'kaneo',
+    getDisclosedToolDefinitions: (): Record<string, unknown> => ({}),
     countTokens: (text: string): number => Math.ceil(text.length / 4),
     ...resolveCollectorOverrides(overrides),
   }
@@ -133,24 +133,26 @@ describe('collectContext', () => {
     expect(convo.detail).toBe('3 messages')
   })
 
-  test('Tools detail shows count and provider name', () => {
+  test('Tools detail reports disclosed active count and full catalog available count', () => {
     const deps = makeDeps({
       getActiveToolDefinitions: () => ({ a: {}, b: {}, c: {} }),
-      getProviderName: () => 'kaneo',
+      getDisclosedToolDefinitions: () => ({ search_tools: {}, load_tool: {} }),
     })
     const snapshot = collectContext('user1', deps)
     const tools = requireSection(snapshot.sections, 'Tools')
-    expect(tools.detail).toBe('3 active, gated by kaneo')
+    expect(tools.detail).toBe('2 active · 3 available (progressive disclosure)')
   })
 
-  test('Tools detail stays provider-focused without routing info', () => {
+  test('Tools tokens count only the disclosed surface, not the full catalog', () => {
     const deps = makeDeps({
-      getActiveToolDefinitions: () => ({ save_memo: {}, search_memos: {} }),
-      getProviderName: () => 'kaneo',
+      countTokens: (text: string) => text.length,
+      getActiveToolDefinitions: () => ({ heavy: { description: 'X'.repeat(1000) } }),
+      getDisclosedToolDefinitions: () => ({ search_tools: { description: 'find tools' } }),
     })
     const snapshot = collectContext('user1', deps)
     const tools = requireSection(snapshot.sections, 'Tools')
-    expect(tools.detail).toBe('2 active, gated by kaneo')
+    expect(tools.tokens).toBeGreaterThan(0)
+    expect(tools.tokens).toBeLessThan(200)
   })
 
   test('returns maxTokens=null for unknown model', () => {
@@ -309,7 +311,7 @@ describe('encoding-sensitive collection', () => {
     })
 
     const deps = makeDeps({
-      getActiveToolDefinitions: () => ({ x: cyclicTool }),
+      getDisclosedToolDefinitions: () => ({ x: cyclicTool }),
       countTokens: (text: string) => text.length,
     })
     const snapshot = collectContext('user1', deps)

--- a/tests/commands/context-disclosed-tools.test.ts
+++ b/tests/commands/context-disclosed-tools.test.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { resolveDisclosedToolDefinitions } from '../../src/commands/context-tool-resolution.js'
+import { ALWAYS_ON_TOOL_NAMES } from '../../src/tools/disclosure/core.js'
+import { makeTools } from '../../src/tools/index.js'
+import { createMockProvider } from '../tools/mock-provider.js'
+import { mockLogger, setupTestDb } from '../utils/test-helpers.js'
+
+describe('resolveDisclosedToolDefinitions', () => {
+  beforeEach(() => {
+    mockLogger()
+  })
+
+  test('narrows a full catalog to the always-on disclosure surface plus injected meta tools', () => {
+    const surface = {
+      definitions: {
+        get_current_time: { description: 'Return the current time.' },
+        expand_result: { description: 'Page a stored tool result.' },
+        create_task: { description: 'Create a task.' },
+        list_tasks: { description: 'List tasks.' },
+        search_projects: { description: 'Search projects.' },
+      },
+    }
+
+    const disclosed = resolveDisclosedToolDefinitions(surface)
+
+    expect(Object.keys(disclosed).sort()).toEqual(['expand_result', 'get_current_time', 'load_tool', 'search_tools'])
+  })
+
+  test('injects search_tools and load_tool with real input schemas', () => {
+    const surface = {
+      definitions: {
+        get_current_time: { description: 'Return the current time.' },
+        create_task: { description: 'Create a task.' },
+      },
+    }
+
+    const disclosed = resolveDisclosedToolDefinitions(surface)
+
+    expect(disclosed['search_tools']).toHaveProperty('inputSchema')
+    expect(disclosed['load_tool']).toHaveProperty('inputSchema')
+  })
+
+  test('returns only the injected meta tools when the catalog has no always-on tools', () => {
+    const surface = {
+      definitions: {
+        create_task: { description: 'Create a task.' },
+        list_tasks: { description: 'List tasks.' },
+      },
+    }
+
+    const disclosed = resolveDisclosedToolDefinitions(surface)
+
+    expect(Object.keys(disclosed).sort()).toEqual(['load_tool', 'search_tools'])
+  })
+
+  test('excludes the non-disclosed catalog tools from the returned surface', () => {
+    const surface = {
+      definitions: {
+        get_current_time: { description: 'Return the current time.' },
+        create_task: { description: 'Create a task.' },
+      },
+    }
+
+    const disclosed = resolveDisclosedToolDefinitions(surface)
+
+    expect(disclosed).not.toHaveProperty('create_task')
+  })
+
+  test('narrows a real provider-backed catalog to a handful of tools, not the whole catalog', async () => {
+    await setupTestDb()
+    const catalog = await makeTools(createMockProvider(), {
+      storageContextId: 'user1',
+      chatUserId: 'user1',
+      mode: 'normal',
+      contextType: 'dm',
+    })
+    const catalogSize = Object.keys(catalog).length
+
+    const disclosed = resolveDisclosedToolDefinitions({ definitions: catalog })
+
+    // The real catalog is large; disclosure exposes only the always-on surface at turn start.
+    expect(catalogSize).toBeGreaterThan(10)
+    expect(Object.keys(disclosed).length).toBeLessThanOrEqual(ALWAYS_ON_TOOL_NAMES.size)
+    // The injected meta tools are always part of the disclosed surface.
+    expect(disclosed).toHaveProperty('search_tools')
+    expect(disclosed).toHaveProperty('load_tool')
+    // A run-of-the-mill catalog tool is not disclosed until load_tool pulls it in.
+    expect(disclosed).not.toHaveProperty('create_task')
+  })
+})

--- a/tests/commands/context.test.ts
+++ b/tests/commands/context.test.ts
@@ -12,6 +12,7 @@ import type { ChatProvider, CommandHandler, ContextRendered, ContextSnapshot } f
 import {
   resolveActiveToolDefinitions,
   resolveContextToolSurface,
+  resolveDisclosedToolDefinitions,
   safeBuildProvider,
 } from '../../src/commands/context-tool-resolution.js'
 import type { ContextCommandDeps } from '../../src/commands/context.js'
@@ -69,6 +70,7 @@ function snapshotDeps(overrides: Partial<ContextCommandDeps> | null): ContextCom
       })
     },
     resolveActiveToolDefinitions,
+    resolveDisclosedToolDefinitions,
     resolveToolSurface: resolveContextToolSurface,
     ...resolveOverrides(overrides),
   }


### PR DESCRIPTION
## Problem

The `/context` breakdown's **Tools** row reported a wildly inflated count and token total — e.g. `Tools 81,011 tk · 60 active, gated by kaneo` — when only ~4 tools are actually loaded at a turn's first step.

**Root cause:** the `/context` path counted the entire merged tool catalog (builtins + MCP + plugin tools, ~87 in practice), serializing every tool's full JSON Schema. But a live turn never sends that. Under progressive disclosure, each step's `activeTools` = core ∪ meta ∪ loaded (`src/tools/disclosure/registry.ts`). At turn start that's just the always-on set — `get_current_time`, `search_tools`, `load_tool`, `expand_result`. The rest are only ranked *briefs*; their schemas enter context on demand via `load_tool`. The `/context` collector never applied `maybeApplyDisclosure`, so it reported the raw catalog.

## Fix

- **`context-tool-resolution.ts`** — new `resolveDisclosedToolDefinitions()` mirrors the orchestrator's `maybeApplyDisclosure` + `DisclosureSession.activeToolNames()` (using a zero-dependency `LexicalToolRetriever` that is never executed — schemas only), returning the active surface incl. the real injected `search_tools`/`load_tool` schemas. Robust `try/catch` fallback to always-on catalog names.
- **`context-collector.ts`** — `buildToolsSection` now counts tokens over the disclosed subset and labels it `N active · M available (progressive disclosure)`; dropped the misleading `gated by <provider>` text.
- **`context.ts`** — wired the new dep through; removed the now-unused provider-name plumbing.

## Result

`Tools 81,011 tk · 60 active` → `Tools <disclosed> tk · 4 active · 87 available (progressive disclosure)`.

## Testing

- New `tests/commands/context-disclosed-tools.test.ts` — unit + a real-catalog integration test proving 87 → 4 (`["expand_result","get_current_time","load_tool","search_tools"]`).
- Updated collector/context/fixture tests for the new detail format and token source (TDD, red→green).
- 932 related tests pass; format, lint, and typecheck clean.