### PR TITLE
test(mutation): raise src/history.ts floor 0.21 → 1.0 + fix Stryker sandbox .opencode regression

### DIFF
--- a/docs/superpowers/plans/2026-08-02-history-mutation-coverage.md
+++ b/docs/superpowers/plans/2026-08-02-history-mutation-coverage.md
@@ -1,0 +1,534 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# `src/history.ts` Mutation Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Raise the ratcheted mutation floor of `src/history.ts` from 0.21 to the measured maximum (target 1.0) and fix the Stryker sandbox regression that errors every top-level `src/*` paired mutation run.
+
+**Architecture:** Three small, independent changes: (1) a glob-negation fix in `stryker.config.json` so the sandbox copies `.opencode/plugins` (the dry-run blocker), (2) two role-guard tests added to the existing `tests/history-edit.test.ts`, (3) a new `tests/history.test.ts` covering `clearHistory` and the structured-log contracts via a tracked logger mock bound through cache-busting dynamic imports. Then re-measure with the official paired runner and ratchet `scripts/mutation/baseline.json`.
+
+**Tech Stack:** Bun test (`bun:test`), Stryker + `@hughescr/stryker-bun-runner`, drizzle-orm (in-memory test DB), repo helpers `createTrackedLoggerMock()` / `setupTestDb()`.
+
+**Spec:** `docs/superpowers/specs/2026-08-02-history-mutation-coverage-design.md`
+
+## Global Constraints
+
+- New files MUST start with the BUSL-1.1 header comment (pre-commit hook `license-headers` blocks without it):
+  ```ts
+  // SPDX-License-Identifier: BUSL-1.1
+  // Copyright (c) 2026 Dmitriy Lazarev
+  // Use of this software is governed by the Business Source License 1.1.
+  // See LICENSE in the project root for details.
+  ```
+- Import paths in TS use the `.js` extension (`../src/history.js`).
+- Never add lint-disable or type-ignore comments (hook policy blocks them).
+- Test runner is Bun (`bun test <file>`); no Jest/Vitest APIs.
+- Conventional commit messages matching repo style, e.g. `fix(mutation): ...`, `test(history): ...`, `chore(mutation): ratchet baseline`.
+- `scripts/mutation/overrides.json` already contains `"src/history.ts": ["tests/history-edit.test.ts", "tests/history.test.ts"]` in the working tree (uncommitted); it ships with Task 3.
+- Mutant inventory reference (companion-only probe, `ignoreStatic: false`): 86 mutants = 59 killed + 21 survived + 6 no-coverage. Survivors: role-guards L64/L106, arithmetic L120, 18 log StringLiteral/ObjectLiteral (L15, L18, L23, L25, L29, L80, L84, L114, L120, L121). No-coverage: `clearHistory` body L33-41.
+
+---
+
+### Task 1: Stryker sandbox copies `.opencode/plugins`
+
+`tests/opencode-tdd-enforcement.test.ts` imports `../.opencode/plugins/tdd-enforcement.ts`. Commit `ae61aa748` added `.opencode` to Stryker `ignorePatterns`, so the sandbox copy lacks the plugin and every dry run whose test set includes that file fails with `Cannot find module`. The "same-package" expansion for root `src/*.ts` is all of `tests/*.test.ts`, so **every** top-level `src/` paired run errors. `.opencode/node_modules` (61M) is the junk the ignore targeted; `.opencode/plugins` (20K) must be copied. Globby negations express exactly that.
+
+**Files:**
+- Modify: `stryker.config.json` (the `ignorePatterns` array)
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: dry runs including `tests/opencode-tdd-enforcement.test.ts` pass inside the Stryker sandbox (validated again end-to-end in Task 5)
+
+- [ ] **Step 1: Apply the ignorePatterns fix**
+
+In `stryker.config.json`, replace:
+
+```json
+  "ignorePatterns": ["node_modules", ".stryker-tmp", "reports", ".agents", ".codex", ".opencode", ".worktrees"],
+```
+
+with:
+
+```json
+  "ignorePatterns": ["node_modules", ".stryker-tmp", "reports", ".agents", ".codex", ".opencode", "!.opencode/plugins", "!.opencode/plugins/**", ".worktrees"],
+```
+
+- [ ] **Step 2: Write the verification probe config**
+
+Create `.stryker-tmp/stryker.opencode-probe.json` (`.stryker-tmp/` is gitignored; this is a throwaway verification artifact). The two test files are the minimal pair that failed before the fix:
+
+```json
+{
+  "testRunner": "bun",
+  "appendPlugins": ["@hughescr/stryker-bun-runner"],
+  "bun": {
+    "timeout": 120000,
+    "testFiles": ["./tests/ai-output-settings.test.ts", "./tests/opencode-tdd-enforcement.test.ts"]
+  },
+  "mutate": ["src/history.ts"],
+  "coverageAnalysis": "perTest",
+  "ignoreStatic": false,
+  "incremental": false,
+  "concurrency": 8,
+  "timeoutMS": 60000,
+  "timeoutFactor": 2,
+  "thresholds": { "high": 80, "low": 60, "break": 0 },
+  "reporters": ["json"],
+  "jsonReporter": { "fileName": "reports/paired/opencode-probe.json" },
+  "ignorePatterns": ["node_modules", ".stryker-tmp", "reports", ".agents", ".codex", ".opencode", "!.opencode/plugins", "!.opencode/plugins/**", ".worktrees"],
+  "cleanTempDir": true
+}
+```
+
+- [ ] **Step 3: Run the probe — expect the dry run to pass**
+
+Run: `bunx stryker run .stryker-tmp/stryker.opencode-probe.json 2>&1 | grep -E "Initial test run succeeded|failed in the initial"`
+Expected: `INFO DryRunExecutor Initial test run succeeded.` (Before the fix the same probe failed with `ConfigError: There were failed tests in the initial test run.` caused by `Cannot find module '../.opencode/plugins/tdd-enforcement.ts'`.) The run continues into mutation testing afterwards; the final score is irrelevant here (these two tests barely cover `src/history.ts`), let it finish or Ctrl-C after the dry-run line.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add stryker.config.json
+git commit -m "fix(mutation): copy .opencode/plugins into Stryker sandbox"
+```
+
+---
+
+### Task 2: Role-guard mutant tests in `tests/history-edit.test.ts`
+
+Kills the two survived ConditionalExpression mutants that replace `msg.role !== 'user'` with `false` (`src/history.ts:64` in `applyEditToHistory`, `src/history.ts:106` in `trimTurnForRegeneration`). Both tests pass against current code; they exist so the mutants die.
+
+**Files:**
+- Test: `tests/history-edit.test.ts` (append one test to each existing `describe`)
+
+**Interfaces:**
+- Consumes: `appendHistory`, `applyEditToHistory`, `loadHistory`, `trimTurnForRegeneration` from `../src/history.js` (already imported in the file); `ModelMessage` from `ai` (already imported)
+- Produces: no new exports
+
+- [ ] **Step 1: Add the `applyEditToHistory` role-guard test**
+
+Inside the existing `describe('applyEditToHistory', ...)`, after the last test, add:
+
+```ts
+  test('skips a non-user turn that carries the edited messageId', () => {
+    const assistantWithMeta = {
+      role: 'assistant',
+      content: 'old answer',
+      providerOptions: {
+        papai: {
+          messageIds: ['m1'],
+          segments: [{ messageId: 'm1', text: 'hello', username: null }],
+          isThread: false,
+          isDm: true,
+        },
+      },
+    } as ModelMessage
+    const userMsg = {
+      role: 'user',
+      content: 'hello',
+      providerOptions: {
+        papai: {
+          messageIds: ['m1'],
+          segments: [{ messageId: 'm1', text: 'hello', username: null }],
+          isThread: false,
+          isDm: true,
+        },
+      },
+    } as ModelMessage
+    appendHistory('ctx-role-edit', [assistantWithMeta, userMsg])
+
+    const changed = applyEditToHistory('ctx-role-edit', 'm1', 'hello (edited)')
+    expect(changed).toBe(true)
+
+    const history = loadHistory('ctx-role-edit')
+    expect(history[0]!.content).toBe('old answer')
+    expect(history[1]!.content).toBe('hello (edited)')
+  })
+```
+
+- [ ] **Step 2: Add the `trimTurnForRegeneration` role-guard test**
+
+Inside the existing `describe('trimTurnForRegeneration', ...)`, after the last test, add:
+
+```ts
+  test('trims at the user turn, not a trailing assistant turn with the same messageId', () => {
+    const userMsg = {
+      role: 'user',
+      content: 'hello',
+      providerOptions: {
+        papai: {
+          messageIds: ['m1'],
+          segments: [{ messageId: 'm1', text: 'hello', username: null }],
+          isThread: false,
+          isDm: true,
+        },
+      },
+    } as ModelMessage
+    const assistantWithMeta = {
+      role: 'assistant',
+      content: 'old answer',
+      providerOptions: {
+        papai: {
+          messageIds: ['m1'],
+          segments: [{ messageId: 'm1', text: 'hello', username: null }],
+          isThread: false,
+          isDm: true,
+        },
+      },
+    } as ModelMessage
+    appendHistory('ctx-role-trim', [userMsg, assistantWithMeta])
+
+    const trimmed = trimTurnForRegeneration('ctx-role-trim', 'm1')
+
+    expect(trimmed).toBe(true)
+    expect(loadHistory('ctx-role-trim')).toEqual([])
+  })
+```
+
+- [ ] **Step 3: Run the file — expect all tests to pass**
+
+Run: `bun test tests/history-edit.test.ts`
+Expected: `11 pass, 0 fail` (9 existing + 2 new)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/history-edit.test.ts
+git commit -m "test(history): cover user-role guards in edit/trim turn matching"
+```
+
+---
+
+### Task 3: `tests/history.test.ts` — `clearHistory` coverage + log contracts
+
+Covers the 6 no-coverage mutants in `clearHistory` (L33-41) and kills the 19 survived log-metadata mutants (L15 child scope; L18/L23/L25/L29 load/save/append; L80/L84 edit miss/hit; L114/L121 trim miss/hit; L120 `removedCount` arithmetic).
+
+Pattern constraint: `src/history.ts` binds `const log = logger.child({ scope: 'history' })` at module evaluation. Static imports evaluate before the importing file's body, so a static `import` would bind the real logger. The proven repo pattern (`tests/startup-helpers.test.ts`) is: register `mock.module('../src/logger.js', ...)` inside the test body, then force a fresh module evaluation with a cache-busting query string (`?t=${crypto.randomUUID()}`). Each test builds a fresh `createTrackedLoggerMock()` so calls never leak between tests. The cache-busted module re-evaluates `src/history.ts` only; its imports (`cache.js`, drizzle, etc.) stay shared singletons, so `appendHistory`/`loadHistory` still hit the same in-memory store.
+
+`syncHistoryToDb` writes through `queueMicrotask`, so the `clearHistory` test flushes microtasks with one `await Promise.resolve()` before asserting the row exists, and asserts the post-clear row state synchronously (the clear-time upsert microtask must not have run yet).
+
+**Files:**
+- Create: `tests/history.test.ts`
+- Modify: `scripts/mutation/overrides.json` (already modified in the working tree — stage it with this task)
+
+**Interfaces:**
+- Consumes: `createTrackedLoggerMock`, `TrackedLoggerMock`, `LogCall` from `./utils/logger-mock.js`; `setupTestDb` from `./utils/test-helpers.js`; `conversationHistory` from `../src/db/schema.js`; `eq` from `drizzle-orm`; `ModelMessage` from `ai`
+- Produces: no exports (test file)
+
+- [ ] **Step 1: Create the test file**
+
+Create `tests/history.test.ts` with exactly this content:
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+import type { ModelMessage } from 'ai'
+import { eq } from 'drizzle-orm'
+
+import { conversationHistory } from '../src/db/schema.js'
+import { createTrackedLoggerMock, type LogCall, type TrackedLoggerMock } from './utils/logger-mock.js'
+import { setupTestDb } from './utils/test-helpers.js'
+
+type HistoryModule = typeof import('../src/history.js')
+
+// src/history.ts binds `logger.child({ scope: 'history' })` at module-eval time.
+// A static import would capture the real logger before the per-test mock is
+// registered, so install the mock and force a fresh evaluation with a
+// cache-busting query (mirrors tests/startup-helpers.test.ts).
+async function loadHistoryModule(tracked: TrackedLoggerMock): Promise<HistoryModule> {
+  void mock.module('../src/logger.js', () => ({
+    getLogLevel: tracked.getLogLevel,
+    logger: tracked.logger,
+  }))
+  return import(`../src/history.js?t=${crypto.randomUUID()}`)
+}
+
+function findCall(tracked: TrackedLoggerMock, level: LogCall['level'], message: string): LogCall | undefined {
+  return tracked.getCallsByLevel(level).find((call) => call.args[1] === message)
+}
+
+const makeUserMsg = (messageId: string, text: string): ModelMessage =>
+  ({
+    role: 'user',
+    content: text,
+    providerOptions: {
+      papai: {
+        messageIds: [messageId],
+        segments: [{ messageId, text, username: null }],
+        isThread: false,
+        isDm: true,
+      },
+    },
+  }) as ModelMessage
+
+describe('history log contracts and clearHistory', () => {
+  let db: Awaited<ReturnType<typeof setupTestDb>>
+
+  beforeEach(async () => {
+    db = await setupTestDb()
+  })
+
+  test('clearHistory clears the cache, deletes the DB row, and logs both lines', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
+    history.appendHistory('ctx-clear', [makeUserMsg('m1', 'hello')])
+    await Promise.resolve()
+
+    const before = db.select().from(conversationHistory).where(eq(conversationHistory.userId, 'ctx-clear')).get()
+    expect(before).toBeDefined()
+
+    history.clearHistory('ctx-clear')
+
+    expect(history.loadHistory('ctx-clear')).toEqual([])
+    const after = db.select().from(conversationHistory).where(eq(conversationHistory.userId, 'ctx-clear')).get()
+    expect(after).toBeUndefined()
+
+    const debugCall = findCall(tracked, 'debug', 'clearHistory called')
+    expect(debugCall?.args[0]).toEqual({ userId: 'ctx-clear' })
+    const infoCall = findCall(tracked, 'info', 'History cleared')
+    expect(infoCall?.args[0]).toEqual({ userId: 'ctx-clear' })
+  })
+
+  test('loadHistory logs the lookup with userId', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
+
+    history.loadHistory('ctx-load')
+
+    const call = findCall(tracked, 'debug', 'loadHistory called')
+    expect(call?.args[0]).toEqual({ userId: 'ctx-load' })
+  })
+
+  test('saveHistory logs debug and info with the message count', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
+
+    history.saveHistory('ctx-save', [makeUserMsg('m1', 'hello')])
+
+    const debugCall = findCall(tracked, 'debug', 'saveHistory called')
+    expect(debugCall?.args[0]).toEqual({ userId: 'ctx-save', messageCount: 1 })
+    const infoCall = findCall(tracked, 'info', 'History saved to cache (DB sync in background)')
+    expect(infoCall?.args[0]).toEqual({ userId: 'ctx-save', messageCount: 1 })
+  })
+
+  test('appendHistory logs the append count', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
+
+    history.appendHistory('ctx-append', [makeUserMsg('m1', 'hello')])
+
+    const call = findCall(tracked, 'debug', 'appendHistory called')
+    expect(call?.args[0]).toEqual({ userId: 'ctx-append', appendCount: 1 })
+  })
+
+  test('binds the history child logger with its scope', async () => {
+    const tracked = createTrackedLoggerMock()
+    await loadHistoryModule(tracked)
+
+    expect(tracked.logger.child).toHaveBeenCalledWith({ scope: 'history' })
+  })
+
+  test('applyEditToHistory logs the rewrite on a hit', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
+    history.appendHistory('ctx-edit-hit', [makeUserMsg('m1', 'hello')])
+
+    expect(history.applyEditToHistory('ctx-edit-hit', 'm1', 'hello (edited)')).toBe(true)
+
+    const call = findCall(tracked, 'info', 'applyEditToHistory: user turn rewritten')
+    expect(call?.args[0]).toEqual({ contextId: 'ctx-edit-hit', messageId: 'm1' })
+  })
+
+  test('applyEditToHistory logs the miss when no turn carries the messageId', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
+
+    expect(history.applyEditToHistory('ctx-edit-miss', 'missing', 'x')).toBe(false)
+
+    const call = findCall(tracked, 'debug', 'applyEditToHistory: messageId not found in any user turn')
+    expect(call?.args[0]).toEqual({ contextId: 'ctx-edit-miss', messageId: 'missing' })
+  })
+
+  test('trimTurnForRegeneration logs the removed count on a hit', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
+    history.appendHistory('ctx-trim-hit', [
+      makeUserMsg('m1', 'hello'),
+      { role: 'assistant', content: 'old answer' } as ModelMessage,
+      { role: 'tool', content: [] } as ModelMessage,
+    ])
+
+    expect(history.trimTurnForRegeneration('ctx-trim-hit', 'm1')).toBe(true)
+
+    const call = findCall(tracked, 'info', 'trimTurnForRegeneration: trailing turn removed for regeneration')
+    expect(call?.args[0]).toEqual({ contextId: 'ctx-trim-hit', messageId: 'm1', removedCount: 3 })
+  })
+
+  test('trimTurnForRegeneration logs the miss when no turn carries the messageId', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
+
+    expect(history.trimTurnForRegeneration('ctx-trim-miss', 'missing')).toBe(false)
+
+    const call = findCall(tracked, 'debug', 'trimTurnForRegeneration: originating user message not found')
+    expect(call?.args[0]).toEqual({ contextId: 'ctx-trim-miss', messageId: 'missing' })
+  })
+})
+```
+
+- [ ] **Step 2: Run the new file — expect all tests to pass**
+
+Run: `bun test tests/history.test.ts`
+Expected: `9 pass, 0 fail`
+
+- [ ] **Step 3: Commit (including the pre-staged overrides entry)**
+
+```bash
+git add tests/history.test.ts scripts/mutation/overrides.json
+git commit -m "test(history): cover clearHistory and structured log contracts"
+```
+
+---
+
+### Task 4: Probe verification — 86/86 mutants
+
+Confirms Tasks 2+3 killed every mutant before touching the baseline. Uses the same paired-runner machinery (`ignoreStatic: false`, perTest coverage) with only the two history test files so a failure is fast to diagnose.
+
+**Files:**
+- Create: `.stryker-tmp/stryker.history-probe.json` (gitignored throwaway)
+
+**Interfaces:**
+- Consumes: outputs of Tasks 1-3
+- Produces: `reports/paired/history-probe.json` with 0 surviving + 0 no-coverage mutants
+
+- [ ] **Step 1: Write the probe config**
+
+Create `.stryker-tmp/stryker.history-probe.json`:
+
+```json
+{
+  "testRunner": "bun",
+  "appendPlugins": ["@hughescr/stryker-bun-runner"],
+  "bun": {
+    "timeout": 120000,
+    "testFiles": ["./tests/history-edit.test.ts", "./tests/history.test.ts"]
+  },
+  "mutate": ["src/history.ts"],
+  "coverageAnalysis": "perTest",
+  "ignoreStatic": false,
+  "incremental": false,
+  "concurrency": 8,
+  "timeoutMS": 60000,
+  "timeoutFactor": 2,
+  "thresholds": { "high": 80, "low": 60, "break": 0 },
+  "reporters": ["json"],
+  "jsonReporter": { "fileName": "reports/paired/history-probe.json" },
+  "ignorePatterns": ["node_modules", ".stryker-tmp", "reports", ".agents", ".codex", ".opencode", "!.opencode/plugins", "!.opencode/plugins/**", ".worktrees"],
+  "cleanTempDir": true
+}
+```
+
+- [ ] **Step 2: Run the probe**
+
+Run: `bunx stryker run .stryker-tmp/stryker.history-probe.json 2>&1 | grep -E "Final mutation score|Initial test run"`
+Expected: `Final mutation score of 100.00 ...` (86/86 killed)
+
+- [ ] **Step 3: If anything survives, inspect and kill it**
+
+Only if Step 2 is below 100:
+
+```bash
+bun -e '
+const r = await Bun.file("reports/paired/history-probe.json").json();
+const f = r.files["src/history.ts"];
+for (const m of f.mutants.filter((m) => m.status === "Survived" || m.status === "NoCoverage"))
+  console.log(`${m.status} ${m.mutatorName} L${m.location.start.line}: ${m.replacement ?? ""}`);
+'
+```
+
+Add the missing assertion to `tests/history.test.ts` or `tests/history-edit.test.ts` (whichever owns the behavior), re-run that file's tests, then re-run Step 2. If a mutant is genuinely equivalent (no observable behavior difference — none are expected in this file), stop and report it to the user instead of adding Stryker-ignore comments.
+
+- [ ] **Step 4: Commit any follow-up test changes**
+
+```bash
+git add tests/history.test.ts tests/history-edit.test.ts
+git commit -m "test(history): kill remaining surviving mutants"
+```
+
+(Skip the commit if Step 2 was already 100.)
+
+---
+
+### Task 5: Official paired run + baseline ratchet
+
+Measures `src/history.ts` through the official path (`bun test:mutate:file`, which builds its config from the fixed `stryker.config.json` — this is also the end-to-end proof of Task 1) and raises the monotonic floor in `scripts/mutation/baseline.json`. The ratchet uses the repo's own `mergeReports`/`loadBaseline`/`writeBaseline` functions so the score formula `(killed + timeout) / (killed + survived + noCoverage + timeout)` and the sorted-JSON format match the automation exactly.
+
+**Files:**
+- Modify: `scripts/mutation/baseline.json` (the `"src/history.ts"` entry, currently `0.21052631578947367`)
+
+**Interfaces:**
+- Consumes: `mergeReports` from `scripts/mutation/score-merger.ts`; `loadBaseline`, `writeBaseline` from `scripts/mutation/baseline.ts`; Stryker report at `reports/paired/src__history.ts.json` (written by the paired run)
+- Produces: updated `scripts/mutation/baseline.json`
+
+- [ ] **Step 1: Run the official paired measurement**
+
+Run: `bun test:mutate:file src/history.ts 2>&1 | tail -3`
+Expected: a final summary line like `Paired mutation summary: files=1 skipped=0 errored=0 killed=86 survived=0 pending=0 score=1` — crucially `errored=0` (previously `errored=1` due to the `.opencode` sandbox bug). Several minutes is normal; the dry run alone runs the 115-file batch per worker.
+
+- [ ] **Step 2: Ratchet the baseline entry**
+
+```bash
+bun -e '
+import { loadBaseline, writeBaseline } from "./scripts/mutation/baseline.js"
+import { mergeReports } from "./scripts/mutation/score-merger.js"
+const report = await Bun.file("reports/paired/src__history.ts.json").json()
+const merged = mergeReports([report])
+const baseline = loadBaseline("scripts/mutation/baseline.json") ?? {}
+const current = baseline["src/history.ts"] ?? 0
+if (merged.score <= current) throw new Error(`score ${merged.score} did not improve on baseline ${current}`)
+baseline["src/history.ts"] = merged.score
+writeBaseline("scripts/mutation/baseline.json", baseline)
+console.log(`src/history.ts: ${current} -> ${merged.score}`)
+'
+```
+
+Expected output: `src/history.ts: 0.21052631578947367 -> 1` (or the measured value if below 1).
+
+If the measured score is below 1, do **not** lower expectations silently: go back to Task 4 Step 3 diagnostics (this time against `reports/paired/src__history.ts.json`), kill the survivors, re-run Task 5 Step 1.
+
+- [ ] **Step 3: Regression — root test batch + lint + typecheck**
+
+```bash
+bun test tests/*.test.ts
+bun run lint
+bun run typecheck
+```
+
+Expected: root batch all pass (this is the same 115-file set the paired dry run uses), lint clean, typecheck clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/mutation/baseline.json
+git commit -m "chore(mutation): ratchet baseline"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: sandbox fix (Task 1), role-guard tests (Task 2), clearHistory + log contracts (Task 3), probe verification (Task 4), official measurement + ratchet + regression (Task 5) — every spec section maps to a task.
+- `src/history.ts` itself is intentionally unmodified — the work is test-side plus tooling config.
+- Follow-up (out of scope, noted in spec): other top-level `src/*` floors (`src/config.ts`, `src/recurring.ts`, `src/memory.ts`, …) can now be re-measured and ratcheted the same way.

--- a/docs/superpowers/plans/2026-08-02-history-mutation-coverage.md
+++ b/docs/superpowers/plans/2026-08-02-history-mutation-coverage.md
@@ -479,7 +479,7 @@ Measures `src/history.ts` through the official path (`bun test:mutate:file`, whi
 - Modify: `scripts/mutation/baseline.json` (the `"src/history.ts"` entry, currently `0.21052631578947367`)
 
 **Interfaces:**
-- Consumes: `mergeReports` from `scripts/mutation/score-merger.ts`; `loadBaseline`, `writeBaseline` from `scripts/mutation/baseline.ts`; Stryker report at `reports/paired/src__history.ts.json` (written by the paired run)
+- Consumes: `mergeReports` from `scripts/mutation/score-merger.ts`; `loadBaseline`, `writeBaseline` from `scripts/mutation/baseline.ts`; Stryker report at `reports/paired/src__history.ts.stryker-report.json` (written by the paired run)
 - Produces: updated `scripts/mutation/baseline.json`
 
 - [ ] **Step 1: Run the official paired measurement**
@@ -493,7 +493,7 @@ Expected: a final summary line like `Paired mutation summary: files=1 skipped=0 
 bun -e '
 import { loadBaseline, writeBaseline } from "./scripts/mutation/baseline.js"
 import { mergeReports } from "./scripts/mutation/score-merger.js"
-const report = await Bun.file("reports/paired/src__history.ts.json").json()
+const report = await Bun.file("reports/paired/src__history.ts.stryker-report.json").json()
 const merged = mergeReports([report])
 const baseline = loadBaseline("scripts/mutation/baseline.json") ?? {}
 const current = baseline["src/history.ts"] ?? 0
@@ -506,7 +506,7 @@ console.log(`src/history.ts: ${current} -> ${merged.score}`)
 
 Expected output: `src/history.ts: 0.21052631578947367 -> 1` (or the measured value if below 1).
 
-If the measured score is below 1, do **not** lower expectations silently: go back to Task 4 Step 3 diagnostics (this time against `reports/paired/src__history.ts.json`), kill the survivors, re-run Task 5 Step 1.
+If the measured score is below 1, do **not** lower expectations silently: go back to Task 4 Step 3 diagnostics (this time against `reports/paired/src__history.ts.stryker-report.json`), kill the survivors, re-run Task 5 Step 1.
 
 - [ ] **Step 3: Regression — root test batch + lint + typecheck**
 

--- a/docs/superpowers/specs/2026-08-02-history-mutation-coverage-design.md
+++ b/docs/superpowers/specs/2026-08-02-history-mutation-coverage-design.md
@@ -1,0 +1,173 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation coverage: `src/history.ts` + Stryker sandbox `.opencode` fix
+
+Date: 2026-08-02
+Status: approved
+
+## Goal
+
+Raise the mutation-tested floor of `src/history.ts` (baseline `0.21`, the
+weakest core conversation-state file in `scripts/mutation/baseline.json`) to
+~1.0, and fix the infrastructure regression that makes the official paired
+mutation runner error on every top-level `src/*` file.
+
+## Background and findings
+
+### Why `src/history.ts`
+
+Selected from `scripts/mutation/baseline.json` as the most valuable target:
+core conversation state (`applyEditToHistory`, `trimTurnForRegeneration`)
+used by the message-edit / W2-regeneration flows, a low score (0.21), and
+pure-ish logic over the in-memory history cache that is cheap to test
+precisely. Zero-score files are thin Kaneo CRUD wrappers (low value per
+effort); `src/recurring.ts` has more survivors in absolute terms but is
+DB-plumbing heavy; `src/announcements/humanize.ts` is easy but low
+criticality.
+
+### Mutant inventory (probe: companion test only, `ignoreStatic: false`)
+
+86 mutants: **59 killed, 21 survived, 6 no-coverage** (score 68.6%).
+
+- **`clearHistory` (src/history.ts:33-41) — 6 no-coverage mutants.** The whole
+  function is untested: cache clear, `clearCachedHistoryFlag`, and the drizzle
+  `conversationHistory` delete.
+- **Role-guard conditionals — 2 survived.** `src/history.ts:64`
+  (`applyEditToHistory`) and `src/history.ts:106` (`trimTurnForRegeneration`):
+  replacing `msg.role !== 'user'` with `false` survives because no test has a
+  non-user message carrying matching `providerOptions.papai.messageIds`.
+- **Log-metadata mutants — 13 survived** (12 StringLiteral/ObjectLiteral +
+  1 ArithmeticOperator). `logger.child({ scope: 'history' })` (L15),
+  debug/info calls in `loadHistory`/`saveHistory`/`appendHistory` (L18, L23,
+  L25, L29), `applyEditToHistory` miss/hit logs (L80, L84),
+  `trimTurnForRegeneration` miss/hit logs (L114, L121), and the
+  `removedCount: history.length - trimmed.length` arithmetic (L120). Killable
+  via `createTrackedLoggerMock()` assertions (tests/utils/logger-mock.ts).
+
+### Root cause: paired runner errors on all top-level `src/*` files
+
+`bun test:mutate:file src/history.ts` fails its dry run deterministically:
+
+```
+tests/opencode-tdd-enforcement.test.ts > TddEnforcement > runs check:full without tests during session.idle rechecks
+```
+
+Reproduction and bisection (probe Stryker configs, 114 → 2 files) showed the
+failure is **not** test pollution: `tests/opencode-tdd-enforcement.test.ts`
+imports `../.opencode/plugins/tdd-enforcement.ts`, but commit `ae61aa748`
+("ignore local agent-tool dirs in stryker sandbox copy") added `.opencode` to
+`ignorePatterns` in `stryker.config.json`, so the Stryker sandbox copy lacks
+the plugin and the test dies with `Cannot find module
+'../.opencode/plugins/tdd-enforcement.ts'`. Verified directly inside a
+sandbox directory.
+
+Because the coverage map's "same-package" expansion for root `src/*.ts` files
+is all of `tests/*.test.ts` (115 files, including this one), **every**
+top-level `src/` paired run errors and the file is excluded from scoring —
+floors for `src/history.ts`, `src/config.ts`, `src/memory.ts`,
+`src/recurring.ts`, etc. can never be re-measured or raised. This is why
+`src/history.ts` is stuck at 0.21.
+
+`.opencode/` contains `plugins/` (20K, needed by the test) and
+`node_modules/` (61M, the junk the ignore actually targeted). Globby
+negations keep the latter excluded while copying the former; validated with a
+probe run (dry run passes).
+
+## Design (approach A: fix + tests + ratchet)
+
+### 1. Stryker sandbox fix
+
+`stryker.config.json`:
+
+```json
+"ignorePatterns": ["node_modules", ".stryker-tmp", ".agents", ".codex", ".opencode", "!.opencode/plugins", "!.opencode/plugins/**", ".worktrees"]
+```
+
+### 2. Mutant-killing tests
+
+**`tests/history-edit.test.ts`** — two additions in the existing
+static-import style:
+
+- `applyEditToHistory` skips non-user turns: history = [assistant message
+  **with** papai meta `messageIds: ['m1']`, user message with the same id] →
+  `applyEditToHistory(ctx, 'm1', ...)` → assistant content untouched, user
+  turn rewritten. Fails under the L64 mutant (assistant would be rewritten
+  and the user left stale). Kills mutant L64.
+- `trimTurnForRegeneration` trims only at user turns: history = [user message
+  meta `['m1']`, assistant message meta `['m1']`] → trim → history becomes
+  `[]`. Under the L106 mutant the scan matches the trailing assistant
+  (`originIndex = 1`) and `[user]` survives, so the assertion on `[]` fails.
+  Kills mutant L106.
+
+**`tests/history.test.ts`** — new file. Log-contract assertions require the
+tracked logger to be bound before `src/history.ts` module evaluation (its
+`log` is a module-level `logger.child(...)`), and ES static imports evaluate
+before module body code, so the file must use:
+
+- file-scope `createTrackedLoggerMock()` + top-level
+  `mock.module('../src/logger.js', ...)`;
+- dynamic `await import('../src/history.js')` in `beforeAll` (after mock
+  registration; the module is then cached for all tests in the file);
+- `clearCalls()` in `beforeEach`; `mockLogger()` is **not** used here.
+
+Tests:
+
+- `clearHistory`: seed cache via `appendHistory`, insert a
+  `conversationHistory` row via drizzle (`setupTestDb()`), call
+  `clearHistory` → assert `loadHistory` returns empty, the DB row is gone,
+  and the `'History cleared'` info log fired with `{ userId }`. Covers the 6
+  no-coverage mutants (including the BlockStatement→`{}` at L33).
+- Log contracts: for `loadHistory`, `saveHistory`, `appendHistory`,
+  `applyEditToHistory` (hit + miss), `trimTurnForRegeneration` (hit + miss),
+  assert exact metadata objects and message strings from the tracked logger;
+  assert `logger.child` was called with `{ scope: 'history' }`; assert the
+  trim-hit info log carries `removedCount: 3` for a 3-message removal (kills
+  the L120 `+`/`-` ArithmeticOperator mutant).
+
+### 3. Measurement and ratchet
+
+1. Probe verification: Stryker config with
+   `testFiles = ["./tests/history-edit.test.ts", "./tests/history.test.ts"]`,
+   `mutate = ["src/history.ts"]`, `ignoreStatic: false` → target 86/86
+   (100%). Any survivor is investigated and either killed or shown to be an
+   equivalent mutant (equivalent mutants are not expected here).
+2. Official measurement: `bun test:mutate:file src/history.ts` (dry run now
+   passes thanks to section 1).
+3. Ratchet: set `scripts/mutation/baseline.json` → `"src/history.ts"` to the
+   officially measured score (monotonic up from 0.21). The
+   `scripts/mutation/overrides.json` entry
+   `"src/history.ts": ["tests/history-edit.test.ts", "tests/history.test.ts"]`
+   is already in the working tree and ships with this change.
+
+### Regression checks
+
+- `bun test tests/history-edit.test.ts tests/history.test.ts tests/opencode-tdd-enforcement.test.ts`
+- `bun test tests/*.test.ts` (root batch sanity; the 115-file dry-run set)
+- repo lint/typecheck per `package.json` scripts
+
+## Trade-offs and risks
+
+- **Log-text coupling.** Asserting exact log strings/metadata makes tests
+  sensitive to log wording changes. Accepted: the repo mandates structured
+  logging, the mutation gate counts these mutants, and
+  `createTrackedLoggerMock()` exists precisely for this.
+- **Probe vs paired score divergence.** The 115-file paired run may attribute
+  coverage slightly differently than the two-file probe; the baseline records
+  the official paired number regardless of the probe result.
+- **Scope.** Only `src/history.ts` is re-baselined. Other top-level `src/*`
+  files remain at their current (also stale) floors; re-measuring them is
+  follow-up work now unblocked by section 1.
+
+## Alternatives considered
+
+- **B: tests only, hand-edit baseline from probe.** Rejected: the official
+  runner keeps erroring, the floor is never CI-enforced, probe and paired
+  scores may diverge.
+- **C: exclude the tdd-enforcement test from mutation sets.** Rejected: hides
+  a real module-resolution bug and requires new exclusion machinery in the
+  coverage-map tooling.

--- a/docs/superpowers/specs/2026-08-02-history-mutation-coverage-design.md
+++ b/docs/superpowers/specs/2026-08-02-history-mutation-coverage-design.md
@@ -41,7 +41,7 @@ criticality.
   (`applyEditToHistory`) and `src/history.ts:106` (`trimTurnForRegeneration`):
   replacing `msg.role !== 'user'` with `false` survives because no test has a
   non-user message carrying matching `providerOptions.papai.messageIds`.
-- **Log-metadata mutants — 13 survived** (12 StringLiteral/ObjectLiteral +
+- **Log-metadata mutants — 19 survived** (18 StringLiteral/ObjectLiteral +
   1 ArithmeticOperator). `logger.child({ scope: 'history' })` (L15),
   debug/info calls in `loadHistory`/`saveHistory`/`appendHistory` (L18, L23,
   L25, L29), `applyEditToHistory` miss/hit logs (L80, L84),

--- a/scripts/mutation/baseline.json
+++ b/scripts/mutation/baseline.json
@@ -170,7 +170,7 @@
   "src/deferred-prompts/schedule-update-helpers.ts": 0.6461538461538462,
   "src/deferred-prompts/tool-handlers.ts": 0.5805243445692884,
   "src/errors.ts": 0.7579617834394905,
-  "src/history.ts": 0.21052631578947367,
+  "src/history.ts": 1,
   "src/live-status/tool-status-labels.ts": 0.46190476190476193,
   "src/llm-providers/discovery.ts": 0.5303030303030303,
   "src/llm-providers/env-bootstrap.ts": 0.5540540540540541,

--- a/scripts/mutation/overrides.json
+++ b/scripts/mutation/overrides.json
@@ -172,6 +172,7 @@
     "tests/plugins/task-provider-youtrack/schemas/issue.test.ts"
   ],
   "plugins/task-provider-youtrack/validate-config.ts": ["tests/plugins/task-provider-youtrack/index.test.ts"],
+  "src/history.ts": ["tests/history-edit.test.ts", "tests/history.test.ts"],
   "src/providers/config-validation.ts": ["tests/providers/resolver.test.ts"],
   "src/tools/add-comment.ts": ["tests/tools/comment-tools.test.ts", "tests/tools/add-comment-reaction.test.ts"],
   "src/tools/add-task-relation.ts": ["tests/tools/task-relation-tools.test.ts"],

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -43,6 +43,16 @@
   "jsonReporter": {
     "fileName": "reports/mutation.json"
   },
-  "ignorePatterns": ["node_modules", ".stryker-tmp", "reports", ".agents", ".codex", ".opencode", ".worktrees"],
+  "ignorePatterns": [
+    "node_modules",
+    ".stryker-tmp",
+    "reports",
+    ".agents",
+    ".codex",
+    ".opencode",
+    "!.opencode/plugins",
+    "!.opencode/plugins/**",
+    ".worktrees"
+  ],
   "cleanTempDir": true
 }

--- a/tests/history-edit.test.ts
+++ b/tests/history-edit.test.ts
@@ -141,6 +141,41 @@ describe('applyEditToHistory', () => {
     expect(users[0]!.content).toBe('rewritten')
     expect(users[1]!.content).toBe('b-text')
   })
+
+  test('skips a non-user turn that carries the edited messageId', () => {
+    const assistantWithMeta = {
+      role: 'assistant',
+      content: 'old answer',
+      providerOptions: {
+        papai: {
+          messageIds: ['m1'],
+          segments: [{ messageId: 'm1', text: 'hello', username: null }],
+          isThread: false,
+          isDm: true,
+        },
+      },
+    } as ModelMessage
+    const userMsg = {
+      role: 'user',
+      content: 'hello',
+      providerOptions: {
+        papai: {
+          messageIds: ['m1'],
+          segments: [{ messageId: 'm1', text: 'hello', username: null }],
+          isThread: false,
+          isDm: true,
+        },
+      },
+    } as ModelMessage
+    appendHistory('ctx-role-edit', [assistantWithMeta, userMsg])
+
+    const changed = applyEditToHistory('ctx-role-edit', 'm1', 'hello (edited)')
+    expect(changed).toBe(true)
+
+    const history = loadHistory('ctx-role-edit')
+    expect(history[0]!.content).toBe('old answer')
+    expect(history[1]!.content).toBe('hello (edited)')
+  })
 })
 
 describe('trimTurnForRegeneration', () => {
@@ -236,5 +271,38 @@ describe('trimTurnForRegeneration', () => {
 
     expect(trimTurnForRegeneration('ctx-legacy', 'm1')).toBe(false)
     expect(loadHistory('ctx-legacy').length).toBe(1)
+  })
+
+  test('trims at the user turn, not a trailing assistant turn with the same messageId', () => {
+    const userMsg = {
+      role: 'user',
+      content: 'hello',
+      providerOptions: {
+        papai: {
+          messageIds: ['m1'],
+          segments: [{ messageId: 'm1', text: 'hello', username: null }],
+          isThread: false,
+          isDm: true,
+        },
+      },
+    } as ModelMessage
+    const assistantWithMeta = {
+      role: 'assistant',
+      content: 'old answer',
+      providerOptions: {
+        papai: {
+          messageIds: ['m1'],
+          segments: [{ messageId: 'm1', text: 'hello', username: null }],
+          isThread: false,
+          isDm: true,
+        },
+      },
+    } as ModelMessage
+    appendHistory('ctx-role-trim', [userMsg, assistantWithMeta])
+
+    const trimmed = trimTurnForRegeneration('ctx-role-trim', 'm1')
+
+    expect(trimmed).toBe(true)
+    expect(loadHistory('ctx-role-trim')).toEqual([])
   })
 })

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -4,13 +4,17 @@
 // See LICENSE in the project root for details.
 
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import assert from 'node:assert/strict'
 
 import type { ModelMessage } from 'ai'
 import { eq } from 'drizzle-orm'
 
+import { getCachedHistory, userCachesForTesting } from '../src/cache.js'
 import { conversationHistory } from '../src/db/schema.js'
+import * as schema from '../src/db/schema.js'
+import { appendHistory, clearHistory, loadHistory, saveHistory } from '../src/history.js'
 import { createTrackedLoggerMock, type LogCall, type TrackedLoggerMock } from './utils/logger-mock.js'
-import { setupTestDb } from './utils/test-helpers.js'
+import { flushMicrotasks, mockLogger, setupTestDb } from './utils/test-helpers.js'
 
 type HistoryModule = typeof import('../src/history.js')
 
@@ -70,6 +74,7 @@ describe('history log contracts and clearHistory', () => {
     history.clearHistory('ctx-clear')
 
     expect(history.loadHistory('ctx-clear')).toEqual([])
+    // Assert before the queued setCachedHistory microtask re-inserts an empty row.
     const after = db.select().from(conversationHistory).where(eq(conversationHistory.userId, 'ctx-clear')).get()
     expect(after).toBeUndefined()
 
@@ -164,5 +169,347 @@ describe('history log contracts and clearHistory', () => {
 
     const call = findCall(tracked, 'debug', 'trimTurnForRegeneration: originating user message not found')
     expect(call?.args[0]).toEqual({ contextId: 'ctx-trim-miss', messageId: 'missing' })
+  })
+})
+
+describe('history cache + DB persistence behavior', () => {
+  beforeEach(() => {
+    mockLogger()
+  })
+
+  describe('loadHistory', () => {
+    let testDb: Awaited<ReturnType<typeof setupTestDb>>
+
+    beforeEach(async () => {
+      testDb = await setupTestDb()
+    })
+
+    test('returns empty array when no row exists', () => {
+      const result = loadHistory('999')
+      expect(result).toEqual([])
+    })
+
+    test('returns deserialised messages for valid row', () => {
+      const messages = [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: 'hi there' },
+      ]
+      testDb
+        .insert(schema.conversationHistory)
+        .values({ userId: '1', messages: JSON.stringify(messages) })
+        .run()
+
+      const result = loadHistory('1')
+      expect(result).toHaveLength(2)
+      expect(result[0]).toEqual({ role: 'user', content: 'hello' })
+      expect(result[1]).toEqual({ role: 'assistant', content: 'hi there' })
+    })
+
+    test('returns empty array for corrupt JSON', () => {
+      testDb.insert(schema.conversationHistory).values({ userId: '2', messages: 'not-valid-json' }).run()
+
+      const result = loadHistory('2')
+      expect(result).toEqual([])
+    })
+
+    test('returns empty array when messages lack role field', () => {
+      testDb
+        .insert(schema.conversationHistory)
+        .values({ userId: '3', messages: JSON.stringify([{ content: 'no role' }]) })
+        .run()
+
+      const result = loadHistory('3')
+      expect(result).toEqual([])
+    })
+
+    test('strips unknown fields not in ModelMessage schema', () => {
+      // modelMessageSchema uses Zod which strips unrecognised properties — unknown
+      // keys like `toolCalls` (not part of AssistantModelMessage in SDK v6) are dropped.
+      const messages = [{ role: 'assistant', content: 'hi', unknownField: 'value' }]
+      testDb
+        .insert(schema.conversationHistory)
+        .values({ userId: '4', messages: JSON.stringify(messages) })
+        .run()
+
+      const result = loadHistory('4')
+      expect(result).toHaveLength(1)
+      const first = result[0]
+      expect(first).toBeDefined()
+      expect(first?.content).toBe('hi')
+    })
+
+    test('returns messages when content is an array (tool call / tool result messages)', () => {
+      // The Vercel AI SDK uses array content for tool calls and tool results.
+      // Regression: the previous custom validator required content to be a string,
+      // causing the entire history to be dropped after cache eviction whenever
+      // tool-calling had occurred in the conversation.
+      const messages = [
+        { role: 'user', content: 'what tasks do I have?' },
+        {
+          role: 'assistant',
+          content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'list_tasks', input: {} }],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'tc1',
+              toolName: 'list_tasks',
+              output: { type: 'json', value: [] },
+            },
+          ],
+        },
+        { role: 'assistant', content: 'You have no tasks.' },
+      ]
+      testDb
+        .insert(schema.conversationHistory)
+        .values({ userId: '5', messages: JSON.stringify(messages) })
+        .run()
+
+      const result = loadHistory('5')
+      expect(result).toHaveLength(4)
+
+      // Verify assistant message has tool-call content
+      const assistantMsg = result[1]
+      expect(assistantMsg).toBeDefined()
+      const assistantContent = assistantMsg?.content
+      assert(Array.isArray(assistantContent))
+      expect(assistantContent).toHaveLength(1)
+      // Verify structure of first item in array content
+      expect(assistantContent[0]).toMatchObject({
+        type: 'tool-call',
+        toolCallId: 'tc1',
+        toolName: 'list_tasks',
+      })
+
+      // Verify tool message has tool-result content
+      const toolMsg = result[2]
+      expect(toolMsg).toBeDefined()
+      const toolContent = toolMsg?.content
+      assert(Array.isArray(toolContent))
+      expect(toolContent).toHaveLength(1)
+      // Verify structure of first item in array content
+      expect(toolContent[0]).toMatchObject({
+        type: 'tool-result',
+        toolCallId: 'tc1',
+        toolName: 'list_tasks',
+      })
+    })
+
+    test('rejects messages where content is neither string nor array', () => {
+      const messages = [{ role: 'user', content: 42 }]
+      testDb
+        .insert(schema.conversationHistory)
+        .values({ userId: '6', messages: JSON.stringify(messages) })
+        .run()
+
+      const result = loadHistory('6')
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('saveHistory', () => {
+    let testDb: Awaited<ReturnType<typeof setupTestDb>>
+
+    beforeEach(async () => {
+      testDb = await setupTestDb()
+    })
+
+    test('persists messages as JSON', async () => {
+      const messages: ModelMessage[] = [{ role: 'user', content: 'test' }]
+      saveHistory('10', messages)
+
+      // Wait for background DB sync
+      await flushMicrotasks()
+
+      const row = testDb
+        .select()
+        .from(schema.conversationHistory)
+        .where(eq(schema.conversationHistory.userId, '10'))
+        .get()
+      expect(row).toBeDefined()
+      expect(JSON.parse(row!.messages)).toEqual(messages)
+    })
+
+    test('calls INSERT OR REPLACE', async () => {
+      const empty: ModelMessage[] = []
+      saveHistory('10', empty)
+
+      // Wait for background DB sync
+      await flushMicrotasks()
+
+      const row = testDb
+        .select()
+        .from(schema.conversationHistory)
+        .where(eq(schema.conversationHistory.userId, '10'))
+        .get()
+      expect(row).toBeDefined()
+      expect(row!.userId).toBe('10')
+    })
+  })
+
+  describe('clearHistory', () => {
+    let testDb: Awaited<ReturnType<typeof setupTestDb>>
+
+    beforeEach(async () => {
+      testDb = await setupTestDb()
+    })
+
+    test('removes entry from store', () => {
+      testDb
+        .insert(schema.conversationHistory)
+        .values({ userId: '20', messages: JSON.stringify([]) })
+        .run()
+      clearHistory('20')
+      const row = testDb
+        .select()
+        .from(schema.conversationHistory)
+        .where(eq(schema.conversationHistory.userId, '20'))
+        .get()
+      expect(row).toBeUndefined()
+    })
+
+    test('calls DELETE statement', () => {
+      clearHistory('20')
+      const row = testDb
+        .select()
+        .from(schema.conversationHistory)
+        .where(eq(schema.conversationHistory.userId, '20'))
+        .get()
+      expect(row).toBeUndefined()
+    })
+  })
+
+  describe('appendHistory', () => {
+    beforeEach(async () => {
+      await setupTestDb()
+      userCachesForTesting.clear()
+    })
+
+    test('appends messages to empty history', () => {
+      const messages: ModelMessage[] = [{ role: 'user', content: 'hello' }]
+      appendHistory('append-1', messages)
+      const result = getCachedHistory('append-1')
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({ role: 'user', content: 'hello' })
+    })
+
+    test('appends to existing history', () => {
+      saveHistory('append-2', [
+        { role: 'user', content: 'first' },
+        { role: 'assistant', content: 'second' },
+      ])
+      appendHistory('append-2', [{ role: 'user', content: 'third' }])
+      const result = getCachedHistory('append-2')
+      expect(result).toHaveLength(3)
+      expect(result[0]!.content).toBe('first')
+      expect(result[1]!.content).toBe('second')
+      expect(result[2]!.content).toBe('third')
+    })
+
+    test('preserves message types (user, assistant, tool)', () => {
+      const messages: ModelMessage[] = [
+        { role: 'user', content: 'question' },
+        { role: 'assistant', content: 'answer' },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'tc1',
+              toolName: 'test',
+              output: { type: 'text', value: 'ok' },
+            },
+          ],
+        },
+      ]
+      appendHistory('append-3', messages)
+      const result = getCachedHistory('append-3')
+      expect(result).toHaveLength(3)
+      expect(result[0]!.role).toBe('user')
+      expect(result[1]!.role).toBe('assistant')
+      expect(result[2]!.role).toBe('tool')
+    })
+  })
+
+  describe('getCachedHistory cold-cache behavior', () => {
+    let testDb: Awaited<ReturnType<typeof setupTestDb>>
+
+    beforeEach(async () => {
+      testDb = await setupTestDb()
+      // Clear all caches to ensure cold state
+      userCachesForTesting.clear()
+    })
+
+    test('loads messages from DB when cache is cold and DB has data', () => {
+      const messages = [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: 'hi there' },
+      ]
+      testDb
+        .insert(schema.conversationHistory)
+        .values({ userId: 'user1', messages: JSON.stringify(messages) })
+        .run()
+
+      const result = getCachedHistory('user1')
+      expect(result).toHaveLength(2)
+      expect(result[0]).toEqual({ role: 'user', content: 'hello' })
+      expect(result[1]).toEqual({ role: 'assistant', content: 'hi there' })
+    })
+
+    test('returns empty array when cache is cold and DB has no data', () => {
+      const result = getCachedHistory('user2')
+      expect(result).toEqual([])
+    })
+
+    test('does not query DB again on second call after cold load', () => {
+      const messages = [{ role: 'user', content: 'test' }]
+      testDb
+        .insert(schema.conversationHistory)
+        .values({ userId: 'user3', messages: JSON.stringify(messages) })
+        .run()
+
+      // First call loads from DB
+      const result1 = getCachedHistory('user3')
+      expect(result1).toHaveLength(1)
+
+      // Update DB directly (bypass cache) - need to update since primary key exists
+      const newMessages = [{ role: 'user', content: 'modified' }]
+      testDb
+        .update(schema.conversationHistory)
+        .set({ messages: JSON.stringify(newMessages) })
+        .where(eq(schema.conversationHistory.userId, 'user3'))
+        .run()
+
+      // Second call should return cached result, not DB update
+      const result2 = getCachedHistory('user3')
+      expect(result2).toHaveLength(1)
+      expect(result2[0]!.content).toBe('test')
+    })
+
+    // Story 1 AC Test: "Continuing from previous session"
+    test('Story 1: continuing from previous session', async () => {
+      const userId = 'story1-user'
+      const messages: ModelMessage[] = [
+        { role: 'user', content: 'Create a task for the mobile app' },
+        { role: 'assistant', content: 'I have created task #42 for the mobile app.' },
+      ]
+
+      // Simulate first session: save history
+      saveHistory(userId, messages)
+      await flushMicrotasks()
+
+      // Simulate session end: clear cache (simulating bot restart)
+      userCachesForTesting.clear()
+
+      // Simulate new session: load history
+      const loadedMessages = loadHistory(userId)
+
+      // Verify history is preserved across sessions
+      expect(loadedMessages).toHaveLength(2)
+      expect(loadedMessages[0]).toEqual(messages[0])
+      expect(loadedMessages[1]).toEqual(messages[1])
+    })
   })
 })

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -3,353 +3,164 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { describe, expect, test, beforeEach } from 'bun:test'
-import assert from 'node:assert/strict'
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
 
 import type { ModelMessage } from 'ai'
 import { eq } from 'drizzle-orm'
 
-import { getCachedHistory, userCachesForTesting } from '../src/cache.js'
-import * as schema from '../src/db/schema.js'
-import { appendHistory, loadHistory, saveHistory, clearHistory } from '../src/history.js'
-import { flushMicrotasks, mockLogger, setupTestDb } from './utils/test-helpers.js'
+import { conversationHistory } from '../src/db/schema.js'
+import { createTrackedLoggerMock, type LogCall, type TrackedLoggerMock } from './utils/logger-mock.js'
+import { setupTestDb } from './utils/test-helpers.js'
 
-beforeEach(() => {
-  mockLogger()
-})
+type HistoryModule = typeof import('../src/history.js')
 
-describe('loadHistory', () => {
-  let testDb: Awaited<ReturnType<typeof setupTestDb>>
+const isHistoryModule = (value: unknown): value is HistoryModule =>
+  typeof value === 'object' && value !== null && typeof Reflect.get(value, 'clearHistory') === 'function'
 
-  beforeEach(async () => {
-    testDb = await setupTestDb()
-  })
+// src/history.ts binds `logger.child({ scope: 'history' })` at module-eval time.
+// A static import would capture the real logger before the per-test mock is
+// registered, so install the mock and force a fresh evaluation with a
+// cache-busting query (mirrors tests/startup-helpers.test.ts).
+async function loadHistoryModule(tracked: TrackedLoggerMock): Promise<HistoryModule> {
+  void mock.module('../src/logger.js', () => ({
+    getLogLevel: tracked.getLogLevel,
+    logger: tracked.logger,
+  }))
+  const loaded: unknown = await import(`../src/history.js?t=${crypto.randomUUID()}`)
+  if (!isHistoryModule(loaded)) {
+    throw new Error('history module did not export expected shape')
+  }
+  return loaded
+}
 
-  test('returns empty array when no row exists', () => {
-    const result = loadHistory('999')
-    expect(result).toEqual([])
-  })
+function findCall(tracked: TrackedLoggerMock, level: LogCall['level'], message: string): LogCall | undefined {
+  return tracked.getCallsByLevel(level).find((call) => call.args[1] === message)
+}
 
-  test('returns deserialised messages for valid row', () => {
-    const messages = [
-      { role: 'user', content: 'hello' },
-      { role: 'assistant', content: 'hi there' },
-    ]
-    testDb
-      .insert(schema.conversationHistory)
-      .values({ userId: '1', messages: JSON.stringify(messages) })
-      .run()
-
-    const result = loadHistory('1')
-    expect(result).toHaveLength(2)
-    expect(result[0]).toEqual({ role: 'user', content: 'hello' })
-    expect(result[1]).toEqual({ role: 'assistant', content: 'hi there' })
-  })
-
-  test('returns empty array for corrupt JSON', () => {
-    testDb.insert(schema.conversationHistory).values({ userId: '2', messages: 'not-valid-json' }).run()
-
-    const result = loadHistory('2')
-    expect(result).toEqual([])
-  })
-
-  test('returns empty array when messages lack role field', () => {
-    testDb
-      .insert(schema.conversationHistory)
-      .values({ userId: '3', messages: JSON.stringify([{ content: 'no role' }]) })
-      .run()
-
-    const result = loadHistory('3')
-    expect(result).toEqual([])
-  })
-
-  test('strips unknown fields not in ModelMessage schema', () => {
-    // modelMessageSchema uses Zod which strips unrecognised properties — unknown
-    // keys like `toolCalls` (not part of AssistantModelMessage in SDK v6) are dropped.
-    const messages = [{ role: 'assistant', content: 'hi', unknownField: 'value' }]
-    testDb
-      .insert(schema.conversationHistory)
-      .values({ userId: '4', messages: JSON.stringify(messages) })
-      .run()
-
-    const result = loadHistory('4')
-    expect(result).toHaveLength(1)
-    const first = result[0]
-    expect(first).toBeDefined()
-    expect(first?.content).toBe('hi')
-  })
-
-  test('returns messages when content is an array (tool call / tool result messages)', () => {
-    // The Vercel AI SDK uses array content for tool calls and tool results.
-    // Regression: the previous custom validator required content to be a string,
-    // causing the entire history to be dropped after cache eviction whenever
-    // tool-calling had occurred in the conversation.
-    const messages = [
-      { role: 'user', content: 'what tasks do I have?' },
-      {
-        role: 'assistant',
-        content: [{ type: 'tool-call', toolCallId: 'tc1', toolName: 'list_tasks', input: {} }],
+const makeUserMsg = (messageId: string, text: string): ModelMessage =>
+  ({
+    role: 'user',
+    content: text,
+    providerOptions: {
+      papai: {
+        messageIds: [messageId],
+        segments: [{ messageId, text, username: null }],
+        isThread: false,
+        isDm: true,
       },
-      {
-        role: 'tool',
-        content: [
-          {
-            type: 'tool-result',
-            toolCallId: 'tc1',
-            toolName: 'list_tasks',
-            output: { type: 'json', value: [] },
-          },
-        ],
-      },
-      { role: 'assistant', content: 'You have no tasks.' },
-    ]
-    testDb
-      .insert(schema.conversationHistory)
-      .values({ userId: '5', messages: JSON.stringify(messages) })
-      .run()
+    },
+  }) as ModelMessage
 
-    const result = loadHistory('5')
-    expect(result).toHaveLength(4)
-
-    // Verify assistant message has tool-call content
-    const assistantMsg = result[1]
-    expect(assistantMsg).toBeDefined()
-    const assistantContent = assistantMsg?.content
-    assert(Array.isArray(assistantContent))
-    expect(assistantContent).toHaveLength(1)
-    // Verify structure of first item in array content
-    expect(assistantContent[0]).toMatchObject({
-      type: 'tool-call',
-      toolCallId: 'tc1',
-      toolName: 'list_tasks',
-    })
-
-    // Verify tool message has tool-result content
-    const toolMsg = result[2]
-    expect(toolMsg).toBeDefined()
-    const toolContent = toolMsg?.content
-    assert(Array.isArray(toolContent))
-    expect(toolContent).toHaveLength(1)
-    // Verify structure of first item in array content
-    expect(toolContent[0]).toMatchObject({
-      type: 'tool-result',
-      toolCallId: 'tc1',
-      toolName: 'list_tasks',
-    })
-  })
-
-  test('rejects messages where content is neither string nor array', () => {
-    const messages = [{ role: 'user', content: 42 }]
-    testDb
-      .insert(schema.conversationHistory)
-      .values({ userId: '6', messages: JSON.stringify(messages) })
-      .run()
-
-    const result = loadHistory('6')
-    expect(result).toEqual([])
-  })
-})
-
-describe('saveHistory', () => {
-  let testDb: Awaited<ReturnType<typeof setupTestDb>>
+describe('history log contracts and clearHistory', () => {
+  let db: Awaited<ReturnType<typeof setupTestDb>>
 
   beforeEach(async () => {
-    testDb = await setupTestDb()
+    db = await setupTestDb()
   })
 
-  test('persists messages as JSON', async () => {
-    const messages: ModelMessage[] = [{ role: 'user', content: 'test' }]
-    saveHistory('10', messages)
+  test('clearHistory clears the cache, deletes the DB row, and logs both lines', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
+    history.appendHistory('ctx-clear', [makeUserMsg('m1', 'hello')])
+    await Promise.resolve()
 
-    // Wait for background DB sync
-    await flushMicrotasks()
+    const before = db.select().from(conversationHistory).where(eq(conversationHistory.userId, 'ctx-clear')).get()
+    expect(before).toBeDefined()
 
-    const row = testDb
-      .select()
-      .from(schema.conversationHistory)
-      .where(eq(schema.conversationHistory.userId, '10'))
-      .get()
-    expect(row).toBeDefined()
-    expect(JSON.parse(row!.messages)).toEqual(messages)
+    history.clearHistory('ctx-clear')
+
+    expect(history.loadHistory('ctx-clear')).toEqual([])
+    const after = db.select().from(conversationHistory).where(eq(conversationHistory.userId, 'ctx-clear')).get()
+    expect(after).toBeUndefined()
+
+    const debugCall = findCall(tracked, 'debug', 'clearHistory called')
+    expect(debugCall?.args[0]).toEqual({ userId: 'ctx-clear' })
+    const infoCall = findCall(tracked, 'info', 'History cleared')
+    expect(infoCall?.args[0]).toEqual({ userId: 'ctx-clear' })
   })
 
-  test('calls INSERT OR REPLACE', async () => {
-    const empty: ModelMessage[] = []
-    saveHistory('10', empty)
+  test('loadHistory logs the lookup with userId', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
 
-    // Wait for background DB sync
-    await flushMicrotasks()
+    history.loadHistory('ctx-load')
 
-    const row = testDb
-      .select()
-      .from(schema.conversationHistory)
-      .where(eq(schema.conversationHistory.userId, '10'))
-      .get()
-    expect(row).toBeDefined()
-    expect(row!.userId).toBe('10')
-  })
-})
-
-describe('clearHistory', () => {
-  let testDb: Awaited<ReturnType<typeof setupTestDb>>
-
-  beforeEach(async () => {
-    testDb = await setupTestDb()
+    const call = findCall(tracked, 'debug', 'loadHistory called')
+    expect(call?.args[0]).toEqual({ userId: 'ctx-load' })
   })
 
-  test('removes entry from store', () => {
-    testDb
-      .insert(schema.conversationHistory)
-      .values({ userId: '20', messages: JSON.stringify([]) })
-      .run()
-    clearHistory('20')
-    const row = testDb
-      .select()
-      .from(schema.conversationHistory)
-      .where(eq(schema.conversationHistory.userId, '20'))
-      .get()
-    expect(row).toBeUndefined()
+  test('saveHistory logs debug and info with the message count', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
+
+    history.saveHistory('ctx-save', [makeUserMsg('m1', 'hello')])
+
+    const debugCall = findCall(tracked, 'debug', 'saveHistory called')
+    expect(debugCall?.args[0]).toEqual({ userId: 'ctx-save', messageCount: 1 })
+    const infoCall = findCall(tracked, 'info', 'History saved to cache (DB sync in background)')
+    expect(infoCall?.args[0]).toEqual({ userId: 'ctx-save', messageCount: 1 })
   })
 
-  test('calls DELETE statement', () => {
-    clearHistory('20')
-    const row = testDb
-      .select()
-      .from(schema.conversationHistory)
-      .where(eq(schema.conversationHistory.userId, '20'))
-      .get()
-    expect(row).toBeUndefined()
-  })
-})
+  test('appendHistory logs the append count', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
 
-describe('appendHistory', () => {
-  beforeEach(async () => {
-    await setupTestDb()
-    userCachesForTesting.clear()
+    history.appendHistory('ctx-append', [makeUserMsg('m1', 'hello')])
+
+    const call = findCall(tracked, 'debug', 'appendHistory called')
+    expect(call?.args[0]).toEqual({ userId: 'ctx-append', appendCount: 1 })
   })
 
-  test('appends messages to empty history', () => {
-    const messages: ModelMessage[] = [{ role: 'user', content: 'hello' }]
-    appendHistory('append-1', messages)
-    const result = getCachedHistory('append-1')
-    expect(result).toHaveLength(1)
-    expect(result[0]).toEqual({ role: 'user', content: 'hello' })
+  test('binds the history child logger with its scope', async () => {
+    const tracked = createTrackedLoggerMock()
+    await loadHistoryModule(tracked)
+
+    expect(tracked.logger.child).toHaveBeenCalledWith({ scope: 'history' })
   })
 
-  test('appends to existing history', () => {
-    saveHistory('append-2', [
-      { role: 'user', content: 'first' },
-      { role: 'assistant', content: 'second' },
+  test('applyEditToHistory logs the rewrite on a hit', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
+    history.appendHistory('ctx-edit-hit', [makeUserMsg('m1', 'hello')])
+
+    expect(history.applyEditToHistory('ctx-edit-hit', 'm1', 'hello (edited)')).toBe(true)
+
+    const call = findCall(tracked, 'info', 'applyEditToHistory: user turn rewritten')
+    expect(call?.args[0]).toEqual({ contextId: 'ctx-edit-hit', messageId: 'm1' })
+  })
+
+  test('applyEditToHistory logs the miss when no turn carries the messageId', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
+
+    expect(history.applyEditToHistory('ctx-edit-miss', 'missing', 'x')).toBe(false)
+
+    const call = findCall(tracked, 'debug', 'applyEditToHistory: messageId not found in any user turn')
+    expect(call?.args[0]).toEqual({ contextId: 'ctx-edit-miss', messageId: 'missing' })
+  })
+
+  test('trimTurnForRegeneration logs the removed count on a hit', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
+    history.appendHistory('ctx-trim-hit', [
+      makeUserMsg('m1', 'hello'),
+      { role: 'assistant', content: 'old answer' } as ModelMessage,
+      { role: 'tool', content: [] } as ModelMessage,
     ])
-    appendHistory('append-2', [{ role: 'user', content: 'third' }])
-    const result = getCachedHistory('append-2')
-    expect(result).toHaveLength(3)
-    expect(result[0]!.content).toBe('first')
-    expect(result[1]!.content).toBe('second')
-    expect(result[2]!.content).toBe('third')
+
+    expect(history.trimTurnForRegeneration('ctx-trim-hit', 'm1')).toBe(true)
+
+    const call = findCall(tracked, 'info', 'trimTurnForRegeneration: trailing turn removed for regeneration')
+    expect(call?.args[0]).toEqual({ contextId: 'ctx-trim-hit', messageId: 'm1', removedCount: 3 })
   })
 
-  test('preserves message types (user, assistant, tool)', () => {
-    const messages: ModelMessage[] = [
-      { role: 'user', content: 'question' },
-      { role: 'assistant', content: 'answer' },
-      {
-        role: 'tool',
-        content: [
-          {
-            type: 'tool-result',
-            toolCallId: 'tc1',
-            toolName: 'test',
-            output: { type: 'text', value: 'ok' },
-          },
-        ],
-      },
-    ]
-    appendHistory('append-3', messages)
-    const result = getCachedHistory('append-3')
-    expect(result).toHaveLength(3)
-    expect(result[0]!.role).toBe('user')
-    expect(result[1]!.role).toBe('assistant')
-    expect(result[2]!.role).toBe('tool')
-  })
-})
+  test('trimTurnForRegeneration logs the miss when no turn carries the messageId', async () => {
+    const tracked = createTrackedLoggerMock()
+    const history = await loadHistoryModule(tracked)
 
-describe('getCachedHistory cold-cache behavior', () => {
-  let testDb: Awaited<ReturnType<typeof setupTestDb>>
+    expect(history.trimTurnForRegeneration('ctx-trim-miss', 'missing')).toBe(false)
 
-  beforeEach(async () => {
-    testDb = await setupTestDb()
-    // Clear all caches to ensure cold state
-    userCachesForTesting.clear()
-  })
-
-  test('loads messages from DB when cache is cold and DB has data', () => {
-    const messages = [
-      { role: 'user', content: 'hello' },
-      { role: 'assistant', content: 'hi there' },
-    ]
-    testDb
-      .insert(schema.conversationHistory)
-      .values({ userId: 'user1', messages: JSON.stringify(messages) })
-      .run()
-
-    const result = getCachedHistory('user1')
-    expect(result).toHaveLength(2)
-    expect(result[0]).toEqual({ role: 'user', content: 'hello' })
-    expect(result[1]).toEqual({ role: 'assistant', content: 'hi there' })
-  })
-
-  test('returns empty array when cache is cold and DB has no data', () => {
-    const result = getCachedHistory('user2')
-    expect(result).toEqual([])
-  })
-
-  test('does not query DB again on second call after cold load', () => {
-    const messages = [{ role: 'user', content: 'test' }]
-    testDb
-      .insert(schema.conversationHistory)
-      .values({ userId: 'user3', messages: JSON.stringify(messages) })
-      .run()
-
-    // First call loads from DB
-    const result1 = getCachedHistory('user3')
-    expect(result1).toHaveLength(1)
-
-    // Update DB directly (bypass cache) - need to update since primary key exists
-    const newMessages = [{ role: 'user', content: 'modified' }]
-    testDb
-      .update(schema.conversationHistory)
-      .set({ messages: JSON.stringify(newMessages) })
-      .where(eq(schema.conversationHistory.userId, 'user3'))
-      .run()
-
-    // Second call should return cached result, not DB update
-    const result2 = getCachedHistory('user3')
-    expect(result2).toHaveLength(1)
-    expect(result2[0]!.content).toBe('test')
-  })
-
-  // Story 1 AC Test: "Continuing from previous session"
-  test('Story 1: continuing from previous session', async () => {
-    const userId = 'story1-user'
-    const messages: ModelMessage[] = [
-      { role: 'user', content: 'Create a task for the mobile app' },
-      { role: 'assistant', content: 'I have created task #42 for the mobile app.' },
-    ]
-
-    // Simulate first session: save history
-    saveHistory(userId, messages)
-    await flushMicrotasks()
-
-    // Simulate session end: clear cache (simulating bot restart)
-    userCachesForTesting.clear()
-
-    // Simulate new session: load history
-    const loadedMessages = loadHistory(userId)
-
-    // Verify history is preserved across sessions
-    expect(loadedMessages).toHaveLength(2)
-    expect(loadedMessages[0]).toEqual(messages[0])
-    expect(loadedMessages[1]).toEqual(messages[1])
+    const call = findCall(tracked, 'debug', 'trimTurnForRegeneration: originating user message not found')
+    expect(call?.args[0]).toEqual({ contextId: 'ctx-trim-miss', messageId: 'missing' })
   })
 })

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -143,6 +143,8 @@ describe('history log contracts and clearHistory', () => {
     const tracked = createTrackedLoggerMock()
     const history = await loadHistoryModule(tracked)
     history.appendHistory('ctx-trim-hit', [
+      makeUserMsg('m0', 'earlier turn'),
+      { role: 'assistant', content: 'earlier answer' } as ModelMessage,
       makeUserMsg('m1', 'hello'),
       { role: 'assistant', content: 'old answer' } as ModelMessage,
       { role: 'tool', content: [] } as ModelMessage,


### PR DESCRIPTION
## Summary

Raises the ratcheted mutation floor of `src/history.ts` from **0.21 → 1.0** and fixes the infrastructure regression that made the official paired mutation runner **error on every top-level `src/*` file**.

### Root-cause fix (why the floor was stuck)

`ae61aa748` added `.opencode` to Stryker `ignorePatterns`, so the sandbox copy lacked `.opencode/plugins/tdd-enforcement.ts` and `tests/opencode-tdd-enforcement.test.ts` died with `Cannot find module` in every dry run. Since "same-package" for root `src/*.ts` = all of `tests/*.test.ts`, every top-level `src/` paired run errored out and was excluded from scoring. Fix: globby negations re-include `.opencode/plugins` (20K) while `.opencode/node_modules` (61M) stays excluded. This unblocks re-measurement for `src/config.ts`, `src/recurring.ts`, `src/memory.ts`, etc. — follow-up ratchets are now possible.

### Mutant-killing tests (86 mutants: was 59 killed / 21 survived / 6 no-coverage)

- `tests/history-edit.test.ts`: two role-guard tests — non-user turns carrying matching `providerOptions.papai.messageIds` must not be matched by `applyEditToHistory` / `trimTurnForRegeneration` (kills the L64/L106 `msg.role !== 'user'` → `false` mutants).
- `tests/history.test.ts`: `clearHistory` coverage (cache + DB row + logs; the 6 no-coverage mutants) and structured-log contract assertions via `createTrackedLoggerMock()` with cache-busting dynamic imports (kills the 18 StringLiteral/ObjectLiteral log mutants + the L120 `removedCount` arithmetic mutant, via a `5-2` fixture that distinguishes `-` from `+`).
- Also restores 18 pre-existing cache load/save/clear behavior tests that were briefly overwritten mid-branch (caught in final review), incl. the only direct `parseHistoryFromDb` error-branch coverage.

### Ratchet

- `scripts/mutation/baseline.json`: `"src/history.ts": 0.21052631578947367 → 1`
- `scripts/mutation/overrides.json`: test-set entry for `src/history.ts`
- Spec + plan: `docs/superpowers/specs/2026-08-02-history-mutation-coverage-design.md`, `docs/superpowers/plans/2026-08-02-history-mutation-coverage.md`

## Verification

- Two-file probe (`ignoreStatic: false`): **100.00 — 86/86 killed**
- Official `bun test:mutate:file src/history.ts`: **score=1, errored=0** (dry run passes end-to-end through the fixed sandbox)
- `bun test tests/*.test.ts`: 1089/1089 pass; full suite: touched areas green; review-loop/analytics suites pass serially (their `--parallel` timeouts are pre-existing CPU-contention flakes; CI runs serial)
- `bun run lint` + `bun run typecheck`: clean