### PR TITLE
test(scripts): remove always-skipped opencode.json portability check

### DIFF
--- a/tests/scripts/codeindex-portability.test.ts
+++ b/tests/scripts/codeindex-portability.test.ts
@@ -4,7 +4,7 @@
 // See LICENSE in the project root for details.
 
 import { describe, expect, test } from 'bun:test'
-import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { readFileSync, readdirSync } from 'node:fs'
 import path from 'node:path'
 
 const REPO_ROOT = path.resolve(import.meta.dir, '../..')
@@ -36,17 +36,6 @@ describe('codeindex portability wiring', () => {
     expect(reindexPlugin).not.toContain(staleAbsolutePath)
     expect(readRepoFile('docs/guides/codeindex-verification.md')).not.toContain(staleAbsolutePath)
   })
-
-  // opencode.json is project-local (gitignored), so only validate it when present
-  test.skipIf(!existsSync(path.join(REPO_ROOT, 'opencode.json')))(
-    'opencode.json routes codeindex through the wrapper when present',
-    () => {
-      const openCodeConfig = readRepoFile('opencode.json')
-      const staleAbsolutePath = '/Users/ki/Projects/papai/codeindex/src/cli.ts'
-      expect(openCodeConfig).toContain('"scripts/codeindex-cli.ts"')
-      expect(openCodeConfig).not.toContain(staleAbsolutePath)
-    },
-  )
 
   test('documents wrapper usage and CODEINDEX_DIR remediation', () => {
     const verificationGuide = readRepoFile('docs/guides/codeindex-verification.md')


### PR DESCRIPTION
## Summary

Audit of all skipped tests in the repo (no hard `.skip()`/`.todo()` exists; every skip is a conditional `skipIf` environment/lane guard). All guards are healthy and verified — except one dead test, removed here.

### Audit results

| Test | Guard | Verdict |
|---|---|---|
| `tests/scripts/story-sandbox.test.ts:112` | skips unless CI / `PAPAI_REQUIRE_STORY_SANDBOX=1` / launcher sets `PAPAI_STORY_SANDBOX_DOCKER_MODE=available` | Keep — runs in CI `check` job; locally via `bun test:stories:sandbox` (verified 18/18 on macOS + Docker Desktop) |
| `tests/stories/sandbox/process-boundary.test.ts:46` | skips when Linux sandbox backend unavailable | Keep — runs fail-closed in CI `stories` job; locally via the explicit CI command (verified 8/8) |
| `tests/plugins/discovery.test.ts:144` | skips as root (chmod 000 unreadable for root) | Keep — correct guard; runs locally and in CI (non-root runner) |
| 5 Docker-lane describes (`container-{d,e,p}.smoke.ts`, `mattermost-*.platform.ts`) | `skipIf(!DOCKER)` | Keep — tiered-lane design; run in CI smoke job + nightly platform job |
| ~~`tests/scripts/codeindex-portability.test.ts:41`~~ | `skipIf(!existsSync(opencode.json))` | **Removed — dead in CI** |

### Why remove it

The test validated `opencode.json`, which is gitignored and machine-local, so it skipped on **every** CI run and only executed on dev machines that happen to have the file. The `skipIf` added in 0e37d37de was an admission it doesn't belong in the always-on suite. The committed-config checks in the same file (`.mcp.json`, `.opencode/plugins/codeindex-reindex.ts`) already run everywhere and cover the wrapper-routing regression risk.

After this change the default `bun test` run reports exactly 1 skip (the by-design story-sandbox Linux Docker guard).

## Test plan

- `bun test tests/scripts/codeindex-portability.test.ts` — 5 pass / 0 skip / 0 fail
- Pre-commit hooks: lint, typecheck, format:check, license-headers — all pass