### PR TITLE
test(tools): raise create_recurring_task mutation score from 0.48 to 0.83

### DIFF
--- a/docs/superpowers/plans/2026-08-03-create-recurring-task-mutation.md
+++ b/docs/superpowers/plans/2026-08-03-create-recurring-task-mutation.md
@@ -226,15 +226,23 @@ describe('create-recurring-task — compile branch', () => {
     expect(capturedInput?.rrule).toContain('BYHOUR=9')
     expect(capturedInput?.dtstartUtc).toMatch(/T00:00:00\.000Z$/u)
   })
+
+  test('does not compile when cron reaches execute without a schedule', async () => {
+    const tool = makeCreateRecurringTaskTool('user-1', deps)
+    assert(tool.execute, 'Tool execute is undefined')
+    await tool.execute({ title: 'Task', projectId: 'p1', triggerType: 'cron' }, toolCtx)
+    expect(capturedInput?.rrule).toBeUndefined()
+    expect(capturedInput?.dtstartUtc).toBeUndefined()
+  })
 })
 ```
 
-Note: the second test deliberately bypasses schema validation by calling `execute` directly with an on_complete + schedule combination the schema would reject; it pins the `triggerType === 'cron'` guard so the `&&`→`||` mutant at L73 cannot survive.
+Note: the second test deliberately bypasses schema validation by calling `execute` directly with an on_complete + schedule combination the schema would reject; it pins the `triggerType === 'cron'` guard so the `&&`→`||` mutant at L73 cannot survive. The fourth test does the same for a cron input with no schedule (also schema-invalid), pinning the `schedule !== undefined` right operand of the same guard — the paired run in Task 4 showed that sub-condition mutant survives without it.
 
 - [ ] **Step 2: Run the test file**
 
 Run: `bun test tests/tools/create-recurring-task.test.ts`
-Expected: PASS — 13 tests.
+Expected: PASS — 14 tests.
 
 - [ ] **Step 3: Lint, typecheck, commit**
 
@@ -263,16 +271,18 @@ Background for the expected strings (do not copy into code): `describeCompiledRe
 
 - [ ] **Step 1: Append the result-mapping describe block**
 
+Note on form: the repo's `pedantic: error` oxlint config forbids narrowing casts from `unknown` and flags async functions without `await`, so property assertions use `toMatchObject` (equal strength to `.toBe` for primitive values), `cronInput` is `as const`, and the helper uses `return await`.
+
 ```typescript
 describe('create-recurring-task — result mapping', () => {
   type ToolInput = Parameters<NonNullable<ReturnType<typeof makeCreateRecurringTaskTool>['execute']>>[0]
 
-  const cronInput: ToolInput = {
+  const cronInput = {
     title: 'Task',
     projectId: 'p1',
     triggerType: 'cron',
     schedule: { freq: 'DAILY' },
-  }
+  } as const
 
   beforeEach(() => {
     mockLogger()
@@ -308,7 +318,7 @@ describe('create-recurring-task — result mapping', () => {
     const deps: CreateRecurringTaskDeps = { createRecurringTask: () => record }
     const tool = makeCreateRecurringTaskTool('user-1', deps)
     assert(tool.execute, 'Tool execute is undefined')
-    return tool.execute(input, toolCtx)
+    return await tool.execute(input, toolCtx)
   }
 
   test('describes the compiled schedule for a cron record with rrule and dtstartUtc', async () => {
@@ -325,42 +335,42 @@ describe('create-recurring-task — result mapping', () => {
   })
 
   test('falls back when rrule is null', async () => {
-    const result = (await executeWithRecord(makeResultRecord({ rrule: null }))) as { schedule: string }
-    expect(result.schedule).toBe('after completion of current instance')
+    const result = await executeWithRecord(makeResultRecord({ rrule: null }))
+    expect(result).toMatchObject({ schedule: 'after completion of current instance' })
   })
 
   test('falls back when dtstartUtc is null', async () => {
-    const result = (await executeWithRecord(makeResultRecord({ dtstartUtc: null }))) as { schedule: string }
-    expect(result.schedule).toBe('after completion of current instance')
+    const result = await executeWithRecord(makeResultRecord({ dtstartUtc: null }))
+    expect(result).toMatchObject({ schedule: 'after completion of current instance' })
   })
 
-  test('falls back for on_complete records', async () => {
-    const result = (await executeWithRecord(makeResultRecord({ triggerType: 'on_complete', rrule: null, dtstartUtc: null }), {
+  test('falls back for on_complete records even when rrule and dtstartUtc are populated', async () => {
+    const result = await executeWithRecord(makeResultRecord({ triggerType: 'on_complete' }), {
       title: 'Task',
       projectId: 'p1',
       triggerType: 'on_complete',
-    })) as { schedule: string }
-    expect(result.schedule).toBe('after completion of current instance')
+    })
+    expect(result).toMatchObject({ schedule: 'after completion of current instance' })
   })
 
   test('converts nextRun into the record timezone as naive local time', async () => {
-    const result = (await executeWithRecord(makeResultRecord({ timezone: 'Europe/Berlin' }))) as {
-      nextRun: string
-    }
-    expect(result.nextRun).toBe('2026-06-01T14:00:00')
+    const result = await executeWithRecord(makeResultRecord({ timezone: 'Europe/Berlin' }))
+    expect(result).toMatchObject({ nextRun: '2026-06-01T14:00:00' })
   })
 
   test('passes null nextRun through', async () => {
-    const result = (await executeWithRecord(makeResultRecord({ nextRun: null }))) as { nextRun: string | null }
-    expect(result.nextRun).toBeNull()
+    const result = await executeWithRecord(makeResultRecord({ nextRun: null }))
+    expect(result).toMatchObject({ nextRun: null })
   })
 })
 ```
 
