### PR TITLE
feat(review-loop): verdict-first report output + live issue streaming

### DIFF
--- a/docs/superpowers/plans/2026-08-01-review-loop-report-output.md
+++ b/docs/superpowers/plans/2026-08-01-review-loop-report-output.md
@@ -1,0 +1,1473 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Review-loop Report Output Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework the review-loop CLI's final report (verdict-first, zero-suppressed, per-issue groups, artifact paths) and live rendering (streamed per-issue lines + counter-enriched status tick).
+
+**Architecture:** In-place extension of existing modules. A new pure formatting module `review-loop/src/issue-format.ts` holds all issue-line rendering; `ProgressReporter` gains an optional `issue()`/`statusSuffix()` seam that `LiveRenderer` implements with a counter bag; `loop-controller`/`issue-processor*`/`commit-attempt` emit structured events; `buildSummary` is rewritten to consume the ledger snapshot + run dir.
+
+**Tech Stack:** Bun runtime + `bun:test`, strict TypeScript, zod (unchanged schemas).
+
+**Spec:** `docs/superpowers/specs/2026-08-01-review-loop-report-output-design.md`
+
+## Global Constraints
+
+- New source files MUST start with the BUSL-1.1 header (see any existing `review-loop/src/*.ts` file — `// SPDX-License-Identifier: BUSL-1.1` + 3 comment lines).
+- Strict TypeScript; use `.js` extension in all import paths.
+- Never add lint-disable or type-ignore comments.
+- Error extraction convention: `error instanceof Error ? error.message : String(error)`.
+- TDD: the repo write-hook maps `review-loop/src/**` to `tests/review-loop/**`; write the failing test BEFORE the implementation in every task.
+- Commit style follows history: `feat(review-loop): …`, `refactor(review-loop): …`, `test(review-loop): …`.
+- Run tests from the repo root. Single file: `bun test tests/review-loop/<file>.test.ts`. Full workspace suite: `bun run review-loop:test`. Typecheck: `bun run review-loop:typecheck`.
+- `review-loop/src/trace-log.ts` exports the `Severity` type (`'critical' | 'high' | 'medium' | 'low'`); `ReviewerIssue['severity']` is the same union.
+- Unicode marks used: `✓` (U+2713), `✗` (U+2717), `!`, `·` (U+00B7), `…` (U+2026), `—` (U+2014), `▶` (U+25B6). Reuse the existing constants in `live-renderer.ts` where they exist (`MIDDLE_DOT`, `ELLIPSIS`).
+
+---
+
+### Task 1: Issue line formatting module (`issue-format.ts`)
+
+**Files:**
+- Create: `review-loop/src/issue-format.ts`
+- Test: `tests/review-loop/issue-format.test.ts`
+
+**Interfaces:**
+- Consumes: `LedgerIssueStatus` from `review-loop/src/issue-ledger.js` (type-only import).
+- Produces (used by Tasks 2–4):
+  - `shortIssueId(id: string): string` — first 8 chars.
+  - `IssueRef` — `{ id: string; severity: string; file: string; line: number; title: string }`.
+  - `formatIssueRef(ref: IssueRef): string` — `#<id8> [<severity>] <file>:<line> — <title>` with `[severity]` padded to 10 chars.
+  - `formatFoundLine(ref: IssueRef): string` — `'  + ' + formatIssueRef(ref)`.
+  - `formatDecidedLine(args: { id: string; verdict: string; note?: string }): string` — `<mark> #<id8> → <label>[ (note)]`.
+  - `IssueGroup` — `'needsHuman' | 'fixed' | 'rejected' | 'alreadyFixed' | 'open'`.
+  - `GROUP_ORDER: readonly IssueGroup[]` — `['needsHuman', 'fixed', 'rejected', 'alreadyFixed', 'open']`.
+  - `GROUP_LABEL: Record<IssueGroup, string>` — `{ needsHuman: 'needs human', fixed: 'fixed', rejected: 'rejected', alreadyFixed: 'already fixed', open: 'open' }`.
+  - `GROUP_MARK: Record<IssueGroup, string>` — `{ needsHuman: '!', fixed: '✓', rejected: '✗', alreadyFixed: '·', open: '·' }`.
+  - `groupForStatus(status: LedgerIssueStatus): IssueGroup` — `needs_human→needsHuman`, `closed→fixed`, `rejected→rejected`, `already_fixed→alreadyFixed`, everything else (`discovered`, `verified`, `fixed_pending_review`, `reopened`)→`open`.
+  - `isOpenStatus(status: LedgerIssueStatus): boolean` — true unless status is `closed`/`rejected`/`already_fixed`/`needs_human`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/review-loop/issue-format.test.ts`:
+
+```typescript
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  formatDecidedLine,
+  formatFoundLine,
+  formatIssueRef,
+  groupForStatus,
+  isOpenStatus,
+  shortIssueId,
+} from '../../review-loop/src/issue-format.js'
+
+const ref = {
+  id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  severity: 'high',
+  file: 'src/auth/login.ts',
+  line: 42,
+  title: 'Token refresh race on 401',
+}
+
+describe('shortIssueId', () => {
+  test('takes the first 8 characters', () => {
+    expect(shortIssueId(ref.id)).toBe('a1b2c3d4')
+    expect(shortIssueId('short')).toBe('short')
+  })
+})
+
+describe('formatIssueRef', () => {
+  test('renders id, padded severity, file:line, and title', () => {
+    expect(formatIssueRef(ref)).toBe('#a1b2c3d4 [high]     src/auth/login.ts:42 — Token refresh race on 401')
+  })
+  test('critical severity fills the pad exactly', () => {
+    expect(formatIssueRef({ ...ref, severity: 'critical' })).toBe(
+      '#a1b2c3d4 [critical] src/auth/login.ts:42 — Token refresh race on 401',
+    )
+  })
+})
+
+describe('formatFoundLine', () => {
+  test('prefixes with indented plus', () => {
+    expect(formatFoundLine(ref)).toBe('  + #a1b2c3d4 [high]     src/auth/login.ts:42 — Token refresh race on 401')
+  })
+})
+
+describe('formatDecidedLine', () => {
+  test('maps known verdicts to marks and labels', () => {
+    expect(formatDecidedLine({ id: ref.id, verdict: 'fixed' })).toBe('✓ #a1b2c3d4 → fixed')
+    expect(formatDecidedLine({ id: ref.id, verdict: 'invalid' })).toBe('✗ #a1b2c3d4 → rejected')
+    expect(formatDecidedLine({ id: ref.id, verdict: 'needs_human' })).toBe('! #a1b2c3d4 → needs human')
+    expect(formatDecidedLine({ id: ref.id, verdict: 'already_fixed' })).toBe('· #a1b2c3d4 → already fixed')
+    expect(formatDecidedLine({ id: ref.id, verdict: 'plan_drift' })).toBe('! #a1b2c3d4 → plan drift')
+    expect(formatDecidedLine({ id: ref.id, verdict: 'no_commit' })).toBe('· #a1b2c3d4 → no change')
+  })
+  test('appends note in parentheses', () => {
+    expect(formatDecidedLine({ id: ref.id, verdict: 'needs_human', note: 'merge conflict' })).toBe(
+      '! #a1b2c3d4 → needs human (merge conflict)',
+    )
+  })
+  test('unknown verdict falls back to dot mark and raw verdict', () => {
+    expect(formatDecidedLine({ id: ref.id, verdict: 'mystery' })).toBe('· #a1b2c3d4 → mystery')
+  })
+})
+
+describe('groupForStatus', () => {
+  test('maps ledger statuses to report groups', () => {
+    expect(groupForStatus('needs_human')).toBe('needsHuman')
+    expect(groupForStatus('closed')).toBe('fixed')
+    expect(groupForStatus('rejected')).toBe('rejected')
+    expect(groupForStatus('already_fixed')).toBe('alreadyFixed')
+    expect(groupForStatus('discovered')).toBe('open')
+    expect(groupForStatus('verified')).toBe('open')
+    expect(groupForStatus('fixed_pending_review')).toBe('open')
+    expect(groupForStatus('reopened')).toBe('open')
+  })
+})
+
+describe('isOpenStatus', () => {
+  test('terminal statuses are not open', () => {
+    expect(isOpenStatus('closed')).toBe(false)
+    expect(isOpenStatus('rejected')).toBe(false)
+    expect(isOpenStatus('already_fixed')).toBe(false)
+    expect(isOpenStatus('needs_human')).toBe(false)
+  })
+  test('non-terminal statuses are open', () => {
+    expect(isOpenStatus('discovered')).toBe(true)
+    expect(isOpenStatus('verified')).toBe(true)
+    expect(isOpenStatus('fixed_pending_review')).toBe(true)
+    expect(isOpenStatus('reopened')).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/review-loop/issue-format.test.ts`
+Expected: FAIL — module `../../review-loop/src/issue-format.js` not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `review-loop/src/issue-format.ts`:
+
+```typescript
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { LedgerIssueStatus } from './issue-ledger.js'
+
+const CHECK = '✓'
+const CROSS = '✗'
+const DOT = '·'
+const BANG = '!'
+
+export function shortIssueId(id: string): string {
+  return id.slice(0, 8)
+}
+
+export interface IssueRef {
+  id: string
+  severity: string
+  file: string
+  line: number
+  title: string
+}
+
+export function formatIssueRef(ref: IssueRef): string {
+  return `#${shortIssueId(ref.id)} ${`[${ref.severity}]`.padEnd(10)} ${ref.file}:${ref.line} — ${ref.title}`
+}
+
+export function formatFoundLine(ref: IssueRef): string {
+  return `  + ${formatIssueRef(ref)}`
+}
+
+const DECIDED_MARK: Record<string, string> = {
+  fixed: CHECK,
+  invalid: CROSS,
+  already_fixed: DOT,
+  needs_human: BANG,
+  plan_drift: BANG,
+  no_commit: DOT,
+}
+
+const DECIDED_LABEL: Record<string, string> = {
+  fixed: 'fixed',
+  invalid: 'rejected',
+  already_fixed: 'already fixed',
+  needs_human: 'needs human',
+  plan_drift: 'plan drift',
+  no_commit: 'no change',
+}
+
+export function formatDecidedLine(args: { id: string; verdict: string; note?: string }): string {
+  const mark = DECIDED_MARK[args.verdict] ?? DOT
+  const label = DECIDED_LABEL[args.verdict] ?? args.verdict
+  const note = args.note === undefined ? '' : ` (${args.note})`
+  return `${mark} #${shortIssueId(args.id)} → ${label}${note}`
+}
+
+export type IssueGroup = 'needsHuman' | 'fixed' | 'rejected' | 'alreadyFixed' | 'open'
+
+export const GROUP_ORDER: readonly IssueGroup[] = ['needsHuman', 'fixed', 'rejected', 'alreadyFixed', 'open']
+
+export const GROUP_LABEL: Record<IssueGroup, string> = {
+  needsHuman: 'needs human',
+  fixed: 'fixed',
+  rejected: 'rejected',
+  alreadyFixed: 'already fixed',
+  open: 'open',
+}
+
+export const GROUP_MARK: Record<IssueGroup, string> = {
+  needsHuman: BANG,
+  fixed: CHECK,
+  rejected: CROSS,
+  alreadyFixed: DOT,
+  open: DOT,
+}
+
+const TERMINAL_REPORT_STATUSES: ReadonlySet<LedgerIssueStatus> = new Set([
+  'closed',
+  'rejected',
+  'already_fixed',
+  'needs_human',
+])
+
+export function isOpenStatus(status: LedgerIssueStatus): boolean {
+  return !TERMINAL_REPORT_STATUSES.has(status)
+}
+
+export function groupForStatus(status: LedgerIssueStatus): IssueGroup {
+  switch (status) {
+    case 'needs_human':
+      return 'needsHuman'
+    case 'closed':
+      return 'fixed'
+    case 'rejected':
+      return 'rejected'
+    case 'already_fixed':
+      return 'alreadyFixed'
+    default:
+      return 'open'
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/review-loop/issue-format.test.ts`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add review-loop/src/issue-format.ts tests/review-loop/issue-format.test.ts
+git commit -m "feat(review-loop): add shared issue line formatting module"
+```
+
+---
+
+### Task 2: Reporter seam + LiveRenderer counters and status suffix
+
+**Files:**
+- Modify: `review-loop/src/progress-log.ts` (add `IssueProgressEvent`, optional `issue()`/`statusSuffix()`)
+- Modify: `review-loop/src/live-renderer.ts` (`formatLiveLine` suffix param, `withLivePhase` suffix, `LiveRenderer.issue()`/`statusSuffix()` + counter bag)
+- Modify: `review-loop/src/line-handler.ts` (append `statusSuffix()` in `renderLive`)
+- Test: `tests/review-loop/live-renderer.test.ts`
+
+**Interfaces:**
+- Consumes: `formatFoundLine`, `formatDecidedLine` from `./issue-format.js` (Task 1); `Severity` type from `./trace-log.js`.
+- Produces (used by Tasks 3–4):
+  - `IssueProgressEvent` (from `progress-log.js`):
+    ```typescript
+    type IssueProgressEvent =
+      | { type: 'round'; round: number; maxRounds: number }
+      | { type: 'found'; id: string; severity: Severity; file: string; line: number; title: string }
+      | { type: 'decided'; id: string; verdict: string; title: string; note?: string }
+    ```
+  - `ProgressReporter.issue?(event: IssueProgressEvent): void`
+  - `ProgressReporter.statusSuffix?(): string` — returns e.g. `round 1/3 · issues: 2 open · 1 fixed`, or `''` when nothing to show.
+  - `formatLiveLine(label, tool, arg, elapsedMs, toolCount, status = '')` — new optional 6th param; appended as ` · <status>` when non-empty.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/review-loop/live-renderer.test.ts` (imports already exist there for `formatLiveLine`, `LiveRenderer`; add nothing new at import level — both are already imported):
+
+```typescript
+function makeStream(): { stream: RendererStream; output: string[] } {
+  const output: string[] = []
+  return {
+    output,
+    stream: {
+      write(chunk: string): boolean {
+        output.push(chunk)
+        return true
+      },
+      isTTY: false,
+    },
+  }
+}
+
+describe('formatLiveLine status suffix', () => {
+  test('appends status after tool count when provided', () => {
+    const line = formatLiveLine('fixer', 'read', 'cli.ts', 5000, 3, 'round 1/3 · issues: 2 open')
+    expect(line).toContain('3 tools · round 1/3 · issues: 2 open')
+  })
+  test('omits suffix segment when status is empty', () => {
+    const line = formatLiveLine('fixer', 'read', 'cli.ts', 5000, 3)
+    expect(line).toContain('3 tools')
+    expect(line).not.toContain('round')
+  })
+})
+
+describe('LiveRenderer.issue', () => {
+  test('found events print an indented plus line', () => {
+    const { stream, output } = makeStream()
+    const renderer = new LiveRenderer(stream)
+    renderer.issue({
+      type: 'found',
+      id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      severity: 'high',
+      file: 'src/auth/login.ts',
+      line: 42,
+      title: 'Token refresh race on 401',
+    })
+    expect(output).toContain('  + #a1b2c3d4 [high]     src/auth/login.ts:42 — Token refresh race on 401\n')
+  })
+
+  test('decided events print a mark line with note', () => {
+    const { stream, output } = makeStream()
+    const renderer = new LiveRenderer(stream)
+    renderer.issue({ type: 'decided', id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', verdict: 'needs_human', title: 't', note: 'merge conflict' })
+    expect(output).toContain('! #a1b2c3d4 → needs human (merge conflict)\n')
+  })
+})
+
+describe('LiveRenderer.statusSuffix', () => {
+  test('is empty before any events', () => {
+    const { stream } = makeStream()
+    expect(new LiveRenderer(stream).statusSuffix()).toBe('')
+  })
+
+  test('shows round after a round event', () => {
+    const { stream } = makeStream()
+    const renderer = new LiveRenderer(stream)
+    renderer.issue({ type: 'round', round: 2, maxRounds: 5 })
+    expect(renderer.statusSuffix()).toBe('round 2/5')
+  })
+
+  test('counts found and decided issues, omitting zero segments', () => {
+    const { stream } = makeStream()
+    const renderer = new LiveRenderer(stream)
+    renderer.issue({ type: 'round', round: 1, maxRounds: 3 })
+    renderer.issue({ type: 'found', id: 'aaaaaaaa-0000-0000-0000-000000000000', severity: 'low', file: 'a.ts', line: 1, title: 'A' })
+    renderer.issue({ type: 'found', id: 'bbbbbbbb-0000-0000-0000-000000000000', severity: 'low', file: 'b.ts', line: 2, title: 'B' })
+    renderer.issue({ type: 'decided', id: 'aaaaaaaa-0000-0000-0000-000000000000', verdict: 'fixed', title: 'A' })
+    expect(renderer.statusSuffix()).toBe('round 1/3 · issues: 1 open · 1 fixed')
+  })
+
+  test('decided on an empty pending count does not go negative', () => {
+    const { stream } = makeStream()
+    const renderer = new LiveRenderer(stream)
+    renderer.issue({ type: 'decided', id: 'aaaaaaaa-0000-0000-0000-000000000000', verdict: 'invalid', title: 'A' })
+    expect(renderer.statusSuffix()).toBe('issues: 1 rejected')
+  })
+})
+```
+
+Note: `RendererStream` is already exported from `live-renderer.ts`; add it to the existing import in the test file:
+
+```typescript
+import {
+  formatDuration,
+  formatLiveLine,
+  formatStepFooter,
+  formatToolArg,
+  LiveRenderer,
+  type RendererStream,
+} from '../../review-loop/src/live-renderer.js'
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/review-loop/live-renderer.test.ts`
+Expected: FAIL — `formatLiveLine` ignores the 6th argument; `LiveRenderer.issue`/`statusSuffix` do not exist (type errors / not-a-function).
+
+- [ ] **Step 3: Implement the seam**
+
+Replace the entire contents of `review-loop/src/progress-log.ts` with:
+
+```typescript
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { Severity } from './trace-log.js'
+
+export type IssueProgressEvent =
+  | { type: 'round'; round: number; maxRounds: number }
+  | { type: 'found'; id: string; severity: Severity; file: string; line: number; title: string }
+  | { type: 'decided'; id: string; verdict: string; title: string; note?: string }
+
+export interface ProgressReporter {
+  readonly dynamic: boolean
+  event(message: string): void
+  live(lines: readonly string[]): void
+  clearLive(): void
+  log(message: string): void
+  issue?(event: IssueProgressEvent): void
+  statusSuffix?(): string
+}
+```
+
+In `review-loop/src/live-renderer.ts`:
+
+1. Add imports at the top (after the existing `path` import):
+
+```typescript
+import { formatDecidedLine, formatFoundLine } from './issue-format.js'
+import type { IssueProgressEvent, ProgressReporter } from './progress-log.js'
+```
+
+(The file already imports `type { ProgressReporter }` from `'./progress-log.js'` — merge `IssueProgressEvent` into that existing import instead of adding a duplicate line.)
+
+2. Change `formatLiveLine` to accept the optional suffix:
+
+```typescript
+export function formatLiveLine(
+  label: string,
+  tool: string,
+  arg: string,
+  elapsedMs: number,
+  toolCount: number,
+  status = '',
+): string {
+  const toolPart = tool === '' ? 'thinking' : arg === '' ? tool : `${tool} ${arg}`
+  const tools = `${toolCount} tool${toolCount === 1 ? '' : 's'}`
+  const suffix = status === '' ? '' : ` ${MIDDLE_DOT} ${status}`
+  return `  ${label.padEnd(10)} ${ARROW} ${toolPart} ${MIDDLE_DOT} ${formatDuration(elapsedMs)} ${MIDDLE_DOT} ${tools}${suffix}`
+}
+```
+
+3. In `withLivePhase`, include the suffix in the tick:
+
+```typescript
+    timer = setInterval(() => {
+      const status = reporter.statusSuffix?.() ?? ''
+      const suffix = status === '' ? '' : ` ${MIDDLE_DOT} ${status}`
+      reporter.live([`[${label}] ${formatDuration(Date.now() - start)}...${suffix}`])
+    }, 1000)
+```
+
+4. Add counter state and the two methods to `LiveRenderer` (inside the class, after the `liveActive` field / before `event`):
+
+```typescript
+  private round = 0
+  private maxRounds = 0
+  private readonly counts = { open: 0, fixed: 0, rejected: 0, needsHuman: 0 }
+
+  issue(event: IssueProgressEvent): void {
+    switch (event.type) {
+      case 'round':
+        this.round = event.round
+        this.maxRounds = event.maxRounds
+        return
+      case 'found':
+        this.counts.open += 1
+        this.event(formatFoundLine(event))
+        return
+      case 'decided':
+        this.counts.open = Math.max(0, this.counts.open - 1)
+        if (event.verdict === 'fixed') this.counts.fixed += 1
+        else if (event.verdict === 'invalid') this.counts.rejected += 1
+        else if (event.verdict === 'needs_human' || event.verdict === 'plan_drift') this.counts.needsHuman += 1
+        this.event(formatDecidedLine(event))
+        return
+    }
+  }
+
+  statusSuffix(): string {
+    const parts: string[] = []
+    if (this.round > 0) parts.push(`round ${this.round}/${this.maxRounds}`)
+    const segments: string[] = []
+    if (this.counts.open > 0) segments.push(`${this.counts.open} open`)
+    if (this.counts.fixed > 0) segments.push(`${this.counts.fixed} fixed`)
+    if (this.counts.rejected > 0) segments.push(`${this.counts.rejected} rejected`)
+    if (this.counts.needsHuman > 0) segments.push(`${this.counts.needsHuman} needs human`)
+    if (segments.length > 0) parts.push(`issues: ${segments.join(' · ')}`)
+    return parts.join(' · ')
+  }
+```
+
+Note: `formatFoundLine(event)` works because the `found` event carries exactly `IssueRef`'s fields (`id`, `severity`, `file`, `line`, `title`); the extra `type` property is structurally compatible since `event` is not an object literal at that call site. Same for `formatDecidedLine(event)` (`id`, `verdict`, `note?`).
+
+In `review-loop/src/line-handler.ts`, update `renderLive` to append the suffix:
+
+```typescript
+function renderLive(ctx: LiveCtx): void {
+  const reporter = ctx.reporter
+  if (reporter === undefined) {
+    return
+  }
+  const elapsed = ctx.startedAt === 0 ? 0 : Date.now() - ctx.startedAt
+  reporter.live([formatLiveLine(ctx.label, ctx.tool, ctx.arg, elapsed, ctx.toolCount, reporter.statusSuffix?.() ?? '')])
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/review-loop/live-renderer.test.ts tests/review-loop/line-handler.test.ts`
+Expected: PASS (new tests pass; existing line-handler tests unaffected because fake reporters without `statusSuffix` produce `''`).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run review-loop:typecheck`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add review-loop/src/progress-log.ts review-loop/src/live-renderer.ts review-loop/src/line-handler.ts tests/review-loop/live-renderer.test.ts
+git commit -m "feat(review-loop): add issue event seam and live status counters to reporter"
+```
+
+---
+
+### Task 3: Emit issue events from the loop and processors
+
+**Files:**
+- Modify: `review-loop/src/loop-controller.ts` (round event at round start; found events after match; remove `[round N] Found M issues` log)
+- Modify: `review-loop/src/issue-processor-attempts.ts` (3 `log.log` decision strings → `issue()` events; drop now-unused `shortTitle` import)
+- Modify: `review-loop/src/issue-processor.ts` (1 catch-all decision string → `issue()` event)
+- Modify: `review-loop/src/commit-attempt.ts` (3 decision strings → `issue()` events)
+- Test: `tests/review-loop/progress-log.test.ts` (fake reporter learns `issue()`; assertions updated)
+
+**Interfaces:**
+- Consumes: `ProgressReporter.issue?` + `IssueProgressEvent` (Task 2); `formatFoundLine`, `formatDecidedLine` (Task 1, test-side only).
+- Produces: no new exports. Behavioral contract: every ledger-affecting decision emits exactly one `decided` event; every newly created ledger record emits exactly one `found` event; each round emits one `round` event at start.
+
+- [ ] **Step 1: Update the failing tests first**
+
+In `tests/review-loop/progress-log.test.ts`:
+
+1. Extend the imports:
+
+```typescript
+import { formatDecidedLine, formatFoundLine } from '../../review-loop/src/issue-format.js'
+import type { IssueProgressEvent } from '../../review-loop/src/progress-log.js'
+```
+
+2. Extend `makeReporter` (around line 127) with an `issue` method:
+
+```typescript
+function makeReporter(messages: string[]): ProgressReporter {
+  return {
+    dynamic: false,
+    event: (message: string): void => {
+      messages.push(message)
+    },
+    live: (lines: readonly string[]): void => {
+      for (const line of lines) {
+        messages.push(line)
+      }
+    },
+    clearLive() {},
+    log: (message: string): void => {
+      messages.push(message)
+    },
+    issue: (event: IssueProgressEvent): void => {
+      if (event.type === 'found') {
+        messages.push(formatFoundLine(event))
+      } else if (event.type === 'decided') {
+        messages.push(formatDecidedLine(event))
+      }
+    },
+  }
+}
+```
+
+3. In the test `'logs round start, issue discovery, verification, fix, and done for a clean round'`, replace these two assertions:
+
+```typescript
+    expect(messages).toContain('[round 1] Found 1 issues')
+    expect(messages.some((m) => m.startsWith('[fix] "Missing error handling"'))).toBe(true)
+```
+
+with:
+
+```typescript
+    expect(messages.some((m) => m.startsWith('  + #') && m.includes('src/foo.ts:10 — Missing error handling'))).toBe(true)
+    expect(messages.some((m) => m.startsWith('✓ #') && m.endsWith('→ fixed'))).toBe(true)
+```
+
+4. In the test `'truncates long issue titles in log output'`, the `[fix]` line no longer exists; the decided line carries no title. Replace:
+
+```typescript
+    const fixMessage = messages.find((m) => m.startsWith('[fix]'))
+    expect(fixMessage).toBeDefined()
+    expect(fixMessage!.length).toBeLessThan(longTitle.length + 40)
+```
+
+with:
+
+```typescript
+    const decidedMessage = messages.find((m) => m.startsWith('✗ #') && m.endsWith('→ rejected'))
+    expect(decidedMessage).toBeDefined()
+    expect(decidedMessage!.length).toBeLessThan(40)
+```
+
+Also rename that test to `'decided lines stay short regardless of title length'`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/review-loop/progress-log.test.ts`
+Expected: FAIL — no `  + #` / `✓ #` lines are emitted yet (old `[round 1] Found 1 issues` line still present, but the new assertions look for the new shapes).
+
+- [ ] **Step 3: Emit events from loop-controller**
+
+In `review-loop/src/loop-controller.ts`:
+
+1. In `runRound`, right after `await saveRunState(deps.runState)` at the top, emit the round event:
+
+```typescript
+  deps.runState.currentRound = round
+  await saveRunState(deps.runState)
+  deps.log.issue?.({ type: 'round', round, maxRounds: deps.config.maxRounds })
+```
+
+2. In `runMatchAndRecord`, after `await saveIssueLedger(deps.ledger)` and before the `return`, emit found events for newly created records:
+
+```typescript
+  for (const match of matches) {
+    if (match.existingId !== null) continue
+    const record = roundRecords[match.newIssueIndex]
+    if (record === undefined) continue
+    deps.log.issue?.({
+      type: 'found',
+      id: record.id,
+      severity: record.issue.severity,
+      file: record.issue.file,
+      line: record.issue.lineStart,
+      title: record.issue.title,
+    })
+  }
+```
+
+(`roundRecords` is pushed in issue-index order by `applyMatchedIssues`, so `roundRecords[match.newIssueIndex]` is the record for that issue.)
+
+3. Delete the count log line in `runRound` (per-issue lines replace it):
+
+```typescript
+  deps.log.log(`[round ${round}] Found ${newIssues.length} issues`)
+```
+
+(The `[round ${round}] Fixed …` and `[done] …` logs stay.)
+
+- [ ] **Step 4: Emit decided events from the processors**
+
+In `review-loop/src/issue-processor-attempts.ts`:
+
+1. In `runFixerAttempt`, replace:
+
+```typescript
+    deps.log.log(`[fix] "${shortTitle(record)}" → ${fixerResult.verdict}`)
+```
+
+with:
+
+```typescript
+    deps.log.issue?.({ type: 'decided', id: record.id, verdict: fixerResult.verdict, title: record.issue.title })
+```
+
+2. In `runBuildAttempt`, replace:
+
+```typescript
+      deps.log.log(`[fix] "${shortTitle(record)}" → needs_human (build failed)`)
+```
+
+with:
+
+```typescript
+      deps.log.issue?.({
+        type: 'decided',
+        id: record.id,
+        verdict: 'needs_human',
+        title: record.issue.title,
+        note: 'build failed',
+      })
+```
+
+3. In `runInspectorAttempt`, replace:
+
+```typescript
+      deps.log.log(
+        `[fix] "${shortTitle(record)}" → needs_human (${unavailable ? 'inspector unavailable' : 'inspector rejected'})`,
+      )
+```
+
+with:
+
+```typescript
+      deps.log.issue?.({
+        type: 'decided',
+        id: record.id,
+        verdict: 'needs_human',
+        title: record.issue.title,
+        note: unavailable ? 'inspector unavailable' : 'inspector rejected',
+      })
+```
+
+4. Remove `shortTitle` from the import of `'./issue-processor.js'` (it is now unused in this file), leaving `import { type IssueProcessorDeps } from './issue-processor.js'`.
+
+In `review-loop/src/issue-processor.ts`, in `makeDispatcher`'s catch block, replace:
+
+```typescript
+      deps.log.log(`[fix] "${shortTitle(record)}" → needs_human (issue processing failed: ${msg})`)
+```
+
+with:
+
+```typescript
+      deps.log.issue?.({
+        type: 'decided',
+        id: record.id,
+        verdict: 'needs_human',
+        title: record.issue.title,
+        note: `issue processing failed: ${msg}`,
+      })
+```
+
+(The `ledger save failed` `log.log` in the second catch block stays — it is a warning, not a decision. `shortTitle` is still used there, so keep the function.)
+
+In `review-loop/src/commit-attempt.ts`:
+
+1. In the no-change branch, replace:
+
+```typescript
+      deps.log.log(`[fix] "${shortTitle(record)}" → no change (fixed:true was a false claim)`)
+```
+
+with:
+
+```typescript
+      deps.log.issue?.({
+        type: 'decided',
+        id: record.id,
+        verdict: 'no_commit',
+        title: record.issue.title,
+        note: 'fixed:true was a false claim',
+      })
+```
+
+2. In the merge-conflict branch, replace:
+
+```typescript
+      deps.log.log(`[fix] "${shortTitle(record)}" → needs_human (merge conflict)`)
+```
+
+with:
+
+```typescript
+      deps.log.issue?.({
+        type: 'decided',
+        id: record.id,
+        verdict: 'needs_human',
+        title: record.issue.title,
+        note: 'merge conflict',
+      })
+```
+
+3. In the success branch, replace:
+
+```typescript
+    deps.log.log(
+      attempt === 1 ? `[fix] "${shortTitle(record)}" → fixed` : `[fix] "${shortTitle(record)}" → fixed (after retry)`,
+    )
+```
+
+with:
+
+```typescript
+    deps.log.issue?.({
+      type: 'decided',
+      id: record.id,
+      verdict: 'fixed',
+      title: record.issue.title,
+      note: attempt === 1 ? undefined : 'after retry',
+    })
+```
+
+(The `auto-committed uncommitted changes` `log.log` in `ensureFixerChangesCommitted` stays — informational, not a decision — so the `shortTitle` import stays.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test tests/review-loop/progress-log.test.ts tests/review-loop/loop-controller.test.ts tests/review-loop/issue-processor.test.ts tests/review-loop/issue-processor-attempts.test.ts tests/review-loop/commit-attempt.test.ts tests/review-loop/issue-processor-save-serialization.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck + full workspace suite**
+
+Run: `bun run review-loop:typecheck && bun run review-loop:test`
+Expected: clean typecheck; full suite green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add review-loop/src/loop-controller.ts review-loop/src/issue-processor-attempts.ts review-loop/src/issue-processor.ts review-loop/src/commit-attempt.ts tests/review-loop/progress-log.test.ts
+git commit -m "feat(review-loop): stream per-issue found/decided events instead of fix log strings"
+```
+
+---
+
+### Task 4: Verdict-first final report (`summary.ts` rewrite + CLI wiring)
+
+**Files:**
+- Modify: `review-loop/src/summary.ts` (rewrite `buildSummary`; keep `buildMetricsJson`, `MetricsJson`, `SummaryOptions` and the aggregation helpers)
+- Modify: `review-loop/src/cli.ts` (`writeRunArtifacts` passes ledger + runDir via the new input object)
+- Test: `tests/review-loop/summary.test.ts` (rewritten)
+- Test: `tests/review-loop/cli.test.ts` (two assertion updates)
+
+**Interfaces:**
+- Consumes: `formatIssueRef`, `GROUP_LABEL`, `GROUP_MARK`, `GROUP_ORDER`, `groupForStatus`, `isOpenStatus`, `IssueGroup` from `./issue-format.js` (Task 1); `formatDuration` from `./live-renderer.js`; `IssueLedgerSnapshot`, `LedgerIssueRecord` from `./issue-ledger.js`.
+- Produces:
+  - `SummaryInput` — `{ doneReason: ReviewLoopResult['doneReason']; rounds: number; metrics: readonly RoundMetric[]; ledger: IssueLedgerSnapshot; runDir: string; options: SummaryOptions }`.
+  - `buildSummary(input: SummaryInput): string` — NEW signature (positional args gone).
+  - `buildMetricsJson(doneReason, rounds, closed, metrics, options): MetricsJson` — UNCHANGED signature and behavior.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the entire contents of `tests/review-loop/summary.test.ts` with:
+
+```typescript
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import type { IssueLedgerSnapshot, LedgerIssueRecord } from '../../review-loop/src/issue-ledger.js'
+import type { ReviewerIssue } from '../../review-loop/src/issue-schema.js'
+import { buildMetricsJson, buildSummary, type SummaryInput } from '../../review-loop/src/summary.js'
+import type { RoundMetric } from '../../review-loop/src/trace-log.js'
+
+const issueFixture: ReviewerIssue = {
+  title: 'Token refresh race on 401',
+  severity: 'high',
+  summary: 's',
+  whyItMatters: 'w',
+  evidence: 'e',
+  file: 'src/auth/login.ts',
+  lineStart: 42,
+  lineEnd: 50,
+  suggestedFix: 'f',
+  confidence: 0.9,
+}
+
+let idCounter = 0
+beforeEach(() => {
+  idCounter = 0
+})
+
+function makeRecord(status: LedgerIssueRecord['status'], overrides?: Partial<ReviewerIssue>): LedgerIssueRecord {
+  idCounter += 1
+  return {
+    id: `${String(idCounter).padStart(8, '0')}-0000-0000-0000-000000000000`,
+    issue: { ...issueFixture, ...overrides },
+    status,
+    firstSeenRound: 1,
+    latestSeenRound: 1,
+    fixAttempts: 0,
+    verifierDecision: null,
+  }
+}
+
+function ledgerOf(...records: LedgerIssueRecord[]): IssueLedgerSnapshot {
+  const issues: Record<string, LedgerIssueRecord> = {}
+  for (const record of records) {
+    issues[record.id] = record
+  }
+  return { issues }
+}
+
+function zeroMetric(round: number): RoundMetric {
+  return {
+    round,
+    newIssues: 0,
+    cumulativeOpen: 0,
+    noProgressRounds: 0,
+    decisions: { fixed: 0, invalid: 0, already_fixed: 0, needs_human: 0, plan_drift: 0, no_commit: 0, inspector_rejected: 0 },
+    reviewerSeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    fixerSeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    inspector: { runs: 0, rejected: 0 },
+    phaseMs: { review: 0, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 },
+    usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0 },
+  }
+}
+
+function busyMetric(round: number): RoundMetric {
+  const metric = zeroMetric(round)
+  metric.newIssues = 4
+  metric.cumulativeOpen = 2
+  metric.decisions.fixed = 2
+  metric.decisions.invalid = 1
+  metric.reviewerSeverity = { critical: 0, high: 1, medium: 2, low: 1 }
+  metric.fixerSeverity = { critical: 0, high: 1, medium: 1, low: 1 }
+  metric.phaseMs = { review: 178_300, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 }
+  metric.usage = { inputTokens: 120_000, outputTokens: 8_000, reasoningTokens: 3_000, costUsd: 1.234 }
+  return metric
+}
+
+function inputOf(overrides?: Partial<SummaryInput>): SummaryInput {
+  return {
+    doneReason: 'clean',
+    rounds: 1,
+    metrics: [],
+    ledger: { issues: {} },
+    runDir: '/repo/.review-loop/runs/run-1',
+    options: { poolSize: 1, inspect: false },
+    ...overrides,
+  }
+}
+
+describe('buildSummary verdict', () => {
+  test('clean run with no issues and one round', () => {
+    const summary = buildSummary(inputOf({ metrics: [zeroMetric(1)] }))
+    expect(summary).toContain('Review loop finished: clean — reviewer found no issues in 1 round.')
+    expect(summary).not.toContain('Issues:')
+  })
+
+  test('done run lists the non-zero breakdown', () => {
+    const ledger = ledgerOf(
+      makeRecord('closed'),
+      makeRecord('closed'),
+      makeRecord('closed'),
+      makeRecord('needs_human'),
+      makeRecord('rejected'),
+    )
+    const summary = buildSummary(inputOf({ doneReason: 'max_rounds', rounds: 2, ledger }))
+    expect(summary).toContain('Review loop finished: done — 5 issues: 3 fixed, 1 needs human, 1 rejected.')
+  })
+
+  test('issues remaining leads with the open count', () => {
+    const ledger = ledgerOf(makeRecord('closed'), makeRecord('verified'), makeRecord('discovered'))
+    const summary = buildSummary(inputOf({ doneReason: 'no_progress', rounds: 3, ledger }))
+    expect(summary).toContain('Review loop finished: issues remaining — 2 open (1 fixed).')
+  })
+})
+
+describe('buildSummary zero suppression', () => {
+  test('drops zero wall-clock phases from the duration breakdown', () => {
+    const summary = buildSummary(inputOf({ metrics: [busyMetric(1)] }))
+    expect(summary).toContain('(review 178.3s)')
+    expect(summary).not.toContain('match 0.0s')
+    expect(summary).not.toContain('fix 0.0s')
+  })
+
+  test('omits the burndown table for a single all-zero round', () => {
+    const summary = buildSummary(inputOf({ metrics: [zeroMetric(1)] }))
+    expect(summary).not.toContain('Burndown:')
+  })
+
+  test('keeps the burndown table when a round has activity', () => {
+    const summary = buildSummary(inputOf({ metrics: [busyMetric(1)] }))
+    expect(summary).toContain('Burndown:')
+    expect(summary).toContain('round')
+  })
+})
+
+describe('buildSummary timing and cost', () => {
+  test('renders duration, nonzero phases, and cost on one line', () => {
+    const summary = buildSummary(inputOf({ metrics: [busyMetric(1)] }))
+    expect(summary).toContain(
+      'Duration: 2m58s (review 178.3s) · Cost: $1.234 (in 120000 / out 8000 / reasoning 3000)',
+    )
+  })
+})
+
+describe('buildSummary rounds and pool line', () => {
+  test('omitted for a single round with pool size 1', () => {
+    const summary = buildSummary(inputOf())
+    expect(summary).not.toContain('Rounds:')
+  })
+  test('included when rounds > 1 or pool > 1', () => {
+    expect(buildSummary(inputOf({ rounds: 2 }))).toContain('Rounds: 2')
+    expect(buildSummary(inputOf({ options: { poolSize: 4, inspect: false } }))).toContain('Rounds: 1 · Pool: 4')
+  })
+})
+
+describe('buildSummary issue groups', () => {
+  test('groups in order with marks and issue refs', () => {
+    const ledger = ledgerOf(
+      makeRecord('closed', { title: 'Fixed one' }),
+      makeRecord('needs_human', { title: 'Scary one', severity: 'critical' }),
+      makeRecord('rejected', { title: 'Bogus one', severity: 'low' }),
+    )
+    const summary = buildSummary(inputOf({ rounds: 2, ledger }))
+    const needsIdx = summary.indexOf('  needs human (1):')
+    const fixedIdx = summary.indexOf('  fixed (1):')
+    const rejectedIdx = summary.indexOf('  rejected (1):')
+    expect(needsIdx).toBeGreaterThan(-1)
+    expect(needsIdx).toBeLessThan(fixedIdx)
+    expect(fixedIdx).toBeLessThan(rejectedIdx)
+    expect(summary).toContain('! #00000002 [critical] src/auth/login.ts:42 — Scary one')
+    expect(summary).toContain('✓ #00000001 [high]     src/auth/login.ts:42 — Fixed one')
+    expect(summary).toContain('✗ #00000003 [low]      src/auth/login.ts:42 — Bogus one')
+  })
+
+  test('caps a group at 20 lines with a see-ledger note', () => {
+    const records = Array.from({ length: 21 }, () => makeRecord('needs_human'))
+    const summary = buildSummary(inputOf({ rounds: 2, ledger: ledgerOf(...records) }))
+    expect(summary).toContain('  needs human (21):')
+    expect(summary).toContain('    …and 1 more (see ledger.json)')
+    const bangLines = summary.split('\n').filter((l) => l.startsWith('    ! #'))
+    expect(bangLines).toHaveLength(20)
+  })
+
+  test('open bucket appears only when issues are left open', () => {
+    const summary = buildSummary(inputOf({ doneReason: 'max_rounds', rounds: 2, ledger: ledgerOf(makeRecord('verified')) }))
+    expect(summary).toContain('  open (1):')
+    expect(summary).toContain('· #00000001')
+  })
+})
+
+describe('buildSummary artifacts', () => {
+  test('always lists the run dir and known artifact files', () => {
+    const summary = buildSummary(inputOf())
+    expect(summary).toContain('Artifacts (/repo/.review-loop/runs/run-1):')
+    expect(summary).toContain('summary.txt · metrics.json · ledger.json · trace.jsonl · agent-output.log · state.json')
+  })
+})
+
+describe('buildMetricsJson', () => {
+  test('keeps the existing shape', () => {
+    const json = buildMetricsJson('max_rounds', 2, 1, [busyMetric(1)], { poolSize: 1, inspect: false })
+    expect(json.doneReason).toBe('max_rounds')
+    expect(json.rounds).toBe(2)
+    expect(json.totals.closed).toBe(1)
+    expect(json.usage.inputTokens).toBe(120_000)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/review-loop/summary.test.ts`
+Expected: FAIL — `buildSummary` still takes positional args / `SummaryInput` not exported.
+
+- [ ] **Step 3: Rewrite summary.ts**
+
+Replace the entire contents of `review-loop/src/summary.ts` with:
+
+```typescript
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { IssueLedgerSnapshot, LedgerIssueRecord } from './issue-ledger.js'
+import {
+  formatIssueRef,
+  GROUP_LABEL,
+  GROUP_MARK,
+  GROUP_ORDER,
+  groupForStatus,
+  type IssueGroup,
+} from './issue-format.js'
+import { formatDuration } from './live-renderer.js'
+import type { ReviewLoopResult } from './loop-controller.js'
+import type { PhaseMs, RoundMetric, Severity, SeverityCounts, UsageTotals } from './trace-log.js'
+
+const SEV_WEIGHT: Record<Severity, number> = { critical: 4, high: 3, medium: 2, low: 1 }
+
+const PHASE_KEYS: (keyof PhaseMs)[] = ['review', 'match', 'verify', 'build', 'inspect', 'fix']
+
+const GROUP_CAP = 20
+
+const RUN_ARTIFACTS = ['summary.txt', 'metrics.json', 'ledger.json', 'trace.jsonl', 'agent-output.log', 'state.json']
+
+export interface MetricsJson {
+  doneReason: ReviewLoopResult['doneReason']
+  rounds: number
+  poolSize: number
+  burndown: RoundMetric[]
+  usage: UsageTotals
+  phaseMs: PhaseMs
+  totals: {
+    open: number
+    closed: number
+    rejected: number
+    alreadyFixed: number
+    needsHuman: number
+    reopened: number
+    inspectorRejected: number
+  }
+}
+
+export interface SummaryOptions {
+  poolSize: number
+  inspect: boolean
+}
+
+export interface SummaryInput {
+  doneReason: ReviewLoopResult['doneReason']
+  rounds: number
+  metrics: readonly RoundMetric[]
+  ledger: IssueLedgerSnapshot
+  runDir: string
+  options: SummaryOptions
+}
+
+interface IssueCounts {
+  open: number
+  fixed: number
+  rejected: number
+  needsHuman: number
+  alreadyFixed: number
+}
+
+function countIssues(ledger: IssueLedgerSnapshot): IssueCounts {
+  const counts: IssueCounts = { open: 0, fixed: 0, rejected: 0, needsHuman: 0, alreadyFixed: 0 }
+  for (const record of Object.values(ledger.issues)) {
+    switch (groupForStatus(record.status)) {
+      case 'needsHuman':
+        counts.needsHuman += 1
+        break
+      case 'fixed':
+        counts.fixed += 1
+        break
+      case 'rejected':
+        counts.rejected += 1
+        break
+      case 'alreadyFixed':
+        counts.alreadyFixed += 1
+        break
+      case 'open':
+        counts.open += 1
+        break
+    }
+  }
+  return counts
+}
+
+function plural(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? '' : 's'}`
+}
+
+function breakdownParts(counts: IssueCounts): string[] {
+  const parts: string[] = []
+  if (counts.fixed > 0) parts.push(`${counts.fixed} fixed`)
+  if (counts.needsHuman > 0) parts.push(`${counts.needsHuman} needs human`)
+  if (counts.rejected > 0) parts.push(`${counts.rejected} rejected`)
+  if (counts.alreadyFixed > 0) parts.push(`${counts.alreadyFixed} already fixed`)
+  return parts
+}
+
+function buildVerdict(input: SummaryInput, counts: IssueCounts, total: number): string {
+  const breakdown = breakdownParts(counts).join(', ')
+  if (counts.open > 0) {
+    const suffix = breakdown === '' ? '' : ` (${breakdown})`
+    return `Review loop finished: issues remaining — ${counts.open} open${suffix}.`
+  }
+  if (total === 0) {
+    return `Review loop finished: clean — reviewer found no issues in ${plural(input.rounds, 'round')}.`
+  }
+  return `Review loop finished: done — ${plural(total, 'issue')}: ${breakdown}.`
+}
+
+function sumDecisions(metrics: readonly RoundMetric[], key: keyof RoundMetric['decisions']): number {
+  return metrics.reduce((s, m) => s + m.decisions[key], 0)
+}
+
+function avgSeverity(counts: SeverityCounts, total: number): string {
+  if (total === 0) return '-'
+  const sum =
+    counts.critical * SEV_WEIGHT.critical +
+    counts.high * SEV_WEIGHT.high +
+    counts.medium * SEV_WEIGHT.medium +
+    counts.low * SEV_WEIGHT.low
+  return (sum / total).toFixed(1)
+}
+
+function burndownBlock(metrics: readonly RoundMetric[]): string {
+  const header = '  round  new  open  fixed  rejected  needs_human  plan_drift  insp_rej  avgRev  avgFix'
+  const rows = metrics.map((m) => {
+    const decided =
+      m.decisions.fixed +
+      m.decisions.invalid +
+      m.decisions.already_fixed +
+      m.decisions.needs_human +
+      m.decisions.plan_drift +
+      m.decisions.no_commit +
+      m.decisions.inspector_rejected
+    return [
+      `  ${String(m.round).padEnd(6)}`,
+      String(m.newIssues).padEnd(4),
+      String(m.cumulativeOpen).padEnd(5),
+      String(m.decisions.fixed).padEnd(6),
+      String(m.decisions.invalid).padEnd(9),
+      String(m.decisions.needs_human).padEnd(12),
+      String(m.decisions.plan_drift).padEnd(11),
+      String(m.decisions.inspector_rejected).padEnd(9),
+      avgSeverity(m.reviewerSeverity, m.newIssues).padEnd(7),
+      avgSeverity(m.fixerSeverity, decided),
+    ].join('')
+  })
+  return ['Burndown:', header, ...rows].join('\n')
+}
+
+function burndownIsEmpty(metrics: readonly RoundMetric[]): boolean {
+  return metrics.every(
+    (m) =>
+      m.newIssues === 0 &&
+      m.cumulativeOpen === 0 &&
+      m.decisions.fixed === 0 &&
+      m.decisions.invalid === 0 &&
+      m.decisions.already_fixed === 0 &&
+      m.decisions.needs_human === 0 &&
+      m.decisions.plan_drift === 0 &&
+      m.decisions.no_commit === 0 &&
+      m.decisions.inspector_rejected === 0,
+  )
+}
+
+function aggregatePhaseMs(metrics: readonly RoundMetric[]): PhaseMs {
+  const phaseMs: PhaseMs = { review: 0, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 }
+  for (const m of metrics) {
+    for (const k of PHASE_KEYS) {
+      phaseMs[k] += m.phaseMs[k]
+    }
+  }
+  return phaseMs
+}
+
+function aggregateUsage(metrics: readonly RoundMetric[]): UsageTotals {
+  return metrics.reduce(
+    (acc, m) => ({
+      inputTokens: acc.inputTokens + m.usage.inputTokens,
+      outputTokens: acc.outputTokens + m.usage.outputTokens,
+      reasoningTokens: acc.reasoningTokens + m.usage.reasoningTokens,
+      costUsd: acc.costUsd + m.usage.costUsd,
+    }),
+    { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0 },
+  )
+}
+
+function msToSeconds(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+function buildTimingLine(metrics: readonly RoundMetric[]): string {
+  const phaseMs = aggregatePhaseMs(metrics)
+  const totalMs = PHASE_KEYS.reduce((s, k) => s + phaseMs[k], 0)
+  const parts = PHASE_KEYS.filter((k) => phaseMs[k] > 0).map((k) => `${k} ${msToSeconds(phaseMs[k])}`)
+  const breakdown = parts.length === 0 ? 'no phase timing recorded' : parts.join(', ')
+  const usage = aggregateUsage(metrics)
+  return `Duration: ${formatDuration(totalMs)} (${breakdown}) · Cost: $${usage.costUsd.toFixed(3)} (in ${usage.inputTokens} / out ${usage.outputTokens} / reasoning ${usage.reasoningTokens})`
+}
+
+function buildRoundsLine(input: SummaryInput): string | null {
+  if (input.rounds <= 1 && input.options.poolSize <= 1) return null
+  const pool = input.options.poolSize > 1 ? ` · Pool: ${input.options.poolSize}` : ''
+  return `Rounds: ${input.rounds}${pool}`
+}
+
+function buildInspectorLine(metrics: readonly RoundMetric[], options: SummaryOptions): string | null {
+  if (!options.inspect) return null
+  const runs = metrics.reduce((s, m) => s + m.inspector.runs, 0)
+  if (runs === 0) return null
+  const rejected = metrics.reduce((s, m) => s + m.inspector.rejected, 0)
+  const rate = `${((100 * rejected) / runs).toFixed(1)}%`
+  return `Inspector: ${runs} runs, ${rejected} rejected (${rate} reject rate)`
+}
+
+function issuesBlock(ledger: IssueLedgerSnapshot): string[] {
+  const records = Object.values(ledger.issues)
+  if (records.length === 0) return []
+  const groups = new Map<IssueGroup, LedgerIssueRecord[]>()
+  for (const record of records) {
+    const group = groupForStatus(record.status)
+    groups.set(group, [...(groups.get(group) ?? []), record])
+  }
+  const lines = ['Issues:']
+  for (const group of GROUP_ORDER) {
+    const groupRecords = groups.get(group)
+    if (groupRecords === undefined || groupRecords.length === 0) continue
+    lines.push(`  ${GROUP_LABEL[group]} (${groupRecords.length}):`)
+    for (const record of groupRecords.slice(0, GROUP_CAP)) {
+      lines.push(
+        `    ${GROUP_MARK[group]} ${formatIssueRef({
+          id: record.id,
+          severity: record.issue.severity,
+          file: record.issue.file,
+          line: record.issue.lineStart,
+          title: record.issue.title,
+        })}`,
+      )
+    }
+    if (groupRecords.length > GROUP_CAP) {
+      lines.push(`    …and ${groupRecords.length - GROUP_CAP} more (see ledger.json)`)
+    }
+  }
+  return lines
+}
+
+function artifactsBlock(runDir: string): string[] {
+  return [`Artifacts (${runDir}):`, `  ${RUN_ARTIFACTS.join(' · ')}`]
+}
+
+export function buildSummary(input: SummaryInput): string {
+  const total = Object.keys(input.ledger.issues).length
+  const counts = countIssues(input.ledger)
+  const lines: string[] = [buildVerdict(input, counts, total), buildTimingLine(input.metrics)]
+
+  const roundsLine = buildRoundsLine(input)
+  if (roundsLine !== null) lines.push(roundsLine)
+
+  const inspectorLine = buildInspectorLine(input.metrics, input.options)
+  if (inspectorLine !== null) lines.push(inspectorLine)
+
+  const issues = issuesBlock(input.ledger)
+  if (issues.length > 0) lines.push('', ...issues)
+
+  if (input.metrics.length > 0 && (input.metrics.length > 1 || !burndownIsEmpty(input.metrics))) {
+    lines.push('', burndownBlock(input.metrics))
+  }
+
+  lines.push('', ...artifactsBlock(input.runDir))
+  return lines.join('\n')
+}
+
+export function buildMetricsJson(
+  doneReason: ReviewLoopResult['doneReason'],
+  rounds: number,
+  closed: number,
+  metrics: readonly RoundMetric[],
+  options: SummaryOptions,
+): MetricsJson {
+  const lastMetric = metrics.length > 0 ? metrics[metrics.length - 1] : undefined
+  const openFromMetrics = lastMetric === undefined ? 0 : lastMetric.cumulativeOpen
+  return {
+    doneReason,
+    rounds,
+    poolSize: options.poolSize,
+    burndown: [...metrics],
+    usage: aggregateUsage(metrics),
+    phaseMs: aggregatePhaseMs(metrics),
+    totals: {
+      open: openFromMetrics,
+      closed,
+      rejected: sumDecisions(metrics, 'invalid'),
+      alreadyFixed: sumDecisions(metrics, 'already_fixed'),
+      needsHuman: sumDecisions(metrics, 'needs_human'),
+      reopened: 0,
+      inspectorRejected: metrics.reduce((s, m) => s + m.inspector.rejected, 0),
+    },
+  }
+}
+```
+
+Notes for the implementer:
+- `StatusCounts`, `computeStatusLines`, and `computeObservabilityLines` are deleted; their information now lives in the verdict line, the timing line, and the inspector line.
+- `isOpenStatus` from Task 1 is not used by `summary.ts` (open counting goes through `groupForStatus`); it exists for symmetry and is covered by its own Task 1 tests.
+
+- [ ] **Step 4: Wire the new signature in cli.ts**
+
+In `review-loop/src/cli.ts`, replace the body of `writeRunArtifacts`:
+
+```typescript
+export async function writeRunArtifacts(
+  runDir: string,
+  result: ReviewLoopResult,
+  options: { poolSize: number; inspect: boolean },
+): Promise<void> {
+  const closed = Object.values(result.ledger.issues).filter((r) => r.status === 'closed').length
+  const summary = buildSummary({
+    doneReason: result.doneReason,
+    rounds: result.rounds,
+    metrics: result.metrics ?? [],
+    ledger: result.ledger,
+    runDir,
+    options,
+  })
+  await writeFile(path.join(runDir, 'summary.txt'), `${summary}\n`)
+  try {
+    await writeFile(
+      path.join(runDir, 'metrics.json'),
+      `${JSON.stringify(buildMetricsJson(result.doneReason, result.rounds, closed, result.metrics ?? [], options), null, 2)}\n`,
+    )
+  } catch (error) {
+    console.warn(`[review-loop] metrics.json write failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  console.log(summary)
+}
+```
+
+(Signature and the metrics.json/writeFile logic are unchanged; only the `buildSummary` call changes.)
+
+- [ ] **Step 5: Update cli.test.ts assertions**
+
+In `tests/review-loop/cli.test.ts`:
+
+1. In the test `'--pool-size overrides config.poolSize'` (~line 392), replace:
+
+```typescript
+    expect(summary).toContain('Pool size: 5')
+```
+
+with:
+
+```typescript
+    expect(summary).toContain('Pool: 5')
+```
+
+2. In the stale-worker-cleanup test (~line 533), replace:
+
+```typescript
+    expect(summary).toContain('needs_human')
+```
+
+with:
+
+```typescript
+    expect(summary).toContain('needs human')
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `bun test tests/review-loop/summary.test.ts tests/review-loop/cli.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Typecheck + full workspace suite**
+
+Run: `bun run review-loop:typecheck && bun run review-loop:test`
+Expected: clean; whole suite green (catches any other caller of the old `buildSummary` signature).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add review-loop/src/summary.ts review-loop/src/cli.ts tests/review-loop/summary.test.ts tests/review-loop/cli.test.ts
+git commit -m "feat(review-loop): verdict-first final report with issue groups and artifact paths"
+```
+
+---
+
+## Self-Review Notes (already applied)
+
+- **Spec coverage:** verdict line → Task 4 `buildVerdict`; zero suppression → `buildTimingLine`/`burndownIsEmpty`/group omission; issue groups + cap → `issuesBlock`; artifacts block → `artifactsBlock`; live found/decided lines → Tasks 2–3; status line counters → Task 2 `statusSuffix` + `renderLive`/`withLivePhase`; metrics.json untouched → `buildMetricsJson` preserved; error paths unchanged → no `finalizeRun` ordering change.
+- **Deviations from the first approved spec draft (already synced into the spec file):** `issue()`/`statusSuffix()` are optional on `ProgressReporter`; a third `round` event variant carries round context; artifact filenames match reality (`trace.jsonl`, `agent-output.log`, `state.json`).
+- **Type consistency:** `IssueProgressEvent`, `IssueRef`, `IssueGroup`, `SummaryInput` names are used identically across tasks.

--- a/docs/superpowers/plans/2026-08-01-review-loop-report-output.md
+++ b/docs/superpowers/plans/2026-08-01-review-loop-report-output.md
@@ -50,7 +50,6 @@ See LICENSE in the project root for details.
   - `GROUP_LABEL: Record<IssueGroup, string>` — `{ needsHuman: 'needs human', fixed: 'fixed', rejected: 'rejected', alreadyFixed: 'already fixed', open: 'open' }`.
   - `GROUP_MARK: Record<IssueGroup, string>` — `{ needsHuman: '!', fixed: '✓', rejected: '✗', alreadyFixed: '·', open: '·' }`.
   - `groupForStatus(status: LedgerIssueStatus): IssueGroup` — `needs_human→needsHuman`, `closed→fixed`, `rejected→rejected`, `already_fixed→alreadyFixed`, everything else (`discovered`, `verified`, `fixed_pending_review`, `reopened`)→`open`.
-  - `isOpenStatus(status: LedgerIssueStatus): boolean` — true unless status is `closed`/`rejected`/`already_fixed`/`needs_human`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -69,7 +68,6 @@ import {
   formatFoundLine,
   formatIssueRef,
   groupForStatus,
-  isOpenStatus,
   shortIssueId,
 } from '../../review-loop/src/issue-format.js'
 
@@ -134,21 +132,6 @@ describe('groupForStatus', () => {
     expect(groupForStatus('verified')).toBe('open')
     expect(groupForStatus('fixed_pending_review')).toBe('open')
     expect(groupForStatus('reopened')).toBe('open')
-  })
-})
-
-describe('isOpenStatus', () => {
-  test('terminal statuses are not open', () => {
-    expect(isOpenStatus('closed')).toBe(false)
-    expect(isOpenStatus('rejected')).toBe(false)
-    expect(isOpenStatus('already_fixed')).toBe(false)
-    expect(isOpenStatus('needs_human')).toBe(false)
-  })
-  test('non-terminal statuses are open', () => {
-    expect(isOpenStatus('discovered')).toBe(true)
-    expect(isOpenStatus('verified')).toBe(true)
-    expect(isOpenStatus('fixed_pending_review')).toBe(true)
-    expect(isOpenStatus('reopened')).toBe(true)
   })
 })
 ```
@@ -238,17 +221,6 @@ export const GROUP_MARK: Record<IssueGroup, string> = {
   rejected: CROSS,
   alreadyFixed: DOT,
   open: DOT,
-}
-
-const TERMINAL_REPORT_STATUSES: ReadonlySet<LedgerIssueStatus> = new Set([
-  'closed',
-  'rejected',
-  'already_fixed',
-  'needs_human',
-])
-
-export function isOpenStatus(status: LedgerIssueStatus): boolean {
-  return !TERMINAL_REPORT_STATUSES.has(status)
 }
 
 export function groupForStatus(status: LedgerIssueStatus): IssueGroup {
@@ -842,7 +814,7 @@ git commit -m "feat(review-loop): stream per-issue found/decided events instead 
 - Test: `tests/review-loop/cli.test.ts` (two assertion updates)
 
 **Interfaces:**
-- Consumes: `formatIssueRef`, `GROUP_LABEL`, `GROUP_MARK`, `GROUP_ORDER`, `groupForStatus`, `isOpenStatus`, `IssueGroup` from `./issue-format.js` (Task 1); `formatDuration` from `./live-renderer.js`; `IssueLedgerSnapshot`, `LedgerIssueRecord` from `./issue-ledger.js`.
+- Consumes: `formatIssueRef`, `GROUP_LABEL`, `GROUP_MARK`, `GROUP_ORDER`, `groupForStatus`, `IssueGroup` from `./issue-format.js` (Task 1); `formatDuration` from `./live-renderer.js`; `IssueLedgerSnapshot`, `LedgerIssueRecord` from `./issue-ledger.js`.
 - Produces:
   - `SummaryInput` — `{ doneReason: ReviewLoopResult['doneReason']; rounds: number; metrics: readonly RoundMetric[]; ledger: IssueLedgerSnapshot; runDir: string; options: SummaryOptions }`.
   - `buildSummary(input: SummaryInput): string` — NEW signature (positional args gone).
@@ -1383,7 +1355,7 @@ export function buildMetricsJson(
 
 Notes for the implementer:
 - `StatusCounts`, `computeStatusLines`, and `computeObservabilityLines` are deleted; their information now lives in the verdict line, the timing line, and the inspector line.
-- `isOpenStatus` from Task 1 is not used by `summary.ts` (open counting goes through `groupForStatus`); it exists for symmetry and is covered by its own Task 1 tests.
+- Open counting goes through `groupForStatus`; there is deliberately no separate `isOpenStatus` helper (removed pre-dispatch as unused, YAGNI).
 
 - [ ] **Step 4: Wire the new signature in cli.ts**
 

--- a/docs/superpowers/plans/2026-08-02-review-loop-live-status-and-report-polish.md
+++ b/docs/superpowers/plans/2026-08-02-review-loop-live-status-and-report-polish.md
@@ -1,0 +1,1222 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Review-loop Live Status Line + Report Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persistent multi-line live status area (status line + per-activity slot lines, TTY-only), silence per-tool noise in piped output, and fix final-report defects (burndown alignment, always-zero cost, zero-activity rows, missing wall clock).
+
+**Architecture:** In-place extension of the seam landed in `2026-08-01-review-loop-report-output.md`. `ProgressReporter` gains optional `slot(key, line | null)` and `usage(delta)`; `LiveRenderer` keeps a slot map and renders a `[status line, ...slot lines]` block with multi-line ANSI redraw; `line-handler`/`withLivePhase` route progress through slots. Report fixes are pure formatting in `summary.ts`/`summary-burndown.ts` plus a `wallMs` measurement in `cli.ts`.
+
+**Tech Stack:** Bun runtime + `bun:test`, strict TypeScript, zod (unchanged schemas).
+
+**Spec:** `docs/superpowers/specs/2026-08-02-review-loop-live-status-and-report-polish-design.md`
+
+## Global Constraints
+
+- New source files MUST start with the BUSL-1.1 header (see any existing `review-loop/src/*.ts` file — `// SPDX-License-Identifier: BUSL-1.1` + 3 comment lines).
+- Strict TypeScript; use `.js` extension in all import paths.
+- Never add lint-disable or type-ignore comments.
+- Error extraction convention: `error instanceof Error ? error.message : String(error)`.
+- TDD: the repo write-hook maps `review-loop/src/**` to `tests/review-loop/**`; write the failing test BEFORE the implementation in every task.
+- Commit style follows history: `feat(review-loop): …`, `fix(review-loop): …`, `test(review-loop): …`.
+- Run tests from the repo root. Single file: `bun test tests/review-loop/<file>.test.ts`. Full workspace suite: `bun run review-loop:test`. Typecheck: `bun run review-loop:typecheck`.
+- Unicode marks in use: `✓` (U+2713), `✗` (U+2717), `!`, `·` (U+00B7), `…` (U+2026), `—` (U+2014), `▶` (U+25B6). This plan adds `×` (U+00D7) for activity counts (`fix×2`). Reuse the existing constants in `live-renderer.ts` where they exist (`MIDDLE_DOT`, `ELLIPSIS`).
+- `noUncheckedIndexedAccess` is on: tuple/array index access yields `T | undefined` — handle it (no `!` assertions).
+
+---
+
+### Task 1: Burndown column alignment + zero-activity row suppression
+
+**Files:**
+- Modify: `review-loop/src/summary-burndown.ts` (full rewrite — header/rows generated from shared widths; `burndownIsEmpty` removed)
+- Modify: `review-loop/src/summary.ts` (call site: use `burndownBlock` return value, drop `burndownIsEmpty` import)
+- Test: `tests/review-loop/summary-burndown.test.ts` (rewritten)
+- Test: `tests/review-loop/summary.test.ts` (one new test)
+
+**Interfaces:**
+- Consumes: `RoundMetric` from `./trace-log.js` (unchanged).
+- Produces (used by `summary.ts`): `burndownBlock(metrics: readonly RoundMetric[]): string` — returns `''` when no non-zero rows remain; otherwise the `Burndown:` block. `burndownIsEmpty` is **deleted**; no other consumer exists (verified: only `summary.ts` imported it).
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the entire contents of `tests/review-loop/summary-burndown.test.ts` with:
+
+```typescript
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { burndownBlock } from '../../review-loop/src/summary-burndown.js'
+import type { RoundMetric } from '../../review-loop/src/trace-log.js'
+
+function zeroMetric(round: number): RoundMetric {
+  return {
+    round,
+    newIssues: 0,
+    cumulativeOpen: 0,
+    noProgressRounds: 0,
+    decisions: {
+      fixed: 0,
+      invalid: 0,
+      already_fixed: 0,
+      needs_human: 0,
+      plan_drift: 0,
+      no_commit: 0,
+      inspector_rejected: 0,
+    },
+    reviewerSeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    fixerSeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    inspector: { runs: 0, rejected: 0 },
+    phaseMs: { review: 0, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 },
+    usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0 },
+  }
+}
+
+function busyMetric(round: number): RoundMetric {
+  const metric = zeroMetric(round)
+  metric.newIssues = 4
+  metric.cumulativeOpen = 2
+  metric.decisions.fixed = 2
+  metric.decisions.invalid = 1
+  metric.reviewerSeverity = { critical: 0, high: 1, medium: 2, low: 1 }
+  metric.fixerSeverity = { critical: 0, high: 1, medium: 1, low: 1 }
+  metric.phaseMs = { review: 178_300, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 }
+  metric.usage = { inputTokens: 120_000, outputTokens: 8_000, reasoningTokens: 3_000, costUsd: 1.234 }
+  return metric
+}
+
+describe('burndownBlock', () => {
+  test('returns empty string when every round has zero activity', () => {
+    expect(burndownBlock([zeroMetric(1), zeroMetric(2)])).toBe('')
+  })
+
+  test('renders header aligned with row columns', () => {
+    const block = burndownBlock([busyMetric(1)])
+    const lines = block.split('\n')
+    expect(lines[0]).toBe('Burndown:')
+    expect(lines[1]).toBe('  round new open fixed rejected needs_human plan_drift insp_rej avgRev avgFix')
+    expect(lines[2]).toBe('  1     4   2    2     1        0           0          0        2.0    2.0')
+  })
+
+  test('drops zero-activity rows but keeps active ones', () => {
+    const block = burndownBlock([busyMetric(1), zeroMetric(2)])
+    const lines = block.split('\n')
+    expect(lines).toHaveLength(3)
+    expect(block).not.toContain('  2     0')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/review-loop/summary-burndown.test.ts`
+Expected: FAIL — `burndownIsEmpty` is still exported (test imports only `burndownBlock`, so import works), but the current header literal is `'  round  new  open  fixed  rejected  needs_human  plan_drift  insp_rej  avgRev  avgFix'` (double spaces) and the all-zero input returns a full table instead of `''`.
+
+- [ ] **Step 3: Rewrite summary-burndown.ts**
+
+Replace the entire contents of `review-loop/src/summary-burndown.ts` with:
+
+```typescript
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { RoundMetric, Severity, SeverityCounts } from './trace-log.js'
+
+const SEV_WEIGHT: Record<Severity, number> = { critical: 4, high: 3, medium: 2, low: 1 }
+
+const HEADERS = [
+  '  round',
+  'new',
+  'open',
+  'fixed',
+  'rejected',
+  'needs_human',
+  'plan_drift',
+  'insp_rej',
+  'avgRev',
+  'avgFix',
+] as const
+
+/** Cell widths matching HEADERS; 0 marks the last, unpadded column. */
+const WIDTHS = [8, 4, 5, 6, 9, 12, 11, 9, 7, 0] as const
+
+function avgSeverity(counts: SeverityCounts, total: number): string {
+  if (total === 0) return '-'
+  const sum =
+    counts.critical * SEV_WEIGHT.critical +
+    counts.high * SEV_WEIGHT.high +
+    counts.medium * SEV_WEIGHT.medium +
+    counts.low * SEV_WEIGHT.low
+  return (sum / total).toFixed(1)
+}
+
+function decidedCount(m: RoundMetric): number {
+  return (
+    m.decisions.fixed +
+    m.decisions.invalid +
+    m.decisions.already_fixed +
+    m.decisions.needs_human +
+    m.decisions.plan_drift +
+    m.decisions.no_commit +
+    m.decisions.inspector_rejected
+  )
+}
+
+function rowIsZero(m: RoundMetric): boolean {
+  return m.newIssues === 0 && decidedCount(m) === 0
+}
+
+function renderRow(values: readonly string[]): string {
+  return values
+    .map((value, i) => {
+      const width = WIDTHS[i] ?? 0
+      return width === 0 ? value : value.padEnd(width)
+    })
+    .join('')
+}
+
+function dataRow(m: RoundMetric): string {
+  return renderRow([
+    `  ${m.round}`,
+    String(m.newIssues),
+    String(m.cumulativeOpen),
+    String(m.decisions.fixed),
+    String(m.decisions.invalid),
+    String(m.decisions.needs_human),
+    String(m.decisions.plan_drift),
+    String(m.decisions.inspector_rejected),
+    avgSeverity(m.reviewerSeverity, m.newIssues),
+    avgSeverity(m.fixerSeverity, decidedCount(m)),
+  ])
+}
+
+export function burndownBlock(metrics: readonly RoundMetric[]): string {
+  const rows = metrics.filter((m) => !rowIsZero(m)).map(dataRow)
+  if (rows.length === 0) return ''
+  return ['Burndown:', renderRow(HEADERS), ...rows].join('\n')
+}
+```
+
+Note: `burndownIsEmpty` is gone; a row with `cumulativeOpen > 0` but no new issues and no decisions is now dropped (display-only change — the open count still shows in the verdict line and issues block).
+
+- [ ] **Step 4: Update the summary.ts call site**
+
+In `review-loop/src/summary.ts`, change the import (line 17):
+
+```typescript
+import { burndownBlock } from './summary-burndown.js'
+```
+
+and replace the burndown push in `buildSummary`:
+
+```typescript
+  const burndown = burndownBlock(input.metrics)
+  if (burndown !== '') lines.push('', burndown)
+```
+
+(replacing the previous `if (input.metrics.length > 0 && (input.metrics.length > 1 || !burndownIsEmpty(input.metrics)))` block).
+
+- [ ] **Step 5: Add the summary-level regression test**
+
+In `tests/review-loop/summary.test.ts`, append to `describe('buildSummary zero suppression')`:
+
+```typescript
+  test('drops zero-activity rounds from a multi-round burndown', () => {
+    const summary = buildSummary(inputOf({ metrics: [busyMetric(1), zeroMetric(2)] }))
+    expect(summary).toContain('Burndown:')
+    expect(summary).not.toContain('  2     0')
+  })
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `bun test tests/review-loop/summary-burndown.test.ts tests/review-loop/summary.test.ts`
+Expected: PASS (all tests).
+
+- [ ] **Step 7: Typecheck**
+
+Run: `bun run review-loop:typecheck`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add review-loop/src/summary-burndown.ts review-loop/src/summary.ts tests/review-loop/summary-burndown.test.ts tests/review-loop/summary.test.ts
+git commit -m "fix(review-loop): align burndown columns and drop zero-activity rows"
+```
+
+---
+
+### Task 2: Wall-clock duration + honest cost/token reporting
+
+**Files:**
+- Modify: `review-loop/src/summary.ts` (`SummaryInput.wallMs`, `buildTimingLine` rewrite, `formatCount` helper)
+- Modify: `review-loop/src/cli.ts` (measure `startedAt`, pass `wallMs` through `writeRunArtifacts` options)
+- Test: `tests/review-loop/summary.test.ts` (update `inputOf` + timing test, add zero-cost test)
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (independent).
+- Produces:
+  - `SummaryInput` gains `wallMs: number` (top-level field, before `options`).
+  - `writeRunArtifacts(runDir, result, options)` — `options` gains `wallMs: number`.
+  - Timing line format: `Duration: <wall> wall · phases <sum> (<nonzero phases>) · Cost: $X (in … / out … / reasoning …)` when `costUsd > 0`, else `… · Tokens: in … / out … / reasoning …`. All token counts use `toLocaleString('en-US')` separators.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/review-loop/summary.test.ts`:
+
+1. Add `wallMs` to `inputOf`:
+
+```typescript
+function inputOf(overrides?: Partial<SummaryInput>): SummaryInput {
+  return {
+    doneReason: 'clean',
+    rounds: 1,
+    metrics: [],
+    ledger: { issues: {} },
+    runDir: '/repo/.review-loop/runs/run-1',
+    wallMs: 200_000,
+    options: { poolSize: 1, inspect: false },
+    ...overrides,
+  }
+}
+```
+
+2. Replace the `buildSummary timing and cost` describe block with:
+
+```typescript
+describe('buildSummary timing and cost', () => {
+  test('renders wall time, phase sum, nonzero phases, and cost on one line', () => {
+    const summary = buildSummary(inputOf({ metrics: [busyMetric(1)] }))
+    expect(summary).toContain(
+      'Duration: 3m20s wall · phases 2m58s (review 178.3s) · Cost: $1.234 (in 120,000 / out 8,000 / reasoning 3,000)',
+    )
+  })
+
+  test('hides cost and shows Tokens when the reported cost is zero', () => {
+    const metric = busyMetric(1)
+    metric.usage = { inputTokens: 228_819, outputTokens: 9_824, reasoningTokens: 49_844, costUsd: 0 }
+    const summary = buildSummary(inputOf({ metrics: [metric] }))
+    expect(summary).toContain('· Tokens: in 228,819 / out 9,824 / reasoning 49,844')
+    expect(summary).not.toContain('Cost:')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/review-loop/summary.test.ts`
+Expected: FAIL — `SummaryInput` has no `wallMs` (type error) and the timing line is the old `Duration: 2m58s (review 178.3s) · Cost: $1.234 (in 120000 / …)` shape.
+
+- [ ] **Step 3: Implement in summary.ts**
+
+In `review-loop/src/summary.ts`:
+
+1. Add `wallMs` to `SummaryInput` (after `runDir`):
+
+```typescript
+export interface SummaryInput {
+  doneReason: ReviewLoopResult['doneReason']
+  rounds: number
+  metrics: readonly RoundMetric[]
+  ledger: IssueLedgerSnapshot
+  runDir: string
+  wallMs: number
+  options: SummaryOptions
+}
+```
+
+2. Add the count formatter next to `msToSeconds`:
+
+```typescript
+function formatCount(n: number): string {
+  return n.toLocaleString('en-US')
+}
+```
+
+3. Replace `buildTimingLine`:
+
+```typescript
+function buildTimingLine(metrics: readonly RoundMetric[], wallMs: number): string {
+  const phaseMs = aggregatePhaseMs(metrics)
+  const totalMs = PHASE_KEYS.reduce((s, k) => s + phaseMs[k], 0)
+  const parts = PHASE_KEYS.filter((k) => phaseMs[k] > 0).map((k) => `${k} ${msToSeconds(phaseMs[k])}`)
+  const breakdown = parts.length === 0 ? 'no phase timing recorded' : parts.join(', ')
+  const usage = aggregateUsage(metrics)
+  const tokens = `in ${formatCount(usage.inputTokens)} / out ${formatCount(usage.outputTokens)} / reasoning ${formatCount(usage.reasoningTokens)}`
+  const cost = usage.costUsd > 0 ? `Cost: $${usage.costUsd.toFixed(3)} (${tokens})` : `Tokens: ${tokens}`
+  return `Duration: ${formatDuration(wallMs)} wall · phases ${formatDuration(totalMs)} (${breakdown}) · ${cost}`
+}
+```
+
+4. Update the call in `buildSummary`:
+
+```typescript
+  const lines: string[] = [buildVerdict(input, counts, total), buildTimingLine(input.metrics, input.wallMs)]
+```
+
+- [ ] **Step 4: Wire wallMs in cli.ts**
+
+In `review-loop/src/cli.ts`:
+
+1. `writeRunArtifacts` options gain `wallMs`, forwarded into `buildSummary`:
+
+```typescript
+export async function writeRunArtifacts(
+  runDir: string,
+  result: ReviewLoopResult,
+  options: { poolSize: number; inspect: boolean; wallMs: number },
+): Promise<void> {
+  const closed = Object.values(result.ledger.issues).filter((r) => r.status === 'closed').length
+  const summary = buildSummary({
+    doneReason: result.doneReason,
+    rounds: result.rounds,
+    metrics: result.metrics ?? [],
+    ledger: result.ledger,
+    runDir,
+    wallMs: options.wallMs,
+    options: { poolSize: options.poolSize, inspect: options.inspect },
+  })
+  await writeFile(path.join(runDir, 'summary.txt'), `${summary}\n`)
+  try {
+    await writeFile(
+      path.join(runDir, 'metrics.json'),
+      `${JSON.stringify(buildMetricsJson(result.doneReason, result.rounds, closed, result.metrics ?? [], options), null, 2)}\n`,
+    )
+  } catch (error) {
+    console.warn(`[review-loop] metrics.json write failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  console.log(summary)
+}
+```
+
+(`buildMetricsJson` ignores the extra option field — its signature takes the whole options object positionally today only via `options.poolSize`; passing the extended object is compatible because it reads only `poolSize`.)
+
+2. `executeReviewLoop` gains a `startedAt: number` parameter (append it after `inspect: boolean`) and passes the elapsed wall time:
+
+```typescript
+  const result = await runReviewLoop({
+    config,
+    runState,
+    ledger,
+    spawn: realSpawn,
+    exec,
+    log,
+    trace,
+    pool,
+    inspect,
+  })
+  // Write summary/metrics/trace BEFORE finalizeRun so they always exist for
+  // post-mortem, even if the final build check or merge throws.
+  await writeRunArtifacts(runState.runDir, result, { poolSize: config.poolSize, inspect, wallMs: Date.now() - startedAt })
+```
+
+3. In `runCli`, capture the start time at the top of the function and pass it through:
+
+```typescript
+export async function runCli(argv: readonly string[]): Promise<void> {
+  const startedAt = Date.now()
+  const args = parseCliArgs(argv)
+  ...
+  try {
+    await executeReviewLoop(config, runState, ledger, exec, log, trace, pool, !args.noInspect, startedAt)
+  } finally {
+    await pool.close()
+  }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test tests/review-loop/summary.test.ts tests/review-loop/cli.test.ts`
+Expected: PASS (cli.test.ts does not call `writeRunArtifacts` directly and asserts no Duration-line content — verified).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `bun run review-loop:typecheck`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add review-loop/src/summary.ts review-loop/src/cli.ts tests/review-loop/summary.test.ts
+git commit -m "feat(review-loop): wall-clock duration and honest cost/token reporting"
+```
+
+---
+
+### Task 3: `slot()`/`usage()` seam + LiveRenderer multi-line block
+
+**Files:**
+- Modify: `review-loop/src/progress-log.ts` (add `UsageDelta`, `slot?`, `usage?`)
+- Modify: `review-loop/src/live-renderer.ts` (slot map, block redraw, `event` interleave, EPIPE downgrade)
+- Test: `tests/review-loop/live-renderer.test.ts` (new describes)
+
+**Interfaces:**
+- Consumes: existing `IssueProgressEvent`, `formatFoundLine`/`formatDecidedLine` (unchanged).
+- Produces (used by Tasks 4–5):
+  - `UsageDelta` — `{ input: number; output: number; reasoning: number; cost: number }` (from `progress-log.js`).
+  - `ProgressReporter.slot?(key: string, line: string | null): void` — set/update a per-activity live line; `null` clears it.
+  - `ProgressReporter.usage?(delta: UsageDelta): void` — accumulate token totals.
+  - `LiveRenderer` behavior contract: TTY renders a block `[statusLine?, ...slotLines]` (status line only while ≥1 slot is active and non-empty); non-TTY `slot()` is a no-op; `event()` clears the block, prints, redraws; any stream write throw permanently downgrades `dynamic` to `false`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/review-loop/live-renderer.test.ts`:
+
+```typescript
+describe('LiveRenderer slots', () => {
+  test('non-TTY slot is a no-op', () => {
+    const { stream, output } = makeStream()
+    const r = new LiveRenderer(stream)
+    r.slot('fixer-w1', '  fixer-w1 ▶ edit a.ts')
+    expect(output).toEqual([])
+  })
+
+  test('TTY slot renders the block with the slot line', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 120 })
+    const r = new LiveRenderer(stream)
+    r.slot('fixer-w1', '  fixer-w1 ▶ edit a.ts')
+    expect(output).toHaveLength(1)
+    expect(output[0]).toContain('fixer-w1 ▶ edit a.ts')
+  })
+
+  test('redraw after a multi-line block moves the cursor up to the block top', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 120 })
+    const r = new LiveRenderer(stream)
+    r.slot('a', 'line-a')
+    r.slot('b', 'line-b')
+    r.slot('c', 'line-c')
+    const redraw = output[2]!
+    expect(redraw.startsWith('\r\u001b[1A')).toBe(true)
+    expect(redraw).toContain('line-a')
+    expect(redraw).toContain('line-c')
+  })
+
+  test('clearing the last slot erases the whole block', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 120 })
+    const r = new LiveRenderer(stream)
+    r.slot('a', 'line-a')
+    r.slot('a', null)
+    const cleared = output[1]!
+    expect(cleared.startsWith('\r')).toBe(true)
+    expect(cleared).not.toContain('line-a')
+  })
+
+  test('event clears the block, prints, and redraws it', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 120 })
+    const r = new LiveRenderer(stream)
+    r.issue({ type: 'round', round: 1, maxRounds: 2 })
+    r.slot('fixer-w1', 'line-fix')
+    const before = output.length
+    r.event('hello')
+    expect(output[before]).toContain('\u001b[2K')
+    expect(output[before + 1]).toBe('hello\n')
+    expect(output[before + 2]).toContain('line-fix')
+    expect(output[before + 2]).toContain('round 1/2')
+  })
+
+  test('a throwing stream downgrades the renderer and never rethrows', () => {
+    const stream: RendererStream = {
+      write(): boolean {
+        throw Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })
+      },
+      isTTY: true,
+    }
+    const r = new LiveRenderer(stream)
+    expect(r.dynamic).toBe(true)
+    expect(() => r.event('x')).not.toThrow()
+    expect(r.dynamic).toBe(false)
+    expect(() => r.slot('a', 'line')).not.toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/review-loop/live-renderer.test.ts`
+Expected: FAIL — `r.slot` is not a function.
+
+- [ ] **Step 3: Extend progress-log.ts**
+
+Replace the entire contents of `review-loop/src/progress-log.ts` with:
+
+```typescript
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { Severity } from './trace-log.js'
+
+export type IssueProgressEvent =
+  | { type: 'round'; round: number; maxRounds: number }
+  | { type: 'found'; id: string; severity: Severity; file: string; line: number; title: string }
+  | { type: 'decided'; id: string; verdict: string; title: string; note?: string }
+
+export interface UsageDelta {
+  input: number
+  output: number
+  reasoning: number
+  cost: number
+}
+
+export interface ProgressReporter {
+  readonly dynamic: boolean
+  event(message: string): void
+  live(lines: readonly string[]): void
+  clearLive(): void
+  log(message: string): void
+  issue?(event: IssueProgressEvent): void
+  statusSuffix?(): string
+  slot?(key: string, line: string | null): void
+  usage?(delta: UsageDelta): void
+}
+```
+
+- [ ] **Step 4: Rework LiveRenderer**
+
+In `review-loop/src/live-renderer.ts`:
+
+1. Update the progress-log import:
+
+```typescript
+import type { IssueProgressEvent, ProgressReporter, UsageDelta } from './progress-log.js'
+```
+
+2. Replace the `CLEAR_LINE` constant with:
+
+```typescript
+const ERASE_LINE = '\u001b[2K'
+const CURSOR_DOWN = '\u001b[1B'
+
+function cursorUp(n: number): string {
+  return `\u001b[${n}A`
+}
+```
+
+3. Replace the entire `LiveRenderer` class with:
+
+```typescript
+export class LiveRenderer implements ProgressReporter {
+  private readonly tty: boolean
+  private broken = false
+  private readonly stream: RendererStream
+  private renderedLines = 0
+  private startedAt = 0
+  private round = 0
+  private maxRounds = 0
+  private readonly counts = { open: 0, fixed: 0, rejected: 0, needsHuman: 0 }
+  private readonly usageTotals: UsageDelta = { input: 0, output: 0, reasoning: 0, cost: 0 }
+  private readonly slots = new Map<string, string>()
+
+  constructor(stream: RendererStream) {
+    this.stream = stream
+    this.tty = stream.isTTY === true
+  }
+
+  get dynamic(): boolean {
+    return this.tty && !this.broken
+  }
+
+  issue(event: IssueProgressEvent): void {
+    this.touch()
+    switch (event.type) {
+      case 'round':
+        this.round = event.round
+        this.maxRounds = event.maxRounds
+        return
+      case 'found':
+        this.counts.open += 1
+        this.event(formatFoundLine(event))
+        return
+      case 'decided':
+        this.counts.open = Math.max(0, this.counts.open - 1)
+        if (event.verdict === 'fixed') this.counts.fixed += 1
+        else if (event.verdict === 'invalid') this.counts.rejected += 1
+        else if (event.verdict === 'needs_human' || event.verdict === 'plan_drift') this.counts.needsHuman += 1
+        this.event(formatDecidedLine(event))
+    }
+  }
+
+  statusSuffix(): string {
+    const parts: string[] = []
+    if (this.round > 0) parts.push(`round ${this.round}/${this.maxRounds}`)
+    const segments: string[] = []
+    if (this.counts.open > 0) segments.push(`${this.counts.open} open`)
+    if (this.counts.fixed > 0) segments.push(`${this.counts.fixed} fixed`)
+    if (this.counts.rejected > 0) segments.push(`${this.counts.rejected} rejected`)
+    if (this.counts.needsHuman > 0) segments.push(`${this.counts.needsHuman} needs human`)
+    if (segments.length > 0) parts.push(`issues: ${segments.join(` ${MIDDLE_DOT} `)}`)
+    return parts.join(` ${MIDDLE_DOT} `)
+  }
+
+  slot(key: string, line: string | null): void {
+    this.touch()
+    if (line === null) {
+      this.slots.delete(key)
+    } else {
+      this.slots.set(key, line)
+    }
+    if (!this.dynamic) return
+    this.renderBlock()
+  }
+
+  usage(delta: UsageDelta): void {
+    this.touch()
+    this.usageTotals.input += delta.input
+    this.usageTotals.output += delta.output
+    this.usageTotals.reasoning += delta.reasoning
+    this.usageTotals.cost += delta.cost
+  }
+
+  event(message: string): void {
+    this.touch()
+    if (!this.dynamic) {
+      this.writeSafe(`${message}\n`)
+      return
+    }
+    this.clearBlock()
+    this.writeSafe(`${message}\n`)
+    this.renderBlock()
+  }
+
+  log(message: string): void {
+    this.event(message)
+  }
+
+  live(lines: readonly string[]): void {
+    if (!this.dynamic) {
+      for (const line of lines) {
+        this.writeSafe(`${line}\n`)
+      }
+      return
+    }
+    this.writeBlock([...lines])
+  }
+
+  clearLive(): void {
+    this.clearBlock()
+  }
+
+  private touch(): void {
+    if (this.startedAt === 0) this.startedAt = Date.now()
+  }
+
+  private statusLine(): string {
+    if (this.slots.size === 0) return ''
+    const suffix = this.statusSuffix()
+    return suffix === '' ? '' : `  ${'status'.padEnd(10)} ${suffix}`
+  }
+
+  private renderBlock(): void {
+    const status = this.statusLine()
+    const lines = status === '' ? [...this.slots.values()] : [status, ...this.slots.values()]
+    if (lines.length === 0) {
+      this.clearBlock()
+      return
+    }
+    this.writeBlock(lines)
+  }
+
+  private writeBlock(lines: string[]): void {
+    let out = '\r'
+    if (this.renderedLines > 1) out += cursorUp(this.renderedLines - 1)
+    out += ERASE_LINE + lines.map((line) => this.fit(line)).join(`\n${ERASE_LINE}`)
+    this.writeSafe(out)
+    this.renderedLines = lines.length
+  }
+
+  private clearBlock(): void {
+    if (this.renderedLines === 0) return
+    let out = '\r'
+    if (this.renderedLines > 1) out += cursorUp(this.renderedLines - 1)
+    for (let i = 0; i < this.renderedLines; i++) {
+      out += ERASE_LINE
+      if (i < this.renderedLines - 1) out += CURSOR_DOWN
+    }
+    if (this.renderedLines > 1) out += cursorUp(this.renderedLines - 1)
+    this.writeSafe(out)
+    this.renderedLines = 0
+  }
+
+  private writeSafe(chunk: string): void {
+    if (this.broken) return
+    try {
+      this.stream.write(chunk)
+    } catch {
+      this.broken = true
+    }
+  }
+
+  private fit(line: string): string {
+    const max = this.stream.columns ?? 80
+    return truncate(line, max)
+  }
+}
+```
+
+Notes for the implementer:
+- `dynamic` changes from a readonly field to a getter over `tty && !broken` — the `ProgressReporter` interface's `readonly dynamic: boolean` is satisfied by a getter.
+- `live(lines)` deliberately does NOT `touch()` and does NOT inject the status line: it stays a raw block write so existing tests (`'TTY live writes clear-line + content with no newline'`, `'event after a live line clears it first (TTY)'`) keep passing byte-for-byte.
+- `withLivePhase` still calls `reporter.live([...])`/`clearLive()` at this point; Task 5 reroutes it.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test tests/review-loop/live-renderer.test.ts`
+Expected: PASS (new slot tests + all pre-existing tests unchanged).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `bun run review-loop:typecheck`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add review-loop/src/progress-log.ts review-loop/src/live-renderer.ts tests/review-loop/live-renderer.test.ts
+git commit -m "feat(review-loop): per-activity live slots with multi-line redraw and EPIPE downgrade"
+```
+
+---
+
+### Task 4: Status line content (activity, elapsed, tokens)
+
+**Files:**
+- Modify: `review-loop/src/live-renderer.ts` (`statusLine` full segment builder, `activitySummary`, `formatTokenCount`)
+- Test: `tests/review-loop/live-renderer.test.ts` (new describes)
+
+**Interfaces:**
+- Consumes: Task 3's slot map, counters, `usageTotals`, `startedAt`.
+- Produces (used by nothing else directly — internal rendering; `formatTokenCount` exported for tests):
+  - `formatTokenCount(n: number): string` — `999` → `'999'`, `9824` → `'9.8k'`, `228819` → `'228.8k'`, `1500000` → `'1.50M'`.
+  - Status line: `  status     <round X/Y> · <activity> · <elapsed> · <issues: …> · <in X / out Y>` — zero/absent segments omitted; `activity` derived from slot keys (`reviewer→review`, `matcher→match`, `fixer→fix`, `inspector→inspect`, `build→build`; `-w<N>`/`-retry` suffixes stripped; duplicates counted as `fix×2`; verbs joined with `+`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/review-loop/live-renderer.test.ts` (extend the top import with `formatTokenCount`):
+
+```typescript
+import {
+  formatDuration,
+  formatLiveLine,
+  formatStepFooter,
+  formatTokenCount,
+  formatToolArg,
+  LiveRenderer,
+  type RendererStream,
+} from '../../review-loop/src/live-renderer.js'
+```
+
+```typescript
+describe('formatTokenCount', () => {
+  test('formats compact token counts', () => {
+    expect(formatTokenCount(999)).toBe('999')
+    expect(formatTokenCount(1000)).toBe('1.0k')
+    expect(formatTokenCount(9824)).toBe('9.8k')
+    expect(formatTokenCount(228819)).toBe('228.8k')
+    expect(formatTokenCount(1500000)).toBe('1.50M')
+  })
+})
+
+describe('status line', () => {
+  test('combines round, activity, issues, and tokens', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 200 })
+    const r = new LiveRenderer(stream)
+    r.issue({ type: 'round', round: 1, maxRounds: 2 })
+    r.issue({
+      type: 'found',
+      id: 'aaaaaaaa-0000-0000-0000-000000000000',
+      severity: 'low',
+      file: 'a.ts',
+      line: 1,
+      title: 'A',
+    })
+    r.usage({ input: 228819, output: 9824, reasoning: 49844, cost: 0 })
+    r.slot('fixer-w1', 'x')
+    r.slot('fixer-w2-retry', 'y')
+    const status = output[output.length - 1]!.split('\n')[0]!
+    expect(status).toContain('status')
+    expect(status).toContain('round 1/2')
+    expect(status).toContain('fix×2')
+    expect(status).toContain('issues: 1 open')
+    expect(status).toContain('in 228.8k / out 9.8k')
+  })
+
+  test('maps slot keys to activity verbs', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 200 })
+    const r = new LiveRenderer(stream)
+    r.slot('reviewer', 'x')
+    const status = output[output.length - 1]!.split('\n')[0]!
+    expect(status).toContain('review')
+    expect(status).not.toContain('reviewer')
+  })
+
+  test('accumulates usage across calls', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 200 })
+    const r = new LiveRenderer(stream)
+    r.usage({ input: 500, output: 0, reasoning: 0, cost: 0 })
+    r.usage({ input: 600, output: 100, reasoning: 0, cost: 0 })
+    r.slot('a', 'x')
+    const status = output[output.length - 1]!.split('\n')[0]!
+    expect(status).toContain('in 1.1k / out 100')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/review-loop/live-renderer.test.ts`
+Expected: FAIL — `formatTokenCount` is not exported; status line lacks activity/token segments.
+
+- [ ] **Step 3: Implement in live-renderer.ts**
+
+1. Add after `formatStepFooter`:
+
+```typescript
+export function formatTokenCount(n: number): string {
+  if (n < 1000) return String(n)
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`
+  return `${(n / 1_000_000).toFixed(2)}M`
+}
+```
+
+2. Add the `TIMES` constant next to the other mark constants:
+
+```typescript
+const TIMES = '×'
+```
+
+3. Add the activity mapper (module scope, above the class):
+
+```typescript
+const ACTIVITY_VERB: Record<string, string> = {
+  reviewer: 'review',
+  matcher: 'match',
+  fixer: 'fix',
+  inspector: 'inspect',
+  build: 'build',
+}
+
+function activitySummary(keys: Iterable<string>): string {
+  const counts = new Map<string, number>()
+  for (const key of keys) {
+    const base = key.split('-')[0] ?? key
+    const verb = ACTIVITY_VERB[base] ?? base
+    counts.set(verb, (counts.get(verb) ?? 0) + 1)
+  }
+  const parts: string[] = []
+  for (const [verb, n] of counts) {
+    parts.push(n === 1 ? verb : `${verb}${TIMES}${n}`)
+  }
+  return parts.join('+')
+}
+```
+
+4. Replace the `statusLine()` method (the Task 3 minimal version) with:
+
+```typescript
+  private statusLine(): string {
+    if (this.slots.size === 0) return ''
+    const parts: string[] = []
+    if (this.round > 0) parts.push(`round ${this.round}/${this.maxRounds}`)
+    const activity = activitySummary(this.slots.keys())
+    if (activity !== '') parts.push(activity)
+    if (this.startedAt !== 0) parts.push(formatDuration(Date.now() - this.startedAt))
+    const segments: string[] = []
+    if (this.counts.open > 0) segments.push(`${this.counts.open} open`)
+    if (this.counts.fixed > 0) segments.push(`${this.counts.fixed} fixed`)
+    if (this.counts.rejected > 0) segments.push(`${this.counts.rejected} rejected`)
+    if (this.counts.needsHuman > 0) segments.push(`${this.counts.needsHuman} needs human`)
+    if (segments.length > 0) parts.push(`issues: ${segments.join(` ${MIDDLE_DOT} `)}`)
+    if (this.usageTotals.input > 0 || this.usageTotals.output > 0) {
+      parts.push(`in ${formatTokenCount(this.usageTotals.input)} / out ${formatTokenCount(this.usageTotals.output)}`)
+    }
+    if (parts.length === 0) return ''
+    return `  ${'status'.padEnd(10)} ${parts.join(` ${MIDDLE_DOT} `)}`
+  }
+```
+
+`statusSuffix()` stays as a public interface member (spec decision: interface compatibility) even though the status line no longer consumes it; its tests stay green.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/review-loop/live-renderer.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run review-loop:typecheck`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add review-loop/src/live-renderer.ts tests/review-loop/live-renderer.test.ts
+git commit -m "feat(review-loop): status line with round, activity, issues, and tokens"
+```
+
+---
+
+### Task 5: Wire slots + usage through line-handler and withLivePhase
+
+**Files:**
+- Modify: `review-loop/src/line-handler.ts` (`renderLive` → `slot()`, `step_finish` → `usage()`, `dispose` clears slot)
+- Modify: `review-loop/src/live-renderer.ts` (`withLivePhase` tick/clear via `slot()`; `formatLiveLine` drops the 6th `status` param)
+- Test: `tests/review-loop/line-handler.test.ts` (new describe)
+- Test: `tests/review-loop/live-renderer.test.ts` (delete the `formatLiveLine status suffix` describe; add `withLivePhase` describe)
+
+**Interfaces:**
+- Consumes: Task 3's `slot`/`usage` seam, Task 4's status line.
+- Produces: no new exports. Behavioral contract: with a `slot`-capable reporter (the real `LiveRenderer`), per-tool progress lands in the label's slot; without one (test fakes), behavior is byte-identical to before (minus the removed `statusSuffix` append, which no fake implements — no observable change).
+
+- [ ] **Step 1: Update the failing tests first**
+
+1. In `tests/review-loop/live-renderer.test.ts`, **delete** the entire `describe('formatLiveLine status suffix', ...)` block (the 6th parameter is going away).
+
+2. In `tests/review-loop/live-renderer.test.ts`, extend the import from `live-renderer.js` to include `withLivePhase`, add `import type { ProgressReporter } from '../../review-loop/src/progress-log.js'`, and append:
+
+```typescript
+describe('withLivePhase', () => {
+  test('clears its slot when the phase ends', async () => {
+    const slots: Array<readonly [string, string | null]> = []
+    const reporter: ProgressReporter = {
+      dynamic: true,
+      event: () => {},
+      live: () => {},
+      clearLive: () => {},
+      log: () => {},
+      slot: (key, line) => {
+        slots.push([key, line] as const)
+      },
+    }
+    const { result } = await withLivePhase(reporter, 'build', () => Promise.resolve('done'))
+    expect(result).toBe('done')
+    expect(slots[slots.length - 1]).toEqual(['build', null])
+  })
+})
+```
+
+3. In `tests/review-loop/line-handler.test.ts`, extend imports:
+
+```typescript
+import type { RunAgentOptions, SpawnResult } from '../../review-loop/src/agent-runner.js'
+import { createLineHandler, enqueueLog } from '../../review-loop/src/line-handler.js'
+import type { ProgressReporter, UsageDelta } from '../../review-loop/src/progress-log.js'
+```
+
+and append:
+
+```typescript
+describe('createLineHandler reporter wiring', () => {
+  function makeReporter(overrides: Partial<ProgressReporter>): ProgressReporter {
+    return {
+      dynamic: false,
+      event: () => {},
+      live: () => {},
+      clearLive: () => {},
+      log: () => {},
+      ...overrides,
+    }
+  }
+
+  test('step_finish forwards usage to the reporter', () => {
+    const cwd = makeTempDir('line-handler-usage-')
+    const deltas: UsageDelta[] = []
+    const reporter = makeReporter({
+      usage: (d) => {
+        deltas.push(d)
+      },
+    })
+    const handler = createLineHandler({ ...makeOptions(cwd, path.join(cwd, 'agent.log')), reporter })
+    handler.onLine(
+      JSON.stringify({
+        type: 'step_finish',
+        part: { reason: 'stop', tokens: { input: 5, output: 2, reasoning: 1 }, cost: 0.5 },
+      }),
+    )
+    expect(deltas).toEqual([{ input: 5, output: 2, reasoning: 1, cost: 0.5 }])
+  })
+
+  test('tool progress goes to reporter.slot and dispose clears it', async () => {
+    const cwd = makeTempDir('line-handler-slot-')
+    const slots: Array<readonly [string, string | null]> = []
+    const reporter = makeReporter({
+      slot: (key, line) => {
+        slots.push([key, line] as const)
+      },
+    })
+    const handler = createLineHandler({ ...makeOptions(cwd, path.join(cwd, 'agent.log')), reporter })
+    handler.onLine(JSON.stringify({ type: 'step_start', timestamp: 1, part: {} }))
+    handler.onLine(
+      JSON.stringify({
+        type: 'tool_use',
+        part: { tool: 'read', callID: 'c1', state: { status: 'running', input: { filePath: '/a/cli.ts' } } },
+      }),
+    )
+    expect(slots.some(([key, line]) => key === 'drain' && line !== null && line.includes('read'))).toBe(true)
+    await handler.dispose()
+    expect(slots[slots.length - 1]).toEqual(['drain', null])
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/review-loop/live-renderer.test.ts tests/review-loop/line-handler.test.ts`
+Expected: FAIL — `formatLiveLine` still accepts 6 args (old suffix tests deleted, so no failure there), but the `withLivePhase` slot test fails (tick uses `live()` / clear uses `clearLive()`), `step_finish` never calls `usage()`, and `renderLive` never calls `slot()`.
+
+- [ ] **Step 3: Revert formatLiveLine to 5 parameters**
+
+In `review-loop/src/live-renderer.ts`, replace `formatLiveLine`:
+
+```typescript
+export function formatLiveLine(label: string, tool: string, arg: string, elapsedMs: number, toolCount: number): string {
+  const toolPart = tool === '' ? 'thinking' : arg === '' ? tool : `${tool} ${arg}`
+  const tools = `${toolCount} tool${toolCount === 1 ? '' : 's'}`
+  return `  ${label.padEnd(10)} ${ARROW} ${toolPart} ${MIDDLE_DOT} ${formatDuration(elapsedMs)} ${MIDDLE_DOT} ${tools}`
+}
+```
+
+- [ ] **Step 4: Reroute withLivePhase through slots**
+
+In `review-loop/src/live-renderer.ts`, replace `withLivePhase`:
+
+```typescript
+export async function withLivePhase<T>(
+  reporter: ProgressReporter,
+  label: string,
+  fn: () => Promise<T>,
+): Promise<{ result: T; durationMs: number }> {
+  reporter.event(`[${label}] running...`)
+  const start = Date.now()
+  let timer: ReturnType<typeof setInterval> | null = null
+  if (reporter.dynamic) {
+    timer = setInterval(() => {
+      const line = `[${label}] ${formatDuration(Date.now() - start)}...`
+      if (reporter.slot !== undefined) {
+        reporter.slot(label, line)
+      } else {
+        reporter.live([line])
+      }
+    }, 1000)
+  }
+  try {
+    const result = await fn()
+    return { result, durationMs: Date.now() - start }
+  } finally {
+    if (timer !== null) {
+      clearInterval(timer)
+    }
+    if (reporter.slot !== undefined) {
+      reporter.slot(label, null)
+    } else {
+      reporter.clearLive()
+    }
+  }
+}
+```
+
+(The `statusSuffix` append inside the tick is gone — the status line carries that information now.)
+
+- [ ] **Step 5: Reroute line-handler through slots and usage**
+
+In `review-loop/src/line-handler.ts`:
+
+1. Replace `renderLive`:
+
+```typescript
+function renderLive(ctx: LiveCtx): void {
+  const reporter = ctx.reporter
+  if (reporter === undefined) {
+    return
+  }
+  const elapsed = ctx.startedAt === 0 ? 0 : Date.now() - ctx.startedAt
+  const line = formatLiveLine(ctx.label, ctx.tool, ctx.arg, elapsed, ctx.toolCount)
+  if (reporter.slot !== undefined) {
+    reporter.slot(ctx.label, line)
+  } else {
+    reporter.live([line])
+  }
+}
+```
+
+2. In `applyEvent`'s `step_finish` case, forward usage before the footer:
+
+```typescript
+    case 'step_finish':
+      ctx.usage.inputTokens += evt.tokens.input
+      ctx.usage.outputTokens += evt.tokens.output
+      ctx.usage.reasoningTokens += evt.tokens.reasoning
+      ctx.usage.costUsd += evt.cost
+      if (reporter !== undefined) {
+        reporter.usage?.({
+          input: evt.tokens.input,
+          output: evt.tokens.output,
+          reasoning: evt.tokens.reasoning,
+          cost: evt.cost,
+        })
+        reporter.clearLive()
+        reporter.event(
+          formatStepFooter(ctx.label, ctx.startedAt === 0 ? 0 : Date.now() - ctx.startedAt, ctx.toolCount, evt.tokens),
+        )
+      }
+      break
+```
+
+(`reporter.clearLive()` stays for legacy reporters whose `event()` doesn't clear; for `LiveRenderer` it's a harmless no-op since `event()` clears and redraws itself.)
+
+3. In `dispose`, clear only this handler's slot:
+
+```typescript
+  const dispose = async (): Promise<void> => {
+    if (ctx.timer !== null) {
+      clearInterval(ctx.timer)
+    }
+    const reporter = ctx.reporter
+    if (reporter !== undefined) {
+      if (reporter.slot !== undefined) {
+        reporter.slot(ctx.label, null)
+      } else {
+        reporter.clearLive()
+      }
+    }
+    await ctx.logChain
+  }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `bun test tests/review-loop/live-renderer.test.ts tests/review-loop/line-handler.test.ts tests/review-loop/progress-log.test.ts tests/review-loop/build-checker.test.ts tests/review-loop/loop-controller.test.ts`
+Expected: PASS. (`progress-log`/`loop-controller` fakes don't implement `slot`/`usage` → fallback paths keep them byte-identical; `build-checker` exercises `withLivePhase` through a fake without `slot` → same fallback.)
+
+- [ ] **Step 7: Typecheck + full workspace suite**
+
+Run: `bun run review-loop:typecheck && bun run review-loop:test`
+Expected: clean typecheck; full suite green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add review-loop/src/line-handler.ts review-loop/src/live-renderer.ts tests/review-loop/line-handler.test.ts tests/review-loop/live-renderer.test.ts
+git commit -m "feat(review-loop): route live progress through slots and forward usage"
+```
+
+---
+
+## Self-review notes (already applied)
+
+- **Spec coverage:** seam (`slot`/`usage`) → Task 3; multi-line redraw + event interleave → Task 3; EPIPE downgrade → Task 3; status line content (round/activity/elapsed/issues/tokens) → Task 4; non-TTY `slot` no-op → Task 3; `line-handler`/`withLivePhase` wiring → Task 5; burndown alignment + zero-row suppression → Task 1; cost-hidden-when-zero + separators → Task 2; wall clock → Task 2. `metrics.json` unchanged — no task touches it.
+- **Type consistency:** `UsageDelta` field names (`input`/`output`/`reasoning`/`cost`) are identical in Task 3 (definition), Task 4 (tests), and Task 5 (call site). `slot(key, line | null)` signature identical everywhere. `wallMs` is a top-level `SummaryInput` field in both Task 2 test and implementation.
+- **Ordering:** Tasks 1 and 2 are independent of each other and of Tasks 3–5; Task 4 requires Task 3; Task 5 requires Tasks 3–4. Executing in plan order satisfies all dependencies.

--- a/docs/superpowers/specs/2026-08-01-review-loop-report-output-design.md
+++ b/docs/superpowers/specs/2026-08-01-review-loop-report-output-design.md
@@ -1,0 +1,149 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Review-loop report output redesign
+
+Date: 2026-08-01
+Status: approved (design)
+Scope: `review-loop/` workspace — final result report (`summary.ts` → console + `summary.txt`) and live in-run rendering (`live-renderer.ts`).
+
+## Problem
+
+The end-of-run report is hard to read at a glance:
+
+- **No clear verdict** — outcome must be inferred from a burndown row of zeros.
+- **Zero-heavy tables are noise** — a clean one-round run prints a full burndown table and six wall-clock phases that are all `0.0s`.
+- **No artifact pointers** — the report never says where `summary.txt`, `metrics.json`, the ledger, traces, or transcripts landed.
+- **No per-issue detail** — counts only; finding *which* issues were fixed/rejected requires opening the ledger JSON by hand.
+- **Elision losses** — the terminal harness elides long output (`[52 lines elided]`), so useful sections disappear; the report must be compact and front-load the verdict.
+
+Live rendering also under-reports substance: a completed review round logs only `[round N] Found M issues`, and the in-phase tick shows only `[label] 45s...` with no issue counters.
+
+## Approach
+
+In-place extension of the existing pieces (chosen over a dedicated event-bus report module and over a post-hoc `report` subcommand):
+
+1. Rework `buildSummary` into a verdict-first, zero-suppressed report with capped per-issue groups and an artifacts block.
+2. Add a single structured `issue(event)` method to `ProgressReporter`; `LiveRenderer` uses it to print per-issue lines and maintain counters for an enriched status tick.
+3. Pass the ledger snapshot and run dir into `buildSummary`; `metrics.json` stays unchanged.
+
+## Final report format
+
+Clean run (no issues):
+
+```
+Review loop finished: clean — reviewer found no issues in round 1.
+Duration: 6m01s (review 178.3s) · Cost: $1.234 (in 120000 / out 8000 / reasoning 3000)
+
+Artifacts (.review-loop/runs/2026-08-01T12-00-00-000Z-abcd1234/):
+  summary.txt · metrics.json · ledger.json · trace.log · transcripts/
+```
+
+Run with issues:
+
+```
+Review loop finished: done — 5 issues: 3 fixed, 1 needs human, 1 rejected.
+Duration: 12m40s (review 320.1s, fix 401.2s) · Cost: $2.431 (in 240000 / out 31000 / reasoning 9000)
+Rounds: 2 · Pool: 4
+
+Issues:
+  needs human (1):
+    ! #g7h8i9j0 [critical] src/db/migrate.ts:55 — Migration drops index concurrently
+  fixed (3):
+    ✓ #a1b2c3d4 [high]   src/auth/login.ts:42 — Token refresh race on 401
+    ✓ #c3d4e5f6 [medium] src/chat/router.ts:117 — Unguarded null platform instance
+    ✓ #e5f6a7b8 [low]    src/tools/prefs.ts:8 — Typo in deny message
+  rejected (1):
+    ✗ #i9j0k1l2 [medium] src/cli.ts:31 — Flag parsing duplicates
+
+Burndown:
+  round  new  open  fixed  rejected  needs_human  plan_drift  insp_rej  avgRev  avgFix
+  1      4    2     2      1         0            0           0         2.8     2.5
+```
+
+Rules:
+
+- **Verdict line** (first line) derived from `doneReason` + counts, in plain language. The mapping is total and explicit — every `doneReason` value has a defined rendering:
+  - No issues ever found (`clean`) → "clean — reviewer found no issues in round N."
+  - Issues found, none left open (`clean_after_rounds`, or `max_rounds`/`no_progress` with zero open) → "done — N issues: X fixed, Y needs human, Z rejected" (zero counts omitted).
+  - Issues left open (`max_rounds` / `no_progress`) → "issues remaining — N open (X fixed, Y needs human, Z rejected)".
+- **Zero suppression**:
+  - Wall-clock phases with `0.0s` are dropped from the duration breakdown (at least one phase is always shown — the nonzero ones; if all are zero, show `0.0s` total only).
+  - Zero-count status lines are dropped from the verdict counts.
+  - The burndown table is omitted when there is exactly one round and every value in it is zero.
+- **Issue groups**: bucketed from `Object.values(ledger.issues)` by status, ordered `needs_human → closed (fixed) → rejected → already_fixed → open` (open bucket only appears when the loop stops with non-terminal issues). Each group is capped at 20 lines, then `…and N more (see ledger.json)`.
+- **Issue line format**: `<mark> #<shortId> [<severity>] <file>:<lineStart> — <title>`, taken from the `LedgerIssueRecord` (`id`, `issue.severity`, `issue.file`, `issue.lineStart`, `issue.title`). `shortId` is the first 8 characters of the ledger UUID (same convention as run ids); it is display-only — full ids live in `ledger.json`. Marks: `✓` fixed, `!` needs human, `✗` rejected, `·` already fixed/open.
+- **Artifacts block** always printed, listing the run dir plus the files the run wrote: `summary.txt`, `metrics.json`, `ledger.json`, the trace log (`runState.tracePath`), and the transcripts directory. No filesystem probing — the writer lists what it knows it wrote.
+- **Size budget**: a typical report is ≤ 40 lines so harness elision does not hide the verdict; the verdict is the first line and the counts stay within the tail window.
+- `summary.txt` receives the identical text as the console. `metrics.json` schema is unchanged.
+
+## Live rendering
+
+**Streamed issue lines.** When a review round completes, replace the single `[round N] Found M issues` log with one line per issue as it enters the ledger:
+
+```
+[round 1/3] Reviewing... ✓ 178s · 14 tools · in 120000 / out 8000
+  + #a1b2c3d4 [high]   src/auth/login.ts:42 — Token refresh race on 401
+  + #c3d4e5f6 [medium] src/chat/router.ts:117 — Unguarded null platform instance
+```
+
+Fix/verify decisions already stream per issue; they are restyled to the same visual shape (`✓ #a1b2c3d4 → fixed`, `! #g7h8i9j0 → needs_human (merge conflict)`), replacing the current `[fix] "title" → verdict` strings.
+
+**Persistent status line.** The `withLivePhase` tick renders an enriched single status line:
+
+```
+[fix] 1m12s… · round 1/3 · issues: 2 open · 1 fixed · 1 rejected
+```
+
+`LiveRenderer` keeps a counter bag `{ round, maxRounds, open, fixed, rejected, needsHuman }`, updated by the structured issue events; zero-count segments are omitted from the line.
+
+**The seam.** `ProgressReporter` gains one method:
+
+```ts
+issue(event: IssueProgressEvent): void
+
+type IssueProgressEvent =
+  | { type: 'found'; id: string; severity: Severity; file: string; line: number; title: string }
+  | { type: 'decided'; id: string; verdict: string; title: string; note?: string }
+```
+
+- `loop-controller` calls `issue({type: 'found', …})` per new ledger addition at the review boundary.
+- `issue-processor.ts` / `issue-processor-attempts.ts` / `commit-attempt.ts` call `issue({type: 'decided', …})` where they currently emit `[fix] "…"` string logs; the old strings are replaced, not duplicated.
+- `LiveRenderer.issue()` formats the line via `event()` and updates the status counters.
+- Non-TTY mode (`dynamic === false`) prints the same lines with no ticker — behavior otherwise unchanged.
+- Any other `ProgressReporter` implementations (test fakes, file loggers) implement `issue()` by formatting to text.
+
+## Data flow
+
+- `writeRunArtifacts` (cli.ts) already receives `result.ledger` and `runState.runDir`; it now passes the ledger snapshot and run dir into `buildSummary`, whose signature becomes approximately `buildSummary({ doneReason, rounds, metrics, ledger, runDir, options })`.
+- `buildMetricsJson` is untouched.
+- Artifact ordering is unchanged: summary/metrics/trace are written **before** `finalizeRun`, so build-failure and merge-conflict runs still produce a full report; the finalize error prints after it, as today.
+
+## Error handling
+
+- No new failure modes: reporting is pure formatting over data already in memory.
+- If `metrics.json` write fails, the existing warn-and-continue behavior stays; the console report is unaffected.
+- A run with zero ledger issues never renders an `Issues:` block.
+
+## Testing
+
+TDD per workspace rules (`review-loop/src/**` gates against `tests/review-loop/**`):
+
+- **`summary` tests** (extend existing): verdict wording per `doneReason` × counts; zero suppression (all-zero single round → no burndown; `0.0s` phases dropped); group ordering and the 20-line cap with `…and N more`; issue line formatting (id/severity/file:line/title); artifacts block contents.
+- **`LiveRenderer` tests** (extend existing): `issue()` found/decided line formats; counters update and appear in the tick line; zero-count segments omitted; non-TTY prints lines without a ticker; `clearLive` interplay unchanged.
+- **Loop-level tests** (existing fake-reporter patterns): a run with found issues emits one `issue` event per ledger addition; fix decisions emit `decided` events instead of the old `[fix]` strings.
+
+## Out of scope
+
+- `metrics.json` / trace schema changes.
+- A post-hoc `review-loop report` subcommand (possible future follow-up).
+- HTML/GUI reports, notifications.
+- New CLI flags (the new output is default-on; it is output-only).
+
+## Rollout
+
+Single change-set: report rework + live rendering land together, no flags. Output-only change; safe to default-on.

--- a/docs/superpowers/specs/2026-08-01-review-loop-report-output-design.md
+++ b/docs/superpowers/specs/2026-08-01-review-loop-report-output-design.md
@@ -37,10 +37,10 @@ Clean run (no issues):
 
 ```
 Review loop finished: clean — reviewer found no issues in round 1.
-Duration: 6m01s (review 178.3s) · Cost: $1.234 (in 120000 / out 8000 / reasoning 3000)
+Duration: 2m58s (review 178.3s) · Cost: $1.234 (in 120000 / out 8000 / reasoning 3000)
 
 Artifacts (.review-loop/runs/2026-08-01T12-00-00-000Z-abcd1234/):
-  summary.txt · metrics.json · ledger.json · trace.log · transcripts/
+  summary.txt · metrics.json · ledger.json · trace.jsonl · agent-output.log · state.json
 ```
 
 Run with issues:
@@ -68,8 +68,8 @@ Burndown:
 Rules:
 
 - **Verdict line** (first line) derived from `doneReason` + counts, in plain language. The mapping is total and explicit — every `doneReason` value has a defined rendering:
-  - No issues ever found (`clean`) → "clean — reviewer found no issues in round N."
-  - Issues found, none left open (`clean_after_rounds`, or `max_rounds`/`no_progress` with zero open) → "done — N issues: X fixed, Y needs human, Z rejected" (zero counts omitted).
+  - No issues ever found (`clean` in round 1) → "clean — reviewer found no issues in round N."
+  - Issues found, none left open (`clean` after round 1, or `max_rounds`/`no_progress` with zero open) → "done — N issues: X fixed, Y needs human, Z rejected" (zero counts omitted).
   - Issues left open (`max_rounds` / `no_progress`) → "issues remaining — N open (X fixed, Y needs human, Z rejected)".
 - **Zero suppression**:
   - Wall-clock phases with `0.0s` are dropped from the duration breakdown (at least one phase is always shown — the nonzero ones; if all are zero, show `0.0s` total only).
@@ -77,7 +77,7 @@ Rules:
   - The burndown table is omitted when there is exactly one round and every value in it is zero.
 - **Issue groups**: bucketed from `Object.values(ledger.issues)` by status, ordered `needs_human → closed (fixed) → rejected → already_fixed → open` (open bucket only appears when the loop stops with non-terminal issues). Each group is capped at 20 lines, then `…and N more (see ledger.json)`.
 - **Issue line format**: `<mark> #<shortId> [<severity>] <file>:<lineStart> — <title>`, taken from the `LedgerIssueRecord` (`id`, `issue.severity`, `issue.file`, `issue.lineStart`, `issue.title`). `shortId` is the first 8 characters of the ledger UUID (same convention as run ids); it is display-only — full ids live in `ledger.json`. Marks: `✓` fixed, `!` needs human, `✗` rejected, `·` already fixed/open.
-- **Artifacts block** always printed, listing the run dir plus the files the run wrote: `summary.txt`, `metrics.json`, `ledger.json`, the trace log (`runState.tracePath`), and the transcripts directory. No filesystem probing — the writer lists what it knows it wrote.
+- **Artifacts block** always printed, listing the run dir plus the files the run writes: `summary.txt`, `metrics.json`, `ledger.json`, `trace.jsonl` (`runState.tracePath`), `agent-output.log` (`runState.logPath`), and `state.json`. No filesystem probing — the writer lists what it knows it wrote.
 - **Size budget**: a typical report is ≤ 40 lines so harness elision does not hide the verdict; the verdict is the first line and the counts stay within the tail window.
 - `summary.txt` receives the identical text as the console. `metrics.json` schema is unchanged.
 
@@ -101,21 +101,23 @@ Fix/verify decisions already stream per issue; they are restyled to the same vis
 
 `LiveRenderer` keeps a counter bag `{ round, maxRounds, open, fixed, rejected, needsHuman }`, updated by the structured issue events; zero-count segments are omitted from the line.
 
-**The seam.** `ProgressReporter` gains one method:
+**The seam.** `ProgressReporter` gains one optional method plus an optional status accessor (optional so existing fakes/reporters don't break):
 
 ```ts
-issue(event: IssueProgressEvent): void
+issue?(event: IssueProgressEvent): void
+statusSuffix?(): string
 
 type IssueProgressEvent =
+  | { type: 'round'; round: number; maxRounds: number }
   | { type: 'found'; id: string; severity: Severity; file: string; line: number; title: string }
   | { type: 'decided'; id: string; verdict: string; title: string; note?: string }
 ```
 
-- `loop-controller` calls `issue({type: 'found', …})` per new ledger addition at the review boundary.
-- `issue-processor.ts` / `issue-processor-attempts.ts` / `commit-attempt.ts` call `issue({type: 'decided', …})` where they currently emit `[fix] "…"` string logs; the old strings are replaced, not duplicated.
-- `LiveRenderer.issue()` formats the line via `event()` and updates the status counters.
+- `loop-controller` emits `round` at each round start and `found` per new ledger addition at the review/match boundary.
+- `issue-processor.ts` / `issue-processor-attempts.ts` / `commit-attempt.ts` call `issue({type: 'decided', …})` where they currently emit `[fix] "…"` decision strings; those decision strings are replaced, not duplicated (purely informational `[fix]` logs like auto-commit and ledger-save-retry stay).
+- `LiveRenderer.issue()` formats the line via `event()` and updates the status counters; `LiveRenderer.statusSuffix()` renders `round N/M · issues: X open · Y fixed · …` (zero segments omitted) and is appended to the live tick by `line-handler.renderLive` and `withLivePhase`.
 - Non-TTY mode (`dynamic === false`) prints the same lines with no ticker — behavior otherwise unchanged.
-- Any other `ProgressReporter` implementations (test fakes, file loggers) implement `issue()` by formatting to text.
+- Test fakes that want to observe issue events implement `issue()` by formatting to text via the shared `issue-format.ts` helpers; fakes that don't care omit it.
 
 ## Data flow
 

--- a/docs/superpowers/specs/2026-08-02-review-loop-live-status-and-report-polish-design.md
+++ b/docs/superpowers/specs/2026-08-02-review-loop-live-status-and-report-polish-design.md
@@ -1,0 +1,125 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Review-loop live status line + report polish
+
+Date: 2026-08-02
+Status: approved (design)
+Scope: `review-loop/` workspace — live in-run rendering (`live-renderer.ts`, `line-handler.ts`, `progress-log.ts`) and final report fixes (`summary.ts`, `summary-burndown.ts`, `cli.ts`).
+Follow-up to: `2026-08-01-review-loop-report-output-design.md` (verdict-first report + issue event seam, landed).
+
+## Problem
+
+Observed on a real 27-minute run (pool 3, output piped through `bun run --filter`):
+
+- **No persistent status line in practice.** The status suffix from the previous spec exists, but (a) it only renders on a TTY, and (b) with pool > 1 every worker writes to the same single live-line slot, clobbering each other's tool lines. The information a user glances at during a long run — current phase, elapsed wall time, tokens so far — is absent entirely.
+- **Non-TTY mode is noisy.** `dynamic === false` makes `live()` print a full progress line on *every* tool call of every worker. A 27-minute run produced ~190 lines, most of them redundant live lines; the harness elided 188 of them.
+- **Report defects:**
+  - Burndown header is a hand-written literal whose column widths don't match the `padEnd` row widths — every data column sits one space left of its header.
+  - `Cost: $0.000` is printed next to 228k input tokens: opencode reports `cost: 0` in every `step_finish` event (verified: all 90 events in the run's `agent-output.log`), so the figure is always wrong-looking. Token counts are printed as raw digits (`228819`), hard to scan.
+  - All-zero burndown rows (a round that found and decided nothing) are printed whenever the run has more than one round.
+  - `Duration` is the sum of `phaseMs` only (24m35s) while wall clock was 27m42s; ~3 minutes of setup/match/teardown is invisible.
+
+## Approach
+
+Extend the seam-based design that landed yesterday (chosen over extracting a separate `StatusBoard` state module — that would re-architect fresh code for no user-visible gain, and over report-only fixes — the user explicitly wants the persistent status line):
+
+1. `ProgressReporter` gains two optional methods: `slot(key, line | null)` for per-activity live lines and `usage(delta)` for token accumulation.
+2. `LiveRenderer` renders a multi-line live area: a persistent **status line** on top plus one line per active activity (worker/agent) below, redrawn atomically.
+3. Non-TTY mode: `slot()` is a no-op; piped output keeps only phase logs, step footers, and issue lines.
+4. Final report: burndown alignment, cost-hidden-when-zero, thousands separators, zero-row suppression, wall-clock duration.
+
+## Live area rendering
+
+TTY layout — status line always the top line of the live block, activities below in insertion order:
+
+```
+  status     round 1/2 · fix×2 · 15m02s · issues: 1 open · in 228.8k / out 9.8k
+  fixer-w1   ▶ edit issue-format.ts · 1m03s · 7 tools
+  fixer-w2   ▶ bash bun test · 42s · 12 tools
+```
+
+### The seam
+
+```ts
+// ProgressReporter gains (both optional — existing fakes don't break):
+slot?(key: string, line: string | null): void
+usage?(delta: { input: number; output: number; reasoning: number; cost: number }): void
+```
+
+- `issue()`, `statusSuffix()`, `live()`, `clearLive()`, `event()`, `log()` are unchanged as interface members. After the rework nothing outside `LiveRenderer` calls `live()`; it stays on the interface for compatibility.
+- Slot keys are the agent labels already in use — `reviewer`, `matcher`, `fixer-w1`, `fixer-w2-retry`, `inspector-w2`, `build` — unique per concurrent activity, so no new keying scheme is needed.
+
+### `LiveRenderer` state and redraw
+
+New state: `startedAt` (set on first event/slot, drives elapsed), `usage` totals, `slots: Map<string, string>` (insertion-ordered). Existing round/issue counters unchanged.
+
+- `slot(key, line)`: set/update/delete the slot, then redraw the whole block (status line + all slot lines). Multi-line redraw: track the rendered line count; on update emit `ESC[<n-1>A` (cursor up) then clear+rewrite each line. `clearLive()` clears all lines of the block.
+- `event(message)`: clear the block, write `message\n`, redraw the block below — the status line stays persistent at the bottom edge of the scrollback while history scrolls above it.
+- `usage(delta)`: accumulate totals; no immediate redraw (the next slot update or tick picks it up).
+- **Non-TTY** (`dynamic === false`): `slot()` is a no-op. `event()`/`log()`/`issue()` print exactly as today. Footers, phase logs (`[round 1/2] Reviewing...`), and issue lines still reach piped output; per-tool live lines do not.
+
+### Status line content
+
+Zero-value segments are omitted (same rule as `statusSuffix()` today):
+
+```
+  status     round 1/2 · fix×2 · 15m02s · issues: 1 open · in 228.8k / out 9.8k
+```
+
+- `round X/Y` — from the existing round event.
+- **Activity summary** — derived from active slot keys: strip the `-w<N>` / `-retry` suffixes, map to verbs (`reviewer→review`, `matcher→match`, `fixer→fix`, `inspector→inspect`, `build→build`), join with `+` and count duplicates (`fix×2`). Omitted when no slots are active.
+- Elapsed — wall time since the renderer's first event, ticking once per second while any slot is active.
+- `issues: N open · M fixed · …` — existing counters, zero segments omitted.
+- `in <k> / out <k>` — compact k-formatted cumulative tokens (`228.8k`, `9.8k`); reasoning and cost omitted from the live line (cost is always 0 from opencode today; tokens are the useful proxy).
+
+### Wiring changes
+
+- `line-handler.renderLive` calls `reporter.slot?.(ctx.label, formatLiveLine(...))` instead of `reporter.live([...])`; `dispose()` calls `reporter.slot?.(ctx.label, null)`. The per-second timer and tool-use trigger are unchanged. `formatLiveLine` keeps its current shape minus the status suffix parameter (status now lives on its own line).
+- `line-handler` on `step_finish` calls `reporter.usage?.({ input, output, reasoning, cost })` before printing the footer (footer format unchanged).
+- `withLivePhase` (used for the build check) writes its tick to `reporter.slot?.(label, …)` and clears the slot in `finally`; the `[label] running...` event stays.
+
+## Final report fixes
+
+Same overall shape as the previous spec; only these changes:
+
+- **Burndown alignment** — column widths become a single shared constant array in `summary-burndown.ts`; header and rows are both generated from it. Off-by-one drift becomes structurally impossible.
+- **Zero-activity rows dropped** — a round row with `newIssues === 0` and all decision counters 0 is omitted. If no rows remain, the `Burndown:` block is omitted (extends the existing single-all-zero-round suppression). Round numbers in the header column may skip; that's fine.
+- **Cost hidden when zero** — `usage.costUsd > 0` → `· Cost: $1.234 (in 120,000 / out 8,000 / reasoning 3,000)`; otherwise the segment reads `· Tokens: in 228,819 / out 9,824 / reasoning 49,844`. Thousands separators via `toLocaleString('en-US')` in both variants.
+- **Wall clock** — `SummaryInput` gains `wallMs: number`. `runCli` timestamps around `executeReviewLoop` and passes it through `writeRunArtifacts`. Timing line becomes:
+
+```
+Duration: 27m42s wall · phases 24m35s (review 909.5s, match 40.2s, verify 525.7s) · Tokens: in 228,819 / out 9,824 / reasoning 49,844
+```
+
+`metrics.json` schema is unchanged (phase sums stay as they are; wall time is console/summary.txt-only).
+
+## Error handling
+
+- All renderer stream writes are wrapped: on `EPIPE` or any write throw, the renderer permanently downgrades to non-dynamic and swallows the error. A broken pipe must never kill a multi-hour run.
+- Report builders stay pure formatting over in-memory data — no new failure modes. Existing `metrics.json` warn-and-continue behavior is unchanged.
+
+## Testing
+
+TDD per workspace rules (`review-loop/src/**` gates against `tests/review-loop/**`):
+
+- **`live-renderer.test.ts`** (extend): slot set/update/clear; multi-line redraw byte sequence (cursor-up counts match rendered line count); `event()` interleaving (block clears → message prints → block redraws); status line segment composition (round, activity verbs with `×N`, elapsed, issues, k-formatted tokens; zero-omission per segment); `usage()` accumulation; non-TTY `slot()` no-op; EPIPE downgrade.
+- **`line-handler.test.ts`** (extend): `step_finish` forwards a `usage()` call with the step's tokens; `dispose()` clears the label's slot.
+- **`summary-burndown.test.ts`** (new or extended): header and row cell boundaries are identical; zero-activity rows dropped; table omitted when all rows dropped.
+- **`summary.test.ts`** (extend): cost>0 vs cost=0 timing-line variants; thousands separators; wall-time rendering; `metrics.json` shape unchanged.
+- Loop-level fake reporters that don't implement `slot`/`usage` must keep passing unchanged (both methods optional).
+
+## Out of scope
+
+- Verdict wording changes (`done — …` stays as specified in the previous spec).
+- Cost estimation from a model pricing table.
+- Colors, hyperlinks, sound, notifications.
+- `metrics.json` / trace schema changes; new CLI flags (everything is default-on).
+
+## Rollout
+
+Single change-set: live-area rework + report fixes land together, no flags. Output-only change; safe to default-on.

--- a/review-loop/src/build-checker.ts
+++ b/review-loop/src/build-checker.ts
@@ -5,7 +5,8 @@
 
 import { execFile } from 'node:child_process'
 
-import { formatDuration, withLivePhase } from './live-renderer.js'
+import { formatDuration } from './live-format.js'
+import { withLivePhase } from './live-renderer.js'
 import type { ProgressReporter } from './progress-log.js'
 
 export type ShellExecFn = (cwd?: string) => Promise<{ exitCode: number; stdout: string; stderr: string }>

--- a/review-loop/src/cli.ts
+++ b/review-loop/src/cli.ts
@@ -164,7 +164,7 @@ export async function prepareWorktree(config: ReviewLoopConfig, runState: RunSta
 export async function writeRunArtifacts(
   runDir: string,
   result: ReviewLoopResult,
-  options: { poolSize: number; inspect: boolean },
+  options: { poolSize: number; inspect: boolean; wallMs: number },
 ): Promise<void> {
   const closed = Object.values(result.ledger.issues).filter((r) => r.status === 'closed').length
   const summary = buildSummary({
@@ -173,7 +173,8 @@ export async function writeRunArtifacts(
     metrics: result.metrics ?? [],
     ledger: result.ledger,
     runDir,
-    options,
+    wallMs: options.wallMs,
+    options: { poolSize: options.poolSize, inspect: options.inspect },
   })
   await writeFile(path.join(runDir, 'summary.txt'), `${summary}\n`)
   try {
@@ -196,6 +197,7 @@ async function executeReviewLoop(
   trace: TraceLogger,
   pool: WorkerPool,
   inspect: boolean,
+  startedAt: number,
 ): Promise<void> {
   const result = await runReviewLoop({
     config,
@@ -210,11 +212,16 @@ async function executeReviewLoop(
   })
   // Write summary/metrics/trace BEFORE finalizeRun so they always exist for
   // post-mortem, even if the final build check or merge throws.
-  await writeRunArtifacts(runState.runDir, result, { poolSize: config.poolSize, inspect })
+  await writeRunArtifacts(runState.runDir, result, {
+    poolSize: config.poolSize,
+    inspect,
+    wallMs: Date.now() - startedAt,
+  })
   await finalizeRun(config, runState, { exec, runBuildCheck, mergeWorktree, removeWorktree })
 }
 
 export async function runCli(argv: readonly string[]): Promise<void> {
+  const startedAt = Date.now()
   const args = parseCliArgs(argv)
   const config = await loadReviewLoopConfig({ configPath: args.configPath, repoRoot: args.repoRoot })
   if (args.poolSize !== undefined) config.poolSize = args.poolSize
@@ -236,7 +243,7 @@ export async function runCli(argv: readonly string[]): Promise<void> {
   const pool = await createWorkerPool(config, runState)
 
   try {
-    await executeReviewLoop(config, runState, ledger, exec, log, trace, pool, !args.noInspect)
+    await executeReviewLoop(config, runState, ledger, exec, log, trace, pool, !args.noInspect, startedAt)
   } finally {
     await pool.close()
   }

--- a/review-loop/src/cli.ts
+++ b/review-loop/src/cli.ts
@@ -167,7 +167,14 @@ export async function writeRunArtifacts(
   options: { poolSize: number; inspect: boolean },
 ): Promise<void> {
   const closed = Object.values(result.ledger.issues).filter((r) => r.status === 'closed').length
-  const summary = buildSummary(result.doneReason, result.rounds, closed, result.metrics ?? [], options)
+  const summary = buildSummary({
+    doneReason: result.doneReason,
+    rounds: result.rounds,
+    metrics: result.metrics ?? [],
+    ledger: result.ledger,
+    runDir,
+    options,
+  })
   await writeFile(path.join(runDir, 'summary.txt'), `${summary}\n`)
   try {
     await writeFile(

--- a/review-loop/src/commit-attempt.ts
+++ b/review-loop/src/commit-attempt.ts
@@ -8,6 +8,7 @@ import { sanitizeSubject, shortTitle } from './issue-processor.js'
 import type { IssueProcessorDeps } from './issue-processor.js'
 import type { FixerResult } from './issue-schema.js'
 import { emitFixComplete, tallyDecision, tallyFixerSeverity, tallyPhaseMs, type RoundCollector } from './loop-trace.js'
+import { emitDecision } from './progress-log.js'
 import type { Worker } from './worker-pool.js'
 import { execGit } from './worktree.js'
 
@@ -49,7 +50,7 @@ export async function runCommitAttempt(
       collector.decisions.no_commit += 1
       tallyFixerSeverity(collector, fixerResult.severity)
       emitFixComplete(deps.trace, round, record.id, false, null, attempt)
-      deps.log.log(`[fix] "${shortTitle(record)}" → no change (fixed:true was a false claim)`)
+      emitDecision(deps.log, record, 'no_commit', 'fixed:true was a false claim')
       return { fixed: false }
     }
 
@@ -60,7 +61,7 @@ export async function runCommitAttempt(
       recordNeedsHuman(deps.ledger, deps.trace, round, record, reasoning, fixerResult)
       tallyDecision(collector, 'needs_human', false)
       tallyFixerSeverity(collector, fixerResult.severity)
-      deps.log.log(`[fix] "${shortTitle(record)}" → needs_human (merge conflict)`)
+      emitDecision(deps.log, record, 'needs_human', 'merge conflict')
       emitFixComplete(deps.trace, round, record.id, false, null, attempt)
       return { fixed: false }
     }
@@ -68,9 +69,7 @@ export async function runCommitAttempt(
     recordFixAttempt(deps.ledger, record.id)
     tallyDecision(collector, fixerResult.verdict, fixerResult.fixed)
     tallyFixerSeverity(collector, fixerResult.severity)
-    deps.log.log(
-      attempt === 1 ? `[fix] "${shortTitle(record)}" → fixed` : `[fix] "${shortTitle(record)}" → fixed (after retry)`,
-    )
+    emitDecision(deps.log, record, 'fixed', attempt === 1 ? undefined : 'after retry')
     emitFixComplete(deps.trace, round, record.id, true, postSha, attempt)
     return { fixed: true }
   } finally {

--- a/review-loop/src/issue-format.ts
+++ b/review-loop/src/issue-format.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { LedgerIssueStatus } from './issue-ledger.js'
+
+const CHECK = '✓'
+const CROSS = '✗'
+const DOT = '·'
+const BANG = '!'
+
+export function shortIssueId(id: string): string {
+  return id.slice(0, 8)
+}
+
+export interface IssueRef {
+  id: string
+  severity: string
+  file: string
+  line: number
+  title: string
+}
+
+export function formatIssueRef(ref: IssueRef): string {
+  return `#${shortIssueId(ref.id)} ${`[${ref.severity}]`.padEnd(10)} ${ref.file}:${ref.line} — ${ref.title}`
+}
+
+export function formatFoundLine(ref: IssueRef): string {
+  return `  + ${formatIssueRef(ref)}`
+}
+
+const DECIDED_MARK: Record<string, string> = {
+  fixed: CHECK,
+  invalid: CROSS,
+  already_fixed: DOT,
+  needs_human: BANG,
+  plan_drift: BANG,
+  no_commit: DOT,
+}
+
+const DECIDED_LABEL: Record<string, string> = {
+  fixed: 'fixed',
+  invalid: 'rejected',
+  already_fixed: 'already fixed',
+  needs_human: 'needs human',
+  plan_drift: 'plan drift',
+  no_commit: 'no change',
+}
+
+export function formatDecidedLine(args: { id: string; verdict: string; note?: string }): string {
+  const mark = DECIDED_MARK[args.verdict] ?? DOT
+  const label = DECIDED_LABEL[args.verdict] ?? args.verdict
+  const note = args.note === undefined ? '' : ` (${args.note})`
+  return `${mark} #${shortIssueId(args.id)} → ${label}${note}`
+}
+
+export type IssueGroup = 'needsHuman' | 'fixed' | 'rejected' | 'alreadyFixed' | 'open'
+
+export const GROUP_ORDER: readonly IssueGroup[] = ['needsHuman', 'fixed', 'rejected', 'alreadyFixed', 'open']
+
+export const GROUP_LABEL: Record<IssueGroup, string> = {
+  needsHuman: 'needs human',
+  fixed: 'fixed',
+  rejected: 'rejected',
+  alreadyFixed: 'already fixed',
+  open: 'open',
+}
+
+export const GROUP_MARK: Record<IssueGroup, string> = {
+  needsHuman: BANG,
+  fixed: CHECK,
+  rejected: CROSS,
+  alreadyFixed: DOT,
+  open: DOT,
+}
+
+export function groupForStatus(status: LedgerIssueStatus): IssueGroup {
+  switch (status) {
+    case 'needs_human':
+      return 'needsHuman'
+    case 'closed':
+      return 'fixed'
+    case 'rejected':
+      return 'rejected'
+    case 'already_fixed':
+      return 'alreadyFixed'
+    case 'discovered':
+    case 'verified':
+    case 'fixed_pending_review':
+    case 'reopened':
+      return 'open'
+    default:
+      throw new Error('Unhandled ledger issue status')
+  }
+}

--- a/review-loop/src/issue-processor-attempts.ts
+++ b/review-loop/src/issue-processor-attempts.ts
@@ -8,7 +8,7 @@ import { runBuildWithLogging } from './build-checker.js'
 import { runCommitAttempt } from './commit-attempt.js'
 import { runInspectorOrTreatAsRejection } from './issue-inspector.js'
 import { recordNeedsHuman, recordVerify, type LedgerIssueRecord } from './issue-ledger.js'
-import { shortTitle, type IssueProcessorDeps } from './issue-processor.js'
+import type { IssueProcessorDeps } from './issue-processor.js'
 import { FixerResultSchema, type FixerResult } from './issue-schema.js'
 import {
   emitBuildComplete,
@@ -19,6 +19,7 @@ import {
   tallyUsage,
   type RoundCollector,
 } from './loop-trace.js'
+import { emitDecision } from './progress-log.js'
 import { buildFixPrompt, buildRetryFixPrompt, buildRetryFixWithInspectorFeedbackPrompt } from './prompt-templates.js'
 import { workerOutputPath } from './run-state.js'
 import type { Worker } from './worker-pool.js'
@@ -109,7 +110,7 @@ export async function runFixerAttempt(
     await worker.resetToBaseline(baselineSha)
     tallyDecision(collector, fixerResult.verdict, fixerResult.fixed)
     tallyFixerSeverity(collector, fixerResult.severity)
-    deps.log.log(`[fix] "${shortTitle(record)}" → ${fixerResult.verdict}`)
+    emitDecision(deps.log, record, fixerResult.verdict)
     emitFixComplete(deps.trace, round, record.id, false, null, attempt)
     return { kind: 'terminal', outcome: { fixed: false } }
   }
@@ -147,7 +148,7 @@ export async function runBuildAttempt(
       )
       tallyDecision(collector, 'needs_human', false)
       tallyFixerSeverity(collector, fixerResult.severity)
-      deps.log.log(`[fix] "${shortTitle(record)}" → needs_human (build failed)`)
+      emitDecision(deps.log, record, 'needs_human', 'build failed')
       emitFixComplete(deps.trace, round, record.id, false, null, attempt)
       return { kind: 'terminal', outcome: { fixed: false } }
     }
@@ -199,9 +200,8 @@ export async function runInspectorAttempt(
       )
       tallyDecision(collector, unavailable ? 'needs_human' : 'inspector_rejected', false)
       tallyFixerSeverity(collector, fixerResult.severity)
-      deps.log.log(
-        `[fix] "${shortTitle(record)}" → needs_human (${unavailable ? 'inspector unavailable' : 'inspector rejected'})`,
-      )
+      const note = unavailable ? 'inspector unavailable' : 'inspector rejected'
+      emitDecision(deps.log, record, 'needs_human', note)
       emitFixComplete(deps.trace, round, record.id, false, null, attempt)
       return { kind: 'terminal', outcome: { fixed: false } }
     }

--- a/review-loop/src/issue-processor.ts
+++ b/review-loop/src/issue-processor.ts
@@ -9,6 +9,7 @@ import { recordNeedsHuman, saveIssueLedger, type IssueLedger, type LedgerIssueRe
 import { processIssueAttempt, type IssueWorker, type RetryReason } from './issue-processor-attempts.js'
 import type { FixerResult } from './issue-schema.js'
 import { emitFixComplete, tallyDecision, truncate, type RoundCollector } from './loop-trace.js'
+import { emitDecision } from './progress-log.js'
 import type { ProgressReporter } from './progress-log.js'
 import type { RunState } from './run-state.js'
 import type { TraceLogger } from './trace-log.js'
@@ -47,6 +48,19 @@ function fallbackFixerResult(reasoning: string): FixerResult {
     targetFiles: [],
     fixed: false,
   }
+}
+
+function recordProcessingFailure(
+  deps: IssueProcessorDeps,
+  round: number,
+  collector: RoundCollector,
+  record: LedgerIssueRecord,
+  msg: string,
+): void {
+  recordNeedsHuman(deps.ledger, deps.trace, round, record, `issue processing failed: ${msg}`, fallbackFixerResult(msg))
+  tallyDecision(collector, 'needs_human', false)
+  emitDecision(deps.log, record, 'needs_human', `issue processing failed: ${msg}`)
+  emitFixComplete(deps.trace, round, record.id, false, null, 1)
 }
 
 async function processIssue(
@@ -121,17 +135,7 @@ function makeDispatcher(args: {
       result = await processIssue(record, deps, worker, round, collector)
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)
-      recordNeedsHuman(
-        deps.ledger,
-        deps.trace,
-        round,
-        record,
-        `issue processing failed: ${msg}`,
-        fallbackFixerResult(msg),
-      )
-      tallyDecision(collector, 'needs_human', false)
-      deps.log.log(`[fix] "${shortTitle(record)}" → needs_human (issue processing failed: ${msg})`)
-      emitFixComplete(deps.trace, round, record.id, false, null, 1)
+      recordProcessingFailure(deps, round, collector, record, msg)
     }
     try {
       await save(deps.ledger)

--- a/review-loop/src/line-handler.ts
+++ b/review-loop/src/line-handler.ts
@@ -39,7 +39,12 @@ function renderLive(ctx: LiveCtx): void {
     return
   }
   const elapsed = ctx.startedAt === 0 ? 0 : Date.now() - ctx.startedAt
-  reporter.live([formatLiveLine(ctx.label, ctx.tool, ctx.arg, elapsed, ctx.toolCount, reporter.statusSuffix?.() ?? '')])
+  const line = formatLiveLine(ctx.label, ctx.tool, ctx.arg, elapsed, ctx.toolCount)
+  if (reporter.slot === undefined) {
+    reporter.live([line])
+  } else {
+    reporter.slot(ctx.label, line)
+  }
 }
 
 function applyEvent(evt: OpencodeEvent, ctx: LiveCtx): void {
@@ -71,6 +76,12 @@ function applyEvent(evt: OpencodeEvent, ctx: LiveCtx): void {
       ctx.usage.reasoningTokens += evt.tokens.reasoning
       ctx.usage.costUsd += evt.cost
       if (reporter !== undefined) {
+        reporter.usage?.({
+          input: evt.tokens.input,
+          output: evt.tokens.output,
+          reasoning: evt.tokens.reasoning,
+          cost: evt.cost,
+        })
         reporter.clearLive()
         reporter.event(
           formatStepFooter(ctx.label, ctx.startedAt === 0 ? 0 : Date.now() - ctx.startedAt, ctx.toolCount, evt.tokens),
@@ -110,7 +121,11 @@ export function createLineHandler<T>(options: RunAgentOptions<T>): LineHandler {
     }
     const reporter = ctx.reporter
     if (reporter !== undefined) {
-      reporter.clearLive()
+      if (reporter.slot === undefined) {
+        reporter.clearLive()
+      } else {
+        reporter.slot(ctx.label, null)
+      }
     }
     await ctx.logChain
   }

--- a/review-loop/src/line-handler.ts
+++ b/review-loop/src/line-handler.ts
@@ -39,7 +39,7 @@ function renderLive(ctx: LiveCtx): void {
     return
   }
   const elapsed = ctx.startedAt === 0 ? 0 : Date.now() - ctx.startedAt
-  reporter.live([formatLiveLine(ctx.label, ctx.tool, ctx.arg, elapsed, ctx.toolCount)])
+  reporter.live([formatLiveLine(ctx.label, ctx.tool, ctx.arg, elapsed, ctx.toolCount, reporter.statusSuffix?.() ?? '')])
 }
 
 function applyEvent(evt: OpencodeEvent, ctx: LiveCtx): void {

--- a/review-loop/src/line-handler.ts
+++ b/review-loop/src/line-handler.ts
@@ -7,7 +7,7 @@ import { appendFile } from 'node:fs/promises'
 
 import type { AgentUsage, LineSink, RunAgentOptions } from './agent-runner.js'
 import { type OpencodeEvent, parseEventLine } from './event-stream.js'
-import { formatLiveLine, formatStepFooter, formatToolArg } from './live-renderer.js'
+import { formatLiveLine, formatStepFooter, formatToolArg } from './live-format.js'
 import type { ProgressReporter } from './progress-log.js'
 
 export interface LineHandler {

--- a/review-loop/src/live-format.ts
+++ b/review-loop/src/live-format.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import path from 'node:path'
+
+const ELLIPSIS = '\u2026'
+const ARROW = '\u25B6'
+const CHECK = '\u2713'
+export const MIDDLE_DOT = '\u00B7'
+const TIMES = '×'
+
+export function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`
+  }
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}m${seconds.toString().padStart(2, '0')}s`
+}
+
+export function truncate(value: string, max: number): string {
+  if (max <= 0) {
+    return ''
+  }
+  if (value.length <= max) {
+    return value
+  }
+  return `${value.slice(0, max - 1)}${ELLIPSIS}`
+}
+
+function pickString(obj: Record<string, unknown>, keys: readonly string[]): string {
+  for (const key of keys) {
+    const value = obj[key]
+    if (typeof value === 'string' && value.length > 0) {
+      return value
+    }
+  }
+  return ''
+}
+
+function firstStringValue(obj: Record<string, unknown>): string {
+  for (const value of Object.values(obj)) {
+    if (typeof value === 'string' && value.length > 0) {
+      return value
+    }
+  }
+  return ''
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object'
+}
+
+export function formatToolArg(tool: string, input: unknown): string {
+  const obj = isRecord(input) ? input : {}
+  switch (tool) {
+    case 'read':
+    case 'edit':
+    case 'write': {
+      const filePath = pickString(obj, ['filePath', 'path'])
+      return filePath === '' ? '' : path.basename(filePath)
+    }
+    case 'bash':
+      return truncate(pickString(obj, ['command']), 40)
+    case 'grep':
+    case 'glob':
+      return truncate(pickString(obj, ['pattern']), 40)
+    case 'task':
+      return truncate(pickString(obj, ['description', 'subagent_type']), 40)
+    default:
+      return truncate(firstStringValue(obj), 40)
+  }
+}
+
+export function formatLiveLine(
+  label: string,
+  tool: string,
+  arg: string,
+  elapsedMs: number,
+  toolCount: number,
+  status = '',
+): string {
+  const toolPart = tool === '' ? 'thinking' : arg === '' ? tool : `${tool} ${arg}`
+  const tools = `${toolCount} tool${toolCount === 1 ? '' : 's'}`
+  const suffix = status === '' ? '' : ` ${MIDDLE_DOT} ${status}`
+  return `  ${label.padEnd(10)} ${ARROW} ${toolPart} ${MIDDLE_DOT} ${formatDuration(elapsedMs)} ${MIDDLE_DOT} ${tools}${suffix}`
+}
+
+export function formatStepFooter(
+  label: string,
+  elapsedMs: number,
+  toolCount: number,
+  tokens: { input: number; output: number },
+): string {
+  const tools = `${toolCount} tool${toolCount === 1 ? '' : 's'}`
+  return `  ${label} ${CHECK} ${formatDuration(elapsedMs)} ${MIDDLE_DOT} ${tools} ${MIDDLE_DOT} in ${tokens.input} / out ${tokens.output}`
+}
+
+export function formatTokenCount(n: number): string {
+  if (n < 1000) return String(n)
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`
+  return `${(n / 1_000_000).toFixed(2)}M`
+}
+
+const ACTIVITY_VERB: Record<string, string> = {
+  reviewer: 'review',
+  matcher: 'match',
+  fixer: 'fix',
+  inspector: 'inspect',
+  build: 'build',
+}
+
+export function activitySummary(keys: Iterable<string>): string {
+  const counts = new Map<string, number>()
+  for (const key of keys) {
+    const base = key.split('-')[0] ?? key
+    const verb = ACTIVITY_VERB[base] ?? base
+    counts.set(verb, (counts.get(verb) ?? 0) + 1)
+  }
+  const parts: string[] = []
+  for (const [verb, n] of counts) {
+    parts.push(n === 1 ? verb : `${verb}${TIMES}${n}`)
+  }
+  return parts.join('+')
+}

--- a/review-loop/src/live-format.ts
+++ b/review-loop/src/live-format.ts
@@ -75,18 +75,10 @@ export function formatToolArg(tool: string, input: unknown): string {
   }
 }
 
-export function formatLiveLine(
-  label: string,
-  tool: string,
-  arg: string,
-  elapsedMs: number,
-  toolCount: number,
-  status = '',
-): string {
+export function formatLiveLine(label: string, tool: string, arg: string, elapsedMs: number, toolCount: number): string {
   const toolPart = tool === '' ? 'thinking' : arg === '' ? tool : `${tool} ${arg}`
   const tools = `${toolCount} tool${toolCount === 1 ? '' : 's'}`
-  const suffix = status === '' ? '' : ` ${MIDDLE_DOT} ${status}`
-  return `  ${label.padEnd(10)} ${ARROW} ${toolPart} ${MIDDLE_DOT} ${formatDuration(elapsedMs)} ${MIDDLE_DOT} ${tools}${suffix}`
+  return `  ${label.padEnd(10)} ${ARROW} ${toolPart} ${MIDDLE_DOT} ${formatDuration(elapsedMs)} ${MIDDLE_DOT} ${tools}`
 }
 
 export function formatStepFooter(

--- a/review-loop/src/live-renderer.ts
+++ b/review-loop/src/live-renderer.ts
@@ -30,9 +30,12 @@ export async function withLivePhase<T>(
   let timer: ReturnType<typeof setInterval> | null = null
   if (reporter.dynamic) {
     timer = setInterval(() => {
-      const status = reporter.statusSuffix?.() ?? ''
-      const suffix = status === '' ? '' : ` ${MIDDLE_DOT} ${status}`
-      reporter.live([`[${label}] ${formatDuration(Date.now() - start)}...${suffix}`])
+      const line = `[${label}] ${formatDuration(Date.now() - start)}...`
+      if (reporter.slot === undefined) {
+        reporter.live([line])
+      } else {
+        reporter.slot(label, line)
+      }
     }, 1000)
   }
   try {
@@ -42,7 +45,11 @@ export async function withLivePhase<T>(
     if (timer !== null) {
       clearInterval(timer)
     }
-    reporter.clearLive()
+    if (reporter.slot === undefined) {
+      reporter.clearLive()
+    } else {
+      reporter.slot(label, null)
+    }
   }
 }
 

--- a/review-loop/src/live-renderer.ts
+++ b/review-loop/src/live-renderer.ts
@@ -5,7 +5,8 @@
 
 import path from 'node:path'
 
-import type { ProgressReporter } from './progress-log.js'
+import { formatDecidedLine, formatFoundLine } from './issue-format.js'
+import type { IssueProgressEvent, ProgressReporter } from './progress-log.js'
 
 const ELLIPSIS = '\u2026'
 const ARROW = '\u25B6'
@@ -84,10 +85,18 @@ export function formatToolArg(tool: string, input: unknown): string {
   }
 }
 
-export function formatLiveLine(label: string, tool: string, arg: string, elapsedMs: number, toolCount: number): string {
+export function formatLiveLine(
+  label: string,
+  tool: string,
+  arg: string,
+  elapsedMs: number,
+  toolCount: number,
+  status = '',
+): string {
   const toolPart = tool === '' ? 'thinking' : arg === '' ? tool : `${tool} ${arg}`
   const tools = `${toolCount} tool${toolCount === 1 ? '' : 's'}`
-  return `  ${label.padEnd(10)} ${ARROW} ${toolPart} ${MIDDLE_DOT} ${formatDuration(elapsedMs)} ${MIDDLE_DOT} ${tools}`
+  const suffix = status === '' ? '' : ` ${MIDDLE_DOT} ${status}`
+  return `  ${label.padEnd(10)} ${ARROW} ${toolPart} ${MIDDLE_DOT} ${formatDuration(elapsedMs)} ${MIDDLE_DOT} ${tools}${suffix}`
 }
 
 export function formatStepFooter(
@@ -110,7 +119,9 @@ export async function withLivePhase<T>(
   let timer: ReturnType<typeof setInterval> | null = null
   if (reporter.dynamic) {
     timer = setInterval(() => {
-      reporter.live([`[${label}] ${formatDuration(Date.now() - start)}...`])
+      const status = reporter.statusSuffix?.() ?? ''
+      const suffix = status === '' ? '' : ` ${MIDDLE_DOT} ${status}`
+      reporter.live([`[${label}] ${formatDuration(Date.now() - start)}...${suffix}`])
     }, 1000)
   }
   try {
@@ -128,10 +139,44 @@ export class LiveRenderer implements ProgressReporter {
   readonly dynamic: boolean
   private readonly stream: RendererStream
   private liveActive = false
+  private round = 0
+  private maxRounds = 0
+  private readonly counts = { open: 0, fixed: 0, rejected: 0, needsHuman: 0 }
 
   constructor(stream: RendererStream) {
     this.stream = stream
     this.dynamic = stream.isTTY === true
+  }
+
+  issue(event: IssueProgressEvent): void {
+    switch (event.type) {
+      case 'round':
+        this.round = event.round
+        this.maxRounds = event.maxRounds
+        return
+      case 'found':
+        this.counts.open += 1
+        this.event(formatFoundLine(event))
+        return
+      case 'decided':
+        this.counts.open = Math.max(0, this.counts.open - 1)
+        if (event.verdict === 'fixed') this.counts.fixed += 1
+        else if (event.verdict === 'invalid') this.counts.rejected += 1
+        else if (event.verdict === 'needs_human' || event.verdict === 'plan_drift') this.counts.needsHuman += 1
+        this.event(formatDecidedLine(event))
+    }
+  }
+
+  statusSuffix(): string {
+    const parts: string[] = []
+    if (this.round > 0) parts.push(`round ${this.round}/${this.maxRounds}`)
+    const segments: string[] = []
+    if (this.counts.open > 0) segments.push(`${this.counts.open} open`)
+    if (this.counts.fixed > 0) segments.push(`${this.counts.fixed} fixed`)
+    if (this.counts.rejected > 0) segments.push(`${this.counts.rejected} rejected`)
+    if (this.counts.needsHuman > 0) segments.push(`${this.counts.needsHuman} needs human`)
+    if (segments.length > 0) parts.push(`issues: ${segments.join(' · ')}`)
+    return parts.join(' · ')
   }
 
   event(message: string): void {

--- a/review-loop/src/live-renderer.ts
+++ b/review-loop/src/live-renderer.ts
@@ -3,15 +3,9 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import path from 'node:path'
-
 import { formatDecidedLine, formatFoundLine } from './issue-format.js'
+import { activitySummary, formatDuration, formatTokenCount, MIDDLE_DOT, truncate } from './live-format.js'
 import type { IssueProgressEvent, ProgressReporter, UsageDelta } from './progress-log.js'
-
-const ELLIPSIS = '\u2026'
-const ARROW = '\u25B6'
-const CHECK = '\u2713'
-const MIDDLE_DOT = '\u00B7'
 
 const ERASE_LINE = '\u001b[2K'
 const CURSOR_DOWN = '\u001b[1B'
@@ -24,94 +18,6 @@ export interface RendererStream {
   write(chunk: string): boolean
   isTTY?: boolean
   columns?: number
-}
-
-export function formatDuration(ms: number): string {
-  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
-  if (totalSeconds < 60) {
-    return `${totalSeconds}s`
-  }
-  const minutes = Math.floor(totalSeconds / 60)
-  const seconds = totalSeconds % 60
-  return `${minutes}m${seconds.toString().padStart(2, '0')}s`
-}
-
-function truncate(value: string, max: number): string {
-  if (max <= 0) {
-    return ''
-  }
-  if (value.length <= max) {
-    return value
-  }
-  return `${value.slice(0, max - 1)}${ELLIPSIS}`
-}
-
-function pickString(obj: Record<string, unknown>, keys: readonly string[]): string {
-  for (const key of keys) {
-    const value = obj[key]
-    if (typeof value === 'string' && value.length > 0) {
-      return value
-    }
-  }
-  return ''
-}
-
-function firstStringValue(obj: Record<string, unknown>): string {
-  for (const value of Object.values(obj)) {
-    if (typeof value === 'string' && value.length > 0) {
-      return value
-    }
-  }
-  return ''
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object'
-}
-
-export function formatToolArg(tool: string, input: unknown): string {
-  const obj = isRecord(input) ? input : {}
-  switch (tool) {
-    case 'read':
-    case 'edit':
-    case 'write': {
-      const filePath = pickString(obj, ['filePath', 'path'])
-      return filePath === '' ? '' : path.basename(filePath)
-    }
-    case 'bash':
-      return truncate(pickString(obj, ['command']), 40)
-    case 'grep':
-    case 'glob':
-      return truncate(pickString(obj, ['pattern']), 40)
-    case 'task':
-      return truncate(pickString(obj, ['description', 'subagent_type']), 40)
-    default:
-      return truncate(firstStringValue(obj), 40)
-  }
-}
-
-export function formatLiveLine(
-  label: string,
-  tool: string,
-  arg: string,
-  elapsedMs: number,
-  toolCount: number,
-  status = '',
-): string {
-  const toolPart = tool === '' ? 'thinking' : arg === '' ? tool : `${tool} ${arg}`
-  const tools = `${toolCount} tool${toolCount === 1 ? '' : 's'}`
-  const suffix = status === '' ? '' : ` ${MIDDLE_DOT} ${status}`
-  return `  ${label.padEnd(10)} ${ARROW} ${toolPart} ${MIDDLE_DOT} ${formatDuration(elapsedMs)} ${MIDDLE_DOT} ${tools}${suffix}`
-}
-
-export function formatStepFooter(
-  label: string,
-  elapsedMs: number,
-  toolCount: number,
-  tokens: { input: number; output: number },
-): string {
-  const tools = `${toolCount} tool${toolCount === 1 ? '' : 's'}`
-  return `  ${label} ${CHECK} ${formatDuration(elapsedMs)} ${MIDDLE_DOT} ${tools} ${MIDDLE_DOT} in ${tokens.input} / out ${tokens.output}`
 }
 
 export async function withLivePhase<T>(
@@ -247,8 +153,22 @@ export class LiveRenderer implements ProgressReporter {
 
   private statusLine(): string {
     if (this.slots.size === 0) return ''
-    const suffix = this.statusSuffix()
-    return suffix === '' ? '' : `  ${'status'.padEnd(10)} ${suffix}`
+    const parts: string[] = []
+    if (this.round > 0) parts.push(`round ${this.round}/${this.maxRounds}`)
+    const activity = activitySummary(this.slots.keys())
+    if (activity !== '') parts.push(activity)
+    if (this.startedAt !== 0) parts.push(formatDuration(Date.now() - this.startedAt))
+    const segments: string[] = []
+    if (this.counts.open > 0) segments.push(`${this.counts.open} open`)
+    if (this.counts.fixed > 0) segments.push(`${this.counts.fixed} fixed`)
+    if (this.counts.rejected > 0) segments.push(`${this.counts.rejected} rejected`)
+    if (this.counts.needsHuman > 0) segments.push(`${this.counts.needsHuman} needs human`)
+    if (segments.length > 0) parts.push(`issues: ${segments.join(` ${MIDDLE_DOT} `)}`)
+    if (this.usageTotals.input > 0 || this.usageTotals.output > 0) {
+      parts.push(`in ${formatTokenCount(this.usageTotals.input)} / out ${formatTokenCount(this.usageTotals.output)}`)
+    }
+    if (parts.length === 0) return ''
+    return `  ${'status'.padEnd(10)} ${parts.join(` ${MIDDLE_DOT} `)}`
   }
 
   private renderBlock(): void {

--- a/review-loop/src/live-renderer.ts
+++ b/review-loop/src/live-renderer.ts
@@ -6,14 +6,19 @@
 import path from 'node:path'
 
 import { formatDecidedLine, formatFoundLine } from './issue-format.js'
-import type { IssueProgressEvent, ProgressReporter } from './progress-log.js'
+import type { IssueProgressEvent, ProgressReporter, UsageDelta } from './progress-log.js'
 
 const ELLIPSIS = '\u2026'
 const ARROW = '\u25B6'
 const CHECK = '\u2713'
 const MIDDLE_DOT = '\u00B7'
 
-const CLEAR_LINE = '\r\u001b[2K'
+const ERASE_LINE = '\u001b[2K'
+const CURSOR_DOWN = '\u001b[1B'
+
+function cursorUp(n: number): string {
+  return `\u001b[${n}A`
+}
 
 export interface RendererStream {
   write(chunk: string): boolean
@@ -136,19 +141,28 @@ export async function withLivePhase<T>(
 }
 
 export class LiveRenderer implements ProgressReporter {
-  readonly dynamic: boolean
+  private readonly tty: boolean
+  private broken = false
   private readonly stream: RendererStream
-  private liveActive = false
+  private renderedLines = 0
+  private startedAt = 0
   private round = 0
   private maxRounds = 0
   private readonly counts = { open: 0, fixed: 0, rejected: 0, needsHuman: 0 }
+  private readonly usageTotals: UsageDelta = { input: 0, output: 0, reasoning: 0, cost: 0 }
+  private readonly slots = new Map<string, string>()
 
   constructor(stream: RendererStream) {
     this.stream = stream
-    this.dynamic = stream.isTTY === true
+    this.tty = stream.isTTY === true
+  }
+
+  get dynamic(): boolean {
+    return this.tty && !this.broken
   }
 
   issue(event: IssueProgressEvent): void {
+    this.touch()
     switch (event.type) {
       case 'round':
         this.round = event.round
@@ -175,13 +189,38 @@ export class LiveRenderer implements ProgressReporter {
     if (this.counts.fixed > 0) segments.push(`${this.counts.fixed} fixed`)
     if (this.counts.rejected > 0) segments.push(`${this.counts.rejected} rejected`)
     if (this.counts.needsHuman > 0) segments.push(`${this.counts.needsHuman} needs human`)
-    if (segments.length > 0) parts.push(`issues: ${segments.join(' · ')}`)
-    return parts.join(' · ')
+    if (segments.length > 0) parts.push(`issues: ${segments.join(` ${MIDDLE_DOT} `)}`)
+    return parts.join(` ${MIDDLE_DOT} `)
+  }
+
+  slot(key: string, line: string | null): void {
+    this.touch()
+    if (line === null) {
+      this.slots.delete(key)
+    } else {
+      this.slots.set(key, line)
+    }
+    if (!this.dynamic) return
+    this.renderBlock()
+  }
+
+  usage(delta: UsageDelta): void {
+    this.touch()
+    this.usageTotals.input += delta.input
+    this.usageTotals.output += delta.output
+    this.usageTotals.reasoning += delta.reasoning
+    this.usageTotals.cost += delta.cost
   }
 
   event(message: string): void {
-    this.clearLive()
-    this.stream.write(`${message}\n`)
+    this.touch()
+    if (!this.dynamic) {
+      this.writeSafe(`${message}\n`)
+      return
+    }
+    this.clearBlock()
+    this.writeSafe(`${message}\n`)
+    this.renderBlock()
   }
 
   log(message: string): void {
@@ -191,21 +230,65 @@ export class LiveRenderer implements ProgressReporter {
   live(lines: readonly string[]): void {
     if (!this.dynamic) {
       for (const line of lines) {
-        this.stream.write(`${line}\n`)
+        this.writeSafe(`${line}\n`)
       }
       return
     }
-    const output = lines.map((line) => this.fit(line)).join('\n')
-    this.stream.write(`${CLEAR_LINE}${output}`)
-    this.liveActive = lines.length > 0
+    this.writeBlock([...lines])
   }
 
   clearLive(): void {
-    if (!this.liveActive) {
+    this.clearBlock()
+  }
+
+  private touch(): void {
+    if (this.startedAt === 0) this.startedAt = Date.now()
+  }
+
+  private statusLine(): string {
+    if (this.slots.size === 0) return ''
+    const suffix = this.statusSuffix()
+    return suffix === '' ? '' : `  ${'status'.padEnd(10)} ${suffix}`
+  }
+
+  private renderBlock(): void {
+    const status = this.statusLine()
+    const lines = status === '' ? [...this.slots.values()] : [status, ...this.slots.values()]
+    if (lines.length === 0) {
+      this.clearBlock()
       return
     }
-    this.stream.write(CLEAR_LINE)
-    this.liveActive = false
+    this.writeBlock(lines)
+  }
+
+  private writeBlock(lines: string[]): void {
+    let out = '\r'
+    if (this.renderedLines > 1) out += cursorUp(this.renderedLines - 1)
+    out += ERASE_LINE + lines.map((line) => this.fit(line)).join(`\n${ERASE_LINE}`)
+    this.writeSafe(out)
+    this.renderedLines = lines.length
+  }
+
+  private clearBlock(): void {
+    if (this.renderedLines === 0) return
+    let out = '\r'
+    if (this.renderedLines > 1) out += cursorUp(this.renderedLines - 1)
+    for (let i = 0; i < this.renderedLines; i++) {
+      out += ERASE_LINE
+      if (i < this.renderedLines - 1) out += CURSOR_DOWN
+    }
+    if (this.renderedLines > 1) out += cursorUp(this.renderedLines - 1)
+    this.writeSafe(out)
+    this.renderedLines = 0
+  }
+
+  private writeSafe(chunk: string): void {
+    if (this.broken) return
+    try {
+      this.stream.write(chunk)
+    } catch {
+      this.broken = true
+    }
   }
 
   private fit(line: string): string {

--- a/review-loop/src/live-renderer.ts
+++ b/review-loop/src/live-renderer.ts
@@ -192,6 +192,11 @@ export class LiveRenderer implements ProgressReporter {
     let out = '\r'
     if (this.renderedLines > 1) out += cursorUp(this.renderedLines - 1)
     out += ERASE_LINE + lines.map((line) => this.fit(line)).join(`\n${ERASE_LINE}`)
+    const leftover = this.renderedLines - lines.length
+    for (let i = 0; i < leftover; i++) {
+      out += `\n${ERASE_LINE}`
+    }
+    if (leftover > 0) out += cursorUp(leftover)
     this.writeSafe(out)
     this.renderedLines = lines.length
   }

--- a/review-loop/src/loop-controller.ts
+++ b/review-loop/src/loop-controller.ts
@@ -16,7 +16,7 @@ import {
 import { matchIssues } from './issue-matcher.js'
 import { processPendingIssues } from './issue-processor.js'
 import { ReviewerIssuesSchema } from './issue-schema.js'
-import type { ReviewerIssue } from './issue-schema.js'
+import type { IssueMatch, ReviewerIssue } from './issue-schema.js'
 import {
   emitLoopEnd,
   emitMatchComplete,
@@ -111,6 +111,30 @@ function filterActionable(records: readonly LedgerIssueRecord[]): readonly Ledge
   return records.filter((r) => !TERMINAL_STATUSES.has(r.status))
 }
 
+function emitFoundEvents(
+  deps: ReviewLoopDeps,
+  matches: readonly IssueMatch[],
+  roundRecords: readonly LedgerIssueRecord[],
+): void {
+  for (const match of matches) {
+    if (match.existingId !== null) {
+      continue
+    }
+    const record = roundRecords[match.newIssueIndex]
+    if (record === undefined) {
+      continue
+    }
+    deps.log.issue?.({
+      type: 'found',
+      id: record.id,
+      severity: record.issue.severity,
+      file: record.issue.file,
+      line: record.issue.lineStart,
+      title: record.issue.title,
+    })
+  }
+}
+
 async function runReviewStep(deps: ReviewLoopDeps, collector: RoundCollector): Promise<readonly ReviewerIssue[]> {
   deps.log.log(`[round ${deps.runState.currentRound}/${deps.config.maxRounds}] Reviewing...`)
 
@@ -174,6 +198,8 @@ async function runMatchAndRecord(
   )
   await saveIssueLedger(deps.ledger)
 
+  emitFoundEvents(deps, matches, roundRecords)
+
   return { records: roundRecords, newCount, matchedCount }
 }
 
@@ -204,6 +230,7 @@ function runProcessPendingIssues(
 async function runRound(round: number, deps: ReviewLoopDeps, metrics: RoundMetric[]): Promise<ReviewLoopResult> {
   deps.runState.currentRound = round
   await saveRunState(deps.runState)
+  deps.log.issue?.({ type: 'round', round, maxRounds: deps.config.maxRounds })
   emitRoundStart(deps.trace, round, deps.config.maxRounds, deps.config.maxNoProgressRounds, deps.config.checkCommand)
   const collector = newCollector()
 
@@ -226,7 +253,6 @@ async function runRound(round: number, deps: ReviewLoopDeps, metrics: RoundMetri
     return finishRound(deps, metrics, round, matched.newCount, collector, 'clean')
   }
 
-  deps.log.log(`[round ${round}] Found ${newIssues.length} issues`)
   const pending = filterActionable(matched.records)
   const fixedThisRound = await runProcessPendingIssues(deps, round, collector, pending)
   deps.log.log(`[round ${round}] Fixed ${fixedThisRound}/${pending.length} issues`)

--- a/review-loop/src/progress-log.ts
+++ b/review-loop/src/progress-log.ts
@@ -19,3 +19,12 @@ export interface ProgressReporter {
   issue?(event: IssueProgressEvent): void
   statusSuffix?(): string
 }
+
+export function emitDecision(
+  log: ProgressReporter,
+  record: { id: string; issue: { title: string } },
+  verdict: string,
+  note?: string,
+): void {
+  log.issue?.({ id: record.id, title: record.issue.title, type: 'decided', verdict, note })
+}

--- a/review-loop/src/progress-log.ts
+++ b/review-loop/src/progress-log.ts
@@ -10,6 +10,13 @@ export type IssueProgressEvent =
   | { type: 'found'; id: string; severity: Severity; file: string; line: number; title: string }
   | { type: 'decided'; id: string; verdict: string; title: string; note?: string }
 
+export interface UsageDelta {
+  input: number
+  output: number
+  reasoning: number
+  cost: number
+}
+
 export interface ProgressReporter {
   readonly dynamic: boolean
   event(message: string): void
@@ -18,6 +25,8 @@ export interface ProgressReporter {
   log(message: string): void
   issue?(event: IssueProgressEvent): void
   statusSuffix?(): string
+  slot?(key: string, line: string | null): void
+  usage?(delta: UsageDelta): void
 }
 
 export function emitDecision(

--- a/review-loop/src/progress-log.ts
+++ b/review-loop/src/progress-log.ts
@@ -3,10 +3,19 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import type { Severity } from './trace-log.js'
+
+export type IssueProgressEvent =
+  | { type: 'round'; round: number; maxRounds: number }
+  | { type: 'found'; id: string; severity: Severity; file: string; line: number; title: string }
+  | { type: 'decided'; id: string; verdict: string; title: string; note?: string }
+
 export interface ProgressReporter {
   readonly dynamic: boolean
   event(message: string): void
   live(lines: readonly string[]): void
   clearLive(): void
   log(message: string): void
+  issue?(event: IssueProgressEvent): void
+  statusSuffix?(): string
 }

--- a/review-loop/src/summary-burndown.ts
+++ b/review-loop/src/summary-burndown.ts
@@ -7,6 +7,22 @@ import type { RoundMetric, Severity, SeverityCounts } from './trace-log.js'
 
 const SEV_WEIGHT: Record<Severity, number> = { critical: 4, high: 3, medium: 2, low: 1 }
 
+const HEADERS = [
+  '  round',
+  'new',
+  'open',
+  'fixed',
+  'rejected',
+  'needs_human',
+  'plan_drift',
+  'insp_rej',
+  'avgRev',
+  'avgFix',
+] as const
+
+/** Cell widths matching HEADERS; 0 marks the last, unpadded column. */
+const WIDTHS = [8, 4, 5, 6, 9, 12, 11, 9, 7, 0] as const
+
 function avgSeverity(counts: SeverityCounts, total: number): string {
   if (total === 0) return '-'
   const sum =
@@ -17,44 +33,48 @@ function avgSeverity(counts: SeverityCounts, total: number): string {
   return (sum / total).toFixed(1)
 }
 
-export function burndownBlock(metrics: readonly RoundMetric[]): string {
-  const header = '  round  new  open  fixed  rejected  needs_human  plan_drift  insp_rej  avgRev  avgFix'
-  const rows = metrics.map((m) => {
-    const decided =
-      m.decisions.fixed +
-      m.decisions.invalid +
-      m.decisions.already_fixed +
-      m.decisions.needs_human +
-      m.decisions.plan_drift +
-      m.decisions.no_commit +
-      m.decisions.inspector_rejected
-    return [
-      `  ${String(m.round).padEnd(6)}`,
-      String(m.newIssues).padEnd(4),
-      String(m.cumulativeOpen).padEnd(5),
-      String(m.decisions.fixed).padEnd(6),
-      String(m.decisions.invalid).padEnd(9),
-      String(m.decisions.needs_human).padEnd(12),
-      String(m.decisions.plan_drift).padEnd(11),
-      String(m.decisions.inspector_rejected).padEnd(9),
-      avgSeverity(m.reviewerSeverity, m.newIssues).padEnd(7),
-      avgSeverity(m.fixerSeverity, decided),
-    ].join('')
-  })
-  return ['Burndown:', header, ...rows].join('\n')
+function decidedCount(m: RoundMetric): number {
+  return (
+    m.decisions.fixed +
+    m.decisions.invalid +
+    m.decisions.already_fixed +
+    m.decisions.needs_human +
+    m.decisions.plan_drift +
+    m.decisions.no_commit +
+    m.decisions.inspector_rejected
+  )
 }
 
-export function burndownIsEmpty(metrics: readonly RoundMetric[]): boolean {
-  return metrics.every(
-    (m) =>
-      m.newIssues === 0 &&
-      m.cumulativeOpen === 0 &&
-      m.decisions.fixed === 0 &&
-      m.decisions.invalid === 0 &&
-      m.decisions.already_fixed === 0 &&
-      m.decisions.needs_human === 0 &&
-      m.decisions.plan_drift === 0 &&
-      m.decisions.no_commit === 0 &&
-      m.decisions.inspector_rejected === 0,
-  )
+function rowIsZero(m: RoundMetric): boolean {
+  return m.newIssues === 0 && decidedCount(m) === 0
+}
+
+function renderRow(values: readonly string[]): string {
+  return values
+    .map((value, i) => {
+      const width = WIDTHS[i] ?? 0
+      return width === 0 ? value : value.padEnd(width)
+    })
+    .join('')
+}
+
+function dataRow(m: RoundMetric): string {
+  return renderRow([
+    `  ${m.round}`,
+    String(m.newIssues),
+    String(m.cumulativeOpen),
+    String(m.decisions.fixed),
+    String(m.decisions.invalid),
+    String(m.decisions.needs_human),
+    String(m.decisions.plan_drift),
+    String(m.decisions.inspector_rejected),
+    avgSeverity(m.reviewerSeverity, m.newIssues),
+    avgSeverity(m.fixerSeverity, decidedCount(m)),
+  ])
+}
+
+export function burndownBlock(metrics: readonly RoundMetric[]): string {
+  const rows = metrics.filter((m) => !rowIsZero(m)).map(dataRow)
+  if (rows.length === 0) return ''
+  return ['Burndown:', renderRow(HEADERS), ...rows].join('\n')
 }

--- a/review-loop/src/summary-burndown.ts
+++ b/review-loop/src/summary-burndown.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { RoundMetric, Severity, SeverityCounts } from './trace-log.js'
+
+const SEV_WEIGHT: Record<Severity, number> = { critical: 4, high: 3, medium: 2, low: 1 }
+
+function avgSeverity(counts: SeverityCounts, total: number): string {
+  if (total === 0) return '-'
+  const sum =
+    counts.critical * SEV_WEIGHT.critical +
+    counts.high * SEV_WEIGHT.high +
+    counts.medium * SEV_WEIGHT.medium +
+    counts.low * SEV_WEIGHT.low
+  return (sum / total).toFixed(1)
+}
+
+export function burndownBlock(metrics: readonly RoundMetric[]): string {
+  const header = '  round  new  open  fixed  rejected  needs_human  plan_drift  insp_rej  avgRev  avgFix'
+  const rows = metrics.map((m) => {
+    const decided =
+      m.decisions.fixed +
+      m.decisions.invalid +
+      m.decisions.already_fixed +
+      m.decisions.needs_human +
+      m.decisions.plan_drift +
+      m.decisions.no_commit +
+      m.decisions.inspector_rejected
+    return [
+      `  ${String(m.round).padEnd(6)}`,
+      String(m.newIssues).padEnd(4),
+      String(m.cumulativeOpen).padEnd(5),
+      String(m.decisions.fixed).padEnd(6),
+      String(m.decisions.invalid).padEnd(9),
+      String(m.decisions.needs_human).padEnd(12),
+      String(m.decisions.plan_drift).padEnd(11),
+      String(m.decisions.inspector_rejected).padEnd(9),
+      avgSeverity(m.reviewerSeverity, m.newIssues).padEnd(7),
+      avgSeverity(m.fixerSeverity, decided),
+    ].join('')
+  })
+  return ['Burndown:', header, ...rows].join('\n')
+}
+
+export function burndownIsEmpty(metrics: readonly RoundMetric[]): boolean {
+  return metrics.every(
+    (m) =>
+      m.newIssues === 0 &&
+      m.cumulativeOpen === 0 &&
+      m.decisions.fixed === 0 &&
+      m.decisions.invalid === 0 &&
+      m.decisions.already_fixed === 0 &&
+      m.decisions.needs_human === 0 &&
+      m.decisions.plan_drift === 0 &&
+      m.decisions.no_commit === 0 &&
+      m.decisions.inspector_rejected === 0,
+  )
+}

--- a/review-loop/src/summary.ts
+++ b/review-loop/src/summary.ts
@@ -14,7 +14,7 @@ import {
 import type { IssueLedgerSnapshot, LedgerIssueRecord } from './issue-ledger.js'
 import { formatDuration } from './live-renderer.js'
 import type { ReviewLoopResult } from './loop-controller.js'
-import { burndownBlock, burndownIsEmpty } from './summary-burndown.js'
+import { burndownBlock } from './summary-burndown.js'
 import type { PhaseMs, RoundMetric, UsageTotals } from './trace-log.js'
 
 const PHASE_KEYS: (keyof PhaseMs)[] = ['review', 'match', 'verify', 'build', 'inspect', 'fix']
@@ -215,9 +215,8 @@ export function buildSummary(input: SummaryInput): string {
   const issues = issuesBlock(input.ledger)
   if (issues.length > 0) lines.push('', ...issues)
 
-  if (input.metrics.length > 0 && (input.metrics.length > 1 || !burndownIsEmpty(input.metrics))) {
-    lines.push('', burndownBlock(input.metrics))
-  }
+  const burndown = burndownBlock(input.metrics)
+  if (burndown !== '') lines.push('', burndown)
 
   lines.push('', ...artifactsBlock(input.runDir))
   return lines.join('\n')

--- a/review-loop/src/summary.ts
+++ b/review-loop/src/summary.ts
@@ -52,6 +52,7 @@ export interface SummaryInput {
   metrics: readonly RoundMetric[]
   ledger: IssueLedgerSnapshot
   runDir: string
+  wallMs: number
   options: SummaryOptions
 }
 
@@ -142,13 +143,19 @@ function msToSeconds(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`
 }
 
-function buildTimingLine(metrics: readonly RoundMetric[]): string {
+function formatCount(n: number): string {
+  return n.toLocaleString('en-US')
+}
+
+function buildTimingLine(metrics: readonly RoundMetric[], wallMs: number): string {
   const phaseMs = aggregatePhaseMs(metrics)
   const totalMs = PHASE_KEYS.reduce((s, k) => s + phaseMs[k], 0)
   const parts = PHASE_KEYS.filter((k) => phaseMs[k] > 0).map((k) => `${k} ${msToSeconds(phaseMs[k])}`)
   const breakdown = parts.length === 0 ? 'no phase timing recorded' : parts.join(', ')
   const usage = aggregateUsage(metrics)
-  return `Duration: ${formatDuration(totalMs)} (${breakdown}) · Cost: $${usage.costUsd.toFixed(3)} (in ${usage.inputTokens} / out ${usage.outputTokens} / reasoning ${usage.reasoningTokens})`
+  const tokens = `in ${formatCount(usage.inputTokens)} / out ${formatCount(usage.outputTokens)} / reasoning ${formatCount(usage.reasoningTokens)}`
+  const cost = usage.costUsd > 0 ? `Cost: $${usage.costUsd.toFixed(3)} (${tokens})` : `Tokens: ${tokens}`
+  return `Duration: ${formatDuration(wallMs)} wall · phases ${formatDuration(totalMs)} (${breakdown}) · ${cost}`
 }
 
 function buildRoundsLine(input: SummaryInput): string | null {
@@ -204,7 +211,7 @@ function artifactsBlock(runDir: string): string[] {
 export function buildSummary(input: SummaryInput): string {
   const total = Object.keys(input.ledger.issues).length
   const counts = countIssues(input.ledger)
-  const lines: string[] = [buildVerdict(input, counts, total), buildTimingLine(input.metrics)]
+  const lines: string[] = [buildVerdict(input, counts, total), buildTimingLine(input.metrics, input.wallMs)]
 
   const roundsLine = buildRoundsLine(input)
   if (roundsLine !== null) lines.push(roundsLine)

--- a/review-loop/src/summary.ts
+++ b/review-loop/src/summary.ts
@@ -3,21 +3,25 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import {
+  formatIssueRef,
+  GROUP_LABEL,
+  GROUP_MARK,
+  GROUP_ORDER,
+  groupForStatus,
+  type IssueGroup,
+} from './issue-format.js'
+import type { IssueLedgerSnapshot, LedgerIssueRecord } from './issue-ledger.js'
+import { formatDuration } from './live-renderer.js'
 import type { ReviewLoopResult } from './loop-controller.js'
-import type { PhaseMs, RoundMetric, Severity, SeverityCounts, UsageTotals } from './trace-log.js'
-
-const SEV_WEIGHT: Record<Severity, number> = { critical: 4, high: 3, medium: 2, low: 1 }
+import { burndownBlock, burndownIsEmpty } from './summary-burndown.js'
+import type { PhaseMs, RoundMetric, UsageTotals } from './trace-log.js'
 
 const PHASE_KEYS: (keyof PhaseMs)[] = ['review', 'match', 'verify', 'build', 'inspect', 'fix']
 
-interface StatusCounts {
-  open: number
-  closed: number
-  rejected: number
-  alreadyFixed: number
-  needsHuman: number
-  reopened: number
-}
+const GROUP_CAP = 20
+
+const RUN_ARTIFACTS = ['summary.txt', 'metrics.json', 'ledger.json', 'trace.jsonl', 'agent-output.log', 'state.json']
 
 export interface MetricsJson {
   doneReason: ReviewLoopResult['doneReason']
@@ -26,7 +30,15 @@ export interface MetricsJson {
   burndown: RoundMetric[]
   usage: UsageTotals
   phaseMs: PhaseMs
-  totals: StatusCounts & { inspectorRejected: number }
+  totals: {
+    open: number
+    closed: number
+    rejected: number
+    alreadyFixed: number
+    needsHuman: number
+    reopened: number
+    inspectorRejected: number
+  }
 }
 
 export interface SummaryOptions {
@@ -34,45 +46,74 @@ export interface SummaryOptions {
   inspect: boolean
 }
 
+export interface SummaryInput {
+  doneReason: ReviewLoopResult['doneReason']
+  rounds: number
+  metrics: readonly RoundMetric[]
+  ledger: IssueLedgerSnapshot
+  runDir: string
+  options: SummaryOptions
+}
+
+interface IssueCounts {
+  open: number
+  fixed: number
+  rejected: number
+  needsHuman: number
+  alreadyFixed: number
+}
+
+function countIssues(ledger: IssueLedgerSnapshot): IssueCounts {
+  const counts: IssueCounts = { open: 0, fixed: 0, rejected: 0, needsHuman: 0, alreadyFixed: 0 }
+  for (const record of Object.values(ledger.issues)) {
+    switch (groupForStatus(record.status)) {
+      case 'needsHuman':
+        counts.needsHuman += 1
+        break
+      case 'fixed':
+        counts.fixed += 1
+        break
+      case 'rejected':
+        counts.rejected += 1
+        break
+      case 'alreadyFixed':
+        counts.alreadyFixed += 1
+        break
+      case 'open':
+        counts.open += 1
+        break
+    }
+  }
+  return counts
+}
+
+function plural(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? '' : 's'}`
+}
+
+function breakdownParts(counts: IssueCounts): string[] {
+  const parts: string[] = []
+  if (counts.fixed > 0) parts.push(`${counts.fixed} fixed`)
+  if (counts.needsHuman > 0) parts.push(`${counts.needsHuman} needs human`)
+  if (counts.rejected > 0) parts.push(`${counts.rejected} rejected`)
+  if (counts.alreadyFixed > 0) parts.push(`${counts.alreadyFixed} already fixed`)
+  return parts
+}
+
+function buildVerdict(input: SummaryInput, counts: IssueCounts, total: number): string {
+  const breakdown = breakdownParts(counts).join(', ')
+  if (counts.open > 0) {
+    const suffix = breakdown === '' ? '' : ` (${breakdown})`
+    return `Review loop finished: issues remaining — ${counts.open} open${suffix}.`
+  }
+  if (total === 0) {
+    return `Review loop finished: clean — reviewer found no issues in ${plural(input.rounds, 'round')}.`
+  }
+  return `Review loop finished: done — ${plural(total, 'issue')}: ${breakdown}.`
+}
+
 function sumDecisions(metrics: readonly RoundMetric[], key: keyof RoundMetric['decisions']): number {
   return metrics.reduce((s, m) => s + m.decisions[key], 0)
-}
-
-function avgSeverity(counts: SeverityCounts, total: number): string {
-  if (total === 0) return '-'
-  const sum =
-    counts.critical * SEV_WEIGHT.critical +
-    counts.high * SEV_WEIGHT.high +
-    counts.medium * SEV_WEIGHT.medium +
-    counts.low * SEV_WEIGHT.low
-  return (sum / total).toFixed(1)
-}
-
-function burndownBlock(metrics: readonly RoundMetric[]): string {
-  const header = 'round  new  open  fixed  rejected  needs_human  plan_drift  insp_rej  avgRev  avgFix'
-  const rows = metrics.map((m) => {
-    const decided =
-      m.decisions.fixed +
-      m.decisions.invalid +
-      m.decisions.already_fixed +
-      m.decisions.needs_human +
-      m.decisions.plan_drift +
-      m.decisions.no_commit +
-      m.decisions.inspector_rejected
-    return [
-      String(m.round).padEnd(6),
-      String(m.newIssues).padEnd(4),
-      String(m.cumulativeOpen).padEnd(5),
-      String(m.decisions.fixed).padEnd(6),
-      String(m.decisions.invalid).padEnd(9),
-      String(m.decisions.needs_human).padEnd(12),
-      String(m.decisions.plan_drift).padEnd(11),
-      String(m.decisions.inspector_rejected).padEnd(9),
-      avgSeverity(m.reviewerSeverity, m.newIssues).padEnd(7),
-      avgSeverity(m.fixerSeverity, decided),
-    ].join('')
-  })
-  return ['Burndown:', header, ...rows].join('\n')
 }
 
 function aggregatePhaseMs(metrics: readonly RoundMetric[]): PhaseMs {
@@ -101,66 +142,85 @@ function msToSeconds(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`
 }
 
-function computeStatusLines(metrics: readonly RoundMetric[], closed: number): string[] {
-  const lastMetric = metrics.length > 0 ? metrics[metrics.length - 1] : undefined
-  const openIssues = lastMetric === undefined ? 0 : lastMetric.cumulativeOpen
-  return [
-    `Closed issues: ${closed}`,
-    `Open issues: ${openIssues}`,
-    `Rejected issues: ${sumDecisions(metrics, 'invalid')}`,
-    `Already fixed: ${sumDecisions(metrics, 'already_fixed')}`,
-    `Needs human: ${sumDecisions(metrics, 'needs_human')}`,
-    `Reopened issues: 0`,
-  ]
+function buildTimingLine(metrics: readonly RoundMetric[]): string {
+  const phaseMs = aggregatePhaseMs(metrics)
+  const totalMs = PHASE_KEYS.reduce((s, k) => s + phaseMs[k], 0)
+  const parts = PHASE_KEYS.filter((k) => phaseMs[k] > 0).map((k) => `${k} ${msToSeconds(phaseMs[k])}`)
+  const breakdown = parts.length === 0 ? 'no phase timing recorded' : parts.join(', ')
+  const usage = aggregateUsage(metrics)
+  return `Duration: ${formatDuration(totalMs)} (${breakdown}) · Cost: $${usage.costUsd.toFixed(3)} (in ${usage.inputTokens} / out ${usage.outputTokens} / reasoning ${usage.reasoningTokens})`
 }
 
-function computeObservabilityLines(metrics: readonly RoundMetric[], options: SummaryOptions): string[] {
-  const totalInspectorRuns = metrics.reduce((s, m) => s + m.inspector.runs, 0)
-  const totalInspectorRejected = metrics.reduce((s, m) => s + m.inspector.rejected, 0)
-  const usage = aggregateUsage(metrics)
-  const phaseMs = aggregatePhaseMs(metrics)
-  const rejectRate =
-    totalInspectorRuns === 0 ? 'n/a' : `${((100 * totalInspectorRejected) / totalInspectorRuns).toFixed(1)}%`
+function buildRoundsLine(input: SummaryInput): string | null {
+  if (input.rounds <= 1 && input.options.poolSize <= 1) return null
+  const pool = input.options.poolSize > 1 ? ` · Pool: ${input.options.poolSize}` : ''
+  return `Rounds: ${input.rounds}${pool}`
+}
 
-  const lines: string[] = []
-  if (options.inspect) {
-    lines.push(`Inspector: ${totalInspectorRuns} runs, ${totalInspectorRejected} rejected (${rejectRate} reject rate)`)
+function buildInspectorLine(metrics: readonly RoundMetric[], options: SummaryOptions): string | null {
+  if (!options.inspect) return null
+  const runs = metrics.reduce((s, m) => s + m.inspector.runs, 0)
+  if (runs === 0) return null
+  const rejected = metrics.reduce((s, m) => s + m.inspector.rejected, 0)
+  const rate = `${((100 * rejected) / runs).toFixed(1)}%`
+  return `Inspector: ${runs} runs, ${rejected} rejected (${rate} reject rate)`
+}
+
+function issuesBlock(ledger: IssueLedgerSnapshot): string[] {
+  const records = Object.values(ledger.issues)
+  if (records.length === 0) return []
+  const groups = new Map<IssueGroup, LedgerIssueRecord[]>()
+  for (const record of records) {
+    const group = groupForStatus(record.status)
+    groups.set(group, [...(groups.get(group) ?? []), record])
   }
-
-  lines.push(
-    '',
-    `Total cost: $${usage.costUsd.toFixed(3)} (in ${usage.inputTokens} / out ${usage.outputTokens} / reasoning ${usage.reasoningTokens} tokens)`,
-    'Wall clock:',
-    `  review:  ${msToSeconds(phaseMs.review)}`,
-    `  match:   ${msToSeconds(phaseMs.match)}`,
-    `  verify:  ${msToSeconds(phaseMs.verify)}`,
-    `  build:   ${msToSeconds(phaseMs.build)}`,
-    `  inspect: ${msToSeconds(phaseMs.inspect)}`,
-    `  fix:     ${msToSeconds(phaseMs.fix)}`,
-  )
+  const lines = ['Issues:']
+  for (const group of GROUP_ORDER) {
+    const groupRecords = groups.get(group)
+    if (groupRecords === undefined || groupRecords.length === 0) continue
+    lines.push(`  ${GROUP_LABEL[group]} (${groupRecords.length}):`)
+    for (const record of groupRecords.slice(0, GROUP_CAP)) {
+      lines.push(
+        `    ${GROUP_MARK[group]} ${formatIssueRef({
+          id: record.id,
+          severity: record.issue.severity,
+          file: record.issue.file,
+          line: record.issue.lineStart,
+          title: record.issue.title,
+        })}`,
+      )
+    }
+    if (groupRecords.length > GROUP_CAP) {
+      lines.push(`    …and ${groupRecords.length - GROUP_CAP} more (see ledger.json)`)
+    }
+  }
   return lines
 }
 
-export function buildSummary(
-  doneReason: string,
-  rounds: number,
-  closed: number,
-  metrics: readonly RoundMetric[],
-  options: SummaryOptions,
-): string {
-  const lines = [
-    `Done reason: ${doneReason}`,
-    `Rounds executed: ${rounds}`,
-    options.poolSize > 1 ? `Pool size: ${options.poolSize}` : '',
-    ...computeStatusLines(metrics, closed),
-    ...computeObservabilityLines(metrics, options),
-  ]
+function artifactsBlock(runDir: string): string[] {
+  return [`Artifacts (${runDir}):`, `  ${RUN_ARTIFACTS.join(' · ')}`]
+}
 
-  if (metrics.length > 0) {
-    lines.push('', burndownBlock(metrics))
+export function buildSummary(input: SummaryInput): string {
+  const total = Object.keys(input.ledger.issues).length
+  const counts = countIssues(input.ledger)
+  const lines: string[] = [buildVerdict(input, counts, total), buildTimingLine(input.metrics)]
+
+  const roundsLine = buildRoundsLine(input)
+  if (roundsLine !== null) lines.push(roundsLine)
+
+  const inspectorLine = buildInspectorLine(input.metrics, input.options)
+  if (inspectorLine !== null) lines.push(inspectorLine)
+
+  const issues = issuesBlock(input.ledger)
+  if (issues.length > 0) lines.push('', ...issues)
+
+  if (input.metrics.length > 0 && (input.metrics.length > 1 || !burndownIsEmpty(input.metrics))) {
+    lines.push('', burndownBlock(input.metrics))
   }
 
-  return lines.filter(Boolean).join('\n')
+  lines.push('', ...artifactsBlock(input.runDir))
+  return lines.join('\n')
 }
 
 export function buildMetricsJson(
@@ -171,6 +231,7 @@ export function buildMetricsJson(
   options: SummaryOptions,
 ): MetricsJson {
   const lastMetric = metrics.length > 0 ? metrics[metrics.length - 1] : undefined
+  const openFromMetrics = lastMetric === undefined ? 0 : lastMetric.cumulativeOpen
   return {
     doneReason,
     rounds,
@@ -179,7 +240,7 @@ export function buildMetricsJson(
     usage: aggregateUsage(metrics),
     phaseMs: aggregatePhaseMs(metrics),
     totals: {
-      open: lastMetric === undefined ? 0 : lastMetric.cumulativeOpen,
+      open: openFromMetrics,
       closed,
       rejected: sumDecisions(metrics, 'invalid'),
       alreadyFixed: sumDecisions(metrics, 'already_fixed'),

--- a/review-loop/src/summary.ts
+++ b/review-loop/src/summary.ts
@@ -12,7 +12,7 @@ import {
   type IssueGroup,
 } from './issue-format.js'
 import type { IssueLedgerSnapshot, LedgerIssueRecord } from './issue-ledger.js'
-import { formatDuration } from './live-renderer.js'
+import { formatDuration } from './live-format.js'
 import type { ReviewLoopResult } from './loop-controller.js'
 import { burndownBlock } from './summary-burndown.js'
 import type { PhaseMs, RoundMetric, UsageTotals } from './trace-log.js'

--- a/tests/review-loop/cli.test.ts
+++ b/tests/review-loop/cli.test.ts
@@ -390,7 +390,7 @@ describe('runCli', () => {
     await fixture.runCliWithPath(['--config', fixture.configPath, '--plan', fixture.planPath, '--pool-size', '5'])
 
     const summary = readFileSync(path.join(fixture.getRunDir(), 'summary.txt'), 'utf8')
-    expect(summary).toContain('Pool size: 5')
+    expect(summary).toContain('Pool: 5')
   })
 
   test('--no-inspect skips inspector calls', async () => {
@@ -530,7 +530,7 @@ describe('runCli', () => {
     // lose only the in-flight attempt, never the run).
     const runDir = fixture.getRunDir()
     const summary = readFileSync(path.join(runDir, 'summary.txt'), 'utf8')
-    expect(summary).toContain('needs_human')
+    expect(summary).toContain('needs human')
     const state = PersistedRunStateSchema.parse(JSON.parse(readFileSync(path.join(runDir, 'state.json'), 'utf8')))
     const worker1Path = path.join(fixture.workDir, 'worktrees', `${state.runId}-worker-1`)
     const worker2Path = path.join(fixture.workDir, 'worktrees', `${state.runId}-worker-2`)

--- a/tests/review-loop/fake-agent-integration.test.ts
+++ b/tests/review-loop/fake-agent-integration.test.ts
@@ -335,7 +335,7 @@ describe('review-loop fake integration', () => {
     const runId = readdirSync(runRoot)[0]
     expect(runId).toBeDefined()
     const summary = readFileSync(path.join(runRoot, runId!, 'summary.txt'), 'utf8')
-    expect(summary).toContain('Done reason: clean')
+    expect(summary).toContain('Review loop finished: issues remaining')
   })
 })
 
@@ -373,7 +373,7 @@ describe('fake agent with pool + inspector', () => {
       ],
     })
 
-    expect(summary).toContain('Done reason: clean')
+    expect(summary).toContain('Review loop finished: done')
 
     const inspectEvents = trace.filter((e) => e.event === 'inspect_complete')
     expect(inspectEvents.length).toBe(3)
@@ -409,7 +409,7 @@ describe('fake agent with pool + inspector', () => {
       ],
     })
 
-    expect(summary).toContain('Done reason: clean')
+    expect(summary).toContain('Review loop finished: done')
 
     const inspectEvents = trace.filter((e) => e.event === 'inspect_complete')
     expect(inspectEvents.length).toBe(2)
@@ -447,7 +447,7 @@ describe('fake agent with pool + inspector', () => {
       fixerResults: [buildFixerResult()],
     })
 
-    expect(summary).toContain('Done reason: clean')
+    expect(summary).toContain('Review loop finished: done')
     expect(trace.some((e) => e.event === 'inspect_complete')).toBe(false)
     expect(existsSync(path.join(runRoot, runId, 'inspect.json'))).toBe(false)
 

--- a/tests/review-loop/issue-format.test.ts
+++ b/tests/review-loop/issue-format.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  formatDecidedLine,
+  formatFoundLine,
+  formatIssueRef,
+  groupForStatus,
+  shortIssueId,
+} from '../../review-loop/src/issue-format.js'
+
+const ref = {
+  id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  severity: 'high',
+  file: 'src/auth/login.ts',
+  line: 42,
+  title: 'Token refresh race on 401',
+}
+
+describe('shortIssueId', () => {
+  test('takes the first 8 characters', () => {
+    expect(shortIssueId(ref.id)).toBe('a1b2c3d4')
+    expect(shortIssueId('short')).toBe('short')
+  })
+})
+
+describe('formatIssueRef', () => {
+  test('renders id, padded severity, file:line, and title', () => {
+    expect(formatIssueRef(ref)).toBe('#a1b2c3d4 [high]     src/auth/login.ts:42 — Token refresh race on 401')
+  })
+  test('critical severity fills the pad exactly', () => {
+    expect(formatIssueRef({ ...ref, severity: 'critical' })).toBe(
+      '#a1b2c3d4 [critical] src/auth/login.ts:42 — Token refresh race on 401',
+    )
+  })
+})
+
+describe('formatFoundLine', () => {
+  test('prefixes with indented plus', () => {
+    expect(formatFoundLine(ref)).toBe('  + #a1b2c3d4 [high]     src/auth/login.ts:42 — Token refresh race on 401')
+  })
+})
+
+describe('formatDecidedLine', () => {
+  test('maps known verdicts to marks and labels', () => {
+    expect(formatDecidedLine({ id: ref.id, verdict: 'fixed' })).toBe('✓ #a1b2c3d4 → fixed')
+    expect(formatDecidedLine({ id: ref.id, verdict: 'invalid' })).toBe('✗ #a1b2c3d4 → rejected')
+    expect(formatDecidedLine({ id: ref.id, verdict: 'needs_human' })).toBe('! #a1b2c3d4 → needs human')
+    expect(formatDecidedLine({ id: ref.id, verdict: 'already_fixed' })).toBe('· #a1b2c3d4 → already fixed')
+    expect(formatDecidedLine({ id: ref.id, verdict: 'plan_drift' })).toBe('! #a1b2c3d4 → plan drift')
+    expect(formatDecidedLine({ id: ref.id, verdict: 'no_commit' })).toBe('· #a1b2c3d4 → no change')
+  })
+  test('appends note in parentheses', () => {
+    expect(formatDecidedLine({ id: ref.id, verdict: 'needs_human', note: 'merge conflict' })).toBe(
+      '! #a1b2c3d4 → needs human (merge conflict)',
+    )
+  })
+  test('unknown verdict falls back to dot mark and raw verdict', () => {
+    expect(formatDecidedLine({ id: ref.id, verdict: 'mystery' })).toBe('· #a1b2c3d4 → mystery')
+  })
+})
+
+describe('groupForStatus', () => {
+  test('maps ledger statuses to report groups', () => {
+    expect(groupForStatus('needs_human')).toBe('needsHuman')
+    expect(groupForStatus('closed')).toBe('fixed')
+    expect(groupForStatus('rejected')).toBe('rejected')
+    expect(groupForStatus('already_fixed')).toBe('alreadyFixed')
+    expect(groupForStatus('discovered')).toBe('open')
+    expect(groupForStatus('verified')).toBe('open')
+    expect(groupForStatus('fixed_pending_review')).toBe('open')
+    expect(groupForStatus('reopened')).toBe('open')
+  })
+})

--- a/tests/review-loop/line-handler.test.ts
+++ b/tests/review-loop/line-handler.test.ts
@@ -11,6 +11,7 @@ import { z } from 'zod'
 
 import type { RunAgentOptions, SpawnResult } from '../../review-loop/src/agent-runner.js'
 import { createLineHandler, enqueueLog } from '../../review-loop/src/line-handler.js'
+import type { ProgressReporter, UsageDelta } from '../../review-loop/src/progress-log.js'
 import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
 
 afterEach(cleanupTempDirs)
@@ -44,5 +45,62 @@ describe('createLineHandler log draining', () => {
     const handler = createLineHandler(makeOptions(cwd, logPath))
     enqueueLog(handler.ctx, 'dropped\n')
     await handler.dispose()
+  })
+})
+
+describe('createLineHandler reporter wiring', () => {
+  function makeReporter(overrides: Partial<ProgressReporter>): ProgressReporter {
+    return {
+      dynamic: false,
+      event: () => {},
+      live: () => {},
+      clearLive: () => {},
+      log: () => {},
+      ...overrides,
+    }
+  }
+
+  function matchesDrainRead(entry: readonly [string, string | null]): boolean {
+    const [key, line] = entry
+    return key === 'drain' && line !== null && line.includes('read')
+  }
+
+  test('step_finish forwards usage to the reporter', () => {
+    const cwd = makeTempDir('line-handler-usage-')
+    const deltas: UsageDelta[] = []
+    const reporter = makeReporter({
+      usage: (d) => {
+        deltas.push(d)
+      },
+    })
+    const handler = createLineHandler({ ...makeOptions(cwd, path.join(cwd, 'agent.log')), reporter })
+    handler.onLine(
+      JSON.stringify({
+        type: 'step_finish',
+        part: { reason: 'stop', tokens: { input: 5, output: 2, reasoning: 1 }, cost: 0.5 },
+      }),
+    )
+    expect(deltas).toEqual([{ input: 5, output: 2, reasoning: 1, cost: 0.5 }])
+  })
+
+  test('tool progress goes to reporter.slot and dispose clears it', async () => {
+    const cwd = makeTempDir('line-handler-slot-')
+    const slots: Array<readonly [string, string | null]> = []
+    const reporter = makeReporter({
+      slot: (key, line) => {
+        slots.push([key, line] as const)
+      },
+    })
+    const handler = createLineHandler({ ...makeOptions(cwd, path.join(cwd, 'agent.log')), reporter })
+    handler.onLine(JSON.stringify({ type: 'step_start', timestamp: 1, part: {} }))
+    handler.onLine(
+      JSON.stringify({
+        type: 'tool_use',
+        part: { tool: 'read', callID: 'c1', state: { status: 'running', input: { filePath: '/a/cli.ts' } } },
+      }),
+    )
+    expect(slots.some(matchesDrainRead)).toBe(true)
+    await handler.dispose()
+    expect(slots[slots.length - 1]).toEqual(['drain', null])
   })
 })

--- a/tests/review-loop/live-format.test.ts
+++ b/tests/review-loop/live-format.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  formatDuration,
+  formatLiveLine,
+  formatStepFooter,
+  formatTokenCount,
+  formatToolArg,
+} from '../../review-loop/src/live-format.js'
+
+describe('formatDuration', () => {
+  test('formats seconds under a minute', () => {
+    expect(formatDuration(0)).toBe('0s')
+    expect(formatDuration(42000)).toBe('42s')
+  })
+  test('formats minutes and seconds', () => {
+    expect(formatDuration(125000)).toBe('2m05s')
+  })
+})
+
+describe('formatToolArg', () => {
+  test('read/edit/write use basename of filePath', () => {
+    expect(formatToolArg('read', { filePath: '/a/b/cli.ts' })).toBe('cli.ts')
+    expect(formatToolArg('edit', { path: '/a/b/src/x.ts' })).toBe('x.ts')
+  })
+  test('bash truncates command', () => {
+    expect(formatToolArg('bash', { command: 'echo hi' })).toBe('echo hi')
+    const long = 'x'.repeat(60)
+    expect(formatToolArg('bash', { command: long })).toHaveLength(40)
+  })
+  test('grep/glob use pattern', () => {
+    expect(formatToolArg('grep', { pattern: 'TODO' })).toBe('TODO')
+  })
+  test('task uses description then subagent_type', () => {
+    expect(formatToolArg('task', { description: 'find files' })).toBe('find files')
+    expect(formatToolArg('task', { subagent_type: 'explore' })).toBe('explore')
+  })
+  test('fallback uses first string value', () => {
+    expect(formatToolArg('custom', { a: 'hello', b: 'world' })).toBe('hello')
+  })
+  test('empty input yields empty string', () => {
+    expect(formatToolArg('read', {})).toBe('')
+    expect(formatToolArg('mystery', {})).toBe('')
+  })
+})
+
+describe('formatLiveLine', () => {
+  test('renders label, tool, arg, elapsed, count', () => {
+    const line = formatLiveLine('fixer', 'edit', 'cli.ts', 42000, 3)
+    expect(line).toContain('fixer')
+    expect(line).toContain('edit cli.ts')
+    expect(line).toContain('42s')
+    expect(line).toContain('3 tools')
+  })
+  test('singular tool count', () => {
+    expect(formatLiveLine('reviewer', 'read', 'a.ts', 1000, 1)).toContain('1 tool')
+  })
+  test('no tool yet shows thinking', () => {
+    expect(formatLiveLine('reviewer', '', '', 2000, 0)).toContain('thinking')
+  })
+})
+
+describe('formatStepFooter', () => {
+  test('renders summary with tokens', () => {
+    const footer = formatStepFooter('reviewer', 18000, 4, { input: 13373, output: 31 })
+    expect(footer).toContain('reviewer')
+    expect(footer).toContain('18s')
+    expect(footer).toContain('4 tools')
+    expect(footer).toContain('in 13373 / out 31')
+  })
+})
+
+describe('formatTokenCount', () => {
+  test('formats compact token counts', () => {
+    expect(formatTokenCount(999)).toBe('999')
+    expect(formatTokenCount(1000)).toBe('1.0k')
+    expect(formatTokenCount(9824)).toBe('9.8k')
+    expect(formatTokenCount(228819)).toBe('228.8k')
+    expect(formatTokenCount(1500000)).toBe('1.50M')
+  })
+})
+
+describe('formatLiveLine status suffix', () => {
+  test('appends status after tool count when provided', () => {
+    const line = formatLiveLine('fixer', 'read', 'cli.ts', 5000, 3, 'round 1/3 · issues: 2 open')
+    expect(line).toContain('3 tools · round 1/3 · issues: 2 open')
+  })
+  test('omits suffix segment when status is empty', () => {
+    const line = formatLiveLine('fixer', 'read', 'cli.ts', 5000, 3)
+    expect(line).toContain('3 tools')
+    expect(line).not.toContain('round')
+  })
+})

--- a/tests/review-loop/live-format.test.ts
+++ b/tests/review-loop/live-format.test.ts
@@ -84,15 +84,3 @@ describe('formatTokenCount', () => {
     expect(formatTokenCount(1500000)).toBe('1.50M')
   })
 })
-
-describe('formatLiveLine status suffix', () => {
-  test('appends status after tool count when provided', () => {
-    const line = formatLiveLine('fixer', 'read', 'cli.ts', 5000, 3, 'round 1/3 · issues: 2 open')
-    expect(line).toContain('3 tools · round 1/3 · issues: 2 open')
-  })
-  test('omits suffix segment when status is empty', () => {
-    const line = formatLiveLine('fixer', 'read', 'cli.ts', 5000, 3)
-    expect(line).toContain('3 tools')
-    expect(line).not.toContain('round')
-  })
-})

--- a/tests/review-loop/live-renderer.test.ts
+++ b/tests/review-loop/live-renderer.test.ts
@@ -5,7 +5,8 @@
 
 import { describe, expect, test } from 'bun:test'
 
-import { LiveRenderer, type RendererStream } from '../../review-loop/src/live-renderer.js'
+import { LiveRenderer, type RendererStream, withLivePhase } from '../../review-loop/src/live-renderer.js'
+import type { ProgressReporter } from '../../review-loop/src/progress-log.js'
 
 function makeStream(opts: { isTTY?: boolean; columns?: number } = {}): {
   stream: RendererStream
@@ -280,5 +281,24 @@ describe('status line', () => {
     r.slot('a', 'x')
     const status = output[output.length - 1]!.split('\n')[0]!
     expect(status).toContain('in 1.1k / out 100')
+  })
+})
+
+describe('withLivePhase', () => {
+  test('clears its slot when the phase ends', async () => {
+    const slots: Array<readonly [string, string | null]> = []
+    const reporter: ProgressReporter = {
+      dynamic: true,
+      event: () => {},
+      live: () => {},
+      clearLive: () => {},
+      log: () => {},
+      slot: (key, line) => {
+        slots.push([key, line] as const)
+      },
+    }
+    const { result } = await withLivePhase(reporter, 'build', () => Promise.resolve('done'))
+    expect(result).toBe('done')
+    expect(slots[slots.length - 1]).toEqual(['build', null])
   })
 })

--- a/tests/review-loop/live-renderer.test.ts
+++ b/tests/review-loop/live-renderer.test.ts
@@ -202,6 +202,19 @@ describe('LiveRenderer slots', () => {
     expect(redraw).toContain('line-c')
   })
 
+  test('shrinking the block erases the leftover lines below', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 120 })
+    const r = new LiveRenderer(stream)
+    r.slot('a', 'line-a')
+    r.slot('b', 'line-b')
+    r.slot('b', null)
+    const shrink = output[output.length - 1]!
+    // old block was 3 lines (status + a + b), new block is 2 (status + a):
+    // after writing the 2 new lines, the third line must be erased and the
+    // cursor returned to the new block bottom.
+    expect(shrink.endsWith('\n\u001b[2K\u001b[1A')).toBe(true)
+  })
+
   test('clearing the last slot erases the whole block', () => {
     const { stream, output } = makeStream({ isTTY: true, columns: 120 })
     const r = new LiveRenderer(stream)

--- a/tests/review-loop/live-renderer.test.ts
+++ b/tests/review-loop/live-renderer.test.ts
@@ -251,3 +251,69 @@ describe('LiveRenderer.statusSuffix', () => {
     expect(renderer.statusSuffix()).toBe('issues: 1 rejected')
   })
 })
+
+describe('LiveRenderer slots', () => {
+  test('non-TTY slot is a no-op', () => {
+    const { stream, output } = makeStream()
+    const r = new LiveRenderer(stream)
+    r.slot('fixer-w1', '  fixer-w1 ▶ edit a.ts')
+    expect(output).toEqual([])
+  })
+
+  test('TTY slot renders the block with the slot line', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 120 })
+    const r = new LiveRenderer(stream)
+    r.slot('fixer-w1', '  fixer-w1 ▶ edit a.ts')
+    expect(output).toHaveLength(1)
+    expect(output[0]).toContain('fixer-w1 ▶ edit a.ts')
+  })
+
+  test('redraw after a multi-line block moves the cursor up to the block top', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 120 })
+    const r = new LiveRenderer(stream)
+    r.slot('a', 'line-a')
+    r.slot('b', 'line-b')
+    r.slot('c', 'line-c')
+    const redraw = output[2]!
+    expect(redraw.startsWith('\r\u001b[1A')).toBe(true)
+    expect(redraw).toContain('line-a')
+    expect(redraw).toContain('line-c')
+  })
+
+  test('clearing the last slot erases the whole block', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 120 })
+    const r = new LiveRenderer(stream)
+    r.slot('a', 'line-a')
+    r.slot('a', null)
+    const cleared = output[1]!
+    expect(cleared.startsWith('\r')).toBe(true)
+    expect(cleared).not.toContain('line-a')
+  })
+
+  test('event clears the block, prints, and redraws it', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 120 })
+    const r = new LiveRenderer(stream)
+    r.issue({ type: 'round', round: 1, maxRounds: 2 })
+    r.slot('fixer-w1', 'line-fix')
+    const before = output.length
+    r.event('hello')
+    expect(output[before]).toContain('\u001b[2K')
+    expect(output[before + 1]).toBe('hello\n')
+    expect(output[before + 2]).toContain('line-fix')
+    expect(output[before + 2]).toContain('round 1/2')
+  })
+
+  test('a throwing stream downgrades the renderer and never rethrows', () => {
+    const stream: RendererStream = {
+      write(): boolean {
+        throw Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })
+      },
+      isTTY: true,
+    }
+    const r = new LiveRenderer(stream)
+    expect(r.dynamic).toBe(true)
+    expect(() => r.event('x')).not.toThrow()
+    expect(r.dynamic).toBe(false)
+    expect(() => r.slot('a', 'line')).not.toThrow()
+  })
+})

--- a/tests/review-loop/live-renderer.test.ts
+++ b/tests/review-loop/live-renderer.test.ts
@@ -5,76 +5,7 @@
 
 import { describe, expect, test } from 'bun:test'
 
-import {
-  formatDuration,
-  formatLiveLine,
-  formatStepFooter,
-  formatToolArg,
-  LiveRenderer,
-  type RendererStream,
-} from '../../review-loop/src/live-renderer.js'
-
-describe('formatDuration', () => {
-  test('formats seconds under a minute', () => {
-    expect(formatDuration(0)).toBe('0s')
-    expect(formatDuration(42000)).toBe('42s')
-  })
-  test('formats minutes and seconds', () => {
-    expect(formatDuration(125000)).toBe('2m05s')
-  })
-})
-
-describe('formatToolArg', () => {
-  test('read/edit/write use basename of filePath', () => {
-    expect(formatToolArg('read', { filePath: '/a/b/cli.ts' })).toBe('cli.ts')
-    expect(formatToolArg('edit', { path: '/a/b/src/x.ts' })).toBe('x.ts')
-  })
-  test('bash truncates command', () => {
-    expect(formatToolArg('bash', { command: 'echo hi' })).toBe('echo hi')
-    const long = 'x'.repeat(60)
-    expect(formatToolArg('bash', { command: long })).toHaveLength(40)
-  })
-  test('grep/glob use pattern', () => {
-    expect(formatToolArg('grep', { pattern: 'TODO' })).toBe('TODO')
-  })
-  test('task uses description then subagent_type', () => {
-    expect(formatToolArg('task', { description: 'find files' })).toBe('find files')
-    expect(formatToolArg('task', { subagent_type: 'explore' })).toBe('explore')
-  })
-  test('fallback uses first string value', () => {
-    expect(formatToolArg('custom', { a: 'hello', b: 'world' })).toBe('hello')
-  })
-  test('empty input yields empty string', () => {
-    expect(formatToolArg('read', {})).toBe('')
-    expect(formatToolArg('mystery', {})).toBe('')
-  })
-})
-
-describe('formatLiveLine', () => {
-  test('renders label, tool, arg, elapsed, count', () => {
-    const line = formatLiveLine('fixer', 'edit', 'cli.ts', 42000, 3)
-    expect(line).toContain('fixer')
-    expect(line).toContain('edit cli.ts')
-    expect(line).toContain('42s')
-    expect(line).toContain('3 tools')
-  })
-  test('singular tool count', () => {
-    expect(formatLiveLine('reviewer', 'read', 'a.ts', 1000, 1)).toContain('1 tool')
-  })
-  test('no tool yet shows thinking', () => {
-    expect(formatLiveLine('reviewer', '', '', 2000, 0)).toContain('thinking')
-  })
-})
-
-describe('formatStepFooter', () => {
-  test('renders summary with tokens', () => {
-    const footer = formatStepFooter('reviewer', 18000, 4, { input: 13373, output: 31 })
-    expect(footer).toContain('reviewer')
-    expect(footer).toContain('18s')
-    expect(footer).toContain('4 tools')
-    expect(footer).toContain('in 13373 / out 31')
-  })
-})
+import { LiveRenderer, type RendererStream } from '../../review-loop/src/live-renderer.js'
 
 function makeStream(opts: { isTTY?: boolean; columns?: number } = {}): {
   stream: RendererStream
@@ -163,18 +94,6 @@ describe('LiveRenderer', () => {
     r.live(['line 1', 'line 2'])
     expect(captured.join('')).toContain('line 1')
     expect(captured.join('')).toContain('line 2')
-  })
-})
-
-describe('formatLiveLine status suffix', () => {
-  test('appends status after tool count when provided', () => {
-    const line = formatLiveLine('fixer', 'read', 'cli.ts', 5000, 3, 'round 1/3 · issues: 2 open')
-    expect(line).toContain('3 tools · round 1/3 · issues: 2 open')
-  })
-  test('omits suffix segment when status is empty', () => {
-    const line = formatLiveLine('fixer', 'read', 'cli.ts', 5000, 3)
-    expect(line).toContain('3 tools')
-    expect(line).not.toContain('round')
   })
 })
 
@@ -275,7 +194,9 @@ describe('LiveRenderer slots', () => {
     r.slot('b', 'line-b')
     r.slot('c', 'line-c')
     const redraw = output[2]!
-    expect(redraw.startsWith('\r\u001b[1A')).toBe(true)
+    // statusLine renders one block line above the slots, so the block is now 4 lines
+    // ([status, line-a, line-b, line-c]) and the third redraw moves the cursor up 2.
+    expect(redraw.startsWith('\r\u001b[2A')).toBe(true)
     expect(redraw).toContain('line-a')
     expect(redraw).toContain('line-c')
   })
@@ -315,5 +236,49 @@ describe('LiveRenderer slots', () => {
     expect(() => r.event('x')).not.toThrow()
     expect(r.dynamic).toBe(false)
     expect(() => r.slot('a', 'line')).not.toThrow()
+  })
+})
+
+describe('status line', () => {
+  test('combines round, activity, issues, and tokens', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 200 })
+    const r = new LiveRenderer(stream)
+    r.issue({ type: 'round', round: 1, maxRounds: 2 })
+    r.issue({
+      type: 'found',
+      id: 'aaaaaaaa-0000-0000-0000-000000000000',
+      severity: 'low',
+      file: 'a.ts',
+      line: 1,
+      title: 'A',
+    })
+    r.usage({ input: 228819, output: 9824, reasoning: 49844, cost: 0 })
+    r.slot('fixer-w1', 'x')
+    r.slot('fixer-w2-retry', 'y')
+    const status = output[output.length - 1]!.split('\n')[0]!
+    expect(status).toContain('status')
+    expect(status).toContain('round 1/2')
+    expect(status).toContain('fix×2')
+    expect(status).toContain('issues: 1 open')
+    expect(status).toContain('in 228.8k / out 9.8k')
+  })
+
+  test('maps slot keys to activity verbs', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 200 })
+    const r = new LiveRenderer(stream)
+    r.slot('reviewer', 'x')
+    const status = output[output.length - 1]!.split('\n')[0]!
+    expect(status).toContain('review')
+    expect(status).not.toContain('reviewer')
+  })
+
+  test('accumulates usage across calls', () => {
+    const { stream, output } = makeStream({ isTTY: true, columns: 200 })
+    const r = new LiveRenderer(stream)
+    r.usage({ input: 500, output: 0, reasoning: 0, cost: 0 })
+    r.usage({ input: 600, output: 100, reasoning: 0, cost: 0 })
+    r.slot('a', 'x')
+    const status = output[output.length - 1]!.split('\n')[0]!
+    expect(status).toContain('in 1.1k / out 100')
   })
 })

--- a/tests/review-loop/live-renderer.test.ts
+++ b/tests/review-loop/live-renderer.test.ts
@@ -11,6 +11,7 @@ import {
   formatStepFooter,
   formatToolArg,
   LiveRenderer,
+  type RendererStream,
 } from '../../review-loop/src/live-renderer.js'
 
 describe('formatDuration', () => {
@@ -76,8 +77,8 @@ describe('formatStepFooter', () => {
 })
 
 function makeStream(opts: { isTTY?: boolean; columns?: number } = {}): {
+  stream: RendererStream
   output: string[]
-  stream: { write(s: string): boolean; isTTY?: boolean; columns?: number }
 } {
   const output: string[] = []
   return {
@@ -162,5 +163,91 @@ describe('LiveRenderer', () => {
     r.live(['line 1', 'line 2'])
     expect(captured.join('')).toContain('line 1')
     expect(captured.join('')).toContain('line 2')
+  })
+})
+
+describe('formatLiveLine status suffix', () => {
+  test('appends status after tool count when provided', () => {
+    const line = formatLiveLine('fixer', 'read', 'cli.ts', 5000, 3, 'round 1/3 · issues: 2 open')
+    expect(line).toContain('3 tools · round 1/3 · issues: 2 open')
+  })
+  test('omits suffix segment when status is empty', () => {
+    const line = formatLiveLine('fixer', 'read', 'cli.ts', 5000, 3)
+    expect(line).toContain('3 tools')
+    expect(line).not.toContain('round')
+  })
+})
+
+describe('LiveRenderer.issue', () => {
+  test('found events print an indented plus line', () => {
+    const { stream, output } = makeStream()
+    const renderer = new LiveRenderer(stream)
+    renderer.issue({
+      type: 'found',
+      id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      severity: 'high',
+      file: 'src/auth/login.ts',
+      line: 42,
+      title: 'Token refresh race on 401',
+    })
+    expect(output).toContain('  + #a1b2c3d4 [high]     src/auth/login.ts:42 — Token refresh race on 401\n')
+  })
+
+  test('decided events print a mark line with note', () => {
+    const { stream, output } = makeStream()
+    const renderer = new LiveRenderer(stream)
+    renderer.issue({
+      type: 'decided',
+      id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      verdict: 'needs_human',
+      title: 't',
+      note: 'merge conflict',
+    })
+    expect(output).toContain('! #a1b2c3d4 → needs human (merge conflict)\n')
+  })
+})
+
+describe('LiveRenderer.statusSuffix', () => {
+  test('is empty before any events', () => {
+    const { stream } = makeStream()
+    expect(new LiveRenderer(stream).statusSuffix()).toBe('')
+  })
+
+  test('shows round after a round event', () => {
+    const { stream } = makeStream()
+    const renderer = new LiveRenderer(stream)
+    renderer.issue({ type: 'round', round: 2, maxRounds: 5 })
+    expect(renderer.statusSuffix()).toBe('round 2/5')
+  })
+
+  test('counts found and decided issues, omitting zero segments', () => {
+    const { stream } = makeStream()
+    const renderer = new LiveRenderer(stream)
+    renderer.issue({ type: 'round', round: 1, maxRounds: 3 })
+    renderer.issue({
+      type: 'found',
+      id: 'aaaaaaaa-0000-0000-0000-000000000000',
+      severity: 'low',
+      file: 'a.ts',
+      line: 1,
+      title: 'A',
+    })
+    renderer.issue({
+      type: 'found',
+      id: 'bbbbbbbb-0000-0000-0000-000000000000',
+      severity: 'low',
+      file: 'b.ts',
+      line: 2,
+      title: 'B',
+    })
+    renderer.issue({ type: 'decided', id: 'aaaaaaaa-0000-0000-0000-000000000000', verdict: 'fixed', title: 'A' })
+    expect(renderer.statusSuffix()).toBe('round 1/3 · issues: 1 open · 1 fixed')
+  })
+
+  test('decided on an empty pending count does not go negative', () => {
+    const { stream } = makeStream()
+    const renderer = new LiveRenderer(stream)
+    renderer.issue({ type: 'decided', id: 'aaaaaaaa-0000-0000-0000-000000000000', verdict: 'invalid', title: 'A' })
+    expect(renderer.statusSuffix()).toBe('issues: 1 rejected')
   })
 })

--- a/tests/review-loop/progress-log.test.ts
+++ b/tests/review-loop/progress-log.test.ts
@@ -9,10 +9,11 @@ import path from 'node:path'
 
 import type { SpawnFn, SpawnResult } from '../../review-loop/src/agent-runner.js'
 import type { ShellExecFn } from '../../review-loop/src/build-checker.js'
+import { formatDecidedLine, formatFoundLine } from '../../review-loop/src/issue-format.js'
 import { createIssueLedger } from '../../review-loop/src/issue-ledger.js'
 import type { IssueMatch, ReviewerIssue } from '../../review-loop/src/issue-schema.js'
 import { runReviewLoop } from '../../review-loop/src/loop-controller.js'
-import type { ProgressReporter } from '../../review-loop/src/progress-log.js'
+import type { IssueProgressEvent, ProgressReporter } from '../../review-loop/src/progress-log.js'
 import { createRunState } from '../../review-loop/src/run-state.js'
 import { execGit } from '../../review-loop/src/worktree.js'
 import { cleanupTempDirs, createReviewLoopConfigFixture, makeTempDir, fakePool, silentTrace } from './test-helpers.js'
@@ -124,6 +125,18 @@ function createMockSpawn(handlers: {
 const passingExec: ShellExecFn = (_cwd?: string): Promise<{ exitCode: number; stdout: string; stderr: string }> =>
   Promise.resolve({ exitCode: 0, stdout: '', stderr: '' })
 
+function isFoundFooLine(line: string): boolean {
+  return line.startsWith('  + #') && line.includes('src/foo.ts:10 — Missing error handling')
+}
+
+function isFixedDecidedLine(line: string): boolean {
+  return line.startsWith('✓ #') && line.endsWith('→ fixed')
+}
+
+function isRejectedDecidedLine(line: string): boolean {
+  return line.startsWith('✗ #') && line.endsWith('→ rejected')
+}
+
 function makeReporter(messages: string[]): ProgressReporter {
   return {
     dynamic: false,
@@ -138,6 +151,13 @@ function makeReporter(messages: string[]): ProgressReporter {
     clearLive() {},
     log: (message: string): void => {
       messages.push(message)
+    },
+    issue: (event: IssueProgressEvent): void => {
+      if (event.type === 'found') {
+        messages.push(formatFoundLine(event))
+      } else if (event.type === 'decided') {
+        messages.push(formatDecidedLine(event))
+      }
     },
   }
 }
@@ -185,8 +205,8 @@ describe('progress logging', () => {
 
     expect(result.doneReason).toBe('clean')
     expect(messages).toContain('[round 1/5] Reviewing...')
-    expect(messages).toContain('[round 1] Found 1 issues')
-    expect(messages.some((m) => m.startsWith('[fix] "Missing error handling"'))).toBe(true)
+    expect(messages.some(isFoundFooLine)).toBe(true)
+    expect(messages.some(isFixedDecidedLine)).toBe(true)
     expect(messages).toContain('[round 1] Fixed 1/1 issues')
     expect(messages).toContain('[done] clean after 2 rounds')
     expect(messages.some((m) => m.startsWith('[build] passed'))).toBe(true)
@@ -228,7 +248,7 @@ describe('progress logging', () => {
     expect(messages).toContain('[done] no_progress')
   })
 
-  test('truncates long issue titles in log output', async () => {
+  test('decided lines stay short regardless of title length', async () => {
     const repoRoot = makeTempDir('review-loop-progress-')
     const config = createReviewLoopConfigFixture(repoRoot)
     const planPath = path.join(repoRoot, 'plan.md')
@@ -257,9 +277,9 @@ describe('progress logging', () => {
       inspect: true,
     })
 
-    const fixMessage = messages.find((m) => m.startsWith('[fix]'))
-    expect(fixMessage).toBeDefined()
-    expect(fixMessage!.length).toBeLessThan(longTitle.length + 40)
+    const decidedMessage = messages.find(isRejectedDecidedLine)
+    expect(decidedMessage).toBeDefined()
+    expect(decidedMessage!.length).toBeLessThan(40)
   })
 
   test('round summary denominator counts only actionable issues, excluding terminal matches', async () => {

--- a/tests/review-loop/summary-burndown.test.ts
+++ b/tests/review-loop/summary-burndown.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, test } from 'bun:test'
 
-import { burndownBlock, burndownIsEmpty } from '../../review-loop/src/summary-burndown.js'
+import { burndownBlock } from '../../review-loop/src/summary-burndown.js'
 import type { RoundMetric } from '../../review-loop/src/trace-log.js'
 
 function zeroMetric(round: number): RoundMetric {
@@ -31,23 +31,36 @@ function zeroMetric(round: number): RoundMetric {
   }
 }
 
-describe('burndownIsEmpty', () => {
-  test('true when every round is entirely zero', () => {
-    expect(burndownIsEmpty([zeroMetric(1), zeroMetric(2)])).toBe(true)
-  })
-
-  test('false as soon as any field is non-zero', () => {
-    const metric = zeroMetric(1)
-    metric.decisions.fixed = 1
-    expect(burndownIsEmpty([metric])).toBe(false)
-  })
-})
+function busyMetric(round: number): RoundMetric {
+  const metric = zeroMetric(round)
+  metric.newIssues = 4
+  metric.cumulativeOpen = 2
+  metric.decisions.fixed = 2
+  metric.decisions.invalid = 1
+  metric.reviewerSeverity = { critical: 0, high: 1, medium: 2, low: 1 }
+  metric.fixerSeverity = { critical: 0, high: 1, medium: 1, low: 1 }
+  metric.phaseMs = { review: 178_300, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 }
+  metric.usage = { inputTokens: 120_000, outputTokens: 8_000, reasoningTokens: 3_000, costUsd: 1.234 }
+  return metric
+}
 
 describe('burndownBlock', () => {
-  test('renders header and one row per round', () => {
-    const block = burndownBlock([zeroMetric(1)])
-    expect(block).toContain('Burndown:')
-    expect(block).toContain('round')
-    expect(block.split('\n')).toHaveLength(3)
+  test('returns empty string when every round has zero activity', () => {
+    expect(burndownBlock([zeroMetric(1), zeroMetric(2)])).toBe('')
+  })
+
+  test('renders header aligned with row columns', () => {
+    const block = burndownBlock([busyMetric(1)])
+    const lines = block.split('\n')
+    expect(lines[0]).toBe('Burndown:')
+    expect(lines[1]).toBe('  round new open fixed rejected needs_human plan_drift insp_rej avgRev avgFix')
+    expect(lines[2]).toBe('  1     4   2    2     1        0           0          0        2.0    2.0')
+  })
+
+  test('drops zero-activity rows but keeps active ones', () => {
+    const block = burndownBlock([busyMetric(1), zeroMetric(2)])
+    const lines = block.split('\n')
+    expect(lines).toHaveLength(3)
+    expect(block).not.toContain('  2     0')
   })
 })

--- a/tests/review-loop/summary-burndown.test.ts
+++ b/tests/review-loop/summary-burndown.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { burndownBlock, burndownIsEmpty } from '../../review-loop/src/summary-burndown.js'
+import type { RoundMetric } from '../../review-loop/src/trace-log.js'
+
+function zeroMetric(round: number): RoundMetric {
+  return {
+    round,
+    newIssues: 0,
+    cumulativeOpen: 0,
+    noProgressRounds: 0,
+    decisions: {
+      fixed: 0,
+      invalid: 0,
+      already_fixed: 0,
+      needs_human: 0,
+      plan_drift: 0,
+      no_commit: 0,
+      inspector_rejected: 0,
+    },
+    reviewerSeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    fixerSeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    inspector: { runs: 0, rejected: 0 },
+    phaseMs: { review: 0, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 },
+    usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0 },
+  }
+}
+
+describe('burndownIsEmpty', () => {
+  test('true when every round is entirely zero', () => {
+    expect(burndownIsEmpty([zeroMetric(1), zeroMetric(2)])).toBe(true)
+  })
+
+  test('false as soon as any field is non-zero', () => {
+    const metric = zeroMetric(1)
+    metric.decisions.fixed = 1
+    expect(burndownIsEmpty([metric])).toBe(false)
+  })
+})
+
+describe('burndownBlock', () => {
+  test('renders header and one row per round', () => {
+    const block = burndownBlock([zeroMetric(1)])
+    expect(block).toContain('Burndown:')
+    expect(block).toContain('round')
+    expect(block.split('\n')).toHaveLength(3)
+  })
+})

--- a/tests/review-loop/summary.test.ts
+++ b/tests/review-loop/summary.test.ts
@@ -3,19 +3,60 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { describe, expect, test } from 'bun:test'
+import { beforeEach, describe, expect, test } from 'bun:test'
 
-import { buildMetricsJson, buildSummary } from '../../review-loop/src/summary.js'
+import type { IssueLedgerSnapshot, LedgerIssueRecord } from '../../review-loop/src/issue-ledger.js'
+import type { ReviewerIssue } from '../../review-loop/src/issue-schema.js'
+import { buildMetricsJson, buildSummary, type SummaryInput } from '../../review-loop/src/summary.js'
 import type { RoundMetric } from '../../review-loop/src/trace-log.js'
 
-const metricsFixture: RoundMetric[] = [
-  {
-    round: 1,
-    newIssues: 3,
-    cumulativeOpen: 3,
+const issueFixture: ReviewerIssue = {
+  title: 'Token refresh race on 401',
+  severity: 'high',
+  summary: 's',
+  whyItMatters: 'w',
+  evidence: 'e',
+  file: 'src/auth/login.ts',
+  lineStart: 42,
+  lineEnd: 50,
+  suggestedFix: 'f',
+  confidence: 0.9,
+}
+
+let idCounter = 0
+beforeEach(() => {
+  idCounter = 0
+})
+
+function makeRecord(status: LedgerIssueRecord['status'], overrides?: Partial<ReviewerIssue>): LedgerIssueRecord {
+  idCounter += 1
+  return {
+    id: `${String(idCounter).padStart(8, '0')}-0000-0000-0000-000000000000`,
+    issue: { ...issueFixture, ...overrides },
+    status,
+    firstSeenRound: 1,
+    latestSeenRound: 1,
+    fixAttempts: 0,
+    verifierDecision: null,
+  }
+}
+
+function ledgerOf(...records: LedgerIssueRecord[]): IssueLedgerSnapshot {
+  const issues: Record<string, LedgerIssueRecord> = {}
+  for (const record of records) {
+    issues[record.id] = record
+  }
+  return { issues }
+}
+
+function zeroMetric(round: number): RoundMetric {
+  return {
+    round,
+    newIssues: 0,
+    cumulativeOpen: 0,
     noProgressRounds: 0,
     decisions: {
-      fixed: 3,
+      fixed: 0,
       invalid: 0,
       already_fixed: 0,
       needs_human: 0,
@@ -23,137 +64,154 @@ const metricsFixture: RoundMetric[] = [
       no_commit: 0,
       inspector_rejected: 0,
     },
-    reviewerSeverity: { critical: 0, high: 0, medium: 0, low: 3 },
-    fixerSeverity: { critical: 0, high: 0, medium: 0, low: 3 },
-    inspector: { runs: 3, rejected: 0 },
-    phaseMs: { review: 1000, match: 100, verify: 500, build: 300, inspect: 200, fix: 50 },
-    usage: { inputTokens: 1000, outputTokens: 500, reasoningTokens: 100, costUsd: 0.05 },
-  },
-]
+    reviewerSeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    fixerSeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    inspector: { runs: 0, rejected: 0 },
+    phaseMs: { review: 0, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 },
+    usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0 },
+  }
+}
 
-describe('buildSummary', () => {
-  test('emits done reason, rounds, and closed count', () => {
-    const summary = buildSummary('clean', 3, 2, [], { poolSize: 1, inspect: false })
-    expect(summary).toContain('Done reason: clean')
-    expect(summary).toContain('Rounds executed: 3')
-    expect(summary).toContain('Closed issues: 2')
+function busyMetric(round: number): RoundMetric {
+  const metric = zeroMetric(round)
+  metric.newIssues = 4
+  metric.cumulativeOpen = 2
+  metric.decisions.fixed = 2
+  metric.decisions.invalid = 1
+  metric.reviewerSeverity = { critical: 0, high: 1, medium: 2, low: 1 }
+  metric.fixerSeverity = { critical: 0, high: 1, medium: 1, low: 1 }
+  metric.phaseMs = { review: 178_300, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 }
+  metric.usage = { inputTokens: 120_000, outputTokens: 8_000, reasoningTokens: 3_000, costUsd: 1.234 }
+  return metric
+}
+
+function inputOf(overrides?: Partial<SummaryInput>): SummaryInput {
+  return {
+    doneReason: 'clean',
+    rounds: 1,
+    metrics: [],
+    ledger: { issues: {} },
+    runDir: '/repo/.review-loop/runs/run-1',
+    options: { poolSize: 1, inspect: false },
+    ...overrides,
+  }
+}
+
+describe('buildSummary verdict', () => {
+  test('clean run with no issues and one round', () => {
+    const summary = buildSummary(inputOf({ metrics: [zeroMetric(1)] }))
+    expect(summary).toContain('Review loop finished: clean — reviewer found no issues in 1 round.')
+    expect(summary).not.toContain('Issues:')
   })
 
-  test('omits pool size when poolSize is 1', () => {
-    const summary = buildSummary('clean', 1, 0, [], { poolSize: 1, inspect: false })
-    expect(summary).not.toContain('Pool size')
-  })
-
-  test('emits a burndown block when metrics are present', () => {
-    const summary = buildSummary(
-      'max_rounds',
-      2,
-      1,
-      [
-        {
-          round: 1,
-          newIssues: 3,
-          cumulativeOpen: 3,
-          noProgressRounds: 0,
-          decisions: {
-            fixed: 1,
-            invalid: 0,
-            already_fixed: 0,
-            needs_human: 0,
-            plan_drift: 0,
-            no_commit: 0,
-            inspector_rejected: 0,
-          },
-          reviewerSeverity: { critical: 0, high: 2, medium: 1, low: 0 },
-          fixerSeverity: { critical: 0, high: 1, medium: 0, low: 0 },
-          inspector: { runs: 0, rejected: 0 },
-          phaseMs: { review: 0, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 },
-          usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0 },
-        },
-        {
-          round: 2,
-          newIssues: 1,
-          cumulativeOpen: 1,
-          noProgressRounds: 1,
-          decisions: {
-            fixed: 0,
-            invalid: 1,
-            already_fixed: 0,
-            needs_human: 0,
-            plan_drift: 0,
-            no_commit: 0,
-            inspector_rejected: 0,
-          },
-          reviewerSeverity: { critical: 0, high: 0, medium: 1, low: 0 },
-          fixerSeverity: { critical: 0, high: 0, medium: 0, low: 0 },
-          inspector: { runs: 0, rejected: 0 },
-          phaseMs: { review: 0, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 },
-          usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0 },
-        },
-      ],
-      { poolSize: 1, inspect: false },
+  test('done run lists the non-zero breakdown', () => {
+    const ledger = ledgerOf(
+      makeRecord('closed'),
+      makeRecord('closed'),
+      makeRecord('closed'),
+      makeRecord('needs_human'),
+      makeRecord('rejected'),
     )
-    expect(summary).toContain('Burndown')
+    const summary = buildSummary(inputOf({ doneReason: 'max_rounds', rounds: 2, ledger }))
+    expect(summary).toContain('Review loop finished: done — 5 issues: 3 fixed, 1 needs human, 1 rejected.')
+  })
+
+  test('issues remaining leads with the open count', () => {
+    const ledger = ledgerOf(makeRecord('closed'), makeRecord('verified'), makeRecord('discovered'))
+    const summary = buildSummary(inputOf({ doneReason: 'no_progress', rounds: 3, ledger }))
+    expect(summary).toContain('Review loop finished: issues remaining — 2 open (1 fixed).')
+  })
+})
+
+describe('buildSummary zero suppression', () => {
+  test('drops zero wall-clock phases from the duration breakdown', () => {
+    const summary = buildSummary(inputOf({ metrics: [busyMetric(1)] }))
+    expect(summary).toContain('(review 178.3s)')
+    expect(summary).not.toContain('match 0.0s')
+    expect(summary).not.toContain('fix 0.0s')
+  })
+
+  test('omits the burndown table for a single all-zero round', () => {
+    const summary = buildSummary(inputOf({ metrics: [zeroMetric(1)] }))
+    expect(summary).not.toContain('Burndown:')
+  })
+
+  test('keeps the burndown table when a round has activity', () => {
+    const summary = buildSummary(inputOf({ metrics: [busyMetric(1)] }))
+    expect(summary).toContain('Burndown:')
     expect(summary).toContain('round')
   })
+})
 
-  test('summary includes pool size, inspector stats, total cost, and phase wall-clock', () => {
-    const summary = buildSummary('clean', 1, 3, metricsFixture, { poolSize: 3, inspect: true })
-    expect(summary).toContain('Pool size: 3')
-    expect(summary).toContain('Inspector: 3 runs, 0 rejected')
-    expect(summary).toContain('Total cost: $0.05')
-    expect(summary).toContain('Wall clock:')
-    expect(summary).toContain('review:')
-    expect(summary).toContain('insp_rej')
+describe('buildSummary timing and cost', () => {
+  test('renders duration, nonzero phases, and cost on one line', () => {
+    const summary = buildSummary(inputOf({ metrics: [busyMetric(1)] }))
+    expect(summary).toContain('Duration: 2m58s (review 178.3s) · Cost: $1.234 (in 120000 / out 8000 / reasoning 3000)')
+  })
+})
+
+describe('buildSummary rounds and pool line', () => {
+  test('omitted for a single round with pool size 1', () => {
+    const summary = buildSummary(inputOf())
+    expect(summary).not.toContain('Rounds:')
+  })
+  test('included when rounds > 1 or pool > 1', () => {
+    expect(buildSummary(inputOf({ rounds: 2 }))).toContain('Rounds: 2')
+    expect(buildSummary(inputOf({ options: { poolSize: 4, inspect: false } }))).toContain('Rounds: 1 · Pool: 4')
+  })
+})
+
+describe('buildSummary issue groups', () => {
+  test('groups in order with marks and issue refs', () => {
+    const ledger = ledgerOf(
+      makeRecord('closed', { title: 'Fixed one' }),
+      makeRecord('needs_human', { title: 'Scary one', severity: 'critical' }),
+      makeRecord('rejected', { title: 'Bogus one', severity: 'low' }),
+    )
+    const summary = buildSummary(inputOf({ rounds: 2, ledger }))
+    const needsIdx = summary.indexOf('  needs human (1):')
+    const fixedIdx = summary.indexOf('  fixed (1):')
+    const rejectedIdx = summary.indexOf('  rejected (1):')
+    expect(needsIdx).toBeGreaterThan(-1)
+    expect(needsIdx).toBeLessThan(fixedIdx)
+    expect(fixedIdx).toBeLessThan(rejectedIdx)
+    expect(summary).toContain('! #00000002 [critical] src/auth/login.ts:42 — Scary one')
+    expect(summary).toContain('✓ #00000001 [high]     src/auth/login.ts:42 — Fixed one')
+    expect(summary).toContain('✗ #00000003 [low]      src/auth/login.ts:42 — Bogus one')
   })
 
-  test('summary hides inspector line when inspect option is false', () => {
-    const summary = buildSummary('clean', 1, 3, metricsFixture, { poolSize: 3, inspect: false })
-    expect(summary).not.toContain('Inspector:')
+  test('caps a group at 20 lines with a see-ledger note', () => {
+    const records = Array.from({ length: 21 }, () => makeRecord('needs_human'))
+    const summary = buildSummary(inputOf({ rounds: 2, ledger: ledgerOf(...records) }))
+    expect(summary).toContain('  needs human (21):')
+    expect(summary).toContain('    …and 1 more (see ledger.json)')
+    const bangLines = summary.split('\n').filter((l) => l.startsWith('    ! #'))
+    expect(bangLines).toHaveLength(20)
+  })
+
+  test('open bucket appears only when issues are left open', () => {
+    const summary = buildSummary(
+      inputOf({ doneReason: 'max_rounds', rounds: 2, ledger: ledgerOf(makeRecord('verified')) }),
+    )
+    expect(summary).toContain('  open (1):')
+    expect(summary).toContain('· #00000001')
+  })
+})
+
+describe('buildSummary artifacts', () => {
+  test('always lists the run dir and known artifact files', () => {
+    const summary = buildSummary(inputOf())
+    expect(summary).toContain('Artifacts (/repo/.review-loop/runs/run-1):')
+    expect(summary).toContain('summary.txt · metrics.json · ledger.json · trace.jsonl · agent-output.log · state.json')
   })
 })
 
 describe('buildMetricsJson', () => {
-  test('returns burndown series and totals', () => {
-    const parsed = buildMetricsJson(
-      'max_rounds',
-      1,
-      1,
-      [
-        {
-          round: 1,
-          newIssues: 2,
-          cumulativeOpen: 2,
-          noProgressRounds: 0,
-          decisions: {
-            fixed: 1,
-            invalid: 1,
-            already_fixed: 0,
-            needs_human: 0,
-            plan_drift: 0,
-            no_commit: 0,
-            inspector_rejected: 0,
-          },
-          reviewerSeverity: { critical: 0, high: 1, medium: 1, low: 0 },
-          fixerSeverity: { critical: 0, high: 1, medium: 0, low: 0 },
-          inspector: { runs: 0, rejected: 0 },
-          phaseMs: { review: 0, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 },
-          usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0 },
-        },
-      ],
-      { poolSize: 1, inspect: false },
-    )
-    expect(parsed.doneReason).toBe('max_rounds')
-    expect(parsed.rounds).toBe(1)
-    expect(parsed.burndown).toHaveLength(1)
-    expect(parsed.totals).toBeDefined()
-  })
-
-  test('metrics.json includes poolSize, usage, phaseMs, inspectorRejected totals', () => {
-    const m = buildMetricsJson('clean', 1, 3, metricsFixture, { poolSize: 3, inspect: true })
-    expect(m.poolSize).toBe(3)
-    expect(m.usage.costUsd).toBeGreaterThan(0)
-    expect(m.phaseMs.review).toBeGreaterThan(0)
-    expect(m.totals.inspectorRejected).toBe(0)
+  test('keeps the existing shape', () => {
+    const json = buildMetricsJson('max_rounds', 2, 1, [busyMetric(1)], { poolSize: 1, inspect: false })
+    expect(json.doneReason).toBe('max_rounds')
+    expect(json.rounds).toBe(2)
+    expect(json.totals.closed).toBe(1)
+    expect(json.usage.inputTokens).toBe(120_000)
   })
 })

--- a/tests/review-loop/summary.test.ts
+++ b/tests/review-loop/summary.test.ts
@@ -141,6 +141,12 @@ describe('buildSummary zero suppression', () => {
     expect(summary).toContain('Burndown:')
     expect(summary).toContain('round')
   })
+
+  test('drops zero-activity rounds from a multi-round burndown', () => {
+    const summary = buildSummary(inputOf({ metrics: [busyMetric(1), zeroMetric(2)] }))
+    expect(summary).toContain('Burndown:')
+    expect(summary).not.toContain('  2     0')
+  })
 })
 
 describe('buildSummary timing and cost', () => {

--- a/tests/review-loop/summary.test.ts
+++ b/tests/review-loop/summary.test.ts
@@ -92,6 +92,7 @@ function inputOf(overrides?: Partial<SummaryInput>): SummaryInput {
     metrics: [],
     ledger: { issues: {} },
     runDir: '/repo/.review-loop/runs/run-1',
+    wallMs: 200_000,
     options: { poolSize: 1, inspect: false },
     ...overrides,
   }
@@ -150,9 +151,19 @@ describe('buildSummary zero suppression', () => {
 })
 
 describe('buildSummary timing and cost', () => {
-  test('renders duration, nonzero phases, and cost on one line', () => {
+  test('renders wall time, phase sum, nonzero phases, and cost on one line', () => {
     const summary = buildSummary(inputOf({ metrics: [busyMetric(1)] }))
-    expect(summary).toContain('Duration: 2m58s (review 178.3s) · Cost: $1.234 (in 120000 / out 8000 / reasoning 3000)')
+    expect(summary).toContain(
+      'Duration: 3m20s wall · phases 2m58s (review 178.3s) · Cost: $1.234 (in 120,000 / out 8,000 / reasoning 3,000)',
+    )
+  })
+
+  test('hides cost and shows Tokens when the reported cost is zero', () => {
+    const metric = busyMetric(1)
+    metric.usage = { inputTokens: 228_819, outputTokens: 9_824, reasoningTokens: 49_844, costUsd: 0 }
+    const summary = buildSummary(inputOf({ metrics: [metric] }))
+    expect(summary).toContain('· Tokens: in 228,819 / out 9,824 / reasoning 49,844')
+    expect(summary).not.toContain('Cost:')
   })
 })
 


### PR DESCRIPTION
## Summary

Redesigns the review-loop CLI's output per `docs/superpowers/specs/2026-08-01-review-loop-report-output-design.md`:

- **Final report** (`summary.ts` → console + `summary.txt`): verdict-first line (`clean — reviewer found no issues` / `done — N issues: X fixed, Y needs human, Z rejected` / `issues remaining — N open`), zero-suppressed duration/cost line, per-issue groups (capped at 20, ordered needs human → fixed → rejected → already fixed → open), burndown omitted for all-zero single rounds, and an artifacts block with the run dir and file names. `metrics.json` schema unchanged.
- **Live rendering**: reviewer findings stream as `  + #id8 [sev] file:line — title` lines at the match boundary; fix/verify decisions stream as `✓/✗/! #id8 → verdict (note)`; the live tick gains a status suffix (`· round 1/3 · issues: 2 open · 1 fixed`).

## Implementation

4 TDD tasks, each a commit, executed via subagent-driven development with per-task spec+quality review and a clean final whole-branch review:

1. `issue-format.ts` — shared formatting module (ids, refs, marks, groups)
2. Reporter seam — `IssueProgressEvent` + optional `issue?()`/`statusSuffix?()` on `ProgressReporter`; `LiveRenderer` counter bag
3. Event emission — loop-controller (round/found), processors + commit-attempt (decided via `emitDecision`), replacing `[fix] "…"` decision strings
4. `buildSummary` rewrite (new `SummaryInput` signature; burndown extracted to `summary-burndown.ts` for the max-lines gate) + `cli.ts` wiring

## Test plan

- [x] `bun run review-loop:test` — 273 pass / 0 fail at HEAD
- [x] `bun run review-loop:typecheck` — clean
- [x] Pre-commit hooks (lint, typecheck, format, license-headers) green on every commit
- [ ] Manual: run `bun run review-loop:start -- --plan <plan>` and eyeball the new report