### PR TITLE
fix(mutation): lane-aware coverage-map spawns client tests, skips e2e/stories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ COPY --from=build /app/public ./public
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY plugins ./plugins
 COPY src ./src
+# Operator CLIs (runbook: analytics-stage-b-report/backfill/snapshot/rekey) run inside the
+# container via `docker compose exec papai bun run /app/scripts/<name>.ts`.
+COPY scripts ./scripts
 COPY package.json tsconfig.json CHANGELOG.md ./
 COPY LICENSE ./LICENSE
 

--- a/docs/operations/analytics-stage-b-checklist.md
+++ b/docs/operations/analytics-stage-b-checklist.md
@@ -23,6 +23,11 @@ See LICENSE in the project root for details.
 | `<DB_PATH>` | `/var/lib/papai/papai.db` | SQLite DB path (same as the bot's `DB_PATH`) |
 | `<SNAPSHOT_DIR>` | `/var/lib/papai/snapshots` | `ANALYTICS_SNAPSHOT_DIR` |
 
+**docker compose deployments:** the operator CLIs ship inside the image at
+`/app/scripts/`; run them as `docker compose exec papai bun run /app/scripts/<name>.ts`
+(`DB_PATH` is already set by the compose `environment:`, and the CLI opens the DB
+read-only). No host checkout is needed; use `docker compose exec -T` from cron.
+
 **Never during the window:** deploy or restart the bot (an unclean restart =
 `unreconciled_restart_gap` day = the two-week counter restarts); amend an
 evidence commit (corrections land as new commits); estimate or backfill a
@@ -80,6 +85,7 @@ sink.
 
   ```bash
   DB_PATH=<DB_PATH> bun run <PAPAI_DIR>/scripts/analytics-stage-b-report.ts
+  # docker compose: docker compose exec papai bun run /app/scripts/analytics-stage-b-report.ts
   # expect: day=<yesterday> eligible=... summary + a window-log-row; exit 0
   ```
 

--- a/review-loop/src/agent-runner.ts
+++ b/review-loop/src/agent-runner.ts
@@ -4,14 +4,17 @@
 // See LICENSE in the project root for details.
 
 import { existsSync } from 'node:fs'
-import { appendFile, copyFile, mkdir, readFile, unlink } from 'node:fs/promises'
+import { copyFile, mkdir, readFile, unlink } from 'node:fs/promises'
 import path from 'node:path'
 
 import type { z } from 'zod'
 
-import { type OpencodeEvent, parseEventLine } from './event-stream.js'
-import { formatLiveLine, formatStepFooter, formatToolArg } from './live-renderer.js'
+import { createLineHandler, enqueueLog } from './line-handler.js'
+import type { LineHandler } from './line-handler.js'
 import type { ProgressReporter } from './progress-log.js'
+
+export { createLineHandler } from './line-handler.js'
+export type { LineHandler } from './line-handler.js'
 
 export interface SpawnResult {
   exitCode: number
@@ -79,108 +82,6 @@ interface AttemptError {
 
 type Attempt<T> = AttemptResult<T> | AttemptError
 
-export interface LineHandler {
-  readonly ctx: LiveCtx
-  onLine: LineSink
-  dispose: () => void
-}
-
-interface LiveCtx {
-  readonly label: string
-  readonly logPath: string
-  readonly reporter: ProgressReporter | undefined
-  startedAt: number
-  toolCount: number
-  tool: string
-  arg: string
-  readonly seenCalls: Set<string>
-  timer: ReturnType<typeof setInterval> | null
-  usage: AgentUsage
-  firstStepAt: number | null
-}
-
-function renderLive(ctx: LiveCtx): void {
-  const reporter = ctx.reporter
-  if (reporter === undefined) {
-    return
-  }
-  const elapsed = ctx.startedAt === 0 ? 0 : Date.now() - ctx.startedAt
-  reporter.live([formatLiveLine(ctx.label, ctx.tool, ctx.arg, elapsed, ctx.toolCount)])
-}
-
-function applyEvent(evt: OpencodeEvent, ctx: LiveCtx): void {
-  const reporter = ctx.reporter
-  switch (evt.type) {
-    case 'step_start':
-      ctx.firstStepAt ??= Date.now()
-      if (ctx.startedAt === 0) {
-        ctx.startedAt = Date.now()
-        if (reporter?.dynamic === true) {
-          ctx.timer = setInterval(() => {
-            renderLive(ctx)
-          }, 1000)
-        }
-      }
-      break
-    case 'tool_use':
-      if (!ctx.seenCalls.has(evt.callId)) {
-        ctx.seenCalls.add(evt.callId)
-        ctx.toolCount += 1
-      }
-      ctx.tool = evt.tool
-      ctx.arg = formatToolArg(evt.tool, evt.input)
-      renderLive(ctx)
-      break
-    case 'step_finish':
-      ctx.usage.inputTokens += evt.tokens.input
-      ctx.usage.outputTokens += evt.tokens.output
-      ctx.usage.reasoningTokens += evt.tokens.reasoning
-      ctx.usage.costUsd += evt.cost
-      if (reporter !== undefined) {
-        reporter.clearLive()
-        reporter.event(
-          formatStepFooter(ctx.label, ctx.startedAt === 0 ? 0 : Date.now() - ctx.startedAt, ctx.toolCount, evt.tokens),
-        )
-      }
-      break
-    case 'text':
-      break
-  }
-}
-
-function createLineHandler<T>(options: RunAgentOptions<T>): LineHandler {
-  const ctx: LiveCtx = {
-    label: options.label,
-    logPath: options.logPath,
-    reporter: options.reporter,
-    startedAt: 0,
-    toolCount: 0,
-    tool: '',
-    arg: '',
-    seenCalls: new Set<string>(),
-    timer: null,
-    usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0, wallMs: 0 },
-    firstStepAt: null,
-  }
-  const onLine: LineSink = (line: string): void => {
-    void appendFile(ctx.logPath, `${line}\n`)
-    const evt = parseEventLine(line)
-    if (evt !== null) {
-      applyEvent(evt, ctx)
-    }
-  }
-  const dispose = (): void => {
-    if (ctx.timer !== null) {
-      clearInterval(ctx.timer)
-    }
-    const reporter = ctx.reporter
-    if (reporter !== undefined) {
-      reporter.clearLive()
-    }
-  }
-  return { ctx, onLine, dispose }
-}
-
 /**
  * Absolute path the agent should write its output to.
  *
@@ -239,7 +140,7 @@ async function runAttempt<T>(options: RunAgentOptions<T>, handler: LineHandler):
   await mkdir(path.resolve(options.cwd, '.review-loop'), { recursive: true })
   const result = await attemptRun(options, handler.onLine)
   if (result.exitCode !== 0) {
-    await appendFile(options.logPath, `[${options.label}] stderr: ${result.stderr}\n`)
+    enqueueLog(handler.ctx, `[${options.label}] stderr: ${result.stderr}\n`)
     return {
       ok: false,
       error: new Error(`${options.label} exited with code ${result.exitCode}: ${result.stderr}`),
@@ -290,6 +191,6 @@ export async function runAgent<T>(options: RunAgentOptions<T>): Promise<AgentRun
     if (second.ok) return finalize(second.value)
     throw new AgentRunError(second.error.message, buildUsage())
   } finally {
-    handler.dispose()
+    await handler.dispose()
   }
 }

--- a/review-loop/src/line-handler.ts
+++ b/review-loop/src/line-handler.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { appendFile } from 'node:fs/promises'
+
+import type { AgentUsage, LineSink, RunAgentOptions } from './agent-runner.js'
+import { type OpencodeEvent, parseEventLine } from './event-stream.js'
+import { formatLiveLine, formatStepFooter, formatToolArg } from './live-renderer.js'
+import type { ProgressReporter } from './progress-log.js'
+
+export interface LineHandler {
+  readonly ctx: LiveCtx
+  onLine: LineSink
+  /** Clears live rendering and resolves after every queued log write has hit disk. */
+  dispose: () => Promise<void>
+}
+
+export interface LiveCtx {
+  readonly label: string
+  readonly logPath: string
+  readonly reporter: ProgressReporter | undefined
+  startedAt: number
+  toolCount: number
+  tool: string
+  arg: string
+  readonly seenCalls: Set<string>
+  timer: ReturnType<typeof setInterval> | null
+  usage: AgentUsage
+  firstStepAt: number | null
+  /** Serializes log appends so `dispose` can drain them; never rejects (logging is best-effort). */
+  logChain: Promise<void>
+}
+
+function renderLive(ctx: LiveCtx): void {
+  const reporter = ctx.reporter
+  if (reporter === undefined) {
+    return
+  }
+  const elapsed = ctx.startedAt === 0 ? 0 : Date.now() - ctx.startedAt
+  reporter.live([formatLiveLine(ctx.label, ctx.tool, ctx.arg, elapsed, ctx.toolCount)])
+}
+
+function applyEvent(evt: OpencodeEvent, ctx: LiveCtx): void {
+  const reporter = ctx.reporter
+  switch (evt.type) {
+    case 'step_start':
+      ctx.firstStepAt ??= Date.now()
+      if (ctx.startedAt === 0) {
+        ctx.startedAt = Date.now()
+        if (reporter?.dynamic === true) {
+          ctx.timer = setInterval(() => {
+            renderLive(ctx)
+          }, 1000)
+        }
+      }
+      break
+    case 'tool_use':
+      if (!ctx.seenCalls.has(evt.callId)) {
+        ctx.seenCalls.add(evt.callId)
+        ctx.toolCount += 1
+      }
+      ctx.tool = evt.tool
+      ctx.arg = formatToolArg(evt.tool, evt.input)
+      renderLive(ctx)
+      break
+    case 'step_finish':
+      ctx.usage.inputTokens += evt.tokens.input
+      ctx.usage.outputTokens += evt.tokens.output
+      ctx.usage.reasoningTokens += evt.tokens.reasoning
+      ctx.usage.costUsd += evt.cost
+      if (reporter !== undefined) {
+        reporter.clearLive()
+        reporter.event(
+          formatStepFooter(ctx.label, ctx.startedAt === 0 ? 0 : Date.now() - ctx.startedAt, ctx.toolCount, evt.tokens),
+        )
+      }
+      break
+    case 'text':
+      break
+  }
+}
+
+export function createLineHandler<T>(options: RunAgentOptions<T>): LineHandler {
+  const ctx: LiveCtx = {
+    label: options.label,
+    logPath: options.logPath,
+    reporter: options.reporter,
+    startedAt: 0,
+    toolCount: 0,
+    tool: '',
+    arg: '',
+    seenCalls: new Set<string>(),
+    timer: null,
+    usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0, wallMs: 0 },
+    firstStepAt: null,
+    logChain: Promise.resolve(),
+  }
+  const onLine: LineSink = (line: string): void => {
+    enqueueLog(ctx, `${line}\n`)
+    const evt = parseEventLine(line)
+    if (evt !== null) {
+      applyEvent(evt, ctx)
+    }
+  }
+  const dispose = async (): Promise<void> => {
+    if (ctx.timer !== null) {
+      clearInterval(ctx.timer)
+    }
+    const reporter = ctx.reporter
+    if (reporter !== undefined) {
+      reporter.clearLive()
+    }
+    await ctx.logChain
+  }
+  return { ctx, onLine, dispose }
+}
+
+/**
+ * Best-effort serialized log append. A fire-and-forget `void appendFile(...)` floats past the
+ * caller's lifetime: if the destination disappears first (temp-dir cleanup, run teardown), the
+ * rejection is unhandled and crashes whichever code is running when it lands. Chaining lets
+ * `dispose` drain the queue so no write outlives `runAgent`'s finally.
+ */
+export function enqueueLog(ctx: LiveCtx, text: string): void {
+  ctx.logChain = ctx.logChain
+    .then(() => appendFile(ctx.logPath, text))
+    .then(
+      () => undefined,
+      () => undefined,
+    )
+}

