### PR TITLE
feat(mutation-improve): autonomous runner for the mutation-improve workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@ WORKDIR /app
 FROM base AS deps
 COPY package.json bun.lock ./
 COPY review-loop/package.json ./review-loop/
+COPY mutation-improve/package.json ./mutation-improve/
 RUN bun install --frozen-lockfile
 
 FROM base AS prod-deps
 COPY package.json bun.lock ./
 COPY review-loop/package.json ./review-loop/
+COPY mutation-improve/package.json ./mutation-improve/
 RUN bun install --frozen-lockfile --production
 
 FROM base AS build

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,16 @@
         "vite": "^8.1.5",
       },
     },
+    "mutation-improve": {
+      "name": "mutation-improve",
+      "dependencies": {
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@typescript/native-preview": "^7.0.0-dev.20260707.2",
+        "typescript": "^7.0.2",
+      },
+    },
     "review-loop": {
       "name": "review-loop",
       "dependencies": {
@@ -1091,6 +1101,8 @@
     "msw-storybook-addon": ["msw-storybook-addon@3.0.0", "", { "peerDependencies": { "msw": ">=2", "storybook": ">=9" }, "bin": { "msw-storybook-migrate": "./build/migrate.mjs" } }, "sha512-tyYmYAwSGcfFSHhrE5yzun/OXuVIkBGOt4YTsH5IR94N38F+hzZhvGqe5scu1ENJh/hOApI/8ZRQkWdFNFsKcw=="],
 
     "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+
+    "mutation-improve": ["mutation-improve@workspace:mutation-improve"],
 
     "mutation-server-protocol": ["mutation-server-protocol@0.4.1", "", { "dependencies": { "zod": "^4.1.12" } }, "sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g=="],
 

--- a/docs/superpowers/plans/2026-08-05-mutation-improve-runner.md
+++ b/docs/superpowers/plans/2026-08-05-mutation-improve-runner.md
@@ -1,0 +1,2329 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation-Improve Runner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `mutation-improve/`, a fully-autonomous single-agent runner that lifts one file's mutation score per iteration via the proven 7-branch procedure (select → spec → plan → tests → verify → ratchet → merge), chaining N iterations into one summary PR.
+
+**Architecture:** New sibling Bun workspace mirroring `review-loop/`'s layout, importing review-loop's harness primitives (`agent-runner`, `spawn`, `build-checker`, `worktree`, `live-renderer`, `trace-log`) and the paired-runner's score logic (`scripts/mutation/score-merger.ts`, `json-readers.ts`). Two phased invocations of ONE agent/model per file (select, then improve). The runner owns all measurement and integrity-sensitive steps (score measurement, baseline bump, diff-scope guard, build gate, merge, PR); the agent owns judgment and creation. Approach A from the design spec.
+
+**Tech Stack:** Bun runtime, `bun:test`, Zod v4, `opencode run --auto` via review-loop's `runAgent`, Stryker via the repo's paired runner (`bun test:mutate:file`).
+
+## Global Constraints
+
+- **Reuse, don't duplicate:** harness primitives come from `../review-loop/src/*.js`; score math from `../../scripts/mutation/score-merger.js` and `../../scripts/mutation/json-readers.js`. Do not reimplement.
+- **One shared-file change only:** `review-loop/src/worktree.ts` is parametrized for the branch prefix (backward-compatible, default keeps `'review-loop'`). No other review-loop file changes.
+- **Runner measures, agent creates:** the runner runs `bun test:mutate:file` itself and reads the Stryker report; it never trusts an agent-reported score. The runner writes `scripts/mutation/baseline.json`; the agent is forbidden from editing it (enforced by the diff-scope guard).
+- **Test-only worktree edits:** the diff-scope guard allows only `tests/**` and `docs/superpowers/**`. `src/`, `client/`, `plugins/`, `scripts/`, and `baseline.json` are violations.
+- **Strict TypeScript, `.js` import extensions, no lint-disable/type-ignore comments, no emoji unless copied verbatim from source.**
+- **SPDX license header** (`BUSL-1.1`) on every new `mutation-improve/src/*.ts` and `tests/mutation-improve/*.ts` file, copied verbatim from `review-loop/src/spawn.ts:1-4`.
+- **TDD:** every task writes the failing test first, runs it red, implements, runs green, commits. Tests inject all externals (no real `opencode`/`git`/Stryker in the suite), mirroring `tests/review-loop/`.
+- **Score formula (reused verbatim):** `scored = killed + survived + noCoverage + timeout; score = (killed + timeout) / scored` (from `scripts/mutation/score-merger.ts:79-83`). Per-file report path: `reports/paired/<safeFileStem(srcFile)>.stryker-report.json` where `safeFileStem = (s: string) => s.replaceAll(/[^a-zA-Z0-9._-]+/gu, '__')` (`scripts/mutation/paired-run.ts:115`).
+- **Per-file Stryker report path:** `reports/paired/<safeFileStem(srcFile)>.stryker-report.json` where `safeFileStem = (s) => s.replaceAll(/[^a-zA-Z0-9._-]+/gu, '__')` (`scripts/mutation/paired-run.ts:115`).
+- **Defaults:** `threshold = 0.95`, `epsilon = 0.02`, `base = 'master'`, `upstream = 'origin'`, `prBranchPrefix = 'mutation-improve'`, `count = 1`, `checkCommand = 'bun check:full'`, `mutateFileCommand = 'bun test:mutate:file'`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `mutation-improve/package.json` | workspace manifest; deps: zod; scripts mirror review-loop |
+| `mutation-improve/tsconfig.json` | extends `../tsconfig.json`, includes `src/**/*.ts` |
+| `mutation-improve/config.example.json` | documented config shape |
+| `mutation-improve/src/config.ts` | Zod schema + loader (`loadMutationImproveConfig`) |
+| `mutation-improve/src/selection-schema.ts` | `SelectionSchema` / `Selection` (agent → runner, select phase) |
+| `mutation-improve/src/result-schema.ts` | `ResultSchema` / `Result` (agent → runner, improve phase) |
+| `mutation-improve/src/score-reader.ts` | `safeFileStem`, `reportPathFor`, `measureMutationScore` (reuses `score-merger`/`json-readers`) |
+| `mutation-improve/src/baseline.ts` | `parseBaseline`/`serializeBaseline`/`bumpScore` (pure) + `readBaseline`/`writeBaseline` (IO) |
+| `mutation-improve/src/diff-guard.ts` | `classifyDiff` (pure) + `runDiffGuard` (git-backed) |
+| `mutation-improve/src/run-state.ts` | `MutationImproveRunState`, `createRunState`/`loadRunState`/`saveRunState`, `iterDir` |
+| `mutation-improve/src/prompt-templates.ts` | `buildSelectPrompt`, `buildImprovePrompt` (pure string builders) |
+| `mutation-improve/src/pipeline.ts` | `runSelect`/`runImprove`/`runVerify`/`runRatchetMerge`/`runIteration`/`runPipeline` |
+| `mutation-improve/src/finalize.ts` | `buildSummaryBody`, `runFinalize` (push + `gh pr create`) |
+| `mutation-improve/src/cli.ts` | `parseCliArgs`, `runCli` orchestration |
+| `tests/mutation-improve/test-helpers.ts` | `makeTempDir`, fixtures, fake `SpawnFn`/`execGit` |
+| `tests/mutation-improve/*.test.ts` | one test file per module + `pipeline.test.ts` spine + `integration.test.ts` |
+
+---
+
+## Task 1: Workspace scaffold + root wiring
+
+**Files:**
+- Create: `mutation-improve/package.json`
+- Create: `mutation-improve/tsconfig.json`
+- Modify: `package.json` (root — workspaces array + scripts)
+- Create: `tests/mutation-improve/.gitkeep` (so the test dir exists for the `:test` script)
+
+**Interfaces:**
+- Produces: a resolvable Bun workspace `mutation-improve` with no source yet; `bun run --filter mutation-improve typecheck` exits 0.
+
+- [ ] **Step 1: Create `mutation-improve/package.json`**
+
+```json
+{
+  "name": "mutation-improve",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "cd .. && bun test tests/mutation-improve",
+    "typecheck": "tsgo --project tsconfig.json --noEmit",
+    "lint": "cd .. && oxlint --config .oxlintrc.json mutation-improve/src tests/mutation-improve",
+    "format": "cd .. && oxfmt --write mutation-improve/src tests/mutation-improve --ignore-path=.oxfmtignore",
+    "format:check": "cd .. && oxfmt --check mutation-improve/src tests/mutation-improve --ignore-path=.oxfmtignore",
+    "start": "bun run src/cli.ts"
+  },
+  "dependencies": {
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
+    "typescript": "^7.0.2"
+  }
+}
+```
+
+- [ ] **Step 2: Create `mutation-improve/tsconfig.json`**
+
+```json
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"]
+}
+```
+
+- [ ] **Step 3: Wire into root `package.json`**
+
+In root `package.json`, add `"mutation-improve"` to the `workspaces` array (after `"review-loop"`), and add these lines after the `review-loop:start` line in `scripts`:
+
+```json
+    "mutation-improve:test": "bun run --filter mutation-improve test",
+    "mutation-improve:typecheck": "bun run --filter mutation-improve typecheck",
+    "mutation-improve:lint": "bun run --filter mutation-improve lint",
+    "mutation-improve:format:check": "bun run --filter mutation-improve format:check",
+    "mutation-improve:start": "bun run --filter mutation-improve start",
+```
+
+Extend the `check:verbose` script by appending `mutation-improve:lint mutation-improve:typecheck mutation-improve:format:check mutation-improve:test` after `review-loop:test`.
+
+- [ ] **Step 4: Create `tests/mutation-improve/.gitkeep`** (empty file).
+
+- [ ] **Step 5: Verify the workspace resolves**
+
+Run: `bun run --filter mutation-improve typecheck`
+Expected: exits 0 (no source files yet, nothing to check).
+
+Run: `bun pm ls 2>&1 | rg mutation-improve`
+Expected: prints a line containing `mutation-improve`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mutation-improve/package.json mutation-improve/tsconfig.json package.json tests/mutation-improve/.gitkeep
+git commit -m "chore(mutation-improve): scaffold workspace and root wiring"
+```
+
+---
+
+## Task 2: Parametrize review-loop worktree branch prefix (shared-file change)
+
+**Files:**
+- Modify: `review-loop/src/worktree.ts:38-44` (`createWorktree`) and `review-loop/src/worktree.ts:101-110` (`removeWorktree`)
+- Test: `tests/review-loop/worktree.test.ts` (add cases — no new file)
+
+**Interfaces:**
+- Produces: `createWorktree(repoRoot, worktreePath, runId, branchPrefix = 'review-loop')` and `removeWorktree(repoRoot, worktreePath, runId, branchPrefix = 'review-loop')`. Existing review-loop callers omit the new arg and behave identically.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `tests/review-loop/worktree.test.ts` inside the existing top-level `describe` (if the file has no top-level describe, wrap in `describe('worktree branch prefix', () => { … })`):
+
+```ts
+  test('createWorktree uses the branchPrefix argument', async () => {
+    const repoRoot = makeTempDir('wt-prefix-')
+    await execGit(repoRoot, ['init', '--quiet'])
+    await execGit(repoRoot, ['config', 'user.email', 't@t'])
+    await execGit(repoRoot, ['config', 'user.name', 't'])
+    await writeFile(path.join(repoRoot, 'a.txt'), 'x')
+    await execGit(repoRoot, ['add', '.'])
+    await execGit(repoRoot, ['commit', '-m', 'init', '--quiet'])
+    const wt = path.join(repoRoot, 'wt')
+    await createWorktree(repoRoot, wt, 'run-1', 'mutation-improve')
+    const { stdout } = await execGit(repoRoot, ['branch', '--list'])
+    expect(stdout).toContain('mutation-improve/run-1')
+  })
+
+  test('removeWorktree deletes a branch under branchPrefix', async () => {
+    const repoRoot = makeTempDir('wt-prefix-rm-')
+    await execGit(repoRoot, ['init', '--quiet'])
+    await execGit(repoRoot, ['config', 'user.email', 't@t'])
+    await execGit(repoRoot, ['config', 'user.name', 't'])
+    await writeFile(path.join(repoRoot, 'a.txt'), 'x')
+    await execGit(repoRoot, ['add', '.'])
+    await execGit(repoRoot, ['commit', '-m', 'init', '--quiet'])
+    const wt = path.join(repoRoot, 'wt')
+    await createWorktree(repoRoot, wt, 'run-2', 'mutation-improve')
+    await removeWorktree(repoRoot, wt, 'run-2', 'mutation-improve')
+    const { stdout } = await execGit(repoRoot, ['branch', '--list'])
+    expect(stdout).not.toContain('mutation-improve/run-2')
+  })
+```
+
+Add to the import block at the top: `import { createWorktree, removeWorktree, execGit } from '../../review-loop/src/worktree.js'` and `import { writeFile } from 'node:fs/promises'` and `import path from 'node:path'` and `import { makeTempDir } from './test-helpers.js'` (adjust to match what the file already imports; reuse existing imports where present).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test tests/review-loop/worktree.test.ts`
+Expected: both new tests FAIL (current `createWorktree`/`removeWorktree` ignore any prefix and always use `review-loop/`).
+
+- [ ] **Step 3: Parametrize `createWorktree`**
+
+In `review-loop/src/worktree.ts`, replace the `createWorktree` signature and branch literal:
+
+```ts
+export async function createWorktree(
+  repoRoot: string,
+  worktreePath: string,
+  runId: string,
+  branchPrefix = 'review-loop',
+): Promise<void> {
+  const parentDir = path.dirname(worktreePath)
+  if (!existsSync(parentDir)) {
+    await mkdir(parentDir, { recursive: true })
+  }
+  await execGit(repoRoot, ['worktree', 'add', worktreePath, '-b', `${branchPrefix}/${runId}`])
+}
+```
+
+- [ ] **Step 4: Parametrize `removeWorktree`**
+
+In the same file, replace the `removeWorktree` signature and branch literal:
+
+```ts
+export async function removeWorktree(
+  repoRoot: string,
+  worktreePath: string,
+  runId: string,
+  branchPrefix = 'review-loop',
+): Promise<void> {
+  if (existsSync(worktreePath)) {
+    await execGit(repoRoot, ['worktree', 'remove', worktreePath, '--force'])
+  }
+  try {
+    await execGit(repoRoot, ['branch', '-D', `${branchPrefix}/${runId}`])
+  } catch {
+    // Branch may not exist if already merged and deleted
+  }
+}
+```
+
+- [ ] **Step 5: Run all review-loop tests to confirm no regression**
+
+Run: `bun run review-loop:test`
+Expected: all tests PASS (existing callers omit the new arg; default keeps `'review-loop'`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add review-loop/src/worktree.ts tests/review-loop/worktree.test.ts
+git commit -m "refactor(review-loop): parametrize worktree branch prefix"
+```
+
+---
+
+## Task 3: Config schema + loader
+
+**Files:**
+- Create: `mutation-improve/src/config.ts`
+- Create: `mutation-improve/config.example.json`
+- Create: `tests/mutation-improve/config.test.ts`
+- Create: `tests/mutation-improve/test-helpers.ts`
+
+**Interfaces:**
+- Produces: `MutationImproveConfig` type, `MutationImproveConfigSchema`, `loadMutationImproveConfig({ configPath, repoRoot? }) => Promise<MutationImproveConfig>`. `MutationImproveConfig` has: `repoRoot: string`, `workDir: string`, `base: string`, `upstream: string`, `count: number`, `threshold: number`, `epsilon: number`, `agentTimeoutMs: number`, `buildTimeoutMs: number`, `checkCommand: string`, `mutateFileCommand: string`, `agent: { model: string; extraArgs: string[]; timeoutMs: number }`, `prBranchPrefix: string`.
+
+- [ ] **Step 1: Create `tests/mutation-improve/test-helpers.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+const tempDirs: string[] = []
+
+export function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+export function cleanupTempDirs(): void {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing test `tests/mutation-improve/config.test.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { MutationImproveConfigSchema, loadMutationImproveConfig } from '../../mutation-improve/src/config.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+const minimalValid = {
+  workDir: '.mutation-improve',
+  agent: { model: 'opencode/claude-sonnet-4-6', extraArgs: [] },
+}
+
+describe('config', () => {
+  test('MutationImproveConfigSchema applies defaults', () => {
+    const parsed = MutationImproveConfigSchema.parse(minimalValid)
+    expect(parsed.base).toBe('master')
+    expect(parsed.upstream).toBe('origin')
+    expect(parsed.count).toBe(1)
+    expect(parsed.threshold).toBe(0.95)
+    expect(parsed.epsilon).toBe(0.02)
+    expect(parsed.checkCommand).toBe('bun check:full')
+    expect(parsed.mutateFileCommand).toBe('bun test:mutate:file')
+    expect(parsed.prBranchPrefix).toBe('mutation-improve')
+    expect(parsed.agent.timeoutMs).toBe(1_800_000)
+  })
+
+  test('MutationImproveConfigSchema rejects threshold out of [0,1]', () => {
+    expect(() => MutationImproveConfigSchema.parse({ ...minimalValid, threshold: 1.5 })).toThrow()
+    expect(() => MutationImproveConfigSchema.parse({ ...minimalValid, threshold: -0.1 })).toThrow()
+  })
+
+  test('loadMutationImproveConfig resolves workDir against repoRoot and creates it', async () => {
+    const repoRoot = makeTempDir('cfg-')
+    const configPath = path.join(repoRoot, 'config.json')
+    writeFileSync(configPath, JSON.stringify({ ...minimalValid, repoRoot }))
+    const config = await loadMutationImproveConfig({ configPath })
+    expect(config.repoRoot).toBe(repoRoot)
+    expect(config.workDir).toBe(path.resolve(repoRoot, '.mutation-improve'))
+  })
+})
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `bun test tests/mutation-improve/config.test.ts`
+Expected: FAIL — cannot resolve `../../mutation-improve/src/config.js`.
+
+- [ ] **Step 4: Implement `mutation-improve/src/config.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { mkdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { z } from 'zod'
+
+import { detectGitRoot } from '../review-loop/src/worktree.js'
+
+const AgentConfigSchema = z.object({
+  model: z.string().min(1),
+  extraArgs: z.array(z.string()).default([]),
+  timeoutMs: z.number().int().min(0).default(1_800_000),
+})
+
+export const MutationImproveConfigSchema = z.object({
+  repoRoot: z.string().min(1).optional(),
+  workDir: z.string().min(1),
+  base: z.string().min(1).default('master'),
+  upstream: z.string().min(1).default('origin'),
+  count: z.number().int().positive().default(1),
+  threshold: z.number().min(0).max(1).default(0.95),
+  epsilon: z.number().min(0).max(1).default(0.02),
+  agentTimeoutMs: z.number().int().min(0).default(1_800_000),
+  buildTimeoutMs: z.number().int().min(0).default(600_000),
+  checkCommand: z.string().min(1).default('bun check:full'),
+  mutateFileCommand: z.string().min(1).default('bun test:mutate:file'),
+  agent: AgentConfigSchema,
+  prBranchPrefix: z.string().min(1).default('mutation-improve'),
+})
+
+export interface MutationImproveConfig extends z.infer<typeof MutationImproveConfigSchema> {
+  repoRoot: string
+  workDir: string
+}
+
+export interface ConfigLoadInput {
+  configPath: string
+  repoRoot?: string
+}
+
+export async function loadMutationImproveConfig(input: ConfigLoadInput): Promise<MutationImproveConfig> {
+  const configPath = path.resolve(input.configPath)
+  const raw = JSON.parse(await readFile(configPath, 'utf8')) as unknown
+  const parsed = MutationImproveConfigSchema.parse(raw)
+
+  const repoRootSource = input.repoRoot ?? parsed.repoRoot
+  const repoRoot = repoRootSource === undefined ? await detectGitRoot(process.cwd()) : path.resolve(repoRootSource)
+  const workDir = path.resolve(repoRoot, parsed.workDir)
+
+  await mkdir(workDir, { recursive: true })
+
+  return { ...parsed, repoRoot, workDir }
+}
+```
+
+- [ ] **Step 5: Create `mutation-improve/config.example.json`**
+
+```json
+{
+  "repoRoot": ".",
+  "workDir": ".mutation-improve",
+  "base": "master",
+  "upstream": "origin",
+  "count": 1,
+  "threshold": 0.95,
+  "epsilon": 0.02,
+  "agentTimeoutMs": 1800000,
+  "buildTimeoutMs": 600000,
+  "checkCommand": "bun check:full",
+  "mutateFileCommand": "bun test:mutate:file",
+  "agent": {
+    "model": "opencode/claude-sonnet-4-6",
+    "extraArgs": [],
+    "timeoutMs": 1800000
+  },
+  "prBranchPrefix": "mutation-improve"
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `bun test tests/mutation-improve/config.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mutation-improve/src/config.ts mutation-improve/config.example.json tests/mutation-improve/config.test.ts tests/mutation-improve/test-helpers.ts
+git commit -m "feat(mutation-improve): config schema and loader"
+```
+
+---
+
+## Task 4: Agent ↔ runner contracts (selection + result schemas)
+
+**Files:**
+- Create: `mutation-improve/src/selection-schema.ts`
+- Create: `mutation-improve/src/result-schema.ts`
+- Create: `tests/mutation-improve/contracts.test.ts`
+
+**Interfaces:**
+- Produces: `SelectionSchema`/`Selection` (`{ file, beforeScore, rationale, runnerUps: {file, score, why}[] }`) and `ResultSchema`/`Result` (`{ specPath, planPath, testPaths: string[], residuals: {loc, why}[], notes }`).
+
+- [ ] **Step 1: Write the failing test `tests/mutation-improve/contracts.test.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { SelectionSchema } from '../../mutation-improve/src/selection-schema.js'
+import { ResultSchema } from '../../mutation-improve/src/result-schema.js'
+
+describe('contracts', () => {
+  test('SelectionSchema accepts a well-formed selection and rejects missing runnerUps', () => {
+    const valid = {
+      file: 'src/live-status/tool-status-labels.ts',
+      beforeScore: 0.46,
+      rationale: 'Pure, dependency-free, user-facing.',
+      runnerUps: [{ file: 'src/tools/tool-metadata.ts', score: 0.29, why: 'declarative table' }],
+    }
+    expect(() => SelectionSchema.parse(valid)).not.toThrow()
+    expect(() => SelectionSchema.parse({ ...valid, runnerUps: undefined })).toThrow()
+  })
+
+  test('SelectionSchema rejects beforeScore out of [0,1]', () => {
+    const base = {
+      file: 'a.ts',
+      beforeScore: 0.5,
+      rationale: 'x',
+      runnerUps: [],
+    }
+    expect(() => SelectionSchema.parse({ ...base, beforeScore: 1.2 })).toThrow()
+  })
+
+  test('ResultSchema accepts empty residuals and defaults notes to empty string', () => {
+    const parsed = ResultSchema.parse({
+      specPath: 'docs/superpowers/specs/x-design.md',
+      planPath: 'docs/superpowers/plans/x.md',
+      testPaths: ['tests/live-status/x.test.ts'],
+      residuals: [],
+    })
+    expect(parsed.notes).toBe('')
+  })
+
+  test('ResultSchema requires at least one testPath', () => {
+    const base = {
+      specPath: 'd.md',
+      planPath: 'p.md',
+      testPaths: [],
+      residuals: [],
+    }
+    expect(() => ResultSchema.parse(base)).toThrow()
+    expect(() => ResultSchema.parse({ ...base, testPaths: ['tests/x.test.ts'] })).not.toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test tests/mutation-improve/contracts.test.ts`
+Expected: FAIL — cannot resolve the schema modules.
+
+- [ ] **Step 3: Implement `mutation-improve/src/selection-schema.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+const RunnerUpSchema = z.object({
+  file: z.string().min(1),
+  score: z.number().min(0).max(1),
+  why: z.string(),
+})
+
+export const SelectionSchema = z.object({
+  file: z.string().min(1),
+  beforeScore: z.number().min(0).max(1),
+  rationale: z.string(),
+  runnerUps: z.array(RunnerUpSchema).max(5),
+})
+
+export type Selection = z.infer<typeof SelectionSchema>
+```
+
+- [ ] **Step 4: Implement `mutation-improve/src/result-schema.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+const ResidualSchema = z.object({
+  loc: z.string(),
+  why: z.string(),
+})
+
+export const ResultSchema = z.object({
+  specPath: z.string().min(1),
+  planPath: z.string().min(1),
+  testPaths: z.array(z.string().min(1)).min(1),
+  residuals: z.array(ResidualSchema),
+  notes: z.string().default(''),
+})
+
+export type Result = z.infer<typeof ResultSchema>
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `bun test tests/mutation-improve/contracts.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mutation-improve/src/selection-schema.ts mutation-improve/src/result-schema.ts tests/mutation-improve/contracts.test.ts
+git commit -m "feat(mutation-improve): selection and result contracts"
+```
+
+---
+
+## Task 5: score-reader (reuses paired-runner score math)
+
+**Files:**
+- Create: `mutation-improve/src/score-reader.ts`
+- Create: `tests/mutation-improve/score-reader.test.ts`
+
+**Interfaces:**
+- Consumes: `mergeReports`, `StrykerReport` from `../../scripts/mutation/score-merger.js`; `readStrykerReport` from `../../scripts/mutation/json-readers.js`.
+- Produces:
+  - `safeFileStem(srcFile: string): string`
+  - `reportPathFor(reportDir: string, srcFile: string): string`
+  - `measureMutationScore(deps: MeasureDeps, reportDir: string, srcFile: string): Promise<number>` where `MeasureDeps = { exec: () => Promise<{ exitCode: number; stdout: string; stderr: string }>; readReport?: (p: string) => StrykerReport }`. Runs `deps.exec()`, reads the report; on missing/malformed, retries `exec()` once; if still failing, throws.
+
+- [ ] **Step 1: Write the failing test `tests/mutation-improve/score-reader.test.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import type { StrykerReport } from '../../scripts/mutation/score-merger.js'
+import { measureMutationScore, reportPathFor, safeFileStem } from '../../mutation-improve/src/score-reader.js'
+
+const reportWith = (killed: number, survived: number, noCoverage = 0, timeout = 0): StrykerReport => ({
+  files: {
+    'src/foo.ts': {
+      mutants: [
+        ...Array.from({ length: killed }, () => ({ status: 'Killed' })),
+        ...Array.from({ length: survived }, () => ({ status: 'Survived' })),
+        ...Array.from({ length: noCoverage }, () => ({ status: 'NoCoverage' })),
+        ...Array.from({ length: timeout }, () => ({ status: 'Timeout' })),
+      ],
+    },
+  },
+})
+
+describe('score-reader', () => {
+  test('safeFileStem escapes path separators', () => {
+    expect(safeFileStem('src/live-status/x.ts')).toBe('src__live-status__x.ts')
+    expect(reportPathFor('reports/paired', 'src/live-status/x.ts')).toBe(
+      'reports/paired/src__live-status__x.ts.stryker-report.json',
+    )
+  })
+
+  test('measureMutationScore reads the report after exec and returns (killed+timeout)/scored', async () => {
+    let calls = 0
+    const exec = async () => {
+      calls += 1
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+    const score = await measureMutationScore(
+      { exec, readReport: () => reportWith(8, 2) },
+      'reports/paired',
+      'src/foo.ts',
+    )
+    expect(calls).toBe(1)
+    expect(score).toBeCloseTo(0.8, 5) // 8 killed / (8+2) scored
+  })
+
+  test('measureMutationScore retries exec once when the report read throws, then succeeds', async () => {
+    let execCalls = 0
+    let readCalls = 0
+    const exec = async () => {
+      execCalls += 1
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+    const readReport = (): StrykerReport => {
+      readCalls += 1
+      if (readCalls === 1) throw new Error('malformed')
+      return reportWith(10, 0)
+    }
+    const score = await measureMutationScore({ exec, readReport }, 'reports/paired', 'src/foo.ts')
+    expect(execCalls).toBe(2)
+    expect(score).toBe(1)
+  })
+
+  test('measureMutationScore throws after a failed retry', async () => {
+    const exec = async () => ({ exitCode: 0, stdout: '', stderr: '' })
+    await expect(
+      measureMutationScore({ exec, readReport: () => {
+        throw new Error('still malformed')
+      } }, 'reports/paired', 'src/foo.ts'),
+    ).rejects.toThrow(/malformed|stryker/iu)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test tests/mutation-improve/score-reader.test.ts`
+Expected: FAIL — cannot resolve `../../mutation-improve/src/score-reader.js`.
+
+- [ ] **Step 3: Implement `mutation-improve/src/score-reader.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { mergeReports, type StrykerReport } from '../../scripts/mutation/score-merger.js'
+
+export const safeFileStem = (srcFile: string): string => srcFile.replaceAll(/[^a-zA-Z0-9._-]+/gu, '__')
+
+export const reportPathFor = (reportDir: string, srcFile: string): string =>
+  `${reportDir}/${safeFileStem(srcFile)}.stryker-report.json`
+
+export interface MeasureDeps {
+  exec: () => Promise<{ exitCode: number; stdout: string; stderr: string }>
+  readReport?: (reportPath: string) => StrykerReport
+}
+
+const defaultReadReport = (reportPath: string): StrykerReport => {
+  // Lazy require so the module stays pure-importable in tests that inject readReport.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mod = require('../../scripts/mutation/json-readers.js') as { readStrykerReport: (p: string) => StrykerReport }
+  return mod.readStrykerReport(reportPath)
+}
+
+export async function measureMutationScore(deps: MeasureDeps, reportDir: string, srcFile: string): Promise<number> {
+  const read = deps.readReport ?? defaultReadReport
+  const reportPath = reportPathFor(reportDir, srcFile)
+  const attempt = async (): Promise<number> => {
+    await deps.exec()
+    return mergeReports([read(reportPath)]).score
+  }
+  try {
+    return await attempt()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (/enoent|malformed|must contain a stryker/iu.test(message)) {
+      return await attempt() // one retry: re-run exec, re-read
+    }
+    throw error
+  }
+}
+```
+
+> Note: the pre-commit lint hook blocks `eslint-disable` comments. The lazy `require` above is the one lint risk — replace it with a static import of `readStrykerReport` at the top of the file instead:
+>
+> ```ts
+> import { readStrykerReport } from '../../scripts/mutation/json-readers.js'
+> ```
+> and use `readStrykerReport` directly as the default. The `require` form is shown only to illustrate the fallback; the implementer MUST use the static import (no lint disables allowed — Global Constraints).
+
+- [ ] **Step 4: Replace the `defaultReadReport` with the static import and rerun**
+
+Implement `mutation-improve/src/score-reader.ts` with the static import form (drop `defaultReadReport` entirely):
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { readStrykerReport } from '../../scripts/mutation/json-readers.js'
+import { mergeReports, type StrykerReport } from '../../scripts/mutation/score-merger.js'
+
+export const safeFileStem = (srcFile: string): string => srcFile.replaceAll(/[^a-zA-Z0-9._-]+/gu, '__')
+
+export const reportPathFor = (reportDir: string, srcFile: string): string =>
+  `${reportDir}/${safeFileStem(srcFile)}.stryker-report.json`
+
+export interface MeasureDeps {
+  exec: () => Promise<{ exitCode: number; stdout: string; stderr: string }>
+  readReport?: (reportPath: string) => StrykerReport
+}
+
+export async function measureMutationScore(deps: MeasureDeps, reportDir: string, srcFile: string): Promise<number> {
+  const read = deps.readReport ?? readStrykerReport
+  const reportPath = reportPathFor(reportDir, srcFile)
+  const attempt = async (): Promise<number> => {
+    await deps.exec()
+    return mergeReports([read(reportPath)]).score
+  }
+  try {
+    return await attempt()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (/enoent|malformed|must contain a stryker/iu.test(message)) {
+      return await attempt()
+    }
+    throw error
+  }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `bun test tests/mutation-improve/score-reader.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mutation-improve/src/score-reader.ts tests/mutation-improve/score-reader.test.ts
+git commit -m "feat(mutation-improve): score reader reusing paired-runner math"
+```
+
+---
+
+## Task 6: baseline read/write/bump
+
+**Files:**
+- Create: `mutation-improve/src/baseline.ts`
+- Create: `tests/mutation-improve/baseline.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `BaselineMap = Record<string, number>`
+  - `parseBaseline(json: string): BaselineMap`
+  - `serializeBaseline(map: BaselineMap): string` (sorted keys, 2-space indent, trailing newline)
+  - `bumpScore(map: BaselineMap, file: string, score: number): BaselineMap` (pure; raises-if-lower guard returns the higher of old/new so a measured dip never lowers the floor)
+  - `readBaseline(repoRoot: string): Promise<BaselineMap>` (reads `scripts/mutation/baseline.json`)
+  - `writeBaseline(repoRoot: string, map: BaselineMap): Promise<void>`
+
+- [ ] **Step 1: Write the failing test `tests/mutation-improve/baseline.test.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { bumpScore, parseBaseline, readBaseline, serializeBaseline, writeBaseline } from '../../mutation-improve/src/baseline.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+describe('baseline', () => {
+  test('serializeBaseline sorts keys and adds a trailing newline', () => {
+    const out = serializeBaseline({ b: 1, a: 0.5 })
+    expect(out).toBe('{\n  "a": 0.5,\n  "b": 1\n}\n')
+  })
+
+  test('parseBaseline + serializeBaseline round-trip is stable', () => {
+    const map = { 'src/z.ts': 0.9, 'src/a.ts': 0.1 }
+    expect(parseBaseline(serializeBaseline(map))).toEqual({ 'src/a.ts': 0.1, 'src/z.ts': 0.9 })
+  })
+
+  test('bumpScore raises the floor and never lowers it', () => {
+    const before = { 'src/foo.ts': 0.4 }
+    expect(bumpScore(before, 'src/foo.ts', 0.95)['src/foo.ts']).toBe(0.95)
+    expect(bumpScore(before, 'src/foo.ts', 0.2)['src/foo.ts']).toBe(0.4) // measured dip ignored
+    expect(bumpScore(before, 'src/new.ts', 0.7)['src/new.ts']).toBe(0.7) // new entry
+  })
+
+  test('readBaseline + writeBaseline round-trip through scripts/mutation/baseline.json', async () => {
+    const repoRoot = makeTempDir('bl-')
+    await mkdir(path.join(repoRoot, 'scripts', 'mutation'), { recursive: true })
+    await writeBaseline(repoRoot, { 'src/a.ts': 0.3 })
+    const onDisk = await readFile(path.join(repoRoot, 'scripts', 'mutation', 'baseline.json'), 'utf8')
+    expect(onDisk).toContain('"src/a.ts": 0.3')
+    const readBack = await readBaseline(repoRoot)
+    expect(readBack['src/a.ts']).toBe(0.3)
+  })
+
+  test('readBaseline on a missing file returns empty map', async () => {
+    const repoRoot = makeTempDir('bl-missing-')
+    const map = await readBaseline(repoRoot)
+    expect(map).toEqual({})
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test tests/mutation-improve/baseline.test.ts`
+Expected: FAIL — cannot resolve `../../mutation-improve/src/baseline.js`.
+
+- [ ] **Step 3: Implement `mutation-improve/src/baseline.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+export type BaselineMap = Record<string, number>
+
+const BASELINE_REL = path.join('scripts', 'mutation', 'baseline.json')
+
+export function parseBaseline(json: string): BaselineMap {
+  const parsed = JSON.parse(json) as unknown
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('baseline.json must be a JSON object mapping file paths to scores')
+  }
+  const out: BaselineMap = {}
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw new Error(`baseline.json entry "${key}" must be a finite number`)
+    }
+    out[key] = value
+  }
+  return out
+}
+
+export function serializeBaseline(map: BaselineMap): string {
+  const sorted: BaselineMap = {}
+  for (const key of Object.keys(map).sort()) sorted[key] = map[key]
+  return `${JSON.stringify(sorted, null, 2)}\n`
+}
+
+export function bumpScore(map: BaselineMap, file: string, score: number): BaselineMap {
+  const previous = map[file] ?? -Infinity
+  return { ...map, [file]: Math.max(previous, score) }
+}
+
+export async function readBaseline(repoRoot: string): Promise<BaselineMap> {
+  const filePath = path.join(repoRoot, BASELINE_REL)
+  try {
+    return parseBaseline(await readFile(filePath, 'utf8'))
+  } catch (error) {
+    if (error !== null && typeof error === 'object' && (error as { code?: string }).code === 'ENOENT') return {}
+    throw error
+  }
+}
+
+export async function writeBaseline(repoRoot: string, map: BaselineMap): Promise<void> {
+  await writeFile(path.join(repoRoot, BASELINE_REL), serializeBaseline(map))
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun test tests/mutation-improve/baseline.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mutation-improve/src/baseline.ts tests/mutation-improve/baseline.test.ts
+git commit -m "feat(mutation-improve): baseline read/write/bump"
+```
+
+---
+
+## Task 7: diff-guard
+
+**Files:**
+- Create: `mutation-improve/src/diff-guard.ts`
+- Create: `tests/mutation-improve/diff-guard.test.ts`
+
+**Interfaces:**
+- Consumes: `execGit`-shaped function `(cwd, args) => Promise<{ stdout, stderr }>` (matches `review-loop/src/worktree.ts`'s `execGit`).
+- Produces:
+  - `ALLOWED_PREFIXES = ['tests/', 'docs/superpowers/']`
+  - `classifyDiff(paths: readonly string[]): { allowed: string[]; violations: string[] }`
+  - `runDiffGuard(execGit, cwd): Promise<{ ok: true } | { ok: false; violations: string[] }>` — runs `git diff --name-only HEAD` in `cwd` and classifies.
+
+- [ ] **Step 1: Write the failing test `tests/mutation-improve/diff-guard.test.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { ALLOWED_PREFIXES, classifyDiff, runDiffGuard } from '../../mutation-improve/src/diff-guard.js'
+
+describe('diff-guard', () => {
+  test('ALLOWED_PREFIXES is tests/ and docs/superpowers/', () => {
+    expect(ALLOWED_PREFIXES).toEqual(['tests/', 'docs/superpowers/'])
+  })
+
+  test('classifyDiff splits allowed from violations', () => {
+    const result = classifyDiff([
+      'tests/live-status/x.test.ts',
+      'docs/superpowers/specs/x-design.md',
+      'src/foo.ts',
+      'scripts/mutation/baseline.json',
+    ])
+    expect(result.allowed).toEqual(['tests/live-status/x.test.ts', 'docs/superpowers/specs/x-design.md'])
+    expect(result.violations).toEqual(['src/foo.ts', 'scripts/mutation/baseline.json'])
+  })
+
+  test('runDiffGuard returns ok when all changed paths are allowed', async () => {
+    const execGit = async (_cwd: string, args: readonly string[]) => {
+      expect(args).toEqual(['diff', '--name-only', 'HEAD'])
+      return { stdout: 'tests/a.test.ts\ndocs/superpowers/plans/p.md\n', stderr: '' }
+    }
+    const result = await runDiffGuard(execGit, '/repo/wt')
+    expect(result).toEqual({ ok: true })
+  })
+
+  test('runDiffGuard returns violations when src/ or baseline.json changed', async () => {
+    const execGit = async () => ({ stdout: 'tests/a.test.ts\nsrc/foo.ts\n', stderr: '' })
+    const result = await runDiffGuard(execGit, '/repo/wt')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.violations).toEqual(['src/foo.ts'])
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test tests/mutation-improve/diff-guard.test.ts`
+Expected: FAIL — cannot resolve the module.
+
+- [ ] **Step 3: Implement `mutation-improve/src/diff-guard.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+export const ALLOWED_PREFIXES = ['tests/', 'docs/superpowers/']
+
+export type ExecGitFn = (cwd: string, args: readonly string[]) => Promise<{ stdout: string; stderr: string }>
+
+export function classifyDiff(paths: readonly string[]): { allowed: string[]; violations: string[] } {
+  const allowed: string[] = []
+  const violations: string[] = []
+  for (const p of paths) {
+    if (ALLOWED_PREFIXES.some((prefix) => p.startsWith(prefix))) allowed.push(p)
+    else violations.push(p)
+  }
+  return { allowed, violations }
+}
+
+export async function runDiffGuard(
+  execGit: ExecGitFn,
+  cwd: string,
+): Promise<{ ok: true } | { ok: false; violations: string[] }> {
+  const { stdout } = await execGit(cwd, ['diff', '--name-only', 'HEAD'])
+  const paths = stdout.split('\n').map((line) => line.trim()).filter((line) => line.length > 0)
+  const { violations } = classifyDiff(paths)
+  return violations.length === 0 ? { ok: true } : { ok: false, violations }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun test tests/mutation-improve/diff-guard.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mutation-improve/src/diff-guard.ts tests/mutation-improve/diff-guard.test.ts
+git commit -m "feat(mutation-improve): diff-scope guard"
+```
+
+---
+
+## Task 8: run-state
+
+**Files:**
+- Create: `mutation-improve/src/run-state.ts`
+- Create: `tests/mutation-improve/run-state.test.ts`
+
+**Interfaces:**
+- Produces: `MutationImproveRunState` interface with all paths from the spec's persisted-state shape; `createRunState(config) => Promise<RunState>`; `loadRunState(workDir, runId) => Promise<RunState>`; `saveRunState(state) => Promise<void>`; `iterDir(runDir, iter) => string`; `PersistedRunStateSchema`.
+
+- [ ] **Step 1: Write the failing test `tests/mutation-improve/run-state.test.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { createRunState, iterDir, loadRunState, PersistedRunStateSchema, saveRunState } from '../../mutation-improve/src/run-state.js'
+import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+const baseConfig = (repoRoot: string, workDir: string): MutationImproveConfig => ({
+  repoRoot,
+  workDir,
+  base: 'master',
+  upstream: 'origin',
+  count: 1,
+  threshold: 0.95,
+  epsilon: 0.02,
+  agentTimeoutMs: 1_800_000,
+  buildTimeoutMs: 600_000,
+  checkCommand: 'bun check:full',
+  mutateFileCommand: 'bun test:mutate:file',
+  agent: { model: 'm', extraArgs: [], timeoutMs: 1_800_000 },
+  prBranchPrefix: 'mutation-improve',
+})
+
+describe('run-state', () => {
+  test('createRunState persists and round-trips through loadRunState', async () => {
+    const repoRoot = makeTempDir('rs-')
+    const config = baseConfig(repoRoot, path.join(repoRoot, '.mutation-improve'))
+    const created = await createRunState(config)
+    expect(created.currentIteration).toBe(0)
+    expect(created.doneSet).toEqual([])
+    expect(created.status).toBe('running')
+    created.doneSet = ['src/a.ts']
+    created.currentIteration = 1
+    await saveRunState(created)
+    const reloaded = await loadRunState(config.workDir, created.runId)
+    expect(reloaded.doneSet).toEqual(['src/a.ts'])
+    expect(reloaded.currentIteration).toBe(1)
+  })
+
+  test('iterDir is <runDir>/iter/<i>', () => {
+    expect(iterDir('/runs/r1', 3)).toBe(path.join('/runs/r1', 'iter', '3'))
+  })
+
+  test('PersistedRunStateSchema rejects unknown status', () => {
+    const valid = {
+      runId: 'r',
+      repoRoot: '/r',
+      base: 'master',
+      threshold: 0.95,
+      count: 1,
+      currentIteration: 0,
+      doneSet: [],
+      merged: [],
+      failed: [],
+      status: 'running',
+    }
+    expect(() => PersistedRunStateSchema.parse(valid)).not.toThrow()
+    expect(() => PersistedRunStateSchema.parse({ ...valid, status: 'bogus' })).toThrow()
+  })
+})
+```
+
+Add `import path from 'node:path'` to the test's imports.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test tests/mutation-improve/run-state.test.ts`
+Expected: FAIL — cannot resolve the module.
+
+- [ ] **Step 3: Implement `mutation-improve/src/run-state.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { z } from 'zod'
+
+import type { MutationImproveConfig } from './config.js'
+
+const MergedEntrySchema = z.object({
+  file: z.string(),
+  beforeScore: z.number(),
+  afterScore: z.number(),
+  iter: z.number().int(),
+})
+
+const FailedEntrySchema = z.object({
+  iter: z.number().int(),
+  file: z.string().optional(),
+  gate: z.string(),
+  reason: z.string(),
+})
+
+export const PersistedRunStateSchema = z.object({
+  runId: z.string(),
+  repoRoot: z.string(),
+  base: z.string(),
+  threshold: z.number(),
+  count: z.number().int(),
+  currentIteration: z.number().int().nonnegative(),
+  doneSet: z.array(z.string()),
+  merged: z.array(MergedEntrySchema),
+  failed: z.array(FailedEntrySchema),
+  status: z.enum(['running', 'completed', 'aborted']),
+})
+
+export type PersistedRunState = z.infer<typeof PersistedRunStateSchema>
+
+export interface MutationImproveRunState extends PersistedRunState {
+  runDir: string
+  workDir: string
+  statePath: string
+}
+
+function makeRunId(): string {
+  return `${new Date().toISOString().replace(/[:.]/gu, '-')}-${randomUUID().slice(0, 8)}`
+}
+
+export function iterDir(runDir: string, iter: number): string {
+  return path.join(runDir, 'iter', String(iter))
+}
+
+export async function createRunState(config: MutationImproveConfig): Promise<MutationImproveRunState> {
+  const runId = makeRunId()
+  const runDir = path.join(config.workDir, 'runs', runId)
+  await mkdir(runDir, { recursive: true })
+  const state: MutationImproveRunState = {
+    runId,
+    runDir,
+    workDir: config.workDir,
+    statePath: path.join(runDir, 'state.json'),
+    repoRoot: config.repoRoot,
+    base: config.base,
+    threshold: config.threshold,
+    count: config.count,
+    currentIteration: 0,
+    doneSet: [],
+    merged: [],
+    failed: [],
+    status: 'running',
+  }
+  await saveRunState(state)
+  return state
+}
+
+export async function loadRunState(workDir: string, runId: string): Promise<MutationImproveRunState> {
+  const runDir = path.join(workDir, 'runs', runId)
+  const statePath = path.join(runDir, 'state.json')
+  const persisted = PersistedRunStateSchema.parse(JSON.parse(await readFile(statePath, 'utf8')))
+  return { ...persisted, runDir, workDir, statePath }
+}
+
+export async function saveRunState(state: MutationImproveRunState): Promise<void> {
+  const persisted = PersistedRunStateSchema.parse(state)
+  await writeFile(state.statePath, JSON.stringify(persisted, null, 2))
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun test tests/mutation-improve/run-state.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mutation-improve/src/run-state.ts tests/mutation-improve/run-state.test.ts
+git commit -m "feat(mutation-improve): run-state persistence"
+```
+
+---
+
+## Task 9: prompt-templates
+
+**Files:**
+- Create: `mutation-improve/src/prompt-templates.ts`
+- Create: `tests/mutation-improve/prompt-templates.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `buildSelectPrompt(input: { doneSet: readonly string[]; baselineSummary: string; outputPath: string }): string`
+  - `buildImprovePrompt(input: { file: string; beforeScore: number; threshold: number; date: string; outputPath: string }): string`
+
+- [ ] **Step 1: Write the failing test `tests/mutation-improve/prompt-templates.test.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { buildImprovePrompt, buildSelectPrompt } from '../../mutation-improve/src/prompt-templates.js'
+
+describe('prompt-templates', () => {
+  test('buildSelectPrompt names the output path, the done-set, and the rejection rules', () => {
+    const prompt = buildSelectPrompt({
+      doneSet: ['src/a.ts'],
+      baselineSummary: '{"src/b.ts":0.2}',
+      outputPath: '/run/iter/1/selection.json',
+    })
+    expect(prompt).toContain('/run/iter/1/selection.json')
+    expect(prompt).toContain('src/a.ts')
+    expect(prompt).toContain('Math.random')
+    expect(prompt).toContain('baseline.json')
+  })
+
+  test('buildImprovePrompt states the no-src and no-baseline hard constraints and the exact-equality discipline', () => {
+    const prompt = buildImprovePrompt({
+      file: 'src/foo.ts',
+      beforeScore: 0.3,
+      threshold: 0.95,
+      date: '2026-08-05',
+      outputPath: '/run/iter/1/result.json',
+    })
+    expect(prompt).toContain('MUST NOT edit anything under src/')
+    expect(prompt).toContain('MUST NOT edit scripts/mutation/baseline.json')
+    expect(prompt).toContain('toBe(')
+    expect(prompt).toContain('0.95')
+    expect(prompt).toContain('/run/iter/1/result.json')
+    expect(prompt).toContain('docs/superpowers/specs/2026-08-05-mutation-coverage-foo-design.md')
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test tests/mutation-improve/prompt-templates.test.ts`
+Expected: FAIL — cannot resolve the module.
+
+- [ ] **Step 3: Implement `mutation-improve/src/prompt-templates.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import path from 'node:path'
+
+const stemFrom = (file: string): string => {
+  const base = path.basename(file).replace(/\.ts$/u, '')
+  return base
+}
+
+export function buildSelectPrompt(input: {
+  doneSet: readonly string[]
+  baselineSummary: string
+  outputPath: string
+}): string {
+  const excluded = input.doneSet.length === 0 ? '(none)' : input.doneSet.join(', ')
+  return [
+    'You are the SELECT phase of an autonomous mutation-coverage improvement runner.',
+    '',
+    'Read scripts/mutation/baseline.json (a {filePath: score} map; current contents below) and pick',
+    'the SINGLE highest-ROI source file to improve, where ROI = reliable mutation-score gain per',
+    'unit of test effort. Prefer pure functions with zero external dependencies, an existing',
+    'companion test file, and surviving mutants that each map to an observable bug.',
+    '',
+    'REJECT files matching any of these patterns (they waste effort):',
+    '- Declarative lookup tables / schema files where >80% of lines are data (e.g. big REGISTRY/Zod maps) and the score is already >= 0.9.',
+    '- Files whose non-determinism caps the reachable score (e.g. Math.random jitter, real wall-clock) — jitter mutants can only be bounds-checked.',
+    '- Single-statement passthrough wrappers whose real logic lives elsewhere.',
+    '- Files whose companion test cannot exercise the behaviour without a full chat/LLM runtime.',
+    '',
+    `Files already improved in this run (DO NOT pick): ${excluded}`,
+    '',
+    `baseline.json contents: ${input.baselineSummary}`,
+    '',
+    `Write your pick as JSON to this ABSOLUTE path: ${input.outputPath}`,
+    'Schema: { file: string (repo-relative), beforeScore: number (your read of baseline[file], 0..1),',
+    'rationale: string (1-3 sentences), runnerUps: [{file, score, why}] (2-3 rejected candidates) }.',
+    'Write ONLY that file; do not edit any source.',
+  ].join('\n')
+}
+
+export function buildImprovePrompt(input: {
+  file: string
+  beforeScore: number
+  threshold: number
+  date: string
+  outputPath: string
+}): string {
+  const stem = stemFrom(input.file)
+  const specPath = `docs/superpowers/specs/${input.date}-mutation-coverage-${stem}-design.md`
+  const planPath = `docs/superpowers/plans/${input.date}-mutation-coverage-${stem}.md`
+  return [
+    `You are the IMPROVE phase of an autonomous mutation-coverage improvement runner.`,
+    `Target file: ${input.file} (current mutation score: ${input.beforeScore}; target: >= ${input.threshold})`,
+    '',
+    'Execute, in order, the FULL procedure:',
+    '',
+    '1. MEASURE. Run `bun test:mutate:file ' + input.file + '` and inspect reports/paired/ to enumerate',
+    '   the ACTUAL surviving mutants. Ground every later step in the real report, not speculation.',
+    '2. SPEC. Write ' + specPath + ' with sections: Summary / Why this file / Non-goals / Gap analysis',
+    '   (a table of surviving mutant classes, one row per class) / Design - tests to add (mapped one-to-one',
+    '   onto the gap classes) / Verification / Accepted residuals.',
+    '3. PLAN. Write ' + planPath + ' with task-per-mutant-class checkboxes and global constraints.',
+    '4. TESTS. Extend the existing companion test file (tests/.../<stem>.test.ts). Every new assertion',
+    '   MUST use exact equality toBe(...) - never startsWith/endsWith/toContain where a full string is',
+    '   knowable. One test per mutant class.',
+    '5. RESIDUALS. Enumerate equivalent mutants that survive and genuinely cannot be killed, with per-loc',
+    '   reasoning.',
+    '',
+    `Write your result as JSON to this ABSOLUTE path: ${input.outputPath}`,
+    'Schema: { specPath: string, planPath: string, testPaths: string[] (>=1),',
+    'residuals: [{loc, why}], notes: string }.',
+    '',
+    'HARD CONSTRAINTS (the runner verifies these and REJECTS the iteration if violated):',
+    '- MUST NOT edit anything under src/, client/, plugins/, or scripts/. Test-only.',
+    '- MUST NOT edit scripts/mutation/baseline.json (the runner owns it).',
+    '- Run `bun test tests/<companion>` green before finishing.',
+    '- SPDX license headers on any new file; emoji copied verbatim from source.',
+  ].join('\n')
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun test tests/mutation-improve/prompt-templates.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mutation-improve/src/prompt-templates.ts tests/mutation-improve/prompt-templates.test.ts
+git commit -m "feat(mutation-improve): select and improve prompt templates"
+```
+
+---
+
+## Task 10: pipeline (the spine)
+
+**Files:**
+- Create: `mutation-improve/src/pipeline.ts`
+- Create: `tests/mutation-improve/pipeline.test.ts`
+
+**Interfaces:**
+- Consumes: `MutationImproveConfig`, `MutationImproveRunState`, `SelectionSchema`/`ResultSchema`, `measureMutationScore`, `readBaseline`/`writeBaseline`/`bumpScore`, `runDiffGuard`, `buildSelectPrompt`/`buildImprovePrompt`, review-loop's `runAgent`/`agentWritePath`/`createWorktree`/`mergeWorktree`/`removeWorktree`/`resetWorktree`/`createShellExec`/`runBuildCheck`.
+- Produces:
+  - `IterationResult = { iter, outcome: 'improved'|'skipped'|'failed', file?, beforeScore?, afterScore?, gate?, reason? }`
+  - `PipelineDeps` (all externals injected)
+  - `runIteration(deps, iter): Promise<IterationResult>`
+  - `runPipeline(deps): Promise<{ results: IterationResult[]; aborted: boolean }>`
+
+- [ ] **Step 1: Write the failing test `tests/mutation-improve/pipeline.test.ts`** (happy path first)
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { runIteration, type PipelineDeps } from '../../mutation-improve/src/pipeline.js'
+import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
+import type { MutationImproveRunState } from '../../mutation-improve/src/run-state.js'
+import type { Selection } from '../../mutation-improve/src/selection-schema.js'
+import type { Result } from '../../mutation-improve/src/result-schema.js'
+
+const config = (overrides: Partial<MutationImproveConfig> = {}): MutationImproveConfig => ({
+  repoRoot: '/repo',
+  workDir: '/repo/.mutation-improve',
+  base: 'master',
+  upstream: 'origin',
+  count: 1,
+  threshold: 0.95,
+  epsilon: 0.02,
+  agentTimeoutMs: 1_800_000,
+  buildTimeoutMs: 600_000,
+  checkCommand: 'bun check:full',
+  mutateFileCommand: 'bun test:mutate:file',
+  agent: { model: 'm', extraArgs: [], timeoutMs: 1_800_000 },
+  prBranchPrefix: 'mutation-improve',
+  ...overrides,
+})
+
+const runState = (overrides: Partial<MutationImproveRunState> = {}): MutationImproveRunState => ({
+  runId: 'r1',
+  repoRoot: '/repo',
+  workDir: '/repo/.mutation-improve',
+  runDir: '/repo/.mutation-improve/runs/r1',
+  statePath: '/repo/.mutation-improve/runs/r1/state.json',
+  base: 'master',
+  threshold: 0.95,
+  count: 1,
+  currentIteration: 0,
+  doneSet: [],
+  merged: [],
+  failed: [],
+  status: 'running',
+  ...overrides,
+})
+
+const selection: Selection = {
+  file: 'src/live-status/tool-status-labels.ts',
+  beforeScore: 0.46,
+  rationale: 'pure',
+  runnerUps: [],
+}
+
+const result: Result = {
+  specPath: 'docs/superpowers/specs/x-design.md',
+  planPath: 'docs/superpowers/plans/x.md',
+  testPaths: ['tests/live-status/x.test.ts'],
+  residuals: [],
+  notes: '',
+}
+
+const happyDeps = (): PipelineDeps => {
+  let baseline = { 'src/live-status/tool-status-labels.ts': 0.46 }
+  return {
+    config: config(),
+    runState: runState(),
+    spawn: (async () => ({ exitCode: 0, stdout: '', stderr: '' })) as never,
+    createWorktree: (async () => undefined) as never,
+    resetWorktree: (async () => undefined) as never,
+    removeWorktree: (async () => undefined) as never,
+    mergeWorktree: (async () => ({ ok: true })) as never,
+    execGit: (async () => ({ stdout: 'tests/live-status/x.test.ts\n', stderr: '' })) as never,
+    runBuildCheck: (async () => ({ passed: true, stdout: '', stderr: '' })) as never,
+    measureScore: (async () => 0.97) as never,
+    readBaseline: (async () => baseline) as never,
+    writeBaseline: (async (_root: string, map: Record<string, number>) => {
+      baseline = map
+    }) as never,
+    runSelectAgent: (async () => ({ value: selection, usage: emptyUsage() })) as never,
+    runImproveAgent: (async () => ({ value: result, usage: emptyUsage() })) as never,
+    log: { log: () => undefined, issue: undefined },
+  }
+}
+
+const emptyUsage = () => ({ inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0, wallMs: 0 })
+
+describe('pipeline runIteration', () => {
+  test('happy path: improved, merged, baseline ratcheted', async () => {
+    const deps = happyDeps()
+    const outcome = await runIteration(deps, 1)
+    expect(outcome).toEqual({
+      iter: 1,
+      outcome: 'improved',
+      file: 'src/live-status/tool-status-labels.ts',
+      beforeScore: 0.46,
+      afterScore: 0.97,
+    })
+    expect(deps.runState.merged).toHaveLength(1)
+    expect(deps.runState.merged[0].afterScore).toBe(0.97)
+    expect(deps.runState.doneSet).toContain('src/live-status/tool-status-labels.ts')
+    // baseline bump is runner-owned
+    const bumped = await deps.readBaseline('/repo')
+    expect(bumped['src/live-status/tool-status-labels.ts']).toBe(0.97)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test tests/mutation-improve/pipeline.test.ts`
+Expected: FAIL — cannot resolve `../../mutation-improve/src/pipeline.js`.
+
+- [ ] **Step 3: Implement `mutation-improve/src/pipeline.ts`** (happy path + all gates)
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
+
+import type { AgentRunResult } from '../review-loop/src/agent-runner.js'
+import type { MergeResult } from '../review-loop/src/worktree.js'
+
+import type { MutationImproveConfig } from './config.js'
+import type { Result } from './result-schema.js'
+import { SelectionSchema } from './selection-schema.js'
+import { ResultSchema } from './result-schema.js'
+import type { Selection } from './selection-schema.js'
+import type { MutationImproveRunState } from './run-state.js'
+import { iterDir } from './run-state.js'
+import { bumpScore } from './baseline.js'
+import { runDiffGuard } from './diff-guard.js'
+import { buildImprovePrompt, buildSelectPrompt } from './prompt-templates.js'
+
+export interface IterationResult {
+  iter: number
+  outcome: 'improved' | 'skipped' | 'failed'
+  file?: string
+  beforeScore?: number
+  afterScore?: number
+  gate?: string
+  reason?: string
+}
+
+export interface PipelineDeps {
+  config: MutationImproveConfig
+  runState: MutationImproveRunState
+  spawn: unknown
+  createWorktree: (repoRoot: string, worktreePath: string, runId: string, branchPrefix: string) => Promise<void>
+  resetWorktree: (worktreePath: string) => Promise<void>
+  removeWorktree: (repoRoot: string, worktreePath: string, runId: string, branchPrefix: string) => Promise<void>
+  mergeWorktree: (repoRoot: string, branchName: string) => Promise<MergeResult>
+  execGit: (cwd: string, args: readonly string[]) => Promise<{ stdout: string; stderr: string }>
+  runBuildCheck: () => Promise<{ passed: boolean; stdout: string; stderr: string }>
+  measureScore: (worktreePath: string, srcFile: string) => Promise<number>
+  readBaseline: (repoRoot: string) => Promise<Record<string, number>>
+  writeBaseline: (repoRoot: string, map: Record<string, number>) => Promise<void>
+  runSelectAgent: (worktreePath: string, prompt: string) => Promise<AgentRunResult<Selection>>
+  runImproveAgent: (worktreePath: string, prompt: string) => Promise<AgentRunResult<Result>>
+  log: { log: (msg: string) => void; issue?: unknown }
+}
+
+function branchFor(deps: PipelineDeps, iter: number): string {
+  return `${deps.config.prBranchPrefix}/${deps.runState.runId}-iter${iter}`
+}
+
+function worktreeFor(deps: PipelineDeps, iter: number): string {
+  return path.join(deps.config.workDir, 'worktrees', `${deps.runState.runId}-iter${iter}`)
+}
+
+export async function runIteration(deps: PipelineDeps, iter: number): Promise<IterationResult> {
+  const worktreePath = worktreeFor(deps, iter)
+  const iterPath = iterDir(deps.runState.runDir, iter)
+  await mkdir(iterPath, { recursive: true })
+  await deps.createWorktree(deps.config.repoRoot, worktreePath, `${deps.runState.runId}-iter${iter}`, deps.config.prBranchPrefix)
+
+  // ① SELECT
+  const baseline = await deps.readBaseline(deps.config.repoRoot)
+  const selectOut = path.join(iterPath, 'selection.json')
+  const selectRes = await deps.runSelectAgent(
+    worktreePath,
+    buildSelectPrompt({ doneSet: deps.runState.doneSet, baselineSummary: JSON.stringify(baseline), outputPath: selectOut }),
+  )
+  const selection = SelectionSchema.parse(selectRes.value)
+
+  if (deps.runState.doneSet.includes(selection.file) || baseline[selection.file] === undefined) {
+    return failIter(deps, iter, worktreePath, 'select', 'selection file not in baseline or already done')
+  }
+
+  // ② CAPTURE BEFORE (runner-owned measurement)
+  const beforeScore = await deps.measureScore(worktreePath, selection.file)
+  if (beforeScore >= deps.config.threshold) {
+    deps.runState.doneSet.push(selection.file)
+    return skipIter(deps, iter, worktreePath, selection.file, beforeScore)
+  }
+
+  // ③ IMPROVE
+  const improveOut = path.join(iterPath, 'result.json')
+  const improveRes = await deps.runImproveAgent(
+    worktreePath,
+    buildImprovePrompt({
+      file: selection.file,
+      beforeScore,
+      threshold: deps.config.threshold,
+      date: new Date().toISOString().slice(0, 10),
+      outputPath: improveOut,
+    }),
+  )
+  const result = ResultSchema.parse(improveRes.value)
+
+  // ④a DIFF-GUARD
+  const diff = await runDiffGuard(deps.execGit, worktreePath)
+  if (!diff.ok) {
+    return failIter(deps, iter, worktreePath, 'diff-scope', `forbidden paths changed: ${diff.violations.join(', ')}`)
+  }
+
+  // ④b BUILD GREEN
+  const build = await deps.runBuildCheck()
+  if (!build.passed) {
+    return failIter(deps, iter, worktreePath, 'build', build.stderr || build.stdout)
+  }
+
+  // ⑤ VERIFY (runner-measured)
+  const afterScore = await deps.measureScore(worktreePath, selection.file)
+  const justified = result.residuals.length > 0 && afterScore >= deps.config.threshold - deps.config.epsilon
+  if (afterScore < deps.config.threshold && !justified) {
+    return failIter(deps, iter, worktreePath, 'score', `afterScore ${afterScore} < threshold ${deps.config.threshold}`)
+  }
+
+  // ⑥ RATCHET (runner-owned)
+  const bumped = bumpScore(baseline, selection.file, afterScore)
+  await deps.writeBaseline(deps.config.repoRoot, bumped)
+
+  // ⑦ MERGE
+  const merge = await deps.mergeWorktree(deps.config.repoRoot, branchFor(deps, iter))
+  if (!merge.ok) {
+    return { iter, outcome: 'failed', file: selection.file, beforeScore, afterScore, gate: 'merge', reason: `conflict: ${merge.conflictFiles.join(', ')}` }
+  }
+
+  await deps.removeWorktree(deps.config.repoRoot, worktreePath, `${deps.runState.runId}-iter${iter}`, deps.config.prBranchPrefix)
+  deps.runState.doneSet.push(selection.file)
+  deps.runState.merged.push({ file: selection.file, beforeScore, afterScore, iter })
+  return { iter, outcome: 'improved', file: selection.file, beforeScore, afterScore }
+}
+
+async function failIter(deps: PipelineDeps, iter: number, worktreePath: string, gate: string, reason: string): Promise<IterationResult> {
+  await deps.resetWorktree(worktreePath)
+  await deps.removeWorktree(deps.config.repoRoot, worktreePath, `${deps.runState.runId}-iter${iter}`, deps.config.prBranchPrefix)
+  deps.runState.failed.push({ iter, gate, reason })
+  return { iter, outcome: 'failed', gate, reason }
+}
+
+function skipIter(deps: PipelineDeps, iter: number, worktreePath: string, file: string, beforeScore: number): Promise<IterationResult> {
+  return deps.removeWorktree(deps.config.repoRoot, worktreePath, `${deps.runState.runId}-iter${iter}`, deps.config.prBranchPrefix).then(() => ({
+    iter,
+    outcome: 'skipped' as const,
+    file,
+    beforeScore,
+  }))
+}
+
+export async function runPipeline(deps: PipelineDeps): Promise<{ results: IterationResult[]; aborted: boolean }> {
+  const results: IterationResult[] = []
+  let aborted = false
+  for (let iter = deps.runState.currentIteration + 1; iter <= deps.config.count; iter += 1) {
+    deps.runState.currentIteration = iter
+    const outcome = await runIteration(deps, iter)
+    results.push(outcome)
+    if (outcome.gate === 'merge') {
+      aborted = true
+      deps.runState.status = 'aborted'
+      break
+    }
+  }
+  if (!aborted) deps.runState.status = 'completed'
+  return { results, aborted }
+}
+```
+
+- [ ] **Step 4: Run the happy-path test to verify it passes**
+
+Run: `bun test tests/mutation-improve/pipeline.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Add gate-failure tests to `tests/mutation-improve/pipeline.test.ts`**
+
+Append (inside the `describe('pipeline runIteration', …)` block):
+
+```ts
+  test('diff-scope violation fails the iteration without merging or ratcheting', async () => {
+    const deps = happyDeps()
+    deps.execGit = (async () => ({ stdout: 'src/foo.ts\n', stderr: '' })) as never
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('diff-scope')
+    expect(deps.runState.merged).toHaveLength(0)
+    const baseline = await deps.readBaseline('/repo')
+    expect(baseline['src/live-status/tool-status-labels.ts']).toBe(0.46) // unchanged
+  })
+
+  test('score below threshold with no residuals fails the iteration', async () => {
+    const deps = happyDeps()
+    deps.measureScore = (async (_wt: string, _f: string, n = 0) => (n === 0 ? 0.46 : 0.6)) as never
+    deps.runImproveAgent = (async () => ({ value: { ...result, residuals: [] }, usage: emptyUsage() })) as never
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('score')
+  })
+
+  test('score below threshold WITH justified residuals passes', async () => {
+    const deps = happyDeps()
+    // first call (before) returns 0.46, second (after) returns 0.94 (within epsilon of 0.95)
+    let calls = 0
+    deps.measureScore = (async () => {
+      calls += 1
+      return calls === 1 ? 0.46 : 0.94
+    }) as never
+    deps.runImproveAgent = (async () => ({
+      value: { ...result, residuals: [{ loc: 'L21', why: 'equivalent' }] },
+      usage: emptyUsage(),
+    })) as never
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('improved')
+    expect(outcome.afterScore).toBe(0.94)
+  })
+
+  test('merge conflict produces a failed merge-gate outcome', async () => {
+    const deps = happyDeps()
+    deps.mergeWorktree = (async () => ({ ok: false, conflictFiles: ['scripts/mutation/baseline.json'] })) as never
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('merge')
+  })
+```
+
+- [ ] **Step 6: Run the full pipeline test file**
+
+Run: `bun test tests/mutation-improve/pipeline.test.ts`
+Expected: all tests PASS.
+
+- [ ] **Step 7: Add a `runPipeline` chaining test** (append to the file in a new describe)
+
+```ts
+describe('pipeline runPipeline', () => {
+  test('count chains: iteration 2 sees iteration 1 baseline bump; merge conflict aborts', async () => {
+    const deps = happyDeps()
+    deps.config = config({ count: 2 })
+    let measureCalls = 0
+    deps.measureScore = (async () => {
+      measureCalls += 1
+      // before-scores for iters 1,2 then after-scores for iters 1,2
+      const seq = [0.46, 0.5, 0.97, 0.96]
+      return seq[measureCalls - 1] ?? 0.97
+    }) as never
+    const picks = ['src/live-status/tool-status-labels.ts', 'src/tools/memory.ts']
+    let selectCalls = 0
+    deps.runSelectAgent = (async () => {
+      selectCalls += 1
+      return { value: { ...selection, file: picks[selectCalls - 1] ?? picks[0], beforeScore: 0.5 }, usage: emptyUsage() }
+    }) as never
+    const { results, aborted } = await runPipeline(deps)
+    expect(aborted).toBe(false)
+    expect(results).toHaveLength(2)
+    expect(results[0].outcome).toBe('improved')
+    expect(results[1].outcome).toBe('improved')
+    expect(deps.runState.doneSet).toEqual(picks)
+  })
+})
+```
+
+- [ ] **Step 8: Run the chaining test**
+
+Run: `bun test tests/mutation-improve/pipeline.test.ts`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add mutation-improve/src/pipeline.ts tests/mutation-improve/pipeline.test.ts
+git commit -m "feat(mutation-improve): pipeline state machine with runner-measured gates"
+```
+
+---
+
+## Task 11: finalize (push + summary gh PR)
+
+**Files:**
+- Create: `mutation-improve/src/finalize.ts`
+- Create: `tests/mutation-improve/finalize.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `buildSummaryBody(merged, failed): string` (markdown table)
+  - `runFinalize(deps, input): Promise<{ prUrl?: string; pushed: boolean }>` where `input = { config, runState }` and `deps = { execGit, runGh }` (both injected). Pushes `base` to `upstream`, then runs `gh pr create`. On `gh` failure, writes the command to `<runDir>/finalize.log` and resolves with `pushed: true, prUrl: undefined`.
+
+- [ ] **Step 1: Write the failing test `tests/mutation-improve/finalize.test.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { buildSummaryBody, runFinalize } from '../../mutation-improve/src/finalize.js'
+import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
+import type { MutationImproveRunState } from '../../mutation-improve/src/run-state.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+const config = (repoRoot: string): MutationImproveConfig => ({
+  repoRoot, workDir: `${repoRoot}/.mutation-improve`, base: 'master', upstream: 'origin',
+  count: 1, threshold: 0.95, epsilon: 0.02, agentTimeoutMs: 1, buildTimeoutMs: 1,
+  checkCommand: 'x', mutateFileCommand: 'x', agent: { model: 'm', extraArgs: [], timeoutMs: 1 },
+  prBranchPrefix: 'mutation-improve',
+})
+
+describe('finalize', () => {
+  test('buildSummaryBody renders one row per merged file plus a failures section when present', () => {
+    const body = buildSummaryBody(
+      [{ file: 'src/a.ts', beforeScore: 0.4, afterScore: 0.97, iter: 1 }],
+      [{ iter: 2, gate: 'score', reason: 'below' }],
+    )
+    expect(body).toContain('| src/a.ts | 0.4 | 0.97 |')
+    expect(body).toContain('Failed iterations')
+    expect(body).toContain('| 2 | score |')
+  })
+
+  test('runFinalize pushes and opens a PR via gh, returning the URL', async () => {
+    const repoRoot = makeTempDir('fin-')
+    const runState: MutationImproveRunState = {
+      runId: 'r', repoRoot, workDir: `${repoRoot}/.mi`, runDir: `${repoRoot}/.mi/runs/r`,
+      statePath: `${repoRoot}/.mi/runs/r/state.json`, base: 'master', threshold: 0.95, count: 1,
+      currentIteration: 1, doneSet: ['src/a.ts'],
+      merged: [{ file: 'src/a.ts', beforeScore: 0.4, afterScore: 0.97, iter: 1 }],
+      failed: [], status: 'completed',
+    }
+    const seen: string[] = []
+    const execGit = (async (_cwd: string, args: readonly string[]) => {
+      seen.push(args.join(' '))
+      return { stdout: '', stderr: '' }
+    }) as never
+    const runGh = (async () => ({ exitCode: 0, stdout: 'https://github.com/x/pull/9\n', stderr: '' })) as never
+    const out = await runFinalize(
+      { execGit, runGh },
+      { config: config(repoRoot), runState },
+    )
+    expect(out.pushed).toBe(true)
+    expect(out.prUrl).toBe('https://github.com/x/pull/9')
+    expect(seen.some((s) => s.startsWith('push origin master'))).toBe(true)
+  })
+
+  test('runFinalize survives gh failure and still reports pushed=true', async () => {
+    const repoRoot = makeTempDir('fin-fail-')
+    const runState: MutationImproveRunState = {
+      runId: 'r', repoRoot, workDir: `${repoRoot}/.mi`, runDir: `${repoRoot}/.mi/runs/r`,
+      statePath: `${repoRoot}/.mi/runs/r/state.json`, base: 'master', threshold: 0.95, count: 1,
+      currentIteration: 1, doneSet: [], merged: [{ file: 'src/a.ts', beforeScore: 0.4, afterScore: 0.97, iter: 1 }],
+      failed: [], status: 'completed',
+    }
+    const out = await runFinalize(
+      { execGit: (async () => ({ stdout: '', stderr: '' })) as never, runGh: (async () => ({ exitCode: 1, stdout: '', stderr: 'no gh' })) as never },
+      { config: config(repoRoot), runState },
+    )
+    expect(out.pushed).toBe(true)
+    expect(out.prUrl).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test tests/mutation-improve/finalize.test.ts`
+Expected: FAIL — cannot resolve the module.
+
+- [ ] **Step 3: Implement `mutation-improve/src/finalize.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { appendFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import type { MutationImproveConfig } from './config.js'
+import type { MutationImproveRunState } from './run-state.js'
+
+export interface ExecGitFn { (cwd: string, args: readonly string[]): Promise<{ stdout: string; stderr: string }> }
+export interface RunGhFn { (args: readonly string[], cwd: string): Promise<{ exitCode: number; stdout: string; stderr: string }> }
+
+export interface FinalizeDeps { execGit: ExecGitFn; runGh: RunGhFn }
+export interface FinalizeInput { config: MutationImproveConfig; runState: MutationImproveRunState }
+
+export function buildSummaryBody(
+  merged: readonly { file: string; beforeScore: number; afterScore: number; iter: number }[],
+  failed: readonly { iter: number; gate: string; reason: string }[],
+): string {
+  const rows = merged.map((m) => `| ${m.file} | ${m.beforeScore} | ${m.afterScore} | ${m.specPath ?? ''} | ${m.planPath ?? ''} |`).join('\n')
+  const header = '| File | Before | After | Spec | Plan |\n|---|---|---|---|---|\n'
+  let body = `## mutation-improve\n\n${header}${rows}\n`
+  if (failed.length > 0) {
+    body += `\n## Failed iterations\n\n| Iter | Gate | Reason |\n|---|---|---|\n`
+    body += failed.map((f) => `| ${f.iter} | ${f.gate} | ${f.reason} |`).join('\n')
+  }
+  return body
+}
+
+export async function runFinalize(deps: FinalizeDeps, input: FinalizeInput): Promise<{ prUrl?: string; pushed: boolean }> {
+  const { config, runState } = input
+  await deps.execGit(config.repoRoot, ['push', config.upstream, config.base])
+  const title = `mutation-improve: ${runState.merged.map((m) => m.file).join(', ')}`
+  const body = buildSummaryBody(runState.merged, runState.failed)
+  const result = await deps.runGh(
+    ['pr', 'create', '--base', config.base, '--title', title, '--body', body],
+    config.repoRoot,
+  )
+  if (result.exitCode !== 0) {
+    await appendFile(
+      path.join(runState.runDir, 'finalize.log'),
+      `gh pr create failed (exit ${result.exitCode}): ${result.stderr}\nRe-run: gh pr create --base ${config.base} --title ${JSON.stringify(title)} --body <body>\n`,
+    )
+    return { pushed: true }
+  }
+  return { pushed: true, prUrl: result.stdout.trim() || undefined }
+}
+```
+
+> The `buildSummaryBody` test references `m.specPath`/`m.planPath` on merged entries — but `MutationImproveRunState.merged` entries don't carry those fields (see Task 8's `MergedEntrySchema`). The implementer MUST extend `MergedEntrySchema` in `run-state.ts` to include `specPath: z.string().optional()` and `planPath: z.string().optional()`, and the pipeline's `runIteration` must populate them from `result.specPath`/`result.planPath` when pushing to `merged`. Do this as part of this task before running the tests.
+
+- [ ] **Step 4: Extend `MergedEntrySchema` in `mutation-improve/src/run-state.ts`**
+
+```ts
+const MergedEntrySchema = z.object({
+  file: z.string(),
+  beforeScore: z.number(),
+  afterScore: z.number(),
+  iter: z.number().int(),
+  specPath: z.string().optional(),
+  planPath: z.string().optional(),
+})
+```
+
+- [ ] **Step 5: Populate spec/plan in pipeline's merged push**
+
+In `mutation-improve/src/pipeline.ts`, change the merged push to:
+
+```ts
+  deps.runState.merged.push({ file: selection.file, beforeScore, afterScore, iter, specPath: result.specPath, planPath: result.planPath })
+```
+
+- [ ] **Step 6: Run the finalize + pipeline tests**
+
+Run: `bun test tests/mutation-improve/finalize.test.ts tests/mutation-improve/pipeline.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mutation-improve/src/finalize.ts mutation-improve/src/run-state.ts mutation-improve/src/pipeline.ts tests/mutation-improve/finalize.test.ts
+git commit -m "feat(mutation-improve): finalize push + summary gh PR"
+```
+
+---
+
+## Task 12: cli (arg parsing + orchestration)
+
+**Files:**
+- Create: `mutation-improve/src/cli.ts`
+- Create: `tests/mutation-improve/cli.test.ts`
+
+**Interfaces:**
+- Produces: `parseCliArgs(argv) => CliArgs`, `runCli(argv) => Promise<void>` (wires real `realSpawn`, `execGit`, `createShellExec`, `runAgent`, worktree fns; builds `PipelineDeps`; runs `runPipeline`; runs `runFinalize` unless `--no-pr`; exits 1 if any `failed`).
+
+- [ ] **Step 1: Write the failing test `tests/mutation-improve/cli.test.ts`** (arg parsing + precedence)
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { parseCliArgs } from '../../mutation-improve/src/cli.js'
+
+describe('cli parseCliArgs', () => {
+  test('parses --config and requires --config (default exists)', () => {
+    const args = parseCliArgs(['--config', '/c.json'])
+    expect(args.configPath).toBe('/c.json')
+    expect(args.count).toBeUndefined()
+    expect(args.noPr).toBe(false)
+  })
+
+  test('parses --count, --threshold, --base, --no-pr', () => {
+    const args = parseCliArgs(['--count', '3', '--threshold=0.9', '--base', 'develop', '--no-pr'])
+    expect(args.count).toBe(3)
+    expect(args.threshold).toBe(0.9)
+    expect(args.base).toBe('develop')
+    expect(args.noPr).toBe(true)
+  })
+
+  test('rejects non-positive --count', () => {
+    expect(() => parseCliArgs(['--count', '0'])).toThrow()
+  })
+
+  test('parses --resume-run and --reset-worktree', () => {
+    const args = parseCliArgs(['--resume-run', 'r1', '--reset-worktree'])
+    expect(args.resumeRunId).toBe('r1')
+    expect(args.resetWorktree).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test tests/mutation-improve/cli.test.ts`
+Expected: FAIL — cannot resolve the module.
+
+- [ ] **Step 3: Implement `mutation-improve/src/cli.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import path from 'node:path'
+
+import { runAgent, agentWritePath, type SpawnFn, type AgentUsage } from '../review-loop/src/agent-runner.js'
+import { realSpawn } from '../review-loop/src/spawn.js'
+import { createShellExec, runBuildCheck } from '../review-loop/src/build-checker.js'
+import { createWorktree, mergeWorktree, removeWorktree, resetWorktree, execGit } from '../review-loop/src/worktree.js'
+
+import { loadMutationImproveConfig, type MutationImproveConfig } from './config.js'
+import { createRunState, loadRunState, saveRunState, type MutationImproveRunState } from './run-state.js'
+import { SelectionSchema, type Selection } from './selection-schema.js'
+import { ResultSchema, type Result } from './result-schema.js'
+import { measureMutationScore } from './score-reader.js'
+import { readBaseline, writeBaseline } from './baseline.js'
+import { runPipeline, type PipelineDeps } from './pipeline.js'
+import { runFinalize } from './finalize.js'
+import { LiveRenderer } from '../review-loop/src/live-renderer.js'
+
+export interface CliArgs {
+  configPath: string
+  count?: number
+  threshold?: number
+  base?: string
+  resumeRunId?: string
+  resetWorktree: boolean
+  noPr: boolean
+}
+
+function readValueArg(argv: readonly string[], index: number, name: string): string {
+  const value = argv[index + 1]
+  if (value === undefined) throw new Error(`Missing value for ${name}`)
+  return value
+}
+
+export function parseCliArgs(argv: readonly string[]): CliArgs {
+  const flags: CliArgs = { configPath: path.join(import.meta.dir, '..', 'config.json'), resetWorktree: false, noPr: false }
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === undefined) continue
+    if (arg === '--config') { flags.configPath = readValueArg(argv, i, '--config'); i += 1; continue }
+    if (arg === '--count') {
+      const v = Number(readValueArg(argv, i, '--count'))
+      if (!Number.isInteger(v) || v < 1) throw new Error('--count must be a positive integer')
+      flags.count = v; i += 1; continue
+    }
+    if (arg.startsWith('--threshold=')) { flags.threshold = Number(arg.slice('--threshold='.length)); continue }
+    if (arg === '--base') { flags.base = readValueArg(argv, i, '--base'); i += 1; continue }
+    if (arg === '--resume-run') { flags.resumeRunId = readValueArg(argv, i, '--resume-run'); i += 1; continue }
+    if (arg === '--reset-worktree') { flags.resetWorktree = true; continue }
+    if (arg === '--no-pr') { flags.noPr = true; continue }
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+  return flags
+}
+
+export async function runCli(argv: readonly string[]): Promise<void> {
+  const args = parseCliArgs(argv)
+  const config = await loadMutationImproveConfig({ configPath: args.configPath })
+  if (args.count !== undefined) config.count = args.count
+  if (args.threshold !== undefined) config.threshold = args.threshold
+  if (args.base !== undefined) config.base = args.base
+
+  const runState: MutationImproveRunState =
+    args.resumeRunId === undefined
+      ? await createRunState(config)
+      : await loadRunState(config.workDir, args.resumeRunId)
+
+  const log = new LiveRenderer(process.stdout)
+  const deps: PipelineDeps = {
+    config,
+    runState,
+    spawn: realSpawn,
+    createWorktree,
+    resetWorktree,
+    removeWorktree,
+    mergeWorktree,
+    execGit,
+    runBuildCheck: async () => {
+      const exec = createShellExec(runState.runDir, config.checkCommand, config.buildTimeoutMs)
+      return runBuildCheck({ exec: () => exec() })
+    },
+    measureScore: async (worktreePath: string, srcFile: string) => {
+      const exec = createShellExec(worktreePath, `${config.mutateFileCommand} ${srcFile}`, config.agentTimeoutMs)
+      return measureMutationScore({ exec: () => exec() }, path.join(worktreePath, 'reports', 'paired'), srcFile)
+    },
+    readBaseline,
+    writeBaseline,
+    runSelectAgent: (worktreePath, prompt) =>
+      runAgent({
+        spawn: realSpawn as SpawnFn,
+        model: config.agent.model,
+        cwd: worktreePath,
+        prompt,
+        outputPath: path.join(runState.runDir, 'iter', 'selection.json'),
+        outputSchema: SelectionSchema as unknown as import('zod').ZodType<Selection>,
+        label: 'select',
+        logPath: path.join(runState.runDir, 'agent-output.log'),
+        extraArgs: config.agent.extraArgs,
+        reporter: log,
+        timeoutMs: config.agent.timeoutMs,
+      }),
+    runImproveAgent: (worktreePath, prompt) =>
+      runAgent({
+        spawn: realSpawn as SpawnFn,
+        model: config.agent.model,
+        cwd: worktreePath,
+        prompt,
+        outputPath: path.join(runState.runDir, 'iter', 'result.json'),
+        outputSchema: ResultSchema as unknown as import('zod').ZodType<Result>,
+        label: 'improve',
+        logPath: path.join(runState.runDir, 'agent-output.log'),
+        extraArgs: config.agent.extraArgs,
+        reporter: log,
+        timeoutMs: config.agent.timeoutMs,
+      }),
+    log,
+  }
+
+  const { results, aborted } = await runPipeline(deps)
+  await saveRunState(runState)
+
+  const failed = results.filter((r) => r.outcome === 'failed')
+  if (!args.noPr && runState.merged.length > 0 && !aborted) {
+    const runGh = async (ghArgs: readonly string[], cwd: string) => {
+      const { execFile } = await import('node:child_process')
+      return new Promise<{ exitCode: number; stdout: string; stderr: string }>((resolve) => {
+        execFile('gh', [...ghArgs], { cwd, maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) =>
+          resolve({ exitCode: err === null ? 0 : 1, stdout, stderr }),
+        )
+      })
+    }
+    await runFinalize({ execGit, runGh }, { config, runState })
+  }
+  if (failed.length > 0 || aborted) process.exitCode = 1
+}
+
+if (import.meta.main) {
+  runCli(process.argv.slice(2)).catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}
+```
+
+- [ ] **Step 4: Run the cli test to verify it passes**
+
+Run: `bun test tests/mutation-improve/cli.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mutation-improve/src/cli.ts tests/mutation-improve/cli.test.ts
+git commit -m "feat(mutation-improve): cli arg parsing and orchestration"
+```
+
+---
+
+## Task 13: Hermetic end-to-end integration test
+
+**Files:**
+- Create: `tests/mutation-improve/integration.test.ts`
+
+**Goal:** One test that wires the real `runPipeline` to fakes for every external (spawn, git, agent, score, build, gh) and asserts the full `createRunState → runPipeline → runFinalize` flow produces a merged entry, a ratcheted baseline, and a PR URL — proving the modules compose. This mirrors `tests/review-loop/fake-agent-integration.test.ts`.
+
+- [ ] **Step 1: Write the integration test**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { runPipeline, type PipelineDeps } from '../../mutation-improve/src/pipeline.js'
+import { runFinalize } from '../../mutation-improve/src/fipeline-finalize-skip.js' // placeholder: see note
+import { createRunState } from '../../mutation-improve/src/run-state.js'
+import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
+import { readBaseline, writeBaseline } from '../../mutation-improve/src/baseline.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+describe('integration', () => {
+  test('runPipeline + runFinalize end-to-end with all externals faked', async () => {
+    const repoRoot = makeTempDir('e2e-')
+    // seed a baseline file
+    await writeBaseline(repoRoot, { 'src/foo.ts': 0.4 })
+    const config: MutationImproveConfig = {
+      repoRoot,
+      workDir: `${repoRoot}/.mutation-improve`,
+      base: 'master', upstream: 'origin', count: 1, threshold: 0.95, epsilon: 0.02,
+      agentTimeoutMs: 1_800_000, buildTimeoutMs: 600_000,
+      checkCommand: 'bun check:full', mutateFileCommand: 'bun test:mutate:file',
+      agent: { model: 'm', extraArgs: [], timeoutMs: 1_800_000 },
+      prBranchPrefix: 'mutation-improve',
+    }
+    const runState = await createRunState(config)
+
+    const deps: PipelineDeps = {
+      config, runState,
+      spawn: (async () => ({ exitCode: 0, stdout: '', stderr: '' })) as never,
+      createWorktree: (async () => undefined) as never,
+      resetWorktree: (async () => undefined) as never,
+      removeWorktree: (async () => undefined) as never,
+      mergeWorktree: (async () => ({ ok: true })) as never,
+      execGit: (async () => ({ stdout: 'tests/foo.test.ts\n', stderr: '' })) as never,
+      runBuildCheck: (async () => ({ passed: true, stdout: '', stderr: '' })) as never,
+      measureScore: (async () => 0.97) as never,
+      readBaseline: (async () => readBaseline(repoRoot)) as never,
+      writeBaseline: (async (_r: string, m: Record<string, number>) => writeBaseline(repoRoot, m)) as never,
+      runSelectAgent: (async () => ({
+        value: { file: 'src/foo.ts', beforeScore: 0.4, rationale: 'x', runnerUps: [] },
+        usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0, wallMs: 0 },
+      })) as never,
+      runImproveAgent: (async () => ({
+        value: {
+          specPath: 'docs/superpowers/specs/x-design.md', planPath: 'docs/superpowers/plans/x.md',
+          testPaths: ['tests/foo.test.ts'], residuals: [], notes: '',
+        },
+        usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0, wallMs: 0 },
+      })) as never,
+      log: { log: () => undefined },
+    }
+
+    const { results, aborted } = await runPipeline(deps)
+    expect(aborted).toBe(false)
+    expect(results[0]).toMatchObject({ outcome: 'improved', file: 'src/foo.ts', afterScore: 0.97 })
+
+    const finalBaseline = await readBaseline(repoRoot)
+    expect(finalBaseline['src/foo.ts']).toBe(0.97)
+
+    const out = await runFinalize(
+      { execGit: (async () => ({ stdout: '', stderr: '' })) as never, runGh: (async () => ({ exitCode: 0, stdout: 'https://github.com/x/pull/1\n', stderr: '' })) as never },
+      { config, runState },
+    )
+    expect(out.prUrl).toBe('https://github.com/x/pull/1')
+  })
+})
+```
+
+> **Fix the placeholder import** before running: the test imports `runFinalize` from a nonexistent `pipeline-finalize-skip.js`. Change that import line to:
+> ```ts
+> import { runFinalize } from '../../mutation-improve/src/finalize.js'
+> ```
+> (shown broken above purely to force the implementer to wire the real module rather than copy blindly).
+
+- [ ] **Step 2: Fix the import and run the integration test**
+
+Run: `bun test tests/mutation-improve/integration.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full suite + workspace gates**
+
+Run: `bun run mutation-improve:test && bun run mutation-improve:typecheck && bun run mutation-improve:lint && bun run mutation-improve:format:check`
+Expected: all PASS.
+
+- [ ] **Step 4: Run the repo-wide gate to confirm no regression elsewhere**
+
+Run: `bun check:verbose`
+Expected: PASS (including review-loop tests, confirming Task 2's parametrization is backward-compatible).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/mutation-improve/integration.test.ts
+git commit -m "test(mutation-improve): hermetic end-to-end integration test"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:** every section of `2026-08-05-mutation-improve-runner-design.md` maps to a task. Workspace layout → Task 1 + per-module tasks. Reuse list → Tasks 2, 5, 10, 12. State machine (①–⑨) → Task 10 (①–⑧) + Task 11 (⑨). Contracts → Task 4. Prompts → Task 9. Gates table → Task 10 (all five gates). Resume / persisted state → Task 8 + Task 12 (`--resume-run`). Config & CLI → Tasks 3, 12. Score reading → Task 5. Testing strategy → every task is TDD; the spine is Task 10; integration is Task 13.
+
+**Placeholder scan:** the two intentionally-broken markers (the `require(...)` lint-risk illustration in Task 5 Step 3 and the placeholder import in Task 13 Step 1) are both explicitly called out with the fix in the immediately following step. No "TBD"/"implement later"/"similar to Task N" remains.
+
+**Type consistency:** `MergedEntrySchema` gains `specPath`/`planPath` in Task 11 Step 4, and Task 10's pipeline push is updated in Task 11 Step 5 to populate them — `buildSummaryBody` (Task 11) and the integration test (Task 13) both rely on those fields. `PipelineDeps` field names (`runSelectAgent`, `runImproveAgent`, `measureScore`, `readBaseline`, `writeBaseline`, `createWorktree(repoRoot, worktreePath, runId, branchPrefix)`) are identical across Tasks 10, 11, 12, 13. `IterationResult` shape (`iter`, `outcome`, `file`, `beforeScore`, `afterScore`, `gate`, `reason`) is consistent across Tasks 10, 11, 12.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-08-05-mutation-improve-runner.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-08-05-mutation-improve-runner-design.md
+++ b/docs/superpowers/specs/2026-08-05-mutation-improve-runner-design.md
@@ -1,0 +1,452 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation-Improve Runner — Autonomous Workflow Automation
+
+**Date:** 2026-08-05
+**Status:** Design — approved (pending implementation plan)
+**Type:** New tooling workspace (test-only + tooling; no papai runtime changes)
+
+## Summary
+
+The `mutation-improve-01..07` branches each followed an identical, stable
+procedure to lift one file's mutation score: select a high-ROI file from
+`scripts/mutation/baseline.json`, write a design spec, write an implementation
+plan, capture the "before" score, add exact-equality characterization tests
+task-by-task, verify ≥ 0.95, ratchet the baseline, document equivalent
+residuals, and open a PR. Each branch was driven manually by an AI agent.
+
+This spec designs a **single fully-autonomous runner** that automates that
+procedure end-to-end, reusing the `review-loop/` workspace's harness primitives
+(worktree isolation, `opencode run --auto` agent spawning with file-based JSON
+exchange, run-state, config, build-checker, live rendering, trace logging) but
+**not** its review/match/fix issue loop. The runner uses **one agent/model** for
+two phased invocations per file (select, then improve); it does **not** need the
+reviewer/matcher/fixer/inspector roles that review-loop orchestrates.
+
+The runner preserves review-loop's core integrity contract — **the runner
+measures, the agent creates** — by owning every score measurement, the baseline
+bump, the diff-scope guard, the build gate, the merge, and the summary PR. The
+agent cannot fake a score or game the baseline.
+
+## Why this shape
+
+- **Fully autonomous** (chosen) — the procedure is stable; operator kicks off
+  `bun run mutation-improve:start -- --count 3` and gets a summary PR. Mirrors
+  how `review-loop` runs unattended.
+- **Sibling workspace** (chosen) — a new `mutation-improve/` Bun workspace
+  mirrors `review-loop/`'s layout and imports the few reusable primitives from
+  `../review-loop/src/` via path imports. Clean separation; gets its own TDD
+  gate mapped to `tests/mutation-improve/`.
+- **Agent selects the file** (chosen) — rather than encoding fragile
+  selection heuristics in TypeScript, the select-phase agent reads
+  `baseline.json` and applies the same ROI judgment the human branches did
+  (reject declarative tables, `Math.random` jitter, passthrough wrappers,
+  schemas already at ~1.0). `--count N` runs the pipeline on N files in
+  sequence.
+- **Local sequential merge + one summary PR** (chosen) — each iteration
+  merges into `base` in-sequence (review-loop's `mergeWorktree`), so iteration
+  `i+1`'s worktree sees iteration `i`'s baseline bump. After all iterations,
+  one GitHub PR covers the batch. Avoids per-iteration PR conflicts entirely.
+
+## Non-goals
+
+- No changes to papai runtime code under `src/`, `client/`, or `plugins/`.
+- No new mutation-testing infrastructure — reuses `scripts/mutation/`'s paired
+  runner (`bun test:mutate:file`) and `baseline.json` as-is.
+- No parallelism — a single linear pipeline (no worker pool). review-loop's
+  `worker-pool.ts` exists only to fix issues concurrently, which this runner
+  does not do.
+- No re-implementation of review-loop's loop. The `loop-controller`,
+  `issue-ledger`, `issue-matcher`, `issue-processor*`, `issue-schema`,
+  `issue-inspector`, `commit-attempt`, and `summary-burndown` modules are
+  explicitly **not** reused.
+- No automatic inflation of `--count` or speculative retries beyond
+  `runAgent`'s built-in once-retry.
+
+## Workspace layout & reuse
+
+A new sibling Bun workspace `mutation-improve/`, mirroring `review-loop/`'s
+layout:
+
+```
+mutation-improve/
+  package.json          # name: "mutation-improve", private, type: module; deps: zod
+  tsconfig.json         # extends repo TS config, includes src
+  config.example.json   # documented config shape
+  src/
+    cli.ts              # arg parsing, orchestrates the run
+    config.ts           # Zod schema + loader (mirrors review-loop/config.ts)
+    run-state.ts        # per-run + per-iteration persisted state
+    selection-schema.ts # Zod schema for selection.json (agent → runner)
+    result-schema.ts    # Zod schema for result.json (agent → runner)
+    score-reader.ts     # parses reports/paired/*.json → per-file score
+    baseline.ts         # reads/writes scripts/mutation/baseline.json
+    diff-guard.ts       # git diff --name-only scope check
+    pipeline.ts         # the per-file select→improve→verify→ratchet→merge machine
+    prompt-templates.ts # select + improve prompts (the workflow procedure)
+    finalize.ts         # open summary gh PR after N iterations
+tests/mutation-improve/ # TDD gate maps here (per repo convention)
+```
+
+**Reused from `../review-loop/src/` via path imports** (harness primitives,
+unchanged):
+
+- `agent-runner.ts` → `runAgent`, `agentWritePath`, `SpawnFn`, `AgentRunError`
+- `spawn.ts` → `realSpawn`
+- `build-checker.ts` → `createShellExec`, `runBuildCheck`
+- `worktree.ts` → `createWorktree` / `mergeWorktree` / `removeWorktree` /
+  `resetWorktree` / `detectGitRoot` / `cleanWorkerWorktrees`
+- `line-handler.ts`, `progress-log.ts`, `live-renderer.ts`, `trace-log.ts` →
+  reused verbatim for live progress and `trace.jsonl`.
+
+**One backward-compatible change to a shared file:** `worktree.ts` hardcodes
+the branch prefix as `review-loop/${runId}` inside `createWorktree` and
+`removeWorktree`. The reuse strategy parametrizes this with a `branchPrefix`
+argument (default `"review-loop"` so review-loop's own calls are unchanged);
+the new caller passes `"mutation-improve"`. This avoids duplicating ~180 lines
+of git plumbing and keeps a single source of truth for merge/conflict
+recovery.
+
+## Per-file pipeline (the state machine)
+
+For each of `--count N` iterations, the runner drives this linear state
+machine. The runner owns measurement and integrity; the agent owns judgment and
+creation. Both invocations use the **same** agent/model.
+
+```
+ITERATION i  (i = 1..N)
+
+  runner: createWorktree(base)   ← worktree off the configured base branch;
+                                    after iteration 1 merges, iteration 2's
+                                    worktree is created from the updated base,
+                                    so it sees iteration 1's baseline bump.
+
+  ① SELECT  (agent invocation #1)
+     prompt: read baseline.json, pick best-ROI file NOT in the done-set,
+             applying the rejection rules (declarative/schema tables already
+             ≥ 0.9, Math.random jitter, 1-passthrough wrappers, files whose
+             companion test cannot exercise behaviour).
+     agent writes: <runDir>/iter/i/selection.json
+        { file, beforeScore, rationale, runnerUps: [{file, score, why}] }
+     runner validates: file exists, is in baseline.json, is not in the
+                       done-set, beforeScore ≈ baseline.json[file] (sanity).
+     → doneSet.add(file)
+
+  ② CAPTURE BEFORE  (runner, optional sanity)
+     run `bun test:mutate:file <file>` in the worktree
+     parse reports/paired/<file>.json → beforeScore
+     if beforeScore ≥ threshold: nothing to improve, skip iteration
+
+  ③ IMPROVE  (agent invocation #2)
+     prompt: write spec → docs/superpowers/specs/<date>-mutation-coverage-
+             <stem>-design.md; write plan → docs/superpowers/plans/<date>-
+             mutation-coverage-<stem>.md; add exact-equality tests to the
+             companion test file (extend existing describe); MUST NOT edit
+             src/; MUST NOT edit baseline.json; target ≥ threshold; document
+             equivalent residuals.
+     agent writes: <runDir>/iter/i/result.json
+        { specPath, planPath, testPaths: [...],
+          residuals: [{ loc, why }], notes }
+
+  ④a DIFF-GUARD  (runner, hard gate)
+     git diff --name-only in the worktree
+     allowed scope: { tests/**, docs/superpowers/** }
+     (baseline.json is NOT yet touched — the runner owns it; see ⑥)
+     FAIL iteration if any src/ or out-of-scope file changed.
+
+  ④b BUILD GREEN  (runner, hard gate)
+     run `bun check:full` in the worktree via review-loop's runBuildCheck
+     (typecheck + lint + format). The runner measures; it does not trust the
+     agent to have run it.
+     FAIL iteration → write build-check.log.
+
+  ⑤ VERIFY  (runner, hard gate — the integrity hinge)
+     run `bun test:mutate:file <file>` in the worktree (the runner measures;
+     it does NOT trust the agent's reported score).
+     parse → afterScore
+     PASS if: afterScore ≥ threshold
+          OR (afterScore ≥ threshold − epsilon
+              AND result.json.residuals justifies the gap with
+              equivalent-mutant reasoning)
+     FAIL → resetWorktree, record failure to iter/i/failure.json,
+            DO NOT merge, DO NOT ratchet, continue to iteration i+1.
+
+  ⑥ RATCHET  (runner, owns baseline.json)
+     scripts/mutation/baseline.json[file] = afterScore
+        (the runner's measured score, not the agent's)
+     git add + commit:
+        "chore(mutation): ratchet <file> baseline to <score>"
+
+  ⑦ MERGE  (runner)
+     mergeWorktree(base, mutation-improve/<runId>-iter<i>) → base
+     on conflict: abort merge, record, DO NOT continue chaining
+     (review-loop pattern). Run ends with recovery instructions.
+
+  ⑧ removeWorktree; loop to iteration i+1.
+
+After iteration N (or on terminal merge-conflict failure):
+
+  ⑨ FINALIZE  — if ≥ 1 iteration merged:
+     push base; open ONE summary gh PR covering all merged file commits.
+```
+
+### Integrity properties
+
+- **⑤ measures independently of ③** — the agent never reports its own score;
+  the runner re-runs Stryker and reads the JSON report. A misbehaving agent
+  cannot ratchet the baseline wrong.
+- **⑥ baseline bump is runner-owned** — the agent is forbidden from editing
+  `baseline.json` (enforced by ④a's diff-guard before ⑥ ever runs), so the
+  recorded floor always equals the runner's measured score.
+- **④b build gate is runner-run** — consistent with review-loop's
+  `finalizeRun` running `runBuildCheck` itself rather than trusting the agent.
+
+## Agent ↔ runner contracts
+
+The two file-based handshakes are the only coupling between agent and runner.
+Both are Zod-validated on read (mirrors review-loop's `ReviewerIssuesSchema`
+consumption).
+
+### `selection.json` (select-phase output)
+
+```ts
+{
+  file: string            // repo-relative, e.g. "src/live-status/tool-status-labels.ts"
+  beforeScore: number     // agent's read of baseline.json[file]; sanity-checked
+                          //   ≈ runner's own read of baseline.json
+  rationale: string       // 1-3 sentences: why this file (pure, headroom,
+                          //   existing companion test, killable mutants)
+  runnerUps: [            // 2-3 rejected candidates; preserves the human
+                          //   "selection table" artifact
+    { file: string, score: number, why: string }
+  ]
+}
+```
+
+### `result.json` (improve-phase output)
+
+```ts
+{
+  specPath: string        // docs/superpowers/specs/<date>-mutation-coverage-<stem>-design.md
+  planPath: string        // docs/superpowers/plans/<date>-mutation-coverage-<stem>.md
+  testPaths: string[]     // tests/… files the agent added/extended
+  residuals: [            // equivalent mutants the agent accepts; consumed by
+                          //   gate ⑤ as the below-threshold qualifier
+    { loc: string, why: string }   // loc: "src/foo.ts L21 Array.isArray guard";
+                                   // why: equivalent-mutant reasoning
+  ]
+  notes: string           // freeform surprises (e.g. "pre-existing bug in X")
+}
+```
+
+The runner never acts on agent-reported **scores**: `beforeScore` is only a
+sanity cross-check against the runner's `baseline.json` read (mismatch → warn,
+proceed with the runner's value). `residuals` is the only agent-reported field
+that influences a gate, and only as a qualifier on a *measured* below-threshold
+score.
+
+### Prompts (`prompt-templates.ts`)
+
+- **`buildSelectPrompt(doneSet, baselineSummary)`** — instructs: read
+  `scripts/mutation/baseline.json`; pick the highest-ROI file where
+  ROI = reliable score gain per test effort; reject files matching the
+  patterns the human branches rejected (declarative/schema tables already
+  ≥ 0.9, pure `Math.random` jitter, single-statement passthrough wrappers,
+  files whose companion test cannot exercise behaviour); exclude the
+  done-set; write `selection.json` at the absolute scratch path provided.
+  The rejection heuristics are enumerated in the prompt text, distilled from
+  the seven branches' "Why this file" tables, so the agent applies the same
+  judgment a human would.
+
+- **`buildImprovePrompt(file, beforeScore, threshold)`** — instructs the agent
+  to execute, verbatim, the procedure every branch followed:
+  1. **Spec** → `docs/superpowers/specs/<date>-mutation-coverage-<stem>-design.md`
+     using the section template (Summary / Why this file / Non-goals / Gap
+     analysis (surviving mutant classes table) / Design — tests to add
+     (one-to-one onto gap classes) / Verification / Accepted residuals). The
+     agent MUST first run `bun test:mutate:file <file>` to enumerate the
+     actual surviving mutants and ground the gap analysis in the real report,
+     not speculation.
+  2. **Plan** → `docs/superpowers/plans/<date>-mutation-coverage-<stem>.md`
+     with task-per-mutant-class checkbox structure and global constraints
+     (test-only; exact-`toBe`-equality discipline; no `src/` edits; SPDX
+     license headers; emoji copied verbatim from source).
+  3. **Tests** → extend the existing companion `describe` block; every
+     assertion exact `toBe(...)`; one test per mutant class.
+  4. **Residuals** → enumerate equivalent mutants that survive and cannot be
+     killed, with per-loc reasoning → `result.json.residuals`.
+
+  Hard constraints stated in the prompt: MUST NOT edit anything under `src/`
+  (the runner's diff-guard rejects the iteration); MUST NOT edit
+  `scripts/mutation/baseline.json` (runner-owned); MUST run
+  `bun test tests/<companion>` green before finishing; write `result.json`.
+
+Both prompts reuse review-loop's `runAgent` machinery (absolute scratch path
+via `agentWritePath`, `--format json` usage streaming, retry-once-on-failure,
+timeout → `AgentRunError`).
+
+## Gates, failure modes & resume
+
+Hard gates the runner enforces (all measured, none agent-reported). An
+iteration **fails closed**: reset its worktree, record the failure to
+`<runDir>/iter/i/failure.json`, do not merge, do not ratchet, then continue to
+`i+1`. Only a merge conflict aborts the whole run (the base cannot be chained
+past a broken state).
+
+| # | Gate | What | On fail |
+|---|---|---|---|
+| ① | selection validates | `file` exists, in baseline.json, not in done-set, `beforeScore` ≈ baseline entry | skip iteration (re-run select once) |
+| ④a | diff-scope | `git diff --name-only` ⊆ { `tests/**`, `docs/superpowers/**` } — `src/` and `baseline.json` untouched by agent | fail iteration |
+| ④b | build green | runner runs `bun check:full` in worktree via `runBuildCheck` | fail iteration; write `build-check.log` |
+| ⑤ | mutation score | runner-run `bun test:mutate:file <file>`: `afterScore ≥ threshold`, OR `≥ threshold − ε` with justified `result.json.residuals` | fail iteration |
+| ⑦ | merge clean | `mergeWorktree` conflict-free (review-loop pattern; auto-aborts on conflict) | **abort run** with recovery instructions |
+
+Defaults: `threshold = 0.95` (the target every historical branch used),
+`epsilon = 0.02` (the residual-floor tolerance the branches effectively
+allowed — e.g. tool-status-labels settled at 0.9714; some files plateau lower).
+Both configurable.
+
+**Agent-invocation failures** (non-zero exit, timeout, missing or malformed
+JSON scratch file) flow through review-loop's existing `runAgent`
+retry-once-then-`AgentRunError`. An `AgentRunError` in select fails the
+iteration; in improve it fails the iteration (the worktree's tests/spec/plan
+are discarded by reset). Agent usage (tokens/cost/wall) is tallied per
+iteration into `trace.jsonl`.
+
+**Resume (`--resume-run <runId>`)** mirrors review-loop: reload `state.json`,
+skip already-merged iterations, continue from the first non-terminal
+iteration. Persisted per-run state:
+
+```ts
+{
+  runId: string,
+  repoRoot: string,
+  base: string,
+  threshold: number,
+  count: number,
+  currentIteration: number,
+  doneSet: string[],                          // files already improved (select exclusion)
+  merged: [{ file, beforeScore, afterScore, iter }],   // → summary PR body
+  failed: [{ iter, file, gate, reason }],              // → summary PR body + exit code
+  status: 'running' | 'completed' | 'aborted'
+}
+```
+
+**Finalize (⑨)** runs only if `merged.length > 0`: push `base` to
+`<upstream>` (e.g. `git push origin <base>`), then
+`gh pr create --base <base> --title "mutation-improve: <file1>, <file2>, …" --body <summary table>`
+(`--base` takes the branch name, e.g. `master`; `<upstream>` is the remote
+pushed to).
+The summary body is auto-generated: one row per iteration
+(`file | before → after | spec link | plan link | residuals count | ✓/✗`). If
+`failed.length > 0` the PR body includes a "Failed iterations" section and the
+process exits **1** (so CI/operator sees the partial failure), but successful
+merges are still PR'd. `gh` absence or failure warns and writes the push plus
+a ready-to-paste `gh` command to `<runDir>/finalize.log`; the merges already
+happened locally, so nothing is lost.
+
+## Config & CLI
+
+`config.example.json` (mirrors review-loop's shape; loaded by `config.ts` via
+Zod):
+
+```jsonc
+{
+  "repoRoot": ".",
+  "workDir": ".mutation-improve",
+  "base": "master",
+  "upstream": "origin",
+  "count": 1,
+  "threshold": 0.95,
+  "epsilon": 0.02,
+  "agentTimeoutMs": 1800000,
+  "buildTimeoutMs": 600000,
+  "checkCommand": "bun check:full",
+  "mutateFileCommand": "bun test:mutate:file",
+  "agent": {
+    "model": "opencode/claude-sonnet-4-6",
+    "extraArgs": [],
+    "timeoutMs": 1800000
+  },
+  "prBranchPrefix": "mutation-improve"
+}
+```
+
+CLI (`src/cli.ts`, mirrors review-loop's `parseCliArgs`):
+
+```
+bun run mutation-improve:start -- --config <path> [--count N] [--threshold T]
+                                     [--base <branch>] [--resume-run <id>]
+                                     [--reset-worktree] [--no-pr]
+```
+
+- `--count` / `--threshold` / `--base` override config (CLI wins).
+- `--no-pr` skips finalize ⑨ (just merges locally; operator pushes manually) —
+  useful for local dry-runs.
+- `package.json` scripts (run from repo root, exactly like review-loop):
+  `mutation-improve:test` (`bun test tests/mutation-improve`), `:typecheck`,
+  `:lint`, `:format:check`, `:start` (`bun run mutation-improve/src/cli.ts`).
+
+## Score reading
+
+`score-reader.ts`: the paired runner writes `reports/paired/scores.json`
+(aggregate) and `reports/paired/<escaped-file>.json` (per-file Stryker report).
+The reader parses the per-file report's `mutationScore`; if the report is
+missing or malformed it falls back to re-running
+`bun test:mutate:file <file> --threshold=0` (never trusts a missing artifact).
+This module is the single place that interprets Stryker output, so it is
+heavily unit-tested against fixture reports.
+
+## Testing strategy
+
+`tests/mutation-improve/`, TDD-gated like `tests/review-loop/`.
+
+The runner is a deterministic state machine around nondeterministic externals
+(agent subprocess, git, Stryker). All externals are injected (`SpawnFn`,
+`execGit`, `runBuildCheck`, the score-reader, `mergeWorktree`) so tests are
+hermetic — no real `opencode` / `git` / Stryker in the suite, mirroring how
+review-loop's tests inject `spawn`.
+
+- `pipeline.test.ts` — the spine. Drives the state machine through: happy path
+  (select → improve → verify pass → ratchet → merge); each gate failing
+  (selection invalid, diff-scope violation, build red, score below threshold,
+  score below with unjustified residuals, score below with *justified*
+  residuals → passes); merge conflict aborts run; `--count 3` chains
+  (iteration 2's worktree sees iteration 1's baseline bump via a merged
+  doneSet and an updated `baseline.json` fixture); resume skips merged
+  iterations.
+- `selection-schema.test.ts` / `result-schema.test.ts` — `schemaValidates()`
+  round-trips (reuse `tests/utils/test-helpers.ts`).
+- `score-reader.test.ts` — parses real-shape Stryker JSON fixtures (one
+  passing, one missing `mutationScore`, one malformed → triggers fallback
+  re-run).
+- `baseline.test.ts` — bump writes measured score, preserves all other
+  entries, sorts keys for a stable diff.
+- `diff-guard.test.ts` — allows `tests/` + `docs/superpowers/`, rejects `src/`
+  and `baseline.json`.
+- `config.test.ts` — defaults, CLI-override precedence, `--no-pr`.
+
+## Risk & notes
+
+- **Worktree branch-prefix parametrization** is the only change to a shared
+  file (`review-loop/src/worktree.ts`). It is additive with a safe default;
+  review-loop's existing calls are unchanged and its tests stay green.
+- **The improve-phase prompt is large** (spec + plan + tests + residuals).
+  review-loop's experience is that single-shot mega-prompts are less reliable
+  than phased ones — which is exactly why this design splits select from
+  improve. If improve proves unreliable in practice, the natural fallback
+  (future work, not in scope) is to split it further into spec→plan→tests.
+- **The `epsilon` residual-escape at ⑤** is the one place an agent-reported
+  field (`result.json.residuals`) influences a gate. It is bounded
+  (`threshold − ε`, not unbounded) and the residuals are auditable in the PR.
+  The alternative — requiring `≥ threshold` unconditionally — would reject
+  files with genuine equivalent-mutant floors (which the historical branches
+  accepted, e.g. six equivalent residuals in tool-status-labels).
+- **TDD write hooks** apply inside the worktree (it is a real checkout). The
+  workflow is test-only (edits `tests/`), so the `src/` red-green gate does
+  not fire; the runner's own diff-guard (④a) enforces test-only independently.

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -26,10 +26,11 @@ const svelteCompiler = (source: string): string => {
 }
 
 export default {
-  // The review-loop workspace is a standalone developer tool with its own
-  // check suite (review-loop:lint/typecheck/format:check/test) run separately
-  // in check:full. knip-bun cannot resolve its .js-extension imports.
-  ignoreWorkspaces: ['review-loop'],
+  // The review-loop and mutation-improve workspaces are standalone developer
+  // tools with their own check suites (review-loop:lint/typecheck/format:check/test
+  // and mutation-improve:lint/typecheck/format:check/test) run separately
+  // in check:full. knip-bun cannot resolve their .js-extension imports.
+  ignoreWorkspaces: ['review-loop', 'mutation-improve'],
 
   compilers: { '.svelte': svelteCompiler },
 

--- a/mutation-improve/config.example.json
+++ b/mutation-improve/config.example.json
@@ -1,0 +1,19 @@
+{
+  "repoRoot": ".",
+  "workDir": ".mutation-improve",
+  "base": "master",
+  "upstream": "origin",
+  "count": 1,
+  "threshold": 0.95,
+  "epsilon": 0.02,
+  "agentTimeoutMs": 1800000,
+  "buildTimeoutMs": 600000,
+  "checkCommand": "bun check:full",
+  "mutateFileCommand": "bun test:mutate:file",
+  "agent": {
+    "model": "opencode/claude-sonnet-4-6",
+    "extraArgs": [],
+    "timeoutMs": 1800000
+  },
+  "prBranchPrefix": "mutation-improve"
+}

--- a/mutation-improve/package.json
+++ b/mutation-improve/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mutation-improve",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "cd .. && bun test tests/mutation-improve",
+    "typecheck": "tsgo --project tsconfig.json --noEmit",
+    "lint": "cd .. && oxlint --config .oxlintrc.json mutation-improve/src tests/mutation-improve",
+    "format": "cd .. && oxfmt --write mutation-improve/src tests/mutation-improve --ignore-path=.oxfmtignore",
+    "format:check": "cd .. && oxfmt --check mutation-improve/src tests/mutation-improve --ignore-path=.oxfmtignore",
+    "start": "bun run src/cli.ts"
+  },
+  "dependencies": {
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
+    "typescript": "^7.0.2"
+  }
+}

--- a/mutation-improve/src/baseline.ts
+++ b/mutation-improve/src/baseline.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+export type BaselineMap = Record<string, number>
+
+const BASELINE_REL = path.join('scripts', 'mutation', 'baseline.json')
+
+export function parseBaseline(json: string): BaselineMap {
+  const parsed: unknown = JSON.parse(json)
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('baseline.json must be a JSON object mapping file paths to scores')
+  }
+  const out: BaselineMap = {}
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw new Error(`baseline.json entry "${key}" must be a finite number`)
+    }
+    out[key] = value
+  }
+  return out
+}
+
+export function serializeBaseline(map: BaselineMap): string {
+  const sorted: BaselineMap = {}
+  for (const key of Object.keys(map).sort()) {
+    const value = map[key]
+    if (value !== undefined) sorted[key] = value
+  }
+  return `${JSON.stringify(sorted, null, 2)}\n`
+}
+
+export function bumpScore(map: BaselineMap, file: string, score: number): BaselineMap {
+  const previous = map[file] ?? -Infinity
+  return { ...map, [file]: Math.max(previous, score) }
+}
+
+export async function readBaseline(repoRoot: string): Promise<BaselineMap> {
+  const filePath = path.join(repoRoot, BASELINE_REL)
+  try {
+    const content = await readFile(filePath, 'utf8')
+    return parseBaseline(content)
+  } catch (error) {
+    if (
+      error !== null &&
+      typeof error === 'object' &&
+      'code' in error &&
+      (error as { code?: unknown }).code === 'ENOENT'
+    ) {
+      return {}
+    }
+    throw error
+  }
+}
+
+export async function writeBaseline(repoRoot: string, map: BaselineMap): Promise<void> {
+  await writeFile(path.join(repoRoot, BASELINE_REL), serializeBaseline(map))
+}

--- a/mutation-improve/src/cli.ts
+++ b/mutation-improve/src/cli.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import path from 'node:path'
+
+import { runAgent } from '../../review-loop/src/agent-runner.js'
+import { createShellExec, runBuildCheck } from '../../review-loop/src/build-checker.js'
+import { LiveRenderer } from '../../review-loop/src/live-renderer.js'
+import { realSpawn } from '../../review-loop/src/spawn.js'
+import {
+  createWorktree,
+  execGit,
+  mergeWorktree,
+  removeWorktree,
+  resetWorktree,
+} from '../../review-loop/src/worktree.js'
+import { readBaseline, writeBaseline } from './baseline.js'
+import { type MutationImproveConfig, loadMutationImproveConfig } from './config.js'
+import { runFinalize } from './finalize.js'
+import { runPipeline, type PipelineDeps } from './pipeline.js'
+import { ResultSchema } from './result-schema.js'
+import { createRunState, loadRunState, saveRunState, type MutationImproveRunState } from './run-state.js'
+import { measureMutationScore } from './score-reader.js'
+import { SelectionSchema } from './selection-schema.js'
+
+export interface CliArgs {
+  configPath: string
+  count?: number
+  threshold?: number
+  base?: string
+  resumeRunId?: string
+  resetWorktree: boolean
+  noPr: boolean
+}
+
+const DEFAULT_CONFIG_PATH = path.join(import.meta.dir, '..', 'config.json')
+
+interface GhResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+function readValueArg(argv: readonly string[], index: number, name: string): string {
+  const value = argv[index + 1]
+  if (value === undefined) throw new Error(`Missing value for ${name}`)
+  return value
+}
+
+export function parseCliArgs(argv: readonly string[]): CliArgs {
+  const flags: CliArgs = { configPath: DEFAULT_CONFIG_PATH, resetWorktree: false, noPr: false }
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === undefined) continue
+    if (arg === '--config') {
+      flags.configPath = readValueArg(argv, i, '--config')
+      i += 1
+      continue
+    }
+    if (arg === '--count') {
+      const v = Number(readValueArg(argv, i, '--count'))
+      if (!Number.isInteger(v) || v < 1) throw new Error('--count must be a positive integer')
+      flags.count = v
+      i += 1
+      continue
+    }
+    if (arg.startsWith('--threshold=')) {
+      flags.threshold = Number(arg.slice('--threshold='.length))
+      continue
+    }
+    if (arg === '--base') {
+      flags.base = readValueArg(argv, i, '--base')
+      i += 1
+      continue
+    }
+    if (arg === '--resume-run') {
+      flags.resumeRunId = readValueArg(argv, i, '--resume-run')
+      i += 1
+      continue
+    }
+    if (arg === '--reset-worktree') {
+      flags.resetWorktree = true
+      continue
+    }
+    if (arg === '--no-pr') {
+      flags.noPr = true
+      continue
+    }
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+  return flags
+}
+
+function selectRunner(
+  config: MutationImproveConfig,
+  runState: MutationImproveRunState,
+  log: LiveRenderer,
+): PipelineDeps['runSelectAgent'] {
+  return (worktreePath, prompt) =>
+    runAgent({
+      spawn: realSpawn,
+      model: config.agent.model,
+      cwd: worktreePath,
+      prompt,
+      outputPath: path.join(runState.runDir, 'iter', 'selection.json'),
+      outputSchema: SelectionSchema,
+      label: 'select',
+      logPath: path.join(runState.runDir, 'agent-output.log'),
+      extraArgs: config.agent.extraArgs,
+      reporter: log,
+      timeoutMs: config.agent.timeoutMs,
+    })
+}
+
+function improveRunner(
+  config: MutationImproveConfig,
+  runState: MutationImproveRunState,
+  log: LiveRenderer,
+): PipelineDeps['runImproveAgent'] {
+  return (worktreePath, prompt) =>
+    runAgent({
+      spawn: realSpawn,
+      model: config.agent.model,
+      cwd: worktreePath,
+      prompt,
+      outputPath: path.join(runState.runDir, 'iter', 'result.json'),
+      outputSchema: ResultSchema,
+      label: 'improve',
+      logPath: path.join(runState.runDir, 'agent-output.log'),
+      extraArgs: config.agent.extraArgs,
+      reporter: log,
+      timeoutMs: config.agent.timeoutMs,
+    })
+}
+
+function buildPipelineDeps(
+  config: MutationImproveConfig,
+  runState: MutationImproveRunState,
+  log: LiveRenderer,
+): PipelineDeps {
+  return {
+    config,
+    runState,
+    spawn: realSpawn,
+    createWorktree,
+    resetWorktree,
+    removeWorktree,
+    mergeWorktree,
+    execGit,
+    runBuildCheck: () => {
+      const exec = createShellExec(runState.runDir, config.checkCommand, config.buildTimeoutMs)
+      return runBuildCheck({ exec: () => exec() })
+    },
+    measureScore: (worktreePath: string, srcFile: string) => {
+      const exec = createShellExec(worktreePath, `${config.mutateFileCommand} ${srcFile}`, config.agentTimeoutMs)
+      return measureMutationScore({ exec: () => exec() }, path.join(worktreePath, 'reports', 'paired'), srcFile)
+    },
+    readBaseline,
+    writeBaseline,
+    runSelectAgent: selectRunner(config, runState, log),
+    runImproveAgent: improveRunner(config, runState, log),
+    log,
+  }
+}
+
+async function runGh(ghArgs: readonly string[], cwd: string): Promise<GhResult> {
+  const { execFile } = await import('node:child_process')
+  return new Promise<GhResult>((resolve) => {
+    execFile('gh', [...ghArgs], { cwd, maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
+      resolve({ exitCode: err === null ? 0 : 1, stdout, stderr })
+    })
+  })
+}
+
+export async function runCli(argv: readonly string[]): Promise<void> {
+  const args = parseCliArgs(argv)
+  const config = await loadMutationImproveConfig({ configPath: args.configPath })
+  if (args.count !== undefined) config.count = args.count
+  if (args.threshold !== undefined) config.threshold = args.threshold
+  if (args.base !== undefined) config.base = args.base
+
+  const runState: MutationImproveRunState =
+    args.resumeRunId === undefined ? await createRunState(config) : await loadRunState(config.workDir, args.resumeRunId)
+
+  const log = new LiveRenderer(process.stdout)
+  const deps = buildPipelineDeps(config, runState, log)
+  const { results, aborted } = await runPipeline(deps)
+  await saveRunState(runState)
+
+  const failed = results.filter((r) => r.outcome === 'failed')
+  if (!args.noPr && runState.merged.length > 0 && !aborted) {
+    await runFinalize({ execGit, runGh }, { config, runState })
+  }
+  if (failed.length > 0 || aborted) process.exitCode = 1
+}
+
+if (import.meta.main) {
+  runCli(process.argv.slice(2)).catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}

--- a/mutation-improve/src/cli.ts
+++ b/mutation-improve/src/cli.ts
@@ -19,7 +19,7 @@ import {
 import { readBaseline, writeBaseline } from './baseline.js'
 import { type MutationImproveConfig, loadMutationImproveConfig } from './config.js'
 import { runFinalize } from './finalize.js'
-import { runPipeline, type PipelineDeps } from './pipeline.js'
+import { type IterationResult, runPipeline, type PipelineDeps } from './pipeline.js'
 import { ResultSchema } from './result-schema.js'
 import { createRunState, loadRunState, saveRunState, type MutationImproveRunState } from './run-state.js'
 import { measureMutationScore } from './score-reader.js'
@@ -186,8 +186,18 @@ export async function runCli(argv: readonly string[]): Promise<void> {
 
   const log = new LiveRenderer(process.stdout)
   const deps = buildPipelineDeps(config, runState, log)
-  const { results, aborted } = await runPipeline(deps)
-  await saveRunState(runState)
+  // I1: try/finally guarantees saveRunState runs even if runPipeline throws
+  // (e.g. AgentRunError mid-pipeline), so --resume-run sees the last-known
+  // in-memory progress instead of losing everything to a throw.
+  let results: IterationResult[] = []
+  let aborted = false
+  try {
+    const pipelineOut = await runPipeline(deps)
+    results = pipelineOut.results
+    aborted = pipelineOut.aborted
+  } finally {
+    await saveRunState(runState)
+  }
 
   const failed = results.filter((r) => r.outcome === 'failed')
   if (!args.noPr && runState.merged.length > 0 && !aborted) {

--- a/mutation-improve/src/config.ts
+++ b/mutation-improve/src/config.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { mkdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { z } from 'zod'
+
+import { detectGitRoot } from '../../review-loop/src/worktree.js'
+
+const AgentConfigSchema = z.object({
+  model: z.string().min(1),
+  extraArgs: z.array(z.string()).default([]),
+  timeoutMs: z.number().int().min(0).default(1_800_000),
+})
+
+export const MutationImproveConfigSchema = z.object({
+  repoRoot: z.string().min(1).optional(),
+  workDir: z.string().min(1),
+  base: z.string().min(1).default('master'),
+  upstream: z.string().min(1).default('origin'),
+  count: z.number().int().positive().default(1),
+  threshold: z.number().min(0).max(1).default(0.95),
+  epsilon: z.number().min(0).max(1).default(0.02),
+  agentTimeoutMs: z.number().int().min(0).default(1_800_000),
+  buildTimeoutMs: z.number().int().min(0).default(600_000),
+  checkCommand: z.string().min(1).default('bun check:full'),
+  mutateFileCommand: z.string().min(1).default('bun test:mutate:file'),
+  agent: AgentConfigSchema,
+  prBranchPrefix: z.string().min(1).default('mutation-improve'),
+})
+
+export interface MutationImproveConfig extends z.infer<typeof MutationImproveConfigSchema> {
+  repoRoot: string
+  workDir: string
+}
+
+export interface ConfigLoadInput {
+  configPath: string
+  repoRoot?: string
+}
+
+export async function loadMutationImproveConfig(input: ConfigLoadInput): Promise<MutationImproveConfig> {
+  const configPath = path.resolve(input.configPath)
+  const raw = JSON.parse(await readFile(configPath, 'utf8')) as unknown
+  const parsed = MutationImproveConfigSchema.parse(raw)
+
+  const repoRootSource = input.repoRoot ?? parsed.repoRoot
+  const repoRoot = repoRootSource === undefined ? await detectGitRoot(process.cwd()) : path.resolve(repoRootSource)
+  const workDir = path.resolve(repoRoot, parsed.workDir)
+
+  await mkdir(workDir, { recursive: true })
+
+  return { ...parsed, repoRoot, workDir }
+}

--- a/mutation-improve/src/diff-guard.ts
+++ b/mutation-improve/src/diff-guard.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+export const ALLOWED_PREFIXES = ['tests/', 'docs/superpowers/']
+
+export type ExecGitFn = (cwd: string, args: readonly string[]) => Promise<{ stdout: string; stderr: string }>
+
+export function classifyDiff(paths: readonly string[]): { allowed: string[]; violations: string[] } {
+  const allowed: string[] = []
+  const violations: string[] = []
+  for (const p of paths) {
+    if (ALLOWED_PREFIXES.some((prefix) => p.startsWith(prefix))) allowed.push(p)
+    else violations.push(p)
+  }
+  return { allowed, violations }
+}
+
+export async function runDiffGuard(
+  execGit: ExecGitFn,
+  cwd: string,
+): Promise<{ ok: true } | { ok: false; violations: string[] }> {
+  const { stdout } = await execGit(cwd, ['diff', '--name-only', 'HEAD'])
+  const paths = stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+  const { violations } = classifyDiff(paths)
+  return violations.length === 0 ? { ok: true } : { ok: false, violations }
+}

--- a/mutation-improve/src/diff-guard.ts
+++ b/mutation-improve/src/diff-guard.ts
@@ -21,11 +21,12 @@ export async function runDiffGuard(
   execGit: ExecGitFn,
   cwd: string,
 ): Promise<{ ok: true } | { ok: false; violations: string[] }> {
-  const { stdout } = await execGit(cwd, ['diff', '--name-only', 'HEAD'])
+  const { stdout } = await execGit(cwd, ['status', '--porcelain', '--untracked-files=all'])
   const paths = stdout
     .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0)
+    .map((line) => line.slice(3).trim())
+    .map((p) => p.replace(/^"|"$/gu, ''))
+    .filter((p) => p.length > 0)
   const { violations } = classifyDiff(paths)
   return violations.length === 0 ? { ok: true } : { ok: false, violations }
 }

--- a/mutation-improve/src/finalize.ts
+++ b/mutation-improve/src/finalize.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { appendFile, mkdir } from 'node:fs/promises'
+import path from 'node:path'
+
+import type { MutationImproveConfig } from './config.js'
+import type { MutationImproveRunState } from './run-state.js'
+
+export interface ExecGitFn {
+  (cwd: string, args: readonly string[]): Promise<{ stdout: string; stderr: string }>
+}
+
+export interface RunGhFn {
+  (args: readonly string[], cwd: string): Promise<{ exitCode: number; stdout: string; stderr: string }>
+}
+
+export interface FinalizeDeps {
+  execGit: ExecGitFn
+  runGh: RunGhFn
+}
+
+export interface FinalizeInput {
+  config: MutationImproveConfig
+  runState: MutationImproveRunState
+}
+
+export interface FinalizeResult {
+  prUrl?: string
+  pushed: boolean
+}
+
+interface MergedRow {
+  file: string
+  beforeScore: number
+  afterScore: number
+  iter: number
+  specPath?: string
+  planPath?: string
+}
+
+interface FailedRow {
+  iter: number
+  gate: string
+  reason: string
+}
+
+export function buildSummaryBody(merged: readonly MergedRow[], failed: readonly FailedRow[]): string {
+  const rows = merged
+    .map((m) => `| ${m.file} | ${m.beforeScore} | ${m.afterScore} | ${m.specPath ?? ''} | ${m.planPath ?? ''} |`)
+    .join('\n')
+  const header = '| File | Before | After | Spec | Plan |\n|---|---|---|---|---|\n'
+  let body = `## mutation-improve\n\n${header}${rows}\n`
+  if (failed.length > 0) {
+    body += `\n## Failed iterations\n\n| Iter | Gate | Reason |\n|---|---|---|\n`
+    body += failed.map((f) => `| ${f.iter} | ${f.gate} | ${f.reason} |`).join('\n')
+  }
+  return body
+}
+
+export async function runFinalize(deps: FinalizeDeps, input: FinalizeInput): Promise<FinalizeResult> {
+  const { config, runState } = input
+  await deps.execGit(config.repoRoot, ['push', config.upstream, config.base])
+  const title = `mutation-improve: ${runState.merged.map((m) => m.file).join(', ')}`
+  const body = buildSummaryBody(runState.merged, runState.failed)
+  const result = await deps.runGh(
+    ['pr', 'create', '--base', config.base, '--title', title, '--body', body],
+    config.repoRoot,
+  )
+  if (result.exitCode !== 0) {
+    const logPath = path.join(runState.runDir, 'finalize.log')
+    await mkdir(path.dirname(logPath), { recursive: true })
+    await appendFile(
+      logPath,
+      `gh pr create failed (exit ${result.exitCode}): ${result.stderr}\nRe-run: gh pr create --base ${config.base} --title ${JSON.stringify(title)} --body <body>\n`,
+    )
+    return { pushed: true }
+  }
+  return { pushed: true, prUrl: result.stdout.trim() || undefined }
+}

--- a/mutation-improve/src/index.ts
+++ b/mutation-improve/src/index.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+export {}

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -153,7 +153,14 @@ async function finalizePhase(
   improved: Result,
 ): Promise<IterationResult> {
   const bumped = bumpScore(baseline, file, afterScore)
-  await deps.writeBaseline(deps.config.repoRoot, bumped)
+  // C1: write the baseline bump into the WORKTREE (not repoRoot) and commit the
+  // agent's spec/plan/test outputs together with the bump on the worktree
+  // branch BEFORE mergeWorktree. Without this, mergeWorktree merges an empty
+  // branch ("Already up to date"), writeBaseline never propagates to base, and
+  // removeWorktree --force discards the agent's uncommitted files.
+  await deps.writeBaseline(worktreePath, bumped)
+  await deps.execGit(worktreePath, ['add', '-A'])
+  await deps.execGit(worktreePath, ['commit', '-m', `chore(mutation): ratchet ${file} baseline to ${afterScore}`])
   const merge = await deps.mergeWorktree(deps.config.repoRoot, branchFor(deps, iter))
   if (!merge.ok) {
     return {

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -138,10 +138,12 @@ async function gatePhase(
   return { ok: true, value: afterScore }
 }
 
-// ⑥ RATCHET (runner-owned) → ⑦ MERGE. Baseline bump happens BEFORE merge so a
-// merge conflict still leaves the persisted baseline advanced (the work is
-// done; only the integration failed). Merge-conflict returns gate:'merge',
-// which runPipeline treats as abort.
+// ⑥ RATCHET (runner-owned) → ⑦ MERGE. The baseline bump is written into the
+// worktree and committed there together with the agent's spec/plan/test work,
+// so mergeWorktree propagates ALL of it to base. On merge conflict the bump
+// stays on the unmerged iteration branch (kept for inspection) and does NOT
+// advance base; the run aborts (gate:'merge') so no later iteration chains
+// off a stale base.
 async function finalizePhase(
   deps: PipelineDeps,
   iter: number,
@@ -160,7 +162,12 @@ async function finalizePhase(
   // removeWorktree --force discards the agent's uncommitted files.
   await deps.writeBaseline(worktreePath, bumped)
   await deps.execGit(worktreePath, ['add', '-A'])
-  await deps.execGit(worktreePath, ['commit', '-m', `chore(mutation): ratchet ${file} baseline to ${afterScore}`])
+  await deps.execGit(worktreePath, [
+    'commit',
+    '--allow-empty',
+    '-m',
+    `chore(mutation): ratchet ${file} baseline to ${afterScore}`,
+  ])
   const merge = await deps.mergeWorktree(deps.config.repoRoot, branchFor(deps, iter))
   if (!merge.ok) {
     return {

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
+
+import type { AgentRunResult } from '../../review-loop/src/agent-runner.js'
+import type { MergeResult } from '../../review-loop/src/worktree.js'
+import { bumpScore, type BaselineMap } from './baseline.js'
+import type { MutationImproveConfig } from './config.js'
+import { runDiffGuard } from './diff-guard.js'
+import { buildImprovePrompt, buildSelectPrompt } from './prompt-templates.js'
+import type { Result } from './result-schema.js'
+import { ResultSchema } from './result-schema.js'
+import type { MutationImproveRunState } from './run-state.js'
+import { iterDir } from './run-state.js'
+import { SelectionSchema } from './selection-schema.js'
+import type { Selection } from './selection-schema.js'
+
+export interface IterationResult {
+  iter: number
+  outcome: 'improved' | 'skipped' | 'failed'
+  file?: string
+  beforeScore?: number
+  afterScore?: number
+  gate?: string
+  reason?: string
+}
+
+export interface PipelineDeps {
+  config: MutationImproveConfig
+  runState: MutationImproveRunState
+  spawn: unknown
+  createWorktree: (repoRoot: string, worktreePath: string, runId: string, branchPrefix: string) => Promise<void>
+  resetWorktree: (worktreePath: string) => Promise<void>
+  removeWorktree: (repoRoot: string, worktreePath: string, runId: string, branchPrefix: string) => Promise<void>
+  mergeWorktree: (repoRoot: string, branchName: string) => Promise<MergeResult>
+  execGit: (cwd: string, args: readonly string[]) => Promise<{ stdout: string; stderr: string }>
+  runBuildCheck: () => Promise<{ passed: boolean; stdout: string; stderr: string }>
+  measureScore: (worktreePath: string, srcFile: string) => Promise<number>
+  readBaseline: (repoRoot: string) => Promise<BaselineMap>
+  writeBaseline: (repoRoot: string, map: BaselineMap) => Promise<void>
+  runSelectAgent: (worktreePath: string, prompt: string) => Promise<AgentRunResult<Selection>>
+  runImproveAgent: (worktreePath: string, prompt: string) => Promise<AgentRunResult<Result>>
+  log: { log: (msg: string) => void; issue?: unknown }
+}
+
+type PhaseOk<T> = { ok: true; value: T }
+type PhaseFail = { ok: false; gate: string; reason: string }
+type PhaseResult<T> = PhaseOk<T> | PhaseFail
+
+function branchFor(deps: PipelineDeps, iter: number): string {
+  return `${deps.config.prBranchPrefix}/${deps.runState.runId}-iter${iter}`
+}
+
+function worktreeFor(deps: PipelineDeps, iter: number): string {
+  return path.join(deps.config.workDir, 'worktrees', `${deps.runState.runId}-iter${iter}`)
+}
+
+function runIdFor(deps: PipelineDeps, iter: number): string {
+  return `${deps.runState.runId}-iter${iter}`
+}
+
+// ① SELECT — runner reads baseline; agent only suggests. Reject picks not in baseline
+// (nothing to improve) or already done (would re-do work). Both are agent mistakes.
+async function selectPhase(
+  deps: PipelineDeps,
+  worktreePath: string,
+  iterPath: string,
+): Promise<PhaseResult<{ selection: Selection; baseline: BaselineMap }>> {
+  const baseline = await deps.readBaseline(deps.config.repoRoot)
+  const selectOut = path.join(iterPath, 'selection.json')
+  const selectRes = await deps.runSelectAgent(
+    worktreePath,
+    buildSelectPrompt({
+      doneSet: deps.runState.doneSet,
+      baselineSummary: JSON.stringify(baseline),
+      outputPath: selectOut,
+    }),
+  )
+  const selection = SelectionSchema.parse(selectRes.value)
+  if (deps.runState.doneSet.includes(selection.file) || baseline[selection.file] === undefined) {
+    return { ok: false, gate: 'select', reason: 'selection file not in baseline or already done' }
+  }
+  return { ok: true, value: { selection, baseline } }
+}
+
+// ③ IMPROVE — agent writes spec/plan/tests; runner only parses its declared result.
+// The agent's own score claims are NEVER trusted; only the runner-measured score
+// from ⑤ counts. We parse here to fail fast on a malformed agent output.
+async function improvePhase(
+  deps: PipelineDeps,
+  worktreePath: string,
+  iterPath: string,
+  file: string,
+  beforeScore: number,
+): Promise<Result> {
+  const improveOut = path.join(iterPath, 'result.json')
+  const improveRes = await deps.runImproveAgent(
+    worktreePath,
+    buildImprovePrompt({
+      file,
+      beforeScore,
+      threshold: deps.config.threshold,
+      date: new Date().toISOString().slice(0, 10),
+      outputPath: improveOut,
+    }),
+  )
+  return ResultSchema.parse(improveRes.value)
+}
+
+// ④a DIFF-GUARD → ④b BUILD → ⑤ VERIFY. Diff-guard runs BEFORE verify so any agent
+// attempt to edit baseline.json or src/ is caught before the runner spends a
+// mutation-score run on tampered inputs. The after-score is runner-measured;
+// the residual escape hatch only opens when the agent declared residuals AND
+// the measured score lands within epsilon of the threshold.
+async function gatePhase(
+  deps: PipelineDeps,
+  worktreePath: string,
+  file: string,
+  improved: Result,
+): Promise<PhaseResult<number>> {
+  const diff = await runDiffGuard(deps.execGit, worktreePath)
+  if (!diff.ok) {
+    return { ok: false, gate: 'diff-scope', reason: `forbidden paths changed: ${diff.violations.join(', ')}` }
+  }
+  const build = await deps.runBuildCheck()
+  if (!build.passed) {
+    return { ok: false, gate: 'build', reason: build.stderr || build.stdout }
+  }
+  const afterScore = await deps.measureScore(worktreePath, file)
+  const justified = improved.residuals.length > 0 && afterScore >= deps.config.threshold - deps.config.epsilon
+  if (afterScore < deps.config.threshold && !justified) {
+    return { ok: false, gate: 'score', reason: `afterScore ${afterScore} < threshold ${deps.config.threshold}` }
+  }
+  return { ok: true, value: afterScore }
+}
+
+// ⑥ RATCHET (runner-owned) → ⑦ MERGE. Baseline bump happens BEFORE merge so a
+// merge conflict still leaves the persisted baseline advanced (the work is
+// done; only the integration failed). Merge-conflict returns gate:'merge',
+// which runPipeline treats as abort.
+async function finalizePhase(
+  deps: PipelineDeps,
+  iter: number,
+  worktreePath: string,
+  file: string,
+  baseline: BaselineMap,
+  beforeScore: number,
+  afterScore: number,
+): Promise<IterationResult> {
+  const bumped = bumpScore(baseline, file, afterScore)
+  await deps.writeBaseline(deps.config.repoRoot, bumped)
+  const merge = await deps.mergeWorktree(deps.config.repoRoot, branchFor(deps, iter))
+  if (!merge.ok) {
+    return {
+      iter,
+      outcome: 'failed',
+      file,
+      beforeScore,
+      afterScore,
+      gate: 'merge',
+      reason: `conflict: ${merge.conflictFiles.join(', ')}`,
+    }
+  }
+  await deps.removeWorktree(deps.config.repoRoot, worktreePath, runIdFor(deps, iter), deps.config.prBranchPrefix)
+  deps.runState.doneSet.push(file)
+  deps.runState.merged.push({ file, beforeScore, afterScore, iter })
+  return { iter, outcome: 'improved', file, beforeScore, afterScore }
+}
+
+async function failIter(
+  deps: PipelineDeps,
+  iter: number,
+  worktreePath: string,
+  gate: string,
+  reason: string,
+): Promise<IterationResult> {
+  await deps.resetWorktree(worktreePath)
+  await deps.removeWorktree(deps.config.repoRoot, worktreePath, runIdFor(deps, iter), deps.config.prBranchPrefix)
+  deps.runState.failed.push({ iter, gate, reason })
+  return { iter, outcome: 'failed', gate, reason }
+}
+
+function skipIter(
+  deps: PipelineDeps,
+  iter: number,
+  worktreePath: string,
+  file: string,
+  beforeScore: number,
+): Promise<IterationResult> {
+  return deps
+    .removeWorktree(deps.config.repoRoot, worktreePath, runIdFor(deps, iter), deps.config.prBranchPrefix)
+    .then((): IterationResult => ({ iter, outcome: 'skipped', file, beforeScore }))
+}
+
+export async function runIteration(deps: PipelineDeps, iter: number): Promise<IterationResult> {
+  const worktreePath = worktreeFor(deps, iter)
+  const iterPath = iterDir(deps.runState.runDir, iter)
+  await mkdir(iterPath, { recursive: true })
+  await deps.createWorktree(deps.config.repoRoot, worktreePath, runIdFor(deps, iter), deps.config.prBranchPrefix)
+
+  const sel = await selectPhase(deps, worktreePath, iterPath)
+  if (!sel.ok) return failIter(deps, iter, worktreePath, sel.gate, sel.reason)
+  const { selection, baseline } = sel.value
+
+  // ② CAPTURE BEFORE (runner-owned). Already at threshold → nothing to do.
+  const beforeScore = await deps.measureScore(worktreePath, selection.file)
+  if (beforeScore >= deps.config.threshold) {
+    deps.runState.doneSet.push(selection.file)
+    return skipIter(deps, iter, worktreePath, selection.file, beforeScore)
+  }
+
+  const improved = await improvePhase(deps, worktreePath, iterPath, selection.file, beforeScore)
+
+  const gate = await gatePhase(deps, worktreePath, selection.file, improved)
+  if (!gate.ok) return failIter(deps, iter, worktreePath, gate.gate, gate.reason)
+
+  return finalizePhase(deps, iter, worktreePath, selection.file, baseline, beforeScore, gate.value)
+}
+
+export async function runPipeline(deps: PipelineDeps): Promise<{ results: IterationResult[]; aborted: boolean }> {
+  const results: IterationResult[] = []
+  // Recurse instead of `for + await` so we don't trip no-await-in-loop. Sequential
+  // iteration is required: each iter observes the prior iter's baseline bump and
+  // doneSet mutation, so Promise.all parallelism would race the shared runState.
+  const runFrom = async (iter: number, aborted: boolean): Promise<{ results: IterationResult[]; aborted: boolean }> => {
+    if (aborted || iter > deps.config.count) return { results, aborted }
+    deps.runState.currentIteration = iter
+    const outcome = await runIteration(deps, iter)
+    results.push(outcome)
+    if (outcome.gate === 'merge') {
+      deps.runState.status = 'aborted'
+      return { results, aborted: true }
+    }
+    return runFrom(iter + 1, false)
+  }
+  const final = await runFrom(deps.runState.currentIteration + 1, false)
+  if (!final.aborted) deps.runState.status = 'completed'
+  return final
+}

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -150,6 +150,7 @@ async function finalizePhase(
   baseline: BaselineMap,
   beforeScore: number,
   afterScore: number,
+  improved: Result,
 ): Promise<IterationResult> {
   const bumped = bumpScore(baseline, file, afterScore)
   await deps.writeBaseline(deps.config.repoRoot, bumped)
@@ -167,7 +168,14 @@ async function finalizePhase(
   }
   await deps.removeWorktree(deps.config.repoRoot, worktreePath, runIdFor(deps, iter), deps.config.prBranchPrefix)
   deps.runState.doneSet.push(file)
-  deps.runState.merged.push({ file, beforeScore, afterScore, iter })
+  deps.runState.merged.push({
+    file,
+    beforeScore,
+    afterScore,
+    iter,
+    specPath: improved.specPath,
+    planPath: improved.planPath,
+  })
   return { iter, outcome: 'improved', file, beforeScore, afterScore }
 }
 
@@ -218,7 +226,7 @@ export async function runIteration(deps: PipelineDeps, iter: number): Promise<It
   const gate = await gatePhase(deps, worktreePath, selection.file, improved)
   if (!gate.ok) return failIter(deps, iter, worktreePath, gate.gate, gate.reason)
 
-  return finalizePhase(deps, iter, worktreePath, selection.file, baseline, beforeScore, gate.value)
+  return finalizePhase(deps, iter, worktreePath, selection.file, baseline, beforeScore, gate.value, improved)
 }
 
 export async function runPipeline(deps: PipelineDeps): Promise<{ results: IterationResult[]; aborted: boolean }> {

--- a/mutation-improve/src/prompt-templates.ts
+++ b/mutation-improve/src/prompt-templates.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import path from 'node:path'
+
+const stemFrom = (file: string): string => {
+  const base = path.basename(file).replace(/\.ts$/u, '')
+  return base
+}
+
+export function buildSelectPrompt(input: {
+  doneSet: readonly string[]
+  baselineSummary: string
+  outputPath: string
+}): string {
+  const excluded = input.doneSet.length === 0 ? '(none)' : input.doneSet.join(', ')
+  return [
+    'You are the SELECT phase of an autonomous mutation-coverage improvement runner.',
+    '',
+    'Read scripts/mutation/baseline.json (a {filePath: score} map; current contents below) and pick',
+    'the SINGLE highest-ROI source file to improve, where ROI = reliable mutation-score gain per',
+    'unit of test effort. Prefer pure functions with zero external dependencies, an existing',
+    'companion test file, and surviving mutants that each map to an observable bug.',
+    '',
+    'REJECT files matching any of these patterns (they waste effort):',
+    '- Declarative lookup tables / schema files where >80% of lines are data (e.g. big REGISTRY/Zod maps) and the score is already >= 0.9.',
+    '- Files whose non-determinism caps the reachable score (e.g. Math.random jitter, real wall-clock) — jitter mutants can only be bounds-checked.',
+    '- Single-statement passthrough wrappers whose real logic lives elsewhere.',
+    '- Files whose companion test cannot exercise the behaviour without a full chat/LLM runtime.',
+    '',
+    `Files already improved in this run (DO NOT pick): ${excluded}`,
+    '',
+    `baseline.json contents: ${input.baselineSummary}`,
+    '',
+    `Write your pick as JSON to this ABSOLUTE path: ${input.outputPath}`,
+    'Schema: { file: string (repo-relative), beforeScore: number (your read of baseline[file], 0..1),',
+    'rationale: string (1-3 sentences), runnerUps: [{file, score, why}] (2-3 rejected candidates) }.',
+    'Write ONLY that file; do not edit any source.',
+  ].join('\n')
+}
+
+export function buildImprovePrompt(input: {
+  file: string
+  beforeScore: number
+  threshold: number
+  date: string
+  outputPath: string
+}): string {
+  const stem = stemFrom(input.file)
+  const specPath = `docs/superpowers/specs/${input.date}-mutation-coverage-${stem}-design.md`
+  const planPath = `docs/superpowers/plans/${input.date}-mutation-coverage-${stem}.md`
+  return [
+    `You are the IMPROVE phase of an autonomous mutation-coverage improvement runner.`,
+    `Target file: ${input.file} (current mutation score: ${input.beforeScore}; target: >= ${input.threshold})`,
+    '',
+    'Execute, in order, the FULL procedure:',
+    '',
+    '1. MEASURE. Run `bun test:mutate:file ' + input.file + '` and inspect reports/paired/ to enumerate',
+    '   the ACTUAL surviving mutants. Ground every later step in the real report, not speculation.',
+    '2. SPEC. Write ' + specPath + ' with sections: Summary / Why this file / Non-goals / Gap analysis',
+    '   (a table of surviving mutant classes, one row per class) / Design - tests to add (mapped one-to-one',
+    '   onto the gap classes) / Verification / Accepted residuals.',
+    '3. PLAN. Write ' + planPath + ' with task-per-mutant-class checkboxes and global constraints.',
+    '4. TESTS. Extend the existing companion test file (tests/.../<stem>.test.ts). Every new assertion',
+    '   MUST use exact equality toBe(...) - never startsWith/endsWith/toContain where a full string is',
+    '   knowable. One test per mutant class.',
+    '5. RESIDUALS. Enumerate equivalent mutants that survive and genuinely cannot be killed, with per-loc',
+    '   reasoning.',
+    '',
+    `Write your result as JSON to this ABSOLUTE path: ${input.outputPath}`,
+    'Schema: { specPath: string, planPath: string, testPaths: string[] (>=1),',
+    'residuals: [{loc, why}], notes: string }.',
+    '',
+    'HARD CONSTRAINTS (the runner verifies these and REJECTS the iteration if violated):',
+    '- MUST NOT edit anything under src/, client/, plugins/, or scripts/. Test-only.',
+    '- MUST NOT edit scripts/mutation/baseline.json (the runner owns it).',
+    '- Run `bun test tests/<companion>` green before finishing.',
+    '- SPDX license headers on any new file; emoji copied verbatim from source.',
+  ].join('\n')
+}

--- a/mutation-improve/src/result-schema.ts
+++ b/mutation-improve/src/result-schema.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+const ResidualSchema = z.object({
+  loc: z.string(),
+  why: z.string(),
+})
+
+export const ResultSchema = z.object({
+  specPath: z.string().min(1),
+  planPath: z.string().min(1),
+  testPaths: z.array(z.string().min(1)).min(1),
+  residuals: z.array(ResidualSchema),
+  notes: z.string().default(''),
+})
+
+export type Result = z.infer<typeof ResultSchema>

--- a/mutation-improve/src/run-state.ts
+++ b/mutation-improve/src/run-state.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { z } from 'zod'
+
+import type { MutationImproveConfig } from './config.js'
+
+const MergedEntrySchema = z.object({
+  file: z.string(),
+  beforeScore: z.number(),
+  afterScore: z.number(),
+  iter: z.number().int(),
+})
+
+const FailedEntrySchema = z.object({
+  iter: z.number().int(),
+  file: z.string().optional(),
+  gate: z.string(),
+  reason: z.string(),
+})
+
+export const PersistedRunStateSchema = z.object({
+  runId: z.string(),
+  repoRoot: z.string(),
+  base: z.string(),
+  threshold: z.number(),
+  count: z.number().int(),
+  currentIteration: z.number().int().nonnegative(),
+  doneSet: z.array(z.string()),
+  merged: z.array(MergedEntrySchema),
+  failed: z.array(FailedEntrySchema),
+  status: z.enum(['running', 'completed', 'aborted']),
+})
+
+export type PersistedRunState = z.infer<typeof PersistedRunStateSchema>
+
+export interface MutationImproveRunState extends PersistedRunState {
+  runDir: string
+  workDir: string
+  statePath: string
+}
+
+function makeRunId(): string {
+  return `${new Date().toISOString().replace(/[:.]/gu, '-')}-${randomUUID().slice(0, 8)}`
+}
+
+export function iterDir(runDir: string, iter: number): string {
+  return path.join(runDir, 'iter', String(iter))
+}
+
+export async function createRunState(config: MutationImproveConfig): Promise<MutationImproveRunState> {
+  const runId = makeRunId()
+  const runDir = path.join(config.workDir, 'runs', runId)
+  await mkdir(runDir, { recursive: true })
+  const state: MutationImproveRunState = {
+    runId,
+    runDir,
+    workDir: config.workDir,
+    statePath: path.join(runDir, 'state.json'),
+    repoRoot: config.repoRoot,
+    base: config.base,
+    threshold: config.threshold,
+    count: config.count,
+    currentIteration: 0,
+    doneSet: [],
+    merged: [],
+    failed: [],
+    status: 'running',
+  }
+  await saveRunState(state)
+  return state
+}
+
+export async function loadRunState(workDir: string, runId: string): Promise<MutationImproveRunState> {
+  const runDir = path.join(workDir, 'runs', runId)
+  const statePath = path.join(runDir, 'state.json')
+  const persisted = PersistedRunStateSchema.parse(JSON.parse(await readFile(statePath, 'utf8')))
+  return { ...persisted, runDir, workDir, statePath }
+}
+
+export async function saveRunState(state: MutationImproveRunState): Promise<void> {
+  const persisted = PersistedRunStateSchema.parse(state)
+  await writeFile(state.statePath, JSON.stringify(persisted, null, 2))
+}

--- a/mutation-improve/src/run-state.ts
+++ b/mutation-improve/src/run-state.ts
@@ -16,6 +16,8 @@ const MergedEntrySchema = z.object({
   beforeScore: z.number(),
   afterScore: z.number(),
   iter: z.number().int(),
+  specPath: z.string().optional(),
+  planPath: z.string().optional(),
 })
 
 const FailedEntrySchema = z.object({

--- a/mutation-improve/src/score-reader.ts
+++ b/mutation-improve/src/score-reader.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { readStrykerReport } from '../../scripts/mutation/json-readers.js'
+import { mergeReports, type StrykerReport } from '../../scripts/mutation/score-merger.js'
+
+export const safeFileStem = (srcFile: string): string => srcFile.replaceAll(/[^a-zA-Z0-9._-]+/gu, '__')
+
+export const reportPathFor = (reportDir: string, srcFile: string): string =>
+  `${reportDir}/${safeFileStem(srcFile)}.stryker-report.json`
+
+export interface MeasureDeps {
+  exec: () => Promise<{ exitCode: number; stdout: string; stderr: string }>
+  readReport?: (reportPath: string) => StrykerReport
+}
+
+export async function measureMutationScore(deps: MeasureDeps, reportDir: string, srcFile: string): Promise<number> {
+  const read = deps.readReport ?? readStrykerReport
+  const reportPath = reportPathFor(reportDir, srcFile)
+  const attempt = async (): Promise<number> => {
+    await deps.exec()
+    return mergeReports([read(reportPath)]).score
+  }
+  try {
+    const score = await attempt()
+    return score
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (/enoent|malformed|must contain a stryker/iu.test(message)) {
+      const retried = await attempt()
+      return retried
+    }
+    throw error
+  }
+}

--- a/mutation-improve/src/selection-schema.ts
+++ b/mutation-improve/src/selection-schema.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+const RunnerUpSchema = z.object({
+  file: z.string().min(1),
+  score: z.number().min(0).max(1),
+  why: z.string(),
+})
+
+export const SelectionSchema = z.object({
+  file: z.string().min(1),
+  beforeScore: z.number().min(0).max(1),
+  rationale: z.string(),
+  runnerUps: z.array(RunnerUpSchema).max(5),
+})
+
+export type Selection = z.infer<typeof SelectionSchema>

--- a/mutation-improve/tsconfig.json
+++ b/mutation-improve/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "papai — an intelligent Telegram bot for managing Kaneo tasks with LLM.",
   "license": "BUSL-1.1",
   "workspaces": [
-    "review-loop"
+    "review-loop",
+    "mutation-improve"
   ],
   "type": "module",
   "module": "src/index.ts",
@@ -29,6 +30,11 @@
     "review-loop:lint": "bun run --filter review-loop lint",
     "review-loop:format:check": "bun run --filter review-loop format:check",
     "review-loop:start": "bun run --filter review-loop start",
+    "mutation-improve:test": "bun run --filter mutation-improve test",
+    "mutation-improve:typecheck": "bun run --filter mutation-improve typecheck",
+    "mutation-improve:lint": "bun run --filter mutation-improve lint",
+    "mutation-improve:format:check": "bun run --filter mutation-improve format:check",
+    "mutation-improve:start": "bun run --filter mutation-improve start",
     "knip": "knip-bun --strict --no-gitignore",
     "typecheck": "tsgo --noEmit",
     "lint": "oxlint --config .oxlintrc.json --ignore-path .oxlintignore .",
@@ -62,7 +68,7 @@
     "test:stories:compat": "bun scripts/story/test-stories.ts --compat",
     "check": "./scripts/check.sh --staged",
     "check:full": "./scripts/check.sh",
-    "check:verbose": "bun run --parallel lint typecheck format:check knip test duplicates review-loop:lint review-loop:typecheck review-loop:format:check review-loop:test",
+    "check:verbose": "bun run --parallel lint typecheck format:check knip test duplicates review-loop:lint review-loop:typecheck review-loop:format:check review-loop:test mutation-improve:lint mutation-improve:typecheck mutation-improve:format:check mutation-improve:test",
     "fix": "bun run lint:fix && bun run format",
     "duplicates": "bun run scripts/detect-duplicates.ts",
     "prepare": "[ -d .git ] && cp scripts/pre-commit.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit || true",

--- a/review-loop/src/worktree.ts
+++ b/review-loop/src/worktree.ts
@@ -35,12 +35,17 @@ export async function detectGitRoot(cwd: string): Promise<string> {
   return stdout.trim()
 }
 
-export async function createWorktree(repoRoot: string, worktreePath: string, runId: string): Promise<void> {
+export async function createWorktree(
+  repoRoot: string,
+  worktreePath: string,
+  runId: string,
+  branchPrefix = 'review-loop',
+): Promise<void> {
   const parentDir = path.dirname(worktreePath)
   if (!existsSync(parentDir)) {
     await mkdir(parentDir, { recursive: true })
   }
-  await execGit(repoRoot, ['worktree', 'add', worktreePath, '-b', `review-loop/${runId}`])
+  await execGit(repoRoot, ['worktree', 'add', worktreePath, '-b', `${branchPrefix}/${runId}`])
 }
 
 export function worktreeExists(worktreePath: string): boolean {
@@ -98,12 +103,17 @@ export async function mergeWorktree(repoRoot: string, branchName: string): Promi
   return { ok: true }
 }
 
-export async function removeWorktree(repoRoot: string, worktreePath: string, runId: string): Promise<void> {
+export async function removeWorktree(
+  repoRoot: string,
+  worktreePath: string,
+  runId: string,
+  branchPrefix = 'review-loop',
+): Promise<void> {
   if (existsSync(worktreePath)) {
     await execGit(repoRoot, ['worktree', 'remove', worktreePath, '--force'])
   }
   try {
-    await execGit(repoRoot, ['branch', '-D', `review-loop/${runId}`])
+    await execGit(repoRoot, ['branch', '-D', `${branchPrefix}/${runId}`])
   } catch {
     // Branch may not exist if already merged and deleted
   }

--- a/tests/mutation-improve/baseline.test.ts
+++ b/tests/mutation-improve/baseline.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import {
+  bumpScore,
+  parseBaseline,
+  readBaseline,
+  serializeBaseline,
+  writeBaseline,
+} from '../../mutation-improve/src/baseline.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+describe('baseline', () => {
+  test('serializeBaseline sorts keys and adds a trailing newline', () => {
+    const out = serializeBaseline({ b: 1, a: 0.5 })
+    expect(out).toBe('{\n  "a": 0.5,\n  "b": 1\n}\n')
+  })
+
+  test('parseBaseline + serializeBaseline round-trip is stable', () => {
+    const map = { 'src/z.ts': 0.9, 'src/a.ts': 0.1 }
+    expect(parseBaseline(serializeBaseline(map))).toEqual({ 'src/a.ts': 0.1, 'src/z.ts': 0.9 })
+  })
+
+  test('bumpScore raises the floor and never lowers it', () => {
+    const before = { 'src/foo.ts': 0.4 }
+    expect(bumpScore(before, 'src/foo.ts', 0.95)['src/foo.ts']).toBe(0.95)
+    // a measured dip must not lower the floor
+    expect(bumpScore(before, 'src/foo.ts', 0.2)['src/foo.ts']).toBe(0.4)
+    // a previously-unseen file creates a new entry
+    expect(bumpScore(before, 'src/new.ts', 0.7)['src/new.ts']).toBe(0.7)
+  })
+
+  test('readBaseline + writeBaseline round-trip through scripts/mutation/baseline.json', async () => {
+    const repoRoot = makeTempDir('bl-')
+    await mkdir(path.join(repoRoot, 'scripts', 'mutation'), { recursive: true })
+    await writeBaseline(repoRoot, { 'src/a.ts': 0.3 })
+    const onDisk = await readFile(path.join(repoRoot, 'scripts', 'mutation', 'baseline.json'), 'utf8')
+    expect(onDisk).toContain('"src/a.ts": 0.3')
+    const readBack = await readBaseline(repoRoot)
+    expect(readBack['src/a.ts']).toBe(0.3)
+  })
+
+  test('readBaseline on a missing file returns empty map', async () => {
+    const repoRoot = makeTempDir('bl-missing-')
+    const map = await readBaseline(repoRoot)
+    expect(map).toEqual({})
+  })
+})

--- a/tests/mutation-improve/cli.test.ts
+++ b/tests/mutation-improve/cli.test.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { parseCliArgs } from '../../mutation-improve/src/cli.js'
+
+describe('cli parseCliArgs', () => {
+  test('parses --config and requires --config (default exists)', () => {
+    const args = parseCliArgs(['--config', '/c.json'])
+    expect(args.configPath).toBe('/c.json')
+    expect(args.count).toBeUndefined()
+    expect(args.noPr).toBe(false)
+  })
+
+  test('parses --count, --threshold, --base, --no-pr', () => {
+    const args = parseCliArgs(['--count', '3', '--threshold=0.9', '--base', 'develop', '--no-pr'])
+    expect(args.count).toBe(3)
+    expect(args.threshold).toBe(0.9)
+    expect(args.base).toBe('develop')
+    expect(args.noPr).toBe(true)
+  })
+
+  test('rejects non-positive --count', () => {
+    expect(() => parseCliArgs(['--count', '0'])).toThrow()
+  })
+
+  test('parses --resume-run and --reset-worktree', () => {
+    const args = parseCliArgs(['--resume-run', 'r1', '--reset-worktree'])
+    expect(args.resumeRunId).toBe('r1')
+    expect(args.resetWorktree).toBe(true)
+  })
+})

--- a/tests/mutation-improve/config.test.ts
+++ b/tests/mutation-improve/config.test.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { MutationImproveConfigSchema, loadMutationImproveConfig } from '../../mutation-improve/src/config.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+const minimalValid = {
+  workDir: '.mutation-improve',
+  agent: { model: 'opencode/claude-sonnet-4-6', extraArgs: [] },
+}
+
+describe('config', () => {
+  test('MutationImproveConfigSchema applies defaults', () => {
+    const parsed = MutationImproveConfigSchema.parse(minimalValid)
+    expect(parsed.base).toBe('master')
+    expect(parsed.upstream).toBe('origin')
+    expect(parsed.count).toBe(1)
+    expect(parsed.threshold).toBe(0.95)
+    expect(parsed.epsilon).toBe(0.02)
+    expect(parsed.checkCommand).toBe('bun check:full')
+    expect(parsed.mutateFileCommand).toBe('bun test:mutate:file')
+    expect(parsed.prBranchPrefix).toBe('mutation-improve')
+    expect(parsed.agent.timeoutMs).toBe(1_800_000)
+  })
+
+  test('MutationImproveConfigSchema rejects threshold out of [0,1]', () => {
+    expect(() => MutationImproveConfigSchema.parse({ ...minimalValid, threshold: 1.5 })).toThrow()
+    expect(() => MutationImproveConfigSchema.parse({ ...minimalValid, threshold: -0.1 })).toThrow()
+  })
+
+  test('loadMutationImproveConfig resolves workDir against repoRoot and creates it', async () => {
+    const repoRoot = makeTempDir('cfg-')
+    const configPath = path.join(repoRoot, 'config.json')
+    writeFileSync(configPath, JSON.stringify({ ...minimalValid, repoRoot }))
+    const config = await loadMutationImproveConfig({ configPath })
+    expect(config.repoRoot).toBe(repoRoot)
+    expect(config.workDir).toBe(path.resolve(repoRoot, '.mutation-improve'))
+  })
+})

--- a/tests/mutation-improve/contracts.test.ts
+++ b/tests/mutation-improve/contracts.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { ResultSchema } from '../../mutation-improve/src/result-schema.js'
+import { SelectionSchema } from '../../mutation-improve/src/selection-schema.js'
+
+describe('contracts', () => {
+  test('SelectionSchema accepts a well-formed selection and rejects missing runnerUps', () => {
+    const valid = {
+      file: 'src/live-status/tool-status-labels.ts',
+      beforeScore: 0.46,
+      rationale: 'Pure, dependency-free, user-facing.',
+      runnerUps: [{ file: 'src/tools/tool-metadata.ts', score: 0.29, why: 'declarative table' }],
+    }
+    expect(() => SelectionSchema.parse(valid)).not.toThrow()
+    expect(() => SelectionSchema.parse({ ...valid, runnerUps: undefined })).toThrow()
+  })
+
+  test('SelectionSchema rejects beforeScore out of [0,1]', () => {
+    const base = {
+      file: 'a.ts',
+      beforeScore: 0.5,
+      rationale: 'x',
+      runnerUps: [],
+    }
+    expect(() => SelectionSchema.parse({ ...base, beforeScore: 1.2 })).toThrow()
+  })
+
+  test('ResultSchema accepts empty residuals and defaults notes to empty string', () => {
+    const parsed = ResultSchema.parse({
+      specPath: 'docs/superpowers/specs/x-design.md',
+      planPath: 'docs/superpowers/plans/x.md',
+      testPaths: ['tests/live-status/x.test.ts'],
+      residuals: [],
+    })
+    expect(parsed.notes).toBe('')
+  })
+
+  test('ResultSchema requires at least one testPath', () => {
+    const base = {
+      specPath: 'd.md',
+      planPath: 'p.md',
+      testPaths: [],
+      residuals: [],
+    }
+    expect(() => ResultSchema.parse(base)).toThrow()
+    expect(() => ResultSchema.parse({ ...base, testPaths: ['tests/x.test.ts'] })).not.toThrow()
+  })
+})

--- a/tests/mutation-improve/diff-guard.test.ts
+++ b/tests/mutation-improve/diff-guard.test.ts
@@ -27,16 +27,32 @@ describe('diff-guard', () => {
 
   test('runDiffGuard returns ok when all changed paths are allowed', async () => {
     const execGit = (_cwd: string, args: readonly string[]): Promise<GitResult> => {
-      expect(args).toEqual(['diff', '--name-only', 'HEAD'])
-      return Promise.resolve({ stdout: 'tests/a.test.ts\ndocs/superpowers/plans/p.md\n', stderr: '' })
+      expect(args).toEqual(['status', '--porcelain', '--untracked-files=all'])
+      return Promise.resolve({ stdout: ' M tests/a.test.ts\n?? docs/superpowers/plans/p.md\n', stderr: '' })
     }
     const result = await runDiffGuard(execGit, '/repo/wt')
     expect(result).toEqual({ ok: true })
   })
 
   test('runDiffGuard returns violations when src/ or baseline.json changed', async () => {
-    const execGit = (): Promise<GitResult> => Promise.resolve({ stdout: 'tests/a.test.ts\nsrc/foo.ts\n', stderr: '' })
+    const execGit = (): Promise<GitResult> =>
+      Promise.resolve({ stdout: ' M tests/a.test.ts\n M src/foo.ts\n', stderr: '' })
     const result = await runDiffGuard(execGit, '/repo/wt')
     expect(result).toEqual({ ok: false, violations: ['src/foo.ts'] })
+  })
+
+  test('runDiffGuard catches an UNTRACKED forbidden file (?? in porcelain)', async () => {
+    // F1 regression guard: `git diff --name-only HEAD` is blind to untracked
+    // files, so a misbehaving agent's untracked src/evil.ts bypassed the guard,
+    // got staged by `git add -A`, and merged to base. porcelain surfaces `??`.
+    const execGit = (): Promise<GitResult> => Promise.resolve({ stdout: '?? src/new.ts\n', stderr: '' })
+    const result = await runDiffGuard(execGit, '/repo/wt')
+    expect(result).toEqual({ ok: false, violations: ['src/new.ts'] })
+  })
+
+  test('runDiffGuard strips porcelain quotes around paths with special chars', async () => {
+    const execGit = (): Promise<GitResult> => Promise.resolve({ stdout: ' M "tests/a b.test.ts"\n', stderr: '' })
+    const result = await runDiffGuard(execGit, '/repo/wt')
+    expect(result).toEqual({ ok: true })
   })
 })

--- a/tests/mutation-improve/diff-guard.test.ts
+++ b/tests/mutation-improve/diff-guard.test.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { ALLOWED_PREFIXES, classifyDiff, runDiffGuard } from '../../mutation-improve/src/diff-guard.js'
+
+type GitResult = { stdout: string; stderr: string }
+
+describe('diff-guard', () => {
+  test('ALLOWED_PREFIXES is tests/ and docs/superpowers/', () => {
+    expect(ALLOWED_PREFIXES).toEqual(['tests/', 'docs/superpowers/'])
+  })
+
+  test('classifyDiff splits allowed from violations', () => {
+    const result = classifyDiff([
+      'tests/live-status/x.test.ts',
+      'docs/superpowers/specs/x-design.md',
+      'src/foo.ts',
+      'scripts/mutation/baseline.json',
+    ])
+    expect(result.allowed).toEqual(['tests/live-status/x.test.ts', 'docs/superpowers/specs/x-design.md'])
+    expect(result.violations).toEqual(['src/foo.ts', 'scripts/mutation/baseline.json'])
+  })
+
+  test('runDiffGuard returns ok when all changed paths are allowed', async () => {
+    const execGit = (_cwd: string, args: readonly string[]): Promise<GitResult> => {
+      expect(args).toEqual(['diff', '--name-only', 'HEAD'])
+      return Promise.resolve({ stdout: 'tests/a.test.ts\ndocs/superpowers/plans/p.md\n', stderr: '' })
+    }
+    const result = await runDiffGuard(execGit, '/repo/wt')
+    expect(result).toEqual({ ok: true })
+  })
+
+  test('runDiffGuard returns violations when src/ or baseline.json changed', async () => {
+    const execGit = (): Promise<GitResult> => Promise.resolve({ stdout: 'tests/a.test.ts\nsrc/foo.ts\n', stderr: '' })
+    const result = await runDiffGuard(execGit, '/repo/wt')
+    expect(result).toEqual({ ok: false, violations: ['src/foo.ts'] })
+  })
+})

--- a/tests/mutation-improve/finalize.test.ts
+++ b/tests/mutation-improve/finalize.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
+import { buildSummaryBody, runFinalize, type ExecGitFn, type RunGhFn } from '../../mutation-improve/src/finalize.js'
+import type { MutationImproveRunState } from '../../mutation-improve/src/run-state.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+const config = (repoRoot: string): MutationImproveConfig => ({
+  repoRoot,
+  workDir: `${repoRoot}/.mutation-improve`,
+  base: 'master',
+  upstream: 'origin',
+  count: 1,
+  threshold: 0.95,
+  epsilon: 0.02,
+  agentTimeoutMs: 1,
+  buildTimeoutMs: 1,
+  checkCommand: 'x',
+  mutateFileCommand: 'x',
+  agent: { model: 'm', extraArgs: [], timeoutMs: 1 },
+  prBranchPrefix: 'mutation-improve',
+})
+
+describe('finalize', () => {
+  test('buildSummaryBody renders one row per merged file plus a failures section when present', () => {
+    const body = buildSummaryBody(
+      [{ file: 'src/a.ts', beforeScore: 0.4, afterScore: 0.97, iter: 1 }],
+      [{ iter: 2, gate: 'score', reason: 'below' }],
+    )
+    expect(body).toContain('| src/a.ts | 0.4 | 0.97 |')
+    expect(body).toContain('Failed iterations')
+    expect(body).toContain('| 2 | score |')
+  })
+
+  test('runFinalize pushes and opens a PR via gh, returning the URL', async () => {
+    const repoRoot = makeTempDir('fin-')
+    const runState: MutationImproveRunState = {
+      runId: 'r',
+      repoRoot,
+      workDir: `${repoRoot}/.mi`,
+      runDir: `${repoRoot}/.mi/runs/r`,
+      statePath: `${repoRoot}/.mi/runs/r/state.json`,
+      base: 'master',
+      threshold: 0.95,
+      count: 1,
+      currentIteration: 1,
+      doneSet: ['src/a.ts'],
+      merged: [{ file: 'src/a.ts', beforeScore: 0.4, afterScore: 0.97, iter: 1 }],
+      failed: [],
+      status: 'completed',
+    }
+    const seen: string[] = []
+    const execGit: ExecGitFn = (_cwd, args) => {
+      seen.push(args.join(' '))
+      return Promise.resolve({ stdout: '', stderr: '' })
+    }
+    const runGh: RunGhFn = () => Promise.resolve({ exitCode: 0, stdout: 'https://github.com/x/pull/9\n', stderr: '' })
+    const out = await runFinalize({ execGit, runGh }, { config: config(repoRoot), runState })
+    expect(out.pushed).toBe(true)
+    expect(out.prUrl).toBe('https://github.com/x/pull/9')
+    expect(seen.some((s) => s.startsWith('push origin master'))).toBe(true)
+  })
+
+  test('runFinalize survives gh failure and still reports pushed=true', async () => {
+    const repoRoot = makeTempDir('fin-fail-')
+    const runState: MutationImproveRunState = {
+      runId: 'r',
+      repoRoot,
+      workDir: `${repoRoot}/.mi`,
+      runDir: `${repoRoot}/.mi/runs/r`,
+      statePath: `${repoRoot}/.mi/runs/r/state.json`,
+      base: 'master',
+      threshold: 0.95,
+      count: 1,
+      currentIteration: 1,
+      doneSet: [],
+      merged: [{ file: 'src/a.ts', beforeScore: 0.4, afterScore: 0.97, iter: 1 }],
+      failed: [],
+      status: 'completed',
+    }
+    const execGit: ExecGitFn = () => Promise.resolve({ stdout: '', stderr: '' })
+    const runGh: RunGhFn = () => Promise.resolve({ exitCode: 1, stdout: '', stderr: 'no gh' })
+    const out = await runFinalize({ execGit, runGh }, { config: config(repoRoot), runState })
+    expect(out.pushed).toBe(true)
+    expect(out.prUrl).toBeUndefined()
+  })
+})

--- a/tests/mutation-improve/integration-git.test.ts
+++ b/tests/mutation-improve/integration-git.test.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { readBaseline, writeBaseline } from '../../mutation-improve/src/baseline.js'
+import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
+import { runPipeline, type PipelineDeps } from '../../mutation-improve/src/pipeline.js'
+import type { Result } from '../../mutation-improve/src/result-schema.js'
+import { createRunState } from '../../mutation-improve/src/run-state.js'
+import type { Selection } from '../../mutation-improve/src/selection-schema.js'
+import type { AgentUsage } from '../../review-loop/src/agent-runner.js'
+import {
+  createWorktree,
+  execGit,
+  mergeWorktree,
+  removeWorktree,
+  resetWorktree,
+} from '../../review-loop/src/worktree.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+const emptyUsage = (): AgentUsage => ({ inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0, wallMs: 0 })
+
+const selection: Selection = {
+  file: 'src/foo.ts',
+  beforeScore: 0.4,
+  rationale: 'x',
+  runnerUps: [],
+}
+
+const improvedResult: Result = {
+  specPath: 'docs/superpowers/specs/x-design.md',
+  planPath: 'docs/superpowers/plans/x.md',
+  testPaths: ['tests/foo.test.ts'],
+  residuals: [],
+  notes: '',
+}
+
+// Sequence-based measureScore: first call returns scores[0], second scores[1],
+// clamped to the last past the end. Kept at module scope so no `??` / ternary
+// lives inside a test body (vitest/no-conditional-tests).
+const sequenceMeasure = (scores: readonly number[]): PipelineDeps['measureScore'] => {
+  let calls = 0
+  return (): Promise<number> => {
+    calls += 1
+    const idx = Math.min(calls - 1, scores.length - 1)
+    return Promise.resolve(scores[idx] ?? 0)
+  }
+}
+
+// C1 regression guard. Uses REAL git for createWorktree / execGit / mergeWorktree
+// / removeWorktree and REAL readBaseline / writeBaseline; only the agent
+// subprocess, build, and score runner are faked. The pre-fix pipeline never
+// committed the worktree, so mergeWorktree was a no-op ("Already up to date"),
+// writeBaseline never propagated to base, and removeWorktree --force discarded
+// the agent's spec/plan/test files. If C1 regresses, all three assertions below
+// fail: no "chore(mutation): ratchet ..." commit on base, tests/foo.test.ts
+// missing from base, and baseline.json on base still at 0.4.
+describe('integration real-git', () => {
+  test('runPipeline commits iteration work before merge and propagates it to base', async () => {
+    const repoRoot = makeTempDir('intgit-')
+    await execGit(repoRoot, ['init', '--quiet'])
+    await execGit(repoRoot, ['config', 'user.email', 't@t.com'])
+    await execGit(repoRoot, ['config', 'user.name', 'T'])
+    await execGit(repoRoot, ['checkout', '-b', 'master'])
+    // Seed a committed baseline.json (0.4) and tests/.gitkeep so the worktree
+    // created from HEAD has the baseline file and the tests/ dir.
+    mkdirSync(path.join(repoRoot, 'scripts', 'mutation'), { recursive: true })
+    await writeBaseline(repoRoot, { 'src/foo.ts': 0.4 })
+    mkdirSync(path.join(repoRoot, 'tests'), { recursive: true })
+    writeFileSync(path.join(repoRoot, 'tests', '.gitkeep'), '')
+    await execGit(repoRoot, ['add', '-A'])
+    await execGit(repoRoot, ['commit', '-m', 'init', '--quiet'])
+
+    const config: MutationImproveConfig = {
+      repoRoot,
+      workDir: path.join(repoRoot, '.mutation-improve'),
+      base: 'master',
+      upstream: 'origin',
+      count: 1,
+      threshold: 0.95,
+      epsilon: 0.02,
+      agentTimeoutMs: 1_800_000,
+      buildTimeoutMs: 600_000,
+      checkCommand: 'bun check:full',
+      mutateFileCommand: 'bun test:mutate:file',
+      agent: { model: 'm', extraArgs: [], timeoutMs: 1_800_000 },
+      prBranchPrefix: 'mutation-improve',
+    }
+    const runState = await createRunState(config)
+
+    // runImproveAgent writes the agent's declared spec/plan/test files INTO the
+    // worktree so `git add -A` has real content to commit. Without these, a
+    // no-op commit would still satisfy "commit exists" but would mask the real
+    // regression (the agent's test work silently lost by removeWorktree).
+    const runImproveAgent: PipelineDeps['runImproveAgent'] = (
+      worktreePath,
+    ): Promise<{ value: Result; usage: AgentUsage }> => {
+      mkdirSync(path.join(worktreePath, 'docs', 'superpowers', 'specs'), { recursive: true })
+      mkdirSync(path.join(worktreePath, 'docs', 'superpowers', 'plans'), { recursive: true })
+      writeFileSync(path.join(worktreePath, 'docs', 'superpowers', 'specs', 'x-design.md'), '# spec\n')
+      writeFileSync(path.join(worktreePath, 'docs', 'superpowers', 'plans', 'x.md'), '# plan\n')
+      writeFileSync(path.join(worktreePath, 'tests', 'foo.test.ts'), "import { test } from 'bun:test'\n")
+      return Promise.resolve({ value: improvedResult, usage: emptyUsage() })
+    }
+
+    const deps: PipelineDeps = {
+      config,
+      runState,
+      spawn: () => Promise.resolve({ exitCode: 0, stdout: '', stderr: '' }),
+      createWorktree,
+      resetWorktree,
+      removeWorktree,
+      mergeWorktree,
+      execGit,
+      runBuildCheck: () => Promise.resolve({ passed: true, stdout: '', stderr: '' }),
+      measureScore: sequenceMeasure([0.4, 0.97]),
+      readBaseline,
+      writeBaseline,
+      runSelectAgent: () => Promise.resolve({ value: selection, usage: emptyUsage() }),
+      runImproveAgent,
+      log: { log: () => undefined },
+    }
+
+    const { results } = await runPipeline(deps)
+    expect(results[0]?.outcome).toBe('improved')
+
+    // C1 guard #1: a "chore(mutation): ratchet ..." commit must exist on base
+    // (repoRoot HEAD). Pre-fix, mergeWorktree merged an empty branch.
+    const { stdout: log } = await execGit(repoRoot, ['log', '--oneline'])
+    expect(log).toContain('chore(mutation): ratchet src/foo.ts baseline to 0.97')
+
+    // C1 guard #2: the agent's test file must exist on base after merge.
+    // Pre-fix, removeWorktree --force discarded the uncommitted work.
+    expect(existsSync(path.join(repoRoot, 'tests', 'foo.test.ts'))).toBe(true)
+
+    // C1 guard #3: baseline bump must have propagated to base via the merge.
+    const finalBaseline = await readBaseline(repoRoot)
+    expect(finalBaseline['src/foo.ts']).toBe(0.97)
+  })
+})

--- a/tests/mutation-improve/integration.test.ts
+++ b/tests/mutation-improve/integration.test.ts
@@ -82,7 +82,7 @@ describe('integration', () => {
       resetWorktree: () => Promise.resolve(),
       removeWorktree: () => Promise.resolve(),
       mergeWorktree: () => Promise.resolve({ ok: true }),
-      execGit: () => Promise.resolve({ stdout: 'tests/foo.test.ts\n', stderr: '' }),
+      execGit: () => Promise.resolve({ stdout: ' M tests/foo.test.ts\n', stderr: '' }),
       runBuildCheck: () => Promise.resolve({ passed: true, stdout: '', stderr: '' }),
       measureScore: sequenceMeasure([0.4, 0.97]),
       readBaseline: () => Promise.resolve(baseline),

--- a/tests/mutation-improve/integration.test.ts
+++ b/tests/mutation-improve/integration.test.ts
@@ -4,10 +4,9 @@
 // See LICENSE in the project root for details.
 
 import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdir } from 'node:fs/promises'
 import path from 'node:path'
 
-import { readBaseline, writeBaseline } from '../../mutation-improve/src/baseline.js'
+import type { BaselineMap } from '../../mutation-improve/src/baseline.js'
 import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
 import { runFinalize } from '../../mutation-improve/src/finalize.js'
 import { runPipeline, type PipelineDeps } from '../../mutation-improve/src/pipeline.js'
@@ -51,9 +50,13 @@ const sequenceMeasure = (scores: readonly number[]): PipelineDeps['measureScore'
 describe('integration', () => {
   test('runPipeline + runFinalize end-to-end with all externals faked', async () => {
     const repoRoot = makeTempDir('e2e-')
-    // seed a baseline file (writeBaseline does not mkdir parents)
-    await mkdir(path.join(repoRoot, 'scripts', 'mutation'), { recursive: true })
-    await writeBaseline(repoRoot, { 'src/foo.ts': 0.4 })
+    // C1 changed the baseline WRITE target from repoRoot to the worktree path.
+    // This composition test fakes createWorktree (no real worktree dir on disk),
+    // so writeBaseline must be faked too — otherwise it would ENOENT on the
+    // non-existent worktree path. Real baseline.ts persistence is exercised by
+    // integration-git.test.ts; this test still proves runPipeline + runFinalize
+    // composition end-to-end.
+    let baseline: BaselineMap = { 'src/foo.ts': 0.4 }
     const config: MutationImproveConfig = {
       repoRoot,
       workDir: path.join(repoRoot, '.mutation-improve'),
@@ -82,8 +85,11 @@ describe('integration', () => {
       execGit: () => Promise.resolve({ stdout: 'tests/foo.test.ts\n', stderr: '' }),
       runBuildCheck: () => Promise.resolve({ passed: true, stdout: '', stderr: '' }),
       measureScore: sequenceMeasure([0.4, 0.97]),
-      readBaseline: () => readBaseline(repoRoot),
-      writeBaseline: (repo: string, map) => writeBaseline(repo, map),
+      readBaseline: () => Promise.resolve(baseline),
+      writeBaseline: (_root: string, map: BaselineMap) => {
+        baseline = map
+        return Promise.resolve()
+      },
       runSelectAgent: () => Promise.resolve({ value: selection, usage: emptyUsage() }),
       runImproveAgent: () => Promise.resolve({ value: improvedResult, usage: emptyUsage() }),
       log: { log: () => undefined },
@@ -93,8 +99,7 @@ describe('integration', () => {
     expect(aborted).toBe(false)
     expect(results[0]).toMatchObject({ outcome: 'improved', file: 'src/foo.ts', afterScore: 0.97 })
 
-    const finalBaseline = await readBaseline(repoRoot)
-    expect(finalBaseline['src/foo.ts']).toBe(0.97)
+    expect(baseline['src/foo.ts']).toBe(0.97)
 
     const out = await runFinalize(
       {

--- a/tests/mutation-improve/integration.test.ts
+++ b/tests/mutation-improve/integration.test.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
+
+import { readBaseline, writeBaseline } from '../../mutation-improve/src/baseline.js'
+import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
+import { runFinalize } from '../../mutation-improve/src/finalize.js'
+import { runPipeline, type PipelineDeps } from '../../mutation-improve/src/pipeline.js'
+import type { Result } from '../../mutation-improve/src/result-schema.js'
+import { createRunState } from '../../mutation-improve/src/run-state.js'
+import type { Selection } from '../../mutation-improve/src/selection-schema.js'
+import type { AgentUsage } from '../../review-loop/src/agent-runner.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+const emptyUsage = (): AgentUsage => ({ inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0, wallMs: 0 })
+
+const selection: Selection = {
+  file: 'src/foo.ts',
+  beforeScore: 0.4,
+  rationale: 'x',
+  runnerUps: [],
+}
+
+const improvedResult: Result = {
+  specPath: 'docs/superpowers/specs/x-design.md',
+  planPath: 'docs/superpowers/plans/x.md',
+  testPaths: ['tests/foo.test.ts'],
+  residuals: [],
+  notes: '',
+}
+
+// Sequence-based measureScore: first call returns the before score (below
+// threshold so the iteration enters improve), second returns the after score
+// (above threshold so the iteration ratchets and merges).
+const sequenceMeasure = (scores: readonly number[]): PipelineDeps['measureScore'] => {
+  let calls = 0
+  return (): Promise<number> => {
+    calls += 1
+    const idx = Math.min(calls - 1, scores.length - 1)
+    return Promise.resolve(scores[idx] ?? 0)
+  }
+}
+
+describe('integration', () => {
+  test('runPipeline + runFinalize end-to-end with all externals faked', async () => {
+    const repoRoot = makeTempDir('e2e-')
+    // seed a baseline file (writeBaseline does not mkdir parents)
+    await mkdir(path.join(repoRoot, 'scripts', 'mutation'), { recursive: true })
+    await writeBaseline(repoRoot, { 'src/foo.ts': 0.4 })
+    const config: MutationImproveConfig = {
+      repoRoot,
+      workDir: path.join(repoRoot, '.mutation-improve'),
+      base: 'master',
+      upstream: 'origin',
+      count: 1,
+      threshold: 0.95,
+      epsilon: 0.02,
+      agentTimeoutMs: 1_800_000,
+      buildTimeoutMs: 600_000,
+      checkCommand: 'bun check:full',
+      mutateFileCommand: 'bun test:mutate:file',
+      agent: { model: 'm', extraArgs: [], timeoutMs: 1_800_000 },
+      prBranchPrefix: 'mutation-improve',
+    }
+    const runState = await createRunState(config)
+
+    const deps: PipelineDeps = {
+      config,
+      runState,
+      spawn: () => Promise.resolve({ exitCode: 0, stdout: '', stderr: '' }),
+      createWorktree: () => Promise.resolve(),
+      resetWorktree: () => Promise.resolve(),
+      removeWorktree: () => Promise.resolve(),
+      mergeWorktree: () => Promise.resolve({ ok: true }),
+      execGit: () => Promise.resolve({ stdout: 'tests/foo.test.ts\n', stderr: '' }),
+      runBuildCheck: () => Promise.resolve({ passed: true, stdout: '', stderr: '' }),
+      measureScore: sequenceMeasure([0.4, 0.97]),
+      readBaseline: () => readBaseline(repoRoot),
+      writeBaseline: (repo: string, map) => writeBaseline(repo, map),
+      runSelectAgent: () => Promise.resolve({ value: selection, usage: emptyUsage() }),
+      runImproveAgent: () => Promise.resolve({ value: improvedResult, usage: emptyUsage() }),
+      log: { log: () => undefined },
+    }
+
+    const { results, aborted } = await runPipeline(deps)
+    expect(aborted).toBe(false)
+    expect(results[0]).toMatchObject({ outcome: 'improved', file: 'src/foo.ts', afterScore: 0.97 })
+
+    const finalBaseline = await readBaseline(repoRoot)
+    expect(finalBaseline['src/foo.ts']).toBe(0.97)
+
+    const out = await runFinalize(
+      {
+        execGit: () => Promise.resolve({ stdout: '', stderr: '' }),
+        runGh: () => Promise.resolve({ exitCode: 0, stdout: 'https://github.com/x/pull/1\n', stderr: '' }),
+      },
+      { config, runState },
+    )
+    expect(out.prUrl).toBe('https://github.com/x/pull/1')
+  })
+})

--- a/tests/mutation-improve/pipeline.test.ts
+++ b/tests/mutation-improve/pipeline.test.ts
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import path from 'node:path'
+
+import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
+import { runIteration, runPipeline, type PipelineDeps } from '../../mutation-improve/src/pipeline.js'
+import type { Result } from '../../mutation-improve/src/result-schema.js'
+import type { MutationImproveRunState } from '../../mutation-improve/src/run-state.js'
+import type { Selection } from '../../mutation-improve/src/selection-schema.js'
+import type { AgentUsage } from '../../review-loop/src/agent-runner.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+const emptyUsage = (): AgentUsage => ({ inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0, wallMs: 0 })
+
+const config = (repoRoot: string, overrides: Partial<MutationImproveConfig> = {}): MutationImproveConfig => ({
+  repoRoot,
+  workDir: path.join(repoRoot, '.mutation-improve'),
+  base: 'master',
+  upstream: 'origin',
+  count: 1,
+  threshold: 0.95,
+  epsilon: 0.02,
+  agentTimeoutMs: 1_800_000,
+  buildTimeoutMs: 600_000,
+  checkCommand: 'bun check:full',
+  mutateFileCommand: 'bun test:mutate:file',
+  agent: { model: 'm', extraArgs: [], timeoutMs: 1_800_000 },
+  prBranchPrefix: 'mutation-improve',
+  ...overrides,
+})
+
+const runState = (repoRoot: string, overrides: Partial<MutationImproveRunState> = {}): MutationImproveRunState => ({
+  runId: 'r1',
+  repoRoot,
+  workDir: path.join(repoRoot, '.mutation-improve'),
+  runDir: path.join(repoRoot, '.mutation-improve', 'runs', 'r1'),
+  statePath: path.join(repoRoot, '.mutation-improve', 'runs', 'r1', 'state.json'),
+  base: 'master',
+  threshold: 0.95,
+  count: 1,
+  currentIteration: 0,
+  doneSet: [],
+  merged: [],
+  failed: [],
+  status: 'running',
+  ...overrides,
+})
+
+const selection: Selection = {
+  file: 'src/live-status/tool-status-labels.ts',
+  beforeScore: 0.46,
+  rationale: 'pure',
+  runnerUps: [],
+}
+
+const result: Result = {
+  specPath: 'docs/superpowers/specs/x-design.md',
+  planPath: 'docs/superpowers/plans/x.md',
+  testPaths: ['tests/live-status/x.test.ts'],
+  residuals: [],
+  notes: '',
+}
+
+// Sequence-based measureScore fake: returns scores[0] on first call, scores[1] on
+// second, etc. The impl calls measureScore twice per iteration (before/after), so
+// a 2-element array covers one iteration; chaining uses a 4-element array. We
+// clamp to the last element past the end (avoids `??` inside test bodies, which
+// trips vitest/no-conditional-in-test).
+const sequenceMeasure = (scores: readonly number[]): PipelineDeps['measureScore'] => {
+  let calls = 0
+  return (): Promise<number> => {
+    calls += 1
+    const idx = Math.min(calls - 1, scores.length - 1)
+    return Promise.resolve(scores[idx] ?? 0)
+  }
+}
+
+// Sequence-based runSelectAgent fake: returns picks[0] on first call, picks[1] on
+// second, etc. Clamps past the end so we never produce `file: string | undefined`.
+const sequenceSelect = (picks: readonly string[], selectionTemplate: Selection): PipelineDeps['runSelectAgent'] => {
+  let calls = 0
+  return (): Promise<{ value: Selection; usage: AgentUsage }> => {
+    calls += 1
+    const idx = Math.min(calls - 1, picks.length - 1)
+    const file = picks[idx] ?? ''
+    return Promise.resolve({
+      value: { ...selectionTemplate, file, beforeScore: 0.5 },
+      usage: emptyUsage(),
+    })
+  }
+}
+
+const happyDeps = (): PipelineDeps => {
+  const repoRoot = makeTempDir('pipe-')
+  let baseline: Record<string, number> = {
+    'src/live-status/tool-status-labels.ts': 0.46,
+    'src/tools/memory.ts': 0.5,
+  }
+  const deps: PipelineDeps = {
+    config: config(repoRoot),
+    runState: runState(repoRoot),
+    spawn: () => Promise.resolve({ exitCode: 0, stdout: '', stderr: '' }),
+    createWorktree: () => Promise.resolve(),
+    resetWorktree: () => Promise.resolve(),
+    removeWorktree: () => Promise.resolve(),
+    mergeWorktree: () => Promise.resolve({ ok: true }),
+    execGit: () => Promise.resolve({ stdout: 'tests/live-status/x.test.ts\n', stderr: '' }),
+    runBuildCheck: () => Promise.resolve({ passed: true, stdout: '', stderr: '' }),
+    measureScore: sequenceMeasure([0.46, 0.97]),
+    readBaseline: () => Promise.resolve(baseline),
+    writeBaseline: (_root: string, map: Record<string, number>) => {
+      baseline = map
+      return Promise.resolve()
+    },
+    runSelectAgent: () => Promise.resolve({ value: selection, usage: emptyUsage() }),
+    runImproveAgent: () => Promise.resolve({ value: result, usage: emptyUsage() }),
+    log: { log: () => undefined, issue: undefined },
+  }
+  return deps
+}
+
+describe('pipeline runIteration', () => {
+  test('happy path: improved, merged, baseline ratcheted', async () => {
+    const deps = happyDeps()
+    const outcome = await runIteration(deps, 1)
+    expect(outcome).toEqual({
+      iter: 1,
+      outcome: 'improved',
+      file: 'src/live-status/tool-status-labels.ts',
+      beforeScore: 0.46,
+      afterScore: 0.97,
+    })
+    expect(deps.runState.merged).toHaveLength(1)
+    expect(deps.runState.merged[0]?.afterScore).toBe(0.97)
+    expect(deps.runState.doneSet).toContain('src/live-status/tool-status-labels.ts')
+    // baseline bump is runner-owned
+    const bumped = await deps.readBaseline(deps.config.repoRoot)
+    expect(bumped['src/live-status/tool-status-labels.ts']).toBe(0.97)
+  })
+
+  test('diff-scope violation fails the iteration without merging or ratcheting', async () => {
+    const deps = happyDeps()
+    deps.execGit = (): Promise<{ stdout: string; stderr: string }> =>
+      Promise.resolve({ stdout: 'src/foo.ts\n', stderr: '' })
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('diff-scope')
+    expect(deps.runState.merged).toHaveLength(0)
+    const baseline = await deps.readBaseline('/repo')
+    // baseline is unchanged because ratchet runs only after a green verify
+    expect(baseline['src/live-status/tool-status-labels.ts']).toBe(0.46)
+  })
+
+  test('score below threshold with no residuals fails the iteration', async () => {
+    const deps = happyDeps()
+    // before and after both 0.46 (< 0.95); no residuals → fail 'score'
+    deps.measureScore = sequenceMeasure([0.46, 0.46])
+    deps.runImproveAgent = (): Promise<{ value: Result; usage: AgentUsage }> =>
+      Promise.resolve({ value: { ...result, residuals: [] }, usage: emptyUsage() })
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('score')
+  })
+
+  test('score below threshold WITH justified residuals passes', async () => {
+    const deps = happyDeps()
+    // before 0.46 (< 0.95), after 0.94 (within epsilon of 0.95) + residuals → pass
+    deps.measureScore = sequenceMeasure([0.46, 0.94])
+    deps.runImproveAgent = (): Promise<{ value: Result; usage: AgentUsage }> =>
+      Promise.resolve({
+        value: { ...result, residuals: [{ loc: 'L21', why: 'equivalent' }] },
+        usage: emptyUsage(),
+      })
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('improved')
+    expect(outcome.afterScore).toBe(0.94)
+  })
+
+  test('merge conflict produces a failed merge-gate outcome', async () => {
+    const deps = happyDeps()
+    deps.mergeWorktree = (): Promise<{ ok: false; conflictFiles: string[] }> =>
+      Promise.resolve({ ok: false, conflictFiles: ['scripts/mutation/baseline.json'] })
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('merge')
+  })
+})
+
+describe('pipeline runPipeline', () => {
+  test('count chains: iteration 2 sees iteration 1 baseline bump; merge conflict aborts', async () => {
+    const deps = happyDeps()
+    deps.config = config(deps.config.repoRoot, { count: 2 })
+    // impl call order is interleaved: iter1.before, iter1.after, iter2.before, iter2.after
+    deps.measureScore = sequenceMeasure([0.46, 0.97, 0.5, 0.96])
+    const picks = ['src/live-status/tool-status-labels.ts', 'src/tools/memory.ts']
+    deps.runSelectAgent = sequenceSelect(picks, selection)
+    const { results, aborted } = await runPipeline(deps)
+    expect(aborted).toBe(false)
+    expect(results).toHaveLength(2)
+    expect(results[0]?.outcome).toBe('improved')
+    expect(results[1]?.outcome).toBe('improved')
+    expect(deps.runState.doneSet).toEqual(picks)
+  })
+
+  test('merge conflict in iteration 1 aborts the pipeline and skips iteration 2', async () => {
+    const deps = happyDeps()
+    deps.config = config(deps.config.repoRoot, { count: 2 })
+    deps.mergeWorktree = (): Promise<{ ok: false; conflictFiles: string[] }> =>
+      Promise.resolve({ ok: false, conflictFiles: ['scripts/mutation/baseline.json'] })
+    const { results, aborted } = await runPipeline(deps)
+    // merge-gate fail aborts: stops chaining, status 'aborted', iter 2 never runs
+    expect(aborted).toBe(true)
+    expect(results).toHaveLength(1)
+    expect(results[0]?.outcome).toBe('failed')
+    expect(results[0]?.gate).toBe('merge')
+    expect(deps.runState.status).toBe('aborted')
+    expect(deps.runState.currentIteration).toBe(1)
+  })
+})

--- a/tests/mutation-improve/pipeline.test.ts
+++ b/tests/mutation-improve/pipeline.test.ts
@@ -182,6 +182,24 @@ describe('pipeline runIteration', () => {
     expect(outcome.afterScore).toBe(0.94)
   })
 
+  // I2: pins the AND of the residual escape. The existing "no residuals → fail"
+  // test uses afterScore=0.46 (also below threshold − ε), so deleting the
+  // `residuals.length > 0 &&` would still leave that test green. This case puts
+  // afterScore INSIDE epsilon with NO residuals: a correct impl fails (no
+  // residuals → not justified); a mutant deleting `&&` would wrongly pass it.
+  test('score within epsilon with NO residuals fails (pins residual-escape AND)', async () => {
+    const deps = happyDeps()
+    // before 0.46 (< 0.95), after 0.94 (within epsilon of 0.95), residuals
+    // empty → must fail 'score'. 0.94 >= 0.95 − 0.02, so the AND is the only
+    // thing standing between this iteration and an unjustified pass.
+    deps.measureScore = sequenceMeasure([0.46, 0.94])
+    deps.runImproveAgent = (): Promise<{ value: Result; usage: AgentUsage }> =>
+      Promise.resolve({ value: { ...result, residuals: [] }, usage: emptyUsage() })
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('score')
+  })
+
   test('merge conflict produces a failed merge-gate outcome', async () => {
     const deps = happyDeps()
     deps.mergeWorktree = (): Promise<{ ok: false; conflictFiles: string[] }> =>

--- a/tests/mutation-improve/pipeline.test.ts
+++ b/tests/mutation-improve/pipeline.test.ts
@@ -110,7 +110,7 @@ const happyDeps = (): PipelineDeps => {
     resetWorktree: () => Promise.resolve(),
     removeWorktree: () => Promise.resolve(),
     mergeWorktree: () => Promise.resolve({ ok: true }),
-    execGit: () => Promise.resolve({ stdout: 'tests/live-status/x.test.ts\n', stderr: '' }),
+    execGit: () => Promise.resolve({ stdout: ' M tests/live-status/x.test.ts\n', stderr: '' }),
     runBuildCheck: () => Promise.resolve({ passed: true, stdout: '', stderr: '' }),
     measureScore: sequenceMeasure([0.46, 0.97]),
     readBaseline: () => Promise.resolve(baseline),
@@ -147,7 +147,7 @@ describe('pipeline runIteration', () => {
   test('diff-scope violation fails the iteration without merging or ratcheting', async () => {
     const deps = happyDeps()
     deps.execGit = (): Promise<{ stdout: string; stderr: string }> =>
-      Promise.resolve({ stdout: 'src/foo.ts\n', stderr: '' })
+      Promise.resolve({ stdout: ' M src/foo.ts\n', stderr: '' })
     const outcome = await runIteration(deps, 1)
     expect(outcome.outcome).toBe('failed')
     expect(outcome.gate).toBe('diff-scope')

--- a/tests/mutation-improve/prompt-templates.test.ts
+++ b/tests/mutation-improve/prompt-templates.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { buildImprovePrompt, buildSelectPrompt } from '../../mutation-improve/src/prompt-templates.js'
+
+describe('prompt-templates', () => {
+  test('buildSelectPrompt names the output path, the done-set, and the rejection rules', () => {
+    const prompt = buildSelectPrompt({
+      doneSet: ['src/a.ts'],
+      baselineSummary: '{"src/b.ts":0.2}',
+      outputPath: '/run/iter/1/selection.json',
+    })
+    expect(prompt).toContain('/run/iter/1/selection.json')
+    expect(prompt).toContain('src/a.ts')
+    expect(prompt).toContain('Math.random')
+    expect(prompt).toContain('baseline.json')
+  })
+
+  test('buildImprovePrompt states the no-src and no-baseline hard constraints and the exact-equality discipline', () => {
+    const prompt = buildImprovePrompt({
+      file: 'src/foo.ts',
+      beforeScore: 0.3,
+      threshold: 0.95,
+      date: '2026-08-05',
+      outputPath: '/run/iter/1/result.json',
+    })
+    expect(prompt).toContain('MUST NOT edit anything under src/')
+    expect(prompt).toContain('MUST NOT edit scripts/mutation/baseline.json')
+    expect(prompt).toContain('toBe(')
+    expect(prompt).toContain('0.95')
+    expect(prompt).toContain('/run/iter/1/result.json')
+    expect(prompt).toContain('docs/superpowers/specs/2026-08-05-mutation-coverage-foo-design.md')
+  })
+})

--- a/tests/mutation-improve/run-state.test.ts
+++ b/tests/mutation-improve/run-state.test.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import path from 'node:path'
+
+import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
+import {
+  createRunState,
+  iterDir,
+  loadRunState,
+  PersistedRunStateSchema,
+  saveRunState,
+} from '../../mutation-improve/src/run-state.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+const baseConfig = (repoRoot: string, workDir: string): MutationImproveConfig => ({
+  repoRoot,
+  workDir,
+  base: 'master',
+  upstream: 'origin',
+  count: 1,
+  threshold: 0.95,
+  epsilon: 0.02,
+  agentTimeoutMs: 1_800_000,
+  buildTimeoutMs: 600_000,
+  checkCommand: 'bun check:full',
+  mutateFileCommand: 'bun test:mutate:file',
+  agent: { model: 'm', extraArgs: [], timeoutMs: 1_800_000 },
+  prBranchPrefix: 'mutation-improve',
+})
+
+describe('run-state', () => {
+  test('createRunState persists and round-trips through loadRunState', async () => {
+    const repoRoot = makeTempDir('rs-')
+    const config = baseConfig(repoRoot, path.join(repoRoot, '.mutation-improve'))
+    const created = await createRunState(config)
+    expect(created.currentIteration).toBe(0)
+    expect(created.doneSet).toEqual([])
+    expect(created.status).toBe('running')
+    created.doneSet = ['src/a.ts']
+    created.currentIteration = 1
+    await saveRunState(created)
+    const reloaded = await loadRunState(config.workDir, created.runId)
+    expect(reloaded.doneSet).toEqual(['src/a.ts'])
+    expect(reloaded.currentIteration).toBe(1)
+  })
+
+  test('iterDir is <runDir>/iter/<i>', () => {
+    expect(iterDir('/runs/r1', 3)).toBe(path.join('/runs/r1', 'iter', '3'))
+  })
+
+  test('PersistedRunStateSchema rejects unknown status', () => {
+    const valid = {
+      runId: 'r',
+      repoRoot: '/r',
+      base: 'master',
+      threshold: 0.95,
+      count: 1,
+      currentIteration: 0,
+      doneSet: [],
+      merged: [],
+      failed: [],
+      status: 'running',
+    }
+    expect(() => PersistedRunStateSchema.parse(valid)).not.toThrow()
+    expect(() => PersistedRunStateSchema.parse({ ...valid, status: 'bogus' })).toThrow()
+  })
+})

--- a/tests/mutation-improve/score-reader.test.ts
+++ b/tests/mutation-improve/score-reader.test.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, mock, test } from 'bun:test'
+
+import { measureMutationScore, reportPathFor, safeFileStem } from '../../mutation-improve/src/score-reader.js'
+import type { StrykerReport } from '../../scripts/mutation/score-merger.js'
+
+const reportWith = (killed: number, survived: number, noCoverage = 0, timeout = 0): StrykerReport => ({
+  files: {
+    'src/foo.ts': {
+      mutants: [
+        ...Array.from({ length: killed }, () => ({ status: 'Killed' })),
+        ...Array.from({ length: survived }, () => ({ status: 'Survived' })),
+        ...Array.from({ length: noCoverage }, () => ({ status: 'NoCoverage' })),
+        ...Array.from({ length: timeout }, () => ({ status: 'Timeout' })),
+      ],
+    },
+  },
+})
+
+type ExecResult = { exitCode: number; stdout: string; stderr: string }
+
+const successfulExec = (): Promise<ExecResult> => Promise.resolve({ exitCode: 0, stdout: '', stderr: '' })
+
+describe('score-reader', () => {
+  test('safeFileStem escapes path separators', () => {
+    expect(safeFileStem('src/live-status/x.ts')).toBe('src__live-status__x.ts')
+    expect(reportPathFor('reports/paired', 'src/live-status/x.ts')).toBe(
+      'reports/paired/src__live-status__x.ts.stryker-report.json',
+    )
+  })
+
+  test('measureMutationScore reads the report after exec and returns (killed+timeout)/scored', async () => {
+    // 8 killed / (8+2) scored = 0.8
+    const exec = mock(successfulExec)
+    const score = await measureMutationScore(
+      { exec, readReport: () => reportWith(8, 2) },
+      'reports/paired',
+      'src/foo.ts',
+    )
+    expect(exec).toHaveBeenCalledTimes(1)
+    expect(score).toBeCloseTo(0.8, 5)
+  })
+
+  test('measureMutationScore retries exec once when the report read throws, then succeeds', async () => {
+    const exec = mock(successfulExec)
+    const readReport = mock((): StrykerReport => reportWith(10, 0)).mockImplementationOnce((): StrykerReport => {
+      throw new Error('malformed')
+    })
+    const score = await measureMutationScore({ exec, readReport }, 'reports/paired', 'src/foo.ts')
+    expect(exec).toHaveBeenCalledTimes(2)
+    expect(score).toBe(1)
+  })
+
+  test('measureMutationScore throws after a failed retry', async () => {
+    const exec = mock(successfulExec)
+    await expect(
+      measureMutationScore(
+        {
+          exec,
+          readReport: (): StrykerReport => {
+            throw new Error('still malformed')
+          },
+        },
+        'reports/paired',
+        'src/foo.ts',
+      ),
+    ).rejects.toThrow(/malformed|stryker/iu)
+  })
+})

--- a/tests/mutation-improve/test-helpers.ts
+++ b/tests/mutation-improve/test-helpers.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+const tempDirs: string[] = []
+
+export function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+export function cleanupTempDirs(): void {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}

--- a/tests/review-loop/worktree.test.ts
+++ b/tests/review-loop/worktree.test.ts
@@ -157,6 +157,8 @@ describe('worktree', () => {
     await execGit(repoRoot, ['commit', '-m', 'init', '--quiet'])
     const wt = path.join(repoRoot, 'wt')
     await createWorktree(repoRoot, wt, 'run-2', 'mutation-improve')
+    const { stdout: afterCreate } = await execGit(repoRoot, ['branch', '--list'])
+    expect(afterCreate).toContain('mutation-improve/run-2')
     await removeWorktree(repoRoot, wt, 'run-2', 'mutation-improve')
     const { stdout } = await execGit(repoRoot, ['branch', '--list'])
     expect(stdout).not.toContain('mutation-improve/run-2')

--- a/tests/review-loop/worktree.test.ts
+++ b/tests/review-loop/worktree.test.ts
@@ -132,6 +132,35 @@ describe('worktree', () => {
     const result = await detectGitRoot(repoRoot)
     expect(result).toBe(realpathSync(repoRoot))
   })
+
+  test('createWorktree uses the branchPrefix argument', async () => {
+    const repoRoot = makeTempDir('wt-prefix-')
+    await execGit(repoRoot, ['init', '--quiet'])
+    await execGit(repoRoot, ['config', 'user.email', 't@t'])
+    await execGit(repoRoot, ['config', 'user.name', 't'])
+    writeFileSync(path.join(repoRoot, 'a.txt'), 'x')
+    await execGit(repoRoot, ['add', '.'])
+    await execGit(repoRoot, ['commit', '-m', 'init', '--quiet'])
+    const wt = path.join(repoRoot, 'wt')
+    await createWorktree(repoRoot, wt, 'run-1', 'mutation-improve')
+    const { stdout } = await execGit(repoRoot, ['branch', '--list'])
+    expect(stdout).toContain('mutation-improve/run-1')
+  })
+
+  test('removeWorktree deletes a branch under branchPrefix', async () => {
+    const repoRoot = makeTempDir('wt-prefix-rm-')
+    await execGit(repoRoot, ['init', '--quiet'])
+    await execGit(repoRoot, ['config', 'user.email', 't@t'])
+    await execGit(repoRoot, ['config', 'user.name', 't'])
+    writeFileSync(path.join(repoRoot, 'a.txt'), 'x')
+    await execGit(repoRoot, ['add', '.'])
+    await execGit(repoRoot, ['commit', '-m', 'init', '--quiet'])
+    const wt = path.join(repoRoot, 'wt')
+    await createWorktree(repoRoot, wt, 'run-2', 'mutation-improve')
+    await removeWorktree(repoRoot, wt, 'run-2', 'mutation-improve')
+    const { stdout } = await execGit(repoRoot, ['branch', '--list'])
+    expect(stdout).not.toContain('mutation-improve/run-2')
+  })
 })
 
 describe('cleanWorkerWorktrees', () => {


### PR DESCRIPTION
Automates the proven 7-branch mutation-coverage procedure end-to-end as a single fully-autonomous runner: **select** highest-ROI file → write spec+plan → add exact-equality tests → **verify** ≥ threshold → **ratchet** baseline → **merge** → one summary PR. Reuses `review-loop/` harness primitives (worktree, agent-runner, spawn, build-checker) but not its review/fix loop. One agent/model, two phased invocations per file (select, then improve).

**Integrity model — "runner measures, agent creates":** the runner runs `bun test:mutate:file` itself and reads the Stryker report (never trusts an agent-reported score); the runner writes `baseline.json` (agent is forbidden via a diff-scope guard that now also catches untracked files). The residual-escape is the only agent-reported field touching a gate, bounded to `threshold − ε` and qualifying a *measured* score.

## What landed
- New sibling workspace `mutation-improve/` (config, schemas, score-reader, baseline, diff-guard, run-state, prompt-templates, pipeline spine, finalize, cli) — mirrors `review-loop/` layout, own TDD gate.
- One backward-compatible shared-file change: `review-loop/src/worktree.ts` branch-prefix parametrization (review-loop 289/289 still green).
- `--count N` chains iterations via local sequential merge so iteration `i+1` sees `i`’s baseline bump; one summary `gh` PR at the end.

## Verification
- 44/44 `mutation-improve` tests pass; `review-loop` 289/289 unaffected; root lint/typecheck/format/knip clean.
- Hermetic per-module tests + a real-git integration test guarding the commit-before-merge step (caught by the final review).
- Spec: `docs/superpowers/specs/2026-08-05-mutation-improve-runner-design.md`. Plan: `docs/superpowers/plans/2026-08-05-mutation-improve-runner.md`.

## Deferred to follow-up (non-blocking, from final review)
`--reset-worktree` flag is parsed but not consumed (architecture has no durable worktree to reset); thin parser coverage; cross-workspace coupling is unguarded (no adapter interface); score-reader retry keys off foreign error wording.