+The on_complete fallback test deliberately keeps `rrule`/`dtstartUtc` populated (the record's `triggerType` alone selects the fallback): the paired run in Task 4 showed the L113 left-operand `ConditionalExpression` mutant survives when they are nulled, because the short-circuit then hides it.
+
 - [ ] **Step 2: Run the test file**
 
 Run: `bun test tests/tools/create-recurring-task.test.ts`
-Expected: PASS — 19 tests. If `'describes the compiled schedule…'` fails on the `schedule` string, print the actual value with a temporary `console.log(result)` and align (it comes from `describeCompiledRecurrence` in src/recurrence.ts — do not change the source).
+Expected: PASS — 20 tests. If `'describes the compiled schedule…'` fails on the `schedule` string, print the actual value with a temporary `console.log(result)` and align (it comes from `describeCompiledRecurrence` in src/recurrence.ts — do not change the source).
 
 - [ ] **Step 3: Lint, typecheck, commit**
 
@@ -401,23 +411,28 @@ describe('create-recurring-task — failure propagation', () => {
       },
     }
     const tool = makeCreateRecurringTaskTool('user-1', deps)
-    assert(tool.execute, 'Tool execute is undefined')
-    expect(() => tool.execute({ title: 'Task', projectId: 'p1', triggerType: 'on_complete' }, toolCtx)).toThrow(
-      'db down',
-    )
+    const exec = tool.execute
+    assert(exec, 'Tool execute is undefined')
+    expect(() => {
+      exec({ title: 'Task', projectId: 'p1', triggerType: 'on_complete' }, toolCtx)
+    }).toThrow('db down')
   })
 })
 ```
 
+The `const exec = tool.execute` capture (instead of asserting `tool.execute` inline) keeps TS narrowing valid inside the closure, and the block-body thunk avoids a `no-unsafe-return` flag — the repo forbids `!` assertions and narrowing casts.
+
 - [ ] **Step 2: Run the test file**
 
 Run: `bun test tests/tools/create-recurring-task.test.ts`
-Expected: PASS — 20 tests.
+Expected: PASS — 21 tests.
 
 - [ ] **Step 3: Run the paired mutation analysis**
 
 Run: `bun test:mutate:file src/tools/create-recurring-task.ts`
-Expected: `killed≈86 survived≈18`, score **≥ 0.78** (pre-change: `killed=50 survived=54 score=0.481`). The ~18 accepted survivors are `.describe()` prose, the logger scope string, and log message/metadata strings/objects (src/tools/create-recurring-task.ts L29, L33–L46, L68, L99, L144).
+Expected: `killed=86 survived=18`, score **0.8269** (pre-change: `killed=50 survived=54 score=0.481`). The 18 accepted survivors are `.describe()` prose, the logger scope string, and log message/metadata strings/objects (src/tools/create-recurring-task.ts L29, L33–L46, L68, L99, L144).
+
+Note: the first run of this task exposed two sub-condition `ConditionalExpression` survivors the original task code missed — the L73 right operand (`schedule !== undefined` → `true`) and the L113 left operand (`record.triggerType === 'cron'` → `true`). They were killed by adding the cron-without-schedule test to the compile-branch describe and by keeping `rrule`/`dtstartUtc` populated in the on_complete fallback test (both already reflected in the Task 2/3 code above).
 
 If any survivor is a ConditionalExpression, LogicalOperator, ArrayDeclaration, or an enum/validation-message string, it was supposed to die: inspect the report with
 

--- a/docs/superpowers/plans/2026-08-03-create-recurring-task-mutation.md
+++ b/docs/superpowers/plans/2026-08-03-create-recurring-task-mutation.md
@@ -394,7 +394,7 @@ describe('create-recurring-task — failure propagation', () => {
     setCachedConfig('user-1', 'timezone', 'UTC')
   })
 
-  test('rethrows when the store fails', async () => {
+  test('rethrows when the store fails', () => {
     const deps: CreateRecurringTaskDeps = {
       createRecurringTask: (): RecurringTaskRecord => {
         throw new Error('db down')
@@ -402,7 +402,7 @@ describe('create-recurring-task — failure propagation', () => {
     }
     const tool = makeCreateRecurringTaskTool('user-1', deps)
     assert(tool.execute, 'Tool execute is undefined')
-    await expect(tool.execute({ title: 'Task', projectId: 'p1', triggerType: 'on_complete' }, toolCtx)).rejects.toThrow(
+    expect(() => tool.execute({ title: 'Task', projectId: 'p1', triggerType: 'on_complete' }, toolCtx)).toThrow(
       'db down',
     )
   })

--- a/docs/superpowers/plans/2026-08-03-create-recurring-task-mutation.md
+++ b/docs/superpowers/plans/2026-08-03-create-recurring-task-mutation.md
@@ -1,0 +1,426 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation coverage for `src/tools/create-recurring-task.ts` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Kill ~36 of the 54 surviving Stryker mutants in `src/tools/create-recurring-task.ts` by adding focused tests, raising the paired mutation score from 0.481 to ~0.83.
+
+**Architecture:** Test-only change. All work lands in the existing companion `tests/tools/create-recurring-task.test.ts`, using the file's established DI-first pattern (`CreateRecurringTaskDeps` injection, `setCachedConfig` for timezone, `mockLogger()`). No source files are modified; `scripts/mutation/baseline.json` is not edited (the CI master seed ratchets the floor).
+
+**Tech Stack:** Bun test runner (`bun:test`), zod v4 (input schema), Vercel AI SDK `tool()`, Stryker via `bun test:mutate:file`.
+
+**Spec:** `docs/superpowers/specs/2026-08-03-create-recurring-task-mutation-design.md`
+
+## Global Constraints
+
+- **Do NOT modify any file under `src/` or `plugins/`.** The only modified file is `tests/tools/create-recurring-task.test.ts`.
+- **Do NOT edit `scripts/mutation/baseline.json` or `scripts/mutation/overrides.json`.**
+- These tests assert **existing, correct behavior** — they are expected to PASS on first run. The failure signal that proves they work is the Stryker run in Task 4: each test names the mutant cluster it kills.
+- Strict TypeScript; relative imports keep the `.js` extension. No new runtime imports beyond what the plan shows.
+- No comments in test code; test names carry the intent.
+- Tests must be isolation-clean (no cross-file state; each new describe has its own `beforeEach`).
+- Commit style follows the repo: `test(tools): <what>`.
+- Lint/typecheck: `bun run lint`, `bun run typecheck` (pre-commit hooks also run them).
+
+## File Structure
+
+- Modify: `tests/tools/create-recurring-task.test.ts` — add one type import and four describe blocks (one per task). Existing imports, `toolCtx`, `makeRecord`, and the 3 DTSTART tests stay untouched.
+
+---
+
+### Task 1: Input-validation describe block
+
+Kills the superRefine cluster (src/tools/create-recurring-task.ts L49/L56: 6 ConditionalExpression + 2 LogicalOperator + 2 ObjectLiteral + 2 ArrayDeclaration + 6 StringLiteral) and the enum cluster (L36/L41: 2 ArrayDeclaration + 7 StringLiteral).
+
+**Files:**
+- Modify: `tests/tools/create-recurring-task.test.ts`
+
+**Interfaces:**
+- Consumes: `makeCreateRecurringTaskTool`, `CreateRecurringTaskDeps`, `RecurringTaskInput`, `RecurringTaskRecord` (already imported in the file); `toolCtx`, `makeRecord`, `mockLogger()`, `setCachedConfig()` (already in the file).
+- Produces: describe block `'create-recurring-task — input validation'`; no exports.
+
+- [ ] **Step 1: Add the zod type import**
+
+In `tests/tools/create-recurring-task.test.ts`, add after the `node:assert/strict` import and a blank line:
+
+```typescript
+import type { z } from 'zod'
+```
+
+- [ ] **Step 2: Append the validation describe block at the end of the file**
+
+```typescript
+describe('create-recurring-task — input validation', () => {
+  let deps: CreateRecurringTaskDeps
+
+  beforeEach(() => {
+    mockLogger()
+    setCachedConfig('user-1', 'timezone', 'UTC')
+    deps = {
+      createRecurringTask: (input: RecurringTaskInput): RecurringTaskRecord => makeRecord(input),
+    }
+  })
+
+  const parseInput = (data: unknown) => {
+    const tool = makeCreateRecurringTaskTool('user-1', deps)
+    const schema = tool.inputSchema as unknown as z.ZodType<unknown>
+    return schema.safeParse(data)
+  }
+
+  test('rejects cron without schedule with a path-scoped custom issue', () => {
+    const result = parseInput({ title: 'Task', projectId: 'p1', triggerType: 'cron' })
+    expect(result.success).toBe(false)
+    assert(!result.success)
+    expect(result.error.issues[0]?.code).toBe('custom')
+    expect(result.error.issues[0]?.message).toBe("schedule is required when triggerType is 'cron'")
+    expect(result.error.issues[0]?.path).toEqual(['schedule'])
+  })
+
+  test('accepts cron with schedule', () => {
+    expect(
+      parseInput({ title: 'Task', projectId: 'p1', triggerType: 'cron', schedule: { freq: 'DAILY' } }).success,
+    ).toBe(true)
+  })
+
+  test('rejects on_complete with schedule with a path-scoped custom issue', () => {
+    const result = parseInput({
+      title: 'Task',
+      projectId: 'p1',
+      triggerType: 'on_complete',
+      schedule: { freq: 'DAILY' },
+    })
+    expect(result.success).toBe(false)
+    assert(!result.success)
+    expect(result.error.issues[0]?.code).toBe('custom')
+    expect(result.error.issues[0]?.message).toBe("schedule must not be provided when triggerType is 'on_complete'")
+    expect(result.error.issues[0]?.path).toEqual(['schedule'])
+  })
+
+  test('accepts on_complete without schedule', () => {
+    expect(parseInput({ title: 'Task', projectId: 'p1', triggerType: 'on_complete' }).success).toBe(true)
+  })
+
+  test('accepts every priority enum value', () => {
+    for (const priority of ['no-priority', 'low', 'medium', 'high', 'urgent'] as const) {
+      expect(
+        parseInput({ title: 'Task', projectId: 'p1', triggerType: 'on_complete', priority }).success,
+      ).toBe(true)
+    }
+  })
+
+  test('rejects an invalid priority', () => {
+    expect(
+      parseInput({ title: 'Task', projectId: 'p1', triggerType: 'on_complete', priority: 'critical' }).success,
+    ).toBe(false)
+  })
+
+  test('rejects an invalid triggerType', () => {
+    expect(parseInput({ title: 'Task', projectId: 'p1', triggerType: 'weekly' }).success).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 3: Run the test file**
+
+Run: `bun test tests/tools/create-recurring-task.test.ts`
+Expected: PASS — 10 tests (3 existing + 7 new). These assert existing behavior; a failure here means a typo in the plan's expected strings, not a source bug. If `'rejects cron without schedule…'` fails on `issues[0]?.code`, check the source `superRefine` at src/tools/create-recurring-task.ts:48-63 and align the expectation with the actual issue.
+
+- [ ] **Step 4: Lint and typecheck**
+
+Run: `bun run lint && bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/tools/create-recurring-task.test.ts
+git commit -m "test(tools): cover create_recurring_task input validation"
+```
+
+---
+
+### Task 2: Compile-branch describe block
+
+Kills the L73 cluster (2 ConditionalExpression + 1 LogicalOperator) in `executeCreate`.
+
+**Files:**
+- Modify: `tests/tools/create-recurring-task.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Task 1's file state (imports, `toolCtx`, `makeRecord`).
+- Produces: describe block `'create-recurring-task — compile branch'`; no exports.
+
+- [ ] **Step 1: Append the compile-branch describe block**
+
+```typescript
+describe('create-recurring-task — compile branch', () => {
+  let capturedInput: RecurringTaskInput | null
+  let deps: CreateRecurringTaskDeps
+
+  beforeEach(() => {
+    mockLogger()
+    capturedInput = null
+    setCachedConfig('user-1', 'timezone', 'UTC')
+    deps = {
+      createRecurringTask: (input: RecurringTaskInput): RecurringTaskRecord => {
+        capturedInput = input
+        return makeRecord(input)
+      },
+    }
+  })
+
+  test('passes no rrule or dtstartUtc for on_complete', async () => {
+    const tool = makeCreateRecurringTaskTool('user-1', deps)
+    assert(tool.execute, 'Tool execute is undefined')
+    await tool.execute({ title: 'Task', projectId: 'p1', triggerType: 'on_complete' }, toolCtx)
+    expect(capturedInput?.rrule).toBeUndefined()
+    expect(capturedInput?.dtstartUtc).toBeUndefined()
+  })
+
+  test('does not compile when a schedule is passed with on_complete', async () => {
+    const tool = makeCreateRecurringTaskTool('user-1', deps)
+    assert(tool.execute, 'Tool execute is undefined')
+    await tool.execute(
+      { title: 'Task', projectId: 'p1', triggerType: 'on_complete', schedule: { freq: 'DAILY' } },
+      toolCtx,
+    )
+    expect(capturedInput?.rrule).toBeUndefined()
+    expect(capturedInput?.dtstartUtc).toBeUndefined()
+  })
+
+  test('passes the compiled rrule and dtstartUtc for cron', async () => {
+    const tool = makeCreateRecurringTaskTool('user-1', deps)
+    assert(tool.execute, 'Tool execute is undefined')
+    await tool.execute(
+      {
+        title: 'Task',
+        projectId: 'p1',
+        triggerType: 'cron',
+        schedule: { freq: 'DAILY', byHour: [9], byMinute: [0], timezone: 'UTC' },
+      },
+      toolCtx,
+    )
+    expect(capturedInput?.rrule).toContain('FREQ=DAILY')
+    expect(capturedInput?.rrule).toContain('BYHOUR=9')
+    expect(capturedInput?.dtstartUtc).toMatch(/T00:00:00\.000Z$/u)
+  })
+})
+```
+
+Note: the second test deliberately bypasses schema validation by calling `execute` directly with an on_complete + schedule combination the schema would reject; it pins the `triggerType === 'cron'` guard so the `&&`→`||` mutant at L73 cannot survive.
+
+- [ ] **Step 2: Run the test file**
+
+Run: `bun test tests/tools/create-recurring-task.test.ts`
+Expected: PASS — 13 tests.
+
+- [ ] **Step 3: Lint, typecheck, commit**
+
+Run: `bun run lint && bun run typecheck`
+Expected: no errors.
+
+```bash
+git add tests/tools/create-recurring-task.test.ts
+git commit -m "test(tools): cover create_recurring_task compile branch"
+```
+
+---
+
+### Task 3: Result-mapping describe block
+
+Kills the L113 cluster (4 ConditionalExpression + 2 LogicalOperator) in `buildRecurringTaskResult` and pins the result shape.
+
+**Files:**
+- Modify: `tests/tools/create-recurring-task.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Task 2's file state; `RecurringTaskRecord` (already imported).
+- Produces: describe block `'create-recurring-task — result mapping'`; no exports.
+
+Background for the expected strings (do not copy into code): `describeCompiledRecurrence({ rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0', dtstartUtc: '2026-06-01T09:00:00.000Z', timezone: 'UTC' })` returns `'daily at 09:00 UTC'`; `utcToLocal('2026-06-01T12:00:00.000Z', 'Europe/Berlin')` returns `'2026-06-01T14:00:00'` (naive local, CEST); with timezone `'UTC'` it returns `'2026-06-01T12:00:00'`.
+
+- [ ] **Step 1: Append the result-mapping describe block**
+
+```typescript
+describe('create-recurring-task — result mapping', () => {
+  type ToolInput = Parameters<NonNullable<ReturnType<typeof makeCreateRecurringTaskTool>['execute']>>[0]
+
+  const cronInput: ToolInput = {
+    title: 'Task',
+    projectId: 'p1',
+    triggerType: 'cron',
+    schedule: { freq: 'DAILY' },
+  }
+
+  beforeEach(() => {
+    mockLogger()
+    setCachedConfig('user-1', 'timezone', 'UTC')
+  })
+
+  function makeResultRecord(overrides: Partial<RecurringTaskRecord>): RecurringTaskRecord {
+    return {
+      id: 'rec-1',
+      userId: 'user-1',
+      projectId: 'p1',
+      title: 'Task',
+      description: null,
+      priority: null,
+      status: null,
+      assignee: null,
+      labels: [],
+      triggerType: 'cron',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstartUtc: '2026-06-01T09:00:00.000Z',
+      timezone: 'UTC',
+      enabled: true,
+      catchUp: false,
+      lastRun: null,
+      nextRun: '2026-06-01T12:00:00.000Z',
+      createdAt: '2026-05-01T00:00:00.000Z',
+      updatedAt: '2026-05-01T00:00:00.000Z',
+      ...overrides,
+    }
+  }
+
+  async function executeWithRecord(record: RecurringTaskRecord, input: ToolInput = cronInput): Promise<unknown> {
+    const deps: CreateRecurringTaskDeps = { createRecurringTask: () => record }
+    const tool = makeCreateRecurringTaskTool('user-1', deps)
+    assert(tool.execute, 'Tool execute is undefined')
+    return tool.execute(input, toolCtx)
+  }
+
+  test('describes the compiled schedule for a cron record with rrule and dtstartUtc', async () => {
+    const result = await executeWithRecord(makeResultRecord({}))
+    expect(result).toEqual({
+      id: 'rec-1',
+      title: 'Task',
+      projectId: 'p1',
+      triggerType: 'cron',
+      schedule: 'daily at 09:00 UTC',
+      nextRun: '2026-06-01T12:00:00',
+      enabled: true,
+    })
+  })
+
+  test('falls back when rrule is null', async () => {
+    const result = (await executeWithRecord(makeResultRecord({ rrule: null }))) as { schedule: string }
+    expect(result.schedule).toBe('after completion of current instance')
+  })
+
+  test('falls back when dtstartUtc is null', async () => {
+    const result = (await executeWithRecord(makeResultRecord({ dtstartUtc: null }))) as { schedule: string }
+    expect(result.schedule).toBe('after completion of current instance')
+  })
+
+  test('falls back for on_complete records', async () => {
+    const result = (await executeWithRecord(makeResultRecord({ triggerType: 'on_complete', rrule: null, dtstartUtc: null }), {
+      title: 'Task',
+      projectId: 'p1',
+      triggerType: 'on_complete',
+    })) as { schedule: string }
+    expect(result.schedule).toBe('after completion of current instance')
+  })
+
+  test('converts nextRun into the record timezone as naive local time', async () => {
+    const result = (await executeWithRecord(makeResultRecord({ timezone: 'Europe/Berlin' }))) as {
+      nextRun: string
+    }
+    expect(result.nextRun).toBe('2026-06-01T14:00:00')
+  })
+
+  test('passes null nextRun through', async () => {
+    const result = (await executeWithRecord(makeResultRecord({ nextRun: null }))) as { nextRun: string | null }
+    expect(result.nextRun).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test file**
+
+Run: `bun test tests/tools/create-recurring-task.test.ts`
+Expected: PASS — 19 tests. If `'describes the compiled schedule…'` fails on the `schedule` string, print the actual value with a temporary `console.log(result)` and align (it comes from `describeCompiledRecurrence` in src/recurrence.ts — do not change the source).
+
+- [ ] **Step 3: Lint, typecheck, commit**
+
+Run: `bun run lint && bun run typecheck`
+Expected: no errors.
+
+```bash
+git add tests/tools/create-recurring-task.test.ts
+git commit -m "test(tools): cover create_recurring_task result mapping"
+```
+
+---
+
+### Task 4: Failure-path test + full mutation verification
+
+Adds the error-propagation lock, then runs the paired mutation analysis as the wholesale proof that the planned mutants died.
+
+**Files:**
+- Modify: `tests/tools/create-recurring-task.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Task 3's file state.
+- Produces: describe block `'create-recurring-task — failure propagation'`; no exports.
+
+- [ ] **Step 1: Append the failure-path describe block**
+
+```typescript
+describe('create-recurring-task — failure propagation', () => {
+  beforeEach(() => {
+    mockLogger()
+    setCachedConfig('user-1', 'timezone', 'UTC')
+  })
+
+  test('rethrows when the store fails', async () => {
+    const deps: CreateRecurringTaskDeps = {
+      createRecurringTask: (): RecurringTaskRecord => {
+        throw new Error('db down')
+      },
+    }
+    const tool = makeCreateRecurringTaskTool('user-1', deps)
+    assert(tool.execute, 'Tool execute is undefined')
+    await expect(tool.execute({ title: 'Task', projectId: 'p1', triggerType: 'on_complete' }, toolCtx)).rejects.toThrow(
+      'db down',
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run the test file**
+
+Run: `bun test tests/tools/create-recurring-task.test.ts`
+Expected: PASS — 20 tests.
+
+- [ ] **Step 3: Run the paired mutation analysis**
+
+Run: `bun test:mutate:file src/tools/create-recurring-task.ts`
+Expected: `killed≈86 survived≈18`, score **≥ 0.78** (pre-change: `killed=50 survived=54 score=0.481`). The ~18 accepted survivors are `.describe()` prose, the logger scope string, and log message/metadata strings/objects (src/tools/create-recurring-task.ts L29, L33–L46, L68, L99, L144).
+
+If any survivor is a ConditionalExpression, LogicalOperator, ArrayDeclaration, or an enum/validation-message string, it was supposed to die: inspect the report with
+
+```bash
+bun -e "
+const r = await Bun.file('reports/paired/src__tools__create-recurring-task.ts.stryker-report.json').json();
+const f = r.files['src/tools/create-recurring-task.ts'];
+for (const m of f.mutants.filter((x) => x.status === 'Survived')) console.log(m.mutatorName, 'L' + m.location.start.line, JSON.stringify(m.replacement));
+"
+```
+
+then strengthen the corresponding test (each block maps to a line cluster per Tasks 1–3) and re-run. Do not edit the source to kill a mutant.
+
+- [ ] **Step 4: Lint, typecheck, commit**
+
+Run: `bun run lint && bun run typecheck`
+Expected: no errors.
+
+```bash
+git add tests/tools/create-recurring-task.test.ts
+git commit -m "test(tools): cover create_recurring_task failure path"
+```

--- a/docs/superpowers/plans/2026-08-03-create-recurring-task-mutation.md
+++ b/docs/superpowers/plans/2026-08-03-create-recurring-task-mutation.md
@@ -45,15 +45,29 @@ Kills the superRefine cluster (src/tools/create-recurring-task.ts L49/L56: 6 Con
 - Consumes: `makeCreateRecurringTaskTool`, `CreateRecurringTaskDeps`, `RecurringTaskInput`, `RecurringTaskRecord` (already imported in the file); `toolCtx`, `makeRecord`, `mockLogger()`, `setCachedConfig()` (already in the file).
 - Produces: describe block `'create-recurring-task — input validation'`; no exports.
 
-- [ ] **Step 1: Add the zod type import**
+- [ ] **Step 1: Append the safeParse helper at the end of the file**
 
-In `tests/tools/create-recurring-task.test.ts`, add after the `node:assert/strict` import and a blank line:
+In `tests/tools/create-recurring-task.test.ts`, append after the existing describe block (this mirrors `isSafeParseable` in tests/utils/test-helpers.ts; the repo lint rules forbid type assertions, so a type guard is required instead of casting `tool.inputSchema`):
 
 ```typescript
-import type { z } from 'zod'
+interface SafeParseIssue {
+  code: string
+  message: string
+  path: PropertyKey[]
+}
+
+type SafeParseOutcome = { success: true } | { success: false; error: { issues: SafeParseIssue[] } }
+
+interface SafeParseable {
+  safeParse: (data: unknown) => SafeParseOutcome
+}
+
+function isSafeParseable(val: unknown): val is SafeParseable {
+  return typeof val === 'object' && val !== null && 'safeParse' in val && typeof val.safeParse === 'function'
+}
 ```
 
-- [ ] **Step 2: Append the validation describe block at the end of the file**
+- [ ] **Step 2: Append the validation describe block after the helper**
 
 ```typescript
 describe('create-recurring-task — input validation', () => {
@@ -67,10 +81,12 @@ describe('create-recurring-task — input validation', () => {
     }
   })
 
-  const parseInput = (data: unknown) => {
+  const parseInput = (data: unknown): SafeParseOutcome => {
     const tool = makeCreateRecurringTaskTool('user-1', deps)
-    const schema = tool.inputSchema as unknown as z.ZodType<unknown>
-    return schema.safeParse(data)
+    if (!isSafeParseable(tool.inputSchema)) {
+      throw new Error('Tool inputSchema does not have safeParse')
+    }
+    return tool.inputSchema.safeParse(data)
   }
 
   test('rejects cron without schedule with a path-scoped custom issue', () => {

--- a/docs/superpowers/specs/2026-08-03-create-recurring-task-mutation-design.md
+++ b/docs/superpowers/specs/2026-08-03-create-recurring-task-mutation-design.md
@@ -1,0 +1,170 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation coverage: `src/tools/create-recurring-task.ts`
+
+Date: 2026-08-03
+Status: approved
+
+## Goal
+
+Raise the mutation score of `src/tools/create-recurring-task.ts` — baseline
+`0.165` in `scripts/mutation/baseline.json`, the weakest user-facing tool file
+in `src/` — to ~0.80 by killing the surviving behavioral mutants with focused
+tests. No source changes.
+
+## Background and findings
+
+### Why this file
+
+Selected from `scripts/mutation/baseline.json` as the most valuable target:
+
+- Baseline `0.165` — among `src/` files only `compaction/constants.ts` (0,
+  constants-only), `update-sprint.ts` (0.12, 48-line narrow agile tool) and
+  `provider-independent-tools-builder.ts` (0.131, assembly wiring) score lower;
+  all three have far fewer mutants or far less behavioral depth.
+- User-facing LLM tool on the core recurring-task path: it validates the
+  schedule/trigger combination, compiles the recurrence in the user's
+  timezone, and shapes the result the LLM reads back. Surviving mutants here
+  are real behavioral risks (validation bypass, wrong DTSTART anchor, wrong
+  schedule description), not wording.
+- Already DI-friendly (`CreateRecurringTaskDeps`), so the repo's preferred
+  DI-first test pattern applies with no refactor.
+
+Alternatives considered: `update-sprint.ts` (lower score but ~25 mutants,
+narrow feature), `src/recurring.ts` (295-line core store at 0.458 but already
+has 785 lines of tests; less headroom), `provider-independent-tools-builder.ts`
+(composition wiring, low value per mutant). Zero-score plugin files are thin
+CRUD wrappers.
+
+### Mutant inventory (`bun test:mutate:file src/tools/create-recurring-task.ts`, 2026-08-03)
+
+104 mutants: **50 killed, 54 survived, 0 no-coverage** — current paired score
+0.481 (the 0.165 baseline entry was seeded with a weaker test set; the
+existing 113-line companion covers only DTSTART anchoring).
+
+Survivors, mapped to source lines:
+
+- **L49 / L56 — superRefine validation rules: 6 ConditionalExpression + 2
+  LogicalOperator + 2 ObjectLiteral + 2 ArrayDeclaration + 6 StringLiteral.**
+  `triggerType === 'cron' && schedule === undefined` and
+  `triggerType === 'on_complete' && schedule !== undefined`, plus the issue
+  objects (`message`, `path: ['schedule']`). No test exercises rejection.
+- **L73 — compile branch: 2 ConditionalExpression + 1 LogicalOperator.**
+  `input.triggerType === 'cron' && input.schedule !== undefined` gates rrule
+  compilation in `executeCreate`. No `on_complete` execution test exists.
+- **L113 — schedule-description fallback: 4 ConditionalExpression + 2
+  LogicalOperator.** `record.triggerType === 'cron' && record.rrule !== null
+  && record.dtstartUtc !== null` selects `describeCompiledRecurrence(...)` vs
+  the `'after completion of current instance'` fallback. Result mapping is
+  untested.
+- **L36 / L41 — enum declarations: 2 ArrayDeclaration + 7 StringLiteral.**
+  `priority` enum (5 values) and `triggerType` enum (2 values); membership is
+  never validated.
+- **Accepted survivors (18), out of scope per approved design:** `.describe()`
+  prose plus the logger scope string (11 StringLiteral across L29–L46), and
+  log message/metadata strings and objects (4 StringLiteral + 3 ObjectLiteral
+  at L68, L99, L144, L29).
+
+## Design
+
+Extend `tests/tools/create-recurring-task.test.ts` (keep the existing 3
+DTSTART tests unchanged) with four describe blocks, following the file's
+existing DI-first pattern (`CreateRecurringTaskDeps`,
+`setCachedConfig('user-1', 'timezone', ...)`, `mockLogger()`), plus
+`schemaValidates()` / `getToolExecutor()` from `tests/utils/test-helpers.ts`
+where they fit.
+
+### 1. Schema validation (kills the L49/L56 + enum clusters)
+
+Using the tool's `inputSchema` — `schemaValidates(tool, data)` for plain
+accept/reject booleans, and direct `inputSchema.safeParse(data)` where issue
+`message`/`path` are asserted (the helper returns only a boolean):
+
+- `cron` without `schedule` → rejected; issue message
+  `"schedule is required when triggerType is 'cron'"`, path `['schedule']`.
+- `cron` with `schedule` → accepted (kills boundary-flip mutants).
+- `on_complete` with `schedule` → rejected; issue message
+  `"schedule must not be provided when triggerType is 'on_complete'"`, path
+  `['schedule']`.
+- `on_complete` without `schedule` → accepted.
+- Each of the five `priority` enum values accepted; an invalid priority
+  rejected (kills the L36 array mutant and the five enum string mutants).
+- An invalid `triggerType` rejected (kills the L41 array mutant and its enum
+  string mutants).
+
+The message/path assertions also kill the L50/L57 issue ObjectLiteral mutants
+and the L53/L60 path array/string mutants.
+
+### 2. Compile branch (kills L73)
+
+- `on_complete` execution → injected `createRecurringTask` receives
+  `rrule: undefined` and `dtstartUtc: undefined` (no compilation attempted;
+  under the `true`/`||` mutants the branch destructures `undefined` and
+  throws, so the assertion fails).
+- `cron` execution → compiled `rrule`/`dtstartUtc` are passed through (the
+  existing DTSTART tests already cover the cron side; this adds the explicit
+  rrule-presence assertion).
+
+### 3. Result mapping (kills L113)
+
+Drive `execute` with injected records and assert the returned object:
+
+- cron record with `rrule` + `dtstartUtc` set → `schedule` equals
+  `describeCompiledRecurrence(...)` output, not the fallback string.
+- cron record with `rrule: null` → `schedule` is
+  `'after completion of current instance'`.
+- `on_complete` record → `schedule` is the fallback string.
+- `nextRun: '2026-06-01T12:00:00.000Z'` with `timezone: 'Europe/Berlin'` →
+  `'2026-06-01T14:00:00'` (naive local, CEST); `nextRun: null` passes through
+  as `null`.
+- `id`, `title`, `projectId`, `triggerType`, `enabled` are mapped through.
+
+### 4. Failure path (behavioral lock)
+
+- Injected `createRecurringTask` throws → `execute` rethrows. Locks the
+  catch/rethrow contract (no listed survivor maps here; the test prevents
+  regressions in the error path at trivial cost).
+
+### Expected outcome
+
+~36 of the 54 survivors killed (all 17 ConditionalExpression/LogicalOperator,
+4 ArrayDeclaration, 2 ObjectLiteral, ~13 StringLiteral) → score ≈
+(50 + 36) / 104 ≈ **0.83**; accept anything ≥ 0.78. Remaining survivors are
+the accepted describe/log/analytics strings.
+
+## Measurement and ratchet
+
+1. `bun test tests/tools/create-recurring-task.test.ts` — new tests pass.
+2. `bun test:mutate:file src/tools/create-recurring-task.ts` — confirm the
+   survivor count drops as predicted; investigate and kill or justify any
+   unexpected survivor in the behavioral clusters.
+3. No `baseline.json` edit in the PR: the CI `mutation-baseline` job re-seeds
+   the floor on master (per-key max) from the changed-files run. The PR gate
+   is regression-only, so the improved score can only raise the floor.
+4. Regression checks: repo lint/typecheck per `package.json` scripts; the
+   mutation run's own dry run validates the rest of the paired test set.
+
+## Trade-offs and risks
+
+- **Validation-message coupling.** Asserting exact superRefine messages ties
+  tests to wording. Accepted: these messages are the LLM-facing contract the
+  model reads when recovery is needed, and the mutation gate counts the
+  string mutants.
+- **Timezone-sensitive assertion.** The `Europe/Berlin` expectation relies on
+  ICU data in the Bun runtime; June is always CEST (UTC+2), no DST edge.
+- **Probe vs future paired divergence.** The recorded floor comes from the
+  official paired runner on master; the local paired number in this spec is
+  the prediction, not the guarantee.
+
+## Alternatives considered
+
+- **Maximal kill (assert `.describe()`/log prose too).** Rejected per design
+  approval: pushes toward ~0.95 but couples tests to wording tweaks with low
+  real value.
+- **Refactor-then-test.** Rejected: the file is already DI-friendly; no
+  structural change is needed to reach the target score.

--- a/tests/tools/create-recurring-task.test.ts
+++ b/tests/tools/create-recurring-task.test.ts
@@ -248,6 +248,14 @@ describe('create-recurring-task — compile branch', () => {
     expect(capturedInput?.rrule).toContain('BYHOUR=9')
     expect(capturedInput?.dtstartUtc).toMatch(/T00:00:00\.000Z$/u)
   })
+
+  test('does not compile when cron reaches execute without a schedule', async () => {
+    const tool = makeCreateRecurringTaskTool('user-1', deps)
+    assert(tool.execute, 'Tool execute is undefined')
+    await tool.execute({ title: 'Task', projectId: 'p1', triggerType: 'cron' }, toolCtx)
+    expect(capturedInput?.rrule).toBeUndefined()
+    expect(capturedInput?.dtstartUtc).toBeUndefined()
+  })
 })
 
 describe('create-recurring-task — result mapping', () => {
@@ -320,15 +328,12 @@ describe('create-recurring-task — result mapping', () => {
     expect(result).toMatchObject({ schedule: 'after completion of current instance' })
   })
 
-  test('falls back for on_complete records', async () => {
-    const result = await executeWithRecord(
-      makeResultRecord({ triggerType: 'on_complete', rrule: null, dtstartUtc: null }),
-      {
-        title: 'Task',
-        projectId: 'p1',
-        triggerType: 'on_complete',
-      },
-    )
+  test('falls back for on_complete records even when rrule and dtstartUtc are populated', async () => {
+    const result = await executeWithRecord(makeResultRecord({ triggerType: 'on_complete' }), {
+      title: 'Task',
+      projectId: 'p1',
+      triggerType: 'on_complete',
+    })
     expect(result).toMatchObject({ schedule: 'after completion of current instance' })
   })
 
@@ -340,5 +345,26 @@ describe('create-recurring-task — result mapping', () => {
   test('passes null nextRun through', async () => {
     const result = await executeWithRecord(makeResultRecord({ nextRun: null }))
     expect(result).toMatchObject({ nextRun: null })
+  })
+})
+
+describe('create-recurring-task — failure propagation', () => {
+  beforeEach(() => {
+    mockLogger()
+    setCachedConfig('user-1', 'timezone', 'UTC')
+  })
+
+  test('rethrows when the store fails', () => {
+    const deps: CreateRecurringTaskDeps = {
+      createRecurringTask: (): RecurringTaskRecord => {
+        throw new Error('db down')
+      },
+    }
+    const tool = makeCreateRecurringTaskTool('user-1', deps)
+    const exec = tool.execute
+    assert(exec, 'Tool execute is undefined')
+    expect(() => {
+      exec({ title: 'Task', projectId: 'p1', triggerType: 'on_complete' }, toolCtx)
+    }).toThrow('db down')
   })
 })

--- a/tests/tools/create-recurring-task.test.ts
+++ b/tests/tools/create-recurring-task.test.ts
@@ -249,3 +249,96 @@ describe('create-recurring-task — compile branch', () => {
     expect(capturedInput?.dtstartUtc).toMatch(/T00:00:00\.000Z$/u)
   })
 })
+
+describe('create-recurring-task — result mapping', () => {
+  type ToolInput = Parameters<NonNullable<ReturnType<typeof makeCreateRecurringTaskTool>['execute']>>[0]
+
+  const cronInput = {
+    title: 'Task',
+    projectId: 'p1',
+    triggerType: 'cron',
+    schedule: { freq: 'DAILY' },
+  } as const
+
+  beforeEach(() => {
+    mockLogger()
+    setCachedConfig('user-1', 'timezone', 'UTC')
+  })
+
+  function makeResultRecord(overrides: Partial<RecurringTaskRecord>): RecurringTaskRecord {
+    return {
+      id: 'rec-1',
+      userId: 'user-1',
+      projectId: 'p1',
+      title: 'Task',
+      description: null,
+      priority: null,
+      status: null,
+      assignee: null,
+      labels: [],
+      triggerType: 'cron',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstartUtc: '2026-06-01T09:00:00.000Z',
+      timezone: 'UTC',
+      enabled: true,
+      catchUp: false,
+      lastRun: null,
+      nextRun: '2026-06-01T12:00:00.000Z',
+      createdAt: '2026-05-01T00:00:00.000Z',
+      updatedAt: '2026-05-01T00:00:00.000Z',
+      ...overrides,
+    }
+  }
+
+  async function executeWithRecord(record: RecurringTaskRecord, input: ToolInput = cronInput): Promise<unknown> {
+    const deps: CreateRecurringTaskDeps = { createRecurringTask: () => record }
+    const tool = makeCreateRecurringTaskTool('user-1', deps)
+    assert(tool.execute, 'Tool execute is undefined')
+    return await tool.execute(input, toolCtx)
+  }
+
+  test('describes the compiled schedule for a cron record with rrule and dtstartUtc', async () => {
+    const result = await executeWithRecord(makeResultRecord({}))
+    expect(result).toEqual({
+      id: 'rec-1',
+      title: 'Task',
+      projectId: 'p1',
+      triggerType: 'cron',
+      schedule: 'daily at 09:00 UTC',
+      nextRun: '2026-06-01T12:00:00',
+      enabled: true,
+    })
+  })
+
+  test('falls back when rrule is null', async () => {
+    const result = await executeWithRecord(makeResultRecord({ rrule: null }))
+    expect(result).toMatchObject({ schedule: 'after completion of current instance' })
+  })
+
+  test('falls back when dtstartUtc is null', async () => {
+    const result = await executeWithRecord(makeResultRecord({ dtstartUtc: null }))
+    expect(result).toMatchObject({ schedule: 'after completion of current instance' })
+  })
+
+  test('falls back for on_complete records', async () => {
+    const result = await executeWithRecord(
+      makeResultRecord({ triggerType: 'on_complete', rrule: null, dtstartUtc: null }),
+      {
+        title: 'Task',
+        projectId: 'p1',
+        triggerType: 'on_complete',
+      },
+    )
+    expect(result).toMatchObject({ schedule: 'after completion of current instance' })
+  })
+
+  test('converts nextRun into the record timezone as naive local time', async () => {
+    const result = await executeWithRecord(makeResultRecord({ timezone: 'Europe/Berlin' }))
+    expect(result).toMatchObject({ nextRun: '2026-06-01T14:00:00' })
+  })
+
+  test('passes null nextRun through', async () => {
+    const result = await executeWithRecord(makeResultRecord({ nextRun: null }))
+    expect(result).toMatchObject({ nextRun: null })
+  })
+})

--- a/tests/tools/create-recurring-task.test.ts
+++ b/tests/tools/create-recurring-task.test.ts
@@ -196,3 +196,56 @@ describe('create-recurring-task — input validation', () => {
     expect(parseInput({ title: 'Task', projectId: 'p1', triggerType: 'weekly' }).success).toBe(false)
   })
 })
+
+describe('create-recurring-task — compile branch', () => {
+  let capturedInput: RecurringTaskInput | null
+  let deps: CreateRecurringTaskDeps
+
+  beforeEach(() => {
+    mockLogger()
+    capturedInput = null
+    setCachedConfig('user-1', 'timezone', 'UTC')
+    deps = {
+      createRecurringTask: (input: RecurringTaskInput): RecurringTaskRecord => {
+        capturedInput = input
+        return makeRecord(input)
+      },
+    }
+  })
+
+  test('passes no rrule or dtstartUtc for on_complete', async () => {
+    const tool = makeCreateRecurringTaskTool('user-1', deps)
+    assert(tool.execute, 'Tool execute is undefined')
+    await tool.execute({ title: 'Task', projectId: 'p1', triggerType: 'on_complete' }, toolCtx)
+    expect(capturedInput?.rrule).toBeUndefined()
+    expect(capturedInput?.dtstartUtc).toBeUndefined()
+  })
+
+  test('does not compile when a schedule is passed with on_complete', async () => {
+    const tool = makeCreateRecurringTaskTool('user-1', deps)
+    assert(tool.execute, 'Tool execute is undefined')
+    await tool.execute(
+      { title: 'Task', projectId: 'p1', triggerType: 'on_complete', schedule: { freq: 'DAILY' } },
+      toolCtx,
+    )
+    expect(capturedInput?.rrule).toBeUndefined()
+    expect(capturedInput?.dtstartUtc).toBeUndefined()
+  })
+
+  test('passes the compiled rrule and dtstartUtc for cron', async () => {
+    const tool = makeCreateRecurringTaskTool('user-1', deps)
+    assert(tool.execute, 'Tool execute is undefined')
+    await tool.execute(
+      {
+        title: 'Task',
+        projectId: 'p1',
+        triggerType: 'cron',
+        schedule: { freq: 'DAILY', byHour: [9], byMinute: [0], timezone: 'UTC' },
+      },
+      toolCtx,
+    )
+    expect(capturedInput?.rrule).toContain('FREQ=DAILY')
+    expect(capturedInput?.rrule).toContain('BYHOUR=9')
+    expect(capturedInput?.dtstartUtc).toMatch(/T00:00:00\.000Z$/u)
+  })
+})

--- a/tests/tools/create-recurring-task.test.ts
+++ b/tests/tools/create-recurring-task.test.ts
@@ -111,3 +111,88 @@ describe('create-recurring-task — DTSTART anchor', () => {
     expect(capturedInput?.dtstartUtc).toMatch(/T00:00:00\.000Z$/u)
   })
 })
+
+interface SafeParseIssue {
+  code: string
+  message: string
+  path: PropertyKey[]
+}
+
+type SafeParseOutcome = { success: true } | { success: false; error: { issues: SafeParseIssue[] } }
+
+interface SafeParseable {
+  safeParse: (data: unknown) => SafeParseOutcome
+}
+
+function isSafeParseable(val: unknown): val is SafeParseable {
+  return typeof val === 'object' && val !== null && 'safeParse' in val && typeof val.safeParse === 'function'
+}
+
+describe('create-recurring-task — input validation', () => {
+  let deps: CreateRecurringTaskDeps
+
+  beforeEach(() => {
+    mockLogger()
+    setCachedConfig('user-1', 'timezone', 'UTC')
+    deps = {
+      createRecurringTask: (input: RecurringTaskInput): RecurringTaskRecord => makeRecord(input),
+    }
+  })
+
+  const parseInput = (data: unknown): SafeParseOutcome => {
+    const tool = makeCreateRecurringTaskTool('user-1', deps)
+    if (!isSafeParseable(tool.inputSchema)) {
+      throw new Error('Tool inputSchema does not have safeParse')
+    }
+    return tool.inputSchema.safeParse(data)
+  }
+
+  test('rejects cron without schedule with a path-scoped custom issue', () => {
+    const result = parseInput({ title: 'Task', projectId: 'p1', triggerType: 'cron' })
+    expect(result.success).toBe(false)
+    assert(!result.success)
+    expect(result.error.issues[0]?.code).toBe('custom')
+    expect(result.error.issues[0]?.message).toBe("schedule is required when triggerType is 'cron'")
+    expect(result.error.issues[0]?.path).toEqual(['schedule'])
+  })
+
+  test('accepts cron with schedule', () => {
+    expect(
+      parseInput({ title: 'Task', projectId: 'p1', triggerType: 'cron', schedule: { freq: 'DAILY' } }).success,
+    ).toBe(true)
+  })
+
+  test('rejects on_complete with schedule with a path-scoped custom issue', () => {
+    const result = parseInput({
+      title: 'Task',
+      projectId: 'p1',
+      triggerType: 'on_complete',
+      schedule: { freq: 'DAILY' },
+    })
+    expect(result.success).toBe(false)
+    assert(!result.success)
+    expect(result.error.issues[0]?.code).toBe('custom')
+    expect(result.error.issues[0]?.message).toBe("schedule must not be provided when triggerType is 'on_complete'")
+    expect(result.error.issues[0]?.path).toEqual(['schedule'])
+  })
+
+  test('accepts on_complete without schedule', () => {
+    expect(parseInput({ title: 'Task', projectId: 'p1', triggerType: 'on_complete' }).success).toBe(true)
+  })
+
+  test('accepts every priority enum value', () => {
+    for (const priority of ['no-priority', 'low', 'medium', 'high', 'urgent'] as const) {
+      expect(parseInput({ title: 'Task', projectId: 'p1', triggerType: 'on_complete', priority }).success).toBe(true)
+    }
+  })
+
+  test('rejects an invalid priority', () => {
+    expect(
+      parseInput({ title: 'Task', projectId: 'p1', triggerType: 'on_complete', priority: 'critical' }).success,
+    ).toBe(false)
+  })
+
+  test('rejects an invalid triggerType', () => {
+    expect(parseInput({ title: 'Task', projectId: 'p1', triggerType: 'weekly' }).success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Targets `src/tools/create-recurring-task.ts` — selected from `scripts/mutation/baseline.json` as the most valuable low-coverage file (baseline 0.165, the weakest user-facing tool in `src/`; 104 mutants, 54 surviving on a fresh paired run).

Adds 18 tests in four describe blocks to the existing companion `tests/tools/create-recurring-task.test.ts`, killing 36 of the 54 surviving mutants:

- **Input validation** — superRefine rules (cron requires schedule / on_complete forbids it) with exact issue `code`/`message`/`path`, plus priority/triggerType enum membership
- **Compile branch** — on_complete passes no rrule/dtstartUtc; cron passes compiled values; schema-invalid direct-`execute` cases pin both operands of the L73 guard
- **Result mapping** — described schedule vs `'after completion of current instance'` fallback across all null/on_complete shapes, `utcToLocal` nextRun conversion, full result shape via `toEqual`
- **Failure propagation** — synchronous rethrow when the store fails

No source, `baseline.json`, or `overrides.json` changes — the CI master seed ratchets the floor automatically.

Paired Stryker run: `killed=86 survived=18 score=0.8269` (pre-change `killed=50 survived=54 score=0.481`). The 18 remaining survivors are deliberately accepted (`.describe()` prose, logger scope, log message/metadata strings).

Design: `docs/superpowers/specs/2026-08-03-create-recurring-task-mutation-design.md`
Plan: `docs/superpowers/plans/2026-08-03-create-recurring-task-mutation.md`

## Test plan

- `bun test tests/tools/create-recurring-task.test.ts` — 21/21 pass
- `bun test:mutate:file src/tools/create-recurring-task.ts` — killed=86 survived=18 score=0.8269
- `bun run lint && bun run typecheck` — clean
- Full local `bun run test` (--parallel): only pre-existing flaky review-loop git-worktree integration failures (pass standalone; non-deterministic counts across runs; CI runs serially), unrelated to this branch