--- a/scripts/mutation/README.md
+++ b/scripts/mutation/README.md
@@ -64,11 +64,18 @@ For each source file, `pairedRun` resolves the test set in this priority:
      a same-package `index.test.ts` exercises the impl through a re-exporting
      barrel rather than importing it directly.
 
-   Each candidate is then run once with `bun test --coverage`, and the source
-   is attributed the candidates whose lcov shows `lines-hit > 0`. A 24h
+   Each candidate is then run once with `bun test --coverage` (lane-aware, see
+   `scripts/mutation/coverage-runner.ts`): tests under `tests/client/**` run
+   with the `test:client` preset (`--conditions=browser --preload
+./tests/client-setup.ts --path-ignore-patterns ''`) because bunfig's
+   `pathIgnorePatterns` otherwise hides them from discovery; `tests/e2e/**` and
+   `tests/stories/**` are excluded from the candidate universe entirely (Docker
+   / sandboxed story runner — not spawnable per-file). The source is
+   attributed the candidates whose lcov shows `lines-hit > 0`. A 24h
    content-keyed cache (`reports/paired/coverage-map.cache.json`) amortizes
    coverage runs across batches; the cache never throws — a malformed file or
-   entry is treated as a miss.
+   entry is treated as a miss — and failed runs are never cached, so transient
+   spawn failures stay retryable.
 
 2. **Overrides (additive)** — `scripts/mutation/overrides.json` is unioned onto
    the coverage-derived set (or used alone if no covering test was found). Use

