### PR TITLE
fix(analytics): tool_completed durationMs float/int contract (#209)

### DIFF
--- a/docs/superpowers/plans/2026-08-02-tool-completed-durationms.md
+++ b/docs/superpowers/plans/2026-08-02-tool-completed-durationms.md
@@ -1,0 +1,321 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# `tool_completed` durationMs float/int fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `tool_completed` analytics facts being rejected `invalid_value` by rounding `durationMs` at emission and closing the subscriber/normalizer contract gap (issue #209).
+
+**Architecture:** Round `durationMs` at the analytics emission site (matching the sibling convention in `turn-observer.ts` / `provider-observer.ts`), and add a `DurationMs` zod schema with a rounding transform applied to `ToolCompletedDataSchema.durationMs` and `LlmErrorDataSchema.durationMs` so the subscriber output is int-guaranteed. The normalizer stays strict and unchanged.
+
+**Tech Stack:** Bun, TypeScript (strict), Zod v4, bun:test.
+
+**Spec:** `docs/superpowers/specs/2026-08-02-tool-completed-durationms-design.md`
+
+## Global Constraints
+
+- Runtime **Bun**; tests use `bun:test` (`describe` / `test` / `expect`). Run focused suites with `bun test <path>`.
+- Strict TypeScript; use `.js` extension in import paths.
+- Never add lint-disable or type-ignore comments.
+- The pre-commit hook runs lint, typecheck, format:check, license-headers — commit only when all pass.
+- Commit style: conventional commits, e.g. `fix(analytics): ...` (see `git log`).
+- Deviation from spec, deliberate (mutation hygiene): the spec sketches `DurationMs` as `.transform(v => Math.max(0, Math.round(v)))`; the plan uses `.transform((value) => Math.round(value))` because `.nonnegative()` already guarantees `value >= 0`, so the `Math.max` branch would be an unkillable mutant. The emission site keeps the full `Math.max(0, Math.round(...))` because its input is unvalidated.
+
+---
+
+### Task 1: Round `durationMs` at analytics emission
+
+**Files:**
+- Modify: `src/llm-orchestrator-tool-events.ts:201` (`emitAnalyticsCompleted`)
+- Test: `tests/llm-orchestrator-tool-events.test.ts` (append to the `describe('analytics terminal ordering')` block, after the `'start and terminal retain identical tool identity fields'` test, i.e. before the closing `})` at line 237)
+
+**Interfaces:**
+- Consumes: existing `ToolCallFinishEvent` (`durationMs: number`, float in practice) and the existing `lifecycle(...)` / `successEvent(...)` / `ofType(...)` helpers in the test file.
+- Produces: `tool:analytics_completed` debug event whose `data.durationMs` is always a non-negative integer. `tool:execute_end` keeps the raw float (unchanged).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside `describe('analytics terminal ordering')`, after the last test:
+
+```ts
+  test('analytics terminal rounds float durationMs; execute_end keeps the raw value', () => {
+    const { collected } = lifecycle({ ...successEvent({ title: 'done' }), durationMs: 42.4 })
+    const terminal = ofType(collected, 'tool:analytics_completed')[0]!
+    expect(terminal.data['durationMs']).toBe(42)
+    const executeEnd = ofType(collected, 'tool:execute_end')[0]!
+    expect(executeEnd.data['durationMs']).toBe(42.4)
+  })
+
+  test('analytics terminal clamps negative durationMs to zero', () => {
+    const { collected } = lifecycle({ ...successEvent({ title: 'done' }), durationMs: -3 })
+    const terminal = ofType(collected, 'tool:analytics_completed')[0]!
+    expect(terminal.data['durationMs']).toBe(0)
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/llm-orchestrator-tool-events.test.ts`
+Expected: FAIL — first test sees `terminal.data['durationMs']` === `42.4` (raw passthrough); second sees `-3`.
+
+- [ ] **Step 3: Apply the emission-side rounding**
+
+In `src/llm-orchestrator-tool-events.ts`, inside `emitAnalyticsCompleted`, change:
+
+```ts
+      analyticsSourceId: analyticsSourceIdOf(ctx, event.toolCall.toolCallId),
+      durationMs: event.durationMs,
+```
+
+to:
+
+```ts
+      analyticsSourceId: analyticsSourceIdOf(ctx, event.toolCall.toolCallId),
+      durationMs: Math.max(0, Math.round(event.durationMs)),
+```
+
+The line `durationMs: event.durationMs,` also appears in the `tool:execute_end` emit inside `handleToolCallFinishEvent` (line 228) — do **not** change that one; the `tool:execute_end` payload must keep the raw float (Task 1's first test asserts this).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/llm-orchestrator-tool-events.test.ts`
+Expected: PASS (all tests in the file, including the two new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/llm-orchestrator-tool-events.ts tests/llm-orchestrator-tool-events.test.ts
+git commit -m "fix(analytics): round tool_completed durationMs at emission (#209)"
+```
+
+---
+
+### Task 2: `DurationMs` rounding schema transform
+
+**Files:**
+- Modify: `src/analytics/subscriber-schemas.ts:80` (`LlmErrorDataSchema.durationMs`) and `:96` (`ToolCompletedDataSchema.durationMs`); add the `DurationMs` export next to `NonNegativeInt` at line 18.
+- Test: `tests/analytics/subscriber-schemas.test.ts` (schema unit tests)
+- Test: `tests/analytics/subscriber.test.ts` (bus-level regression test)
+- Test: `tests/analytics/normalizer.test.ts` (strict-backstop characterization test)
+
+**Interfaces:**
+- Consumes: `z` (zod v4, already imported in `subscriber-schemas.ts`).
+- Produces:
+  ```ts
+  export const DurationMs: ZodPipe<ZodNumber, ZodTransform<number, number>>
+  ```
+  Input: any finite number `>= 0`; output: `Math.round(input)` (always a safe integer). NaN and negatives fail `safeParse`.
+  Used as the `durationMs` field type in `ToolCompletedDataSchema` and `LlmErrorDataSchema`. Downstream readers (`src/analytics/subscriber.ts:127` and `:178`) keep working unchanged — `data.data.durationMs` is still typed `number`.
+
+- [ ] **Step 1: Write the failing schema tests**
+
+In `tests/analytics/subscriber-schemas.test.ts`, first update the import to include `LlmErrorDataSchema`:
+
+```ts
+import {
+  attemptIdentityOf,
+  DisclosureFallbackDataSchema,
+  LlmEndDataSchema,
+  LlmErrorDataSchema,
+  ToolCompletedDataSchema,
+  ToolIdentitySchema,
+} from '../../src/analytics/subscriber-schemas.js'
+```
+
+Then append these tests inside `describe('subscriber event data schemas')`, after the `'tool completed data requires the bounded terminal classification fields'` test:
+
+```ts
+  test('tool completed rounds float durationMs to the nearest integer (half up)', () => {
+    const base = {
+      toolName: 'create_task',
+      toolCallId: 'tc1',
+      argsBytes: 4,
+      executionOutcome: 'semantic_success',
+      resultBytes: 2,
+      errorClass: null,
+      statusClass: 'none',
+      retryable: null,
+      recoveredSameTurn: false,
+    }
+    const floor = ToolCompletedDataSchema.safeParse({ ...base, durationMs: 9.4 })
+    expect(floor.success).toBe(true)
+    expect(floor.data?.durationMs).toBe(9)
+    const half = ToolCompletedDataSchema.safeParse({ ...base, durationMs: 12.5 })
+    expect(half.success).toBe(true)
+    expect(half.data?.durationMs).toBe(13)
+  })
+
+  test('tool completed still rejects negative and NaN durationMs', () => {
+    const base = {
+      toolName: 'create_task',
+      toolCallId: 'tc1',
+      argsBytes: 4,
+      executionOutcome: 'semantic_success',
+      resultBytes: 2,
+      errorClass: null,
+      statusClass: 'none',
+      retryable: null,
+      recoveredSameTurn: false,
+    }
+    expect(ToolCompletedDataSchema.safeParse({ ...base, durationMs: -1 }).success).toBe(false)
+    expect(ToolCompletedDataSchema.safeParse({ ...base, durationMs: Number.NaN }).success).toBe(false)
+  })
+
+  test('llm:error rounds float durationMs and rejects negatives', () => {
+    const parsed = LlmErrorDataSchema.safeParse({ model: 'gpt-x', durationMs: 100.4 })
+    expect(parsed.success).toBe(true)
+    expect(parsed.data?.durationMs).toBe(100)
+    expect(LlmErrorDataSchema.safeParse({ model: 'gpt-x', durationMs: -1 }).success).toBe(false)
+  })
+```
+
+- [ ] **Step 2: Write the failing bus-level regression test (and one strict-backstop characterization test)**
+
+In `tests/analytics/subscriber.test.ts`, append inside `describe('analytics subscriber')`, after the `'maps approved llm:end, llm:error, tool, and disclosure events'` test (line 217):
+
+```ts
+  test('rounds float llm:error and tool durations to integers at the boundary', () => {
+    const { bus, observer, registry } = setup()
+    registry.register({ turnId: 'turn-1', source: memberSource })
+    bus.emit(busEvent('llm:error', { model: 'gpt-x', durationMs: 100.4 }, 'turn-1'))
+    bus.emit(
+      busEvent(
+        'tool:analytics_completed',
+        {
+          toolName: 'core_task_create',
+          toolCallId: 'tc-1',
+          argsBytes: 42,
+          durationMs: 55.6,
+          executionOutcome: 'semantic_success',
+          resultBytes: 120,
+          errorClass: null,
+          statusClass: '2xx',
+          retryable: null,
+          recoveredSameTurn: false,
+          modelRole: 'main',
+        },
+        'turn-1',
+      ),
+    )
+    expect(firstFactOfType(observer.facts, 'llm_failed').durationMs).toBe(100)
+    expect(firstFactOfType(observer.facts, 'tool_completed').durationMs).toBe(56)
+  })
+```
+
+In `tests/analytics/normalizer.test.ts`, append inside the main `describe('normalizer')` block, after the `'execution family: tool_completed emits semantic outcome and status class'` test (line 464), a characterization test pinning that the normalizer stays a strict backstop for facts that bypass the subscriber. This test passes **before** the implementation too — that is expected; it locks the contract boundary so a future "tolerant normalizer" change is a deliberate act:
+
+```ts
+  test('execution family: tool_completed with a float durationMs bypassing the subscriber is still rejected', () => {
+    const result = normalize(
+      {
+        version: 1,
+        type: 'tool_completed',
+        sourceEventId: 'se-tc-float',
+        occurredAtMs: 1_700_000_000_900,
+        source: memberSource,
+        toolSlug: 'core_task_create',
+        toolOrigin: 'core',
+        toolDomain: 'task',
+        risk: 'write',
+        modelRole: 'main',
+        argsBytes: 300,
+        durationMs: 450.5,
+        executionOutcome: 'semantic_success',
+        resultBytes: 120,
+        errorClass: null,
+        statusClass: '2xx',
+        retryable: null,
+        recoveredSameTurn: false,
+      },
+      env,
+    )
+    expect(result).toEqual({ status: 'rejected', sourceEventType: 'tool_completed', reason: 'invalid_value' })
+  })
+```
+
+(Assertion shape mirrors the sibling `'fail-closed: negative duration yields a bounded rejection'` test at `tests/analytics/normalizer.test.ts:1047`.)
+
+- [ ] **Step 3: Run tests to verify the new behavior tests fail**
+
+Run: `bun test tests/analytics/subscriber-schemas.test.ts tests/analytics/subscriber.test.ts tests/analytics/normalizer.test.ts`
+Expected: the schema rounding tests FAIL (raw floats `9.4` / `12.5` / `100.4` come back unrounded) and the bus-level regression test FAILS (`durationMs` `55.6` / `100.4` on the recorded facts). The normalizer characterization test PASSES already (strict backstop is existing behavior) — that is intentional.
+
+- [ ] **Step 4: Add `DurationMs` and apply it to both schemas**
+
+In `src/analytics/subscriber-schemas.ts`, immediately after the `NonNegativeInt` definition (line 18), add:
+
+```ts
+export const DurationMs = z
+  .number()
+  .nonnegative()
+  .transform((value) => Math.round(value))
+```
+
+Then, in `LlmErrorDataSchema` (line 80), change:
+
+```ts
+  durationMs: z.number().nonnegative(),
+```
+
+to:
+
+```ts
+  durationMs: DurationMs,
+```
+
+And in `ToolCompletedDataSchema` (line 96), change:
+
+```ts
+  durationMs: z.number().nonnegative(),
+```
+
+to:
+
+```ts
+  durationMs: DurationMs,
+```
+
+Leave `LlmEndDataSchema.totalDuration` (line 68) as `z.number().nonnegative()` — out of scope per the spec (its only emitter produces integer `Date.now()` deltas).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test tests/analytics/subscriber-schemas.test.ts tests/analytics/subscriber.test.ts tests/analytics/normalizer.test.ts`
+Expected: PASS (all tests in all three files).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/analytics/subscriber-schemas.ts tests/analytics/subscriber-schemas.test.ts tests/analytics/subscriber.test.ts tests/analytics/normalizer.test.ts
+git commit -m "fix(analytics): round durationMs via subscriber schema transform (#209)"
+```
+
+---
+
+### Task 3: Full verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run every test file touching the changed behavior**
+
+Run: `bun test tests/llm-orchestrator-tool-events.test.ts tests/analytics/subscriber-schemas.test.ts tests/analytics/subscriber.test.ts tests/analytics/normalizer.test.ts tests/analytics/contracts.test.ts tests/analytics/provider-observer.test.ts tests/analytics/llm-tool-integration.test.ts`
+Expected: PASS, 0 failures.
+
+- [ ] **Step 2: Run the full in-process suite**
+
+Run: `bun run test`
+Expected: PASS, 0 failures (pre-commit hook already covers lint/typecheck/format on the committed files).
+
+- [ ] **Step 3: Hand off the prod verification query**
+
+Record the issue's post-deploy confirmation query for the PR description (do not execute it locally; pushing/PR creation happens only on explicit user request):
+
+```sql
+SELECT source_event_type, reason, count FROM analytics_normalization_rejections ORDER BY count DESC;
+```
+
+Expect `tool_completed` / `invalid_value` to stop growing after deploy.

--- a/docs/superpowers/specs/2026-08-02-tool-completed-durationms-design.md
+++ b/docs/superpowers/specs/2026-08-02-tool-completed-durationms-design.md
@@ -1,0 +1,136 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Analytics `tool_completed` durationMs float/int fix
+
+**Date:** 2026-08-02
+**Status:** Design approved, pending spec review
+**Issue:** https://github.com/yourpapai/papai/issues/209
+
+## Problem
+
+`tool_completed` analytics facts are rejected by the normalizer with reason
+`invalid_value`, undercounting tool metrics (`tool_semantic_success` /
+`tool_failed`) and inflating the Stage B rejects counter (~20–30/day on
+production).
+
+Root cause: a contract disagreement between the subscriber schema and the
+normalizer on `durationMs`:
+
+- Subscriber accepts a float: `durationMs: z.number().nonnegative()` —
+  `src/analytics/subscriber-schemas.ts:96`
+- Normalizer requires a safe integer: `nonNegativeInt` checks
+  `Number.isSafeInteger` — `src/analytics/normalizer-shared.ts:38-39`, applied
+  at `src/analytics/normalizer-props-execution.ts:190` (`buildToolCompleted`)
+- The tool-call emitter passes `durationMs` raw (a float):
+  `src/llm-orchestrator-tool-events.ts:201` reads `event.durationMs`, sourced
+  from the AI SDK's `toolExecutionMs` (a `performance.now()` delta) via
+  `adaptToolExecutionEnd` at `src/llm-orchestrator-tool-events.ts:138`. No
+  rounding is applied.
+
+Sibling duration paths round explicitly at emission (`turn-observer.ts:74`,
+`provider-observer.ts:117`, `message-edit/w2-regen.ts:107,111`); the tool-call
+path omits this rounding, so a float passes the subscriber but fails the
+normalizer.
+
+Two sibling fields share the loose-schema pattern but are safe in practice
+today:
+
+- `LlmErrorDataSchema.durationMs` (`subscriber-schemas.ts:80`) →
+  `llm_failed.durationMs` → `nonNegativeInt` — protected only because
+  `provider-observer.ts:117` rounds upstream (latent gap).
+- `LlmEndDataSchema.totalDuration` (`subscriber-schemas.ts:68`) →
+  `llm_completed.durationMs` → `nonNegativeInt` — `Date.now()` delta at
+  `llm-orchestrator-events.ts:165` is always an integer.
+
+## Goal
+
+Stop `tool_completed` rejections and close the subscriber/normalizer contract
+gap so no duration field can silently drift into the same failure again.
+
+## Design
+
+### 1. Emission-side rounding
+
+`src/llm-orchestrator-tool-events.ts:201` (`emitAnalyticsCompleted`):
+
+```ts
+durationMs: Math.max(0, Math.round(event.durationMs)),
+```
+
+Matches the established sibling convention. The debug-only `tool:execute_end`
+event (`llm-orchestrator-tool-events.ts:228`) keeps the raw float — it is not
+consumed by the analytics subscriber and sub-millisecond precision is harmless
+there.
+
+### 2. Rounding schema transform (contract closure)
+
+`src/analytics/subscriber-schemas.ts`: add
+
+```ts
+export const DurationMs = z
+  .number()
+  .nonnegative()
+  .transform(v => Math.max(0, Math.round(v)))
+```
+
+and use it for:
+
+- `ToolCompletedDataSchema.durationMs` (`subscriber-schemas.ts:96`)
+- `LlmErrorDataSchema.durationMs` (`subscriber-schemas.ts:80`)
+
+The schema stays tolerant at the boundary (accepts floats, rounds them) but its
+output is int-guaranteed, so the normalizer's `nonNegativeInt` always passes.
+Unlike tightening to plain `NonNegativeInt`, a future non-rounding emitter can
+never cause a *silent* fact drop at the subscriber (`safeParse` failure →
+`return null`, no rejection metric) — worst-case it rounds.
+
+`LlmEndDataSchema.totalDuration` is deliberately left as-is: its only emitter
+produces integer `Date.now()` deltas, and changing it is a no-risk follow-up,
+not part of this fix.
+
+### 3. Normalizer — unchanged
+
+`nonNegativeInt` stays strict as the backstop. NaN and negative values still
+fail `safeParse` at the subscriber schema (zod rejects NaN on `z.number()`;
+`nonnegative()` rejects negatives) via the existing path. No new failure modes.
+
+### Data flow after fix
+
+AI SDK `toolExecutionMs` (float) → `adaptToolExecutionEnd` (raw) →
+`emitAnalyticsCompleted` (rounded int) → `ToolCompletedDataSchema` (tolerant,
+rounds any residual float) → normalizer `nonNegativeInt` (passes).
+
+## Testing
+
+TDD; failing tests first:
+
+1. `tests/llm-orchestrator-tool-events.test.ts` — a tool finish event with a
+   float `toolExecutionMs` emits `tool:analytics_completed` with a rounded
+   integer `durationMs` (`Math.max(0, Math.round(...))` semantics).
+2. `tests/analytics/subscriber-schemas.test.ts` — `ToolCompletedDataSchema`
+   and `LlmErrorDataSchema` parse a float `durationMs` to the rounded integer;
+   negative and NaN inputs still fail.
+3. `tests/analytics/normalizer.test.ts` — explicit regression case: a
+   `tool_completed` fact whose `durationMs` passed through the subscriber as a
+   float is accepted (rounded), not rejected `invalid_value`.
+
+Verification on prod after deploy (from the issue):
+
+```sql
+SELECT source_event_type, reason, count FROM analytics_normalization_rejections ORDER BY count DESC;
+```
+
+Expect `tool_completed` / `invalid_value` to stop growing.
+
+## Out of scope
+
+- `LlmEndDataSchema.totalDuration` schema tightening (integer in practice).
+- Making the normalizer's duration reads tolerant-and-rounding (defense in
+  depth at a third layer; rejected for now — the subscriber transform already
+  guarantees the contract).
+- `tool:execute_end` debug event payload.

--- a/src/analytics/subscriber-schemas.ts
+++ b/src/analytics/subscriber-schemas.ts
@@ -16,6 +16,10 @@ import { ErrorClassSchema, StatusClassSchema } from './controlled-types.js'
 import type { AnalyticsSourceContext } from './source-facts.js'
 
 export const NonNegativeInt = z.number().int().nonnegative()
+export const DurationMs = z
+  .number()
+  .nonnegative()
+  .transform((value) => Math.round(value))
 export const ModelRoleSchema = z.enum(['main', 'small'])
 export const ProviderBindingSchema = z.enum(['global', 'byok', 'mixed'])
 
@@ -77,7 +81,7 @@ export const LlmEndDataSchema = z.looseObject({
 
 export const LlmErrorDataSchema = z.looseObject({
   model: z.string().min(1),
-  durationMs: z.number().nonnegative(),
+  durationMs: DurationMs,
   phase: z.enum(['resolution', 'request', 'stream']).optional(),
   errorClass: ErrorClassSchema.optional(),
   retryable: z.boolean().nullable().optional(),
@@ -93,7 +97,7 @@ export const ToolIdentitySchema = z.looseObject({
 })
 
 export const ToolCompletedDataSchema = ToolIdentitySchema.extend({
-  durationMs: z.number().nonnegative(),
+  durationMs: DurationMs,
   executionOutcome: z.enum(['semantic_success', 'structured_failure', 'thrown_failure', 'permission_denied']),
   resultBytes: NonNegativeInt,
   errorClass: ErrorClassSchema.nullable(),

--- a/src/llm-orchestrator-tool-events.ts
+++ b/src/llm-orchestrator-tool-events.ts
@@ -198,7 +198,7 @@ const emitAnalyticsCompleted = (
       toolName: event.toolCall.toolName,
       toolCallId: event.toolCall.toolCallId,
       analyticsSourceId: analyticsSourceIdOf(ctx, event.toolCall.toolCallId),
-      durationMs: event.durationMs,
+      durationMs: Math.max(0, Math.round(event.durationMs)),
       executionOutcome: terminal.outcome,
       argsBytes: safeByteLength(event.toolCall.input),
       resultBytes: event.success ? (safeByteLength(event.output) ?? 0) : 0,

--- a/tests/analytics/normalizer.test.ts
+++ b/tests/analytics/normalizer.test.ts
@@ -463,6 +463,33 @@ describe('normalizer', () => {
     })
   })
 
+  test('execution family: tool_completed with a float durationMs bypassing the subscriber is still rejected', () => {
+    const result = normalize(
+      {
+        version: 1,
+        type: 'tool_completed',
+        sourceEventId: 'se-tc-float',
+        occurredAtMs: 1_700_000_000_900,
+        source: memberSource,
+        toolSlug: 'core_task_create',
+        toolOrigin: 'core',
+        toolDomain: 'task',
+        risk: 'write',
+        modelRole: 'main',
+        argsBytes: 300,
+        durationMs: 450.5,
+        executionOutcome: 'semantic_success',
+        resultBytes: 120,
+        errorClass: null,
+        statusClass: '2xx',
+        retryable: null,
+        recoveredSameTurn: false,
+      },
+      env,
+    )
+    expect(result).toEqual({ status: 'rejected', sourceEventType: 'tool_completed', reason: 'invalid_value' })
+  })
+
   test('execution family: confirmation_requested fixes the five-minute timeout literal', () => {
     const result = normalize(
       {

--- a/tests/analytics/subscriber-schemas.test.ts
+++ b/tests/analytics/subscriber-schemas.test.ts
@@ -9,6 +9,7 @@ import {
   attemptIdentityOf,
   DisclosureFallbackDataSchema,
   LlmEndDataSchema,
+  LlmErrorDataSchema,
   ToolCompletedDataSchema,
   ToolIdentitySchema,
 } from '../../src/analytics/subscriber-schemas.js'
@@ -82,6 +83,49 @@ describe('subscriber event data schemas', () => {
       recoveredSameTurn: false,
     })
     expect(dynamicOutcome.success).toBe(false)
+  })
+
+  test('tool completed rounds float durationMs to the nearest integer (half up)', () => {
+    const base = {
+      toolName: 'create_task',
+      toolCallId: 'tc1',
+      argsBytes: 4,
+      executionOutcome: 'semantic_success',
+      resultBytes: 2,
+      errorClass: null,
+      statusClass: 'none',
+      retryable: null,
+      recoveredSameTurn: false,
+    }
+    const floor = ToolCompletedDataSchema.safeParse({ ...base, durationMs: 9.4 })
+    expect(floor.success).toBe(true)
+    expect(floor.data?.durationMs).toBe(9)
+    const half = ToolCompletedDataSchema.safeParse({ ...base, durationMs: 12.5 })
+    expect(half.success).toBe(true)
+    expect(half.data?.durationMs).toBe(13)
+  })
+
+  test('tool completed still rejects negative and NaN durationMs', () => {
+    const base = {
+      toolName: 'create_task',
+      toolCallId: 'tc1',
+      argsBytes: 4,
+      executionOutcome: 'semantic_success',
+      resultBytes: 2,
+      errorClass: null,
+      statusClass: 'none',
+      retryable: null,
+      recoveredSameTurn: false,
+    }
+    expect(ToolCompletedDataSchema.safeParse({ ...base, durationMs: -1 }).success).toBe(false)
+    expect(ToolCompletedDataSchema.safeParse({ ...base, durationMs: Number.NaN }).success).toBe(false)
+  })
+
+  test('llm:error rounds float durationMs and rejects negatives', () => {
+    const parsed = LlmErrorDataSchema.safeParse({ model: 'gpt-x', durationMs: 100.4 })
+    expect(parsed.success).toBe(true)
+    expect(parsed.data?.durationMs).toBe(100)
+    expect(LlmErrorDataSchema.safeParse({ model: 'gpt-x', durationMs: -1 }).success).toBe(false)
   })
 
   test('disclosure fallback rejects dynamic reasons', () => {

--- a/tests/analytics/subscriber.test.ts
+++ b/tests/analytics/subscriber.test.ts
@@ -216,6 +216,33 @@ describe('analytics subscriber', () => {
     ])
   })
 
+  test('rounds float llm:error and tool durations to integers at the boundary', () => {
+    const { bus, observer, registry } = setup()
+    registry.register({ turnId: 'turn-1', source: memberSource })
+    bus.emit(busEvent('llm:error', { model: 'gpt-x', durationMs: 100.4 }, 'turn-1'))
+    bus.emit(
+      busEvent(
+        'tool:analytics_completed',
+        {
+          toolName: 'core_task_create',
+          toolCallId: 'tc-1',
+          argsBytes: 42,
+          durationMs: 55.6,
+          executionOutcome: 'semantic_success',
+          resultBytes: 120,
+          errorClass: null,
+          statusClass: '2xx',
+          retryable: null,
+          recoveredSameTurn: false,
+          modelRole: 'main',
+        },
+        'turn-1',
+      ),
+    )
+    expect(firstFactOfType(observer.facts, 'llm_failed').durationMs).toBe(100)
+    expect(firstFactOfType(observer.facts, 'tool_completed').durationMs).toBe(56)
+  })
+
   test('ignores the five categorically excluded sources', () => {
     const { bus, observer, registry } = setup()
     registry.register({ turnId: 'turn-1', source: memberSource })

--- a/tests/llm-orchestrator-tool-events.test.ts
+++ b/tests/llm-orchestrator-tool-events.test.ts
@@ -234,4 +234,18 @@ describe('analytics terminal ordering', () => {
     expect(terminal.data['modelRole']).toBe(request.data['modelRole'])
     expect(terminal.data['argsBytes']).toBe(request.data['argsBytes'])
   })
+
+  test('analytics terminal rounds float durationMs; execute_end keeps the raw value', () => {
+    const { collected } = lifecycle({ ...successEvent({ title: 'done' }), durationMs: 42.4 })
+    const terminal = ofType(collected, 'tool:analytics_completed')[0]!
+    expect(terminal.data['durationMs']).toBe(42)
+    const executeEnd = ofType(collected, 'tool:execute_end')[0]!
+    expect(executeEnd.data['durationMs']).toBe(42.4)
+  })
+
+  test('analytics terminal clamps negative durationMs to zero', () => {
+    const { collected } = lifecycle({ ...successEvent({ title: 'done' }), durationMs: -3 })
+    const terminal = ofType(collected, 'tool:analytics_completed')[0]!
+    expect(terminal.data['durationMs']).toBe(0)
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #209.

`tool_completed` analytics facts were rejected by the normalizer with `invalid_value` (~20–30/day on prod), undercounting `tool_semantic_success` / `tool_failed`, because `durationMs` arrived as a float (AI SDK `toolExecutionMs`, a `performance.now()` delta) while the normalizer requires a safe integer.

## Fix (two layers)

1. **Emission rounding** — `emitAnalyticsCompleted` now emits `durationMs: Math.max(0, Math.round(event.durationMs))`, matching the sibling convention (`turn-observer.ts`, `provider-observer.ts`). The debug-only `tool:execute_end` event keeps the raw float.
2. **Contract closure** — new `DurationMs` zod schema (`z.number().nonnegative().transform(v => Math.round(v))`) applied to `ToolCompletedDataSchema.durationMs` and `LlmErrorDataSchema.durationMs`, so the subscriber boundary is float-tolerant but int-guaranteed on output. Also closes the latent `llm_failed` gap (previously protected only by upstream rounding convention). The normalizer stays strict as the backstop.

Design spec + plan: `docs/superpowers/specs/2026-08-02-tool-completed-durationms-design.md`, `docs/superpowers/plans/2026-08-02-tool-completed-durationms.md`.

## Testing

- TDD: failing tests first (emission rounding incl. negative clamp, schema rounding incl. half-up `12.5 → 13`, negative/NaN rejection, bus-level float regression, strict-backstop characterization)
- Focused suites: 128/128 pass across 7 analytics + tool-events test files
- Full suite: no failures in any file touched by this change (remaining failures are pre-existing environmental: unbuilt client bundles, review-loop spawn timeouts)
- Final whole-branch review: ready to merge, 0 Critical/Important findings

## Post-deploy confirmation

```sql
SELECT source_event_type, reason, count FROM analytics_normalization_rejections ORDER BY count DESC;
```

Expect `tool_completed` / `invalid_value` to stop growing.