### PR TITLE
fix(mutation-improve): PR #222 deferred items + runner dogfood fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ crvy-rprtr-*.json
 # Review loop state
 .review-loop/
 
+# Mutation improve runner state
+.mutation-improve/
+
 codeindex/.codeindex/
 papai-local.tar
 client/assets

--- a/docs/superpowers/plans/2026-08-05-mutation-improve-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-mutation-improve-hardening.md
@@ -1,0 +1,625 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation-Improve Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the three remaining deferred items from PR #222 by hardening the `mutation-improve` runner: complete `parseCliArgs` coverage (+ fix a `NaN`-threshold leak), decouple the score-reader retry from foreign error-message wording via a typed error, and add a cross-workspace contract guard for the review-loop surface mutation-improve consumes.
+
+**Architecture:** Three independent, test-first edits bundled in one PR. (1) Parser: export `DEFAULT_CONFIG_PATH`, add a `Number.isFinite` guard to `--threshold=`, extend `cli.test.ts` with the missing branches. (2) Typed error: `readStrykerReport` throws a new exported `ReportReadError`; `measureMutationScore` retries on `instanceof ReportReadError || err.code === 'ENOENT'` instead of a message regex. (3) Contract: extend `contracts.test.ts` with a behavioral tier (LiveRenderer passthrough, createShellExec+runBuildCheck round-trip) and a runtime inventory tier of the consumed review-loop symbols. No facade, no new workspace, no runtime behavior change.
+
+**Tech Stack:** Bun + `bun:test`, TypeScript (strict, `.js` import paths), Zod v4, oxlint/oxfmt, Stryker. Workspace scripts: `bun run mutation-improve:{test,typecheck,lint,format:check}`.
+
+## Global Constraints
+
+Copied verbatim from the spec / repo conventions; every task implicitly includes these.
+
+- **No runtime behavior change:** the score-reader retry's *trigger set* is preserved exactly (same inputs retry, same inputs propagate); only the detection mechanism changes.
+- **No new facade module, no new shared workspace** — `cli.ts` keeps its direct review-loop imports.
+- **License header:** every new/modified source and test file keeps the verbatim `SPDX-License-Identifier: BUSL-1.1` block already present; do not alter existing headers.
+- **Import paths:** use `.js` extensions in all relative imports.
+- **Never add `lint-disable` / `type-ignore` comments** — hook policy blocks them; fix the underlying issue.
+- **Error extraction:** `error instanceof Error ? error.message : String(error)`.
+- **No comments added to source unless a given step's code block includes them** (repo convention). The code blocks below that contain `// …` comments are intentional and must be copied verbatim.
+- **Test isolation:** no real `git`/`opencode`/Stryker in unit tests (the existing `cli.test.ts` `resetRunWorktrees` block is the documented exception; a Tier-A `sh -c true`/`false` round-trip is permitted and consistent with it). Temp dirs use `makeTempDir` / `cleanupTempDirs` from `tests/mutation-improve/test-helpers.ts`.
+- **Commit style:** conventional commits with scope, e.g. `test(mutation-improve): …`, `feat(mutation): …`, `refactor(mutation-improve): …`.
+- **TDD ordering rule used throughout:** when a test must reference a new symbol by identity (e.g. `toThrow(ReportReadError)` or `toBe(DEFAULT_CONFIG_PATH)`), the symbol's *declaration* lands first as inert plumbing (an exported class that is not yet thrown, or an exported const already in use internally); the test then goes red on *behavior*, and the subsequent step wires the behavior that turns it green. This avoids module-load errors masquerading as red signals.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `mutation-improve/src/cli.ts` | arg parsing + composition root | export `DEFAULT_CONFIG_PATH`; add `Number.isFinite` guard to `--threshold=` branch |
+| `tests/mutation-improve/cli.test.ts` | parser unit tests | add coverage cases (unknown arg, missing value, non-integer count, non-numeric threshold, default path) |
+| `scripts/mutation/json-readers.ts` | read + validate Stryker JSON report | add exported `ReportReadError` class; `readStrykerReport` throws it on bad shape |
+| `mutation-improve/src/score-reader.ts` | run Stryker, parse report, retry once | replace message-regex retry with `isRetryable(error)` typed predicate |
+| `tests/mutation-improve/score-reader.test.ts` | score-reader + readStrykerReport unit tests | rewrite the two string-based retry tests to typed fixtures; add ENOENT-code retry test + plain-Error no-retry test + `ReportReadError` assertion |
+| `tests/mutation-improve/contracts.test.ts` | cross-workspace contract guard | add behavioral (Tier A) + inventory (Tier B) `describe('review-loop surface contract')` block |
+
+No other files change.
+
+---
+
+## Task 1: Harden `parseCliArgs` (NaN guard + coverage)
+
+**Files:**
+- Modify: `mutation-improve/src/cli.ts:38` (export `DEFAULT_CONFIG_PATH`), `mutation-improve/src/cli.ts:69-72` (`--threshold=` branch)
+- Test: `tests/mutation-improve/cli.test.ts`
+
+**Interfaces:**
+- Produces: newly exported `export const DEFAULT_CONFIG_PATH` (string) from `cli.ts`; `parseCliArgs(['--threshold=abc'])` now throws instead of returning `flags.threshold = NaN`.
+
+- [ ] **Step 1: Write the failing NaN test + three characterization tests (no new symbol referenced)**
+
+Append to the existing `describe('cli parseCliArgs')` block in `tests/mutation-improve/cli.test.ts`. These four need no new imports — `parseCliArgs` is already imported:
+
+```typescript
+  test('rejects non-numeric --threshold', () => {
+    expect(() => parseCliArgs(['--threshold=abc'])).toThrow(/threshold/iu)
+  })
+
+  test('throws on unknown argument', () => {
+    expect(() => parseCliArgs(['--bogus'])).toThrow(/Unknown argument/u)
+  })
+
+  test('throws when a value-taking flag is missing its value', () => {
+    for (const flag of ['--config', '--count', '--base', '--resume-run']) {
+      expect(() => parseCliArgs([flag])).toThrow(`Missing value for ${flag}`)
+    }
+  })
+
+  test('rejects fractional and non-numeric --count', () => {
+    expect(() => parseCliArgs(['--count', '3.5'])).toThrow()
+    expect(() => parseCliArgs(['--count', 'abc'])).toThrow()
+  })
+```
+
+- [ ] **Step 2: Run tests to verify the NaN case fails (rest pass as characterization)**
+
+Run: `bun test tests/mutation-improve/cli.test.ts`
+Expected: the `rejects non-numeric --threshold` test FAILS (`Number('abc')` is `NaN`, no throw today); the other three new tests PASS — they exercise already-throwing branches (`cli.ts:48`, `cli.ts:64`, `cli.ts:91`) and are characterization pins.
+
+- [ ] **Step 3: Implement the NaN guard**
+
+In `mutation-improve/src/cli.ts`, change the `--threshold=` branch from:
+
+```typescript
+    if (arg.startsWith('--threshold=')) {
+      flags.threshold = Number(arg.slice('--threshold='.length))
+      continue
+    }
+```
+
+to:
+
+```typescript
+    if (arg.startsWith('--threshold=')) {
+      const threshold = Number(arg.slice('--threshold='.length))
+      if (!Number.isFinite(threshold)) throw new Error('--threshold must be a finite number')
+      flags.threshold = threshold
+      continue
+    }
+```
+
+- [ ] **Step 4: Run tests to verify the NaN case now passes**
+
+Run: `bun test tests/mutation-improve/cli.test.ts`
+Expected: PASS (all parser tests green).
+
+- [ ] **Step 5: Export `DEFAULT_CONFIG_PATH` and add the default-path characterization test**
+
+In `mutation-improve/src/cli.ts`, change the module-local const:
+
+```typescript
+const DEFAULT_CONFIG_PATH = path.join(import.meta.dir, '..', 'config.json')
+```
+
+to:
+
+```typescript
+export const DEFAULT_CONFIG_PATH = path.join(import.meta.dir, '..', 'config.json')
+```
+
+In `tests/mutation-improve/cli.test.ts`, update the existing import:
+
+```typescript
+import { parseCliArgs, resetRunWorktrees } from '../../mutation-improve/src/cli.js'
+```
+
+to:
+
+```typescript
+import { DEFAULT_CONFIG_PATH, parseCliArgs, resetRunWorktrees } from '../../mutation-improve/src/cli.js'
+```
+
+and append to the `describe('cli parseCliArgs')` block:
+
+```typescript
+  test('uses the default config path when --config is absent', () => {
+    expect(parseCliArgs([]).configPath).toBe(DEFAULT_CONFIG_PATH)
+  })
+```
+
+- [ ] **Step 6: Run tests to verify the default-path test passes**
+
+Run: `bun test tests/mutation-improve/cli.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Typecheck + lint + format**
+
+Run: `bun run mutation-improve:typecheck && bun run mutation-improve:lint && bun run mutation-improve:format:check`
+Expected: clean (`DEFAULT_CONFIG_PATH` is consumed by the test, so knip sees the export as used).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mutation-improve/src/cli.ts tests/mutation-improve/cli.test.ts
+git commit -m "test(mutation-improve): cover parseCliArgs edge cases and guard non-numeric --threshold"
+```
+
+---
+
+## Task 2: Add `ReportReadError` to `json-readers`
+
+**Files:**
+- Modify: `scripts/mutation/json-readers.ts` (new exported class; `readStrykerReport` throws it)
+- Test: `tests/mutation-improve/score-reader.test.ts` (no dedicated `json-readers` test home exists; `readStrykerReport` is the boundary score-reader depends on — see spec "Testing strategy")
+
+**Interfaces:**
+- Produces: `export class ReportReadError extends Error` in `scripts/mutation/json-readers.ts`; `readStrykerReport(path)` throws `ReportReadError` (not plain `Error`) when the parsed JSON is not a Stryker report. Consumed by Task 3.
+
+- [ ] **Step 1: Declare the `ReportReadError` class (inert plumbing — not thrown yet) and write the tests**
+
+In `scripts/mutation/json-readers.ts`, add the exported class immediately above `readStrykerReport` (do not change `readStrykerReport` yet — it still throws plain `Error`):
+
+```typescript
+export class ReportReadError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ReportReadError'
+  }
+}
+```
+
+In `tests/mutation-improve/score-reader.test.ts`, add the Node imports at the top (after the existing `import` lines) and extend the json-readers import to pull in the two new symbols:
+
+```typescript
+import { rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+```
+
+```typescript
+import { ReportReadError, readStrykerReport } from '../../scripts/mutation/json-readers.js'
+```
+
+Add a new describe block at the bottom of the file:
+
+```typescript
+describe('readStrykerReport (json-readers contract)', () => {
+  test('throws ReportReadError when the parsed JSON is not a Stryker report', () => {
+    const tmpFile = `${tmpdir()}/mi-not-a-report-${Date.now()}.json`
+    // `files` must be a record; an array is not a valid Stryker report shape
+    writeFileSync(tmpFile, JSON.stringify({ files: [] }))
+    try {
+      expect(() => readStrykerReport(tmpFile)).toThrow(ReportReadError)
+    } finally {
+      rmSync(tmpFile, { force: true })
+    }
+  })
+
+  test('returns the report when the shape is valid', () => {
+    const tmpFile = `${tmpdir()}/mi-valid-${Date.now()}.json`
+    writeFileSync(tmpFile, JSON.stringify({ files: { 'src/x.ts': { mutants: [{ status: 'Killed' }] } } }))
+    try {
+      expect(readStrykerReport(tmpFile).files?.['src/x.ts'].mutants?.length).toBe(1)
+    } finally {
+      rmSync(tmpFile, { force: true })
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify the typed-error case fails on behavior**
+
+Run: `bun test tests/mutation-improve/score-reader.test.ts`
+Expected: the `throws ReportReadError` test FAILS — `readStrykerReport` still throws a plain `Error`, so `toThrow(ReportReadError)` does not match. (The "returns the report" test passes already.) The file loads cleanly because `ReportReadError` now exists (Step 1 declared it).
+
+- [ ] **Step 3: Wire `readStrykerReport` to throw `ReportReadError`**
+
+In `scripts/mutation/json-readers.ts`, change only the throw inside `readStrykerReport` (keep the message string identical for log-grepping humans):
+
+```typescript
+export const readStrykerReport = (reportPath: string): StrykerReport => {
+  const parsed: unknown = JSON.parse(fs.readFileSync(reportPath, 'utf8'))
+  if (!isStrykerReport(parsed)) {
+    throw new Error(`${reportPath} must contain a Stryker JSON report object`)
+  }
+  return parsed
+}
+```
+
+becomes:
+
+```typescript
+export const readStrykerReport = (reportPath: string): StrykerReport => {
+  const parsed: unknown = JSON.parse(fs.readFileSync(reportPath, 'utf8'))
+  if (!isStrykerReport(parsed)) {
+    throw new ReportReadError(`${reportPath} must contain a Stryker JSON report object`)
+  }
+  return parsed
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/mutation-improve/score-reader.test.ts`
+Expected: PASS (both `readStrykerReport` contract cases green; the existing score-reader tests still pass — `ReportReadError extends Error`, so any `instanceof Error` assertions still hold).
+
+- [ ] **Step 5: Regression-check scripts/mutation consumers**
+
+`readStrykerReport` is also imported by `scripts/mutation/paired-run.ts`; confirm nothing there string-matches the old message.
+
+Run: `bun test tests/scripts/mutation/paired-run.test.ts`
+Expected: PASS (paired-run lets the error propagate; the only retry-keying consumer is score-reader, rewritten in Task 3).
+
+- [ ] **Step 6: Typecheck + lint + format**
+
+Run: `bun run mutation-improve:typecheck && bun run mutation-improve:lint && bun run mutation-improve:format:check`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/mutation/json-readers.ts tests/mutation-improve/score-reader.test.ts
+git commit -m "feat(mutation): throw typed ReportReadError from readStrykerReport"
+```
+
+---
+
+## Task 3: Decouple score-reader retry from error wording
+
+**Files:**
+- Modify: `mutation-improve/src/score-reader.ts:19-40` (`measureMutationScore` + new `isRetryable`)
+- Test: `tests/mutation-improve/score-reader.test.ts` (rewrite the two existing string-based retry tests; add ENOENT-code + plain-Error cases)
+
+**Interfaces:**
+- Consumes: `ReportReadError` from `scripts/mutation/json-readers.js` (Task 2 declared and exported it).
+- Produces: `measureMutationScore` unchanged signature; retry now keyed on `isRetryable(error)`.
+
+**Behavioral contract (must be preserved):** report-missing (`ENOENT`) → retry; wrong-shape (`ReportReadError`) → retry; `JSON.parse` SyntaxError and any other error → propagate; non-zero Stryker exit → propagate without retry (already handled before the read).
+
+- [ ] **Step 1: Rewrite the two existing string-based retry tests to typed fixtures**
+
+The import for `ReportReadError` already exists in this file from Task 2. In `tests/mutation-improve/score-reader.test.ts`, replace the existing `retries exec once…` test:
+
+```typescript
+  test('measureMutationScore retries exec once when the report read throws, then succeeds', async () => {
+    const exec = mock(successfulExec)
+    const readReport = mock((): StrykerReport => reportWith(10, 0)).mockImplementationOnce((): StrykerReport => {
+      throw new Error('malformed')
+    })
+    const score = await measureMutationScore({ exec, readReport }, 'reports/paired', 'src/foo.ts')
+    expect(exec).toHaveBeenCalledTimes(2)
+    expect(score).toBe(1)
+  })
+```
+
+with (first read throws a typed `ReportReadError`, retry succeeds):
+
+```typescript
+  test('measureMutationScore retries exec once when the report read throws ReportReadError, then succeeds', async () => {
+    const exec = mock(successfulExec)
+    const readReport = mock((): StrykerReport => reportWith(10, 0)).mockImplementationOnce((): StrykerReport => {
+      throw new ReportReadError('shape')
+    })
+    const score = await measureMutationScore({ exec, readReport }, 'reports/paired', 'src/foo.ts')
+    expect(exec).toHaveBeenCalledTimes(2)
+    expect(score).toBe(1)
+  })
+```
+
+Replace the existing `throws after a failed retry` test:
+
+```typescript
+  test('measureMutationScore throws after a failed retry', async () => {
+    const exec = mock(successfulExec)
+    await expect(
+      measureMutationScore(
+        {
+          exec,
+          readReport: (): StrykerReport => {
+            throw new Error('still malformed')
+          },
+        },
+        'reports/paired',
+        'src/foo.ts',
+      ),
+    ).rejects.toThrow(/malformed|stryker/iu)
+  })
+```
+
+with (both reads throw `ReportReadError`; retry fires then propagates the typed error):
+
+```typescript
+  test('measureMutationScore throws the typed error after a failed retry', async () => {
+    const exec = mock(successfulExec)
+    await expect(
+      measureMutationScore(
+        {
+          exec,
+          readReport: (): StrykerReport => {
+            throw new ReportReadError('shape')
+          },
+        },
+        'reports/paired',
+        'src/foo.ts',
+      ),
+    ).rejects.toBeInstanceOf(ReportReadError)
+    expect(exec).toHaveBeenCalledTimes(2)
+  })
+```
+
+- [ ] **Step 2: Add the ENOENT-code retry test and the plain-Error no-retry test**
+
+Append inside `describe('score-reader')`:
+
+```typescript
+  test('measureMutationScore retries when the report read throws an ENOENT-coded error', async () => {
+    const exec = mock(successfulExec)
+    const enoent = Object.assign(new Error('not found'), { code: 'ENOENT' })
+    const readReport = mock((): StrykerReport => reportWith(6, 0)).mockImplementationOnce((): StrykerReport => {
+      throw enoent
+    })
+    const score = await measureMutationScore({ exec, readReport }, 'reports/paired', 'src/foo.ts')
+    expect(exec).toHaveBeenCalledTimes(2)
+    expect(score).toBe(1)
+  })
+
+  test('measureMutationScore does NOT retry on a plain (non-typed, non-ENOENT) error and propagates it', async () => {
+    const exec = mock(successfulExec)
+    await expect(
+      measureMutationScore(
+        {
+          exec,
+          readReport: (): StrykerReport => {
+            throw new Error('boom')
+          },
+        },
+        'reports/paired',
+        'src/foo.ts',
+      ),
+    ).rejects.toThrow('boom')
+    expect(exec).toHaveBeenCalledTimes(1)
+  })
+```
+
+- [ ] **Step 3: Run tests to verify the retry-case failures against the current regex impl**
+
+Run: `bun test tests/mutation-improve/score-reader.test.ts`
+Expected: RED on three cases —
+- `retries once … ReportReadError` fails: the regex `/enoent|malformed|must contain a stryker/iu` does not match message `'shape'`, so today it does **not** retry → `exec` is called once, not twice, and the `ReportReadError` propagates instead of returning `1`.
+- `throws the typed error after a failed retry` fails: same non-retry → `exec` called once, not twice.
+- `retries … ENOENT-coded error` fails: the mocked error's *message* is `'not found'` (no `enoent` substring), so the message-regex does not match → no retry → `exec` once, not twice. (This is the crux: the old impl keyed on message text; the new impl will key on `.code`.)
+
+The `does NOT retry on a plain error` test PASSES under the current regex too (a plain `Error('boom')` never matched) — it is the behavioral-preservation guard carried forward unchanged.
+
+- [ ] **Step 4: Implement `isRetryable` and use it**
+
+In `mutation-improve/src/score-reader.ts`, change the top import from:
+
+```typescript
+import { readStrykerReport } from '../../scripts/mutation/json-readers.js'
+```
+
+to:
+
+```typescript
+import { ReportReadError, readStrykerReport } from '../../scripts/mutation/json-readers.js'
+```
+
+Add the predicate above `measureMutationScore` (after the `MeasureDeps` interface):
+
+```typescript
+function isRetryable(error: unknown): boolean {
+  if (error instanceof ReportReadError) return true
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code: unknown }).code === 'ENOENT'
+  )
+}
+```
+
+Replace the `catch` block of `measureMutationScore` (currently the regex):
+
+```typescript
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (/enoent|malformed|must contain a stryker/iu.test(message)) {
+      const retried = await attempt()
+      return retried
+    }
+    throw error
+  }
+```
+
+with:
+
+```typescript
+  } catch (error) {
+    if (isRetryable(error)) {
+      return attempt()
+    }
+    throw error
+  }
+```
+
+- [ ] **Step 5: Run tests to verify all pass**
+
+Run: `bun test tests/mutation-improve/score-reader.test.ts`
+Expected: PASS (all five score-reader retry cases + the two json-readers contract cases from Task 2 green).
+
+- [ ] **Step 6: Typecheck + lint + format**
+
+Run: `bun run mutation-improve:typecheck && bun run mutation-improve:lint && bun run mutation-improve:format:check`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mutation-improve/src/score-reader.ts tests/mutation-improve/score-reader.test.ts
+git commit -m "refactor(mutation-improve): key score-reader retry off typed error instead of message text"
+```
+
+---
+
+## Task 4: Cross-workspace contract guard
+
+**Files:**
+- Modify: `tests/mutation-improve/contracts.test.ts`
+- No source changes.
+
+**Interfaces:**
+- Consumes (asserts presence/shape of): `runAgent` (`review-loop/src/agent-runner.js`); `createShellExec`, `runBuildCheck` (`review-loop/src/build-checker.js`); `LiveRenderer` (`review-loop/src/live-renderer.js`); `realSpawn` (`review-loop/src/spawn.js`); `createWorktree`, `detectGitRoot`, `execGit`, `mergeWorktree`, `removeWorktree`, `resetWorktree` (`review-loop/src/worktree.js`). These are exactly the symbols `mutation-improve/src/{cli,config,pipeline}.ts` import today.
+
+**Design note (honesty):** TypeScript already catches symbol removal/rename and most signature/return-shape drift at the call sites in `cli.ts`/`pipeline.ts`. This contract test's added value is (a) behavioral pinning of the two cheap-to-exercise symbols (`LiveRenderer.log` passthrough; `createShellExec`+`runBuildCheck` exit→passed mapping) and (b) a co-located, explicit **inventory** of the consumed surface so drift is surfaced in mutation-improve's own gate even if a future refactor stops reading a field at a call site. review-loop's own suite (`tests/review-loop/**`) remains the behavioral authority for the git-/opencode-requiring symbols.
+
+- [ ] **Step 1: Write the contract tests**
+
+In `tests/mutation-improve/contracts.test.ts`, update the imports. The file currently begins:
+
+```typescript
+import { describe, expect, test } from 'bun:test'
+
+import { ResultSchema } from '../../mutation-improve/src/result-schema.js'
+import { SelectionSchema } from '../../mutation-improve/src/selection-schema.js'
+```
+
+Change to:
+
+```typescript
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { runAgent } from '../../review-loop/src/agent-runner.js'
+import { createShellExec, runBuildCheck } from '../../review-loop/src/build-checker.js'
+import { LiveRenderer } from '../../review-loop/src/live-renderer.js'
+import { realSpawn } from '../../review-loop/src/spawn.js'
+import {
+  createWorktree,
+  detectGitRoot,
+  execGit,
+  mergeWorktree,
+  removeWorktree,
+  resetWorktree,
+} from '../../review-loop/src/worktree.js'
+import { ResultSchema } from '../../mutation-improve/src/result-schema.js'
+import { SelectionSchema } from '../../mutation-improve/src/selection-schema.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers'
+
+afterEach(cleanupTempDirs)
+```
+
+Append a new describe block at the end of the file:
+
+```typescript
+describe('review-loop surface contract', () => {
+  test('Tier A — LiveRenderer.log writes the message through to the stream', () => {
+    const written: string[] = []
+    const sink = {
+      write: (chunk: string): boolean => {
+        written.push(chunk)
+        return true
+      },
+    }
+    new LiveRenderer(sink).log('hello')
+    expect(written.join('')).toBe('hello\n')
+  })
+
+  test('Tier A — createShellExec + runBuildCheck map exit 0 → passed and non-zero → failed', async () => {
+    const dir = makeTempDir('contract-build-')
+    const passed = await runBuildCheck({ exec: createShellExec(dir, 'true') })
+    expect(passed.passed).toBe(true)
+    const failed = await runBuildCheck({ exec: createShellExec(dir, 'false') })
+    expect(failed.passed).toBe(false)
+  })
+
+  test('Tier B — consumed concrete symbols are exported and callable', () => {
+    // Inventory of the review-loop surface mutation-improve consumes today.
+    // Behavioral authority for the git/opencode-requiring functions lives in
+    // tests/review-loop/**; this asserts presence + callability so removal or
+    // export-shape drift fails loudly in mutation-improve's own gate.
+    expect(typeof runAgent).toBe('function')
+    expect(typeof realSpawn).toBe('function')
+    expect(typeof createWorktree).toBe('function')
+    expect(typeof execGit).toBe('function')
+    expect(typeof mergeWorktree).toBe('function')
+    expect(typeof removeWorktree).toBe('function')
+    expect(typeof resetWorktree).toBe('function')
+    expect(typeof detectGitRoot).toBe('function')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `bun test tests/mutation-improve/contracts.test.ts`
+Expected: PASS (all symbols are exported today; `sh -c true` exits 0, `sh -c false` exits non-zero; `LiveRenderer` in non-TTY mode writes `${msg}\n` via `writeSafe` → `stream.write`).
+
+- [ ] **Step 3: Typecheck + lint + format**
+
+Run: `bun run mutation-improve:typecheck && bun run mutation-improve:lint && bun run mutation-improve:format:check`
+Expected: clean. (All newly imported symbols are used by the assertions, so knip / `no-unused-vars` are satisfied. The `sink` literal matches `RendererStream` because `write` returns `boolean` and `isTTY`/`columns` are optional.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/mutation-improve/contracts.test.ts
+git commit -m "test(mutation-improve): pin consumed review-loop surface via contract tests"
+```
+
+---
+
+## Final verification
+
+After all four tasks land on the branch:
+
+- [ ] **Full workspace gate**
+
+Run: `bun run mutation-improve:test && bun run mutation-improve:typecheck && bun run mutation-improve:lint && bun run mutation-improve:format:check`
+Expected: all green.
+
+- [ ] **review-loop unaffected**
+
+Run: `bun run review-loop:test`
+Expected: green (no shared-file change in this PR — `review-loop/src/worktree.ts` is untouched this round).
+
+- [ ] **scripts/mutation regression**
+
+Run: `bun test tests/scripts/mutation`
+Expected: PASS (the `ReportReadError` change is consumed only by score-reader, already covered).
+
+- [ ] **Root check**
+
+Run: `bun check:full`
+Expected: clean (lint/typecheck/format/knip).
+
+- [ ] **Behavioral-preservation spot check**
+
+Open `tests/mutation-improve/score-reader.test.ts` and confirm the five cases enumerate every prior retry trigger: `ENOENT`-coded (report missing) and `ReportReadError` (wrong shape) retry; non-zero Stryker exit (existing `mutation run failed` test), `JSON.parse` SyntaxError, and any other plain error propagate. The `does NOT retry on a plain error` test is the explicit guard against re-introducing over-broad retry.
+
+## Self-review notes (plan author)
+
+- **Spec coverage:** Stream 1 → Task 1; Stream 2 → Tasks 2 + 3; Stream 3 → Task 4. The already-shipped `--reset-worktree` item is intentionally absent. Every spec section maps to a task.
+- **TDD ordering:** Tasks 1 and 2 each declare a new exported symbol (`DEFAULT_CONFIG_PATH`, `ReportReadError`) as inert plumbing *before* the test that references it by identity, so the red signal is behavioral (a failing assertion), not a module-load error. The Global Constraints codify this rule.
+- **Type consistency:** `ReportReadError` is declared in Task 2 and imported by Task 3's `score-reader.ts` and by both test files — name identical everywhere. `DEFAULT_CONFIG_PATH` exported in Task 1 and imported by the Task 1 test. `isRetryable`, `attempt`, `MeasureDeps` names match the existing file.
+- **Typecheck hazards handled:** the Tier-A `sink.write` returns `boolean` (matches `RendererStream.write`), avoiding the `number`-not-assignable-to-`boolean` error that `written.push(chunk)` would cause.
+- **Placeholder scan:** all steps contain real code/commands; no TBD/TODO/"add error handling". Two existing tests are shown with exact before/after because the engineer must rewrite them rather than write fresh.
+- **Known TDD nuance:** Task 1 ships three characterization tests that pass immediately (they pin already-throwing branches) alongside one true red→green test (the NaN guard). Task 3 Step 3's red signal is three cases (the two `ReportReadError` retry cases + the ENOENT-code case); the plain-Error no-retry test passes under both old and new impl by design (behavioral preservation guard).

--- a/docs/superpowers/specs/2026-08-05-mutation-improve-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-05-mutation-improve-hardening-design.md
@@ -1,0 +1,250 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation-Improve Runner — Hardening (PR #222 Deferred Items)
+
+**Date:** 2026-08-05
+**Status:** Design — approved (pending implementation plan)
+**Type:** Tooling hardening, test-only + two small source edits; no papai runtime changes
+
+## Summary
+
+PR #222 landed the autonomous `mutation-improve` runner and listed four
+non-blocking deferred items from its final review. One — `--reset-worktree`
+being parsed but not consumed — is **already resolved** on the `mutation-improve-09`
+branch (commit `70684ef7b` wired it to `resetRunWorktrees`; tested in
+`tests/mutation-improve/cli.test.ts:43`). This spec designs the remaining three,
+bundled as a single hardening PR:
+
+1. **Parser coverage** — `parseCliArgs` has real uncovered branches.
+2. **Score-reader retry fragility** — `score-reader.ts:34` decides whether to
+   retry by regex-matching error-message *wording* emitted by a foreign module
+   (`scripts/mutation/json-readers.ts`); if that wording drifts, the retry
+   silently stops firing.
+3. **Cross-workspace coupling unguarded** — `mutation-improve` consumes a broad
+   surface of `review-loop/src/*`. TypeScript catches removed/renamed symbols at
+   compile time, but there is no guard against **behavioral drift** (review-loop
+   changes a return shape while keeping the name), and `contracts.test.ts`
+   currently only tests the two Zod schemas — it does not pin the review-loop
+   surface at all.
+
+## Why this shape
+
+- **Bundle all three** (chosen) — they are all hardening of one workspace, each
+  small, and a single spec/plan/PR keeps review surface small. The
+  cross-workspace item stays proportionate (contract guard, no new workspace)
+  rather than escalating to a shared `harness/` package that would touch
+  review-loop heavily for a non-blocking follow-up.
+- **Reuse existing test files** (chosen) — parser cases extend the existing
+  `cli.test.ts` describe block; the cross-workspace guard extends the existing
+  `contracts.test.ts`. No new test files unless a split is forced by size.
+- **Decouple by type, not by string** (chosen) — the retry decision is a control
+  that should not depend on a sibling module's prose. A typed error plus a
+  structured FS error-code check removes the wording dependency entirely.
+
+## Non-goals
+
+- No change to `mutation-improve` runtime behavior (gates, pipeline order,
+  config, prompts). The retry's *trigger conditions* are preserved exactly;
+  only the *mechanism* of detecting them changes.
+- No new `harness/` shared workspace, no facade module in `mutation-improve/src`.
+- No rework of `pipeline.ts`'s DI ports — they already insulate the pipeline
+  from concrete review-loop functions. The composition root (`cli.ts`) keeps its
+  direct imports; that is where concrete imports belong.
+- No changes under `src/`, `client/`, or `plugins/`.
+
+## Stream 1 — Parser coverage
+
+`parseCliArgs` (`mutation-improve/src/cli.ts:52`) is a hand-rolled loop with
+several branches the current tests do not reach:
+
+| Uncovered branch | Trigger |
+| --- | --- |
+| unknown-arg throw | any arg not matching a known flag (`cli.ts:91`) |
+| `readValueArg` missing-value throw | `--config` / `--count` / `--base` / `--resume-run` as the last token (`cli.ts:48`) |
+| non-integer `--count` | `--count 3.5`, `--count abc` (`cli.ts:64`) |
+| non-numeric `--threshold=` | `--threshold=abc` (`cli.ts:70`) — currently `Number(...)` yields `NaN` and silently sets `config.threshold = NaN` |
+| default config path | no `--config` → `flags.configPath === DEFAULT_CONFIG_PATH` (`cli.ts:53`) |
+
+The `NaN`-threshold case is a genuine latent bug: `NaN` flows into
+`config.threshold` and every `>= threshold` comparison in the pipeline becomes
+`false`, so gate ⑤ rejects every iteration. The fix is to validate after
+`Number(...)` in the parser (throw on `NaN`), consistent with how `--count`
+already validates.
+
+### Design
+
+Extend the existing `describe('cli parseCliArgs')` block in
+`tests/mutation-improve/cli.test.ts` with one test per row above. Add the
+`NaN`-guard to `parseCliArgs` (`--threshold=` branch) so the parser throws on
+non-numeric thresholds, mirroring the `--count` integer check. No new files.
+
+## Stream 2 — Score-reader retry decoupling
+
+`measureMutationScore` (`mutation-improve/src/score-reader.ts:19`) runs the
+Stryker command then reads the per-file report. On a read failure it retries
+once. Today it decides retry-worthiness by testing the caught error's message:
+
+```ts
+if (/enoent|malformed|must contain a stryker/iu.test(message)) { ... retry ... }
+```
+
+Two problems:
+
+- **Foreign wording dependency.** `must contain a Stryker JSON report object` is
+  emitted by `readStrykerReport` in `scripts/mutation/json-readers.ts:24`; `ENOENT`
+  comes from Node's `fs.readFileSync`. Both are outside score-reader's control.
+  A routine rephrasing of the sibling error silently disables the retry.
+- **Dead alternative.** The `malformed` token matches nothing any code path
+  throws today (`JSON.parse` SyntaxErrors read `Unexpected token…`), so it is
+  misleading dead weight.
+
+### Design
+
+Introduce a typed error and a structured FS check; remove the regex entirely.
+
+1. **New error class** `ReportReadError` in `scripts/mutation/json-readers.ts`,
+   thrown by `readStrykerReport` whenever `isStrykerReport` returns false
+   (replaces the current plain `Error`). Exported for cross-module `instanceof`
+   use. Kept in `json-readers.ts` because that is the module that decides report
+   validity — it owns the failure mode it signals.
+2. **score-reader retry predicate** becomes:
+
+   ```ts
+   function isRetryable(error: unknown): boolean {
+     if (error instanceof ReportReadError) return true
+     return typeof error === 'object' && error !== null && 'code' in error && (error as { code: unknown }).code === 'ENOENT'
+   }
+   ```
+
+   - `ReportReadError` → wrong report shape → retry (preserves today's behavior
+     for the `must contain a Stryker` path).
+   - `err.code === 'ENOENT'` → report file missing → retry (preserves today's
+     `enoent` path, robustly, via Node's stable `.code` rather than message text).
+   - `JSON.parse` SyntaxError and any other error → propagate (unchanged).
+   - Non-zero Stryker exit already throws `mutation run failed (exit N)` and
+     bypasses the retry predicate — unchanged.
+
+Behavior is preserved exactly (same inputs retry, same inputs propagate); only
+the coupling to sibling prose is removed.
+
+### `readJsonRecord`
+
+`readJsonRecord` (same file) also throws a plain `Error` on a non-record. It is
+not on score-reader's path, so it is **not** changed to `ReportReadError` — that
+would widen the typed-error surface beyond the retry use case. Left as-is.
+
+## Stream 3 — Cross-workspace coupling guard
+
+`mutation-improve` imports across the workspace boundary in three places:
+
+- `cli.ts` (composition root): `runAgent`, `createShellExec`,
+  `runBuildCheck`, `LiveRenderer`, `realSpawn`, `createWorktree`, `execGit`,
+  `mergeWorktree`, `removeWorktree`, `resetWorktree`.
+- `config.ts`: `detectGitRoot`.
+- `pipeline.ts` (type-only): `AgentRunResult`, `MergeResult`.
+
+`pipeline.ts` already consumes these through its own `PipelineDeps` interface,
+so the pipeline body is insulated; the concrete imports live in `cli.ts`, which
+is exactly where they belong. TypeScript makes symbol removal/rename a
+compile error already. The genuine unguarded gap is **behavioral drift**:
+review-loop keeps the symbol name but changes its signature or return shape in a
+way mutation-improve relies on, and mutation-improve gets no signal in its own
+gate. `contracts.test.ts` today only exercises the two Zod schemas and provides
+no such signal.
+
+### Design
+
+Repurpose `contracts.test.ts` into a real cross-workspace contract guard with
+two tiers:
+
+**Tier A — behavioral (cheap, no externals).** Exercise the symbols that can be
+run without `git` or `opencode`:
+
+- construct `new LiveRenderer(sink)` and call `.log(msg)`; assert it does not
+  throw and writes through to the sink.
+- round-trip `createShellExec` + `runBuildCheck` in a fresh temp dir against a
+  trivially-passing command (e.g. `true`); assert `{ passed: true }`.
+
+These pin behavior directly and catch signature drift the compiler might miss
+(e.g. a renamed option field).
+
+**Tier B — surface inventory (for the heavy-external symbols).** For
+`runAgent`, `realSpawn`, `createWorktree`, `execGit`, `mergeWorktree`,
+`removeWorktree`, `resetWorktree`, `detectGitRoot` — which require real git or a
+spawned `opencode` subprocess and so cannot be exercised cheaply — assert:
+
+- symbol is defined (`typeof x === 'function'`, or constructable for `LiveRenderer`),
+- function arity (`x.length`) matches what `cli.ts`/`pipeline.ts` call with.
+
+These are weak on their own but make the consumed surface explicit and fail
+loudly on removal/rename/arity drift. Each assertion carries a comment naming
+`review-loop`'s own suite (under `tests/review-loop/`) as the behavioral
+authority for these functions — the contract here is existence and call-shape,
+not full behavior.
+
+The file keeps its existing Zod-schema tests; the new `describe` block is added
+alongside them. No source changes in this stream — `cli.ts` keeps its direct
+imports (no facade). The guard is a test, not an adapter.
+
+### Why not a facade / shared workspace
+
+- **Facade (`harness.ts`)** would relocate imports `cli.ts` already legitimately
+  owns as composition root; the marginal compile-time benefit over the direct
+  imports (which TS already checks) is low, and it adds an indirection layer.
+- **Shared `harness/` workspace** is the correct long-term answer if a third
+  consumer appears, but it touches review-loop heavily and is out of proportion
+  for a non-blocking follow-up. Noted as future work.
+
+## Testing strategy
+
+All new tests live under `tests/mutation-improve/` (the workspace's TDD gate).
+No real `git`, `opencode`, or Stryker in the suite (matches existing hermetic
+conventions; uses `makeTempDir` from `./test-helpers.ts`).
+
+- **cli.test.ts** — the five new parser cases plus the `NaN`-guard.
+- **score-reader.test.ts** — extend the existing fixtures with: report-missing
+  (`ENOENT`) → retries then succeeds; wrong-shape report → `readStrykerReport`
+  throws `ReportReadError` → retries then succeeds; a plain `Error` (non-typed,
+  non-ENOENT) → does **not** retry, propagates. Keeps the existing
+  valid-report and malformed-fallback cases.
+- **contracts.test.ts** — Tier A behavioral + Tier B inventory, in a new
+  `describe('review-loop surface contract')` block.
+- **json-readers** — `readStrykerReport` has no dedicated test home today (it is
+  only covered transitively via `tests/scripts/mutation/paired-run.test.ts`,
+  which uses a *local* stub of the same name, and via score-reader). The
+  `ReportReadError` throw on a non-report is asserted directly in the
+  **score-reader** suite (it already imports `readStrykerReport` and is the
+  boundary that relies on the typed contract): call `readStrykerReport` on a
+  fixture that parses but is not a Stryker report, assert it throws an
+  `instanceof ReportReadError`.
+
+## Verification
+
+- `bun run mutation-improve:test` (44 → 4x+ new cases) green.
+- `bun test scripts/mutation` (json-readers change) green.
+- Root `bun check:full` (lint/typecheck/format/knip) clean.
+- The retry behavior-change is verified by the new score-reader cases asserting
+  retry-fires and retry-skips against typed/ENOENT/plain errors — no behavioral
+  regression vs. the regex path.
+
+## Risk & notes
+
+- **Behavioral preservation (Stream 2).** The retry's trigger set is unchanged
+  by construction: the design enumerates each current trigger and maps it to a
+  typed/`.code` equivalent. The new score-reader tests are the proof.
+- **Contract-test strength (Stream 3).** Tier B is intentionally weak
+  (existence/arity); the spec says so explicitly rather than overselling it as a
+  full behavioral guarantee. The honest claim is "drift in the consumed surface
+  now fails loudly in mutation-improve's own gate," not "review-loop is fully
+  pinned."
+- **`ReportReadError` export surface.** Adding an exported class to
+  `scripts/mutation/json-readers.ts` is the one new public symbol; it is
+  consumed only by `score-reader.ts`. Knip must see both the export and the
+  import or it will flag the class as unused — the wiring lands together.
+- **`--reset-worktree`** is intentionally out of scope: already shipped on this
+  branch.

--- a/docs/superpowers/specs/2026-08-05-mutation-improve-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-05-mutation-improve-hardening-design.md
@@ -178,11 +178,14 @@ These pin behavior directly and catch signature drift the compiler might miss
 `removeWorktree`, `resetWorktree`, `detectGitRoot` — which require real git or a
 spawned `opencode` subprocess and so cannot be exercised cheaply — assert:
 
-- symbol is defined (`typeof x === 'function'`, or constructable for `LiveRenderer`),
-- function arity (`x.length`) matches what `cli.ts`/`pipeline.ts` call with.
+- symbol is defined (`typeof x === 'function'`, or constructable for `LiveRenderer`).
+
+Function arity is not re-asserted at runtime: it is compile-checked at the
+call sites in `cli.ts`/`pipeline.ts`, so a hardcoded `.length` assertion would
+add fragility without catching drift TS already catches.
 
 These are weak on their own but make the consumed surface explicit and fail
-loudly on removal/rename/arity drift. Each assertion carries a comment naming
+loudly on removal/rename drift. Each assertion carries a comment naming
 `review-loop`'s own suite (under `tests/review-loop/`) as the behavioral
 authority for these functions — the contract here is existence and call-shape,
 not full behavior.
@@ -238,7 +241,7 @@ conventions; uses `makeTempDir` from `./test-helpers.ts`).
   by construction: the design enumerates each current trigger and maps it to a
   typed/`.code` equivalent. The new score-reader tests are the proof.
 - **Contract-test strength (Stream 3).** Tier B is intentionally weak
-  (existence/arity); the spec says so explicitly rather than overselling it as a
+  (existence); the spec says so explicitly rather than overselling it as a
   full behavioral guarantee. The honest claim is "drift in the consumed surface
   now fails loudly in mutation-improve's own gate," not "review-loop is fully
   pinned."

--- a/mutation-improve/src/cli.ts
+++ b/mutation-improve/src/cli.ts
@@ -174,6 +174,31 @@ async function runGh(ghArgs: readonly string[], cwd: string): Promise<GhResult> 
   })
 }
 
+// Sweeps stale iteration worktrees left over from a crashed/killed prior run
+// (process death bypasses runIteration's try/catch cleanup, so `<runId>-iterN`
+// worktrees and their `mutation-improve/<runId>-iterN` branches leak). Keyed by
+// runId so concurrent runs sharing a repo are not disturbed — mirrors
+// review-loop's cleanWorkerWorktrees, including the basename-only match (git
+// resolves symlinks in `worktree list`, so a prefix check would miss entries
+// under a `/var`-style tmp root). Removes sequentially because
+// `git worktree remove`/`branch -D` take repo-wide locks and race under load.
+export async function resetRunWorktrees(repoRoot: string, runId: string, branchPrefix: string): Promise<void> {
+  const { stdout } = await execGit(repoRoot, ['worktree', 'list', '--porcelain'])
+  const stale: string[] = []
+  for (const line of stdout.split('\n')) {
+    if (!line.startsWith('worktree ')) continue
+    const wtPath = line.slice('worktree '.length)
+    if (path.basename(wtPath).startsWith(`${runId}-iter`)) stale.push(wtPath)
+  }
+  let chain: Promise<unknown> = Promise.resolve()
+  for (const wtPath of stale) {
+    chain = chain.then(() =>
+      removeWorktree(repoRoot, wtPath, path.basename(wtPath), branchPrefix).catch(() => undefined),
+    )
+  }
+  await chain
+}
+
 export async function runCli(argv: readonly string[]): Promise<void> {
   const args = parseCliArgs(argv)
   const config = await loadMutationImproveConfig({ configPath: args.configPath })
@@ -183,6 +208,10 @@ export async function runCli(argv: readonly string[]): Promise<void> {
 
   const runState: MutationImproveRunState =
     args.resumeRunId === undefined ? await createRunState(config) : await loadRunState(config.workDir, args.resumeRunId)
+
+  if (args.resetWorktree) {
+    await resetRunWorktrees(config.repoRoot, runState.runId, config.prBranchPrefix)
+  }
 
   const log = new LiveRenderer(process.stdout)
   const deps = buildPipelineDeps(config, runState, log)

--- a/mutation-improve/src/cli.ts
+++ b/mutation-improve/src/cli.ts
@@ -35,7 +35,7 @@ export interface CliArgs {
   noPr: boolean
 }
 
-const DEFAULT_CONFIG_PATH = path.join(import.meta.dir, '..', 'config.json')
+export const DEFAULT_CONFIG_PATH = path.join(import.meta.dir, '..', 'config.json')
 
 interface GhResult {
   exitCode: number
@@ -67,7 +67,9 @@ export function parseCliArgs(argv: readonly string[]): CliArgs {
       continue
     }
     if (arg.startsWith('--threshold=')) {
-      flags.threshold = Number(arg.slice('--threshold='.length))
+      const threshold = Number(arg.slice('--threshold='.length))
+      if (!Number.isFinite(threshold)) throw new Error('--threshold must be a finite number')
+      flags.threshold = threshold
       continue
     }
     if (arg === '--base') {

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -222,25 +222,43 @@ export async function runIteration(deps: PipelineDeps, iter: number): Promise<It
   const worktreePath = worktreeFor(deps, iter)
   const iterPath = iterDir(deps.runState.runDir, iter)
   await mkdir(iterPath, { recursive: true })
-  await deps.createWorktree(deps.config.repoRoot, worktreePath, runIdFor(deps, iter), deps.config.prBranchPrefix)
+  // C2: wrap the body so any unexpected throw (AgentRunError, git failure,
+  // stryker crash) still routes through the single cleanup path. Without this,
+  // a thrown exception bypasses failIter entirely: the worktree and its
+  // `mutation-improve/<runId>-iterN` branch are leaked, runState.failed gains
+  // no entry, and the next createWorktree for the same path fails.
+  let worktreeCreated = false
+  try {
+    await deps.createWorktree(deps.config.repoRoot, worktreePath, runIdFor(deps, iter), deps.config.prBranchPrefix)
+    worktreeCreated = true
 
-  const sel = await selectPhase(deps, worktreePath, iterPath)
-  if (!sel.ok) return failIter(deps, iter, worktreePath, sel.gate, sel.reason)
-  const { selection, baseline } = sel.value
+    const sel = await selectPhase(deps, worktreePath, iterPath)
+    if (!sel.ok) return await failIter(deps, iter, worktreePath, sel.gate, sel.reason)
+    const { selection, baseline } = sel.value
 
-  // ② CAPTURE BEFORE (runner-owned). Already at threshold → nothing to do.
-  const beforeScore = await deps.measureScore(worktreePath, selection.file)
-  if (beforeScore >= deps.config.threshold) {
-    deps.runState.doneSet.push(selection.file)
-    return skipIter(deps, iter, worktreePath, selection.file, beforeScore)
+    // ② CAPTURE BEFORE (runner-owned). Already at threshold → nothing to do.
+    const beforeScore = await deps.measureScore(worktreePath, selection.file)
+    if (beforeScore >= deps.config.threshold) {
+      deps.runState.doneSet.push(selection.file)
+      return await skipIter(deps, iter, worktreePath, selection.file, beforeScore)
+    }
+
+    const improved = await improvePhase(deps, worktreePath, iterPath, selection.file, beforeScore)
+
+    const gate = await gatePhase(deps, worktreePath, selection.file, improved)
+    if (!gate.ok) return await failIter(deps, iter, worktreePath, gate.gate, gate.reason)
+
+    return await finalizePhase(deps, iter, worktreePath, selection.file, baseline, beforeScore, gate.value, improved)
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    // If createWorktree itself threw there is nothing to reset/remove; just
+    // record the failure so the run is not silently dropped.
+    if (!worktreeCreated) {
+      deps.runState.failed.push({ iter, gate: 'exception', reason })
+      return { iter, outcome: 'failed', gate: 'exception', reason }
+    }
+    return failIter(deps, iter, worktreePath, 'exception', reason)
   }
-
-  const improved = await improvePhase(deps, worktreePath, iterPath, selection.file, beforeScore)
-
-  const gate = await gatePhase(deps, worktreePath, selection.file, improved)
-  if (!gate.ok) return failIter(deps, iter, worktreePath, gate.gate, gate.reason)
-
-  return finalizePhase(deps, iter, worktreePath, selection.file, baseline, beforeScore, gate.value, improved)
 }
 
 export async function runPipeline(deps: PipelineDeps): Promise<{ results: IterationResult[]; aborted: boolean }> {

--- a/mutation-improve/src/score-reader.ts
+++ b/mutation-improve/src/score-reader.ts
@@ -20,7 +20,10 @@ export async function measureMutationScore(deps: MeasureDeps, reportDir: string,
   const read = deps.readReport ?? readStrykerReport
   const reportPath = reportPathFor(reportDir, srcFile)
   const attempt = async (): Promise<number> => {
-    await deps.exec()
+    const result = await deps.exec()
+    if (result.exitCode !== 0) {
+      throw new Error(`mutation run failed (exit ${result.exitCode}): ${result.stderr}`)
+    }
     return mergeReports([read(reportPath)]).score
   }
   try {

--- a/mutation-improve/src/score-reader.ts
+++ b/mutation-improve/src/score-reader.ts
@@ -3,7 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { readStrykerReport } from '../../scripts/mutation/json-readers.js'
+import { ReportReadError, readStrykerReport } from '../../scripts/mutation/json-readers.js'
 import { mergeReports, type StrykerReport } from '../../scripts/mutation/score-merger.js'
 
 export const safeFileStem = (srcFile: string): string => srcFile.replaceAll(/[^a-zA-Z0-9._-]+/gu, '__')
@@ -14,6 +14,13 @@ export const reportPathFor = (reportDir: string, srcFile: string): string =>
 export interface MeasureDeps {
   exec: () => Promise<{ exitCode: number; stdout: string; stderr: string }>
   readReport?: (reportPath: string) => StrykerReport
+}
+
+function isRetryable(error: unknown): boolean {
+  if (error instanceof ReportReadError) return true
+  return (
+    typeof error === 'object' && error !== null && 'code' in error && (error as { code: unknown }).code === 'ENOENT'
+  )
 }
 
 export async function measureMutationScore(deps: MeasureDeps, reportDir: string, srcFile: string): Promise<number> {
@@ -30,10 +37,8 @@ export async function measureMutationScore(deps: MeasureDeps, reportDir: string,
     const score = await attempt()
     return score
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    if (/enoent|malformed|must contain a stryker/iu.test(message)) {
-      const retried = await attempt()
-      return retried
+    if (isRetryable(error)) {
+      return attempt()
     }
     throw error
   }

--- a/scripts/mutation/json-readers.ts
+++ b/scripts/mutation/json-readers.ts
@@ -18,10 +18,17 @@ export const readJsonRecord = (filePath: string): Record<string, unknown> => {
   return parsed
 }
 
+export class ReportReadError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ReportReadError'
+  }
+}
+
 export const readStrykerReport = (reportPath: string): StrykerReport => {
   const parsed: unknown = JSON.parse(fs.readFileSync(reportPath, 'utf8'))
   if (!isStrykerReport(parsed)) {
-    throw new Error(`${reportPath} must contain a Stryker JSON report object`)
+    throw new ReportReadError(`${reportPath} must contain a Stryker JSON report object`)
   }
   return parsed
 }

--- a/tests/mutation-improve/cli.test.ts
+++ b/tests/mutation-improve/cli.test.ts
@@ -41,6 +41,7 @@ describe('cli parseCliArgs', () => {
 
   test('rejects non-numeric --threshold', () => {
     expect(() => parseCliArgs(['--threshold=abc'])).toThrow(/threshold/iu)
+    expect(() => parseCliArgs(['--threshold=Infinity'])).toThrow(/threshold/iu)
   })
 
   test('throws on unknown argument', () => {

--- a/tests/mutation-improve/cli.test.ts
+++ b/tests/mutation-improve/cli.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, test } from 'bun:test'
 import { existsSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
-import { parseCliArgs, resetRunWorktrees } from '../../mutation-improve/src/cli.js'
+import { DEFAULT_CONFIG_PATH, parseCliArgs, resetRunWorktrees } from '../../mutation-improve/src/cli.js'
 import { execGit } from '../../review-loop/src/worktree.js'
 import { cleanupTempDirs, makeTempDir } from './test-helpers'
 
@@ -37,6 +37,29 @@ describe('cli parseCliArgs', () => {
     const args = parseCliArgs(['--resume-run', 'r1', '--reset-worktree'])
     expect(args.resumeRunId).toBe('r1')
     expect(args.resetWorktree).toBe(true)
+  })
+
+  test('rejects non-numeric --threshold', () => {
+    expect(() => parseCliArgs(['--threshold=abc'])).toThrow(/threshold/iu)
+  })
+
+  test('throws on unknown argument', () => {
+    expect(() => parseCliArgs(['--bogus'])).toThrow(/Unknown argument/u)
+  })
+
+  test('throws when a value-taking flag is missing its value', () => {
+    for (const flag of ['--config', '--count', '--base', '--resume-run']) {
+      expect(() => parseCliArgs([flag])).toThrow(`Missing value for ${flag}`)
+    }
+  })
+
+  test('rejects fractional and non-numeric --count', () => {
+    expect(() => parseCliArgs(['--count', '3.5'])).toThrow()
+    expect(() => parseCliArgs(['--count', 'abc'])).toThrow()
+  })
+
+  test('uses the default config path when --config is absent', () => {
+    expect(parseCliArgs([]).configPath).toBe(DEFAULT_CONFIG_PATH)
   })
 })
 

--- a/tests/mutation-improve/cli.test.ts
+++ b/tests/mutation-improve/cli.test.ts
@@ -3,9 +3,15 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { existsSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
 
-import { parseCliArgs } from '../../mutation-improve/src/cli.js'
+import { parseCliArgs, resetRunWorktrees } from '../../mutation-improve/src/cli.js'
+import { execGit } from '../../review-loop/src/worktree.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers'
+
+afterEach(cleanupTempDirs)
 
 describe('cli parseCliArgs', () => {
   test('parses --config and requires --config (default exists)', () => {
@@ -31,5 +37,44 @@ describe('cli parseCliArgs', () => {
     const args = parseCliArgs(['--resume-run', 'r1', '--reset-worktree'])
     expect(args.resumeRunId).toBe('r1')
     expect(args.resetWorktree).toBe(true)
+  })
+})
+
+describe('resetRunWorktrees', () => {
+  async function setupRepo(): Promise<{ repoRoot: string; worktreesDir: string }> {
+    const repoRoot = makeTempDir('cli-repo-')
+    await execGit(repoRoot, ['init'])
+    await execGit(repoRoot, ['config', 'user.email', 'test@test.com'])
+    await execGit(repoRoot, ['config', 'user.name', 'Test'])
+    await execGit(repoRoot, ['checkout', '-b', 'master'])
+    writeFileSync(path.join(repoRoot, 'README.md'), 'hello')
+    await execGit(repoRoot, ['add', '.'])
+    await execGit(repoRoot, ['commit', '-m', 'init'])
+    return { repoRoot, worktreesDir: path.join(repoRoot, '.mutation-improve', 'worktrees') }
+  }
+
+  test('removes only iteration worktrees and branches matching runId', async () => {
+    const { repoRoot, worktreesDir } = await setupRepo()
+    const sameRun1 = path.join(worktreesDir, 'r1-iter1')
+    const sameRun2 = path.join(worktreesDir, 'r1-iter2')
+    const otherRun = path.join(worktreesDir, 'r2-iter1')
+    await execGit(repoRoot, ['worktree', 'add', sameRun1, '-b', 'mutation-improve/r1-iter1'])
+    await execGit(repoRoot, ['worktree', 'add', sameRun2, '-b', 'mutation-improve/r1-iter2'])
+    await execGit(repoRoot, ['worktree', 'add', otherRun, '-b', 'mutation-improve/r2-iter1'])
+
+    await resetRunWorktrees(repoRoot, 'r1', 'mutation-improve')
+
+    expect(existsSync(sameRun1)).toBe(false)
+    expect(existsSync(sameRun2)).toBe(false)
+    expect(existsSync(otherRun)).toBe(true)
+    const { stdout: branches } = await execGit(repoRoot, ['branch', '--list'])
+    expect(branches).not.toContain('mutation-improve/r1-iter1')
+    expect(branches).not.toContain('mutation-improve/r1-iter2')
+    expect(branches).toContain('mutation-improve/r2-iter1')
+  })
+
+  test('no-op when no matching worktrees exist', async () => {
+    const { repoRoot } = await setupRepo()
+    await expect(resetRunWorktrees(repoRoot, 'r1', 'mutation-improve')).resolves.toBeUndefined()
   })
 })

--- a/tests/mutation-improve/contracts.test.ts
+++ b/tests/mutation-improve/contracts.test.ts
@@ -3,10 +3,25 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
 
 import { ResultSchema } from '../../mutation-improve/src/result-schema.js'
 import { SelectionSchema } from '../../mutation-improve/src/selection-schema.js'
+import { runAgent } from '../../review-loop/src/agent-runner.js'
+import { createShellExec, runBuildCheck } from '../../review-loop/src/build-checker.js'
+import { LiveRenderer } from '../../review-loop/src/live-renderer.js'
+import { realSpawn } from '../../review-loop/src/spawn.js'
+import {
+  createWorktree,
+  detectGitRoot,
+  execGit,
+  mergeWorktree,
+  removeWorktree,
+  resetWorktree,
+} from '../../review-loop/src/worktree.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers'
+
+afterEach(cleanupTempDirs)
 
 describe('contracts', () => {
   test('SelectionSchema accepts a well-formed selection and rejects missing runnerUps', () => {
@@ -49,5 +64,42 @@ describe('contracts', () => {
     }
     expect(() => ResultSchema.parse(base)).toThrow()
     expect(() => ResultSchema.parse({ ...base, testPaths: ['tests/x.test.ts'] })).not.toThrow()
+  })
+})
+
+describe('review-loop surface contract', () => {
+  test('Tier A — LiveRenderer.log writes the message through to the stream', () => {
+    const written: string[] = []
+    const sink = {
+      write: (chunk: string): boolean => {
+        written.push(chunk)
+        return true
+      },
+    }
+    new LiveRenderer(sink).log('hello')
+    expect(written.join('')).toBe('hello\n')
+  })
+
+  test('Tier A — createShellExec + runBuildCheck map exit 0 → passed and non-zero → failed', async () => {
+    const dir = makeTempDir('contract-build-')
+    const passed = await runBuildCheck({ exec: createShellExec(dir, 'true') })
+    expect(passed.passed).toBe(true)
+    const failed = await runBuildCheck({ exec: createShellExec(dir, 'false') })
+    expect(failed.passed).toBe(false)
+  })
+
+  test('Tier B — consumed concrete symbols are exported and callable', () => {
+    // Inventory of the review-loop surface mutation-improve consumes today.
+    // Behavioral authority for the git/opencode-requiring functions lives in
+    // tests/review-loop/**; this asserts presence + callability so removal or
+    // export-shape drift fails loudly in mutation-improve's own gate.
+    expect(typeof runAgent).toBe('function')
+    expect(typeof realSpawn).toBe('function')
+    expect(typeof createWorktree).toBe('function')
+    expect(typeof execGit).toBe('function')
+    expect(typeof mergeWorktree).toBe('function')
+    expect(typeof removeWorktree).toBe('function')
+    expect(typeof resetWorktree).toBe('function')
+    expect(typeof detectGitRoot).toBe('function')
   })
 })

--- a/tests/mutation-improve/pipeline.test.ts
+++ b/tests/mutation-improve/pipeline.test.ts
@@ -208,6 +208,55 @@ describe('pipeline runIteration', () => {
     expect(outcome.outcome).toBe('failed')
     expect(outcome.gate).toBe('merge')
   })
+
+  // C2: an unexpected throw mid-pipeline must route through failIter so the
+  // worktree is reset/removed and the failure is recorded — not leaked.
+  test('thrown exception after worktree creation resets/removes worktree and records exception gate', async () => {
+    const deps = happyDeps()
+    const calls = { reset: 0, remove: 0 }
+    deps.runImproveAgent = (): Promise<{ value: Result; usage: AgentUsage }> =>
+      Promise.reject(new Error('agent blew up'))
+    deps.resetWorktree = (): Promise<void> => {
+      calls.reset += 1
+      return Promise.resolve()
+    }
+    deps.removeWorktree = (): Promise<void> => {
+      calls.remove += 1
+      return Promise.resolve()
+    }
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('exception')
+    expect(outcome.reason).toBe('agent blew up')
+    expect(calls.reset).toBe(1)
+    expect(calls.remove).toBe(1)
+    expect(deps.runState.failed).toEqual([{ iter: 1, gate: 'exception', reason: 'agent blew up' }])
+    expect(deps.runState.merged).toHaveLength(0)
+  })
+
+  // C2: if createWorktree itself throws, the catch must not attempt to
+  // reset/remove a worktree that was never created (resetWorktree would throw
+  // on a missing path); it still records the failure.
+  test('createWorktree throwing records exception gate without touching reset/remove', async () => {
+    const deps = happyDeps()
+    const calls = { reset: 0, remove: 0 }
+    deps.createWorktree = (): Promise<void> => Promise.reject(new Error('worktree add failed'))
+    deps.resetWorktree = (): Promise<void> => {
+      calls.reset += 1
+      return Promise.resolve()
+    }
+    deps.removeWorktree = (): Promise<void> => {
+      calls.remove += 1
+      return Promise.resolve()
+    }
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('exception')
+    expect(outcome.reason).toBe('worktree add failed')
+    expect(calls.reset).toBe(0)
+    expect(calls.remove).toBe(0)
+    expect(deps.runState.failed).toEqual([{ iter: 1, gate: 'exception', reason: 'worktree add failed' }])
+  })
 })
 
 describe('pipeline runPipeline', () => {

--- a/tests/mutation-improve/score-reader.test.ts
+++ b/tests/mutation-improve/score-reader.test.ts
@@ -55,6 +55,16 @@ describe('score-reader', () => {
     expect(score).toBe(1)
   })
 
+  test('measureMutationScore throws when exec exits non-zero, even if a stale report exists', async () => {
+    const exec = mock(
+      (): Promise<ExecResult> => Promise.resolve({ exitCode: 1, stdout: '', stderr: 'stryker crashed' }),
+    )
+    await expect(
+      measureMutationScore({ exec, readReport: () => reportWith(10, 0) }, 'reports/paired', 'src/foo.ts'),
+    ).rejects.toThrow(/mutation run failed/iu)
+    expect(exec).toHaveBeenCalledTimes(1)
+  })
+
   test('measureMutationScore throws after a failed retry', async () => {
     const exec = mock(successfulExec)
     await expect(

--- a/tests/mutation-improve/score-reader.test.ts
+++ b/tests/mutation-improve/score-reader.test.ts
@@ -48,10 +48,10 @@ describe('score-reader', () => {
     expect(score).toBeCloseTo(0.8, 5)
   })
 
-  test('measureMutationScore retries exec once when the report read throws, then succeeds', async () => {
+  test('measureMutationScore retries exec once when the report read throws ReportReadError, then succeeds', async () => {
     const exec = mock(successfulExec)
     const readReport = mock((): StrykerReport => reportWith(10, 0)).mockImplementationOnce((): StrykerReport => {
-      throw new Error('malformed')
+      throw new ReportReadError('shape')
     })
     const score = await measureMutationScore({ exec, readReport }, 'reports/paired', 'src/foo.ts')
     expect(exec).toHaveBeenCalledTimes(2)
@@ -68,20 +68,49 @@ describe('score-reader', () => {
     expect(exec).toHaveBeenCalledTimes(1)
   })
 
-  test('measureMutationScore throws after a failed retry', async () => {
+  test('measureMutationScore throws the typed error after a failed retry', async () => {
     const exec = mock(successfulExec)
     await expect(
       measureMutationScore(
         {
           exec,
           readReport: (): StrykerReport => {
-            throw new Error('still malformed')
+            throw new ReportReadError('shape')
           },
         },
         'reports/paired',
         'src/foo.ts',
       ),
-    ).rejects.toThrow(/malformed|stryker/iu)
+    ).rejects.toBeInstanceOf(ReportReadError)
+    expect(exec).toHaveBeenCalledTimes(2)
+  })
+
+  test('measureMutationScore retries when the report read throws an ENOENT-coded error', async () => {
+    const exec = mock(successfulExec)
+    const enoent = Object.assign(new Error('not found'), { code: 'ENOENT' })
+    const readReport = mock((): StrykerReport => reportWith(6, 0)).mockImplementationOnce((): StrykerReport => {
+      throw enoent
+    })
+    const score = await measureMutationScore({ exec, readReport }, 'reports/paired', 'src/foo.ts')
+    expect(exec).toHaveBeenCalledTimes(2)
+    expect(score).toBe(1)
+  })
+
+  test('measureMutationScore does NOT retry on a plain (non-typed, non-ENOENT) error and propagates it', async () => {
+    const exec = mock(successfulExec)
+    await expect(
+      measureMutationScore(
+        {
+          exec,
+          readReport: (): StrykerReport => {
+            throw new Error('boom')
+          },
+        },
+        'reports/paired',
+        'src/foo.ts',
+      ),
+    ).rejects.toThrow('boom')
+    expect(exec).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/tests/mutation-improve/score-reader.test.ts
+++ b/tests/mutation-improve/score-reader.test.ts
@@ -4,8 +4,11 @@
 // See LICENSE in the project root for details.
 
 import { describe, expect, mock, test } from 'bun:test'
+import { rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 
 import { measureMutationScore, reportPathFor, safeFileStem } from '../../mutation-improve/src/score-reader.js'
+import { ReportReadError, readStrykerReport } from '../../scripts/mutation/json-readers.js'
 import type { StrykerReport } from '../../scripts/mutation/score-merger.js'
 
 const reportWith = (killed: number, survived: number, noCoverage = 0, timeout = 0): StrykerReport => ({
@@ -79,5 +82,28 @@ describe('score-reader', () => {
         'src/foo.ts',
       ),
     ).rejects.toThrow(/malformed|stryker/iu)
+  })
+})
+
+describe('readStrykerReport (json-readers contract)', () => {
+  test('throws ReportReadError when the parsed JSON is not a Stryker report', () => {
+    const tmpFile = `${tmpdir()}/mi-not-a-report-${Date.now()}.json`
+    // `files` must be a record; an array is not a valid Stryker report shape
+    writeFileSync(tmpFile, JSON.stringify({ files: [] }))
+    try {
+      expect(() => readStrykerReport(tmpFile)).toThrow(ReportReadError)
+    } finally {
+      rmSync(tmpFile, { force: true })
+    }
+  })
+
+  test('returns the report when the shape is valid', () => {
+    const tmpFile = `${tmpdir()}/mi-valid-${Date.now()}.json`
+    writeFileSync(tmpFile, JSON.stringify({ files: { 'src/x.ts': { mutants: [{ status: 'Killed' }] } } }))
+    try {
+      expect(readStrykerReport(tmpFile).files?.['src/x.ts']?.mutants?.length).toBe(1)
+    } finally {
+      rmSync(tmpFile, { force: true })
+    }
   })
 })


### PR DESCRIPTION
**Follow-up to #222.** Closes the deferred items called out in #222's final review, plus four robustness fixes surfaced by the first end-to-end dogfood runs of the autonomous runner. No papai runtime code changed — only `mutation-improve/`, `scripts/mutation/json-readers.ts`, and tests.

## Runner robustness fixes (dogfood-driven)

- `2b20cac` — ignore `.mutation-improve/` runtime scratch directory.
- `678b15e` — wrap `runIteration` in try/catch so a thrown exception (`AgentRunError`, git failure, Stryker crash) routes through `failIter` instead of leaking the worktree + its `mutation-improve/<runId>-iterN` branch and dropping the failure from run state.
- `70684ef` — wire the previously-parsed-but-unconsumed `--reset-worktree` flag to `resetRunWorktrees`, which sweeps stale `<runId>-iterN` worktrees left by a crashed/killed prior run (keyed by runId so concurrent runs sharing a repo are undisturbed).
- `71697e7` — throw on non-zero Stryker exit code in `measureMutationScore` so a crashed mutation run can't return a stale report's score.

## Deferred hardening items (from #222 final review)

Spec: `docs/superpowers/specs/2026-08-05-mutation-improve-hardening-design.md`. Plan: `docs/superpowers/plans/2026-08-05-mutation-improve-hardening.md`. Three non-blocking items bundled as one test-first hardening pass:

1. **Parser coverage + NaN guard** (`04786bd`, `c92f35d`) — `parseCliArgs` had uncovered branches (unknown arg, missing value, non-integer `--count`, default config path). Worse, a non-numeric `--threshold=` silently set `config.threshold = NaN` — the CLI override bypasses the Zod `[0,1]` range check — which made gate ⑤ reject every iteration. Guarded with `Number.isFinite` (rejects `NaN` **and** `Infinity`) and added the missing characterization cases.
2. **Typed-error retry** (`aa491aa`, `68fff09`) — `measureMutationScore` decided whether to retry by regex-matching error-message *wording* emitted by a foreign module (`scripts/mutation/json-readers.ts`); a routine rephrasing of that prose would silently disable the retry. Introduced `ReportReadError` (thrown by `readStrykerReport`) and re-keyed the retry on `instanceof ReportReadError || err.code === 'ENOENT'`. The trigger set is preserved exactly (report-missing `ENOENT` and wrong-shape retry; `JSON.parse` SyntaxError / plain errors / non-zero Stryker exit propagate); only the coupling to sibling prose is removed. The dead `malformed` regex alternative matched nothing and is gone.
3. **Cross-workspace contract guard** (`2ff15fb`) — `mutation-improve` consumes a broad surface of `review-loop/src/*`. TypeScript catches symbol removal/rename at compile time, but there was no guard against behavioral drift and `contracts.test.ts` only tested the two Zod schemas. Added a behavioral tier (`LiveRenderer.log` passthrough; `createShellExec`+`runBuildCheck` exit→passed mapping) and a runtime inventory tier of the consumed symbols so drift fails loudly in mutation-improve's own gate. Deliberately **no** facade / shared workspace — `cli.ts` keeps its direct imports (composition root); the spec's Tier-B arity claim was retired (`02750f4`) since arity is compile-checked at the call sites.

## Verification

- `mutation-improve` 61/61; `review-loop` 289/289 (no shared-file change this round); `scripts/mutation` 171/171; root suite 11097/0; `bun check:full` lint/typecheck/format/knip clean.
- Four per-task reviews + a final whole-branch review (merge-ready: **yes**, no critical/important findings). Retry trigger-set preservation verified case-by-case against the prior regex path.
- All edits are test-only or minimal source changes; the score-reader retry's behavior is unchanged by construction.