--- a/scripts/mutation/coverage-map.ts
+++ b/scripts/mutation/coverage-map.ts
@@ -3,7 +3,6 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { execFileSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
@@ -12,6 +11,8 @@ import { Glob } from 'bun'
 
 import { openCoverageCache } from './coverage-cache.js'
 import type { CoverageCache } from './coverage-cache.js'
+import { classifyTestLane, spawnAndParseLcov } from './coverage-runner.js'
+import type { SpawnAndParse, SpawnCoverageOptions } from './coverage-runner.js'
 
 export type CoverageMap = Record<string, string[]>
 
@@ -55,7 +56,10 @@ const DEFAULT_CACHE_PATH = 'reports/paired/coverage-map.cache.json'
 const DEFAULT_CACHE_TTL_MS = 24 * 60 * 60 * 1000
 const DEFAULT_COVERAGE_DIR = 'reports/coverage'
 const DEFAULT_LCOV_NAME = 'lcov.info'
-const DEFAULT_TIMEOUT_MS = 30_000
+// A single-file coverage run is usually a few seconds, but meta-tests like
+// tests/analytics/privacy-contract.test.ts re-spawn ~30 nested `bun test` fixture runs and
+// take ~40s locally; CI runners are slower still. 120s absorbs that without masking a hang.
+const DEFAULT_TIMEOUT_MS = 120_000
 const TEST_SCAN_PATTERN = 'tests/**/*.test.ts'
 
 export interface DefaultCoverageMapDepsOptions {
@@ -77,8 +81,12 @@ interface CandidateContext {
  * two heuristics unioned together: (a) tests whose text directly imports the source (mirrors the
  * TDD write-hook's `testFileImportsImpl`), AND (b) tests in the same package directory as the
  * source's companion (catches transitive coverage where a same-package index test exercises the
- * source indirectly through a re-exporting barrel). `runCoverage` spawns `bun test --coverage`,
- * parses the lcov, and consults a content-keyed TTL cache. Never throws — fails open to empty.
+ * source indirectly through a re-exporting barrel). External-lane tests (tests/e2e/**,
+ * tests/stories/**) are excluded from the universe — they need Docker / the sandboxed story
+ * runner and cannot be spawned per-file. `runCoverage` spawns a per-lane `bun test --coverage`
+ * (tests/client/** runs with the `test:client` preset so bun's pathIgnorePatterns don't hide
+ * it), parses the lcov, and consults a content-keyed TTL cache; failures are never cached.
+ * Never throws — fails open to empty.
  */
 export function createDefaultCoverageMapDeps(
   projectRoot: string,
@@ -136,7 +144,9 @@ const listCandidateTests = (srcFile: string, projectRoot: string, ctx: Candidate
 
 const scanTestFiles = (projectRoot: string): string[] => {
   try {
-    return [...new Glob(TEST_SCAN_PATTERN).scanSync({ cwd: projectRoot, onlyFiles: true })].sort()
+    return [...new Glob(TEST_SCAN_PATTERN).scanSync({ cwd: projectRoot, onlyFiles: true })]
+      .filter((testRel) => classifyTestLane(testRel) !== 'external')
+      .sort()
   } catch {
     return []
   }
@@ -168,7 +178,6 @@ const samePackageTestDir = (srcRel: string): string => {
   }
   return 'tests'
 }
-export { samePackageTestDir as _samePackageTestDirForTest }
 
 /**
  * Mirror of `.hooks/tdd/test-resolver.mjs`'s `testFileImportsImpl`, accepting pre-read content so
@@ -184,13 +193,12 @@ const scanImportsInContent = (content: string, testAbs: string, implAbs: string)
   return content.includes(withJs) || content.includes(`${noExt}'`) || content.includes(`${noExt}"`)
 }
 
-interface RunCoverageOptions {
-  readonly coverageDir: string
-  readonly lcovName: string
-  readonly timeoutMs: number
+interface RunCoverageOptions extends SpawnCoverageOptions {
   readonly cache: CoverageCache
   readonly cacheTtlMs: number
   readonly readTestContent: (testAbs: string) => string
+  /** Test seam: replaces the real bun spawn. Production callers leave it undefined. */
+  readonly spawnAndParse?: SpawnAndParse
 }
 
 const runCoverageFor = (
@@ -202,60 +210,13 @@ const runCoverageFor = (
   const key = cacheKeyForTest(testAbs, opts.readTestContent)
   const cached = opts.cache.get(key, opts.cacheTtlMs)
   if (cached !== undefined) return cached
-  const fresh = spawnAndParseLcov(testFile, projectRoot, opts)
+  const spawn = opts.spawnAndParse ?? spawnAndParseLcov
+  const fresh = spawn(testFile, projectRoot, opts)
+  // Fail open to empty WITHOUT caching: a transient spawn failure (timeout, runner hiccup)
+  // must not poison the 24h content-keyed cache and stick until the test file changes.
+  if (fresh === null) return new Map()
   opts.cache.set(key, fresh)
   return fresh
-}
-
-const spawnAndParseLcov = (
-  testFile: string,
-  projectRoot: string,
-  opts: Pick<RunCoverageOptions, 'coverageDir' | 'lcovName' | 'timeoutMs'>,
-): Map<string, number> => {
-  let spawned = true
-  try {
-    execFileSync('bun', ['test', testFile, '--coverage', '--coverage-reporter=lcov'], {
-      cwd: projectRoot,
-      stdio: 'pipe',
-      timeout: opts.timeoutMs,
-      maxBuffer: 20 * 1024 * 1024,
-    })
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    console.error(`coverage-map: bun coverage failed for ${testFile}: ${message}`)
-    spawned = false
-  }
-  if (!spawned) return new Map()
-  const lcovPath = path.join(projectRoot, opts.coverageDir, opts.lcovName)
-  if (!fs.existsSync(lcovPath)) {
-    console.error(`coverage-map: lcov missing at ${lcovPath} for ${testFile}`)
-    return new Map()
-  }
-  try {
-    return parseLcovAll(lcovPath, projectRoot)
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    console.error(`coverage-map: lcov parse failed for ${lcovPath}: ${message}`)
-    return new Map()
-  }
-}
-
-/** Parse lcov into project-relative `sourceFile -> lines-hit` (keys match requested sourceFiles). */
-const parseLcovAll = (lcovPath: string, projectRoot: string): Map<string, number> => {
-  const content = fs.readFileSync(lcovPath, 'utf8')
-  const out = new Map<string, number>()
-  for (const section of content.split('end_of_record')) {
-    const sfMatch = section.match(/^SF:(.+)$/mu)
-    const lhMatch = section.match(/^LH:(\d+)$/mu)
-    if (sfMatch === null || lhMatch === null) continue
-    const sfPath = sfMatch[1]
-    const lhText = lhMatch[1]
-    if (sfPath === undefined || lhText === undefined) continue
-    const abs = path.resolve(projectRoot, sfPath.trim())
-    const linesHit = Number.parseInt(lhText, 10)
-    if (Number.isFinite(linesHit)) out.set(path.relative(projectRoot, abs), linesHit)
-  }
-  return out
 }
 
 const cacheKeyForTest = (testAbs: string, readContent: (testAbs: string) => string): string => {
@@ -263,3 +224,5 @@ const cacheKeyForTest = (testAbs: string, readContent: (testAbs: string) => stri
   const hash = createHash('sha256').update(content).digest('hex').slice(0, 16)
   return `${testAbs}:${hash}`
 }
+
+export { samePackageTestDir as _samePackageTestDirForTest, runCoverageFor as _runCoverageForTest }

--- a/scripts/mutation/coverage-runner.ts
+++ b/scripts/mutation/coverage-runner.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Runnability/preset lane for a test file, derived from bunfig.toml `[test] pathIgnorePatterns`
+ * and the package.json lane scripts. `client` tests (tests/client/**) are excluded from default
+ * discovery and only run with the `test:client` preset; `external` tests (tests/e2e/** needs
+ * Docker, tests/stories/** needs the sandboxed story runner) cannot be spawned per-file at all.
+ */
+export type TestLane = 'server' | 'client' | 'external'
+
+export const classifyTestLane = (testFile: string): TestLane => {
+  const normalized = testFile.replace(/\\/gu, '/')
+  const under = (prefix: string): boolean => normalized.startsWith(prefix) || normalized.includes(`/${prefix}`)
+  if (under('tests/e2e/') || under('tests/stories/')) return 'external'
+  if (under('tests/client/')) return 'client'
+  return 'server'
+}
+
+/**
+ * bun argv for one coverage run. The client lane mirrors package.json `test:client`: without
+ * `--path-ignore-patterns ''` bun's scanner drops tests/client/** from discovery and fails with
+ * "filters did not match any test files" even when the file exists.
+ */
+export const buildCoverageArgs = (testFile: string): readonly string[] =>
+  classifyTestLane(testFile) === 'client'
+    ? [
+        '--conditions=browser',
+        'test',
+        '--preload',
+        './tests/client-setup.ts',
+        '--path-ignore-patterns',
+        '',
+        testFile,
+        '--coverage',
+        '--coverage-reporter=lcov',
+      ]
+    : ['test', testFile, '--coverage', '--coverage-reporter=lcov']
+
+export interface SpawnCoverageOptions {
+  readonly coverageDir: string
+  readonly lcovName: string
+  readonly timeoutMs: number
+}
+
+export type SpawnAndParse = (
+  testFile: string,
+  projectRoot: string,
+  opts: SpawnCoverageOptions,
+) => Map<string, number> | null
+
+/**
+ * Spawn one per-lane `bun test --coverage` and parse the resulting lcov. Returns null on any
+ * failure (spawn error, non-runnable external lane, missing/unparseable lcov) so the caller can
+ * distinguish failure from legitimately-empty coverage and keep failures out of the cache.
+ */
+export const spawnAndParseLcov = (
+  testFile: string,
+  projectRoot: string,
+  opts: SpawnCoverageOptions,
+): Map<string, number> | null => {
+  if (classifyTestLane(testFile) === 'external') {
+    console.error(`coverage-map: skipping ${testFile}: external lane (e2e/stories) cannot be spawned per-file`)
+    return null
+  }
+  try {
+    execFileSync('bun', [...buildCoverageArgs(testFile)], {
+      cwd: projectRoot,
+      stdio: 'pipe',
+      timeout: opts.timeoutMs,
+      maxBuffer: 20 * 1024 * 1024,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`coverage-map: bun coverage failed for ${testFile}: ${message}`)
+    return null
+  }
+  const lcovPath = path.join(projectRoot, opts.coverageDir, opts.lcovName)
+  if (!fs.existsSync(lcovPath)) {
+    console.error(`coverage-map: lcov missing at ${lcovPath} for ${testFile}`)
+    return null
+  }
+  try {
+    return parseLcovAll(lcovPath, projectRoot)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`coverage-map: lcov parse failed for ${lcovPath}: ${message}`)
+    return null
+  }
+}
+
+/** Parse lcov into project-relative `sourceFile -> lines-hit` (keys match requested sourceFiles). */
+const parseLcovAll = (lcovPath: string, projectRoot: string): Map<string, number> => {
+  const content = fs.readFileSync(lcovPath, 'utf8')
+  const out = new Map<string, number>()
+  for (const section of content.split('end_of_record')) {
+    const sfMatch = section.match(/^SF:(.+)$/mu)
+    const lhMatch = section.match(/^LH:(\d+)$/mu)
+    if (sfMatch === null || lhMatch === null) continue
+    const sfPath = sfMatch[1]
+    const lhText = lhMatch[1]
+    if (sfPath === undefined || lhText === undefined) continue
+    const abs = path.resolve(projectRoot, sfPath.trim())
+    const linesHit = Number.parseInt(lhText, 10)
+    if (Number.isFinite(linesHit)) out.set(path.relative(projectRoot, abs), linesHit)
+  }
+  return out
+}

--- a/tests/review-loop/agent-runner.test.ts
+++ b/tests/review-loop/agent-runner.test.ts
@@ -9,7 +9,13 @@ import path from 'node:path'
 
 import { z } from 'zod'
 
-import { AgentRunError, agentWritePath, runAgent, type SpawnFn } from '../../review-loop/src/agent-runner.js'
+import {
+  AgentRunError,
+  agentWritePath,
+  createLineHandler,
+  runAgent,
+  type SpawnFn,
+} from '../../review-loop/src/agent-runner.js'
 import { ReviewerIssuesSchema } from '../../review-loop/src/issue-schema.js'
 import type { ProgressReporter } from '../../review-loop/src/progress-log.js'
 import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
@@ -379,6 +385,33 @@ function asAgentRunError(value: unknown): AgentRunError {
   }
   return value
 }
+
+describe('createLineHandler log draining', () => {
+  test('dispose resolves only after every queued log write has hit disk', async () => {
+    // Regression: onLine used to fire `void appendFile(...)` and forget it. The floating write
+    // could still be queued when the suite's afterEach cleanup removed the temp dir, rejecting
+    // with ENOENT and failing an unrelated test (CI flake: "concurrent runAgent calls ... do not
+    // race" / "timeout throw carries accumulated usage"). dispose must drain the queue so no
+    // write outlives runAgent's finally.
+    const cwd = makeTempDir('agent-log-drain-')
+    const logPath = path.join(cwd, 'agent.log')
+    const handler = createLineHandler({
+      spawn: () => Promise.resolve({ exitCode: 0, stdout: '', stderr: '' }),
+      model: 'm',
+      cwd,
+      prompt: 'p',
+      outputPath: path.join(cwd, 'result.json'),
+      outputSchema: z.object({ ok: z.boolean() }),
+      label: 'drain',
+      logPath,
+      extraArgs: [],
+    })
+    handler.onLine('first')
+    handler.onLine('second')
+    await handler.dispose()
+    expect(readFileSync(logPath, 'utf8')).toBe('first\nsecond\n')
+  })
+})
 
 describe('runAgent return type', () => {
   test('returns AgentRunResult with value and usage', async () => {

--- a/tests/review-loop/line-handler.test.ts
+++ b/tests/review-loop/line-handler.test.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { z } from 'zod'
+
+import type { RunAgentOptions, SpawnResult } from '../../review-loop/src/agent-runner.js'
+import { createLineHandler, enqueueLog } from '../../review-loop/src/line-handler.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+const makeOptions = (cwd: string, logPath: string): RunAgentOptions<{ ok: boolean }> => ({
+  spawn: (): Promise<SpawnResult> => Promise.resolve({ exitCode: 0, stdout: '', stderr: '' }),
+  model: 'm',
+  cwd,
+  prompt: 'p',
+  outputPath: path.join(cwd, 'result.json'),
+  outputSchema: z.object({ ok: z.boolean() }),
+  label: 'drain',
+  logPath,
+  extraArgs: [],
+})
+
+describe('createLineHandler log draining', () => {
+  test('dispose resolves only after every queued log write has hit disk', async () => {
+    const cwd = makeTempDir('line-handler-drain-')
+    const logPath = path.join(cwd, 'agent.log')
+    const handler = createLineHandler(makeOptions(cwd, logPath))
+    handler.onLine('first')
+    handler.onLine('second')
+    await handler.dispose()
+    expect(readFileSync(logPath, 'utf8')).toBe('first\nsecond\n')
+  })
+
+  test('enqueueLog never rejects when the destination disappears (best-effort logging)', async () => {
+    const cwd = makeTempDir('line-handler-best-effort-')
+    const logPath = path.join(cwd, 'missing-dir', 'agent.log')
+    const handler = createLineHandler(makeOptions(cwd, logPath))
+    enqueueLog(handler.ctx, 'dropped\n')
+    await handler.dispose()
+  })
+})

--- a/tests/scripts/license-setup.test.ts
+++ b/tests/scripts/license-setup.test.ts
@@ -56,6 +56,15 @@ describe('license setup', () => {
     expect(dockerfile).toMatch(/FROM base AS final[\s\S]*COPY LICENSE \.\/LICENSE/u)
   })
 
+  test('copies operator scripts into the final Docker image', () => {
+    // The Stage B runbook CLIs (scripts/analytics-*.ts) must be runnable via
+    // `docker compose exec papai bun run /app/scripts/<name>.ts` — without this COPY the
+    // prod image has no scripts/ tree and the checklist commands fail with "file not found".
+    const dockerfile = readRepoFile('Dockerfile')
+
+    expect(dockerfile).toMatch(/FROM base AS final[\s\S]*COPY scripts \.\/scripts/u)
+  })
+
   test('keeps the BSL text separate from the standalone patent grant', () => {
     const license = readRepoFile('LICENSE')
 

--- a/tests/scripts/mutation/coverage-map.test.ts
+++ b/tests/scripts/mutation/coverage-map.test.ts
@@ -12,6 +12,7 @@ import { openCoverageCache } from '../../../scripts/mutation/coverage-cache.js'
 import {
   buildCoverageMap,
   createDefaultCoverageMapDeps,
+  _runCoverageForTest as runCoverageFor,
   _samePackageTestDirForTest as samePackageTestDir,
 } from '../../../scripts/mutation/coverage-map.js'
 
@@ -159,6 +160,87 @@ describe('createDefaultCoverageMapDeps — listCandidateTests widening', () => {
     const deps = createDefaultCoverageMapDeps(root)
     const candidates = [...deps.listCandidateTests('src/history.ts')].sort()
     expect(candidates).toEqual(['tests/history-edit.test.ts', 'tests/history.test.ts'].sort())
+  })
+})
+
+describe('createDefaultCoverageMapDeps — external lanes are never candidates', () => {
+  it('excludes tests/e2e and tests/stories even when they import the source directly', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cov-map-lanes-'))
+    fs.mkdirSync(path.join(root, 'src', 'analytics'), { recursive: true })
+    fs.writeFileSync(path.join(root, 'src', 'analytics', 'thing.ts'), 'export const t = 1\n')
+    fs.mkdirSync(path.join(root, 'tests', 'analytics'), { recursive: true })
+    fs.writeFileSync(path.join(root, 'tests', 'analytics', 'thing.test.ts'), `import '../../src/analytics/thing.js'\n`)
+    fs.mkdirSync(path.join(root, 'tests', 'e2e'), { recursive: true })
+    fs.writeFileSync(path.join(root, 'tests', 'e2e', 'thing.test.ts'), `import '../../src/analytics/thing.js'\n`)
+    fs.mkdirSync(path.join(root, 'tests', 'stories', 'analytics'), { recursive: true })
+    fs.writeFileSync(
+      path.join(root, 'tests', 'stories', 'analytics', 'thing.story.test.ts'),
+      `import '../../../src/analytics/thing.js'\n`,
+    )
+    const deps = createDefaultCoverageMapDeps(root)
+    expect(deps.listCandidateTests('src/analytics/thing.ts')).toEqual(['tests/analytics/thing.test.ts'])
+  })
+})
+
+describe('runCoverageFor — failure handling', () => {
+  const makeOpts = (
+    cachePath: string,
+    spawn: () => Map<string, number> | null,
+  ): {
+    readonly coverageDir: string
+    readonly lcovName: string
+    readonly timeoutMs: number
+    readonly cache: ReturnType<typeof openCoverageCache>
+    readonly cacheTtlMs: number
+    readonly readTestContent: () => string
+    readonly spawnAndParse: () => Map<string, number> | null
+  } => ({
+    coverageDir: 'reports/coverage',
+    lcovName: 'lcov.info',
+    timeoutMs: 1000,
+    cache: openCoverageCache(cachePath),
+    cacheTtlMs: 60_000,
+    readTestContent: (): string => 'test file content',
+    spawnAndParse: spawn,
+  })
+
+  // Sequencer kept outside the test callbacks: oxlint's no-conditional-in-test forbids
+  // branching inside it() bodies.
+  const spawnSequence = (
+    results: ReadonlyArray<Map<string, number> | null>,
+  ): { readonly spawn: () => Map<string, number> | null; readonly calls: () => number } => {
+    let calls = 0
+    return {
+      spawn: () => {
+        calls += 1
+        return results[calls - 1] ?? null
+      },
+      calls: () => calls,
+    }
+  }
+
+  it('fails open to an empty map without caching the failure (transient errors stay retryable)', () => {
+    const cachePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'cov-run-fail-')), 'cache.json')
+    const success = new Map([['src/a.ts', 3]])
+    // Third entry is defensive: the third call must be served from cache, never reaching spawn
+    // (the calls() assertion below pins that).
+    const seq = spawnSequence([null, success, success])
+    const opts = makeOpts(cachePath, seq.spawn)
+    expect([...runCoverageFor('tests/a.test.ts', '/proj', opts).entries()]).toEqual([])
+    // Second call must re-spawn (failure was not cached) and now succeeds...
+    expect(runCoverageFor('tests/a.test.ts', '/proj', opts).get('src/a.ts')).toBe(3)
+    // ...and the third call is served from the cache.
+    expect(runCoverageFor('tests/a.test.ts', '/proj', opts).get('src/a.ts')).toBe(3)
+    expect(seq.calls()).toBe(2)
+  })
+
+  it('caches successful runs (including legitimately empty coverage)', () => {
+    const cachePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'cov-run-ok-')), 'cache.json')
+    const seq = spawnSequence([new Map()])
+    const opts = makeOpts(cachePath, seq.spawn)
+    expect([...runCoverageFor('tests/a.test.ts', '/proj', opts).entries()]).toEqual([])
+    expect([...runCoverageFor('tests/a.test.ts', '/proj', opts).entries()]).toEqual([])
+    expect(seq.calls()).toBe(1)
   })
 })
 

--- a/tests/scripts/mutation/coverage-runner.test.ts
+++ b/tests/scripts/mutation/coverage-runner.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import { buildCoverageArgs, classifyTestLane } from '../../../scripts/mutation/coverage-runner.js'
+
+describe('classifyTestLane — per-lane runnability and preset selection', () => {
+  // bunfig.toml [test] pathIgnorePatterns excludes tests/e2e|client|visual|stories from
+  // discovery. tests/client/** runs with the `test:client` preset; tests/e2e/** needs Docker
+  // and tests/stories/** the sandboxed story runner, so neither can be spawned per-file.
+  const cases = [
+    ['tests/client/settings/scrollspy.test.ts', 'client'],
+    ['/abs/proj/tests/client/settings/scrollspy.test.ts', 'client'],
+    ['tests/e2e/task-lifecycle.test.ts', 'external'],
+    ['/abs/proj/tests/e2e/task-lifecycle.test.ts', 'external'],
+    ['tests/stories/settings/identity.story.test.ts', 'external'],
+    ['tests/analytics/privacy-contract.test.ts', 'server'],
+    ['tests/client-stuff/not-client.test.ts', 'server'],
+    ['tests/chat/mattermost/file-helpers.test.ts', 'server'],
+  ] as const
+  for (const [input, expected] of cases) {
+    it(`classifies ${input} as ${expected}`, () => {
+      expect(classifyTestLane(input)).toBe(expected)
+    })
+  }
+})
+
+describe('buildCoverageArgs — bun argv per lane', () => {
+  it('server lane keeps the bare invocation (bunfig discovery already includes it)', () => {
+    expect(buildCoverageArgs('tests/analytics/foo.test.ts')).toEqual([
+      'test',
+      'tests/analytics/foo.test.ts',
+      '--coverage',
+      '--coverage-reporter=lcov',
+    ])
+  })
+
+  it('client lane mirrors the test:client preset and clears pathIgnorePatterns', () => {
+    // Mirrors package.json `test:client`: without --path-ignore-patterns '' bun's scanner
+    // drops tests/client/** and reports "filters did not match any test files".
+    expect(buildCoverageArgs('tests/client/settings/scrollspy.test.ts')).toEqual([
+      '--conditions=browser',
+      'test',
+      '--preload',
+      './tests/client-setup.ts',
+      '--path-ignore-patterns',
+      '',
+      'tests/client/settings/scrollspy.test.ts',
+      '--coverage',
+      '--coverage-reporter=lcov',
+    ])
+  })
+})


### PR DESCRIPTION
## Problem

The mutation-testing CI job (`test:mutate:changed`) failed on PR #185 with `coverage-map: bun coverage failed ... The following filters did not match any test files` for every `tests/client/**` candidate, plus `spawnSync bun ETIMEDOUT` for `tests/analytics/privacy-contract.test.ts`. Three root causes in `scripts/mutation/coverage-map.ts`:

1. **Bare `bun test <file>` can't see suite-excluded tests.** `bunfig.toml` `[test] pathIgnorePatterns` excludes `tests/e2e|client|visual|stories` from discovery, so bun's scanner dropped every client candidate. Latent until #185 — the first PR with `client/` mutation targets. (The Stryker stage already solved this in `config-builder.ts`; the coverage map never got the same treatment.)
2. **E2E tests were coverage candidates** via the import-scan heuristic but need Docker — they must never be spawned per-file (same for `tests/stories/**`, which needs the sandboxed story runner).
3. **30s spawn timeout too small.** `privacy-contract.test.ts` is a meta-test that re-spawns ~30 nested `bun test` fixture runs (~40s locally with or without coverage; slower on CI), so it died with `ETIMEDOUT`.

Also: failed runs were written into the 24h content-keyed cache, so a transient failure poisoned local reruns until the test file changed.

## Fix

- New `scripts/mutation/coverage-runner.ts` (extracted for max-lines): lane classification + per-lane argv. `tests/client/**` runs with the `test:client` preset (`--conditions=browser --preload ./tests/client-setup.ts --path-ignore-patterns ''`); server lane unchanged; `tests/e2e|stories/**` refused.
- `coverage-map.ts`: e2e/stories excluded from the candidate scan; timeout 30s → 120s; spawn failures return `null` and are **not cached**.
- Tests: `coverage-runner.test.ts` (lanes/argv), `coverage-map.test.ts` (+external-lane exclusion, +failure-not-cached cache policy). `scripts/mutation/README.md` updated.

## Verification

- Reproduced the CI failure locally (`bun test tests/client/settings/scrollspy.test.ts` → did-not-match), then confirmed the client-preset invocation exits 0 and writes lcov with the source entry.
- Real-repo end-to-end via `createDefaultCoverageMapDeps`: client lane produces hits, server lane intact, e2e skipped without spawn.
- `bun test tests/scripts/mutation/`: 143 pass. `typecheck` / `lint` clean.

## Follow-up (not in this PR)

The Stryker stage pairs client tests via `config-builder.ts` `needsPathIgnoreOverride`, which only clears path ignores — not the browser conditions/preload. #185 was the first PR with `client/` targets, so Stryker-side client support is unproven; if client tests fail inside the Stryker sandbox, that helper needs the same preset treatment.
