### PR TITLE
test(youtrack): mutation coverage for custom-field-values (0 → 0.947)

### DIFF
--- a/docs/superpowers/plans/2026-08-04-youtrack-custom-field-values-mutation.md
+++ b/docs/superpowers/plans/2026-08-04-youtrack-custom-field-values-mutation.md
@@ -1,0 +1,297 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# YouTrack `custom-field-values.ts` Mutation Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Raise the paired mutation score of `plugins/task-provider-youtrack/custom-field-values.ts` from 0 (0 killed / 14 survived / 81 no-coverage, 95 mutants) to ≥ 0.9 by adding a pure unit-test companion file. No source changes.
+
+**Architecture:** One new test file, `tests/plugins/task-provider-youtrack/custom-field-values.test.ts` (standard companion mirror path — auto-discovered by the paired runner's test-resolver, no `overrides.json` edit). All assertions go through the single public export `mapReadOnlyCustomFields`; private helpers are exercised by crafting `value` shapes on a field named `'Team'` (not in the exclusion set). Tests are characterization tests on existing correct code: they PASS immediately; the mutation run in Task 3 is the effectiveness oracle.
+
+**Tech Stack:** Bun test runner (`bun:test`), TypeScript (strict), Stryker via `bun test:mutate:file`. No fetch mocks, no DI, no store.
+
+**Spec:** `docs/superpowers/specs/2026-08-04-youtrack-custom-field-values-mutation-design.md` (approved).
+
+## Global Constraints
+
+- Strict TypeScript; use `.js` extension in relative import paths.
+- Test files must start with the SPDX license header block (enforced by the `license-headers` commit hook):
+  ```ts
+  // SPDX-License-Identifier: BUSL-1.1
+  // Copyright (c) 2026 Dmitriy Lazarev
+  // Use of this software is governed by the Business Source License 1.1.
+  // See LICENSE in the project root for details.
+  ```
+- No comments in code beyond the license header; no lint-disable or type-ignore comments (hook-blocked).
+- Assertions use `toEqual` on the full returned array (deep equality distinguishes `5` from `'5'`, kills `ObjectLiteral {}` mutants, and locks entry order); use `toBeUndefined()` for the empty-shape contract.
+- Do NOT edit `scripts/mutation/baseline.json` — the CI `mutation-baseline` job re-seeds the floor on master (per-key max). The PR gate is regression-only.
+- Do NOT modify `plugins/task-provider-youtrack/custom-field-values.ts` or any other source file.
+- Commit message style follows recent history: `test(youtrack): ...` / `docs: ...` (see `git log --oneline`).
+
+## File Structure
+
+- Create: `tests/plugins/task-provider-youtrack/custom-field-values.test.ts` — the only code artifact. Holds all five describe blocks from the spec (filter/shape, primitives/null, object ladder, array branch, stringify tail).
+
+Reference files (read-only):
+- `plugins/task-provider-youtrack/custom-field-values.ts` — unit under test (57 lines).
+- `plugins/task-provider-youtrack/constants.ts:14` — `YOUTRACK_DUE_DATE_FIELD_NAME = 'Due Date'`.
+- `plugins/task-provider-youtrack/schemas/custom-fields.ts` — `CustomFieldValueSchema` union; test fixtures use `$type: 'SimpleIssueCustomField'` (value `string | number | boolean`, optional) for scalar cases and `$type: 'Custom'` (matches the `UnknownIssueCustomFieldSchema` fallback: `$type: string`, `value: unknown`) for object/array/function/circular cases.
+- `src/providers/domain-types.ts:61` — `TaskCustomField = { name: string; value: string | number | boolean | string[] | null }`.
+
+---
+
+### Task 1: Filter/shape contract + primitive/null handling (spec §1–2)
+
+**Files:**
+- Create: `tests/plugins/task-provider-youtrack/custom-field-values.test.ts`
+- Test: `tests/plugins/task-provider-youtrack/custom-field-values.test.ts`
+
+**Interfaces:**
+- Consumes: `mapReadOnlyCustomFields(customFields: readonly AnyCustomField[] | undefined): TaskCustomField[] | undefined` from `plugins/task-provider-youtrack/custom-field-values.js`; `YOUTRACK_DUE_DATE_FIELD_NAME: string` from `plugins/task-provider-youtrack/constants.js`.
+- Produces: the test file Task 2 appends two describe blocks to (same file, same imports).
+
+- [ ] **Step 1: Create the test file with the filter/shape and primitive describe blocks**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { YOUTRACK_DUE_DATE_FIELD_NAME } from '../../../plugins/task-provider-youtrack/constants.js'
+import { mapReadOnlyCustomFields } from '../../../plugins/task-provider-youtrack/custom-field-values.js'
+
+describe('mapReadOnlyCustomFields filter and shape', () => {
+  test('returns undefined for undefined input', () => {
+    expect(mapReadOnlyCustomFields(undefined)).toBeUndefined()
+  })
+
+  test('returns undefined for an empty array', () => {
+    expect(mapReadOnlyCustomFields([])).toBeUndefined()
+  })
+
+  test('returns undefined when every field is excluded', () => {
+    expect(
+      mapReadOnlyCustomFields([{ $type: 'SimpleIssueCustomField', name: 'State', value: 'Open' }]),
+    ).toBeUndefined()
+  })
+
+  test('drops State, Priority, Assignee and the due-date field, keeps generic fields', () => {
+    const result = mapReadOnlyCustomFields([
+      { $type: 'SimpleIssueCustomField', name: 'State', value: 'Open' },
+      { $type: 'SimpleIssueCustomField', name: 'Priority', value: 'High' },
+      { $type: 'SimpleIssueCustomField', name: 'Assignee', value: 'admin' },
+      { $type: 'SimpleIssueCustomField', name: YOUTRACK_DUE_DATE_FIELD_NAME, value: '2026-08-10' },
+      { $type: 'SimpleIssueCustomField', name: 'Team', value: 'Core' },
+    ])
+    expect(result).toEqual([{ name: 'Team', value: 'Core' }])
+  })
+
+  test('preserves input order and exact { name, value } shape for generic fields', () => {
+    const result = mapReadOnlyCustomFields([
+      { $type: 'SimpleIssueCustomField', name: 'Team B', value: 'Beta' },
+      { $type: 'SimpleIssueCustomField', name: 'Team A', value: 'Alpha' },
+    ])
+    expect(result).toEqual([
+      { name: 'Team B', value: 'Beta' },
+      { name: 'Team A', value: 'Alpha' },
+    ])
+  })
+})
+
+describe('mapReadOnlyCustomFields primitive and null values', () => {
+  test('maps null value to null', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: null }])
+    expect(result).toEqual([{ name: 'Team', value: null }])
+  })
+
+  test('maps a missing value to null', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'SimpleIssueCustomField', name: 'Team' }])
+    expect(result).toEqual([{ name: 'Team', value: null }])
+  })
+
+  test('passes string values through', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'SimpleIssueCustomField', name: 'Team', value: 'abc' }])
+    expect(result).toEqual([{ name: 'Team', value: 'abc' }])
+  })
+
+  test('passes number values through without stringifying', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'SimpleIssueCustomField', name: 'Team', value: 5 }])
+    expect(result).toEqual([{ name: 'Team', value: 5 }])
+  })
+
+  test('passes boolean values through without stringifying', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'SimpleIssueCustomField', name: 'Team', value: false }])
+    expect(result).toEqual([{ name: 'Team', value: false }])
+  })
+})
+```
+
+Note on the null case: it uses `$type: 'Custom'` because the `SimpleIssueCustomField` union member types `value` as `string | number | boolean | undefined`, while the unknown-shape member accepts `unknown` — so `null` typechecks without a cast. This kills the `value === null || value === undefined` `||`→`&&` mutant (under it, `null` falls through the ladder and stringifies to `'null'`).
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `bun test tests/plugins/task-provider-youtrack/custom-field-values.test.ts`
+Expected: PASS — 10 tests, 0 failures. (Characterization tests on existing correct code; they pass immediately by design.)
+
+- [ ] **Step 3: Verify typecheck and lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: both exit 0, no errors in the new file.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/plugins/task-provider-youtrack/custom-field-values.test.ts
+git commit -m "test(youtrack): cover custom-field-values filter and primitive mapping"
+```
+
+---
+
+### Task 2: Object fallback ladder, array branch, stringify tail (spec §3–5)
+
+**Files:**
+- Modify: `tests/plugins/task-provider-youtrack/custom-field-values.test.ts` (append three describe blocks at the end of the file)
+- Test: `tests/plugins/task-provider-youtrack/custom-field-values.test.ts`
+
+**Interfaces:**
+- Consumes: the test file created in Task 1 (same imports; no new imports needed).
+- Produces: complete companion test set consumed by the paired mutation runner in Task 3 via the mirror-path resolver (`plugins/task-provider-youtrack/custom-field-values.ts` → `tests/plugins/task-provider-youtrack/custom-field-values.test.ts`).
+
+- [ ] **Step 1: Append the object-ladder, array, and stringify describe blocks**
+
+```ts
+describe('mapReadOnlyCustomFields object fallback ladder', () => {
+  test('prefers text over name and login', () => {
+    const result = mapReadOnlyCustomFields([
+      { $type: 'Custom', name: 'Team', value: { text: 'T', name: 'N', login: 'L' } },
+    ])
+    expect(result).toEqual([{ name: 'Team', value: 'T' }])
+  })
+
+  test('prefers name over login when text is absent', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: { name: 'N', login: 'L' } }])
+    expect(result).toEqual([{ name: 'Team', value: 'N' }])
+  })
+
+  test('uses login when text and name are absent', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: { login: 'L' } }])
+    expect(result).toEqual([{ name: 'Team', value: 'L' }])
+  })
+
+  test('ignores non-string properties and falls through to stringify', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: { name: 42 } }])
+    expect(result).toEqual([{ name: 'Team', value: '{"name":42}' }])
+  })
+})
+
+describe('mapReadOnlyCustomFields array values', () => {
+  test('passes string arrays through', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: ['a', 'b'] }])
+    expect(result).toEqual([{ name: 'Team', value: ['a', 'b'] }])
+  })
+
+  test('maps object items, keeps strings, drops null and non-string entries', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: [{ name: 'A' }, 'b', null, 42] }])
+    expect(result).toEqual([{ name: 'Team', value: ['A', 'b'] }])
+  })
+
+  test('falls back to login for array items without a name', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: [{ login: 'L' }] }])
+    expect(result).toEqual([{ name: 'Team', value: ['L'] }])
+  })
+})
+
+describe('mapReadOnlyCustomFields stringify tail', () => {
+  test('stringifies plain objects without text, name or login', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: { foo: 'bar' } }])
+    expect(result).toEqual([{ name: 'Team', value: '{"foo":"bar"}' }])
+  })
+
+  test('maps unstringifiable function values to the complex-value placeholder', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: () => undefined }])
+    expect(result).toEqual([{ name: 'Team', value: '[complex value]' }])
+  })
+
+  test('maps circular structures to the complex-value placeholder', () => {
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: circular }])
+    expect(result).toEqual([{ name: 'Team', value: '[complex value]' }])
+  })
+})
+```
+
+These kill: the three negated `!== undefined` ladder guards (priority order), the `typeof prop === 'string'` mutant (42 would be returned as the number `42` instead of the stringified object), the L15 `isRecord` arrow-body survivor (ladder collapses to stringify), the array map/ternary/filter mutants (`42` would survive the filter under the `typeof item !== 'string'` mutant), the L42 `??` mutant (login fallback in array items), the L23 `??` mutant (function → `undefined` instead of the placeholder), and the catch-path mutants (circular input).
+
+- [ ] **Step 2: Run the full test file**
+
+Run: `bun test tests/plugins/task-provider-youtrack/custom-field-values.test.ts`
+Expected: PASS — 20 tests, 0 failures.
+
+- [ ] **Step 3: Verify typecheck and lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: both exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/plugins/task-provider-youtrack/custom-field-values.test.ts
+git commit -m "test(youtrack): cover custom-field-values fallback ladder and stringify tail"
+```
+
+---
+
+### Task 3: Paired mutation measurement, survivor triage, full verification
+
+**Files:**
+- Modify: `tests/plugins/task-provider-youtrack/custom-field-values.test.ts` (only if triage requires an additional kill test)
+- Modify: `docs/superpowers/specs/2026-08-04-youtrack-custom-field-values-mutation-design.md` (only to sync the achieved score, per repo precedent `2846346bf`)
+- Test: `tests/plugins/task-provider-youtrack/custom-field-values.test.ts`
+
+**Interfaces:**
+- Consumes: the complete companion test file from Tasks 1–2; `scripts/mutation/paired-run.ts` CLI (`bun test:mutate:file`).
+- Produces: the achieved paired score recorded in the spec; the terminal state other cycles compare against. `scripts/mutation/baseline.json` is NOT edited (CI master seed re-applies the floor per-key max).
+
+- [ ] **Step 1: Run the official paired measurement**
+
+Run: `bun test:mutate:file plugins/task-provider-youtrack/custom-field-values.ts 2>&1 | tail -5`
+Expected: `killed` ≥ 88 of 95, `noCoverage` = 0, score ≥ 0.9. The only accepted survivors are the two predicted equivalents:
+- L15 `isRecord`: `&&`→`||` — `getStringProperty` is only reachable with records/arrays/functions (null/undefined/primitives returned earlier), where both operators agree.
+- L41 array null-guard: `||`→`&&` — under the mutant a `null` item falls into the ternary and still resolves to `undefined` via `getStringProperty(null, ...)`, so it is filtered identically.
+
+- [ ] **Step 2: Triage any unexpected survivor**
+
+If the survivor set matches the two predicted equivalents and score ≥ 0.9: proceed to Step 3.
+
+Otherwise, for each unexpected survivor, read its mutator/line from `reports/paired/plugins__task-provider-youtrack__custom-field-values.ts.stryker-report.json`:
+
+Run: `bun -e "const r = await Bun.file('reports/paired/plugins__task-provider-youtrack__custom-field-values.ts.stryker-report.json').json(); for (const m of r.files['plugins/task-provider-youtrack/custom-field-values.ts'].mutants.filter((m) => m.status === 'Survived' || m.status === 'NoCoverage')) console.log(m.status, m.mutatorName, 'L' + m.location.start.line, JSON.stringify(m.replacement ?? ''))"`
+
+Add a focused kill test to `tests/plugins/task-provider-youtrack/custom-field-values.test.ts` in the describe block matching the survivor's cluster (or justify it as a third equivalent by extending the accepted-survivor list in the spec). Re-run Step 1 until only accepted equivalents remain.
+
+- [ ] **Step 3: Sync the spec with the achieved score**
+
+Update the `### Expected outcome` section of `docs/superpowers/specs/2026-08-04-youtrack-custom-field-values-mutation-design.md`: replace the prediction paragraph's final sentence with the achieved numbers, e.g. `Achieved (2026-08-04): killed=NN survived=2 noCoverage=0, score=0.NN; survivors are the two predicted equivalents (L15 isRecord, L41 array null-guard).` Keep the prediction text intact above it.
+
+- [ ] **Step 4: Full regression verification**
+
+Run: `bun test && bun run typecheck && bun run lint`
+Expected: full suite green (the new file is additive; no existing suite shares state with it — no fetch mocks, no module mocks, no globals), typecheck and lint exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/plugins/task-provider-youtrack/custom-field-values.test.ts docs/superpowers/specs/2026-08-04-youtrack-custom-field-values-mutation-design.md
+git commit -m "docs: sync spec with achieved custom-field-values mutation score"
+```
+
+If Step 2 added no test changes and Step 3's spec edit is the only change, stage just the spec file.

--- a/docs/superpowers/specs/2026-08-04-youtrack-custom-field-values-mutation-design.md
+++ b/docs/superpowers/specs/2026-08-04-youtrack-custom-field-values-mutation-design.md
@@ -162,8 +162,22 @@ and killed by the oracle assertions above; all 14 current survivors sit in
 the L14 exclusion-set and L51–L56 wrapper clusters targeted by section 1,
 plus the L15 `isRecord` arrow body killed transitively by section 3's object
 ladder). Expected paired score **≥ 0.9**. Predicted accepted survivor:
-the `isRecord` `&&`→`||` equivalent (L15). Any other survivor is investigated
-and either killed with an additional case or justified in the plan.
+the `isRecord` `&&`→`||` equivalent (L15).
+
+Achieved (2026-08-04): killed=90 survived=5 noCoverage=0, score=0.947
+(90/95). The five survivors realize the two predicted equivalent classes:
+L15 `isRecord` (`value !== null`→`true`, a `ConditionalExpression` sibling
+of the predicted `&&`→`||` — redundant because `getStringProperty` is only
+reachable with object/array/function values where the null check is moot),
+and the L41 array null-guard (`||`→`&&` plus three
+`ConditionalExpression`→`false` siblings — redundant because `null`/
+`undefined` items fall through to `getStringProperty`, which returns
+`undefined`, and the `.filter()` drops them). Two unexpected filter-removal
+survivors (L39 `MethodExpression` dropping `.filter()`; L44
+`ConditionalExpression`→`true` filter predicate) were killed by adding a
+`toHaveLength(2)` assertion: `bun:test`'s `toEqual` ignores trailing
+`undefined` array elements, so the original oracle was blind to the filter
+step.
 
 ## Measurement and ratchet
 

--- a/docs/superpowers/specs/2026-08-04-youtrack-custom-field-values-mutation-design.md
+++ b/docs/superpowers/specs/2026-08-04-youtrack-custom-field-values-mutation-design.md
@@ -1,0 +1,211 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation coverage: `plugins/task-provider-youtrack/custom-field-values.ts`
+
+Date: 2026-08-04
+Status: approved
+
+## Goal
+
+Raise the mutation score of
+`plugins/task-provider-youtrack/custom-field-values.ts` — real paired score
+**0** (0 killed / 14 survived / 81 no-coverage, 95 mutants), the worst genuine
+gap found in `scripts/mutation/baseline.json` — to **≥ 0.9** with pure unit
+tests. No source changes.
+
+## Background and findings
+
+### Target selection (baseline triage, 2026-08-04)
+
+`scripts/mutation/baseline.json` lists many 0-score entries. Probing them with
+the official paired runner (`bun test:mutate:file`) splits them into **stale
+seed artifacts** and **genuine gaps**:
+
+| File | Baseline | Paired (K/S/NC) | Verdict |
+| --- | --- | --- | --- |
+| `youtrack/collaboration-provider.ts` | 0 | 19/0/0 → **1.0** | Stale seed; existing integration tests already kill all 19 mutants. Nothing to do. |
+| **`youtrack/custom-field-values.ts`** | 0 | 0/14/**81** → **0** | **Genuine gap — selected target.** |
+| `src/tools/search-memos.ts` | 0.175 | 17/28/51 → 0.177 | Genuine gap; needs tool/store harness; deferred. |
+| `youtrack/validate-config.ts` | 0 | 0/0/32 | No covering test exists; 32 mutants; deferred. |
+| `youtrack/phase-five-provider.ts` | 0 | 0/0/9 | Tiny delegation layer; deferred. |
+| `src/tools/update-sprint.ts` | 0.12 | 3/14/6 → 0.13 | Small; deferred. |
+| `kaneo/create-task.ts` | 0 | 3/6/3 → 0.25 | Thin wrapper, 12 mutants; low value. |
+
+### Why this file
+
+- **Worst genuine measurement:** 95 mutants, none killed; 81 never even
+  executed by the discovered test set.
+- **Production-critical read path:** the sole export `mapReadOnlyCustomFields`
+  feeds `mappers.ts:217`, the issue→task conversion every YouTrack task fetch
+  passes through. Surviving mutants here silently corrupt the custom fields
+  the LLM reads (wrong fallback branch, inverted generic-field filter,
+  stringified `null`).
+- **Cheapest full kill in the repo:** 57 lines of pure functions — no fetch,
+  no store, no DI, no clock. Every mutant is killable with plain input/output
+  assertions.
+- No existing test file references the module (`grep tests/` — no hits).
+
+Alternatives considered: `src/tools/search-memos.ts` (similar mutant count,
+0.177 real, but requires the tool-executor + memo-store harness and half its
+gap is uncovered error/formatting chunks — higher effort, lower kill
+certainty), `youtrack/validate-config.ts` (no covering test at all, 32
+mutants, smaller blast radius than the per-task read path),
+`youtrack/collaboration-provider.ts` (initially selected from the baseline,
+then measured at 1.0 — stale seed, excluded).
+
+### Mutant inventory (`bun test:mutate:file plugins/task-provider-youtrack/custom-field-values.ts`, 2026-08-04)
+
+95 mutants: **0 killed, 14 survived, 81 no-coverage** — paired score 0,
+matching the baseline entry. Mutant classes, mapped to source:
+
+- **L14 — generic-field exclusion set: 3 StringLiteral + 1 ArrayDeclaration
+  (all among the 14 current survivors).**
+  `new Set(['State', 'Priority', 'Assignee', YOUTRACK_DUE_DATE_FIELD_NAME])`;
+  member literals and the array itself are unexercised.
+- **L15 — `isRecord` guard: 1 LogicalOperator + 1 StringLiteral
+  (`typeof value === 'object' && value !== null`).** The `&&`→`||` mutant is
+  predicted **equivalent**: `getStringProperty` is only reachable with
+  records, arrays, and functions (null/undefined/primitives return earlier),
+  and for all of them both operators agree. Accepted survivor if confirmed.
+- **L16–L20 — `getStringProperty`: ConditionalExpression + StringLiteral per
+  branch** (`!isRecord(value)` guard, `typeof prop === 'string'` ternary,
+  `'login' | 'name' | 'text'` literals).
+- **L21–L27 — `stringifyUnknownValue`: 1 StringLiteral (`'[complex value]'`),
+  1 `??` ConditionalExpression/LogicalOperator, catch-block mutants.**
+  `JSON.stringify` returns `undefined` for functions (hits `??`), throws for
+  circular structures (hits `catch`).
+- **L29–L47 — `buildReadOnlyCustomFieldValue` fallback ladder: the bulk of
+  the 95 (~60 mutants).** EqualityOperator/LogicalOperator on
+  `value === null || value === undefined`; the `typeof` triple chain
+  (string/number/boolean) with its literals; three negated
+  `!== undefined` guards ordering `.text` → `.name` → `.login`;
+  `Array.isArray` guard; arrow bodies, ternary, and filter predicate inside
+  the array branch.
+- **L49–L57 — `mapReadOnlyCustomFields`: ~15 mutants, including the
+  remaining 10 current survivors.** Survivors: `?? []` (MethodExpression +
+  LogicalOperator, L52), filter predicate (BooleanLiteral + ArrowFunction,
+  L53), map callback (ArrowFunction, L54), function body (BlockStatement,
+  L51), and the `mapped.length === 0 ? undefined : mapped` tail
+  (ConditionalExpression ×2 + EqualityOperator, L56). No-coverage mutants:
+  `!nonGenericFieldNames.has(...)` negation, map ObjectLiteral
+  (`{ name, value }` → `{}`), and the same tail expressions.
+
+## Design
+
+New companion test file
+`tests/plugins/task-provider-youtrack/custom-field-values.test.ts` (mirror
+path → the paired runner's companion resolver discovers it automatically; no
+`overrides.json` edit). Plain `bun:test` unit tests, no harness. All
+assertions go through the single public export `mapReadOnlyCustomFields`;
+the private helpers are exercised by crafting `value` shapes on a field named
+`'Team'` (not in the exclusion set). `YOUTRACK_DUE_DATE_FIELD_NAME` is
+imported from `plugins/task-provider-youtrack/constants.js` rather than
+hardcoded.
+
+### 1. Filter and shape contract (kills L14, L51–L56 survivors + no-coverage)
+
+- `undefined` input → `undefined` (kills the negated `length === 0` mutant,
+  which would return `[]`).
+- `[]` → `undefined`; input whose fields are all excluded → `undefined`.
+- Fields named `State`, `Priority`, `Assignee`, and
+  `YOUTRACK_DUE_DATE_FIELD_NAME` are dropped; a `'Team'` field survives
+  (kills the `!`-removal mutant, the empty-Set ArrayDeclaration mutant, and
+  each Set-member StringLiteral mutant).
+- Result entries have exactly `{ name, value }` shape (kills the
+  ObjectLiteral `{}` mutant); multiple generic fields preserve input order.
+
+### 2. Primitive and null handling (kills L30–L31)
+
+Each case asserted on a single `'Team'` field:
+
+- `value: null` → `null`; `value: undefined` → `null` (kills the `||`→`&&`
+  mutant: `null` would fall through the ladder and stringify to `'null'`).
+- `value: 'abc'` → `'abc'`; `value: 5` → `5`; `value: false` → `false`.
+  `toBe` distinguishes `5` from `'5'` and `false` from `'false'`, killing the
+  typeof-chain literals and LogicalOperator mutants that would reroute
+  primitives into the property/stringify path.
+
+### 3. Object fallback ladder (kills L32–L37 + getStringProperty cluster)
+
+- `{ text: 'T', name: 'N', login: 'L' }` → `'T'` — priority order (kills the
+  negated `textValue !== undefined` guard, which would return `'N'`).
+- `{ name: 'N', login: 'L' }` → `'N'`; `{ login: 'L' }` → `'L'`.
+- `{ name: 42 }` → falls through (non-string property rejected by
+  `getStringProperty`) to the stringify tail → `'{"name":42}'` (kills the
+  `typeof prop === 'string'` mutants).
+
+### 4. Array branch (kills L38–L45)
+
+- `['a', 'b']` → `['a', 'b']`.
+- Mixed `[{ name: 'A' }, 'b', null, 42]` → `['A', 'b']` — object mapping,
+  string passthrough, and the undefined-filter all asserted in one case
+  (kills the map arrow-body, item ternary, and filter-predicate mutants).
+- `[{ login: 'L' }]` → `['L']` (name→login fallback inside array items).
+
+### 5. Stringify tail (kills L21–L27 + L46)
+
+- `{ foo: 'bar' }` (no text/name/login) → `'{"foo":"bar"}'`.
+- A function value → `'[complex value]'` (`JSON.stringify(fn) === undefined`
+  hits the `??`; kills its removal mutant).
+- A circular object (`obj.self = obj`) → `'[complex value]'` (kills the
+  catch-path mutants).
+
+### Expected outcome
+
+Predicted killed: ~85–92 of 95 (all 81 no-coverage mutants become executed
+and killed by the oracle assertions above; all 14 current survivors sit in
+the L14 exclusion-set and L51–L56 wrapper clusters targeted by section 1,
+plus the L15 `isRecord` arrow body killed transitively by section 3's object
+ladder). Expected paired score **≥ 0.9**. Predicted accepted survivor:
+the `isRecord` `&&`→`||` equivalent (L15). Any other survivor is investigated
+and either killed with an additional case or justified in the plan.
+
+## Measurement and ratchet
+
+1. `bun test tests/plugins/task-provider-youtrack/custom-field-values.test.ts`
+   — new tests pass.
+2. `bun test:mutate:file plugins/task-provider-youtrack/custom-field-values.ts`
+   — confirm killed/survivor counts match the prediction; kill or justify any
+   unexpected survivor in the fallback-ladder clusters.
+3. No `baseline.json` edit in the PR: the CI `mutation-baseline` job re-seeds
+   the floor on master (per-key max) from the changed-files run. The PR gate
+   is regression-only, so the improved score can only raise the floor.
+4. Regression checks: repo lint/typecheck per `package.json` scripts; the
+   mutation run's own dry run validates the rest of the paired test set.
+   Existing youtrack suites are untouched (no shared mocks involved).
+
+## Trade-offs and risks
+
+- **Private behavior asserted through the public API.** The fallback ladder
+  is private; tests craft `value` shapes instead of importing internals.
+  Accepted: the public contract is what `mappers.ts` consumes, and the ladder
+  is fully reachable through it.
+- **JSON.stringify output coupling.** `'{"name":42}'` assertions depend on
+  key order/serialization. Accepted: inputs are single-key object literals,
+  deterministic across JS runtimes.
+- **Probe vs future paired divergence.** The recorded floor comes from the
+  official paired runner on master; the local paired numbers in this spec are
+  the prediction baseline, not the guarantee.
+
+## Alternatives considered
+
+- **Fix the stale `collaboration-provider.ts` baseline entry instead.**
+  Rejected as this cycle's goal: its real score is already 1.0; the floor
+  self-heals on the next master seed that measures the file. No test work
+  exists to do.
+- **`src/tools/search-memos.ts` (0.177, 96 mutants).** Rejected for this
+  cycle: comparable mutant count but needs the tool/store harness and its
+  no-coverage chunks are error/formatting paths with weaker oracles. Strong
+  candidate for the next cycle.
+- **`youtrack/validate-config.ts` (0, 32 mutants, no covering test).**
+  Rejected: smaller blast radius (activation-time validation) than the
+  per-task read path; the kaneo twin's proven pattern (0.969) makes it a
+  cheap follow-up.
+- **Batch several zero-score plugin files in one spec.** Rejected: the repo's
+  established pattern is one file per spec → plan → PR cycle with a clean
+  per-file ratchet.

--- a/docs/superpowers/specs/2026-08-04-youtrack-custom-field-values-mutation-design.md
+++ b/docs/superpowers/specs/2026-08-04-youtrack-custom-field-values-mutation-design.md
@@ -177,7 +177,9 @@ survivors (L39 `MethodExpression` dropping `.filter()`; L44
 `ConditionalExpression`→`true` filter predicate) were killed by adding a
 `toHaveLength(2)` assertion: `bun:test`'s `toEqual` ignores trailing
 `undefined` array elements, so the original oracle was blind to the filter
-step.
+step. The implementation plan refined the forecast from the single predicted
+equivalent class in the section above to the two documented here before
+measurement.
 
 ## Measurement and ratchet
 

--- a/tests/plugins/task-provider-youtrack/custom-field-values.test.ts
+++ b/tests/plugins/task-provider-youtrack/custom-field-values.test.ts
@@ -70,3 +70,63 @@ describe('mapReadOnlyCustomFields primitive and null values', () => {
     expect(result).toEqual([{ name: 'Team', value: false }])
   })
 })
+
+describe('mapReadOnlyCustomFields object fallback ladder', () => {
+  test('prefers text over name and login', () => {
+    const result = mapReadOnlyCustomFields([
+      { $type: 'Custom', name: 'Team', value: { text: 'T', name: 'N', login: 'L' } },
+    ])
+    expect(result).toEqual([{ name: 'Team', value: 'T' }])
+  })
+
+  test('prefers name over login when text is absent', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: { name: 'N', login: 'L' } }])
+    expect(result).toEqual([{ name: 'Team', value: 'N' }])
+  })
+
+  test('uses login when text and name are absent', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: { login: 'L' } }])
+    expect(result).toEqual([{ name: 'Team', value: 'L' }])
+  })
+
+  test('ignores non-string properties and falls through to stringify', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: { name: 42 } }])
+    expect(result).toEqual([{ name: 'Team', value: '{"name":42}' }])
+  })
+})
+
+describe('mapReadOnlyCustomFields array values', () => {
+  test('passes string arrays through', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: ['a', 'b'] }])
+    expect(result).toEqual([{ name: 'Team', value: ['a', 'b'] }])
+  })
+
+  test('maps object items, keeps strings, drops null and non-string entries', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: [{ name: 'A' }, 'b', null, 42] }])
+    expect(result).toEqual([{ name: 'Team', value: ['A', 'b'] }])
+  })
+
+  test('falls back to login for array items without a name', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: [{ login: 'L' }] }])
+    expect(result).toEqual([{ name: 'Team', value: ['L'] }])
+  })
+})
+
+describe('mapReadOnlyCustomFields stringify tail', () => {
+  test('stringifies plain objects without text, name or login', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: { foo: 'bar' } }])
+    expect(result).toEqual([{ name: 'Team', value: '{"foo":"bar"}' }])
+  })
+
+  test('maps unstringifiable function values to the complex-value placeholder', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: (): undefined => undefined }])
+    expect(result).toEqual([{ name: 'Team', value: '[complex value]' }])
+  })
+
+  test('maps circular structures to the complex-value placeholder', () => {
+    const circular: Record<string, unknown> = {}
+    circular['self'] = circular
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: circular }])
+    expect(result).toEqual([{ name: 'Team', value: '[complex value]' }])
+  })
+})

--- a/tests/plugins/task-provider-youtrack/custom-field-values.test.ts
+++ b/tests/plugins/task-provider-youtrack/custom-field-values.test.ts
@@ -101,20 +101,15 @@ describe('mapReadOnlyCustomFields array values', () => {
     expect(result).toEqual([{ name: 'Team', value: ['a', 'b'] }])
   })
 
-  test('maps object items, keeps strings, drops null and non-string entries', () => {
+  test('maps object items, keeps strings, and drops null and non-string entries leaving no undefined entries', () => {
     const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: [{ name: 'A' }, 'b', null, 42] }])
     expect(result).toEqual([{ name: 'Team', value: ['A', 'b'] }])
+    expect(result?.[0]?.value).toHaveLength(2)
   })
 
   test('falls back to login for array items without a name', () => {
     const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: [{ login: 'L' }] }])
     expect(result).toEqual([{ name: 'Team', value: ['L'] }])
-  })
-
-  test('drops null and non-string items leaving no undefined entries (locks the filter step)', () => {
-    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: [{ name: 'A' }, 'b', null, 42] }])
-    expect(result).toEqual([{ name: 'Team', value: ['A', 'b'] }])
-    expect(result?.[0]?.value).toHaveLength(2)
   })
 })
 

--- a/tests/plugins/task-provider-youtrack/custom-field-values.test.ts
+++ b/tests/plugins/task-provider-youtrack/custom-field-values.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { YOUTRACK_DUE_DATE_FIELD_NAME } from '../../../plugins/task-provider-youtrack/constants.js'
+import { mapReadOnlyCustomFields } from '../../../plugins/task-provider-youtrack/custom-field-values.js'
+
+describe('mapReadOnlyCustomFields filter and shape', () => {
+  test('returns undefined for undefined input', () => {
+    expect(mapReadOnlyCustomFields(undefined)).toBeUndefined()
+  })
+
+  test('returns undefined for an empty array', () => {
+    expect(mapReadOnlyCustomFields([])).toBeUndefined()
+  })
+
+  test('returns undefined when every field is excluded', () => {
+    expect(mapReadOnlyCustomFields([{ $type: 'SimpleIssueCustomField', name: 'State', value: 'Open' }])).toBeUndefined()
+  })
+
+  test('drops State, Priority, Assignee and the due-date field, keeps generic fields', () => {
+    const result = mapReadOnlyCustomFields([
+      { $type: 'SimpleIssueCustomField', name: 'State', value: 'Open' },
+      { $type: 'SimpleIssueCustomField', name: 'Priority', value: 'High' },
+      { $type: 'SimpleIssueCustomField', name: 'Assignee', value: 'admin' },
+      { $type: 'SimpleIssueCustomField', name: YOUTRACK_DUE_DATE_FIELD_NAME, value: '2026-08-10' },
+      { $type: 'SimpleIssueCustomField', name: 'Team', value: 'Core' },
+    ])
+    expect(result).toEqual([{ name: 'Team', value: 'Core' }])
+  })
+
+  test('preserves input order and exact { name, value } shape for generic fields', () => {
+    const result = mapReadOnlyCustomFields([
+      { $type: 'SimpleIssueCustomField', name: 'Team B', value: 'Beta' },
+      { $type: 'SimpleIssueCustomField', name: 'Team A', value: 'Alpha' },
+    ])
+    expect(result).toEqual([
+      { name: 'Team B', value: 'Beta' },
+      { name: 'Team A', value: 'Alpha' },
+    ])
+  })
+})
+
+describe('mapReadOnlyCustomFields primitive and null values', () => {
+  test('maps null value to null', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: null }])
+    expect(result).toEqual([{ name: 'Team', value: null }])
+  })
+
+  test('maps a missing value to null', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'SimpleIssueCustomField', name: 'Team' }])
+    expect(result).toEqual([{ name: 'Team', value: null }])
+  })
+
+  test('passes string values through', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'SimpleIssueCustomField', name: 'Team', value: 'abc' }])
+    expect(result).toEqual([{ name: 'Team', value: 'abc' }])
+  })
+
+  test('passes number values through without stringifying', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'SimpleIssueCustomField', name: 'Team', value: 5 }])
+    expect(result).toEqual([{ name: 'Team', value: 5 }])
+  })
+
+  test('passes boolean values through without stringifying', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'SimpleIssueCustomField', name: 'Team', value: false }])
+    expect(result).toEqual([{ name: 'Team', value: false }])
+  })
+})

--- a/tests/plugins/task-provider-youtrack/custom-field-values.test.ts
+++ b/tests/plugins/task-provider-youtrack/custom-field-values.test.ts
@@ -110,6 +110,12 @@ describe('mapReadOnlyCustomFields array values', () => {
     const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: [{ login: 'L' }] }])
     expect(result).toEqual([{ name: 'Team', value: ['L'] }])
   })
+
+  test('drops null and non-string items leaving no undefined entries (locks the filter step)', () => {
+    const result = mapReadOnlyCustomFields([{ $type: 'Custom', name: 'Team', value: [{ name: 'A' }, 'b', null, 42] }])
+    expect(result).toEqual([{ name: 'Team', value: ['A', 'b'] }])
+    expect(result?.[0]?.value).toHaveLength(2)
+  })
 })
 
 describe('mapReadOnlyCustomFields stringify tail', () => {


### PR DESCRIPTION
## Summary

Mutation-testing cycle for `plugins/task-provider-youtrack/custom-field-values.ts` — the module that maps YouTrack custom field values into the normalized `TaskCustomField[]` every issue fetch passes through (`mappers.ts:217`).

- Baseline triage with the official paired runner split the baseline's 0-score entries into stale seeds (`collaboration-provider.ts` already measures 1.0) and genuine gaps; this file was the worst genuine gap: **95 mutants, 0 killed, 81 no-coverage**
- Adds 20 pure unit tests (new companion file `tests/plugins/task-provider-youtrack/custom-field-values.test.ts`) driving the public `mapReadOnlyCustomFields` export: exclusion-set filter, empty-shape contract, primitive passthrough, the text→name→login fallback ladder, array mapping/filtering, and the stringify tail incl. `[complex value]` paths
- Achieved paired score **0.947** (90 killed / 5 survived / 0 no-coverage); the 5 survivors are verified equivalents in two classes (L15 `isRecord` guard, L41 array null-guard family), justified in the spec
- No source changes; `baseline.json` untouched — the CI `mutation-baseline` job re-seeds the floor per-key max on master

Spec: `docs/superpowers/specs/2026-08-04-youtrack-custom-field-values-mutation-design.md`
Plan: `docs/superpowers/plans/2026-08-04-youtrack-custom-field-values-mutation.md`

## Test plan

- `bun test tests/plugins/task-provider-youtrack/custom-field-values.test.ts` — 20/20 pass
- `bun test` — 10874 pass / 0 fail
- `bun run typecheck && bun run lint` — exit 0
- `bun test:mutate:file plugins/task-provider-youtrack/custom-field-values.ts` — killed=90 survived=5 noCoverage=0 score=0.947