### PR TITLE
mutation-improve: gate & finalize fixes (8 verified issues)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,15 +22,16 @@ Detailed reference moved out of this file to keep it short. Read the relevant do
 
 ### Path-scoped `CLAUDE.md` files (read when working under that path)
 
-| Path                      | Covers                                                                 |
-| ------------------------- | ---------------------------------------------------------------------- |
-| `src/providers/CLAUDE.md` | normalized provider interface, capabilities, provider-layer rules      |
-| `src/tools/CLAUDE.md`     | tool assembly, execution wrapping, confirmations, context gating       |
-| `src/commands/CLAUDE.md`  | command handler rules and current command surface                      |
-| `src/chat/CLAUDE.md`      | chat provider interface, capabilities, context rendering, interactions |
-| `src/mcp/CLAUDE.md`       | external MCP server adapter, connection pooling, tool namespacing      |
-| `tests/CLAUDE.md`         | helpers, mocks, mock reset, E2E guidance                               |
-| `review-loop/CLAUDE.md`   | review-loop workspace structure, scripts, storage, TDD rules           |
+| Path                         | Covers                                                                                        |
+| ---------------------------- | --------------------------------------------------------------------------------------------- |
+| `src/providers/CLAUDE.md`    | normalized provider interface, capabilities, provider-layer rules                             |
+| `src/tools/CLAUDE.md`        | tool assembly, execution wrapping, confirmations, context gating                              |
+| `src/commands/CLAUDE.md`     | command handler rules and current command surface                                             |
+| `src/chat/CLAUDE.md`         | chat provider interface, capabilities, context rendering, interactions                        |
+| `src/mcp/CLAUDE.md`          | external MCP server adapter, connection pooling, tool namespacing                             |
+| `tests/CLAUDE.md`            | helpers, mocks, mock reset, E2E guidance                                                      |
+| `review-loop/CLAUDE.md`      | review-loop workspace structure, scripts, storage, TDD rules                                  |
+| `mutation-improve/CLAUDE.md` | mutation-improve workspace: select/improve pipeline, gates, repoRoot snap, storage, TDD rules |
 
 Plugin authors: `docs/plugins/developer-guide.md` + `docs/plugins/examples/hello-world/`. The `codeindex` MCP server lives in a separate project at `~/Projects/papai/codeindex/`.
 

--- a/docs/superpowers/plans/2026-08-06-mutation-improve-runner-fixes.md
+++ b/docs/superpowers/plans/2026-08-06-mutation-improve-runner-fixes.md
@@ -401,15 +401,25 @@ git commit -m "fix(mutation-improve): write agent artifacts to per-iteration dir
 ### Task 4: failure.json + file in failed entries (Unit B)
 
 `failIter` drops the file and never writes the spec'd `iter/<N>/failure.json`.
-Add a `recordFailure` helper used by every failure path.
+Add a `recordFailure` helper (single failure sink), thread the file through,
+and update/extend tests.
+
+> **Execution amendment (controller-authorized):** the verbatim in-pipeline
+> implementation pushed `pipeline.ts` over the repo's 300-line `max-lines`
+> gate, so `recordFailure` + `FailureEntry` live in a new
+> `mutation-improve/src/failure-recorder.ts` with direct unit tests in
+> `tests/mutation-improve/failure-recorder.test.ts`; `pipeline.ts` imports and
+> delegates. Behavior is identical to the inline version below.
 
 **Files:**
+- Create: `mutation-improve/src/failure-recorder.ts`
 - Modify: `mutation-improve/src/pipeline.ts`
-- Test: `tests/mutation-improve/pipeline.test.ts`
+- Test: `tests/mutation-improve/failure-recorder.test.ts`, `tests/mutation-improve/pipeline.test.ts`
 
 **Interfaces:**
-- Consumes: `iterDir(runDir, iter)` from `run-state.ts` (already imported in pipeline.ts).
-- Produces: `PhaseFail` gains `file?: string`; `failIter` gains a trailing
+- Consumes: `iterDir(runDir, iter)` from `run-state.ts`.
+- Produces: `recordFailure(runState: MutationImproveRunState, iter: number, gate: string, reason: string, file?: string): Promise<FailureEntry>` (new module);
+  `PhaseFail` gains `file?: string`; `failIter` gains a trailing
   `file?: string` parameter; every failure writes
   `<runDir>/iter/<N>/failure.json` containing `{iter, gate, reason, file?}`.
 
@@ -490,7 +500,9 @@ Expected: FAIL — updated exception test sees `failed` without `file`;
 
 In `mutation-improve/src/pipeline.ts`:
 
-1. Change the fs import to `import { mkdir, writeFile } from 'node:fs/promises'`.
+1. Leave the fs import as `import { mkdir } from 'node:fs/promises'` (writeFile
+   lives in the new module). Add
+   `import { recordFailure, type FailureEntry } from './failure-recorder.js'`.
 2. Change the `PhaseFail` type:
 
 ```typescript
@@ -505,30 +517,34 @@ type PhaseFail = { ok: false; gate: string; reason: string; file?: string }
   }
 ```
 
-4. Replace `failIter` with `recordFailure` + a slimmer `failIter`:
+4. Create `mutation-improve/src/failure-recorder.ts` (with the repo SPDX
+   header) containing `FailureEntry` + `recordFailure`, and slim `failIter` in
+   pipeline.ts to delegate:
 
 ```typescript
-type FailureEntry = { iter: number; gate: string; reason: string; file?: string }
+// failure-recorder.ts (imports: node:fs/promises writeFile, node:path,
+// { iterDir, type MutationImproveRunState } from './run-state.js')
+export type FailureEntry = { iter: number; gate: string; reason: string; file?: string }
 
 // Single failure sink: every failed iteration leaves a durable
 // iter/<N>/failure.json (runner-spec artifact) and a state.json entry. The
 // file is recorded when known so the summary PR can name what was attempted.
-async function recordFailure(
-  deps: PipelineDeps,
+export async function recordFailure(
+  runState: MutationImproveRunState,
   iter: number,
   gate: string,
   reason: string,
   file?: string,
 ): Promise<FailureEntry> {
   const entry: FailureEntry = file === undefined ? { iter, gate, reason } : { iter, gate, reason, file }
-  await writeFile(
-    path.join(iterDir(deps.runState.runDir, iter), 'failure.json'),
-    `${JSON.stringify(entry, null, 2)}\n`,
-  )
-  deps.runState.failed.push(entry)
+  await writeFile(path.join(iterDir(runState.runDir, iter), 'failure.json'), `${JSON.stringify(entry, null, 2)}\n`)
+  runState.failed.push(entry)
   return entry
 }
+```
 
+```typescript
+// pipeline.ts — failIter delegates
 async function failIter(
   deps: PipelineDeps,
   iter: number,
@@ -537,12 +553,17 @@ async function failIter(
   reason: string,
   file?: string,
 ): Promise<IterationResult> {
-  const entry = await recordFailure(deps, iter, gate, reason, file)
+  const entry = await recordFailure(deps.runState, iter, gate, reason, file)
   await deps.resetWorktree(worktreePath)
   await deps.removeWorktree(deps.config.repoRoot, worktreePath, runIdFor(deps, iter), deps.config.prBranchPrefix)
   return { ...entry, outcome: 'failed' }
 }
 ```
+
+Also create `tests/mutation-improve/failure-recorder.test.ts` (test-first,
+before the module): direct unit tests that `recordFailure` writes
+`iter/<N>/failure.json` and pushes the state entry — with `file` when known,
+without the key when not.
 
 5. In `runIteration`: declare `let file: string | undefined` next to
    `worktreeCreated`; pass `sel.file` on the select-gate failure; set
@@ -555,7 +576,7 @@ async function failIter(
     // If createWorktree itself threw there is nothing to reset/remove; record
     // the failure (no file — selection never ran) so the run is not dropped.
     if (!worktreeCreated) {
-      await recordFailure(deps, iter, 'exception', reason)
+      await recordFailure(deps.runState, iter, 'exception', reason)
       return { iter, outcome: 'failed', gate: 'exception', reason }
     }
     return failIter(deps, iter, worktreePath, 'exception', reason, file)
@@ -574,7 +595,7 @@ expectation (no file) and still passes.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add mutation-improve/src/pipeline.ts tests/mutation-improve/pipeline.test.ts
+git add mutation-improve/src/failure-recorder.ts mutation-improve/src/pipeline.ts tests/mutation-improve/failure-recorder.test.ts tests/mutation-improve/pipeline.test.ts
 git commit -m "fix(mutation-improve): record failure.json and file on failed iterations"
 ```
 
@@ -945,9 +966,18 @@ git commit -m "fix(mutation-improve): push integration branch and PR with explic
 A skip means the floor was stale. Ratchet `baseline.json` directly in repoRoot
 (on the guarded integration branch) with a baseline-only commit.
 
+> **Execution amendment (controller-authorized, anticipated from Task 4):**
+> `pipeline.ts` is near the repo's 300-line `max-lines` gate, so
+> `ratchetVerifiedSkip` lives in a new `mutation-improve/src/skip-ratchet.ts`
+> (importing `type { PipelineDeps }` from `'./pipeline.js'` — type-only
+> circularity is fine) with direct unit tests in
+> `tests/mutation-improve/skip-ratchet.test.ts`. `pipeline.ts` imports and calls
+> it. Behavior identical to the inline version below.
+
 **Files:**
-- Modify: `mutation-improve/src/pipeline.ts` (`runIteration` skip path + helper)
-- Test: `tests/mutation-improve/pipeline.test.ts`
+- Create: `mutation-improve/src/skip-ratchet.ts`
+- Modify: `mutation-improve/src/pipeline.ts` (`runIteration` skip path)
+- Test: `tests/mutation-improve/skip-ratchet.test.ts`, `tests/mutation-improve/pipeline.test.ts`
 
 **Interfaces:**
 - Consumes: `bumpScore`, `BaselineMap` (already imported in pipeline.ts).
@@ -1011,7 +1041,9 @@ Expected: FAIL — baseline stays 0.46, no add/commit calls recorded.
 
 - [ ] **Step 3: Implement ratchetVerifiedSkip**
 
-In `mutation-improve/src/pipeline.ts`, add above `skipIter`:
+Create `mutation-improve/src/skip-ratchet.ts` (with the repo SPDX header;
+imports: `bumpScore`/`BaselineMap` from `'./baseline.js'`,
+`import type { PipelineDeps } from './pipeline.js'`):
 
 ```typescript
 // A skip means the measured score already clears the threshold while the
@@ -1037,7 +1069,7 @@ async function ratchetVerifiedSkip(
 }
 ```
 
-In `runIteration`, change the skip branch:
+In `runIteration` (pipeline.ts), change the skip branch (`import { ratchetVerifiedSkip } from './skip-ratchet.js'` at the top):
 
 ```typescript
     const beforeScore = await deps.measureScore(worktreePath, selection.file)
@@ -1056,7 +1088,7 @@ Expected: PASS.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add mutation-improve/src/pipeline.ts tests/mutation-improve/pipeline.test.ts
+git add mutation-improve/src/skip-ratchet.ts mutation-improve/src/pipeline.ts tests/mutation-improve/skip-ratchet.test.ts tests/mutation-improve/pipeline.test.ts
 git commit -m "fix(mutation-improve): ratchet baseline floor on threshold-verified skips"
 ```
 

--- a/docs/superpowers/plans/2026-08-06-mutation-improve-runner-fixes.md
+++ b/docs/superpowers/plans/2026-08-06-mutation-improve-runner-fixes.md
@@ -1,0 +1,1172 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation-Improve Runner — Gate & Finalize Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix eight verified issues in the `mutation-improve/` runner: two trust-breaking gate bugs, dead per-iteration artifacts, crash-unsafe state saving, a contradictory finalize push/PR flow, a stale-floor skip path, missing failure context, a diff-guard rename bypass, and a misleading timeout config key.
+
+**Architecture:** Four commit units per the approved spec
+(`docs/superpowers/specs/2026-08-06-mutation-improve-runner-fixes-design.md`):
+A) gate integrity, B) artifacts+state, C) finalize flow, D) skip-ratchet+config.
+All changes stay inside `mutation-improve/src` + `tests/mutation-improve` +
+workspace config/docs; review-loop is consumed but never modified.
+
+**Tech Stack:** Bun runtime + `bun:test`, strict TypeScript, Zod v4, DI-first
+deps (`PipelineDeps`, `FinalizeDeps`), real-git integration tests in temp dirs.
+
+## Global Constraints
+
+- Run ALL commands from the repo root (`/Users/ki/Projects/yourpapai/papai/.worktrees/mutation-improve-01`).
+- Test runner is **Bun** (`bun:test`); no Jest/Vitest. Focused run: `bun test tests/mutation-improve/<file>.test.ts`.
+- Unit-green bar (run at the end of every task): `bun run mutation-improve:test && bun run mutation-improve:typecheck && bun run mutation-improve:lint && bun run mutation-improve:format:check`.
+- DI-first tests: fake the `PipelineDeps`/`FinalizeDeps` interfaces; no `mock.module()`.
+- No `??`/ternary/conditionals inside **test bodies** (`vitest/no-conditional-in-test`); sequence/branch helpers live at module scope (see `sequenceMeasure` pattern in `pipeline.test.ts`).
+- Import paths use `.js` extensions.
+- Never add lint-disable or type-ignore comments.
+- `mutation-improve/src/pipeline.ts` has an established explanatory-comment convention (C1/C2/I1 markers); one brief rationale comment per new helper matches it — do not strip existing comments.
+- TDD: write the failing test first, watch it fail, implement, watch it pass, commit.
+- `mutation-improve/AGENTS.md` is a symlink to `mutation-improve/CLAUDE.md` — edit `CLAUDE.md` only.
+- review-loop has its own unrelated `agentTimeoutMs`; never touch `review-loop/**`.
+
+---
+
+### Task 1: Diff-guard rename parsing (Unit A)
+
+`git status --porcelain` rename lines (`R  orig -> new`) are currently sliced as
+one string, so `R  tests/a.ts -> src/b.ts` passes the guard (line starts with an
+allowed prefix). Parse both endpoints and classify each.
+
+**Files:**
+- Modify: `mutation-improve/src/diff-guard.ts`
+- Test: `tests/mutation-improve/diff-guard.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `parsePorcelainPaths(line: string): string[]` (new export);
+  `runDiffGuard(execGit, cwd)` behavior change: rename entries contribute both
+  endpoints to `classifyDiff`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `describe('diff-guard')` block in
+`tests/mutation-improve/diff-guard.test.ts`. Add `parsePorcelainPaths` to the
+existing import from `'../../mutation-improve/src/diff-guard.js'`.
+
+```typescript
+  test('parsePorcelainPaths returns a single path for non-rename entries', () => {
+    expect(parsePorcelainPaths(' M tests/a.test.ts')).toEqual(['tests/a.test.ts'])
+    expect(parsePorcelainPaths('?? "docs/superpowers/a b.md"')).toEqual(['docs/superpowers/a b.md'])
+  })
+
+  test('parsePorcelainPaths splits rename entries into both endpoints', () => {
+    expect(parsePorcelainPaths('R  tests/old.test.ts -> tests/new.test.ts')).toEqual([
+      'tests/old.test.ts',
+      'tests/new.test.ts',
+    ])
+    expect(parsePorcelainPaths('R  "tests/a b.test.ts" -> "tests/c d.test.ts"')).toEqual([
+      'tests/a b.test.ts',
+      'tests/c d.test.ts',
+    ])
+  })
+
+  test('runDiffGuard flags a rename from allowed to forbidden (smuggle)', async () => {
+    const execGit = (): Promise<GitResult> =>
+      Promise.resolve({ stdout: 'R  tests/a.test.ts -> src/foo.ts\n', stderr: '' })
+    const result = await runDiffGuard(execGit, '/repo/wt')
+    expect(result).toEqual({ ok: false, violations: ['src/foo.ts'] })
+  })
+
+  test('runDiffGuard flags a rename from forbidden to allowed (source removal)', async () => {
+    const execGit = (): Promise<GitResult> =>
+      Promise.resolve({ stdout: 'R  src/foo.ts -> tests/foo.test.ts\n', stderr: '' })
+    const result = await runDiffGuard(execGit, '/repo/wt')
+    expect(result).toEqual({ ok: false, violations: ['src/foo.ts'] })
+  })
+
+  test('runDiffGuard allows a rename within tests/', async () => {
+    const execGit = (): Promise<GitResult> =>
+      Promise.resolve({ stdout: 'R  tests/old.test.ts -> tests/new.test.ts\n', stderr: '' })
+    const result = await runDiffGuard(execGit, '/repo/wt')
+    expect(result).toEqual({ ok: true })
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/mutation-improve/diff-guard.test.ts`
+Expected: FAIL — `parsePorcelainPaths is not a function` (and the two smuggle
+tests fail if the import is faked). The `parsePorcelainPaths` import also fails
+typecheck.
+
+- [ ] **Step 3: Implement rename parsing**
+
+In `mutation-improve/src/diff-guard.ts`, replace the whole `runDiffGuard`
+function and add the parser above it:
+
+```typescript
+function unquote(p: string): string {
+  return p.replace(/^"|"$/gu, '')
+}
+
+// Porcelain v1 rename/copy entries look like `R  orig -> new` (each side
+// quoted independently when it contains special chars). Only R/C statuses use
+// the arrow form, so the status check prevents mis-splitting a quoted path
+// that merely contains ' -> '.
+export function parsePorcelainPaths(line: string): string[] {
+  const status = line.slice(0, 2)
+  const body = line.slice(3).trim()
+  if (!status.includes('R') && !status.includes('C')) return [unquote(body)]
+  const arrowIdx = body.indexOf(' -> ')
+  if (arrowIdx === -1) return [unquote(body)]
+  return [unquote(body.slice(0, arrowIdx)), unquote(body.slice(arrowIdx + 4))]
+}
+
+export async function runDiffGuard(
+  execGit: ExecGitFn,
+  cwd: string,
+): Promise<{ ok: true } | { ok: false; violations: string[] }> {
+  const { stdout } = await execGit(cwd, ['status', '--porcelain', '--untracked-files=all'])
+  const paths = stdout
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .flatMap(parsePorcelainPaths)
+    .filter((p) => p.length > 0)
+  const { violations } = classifyDiff(paths)
+  return violations.length === 0 ? { ok: true } : { ok: false, violations }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/mutation-improve/diff-guard.test.ts`
+Expected: PASS (all 10 tests, including the 5 pre-existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mutation-improve/src/diff-guard.ts tests/mutation-improve/diff-guard.test.ts
+git commit -m "fix(mutation-improve): parse porcelain renames in diff-guard"
+```
+
+---
+
+### Task 2: Build gate runs inside the iteration worktree (Unit A)
+
+`runBuildCheck` currently executes `checkCommand` with cwd = `runDir`, so
+`bun check:full` never sees the agent's diff. Thread the worktree path through.
+
+**Files:**
+- Modify: `mutation-improve/src/pipeline.ts` (PipelineDeps type + gatePhase)
+- Modify: `mutation-improve/src/cli.ts` (`buildPipelineDeps`)
+- Test: `tests/mutation-improve/pipeline.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `PipelineDeps.runBuildCheck: (worktreePath: string) => Promise<{ passed: boolean; stdout: string; stderr: string }>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `describe('pipeline runIteration')` in
+`tests/mutation-improve/pipeline.test.ts`:
+
+```typescript
+  test('build gate runs checkCommand inside the iteration worktree', async () => {
+    const deps = happyDeps()
+    let buildCwd = ''
+    deps.runBuildCheck = (worktreePath: string): Promise<{ passed: boolean; stdout: string; stderr: string }> => {
+      buildCwd = worktreePath
+      return Promise.resolve({ passed: true, stdout: '', stderr: '' })
+    }
+    await runIteration(deps, 1)
+    expect(buildCwd).toBe(path.join(deps.config.workDir, 'worktrees', 'r1-iter1'))
+  })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/mutation-improve/pipeline.test.ts -t "build gate runs"`
+Expected: FAIL — `buildCwd` stays `''` because the current impl calls
+`deps.runBuildCheck()` with no argument.
+
+- [ ] **Step 3: Change the dep signature and call site**
+
+In `mutation-improve/src/pipeline.ts`, `PipelineDeps`:
+
+```typescript
+    runBuildCheck: (worktreePath: string) => Promise<{ passed: boolean; stdout: string; stderr: string }>
+```
+
+In `gatePhase`, replace `const build = await deps.runBuildCheck()` with:
+
+```typescript
+  const build = await deps.runBuildCheck(worktreePath)
+```
+
+In `mutation-improve/src/cli.ts` `buildPipelineDeps`, replace the
+`runBuildCheck` entry with:
+
+```typescript
+    runBuildCheck: (worktreePath: string) => {
+      const exec = createShellExec(worktreePath, config.checkCommand, config.buildTimeoutMs)
+      return runBuildCheck({ exec: () => exec() })
+    },
+```
+
+(`createShellExec` and `runBuildCheck` are already imported in cli.ts.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run mutation-improve:test && bun run mutation-improve:typecheck`
+Expected: PASS. The pre-existing `runBuildCheck: () => Promise.resolve(...)`
+stubs in `integration.test.ts` / `integration-git.test.ts` remain valid
+(zero-arg functions are assignable to the new one-arg type).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mutation-improve/src/pipeline.ts mutation-improve/src/cli.ts tests/mutation-improve/pipeline.test.ts
+git commit -m "fix(mutation-improve): run build gate inside the iteration worktree"
+```
+
+---
+
+### Task 3: Per-iteration agent outputPath threading (Unit B)
+
+`cli.ts` hardcodes `iter/selection.json` / `iter/result.json` as the runner copy
+destination, so `iter/<N>/` dirs stay empty and artifacts overwrite each other.
+Pass the pipeline's per-iter path through the dep call.
+
+**Files:**
+- Modify: `mutation-improve/src/pipeline.ts` (PipelineDeps type + selectPhase + improvePhase)
+- Modify: `mutation-improve/src/cli.ts` (`selectRunner`, `improveRunner`)
+- Test: `tests/mutation-improve/pipeline.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  `runSelectAgent: (worktreePath: string, prompt: string, outputPath: string) => Promise<AgentRunResult<Selection>>`
+  and the identical third parameter on `runImproveAgent` (with `Result`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside `describe('pipeline runIteration')` in
+`tests/mutation-improve/pipeline.test.ts`:
+
+```typescript
+  test('select agent receives the per-iteration outputPath', async () => {
+    const deps = happyDeps()
+    let seenOut = ''
+    deps.runSelectAgent = (
+      _worktreePath: string,
+      _prompt: string,
+      outputPath: string,
+    ): Promise<{ value: Selection; usage: AgentUsage }> => {
+      seenOut = outputPath
+      return Promise.resolve({ value: selection, usage: emptyUsage() })
+    }
+    await runIteration(deps, 1)
+    expect(seenOut).toBe(path.join(deps.runState.runDir, 'iter', '1', 'selection.json'))
+  })
+
+  test('improve agent receives the per-iteration outputPath', async () => {
+    const deps = happyDeps()
+    let seenOut = ''
+    deps.runImproveAgent = (
+      _worktreePath: string,
+      _prompt: string,
+      outputPath: string,
+    ): Promise<{ value: Result; usage: AgentUsage }> => {
+      seenOut = outputPath
+      return Promise.resolve({ value: result, usage: emptyUsage() })
+    }
+    await runIteration(deps, 1)
+    expect(seenOut).toBe(path.join(deps.runState.runDir, 'iter', '1', 'result.json'))
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/mutation-improve/pipeline.test.ts -t "per-iteration outputPath"`
+Expected: FAIL — `seenOut` stays `''` (impl calls the deps with two args).
+
+- [ ] **Step 3: Thread outputPath through**
+
+In `mutation-improve/src/pipeline.ts`, `PipelineDeps`:
+
+```typescript
+    runSelectAgent: (worktreePath: string, prompt: string, outputPath: string) => Promise<AgentRunResult<Selection>>
+    runImproveAgent: (worktreePath: string, prompt: string, outputPath: string) => Promise<AgentRunResult<Result>>
+```
+
+In `selectPhase`, change the `deps.runSelectAgent(...)` call so the third
+argument is `selectOut` (the prompt construction is unchanged):
+
+```typescript
+  const selectRes = await deps.runSelectAgent(
+    worktreePath,
+    buildSelectPrompt({
+      doneSet: deps.runState.doneSet,
+      baselineSummary: JSON.stringify(baseline),
+      outputPath: agentWritePath(worktreePath, selectOut),
+    }),
+    selectOut,
+  )
+```
+
+In `improvePhase`, change the `deps.runImproveAgent(...)` call so the third
+argument is `improveOut`:
+
+```typescript
+  const improveRes = await deps.runImproveAgent(
+    worktreePath,
+    buildImprovePrompt({
+      file,
+      beforeScore,
+      threshold: deps.config.threshold,
+      date: new Date().toISOString().slice(0, 10),
+      outputPath: agentWritePath(worktreePath, improveOut),
+    }),
+    improveOut,
+  )
+```
+
+In `mutation-improve/src/cli.ts`, replace both runner factories:
+
+```typescript
+function selectRunner(
+  config: MutationImproveConfig,
+  runState: MutationImproveRunState,
+  log: LiveRenderer,
+): PipelineDeps['runSelectAgent'] {
+  return (worktreePath, prompt, outputPath) =>
+    runAgent({
+      spawn: realSpawn,
+      model: config.agent.model,
+      cwd: worktreePath,
+      prompt,
+      outputPath,
+      outputSchema: SelectionSchema,
+      label: 'select',
+      logPath: path.join(runState.runDir, 'agent-output.log'),
+      extraArgs: config.agent.extraArgs,
+      reporter: log,
+      timeoutMs: config.agent.timeoutMs,
+    })
+}
+
+function improveRunner(
+  config: MutationImproveConfig,
+  runState: MutationImproveRunState,
+  log: LiveRenderer,
+): PipelineDeps['runImproveAgent'] {
+  return (worktreePath, prompt, outputPath) =>
+    runAgent({
+      spawn: realSpawn,
+      model: config.agent.model,
+      cwd: worktreePath,
+      prompt,
+      outputPath,
+      outputSchema: ResultSchema,
+      label: 'improve',
+      logPath: path.join(runState.runDir, 'agent-output.log'),
+      extraArgs: config.agent.extraArgs,
+      reporter: log,
+      timeoutMs: config.agent.timeoutMs,
+    })
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run mutation-improve:test && bun run mutation-improve:typecheck`
+Expected: PASS. The existing prompt-path tests
+(`select prompt directs the agent to the worktree scratch path…`) keep passing
+because the prompt path still derives from the same `selectOut`/`improveOut`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mutation-improve/src/pipeline.ts mutation-improve/src/cli.ts tests/mutation-improve/pipeline.test.ts
+git commit -m "fix(mutation-improve): write agent artifacts to per-iteration dirs"
+```
+
+---
+
+### Task 4: failure.json + file in failed entries (Unit B)
+
+`failIter` drops the file and never writes the spec'd `iter/<N>/failure.json`.
+Add a `recordFailure` helper used by every failure path.
+
+**Files:**
+- Modify: `mutation-improve/src/pipeline.ts`
+- Test: `tests/mutation-improve/pipeline.test.ts`
+
+**Interfaces:**
+- Consumes: `iterDir(runDir, iter)` from `run-state.ts` (already imported in pipeline.ts).
+- Produces: `PhaseFail` gains `file?: string`; `failIter` gains a trailing
+  `file?: string` parameter; every failure writes
+  `<runDir>/iter/<N>/failure.json` containing `{iter, gate, reason, file?}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/mutation-improve/pipeline.test.ts`, add to the imports:
+
+```typescript
+import { readFile } from 'node:fs/promises'
+```
+
+Update the existing test `thrown exception after worktree creation
+resets/removes worktree and records exception gate` — replace its
+`runState.failed` expectation (the throw happens after selection, so the file
+is now recorded) and add a `failure.json` assertion:
+
+```typescript
+    expect(deps.runState.failed).toEqual([
+      { iter: 1, gate: 'exception', reason: 'agent blew up', file: 'src/live-status/tool-status-labels.ts' },
+    ])
+    const failure = JSON.parse(
+      await readFile(path.join(deps.runState.runDir, 'iter', '1', 'failure.json'), 'utf8'),
+    ) as unknown
+    expect(failure).toEqual({
+      iter: 1,
+      gate: 'exception',
+      reason: 'agent blew up',
+      file: 'src/live-status/tool-status-labels.ts',
+    })
+```
+
+Append two new tests inside `describe('pipeline runIteration')`:
+
+```typescript
+  test('select-gate rejection records the invalidly picked file and writes failure.json', async () => {
+    const deps = happyDeps()
+    deps.runSelectAgent = (): Promise<{ value: Selection; usage: AgentUsage }> =>
+      Promise.resolve({ value: { ...selection, file: 'src/not-in-baseline.ts' }, usage: emptyUsage() })
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('select')
+    expect(deps.runState.failed[0]).toEqual({
+      iter: 1,
+      gate: 'select',
+      reason: 'selection file not in baseline or already done',
+      file: 'src/not-in-baseline.ts',
+    })
+    const failure = JSON.parse(
+      await readFile(path.join(deps.runState.runDir, 'iter', '1', 'failure.json'), 'utf8'),
+    ) as unknown
+    expect(failure).toEqual({
+      iter: 1,
+      gate: 'select',
+      reason: 'selection file not in baseline or already done',
+      file: 'src/not-in-baseline.ts',
+    })
+  })
+
+  test('createWorktree throw still writes failure.json without a file', async () => {
+    const deps = happyDeps()
+    deps.createWorktree = (): Promise<void> => Promise.reject(new Error('worktree add failed'))
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    const failure = JSON.parse(
+      await readFile(path.join(deps.runState.runDir, 'iter', '1', 'failure.json'), 'utf8'),
+    ) as unknown
+    expect(failure).toEqual({ iter: 1, gate: 'exception', reason: 'worktree add failed' })
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/mutation-improve/pipeline.test.ts`
+Expected: FAIL — updated exception test sees `failed` without `file`;
+`failure.json` reads throw ENOENT.
+
+- [ ] **Step 3: Implement recordFailure + file threading**
+
+In `mutation-improve/src/pipeline.ts`:
+
+1. Change the fs import to `import { mkdir, writeFile } from 'node:fs/promises'`.
+2. Change the `PhaseFail` type:
+
+```typescript
+type PhaseFail = { ok: false; gate: string; reason: string; file?: string }
+```
+
+3. In `selectPhase`, change the rejection return to carry the picked file:
+
+```typescript
+  if (deps.runState.doneSet.includes(selection.file) || baseline[selection.file] === undefined) {
+    return { ok: false, gate: 'select', reason: 'selection file not in baseline or already done', file: selection.file }
+  }
+```
+
+4. Replace `failIter` with `recordFailure` + a slimmer `failIter`:
+
+```typescript
+type FailureEntry = { iter: number; gate: string; reason: string; file?: string }
+
+// Single failure sink: every failed iteration leaves a durable
+// iter/<N>/failure.json (runner-spec artifact) and a state.json entry. The
+// file is recorded when known so the summary PR can name what was attempted.
+async function recordFailure(
+  deps: PipelineDeps,
+  iter: number,
+  gate: string,
+  reason: string,
+  file?: string,
+): Promise<FailureEntry> {
+  const entry: FailureEntry = file === undefined ? { iter, gate, reason } : { iter, gate, reason, file }
+  await writeFile(
+    path.join(iterDir(deps.runState.runDir, iter), 'failure.json'),
+    `${JSON.stringify(entry, null, 2)}\n`,
+  )
+  deps.runState.failed.push(entry)
+  return entry
+}
+
+async function failIter(
+  deps: PipelineDeps,
+  iter: number,
+  worktreePath: string,
+  gate: string,
+  reason: string,
+  file?: string,
+): Promise<IterationResult> {
+  const entry = await recordFailure(deps, iter, gate, reason, file)
+  await deps.resetWorktree(worktreePath)
+  await deps.removeWorktree(deps.config.repoRoot, worktreePath, runIdFor(deps, iter), deps.config.prBranchPrefix)
+  return { ...entry, outcome: 'failed' }
+}
+```
+
+5. In `runIteration`: declare `let file: string | undefined` next to
+   `worktreeCreated`; pass `sel.file` on the select-gate failure; set
+   `file = selection.file` right after destructuring `sel.value`; pass `file`
+   to the gate-failure `failIter` call. Replace the whole catch block with:
+
+```typescript
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    // If createWorktree itself threw there is nothing to reset/remove; record
+    // the failure (no file — selection never ran) so the run is not dropped.
+    if (!worktreeCreated) {
+      await recordFailure(deps, iter, 'exception', reason)
+      return { iter, outcome: 'failed', gate: 'exception', reason }
+    }
+    return failIter(deps, iter, worktreePath, 'exception', reason, file)
+  }
+```
+
+(The pre-existing C2 comment above the `try` stays.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run mutation-improve:test && bun run mutation-improve:typecheck`
+Expected: PASS. Note the `createWorktree throwing records exception gate
+without touching reset/remove` test keeps its old `runState.failed`
+expectation (no file) and still passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mutation-improve/src/pipeline.ts tests/mutation-improve/pipeline.test.ts
+git commit -m "fix(mutation-improve): record failure.json and file on failed iterations"
+```
+
+---
+
+### Task 5: Save run state per iteration (Unit B)
+
+`state.json` is only persisted in the `cli.ts` finally-block, so a crash loses
+all progress. Save after every iteration through a new dep.
+
+**Files:**
+- Modify: `mutation-improve/src/pipeline.ts` (PipelineDeps + runPipeline)
+- Modify: `mutation-improve/src/cli.ts` (`buildPipelineDeps`)
+- Test: `tests/mutation-improve/pipeline.test.ts`
+- Modify (factory stub): `tests/mutation-improve/integration.test.ts`, `tests/mutation-improve/integration-git.test.ts`
+
+**Interfaces:**
+- Consumes: `saveRunState` from `run-state.ts` (already imported in cli.ts).
+- Produces: `PipelineDeps.saveRunState: (state: MutationImproveRunState) => Promise<void>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside `describe('pipeline runPipeline')` in
+`tests/mutation-improve/pipeline.test.ts`:
+
+```typescript
+  test('saves run state after each iteration', async () => {
+    const deps = happyDeps()
+    deps.config = config(deps.config.repoRoot, { count: 2 })
+    deps.measureScore = sequenceMeasure([0.46, 0.97, 0.5, 0.96])
+    const picks = ['src/live-status/tool-status-labels.ts', 'src/tools/memory.ts']
+    deps.runSelectAgent = sequenceSelect(picks, selection)
+    const savedIterations: number[] = []
+    deps.saveRunState = (state: MutationImproveRunState): Promise<void> => {
+      savedIterations.push(state.currentIteration)
+      return Promise.resolve()
+    }
+    await runPipeline(deps)
+    expect(savedIterations).toEqual([1, 2])
+  })
+
+  test('merge-abort saves state with status aborted', async () => {
+    const deps = happyDeps()
+    deps.mergeWorktree = (): Promise<{ ok: false; conflictFiles: string[] }> =>
+      Promise.resolve({ ok: false, conflictFiles: ['scripts/mutation/baseline.json'] })
+    const savedStatuses: string[] = []
+    deps.saveRunState = (state: MutationImproveRunState): Promise<void> => {
+      savedStatuses.push(state.status)
+      return Promise.resolve()
+    }
+    const { aborted } = await runPipeline(deps)
+    expect(aborted).toBe(true)
+    expect(savedStatuses).toEqual(['aborted'])
+  })
+```
+
+`MutationImproveRunState` is already imported as a type in this file.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/mutation-improve/pipeline.test.ts -t "saves run state"`
+Expected: typecheck breaks (`saveRunState` not on `PipelineDeps`); at runtime
+`deps.saveRunState is not a function`.
+
+- [ ] **Step 3: Implement per-iteration save**
+
+In `mutation-improve/src/pipeline.ts`, `PipelineDeps` gains:
+
+```typescript
+    saveRunState: (state: MutationImproveRunState) => Promise<void>
+```
+
+In `runPipeline`, replace the `runFrom` body so state is persisted after each
+iteration (after the abort-status mutation, so an aborted run resumes correctly):
+
+```typescript
+  const runFrom = async (iter: number, aborted: boolean): Promise<{ results: IterationResult[]; aborted: boolean }> => {
+    if (aborted || iter > deps.config.count) return { results, aborted }
+    deps.runState.currentIteration = iter
+    const outcome = await runIteration(deps, iter)
+    results.push(outcome)
+    if (outcome.gate === 'merge') {
+      deps.runState.status = 'aborted'
+      await deps.saveRunState(deps.runState)
+      return { results, aborted: true }
+    }
+    await deps.saveRunState(deps.runState)
+    return runFrom(iter + 1, false)
+  }
+```
+
+(The trailing `status = 'completed'` assignment stays; the cli.ts
+finally-block save remains the final flush for it.)
+
+In `mutation-improve/src/cli.ts` `buildPipelineDeps`, add the entry
+(`saveRunState` is already imported there):
+
+```typescript
+    saveRunState,
+```
+
+Add the stub to the deps factories: `happyDeps()` in
+`tests/mutation-improve/pipeline.test.ts`, and the inline `deps` literals in
+`tests/mutation-improve/integration.test.ts` and
+`tests/mutation-improve/integration-git.test.ts`:
+
+```typescript
+    saveRunState: () => Promise.resolve(),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run mutation-improve:test && bun run mutation-improve:typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mutation-improve/src/pipeline.ts mutation-improve/src/cli.ts tests/mutation-improve/pipeline.test.ts tests/mutation-improve/integration.test.ts tests/mutation-improve/integration-git.test.ts
+git commit -m "fix(mutation-improve): persist run state after every iteration"
+```
+
+---
+
+### Task 6: Integration-branch startup guard (Unit C)
+
+Iterations merge into whatever branch `repoRoot` is checked out on. Fail fast
+at startup if that is `base` or a detached HEAD.
+
+**Files:**
+- Modify: `mutation-improve/src/finalize.ts` (new export)
+- Modify: `mutation-improve/src/cli.ts` (`runCli`)
+- Test: `tests/mutation-improve/finalize.test.ts`, `tests/mutation-improve/cli.test.ts`
+
+**Interfaces:**
+- Consumes: `ExecGitFn` (already defined in finalize.ts).
+- Produces: `assertIntegrationBranch(execGit: ExecGitFn, repoRoot: string, base: string): Promise<void>` — throws when the checked-out branch is `base` or `HEAD` (detached).
+
+- [ ] **Step 1: Write the failing unit tests**
+
+In `tests/mutation-improve/finalize.test.ts`, add `assertIntegrationBranch` to
+the finalize.js import and append:
+
+```typescript
+describe('assertIntegrationBranch', () => {
+  const branchExec =
+    (branch: string): ExecGitFn =>
+    () =>
+      Promise.resolve({ stdout: `${branch}\n`, stderr: '' })
+
+  test('passes on a non-base branch', async () => {
+    await expect(
+      assertIntegrationBranch(branchExec('mutation-improve-10'), '/repo', 'master'),
+    ).resolves.toBeUndefined()
+  })
+
+  test('throws on the base branch', async () => {
+    await expect(assertIntegrationBranch(branchExec('master'), '/repo', 'master')).rejects.toThrow(
+      /integration branch/u,
+    )
+  })
+
+  test('throws on a detached HEAD', async () => {
+    await expect(assertIntegrationBranch(branchExec('HEAD'), '/repo', 'master')).rejects.toThrow(
+      /integration branch/u,
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/mutation-improve/finalize.test.ts -t "assertIntegrationBranch"`
+Expected: FAIL — export does not exist.
+
+- [ ] **Step 3: Implement the guard and wire it into runCli**
+
+Append to `mutation-improve/src/finalize.ts`:
+
+```typescript
+// Iterations merge into whatever branch repoRoot is checked out on. Starting
+// a run on base (or a detached HEAD) would merge+push straight onto base with
+// no PR, so refuse before any run state is created.
+export async function assertIntegrationBranch(execGit: ExecGitFn, repoRoot: string, base: string): Promise<void> {
+  const { stdout } = await execGit(repoRoot, ['rev-parse', '--abbrev-ref', 'HEAD'])
+  const branch = stdout.trim()
+  if (branch === base || branch === 'HEAD') {
+    throw new Error(
+      `mutation-improve merges iterations into the checked-out branch, but repoRoot is on '${branch}'. Check out a non-base integration branch first (base: ${base}).`,
+    )
+  }
+}
+```
+
+In `mutation-improve/src/cli.ts`: add `assertIntegrationBranch` to the
+`./finalize.js` import, then in `runCli` immediately after the CLI-override
+assignments (`if (args.base !== undefined) config.base = args.base`) and before
+the `runState` creation:
+
+```typescript
+  await assertIntegrationBranch(execGit, config.repoRoot, config.base)
+```
+
+- [ ] **Step 4: Write the runCli guard tests (real git)**
+
+In `tests/mutation-improve/cli.test.ts`: hoist the `setupRepo` function out of
+`describe('resetRunWorktrees')` to file scope (unchanged body), add `runCli` to
+the `'../../mutation-improve/src/cli.js'` import, and append:
+
+```typescript
+describe('runCli integration-branch guard', () => {
+  test('fails fast on the base branch before creating run state', async () => {
+    const { repoRoot } = await setupRepo()
+    const configPath = path.join(repoRoot, 'cfg.json')
+    writeFileSync(configPath, JSON.stringify({ repoRoot, workDir: '.mi', agent: { model: 'm' } }))
+    await expect(runCli(['--config', configPath])).rejects.toThrow(/integration branch/u)
+    expect(existsSync(path.join(repoRoot, '.mi', 'runs'))).toBe(false)
+  })
+
+  test('fails fast on a detached HEAD', async () => {
+    const { repoRoot } = await setupRepo()
+    const { stdout: sha } = await execGit(repoRoot, ['rev-parse', 'HEAD'])
+    await execGit(repoRoot, ['checkout', sha.trim()])
+    const configPath = path.join(repoRoot, 'cfg.json')
+    writeFileSync(configPath, JSON.stringify({ repoRoot, workDir: '.mi', agent: { model: 'm' } }))
+    await expect(runCli(['--config', configPath])).rejects.toThrow(/integration branch/u)
+    expect(existsSync(path.join(repoRoot, '.mi', 'runs'))).toBe(false)
+  })
+})
+```
+
+(setupRepo checks out `master`, which equals the config default `base`.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun run mutation-improve:test && bun run mutation-improve:typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mutation-improve/src/finalize.ts mutation-improve/src/cli.ts tests/mutation-improve/finalize.test.ts tests/mutation-improve/cli.test.ts
+git commit -m "fix(mutation-improve): refuse to start a run on base or detached HEAD"
+```
+
+---
+
+### Task 7: runFinalize pushes the integration branch, PRs with --head (Unit C)
+
+Finalize currently pushes `base` (wrong — merges are on the checked-out
+branch) and opens a PR with no head.
+
+**Files:**
+- Modify: `mutation-improve/src/finalize.ts` (`runFinalize`)
+- Test: `tests/mutation-improve/finalize.test.ts`
+- Modify (mock tweak): `tests/mutation-improve/integration.test.ts`
+
+**Interfaces:**
+- Consumes: `ExecGitFn`, `RunGhFn`, `FinalizeInput` (unchanged shapes).
+- Produces: `runFinalize` resolves the current branch itself; pushes
+  `<upstream> <branch>`; `gh pr create --base <base> --head <branch> …`.
+
+- [ ] **Step 1: Update the failing tests**
+
+In `tests/mutation-improve/finalize.test.ts`, add a module-scope helper above
+`describe('finalize')`:
+
+```typescript
+const branchExecGit =
+  (branch: string, seen?: string[]): ExecGitFn =>
+  (_cwd, args) => {
+    seen?.push(args.join(' '))
+    return Promise.resolve({ stdout: args[0] === 'rev-parse' ? `${branch}\n` : '', stderr: '' })
+  }
+```
+
+Add `readFile` import: `import { readFile } from 'node:fs/promises'`.
+
+Replace the body of `runFinalize pushes and opens a PR via gh, returning the
+URL` from `const seen: string[] = []` onward with:
+
+```typescript
+    const seen: string[] = []
+    const execGit = branchExecGit('mutation-improve-10', seen)
+    let ghArgs: readonly string[] = []
+    const runGh: RunGhFn = (args) => {
+      ghArgs = args
+      return Promise.resolve({ exitCode: 0, stdout: 'https://github.com/x/pull/9\n', stderr: '' })
+    }
+    const out = await runFinalize({ execGit, runGh }, { config: config(repoRoot), runState })
+    expect(out.pushed).toBe(true)
+    expect(out.prUrl).toBe('https://github.com/x/pull/9')
+    expect(seen).toContain('push origin mutation-improve-10')
+    expect(ghArgs).toContain('--head')
+    expect(ghArgs[ghArgs.indexOf('--head') + 1]).toBe('mutation-improve-10')
+```
+
+In `runFinalize survives gh failure and still reports pushed=true`, replace the
+`execGit` line and add a log assertion at the end:
+
+```typescript
+    const execGit = branchExecGit('mutation-improve-10')
+```
+
+```typescript
+    const log = await readFile(`${repoRoot}/.mi/runs/r/finalize.log`, 'utf8')
+    expect(log).toContain('--head mutation-improve-10')
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/mutation-improve/finalize.test.ts`
+Expected: FAIL — push is still `push origin master`, no `--head` in gh args,
+finalize.log lacks `--head`.
+
+- [ ] **Step 3: Implement the runFinalize fix**
+
+In `mutation-improve/src/finalize.ts`, replace the body of `runFinalize`:
+
+```typescript
+export async function runFinalize(deps: FinalizeDeps, input: FinalizeInput): Promise<FinalizeResult> {
+  const { config, runState } = input
+  const { stdout } = await deps.execGit(config.repoRoot, ['rev-parse', '--abbrev-ref', 'HEAD'])
+  const branch = stdout.trim()
+  await deps.execGit(config.repoRoot, ['push', config.upstream, branch])
+  const title = `mutation-improve: ${runState.merged.map((m) => m.file).join(', ')}`
+  const body = buildSummaryBody(runState.merged, runState.failed)
+  const result = await deps.runGh(
+    ['pr', 'create', '--base', config.base, '--head', branch, '--title', title, '--body', body],
+    config.repoRoot,
+  )
+  if (result.exitCode !== 0) {
+    const logPath = path.join(runState.runDir, 'finalize.log')
+    await mkdir(path.dirname(logPath), { recursive: true })
+    await appendFile(
+      logPath,
+      `gh pr create failed (exit ${result.exitCode}): ${result.stderr}\nRe-run: gh pr create --base ${config.base} --head ${branch} --title ${JSON.stringify(title)} --body <body>\n`,
+    )
+    return { pushed: true }
+  }
+  return { pushed: true, prUrl: result.stdout.trim() || undefined }
+}
+```
+
+In `tests/mutation-improve/integration.test.ts`, change the `runFinalize`
+call's `execGit` mock so `rev-parse` yields a branch:
+
+```typescript
+        execGit: () => Promise.resolve({ stdout: 'feat\n', stderr: '' }),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run mutation-improve:test && bun run mutation-improve:typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mutation-improve/src/finalize.ts tests/mutation-improve/finalize.test.ts tests/mutation-improve/integration.test.ts
+git commit -m "fix(mutation-improve): push integration branch and PR with explicit head"
+```
+
+---
+
+### Task 8: Skip-ratchet (Unit D)
+
+A skip means the floor was stale. Ratchet `baseline.json` directly in repoRoot
+(on the guarded integration branch) with a baseline-only commit.
+
+**Files:**
+- Modify: `mutation-improve/src/pipeline.ts` (`runIteration` skip path + helper)
+- Test: `tests/mutation-improve/pipeline.test.ts`
+
+**Interfaces:**
+- Consumes: `bumpScore`, `BaselineMap` (already imported in pipeline.ts).
+- Produces: no new exports; skip path may call `deps.writeBaseline(repoRoot, …)`
+  and `deps.execGit(repoRoot, ['add', …])` / `['commit', …]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside `describe('pipeline runIteration')` in
+`tests/mutation-improve/pipeline.test.ts`:
+
+```typescript
+  test('skip ratchets a stale baseline floor with a baseline-only commit in repoRoot', async () => {
+    const deps = happyDeps()
+    deps.measureScore = sequenceMeasure([0.97])
+    const gitCalls: string[] = []
+    deps.execGit = (cwd: string, args: readonly string[]): Promise<{ stdout: string; stderr: string }> => {
+      gitCalls.push(`${cwd} ${args.join(' ')}`)
+      return Promise.resolve({ stdout: '', stderr: '' })
+    }
+    const outcome = await runIteration(deps, 1)
+    expect(outcome).toEqual({
+      iter: 1,
+      outcome: 'skipped',
+      file: 'src/live-status/tool-status-labels.ts',
+      beforeScore: 0.97,
+    })
+    const baseline = await deps.readBaseline(deps.config.repoRoot)
+    expect(baseline['src/live-status/tool-status-labels.ts']).toBe(0.97)
+    const repoRoot = deps.config.repoRoot
+    expect(gitCalls).toContain(`${repoRoot} add scripts/mutation/baseline.json`)
+    const commitPrefix = `${repoRoot} commit -m chore(mutation): ratchet src/live-status/tool-status-labels.ts baseline to 0.97`
+    expect(gitCalls.some((c) => c.startsWith(commitPrefix))).toBe(true)
+  })
+
+  test('skip with an accurate floor does not rewrite or commit the baseline', async () => {
+    const deps = happyDeps()
+    deps.readBaseline = () => Promise.resolve({ 'src/live-status/tool-status-labels.ts': 0.97 })
+    let writes = 0
+    deps.writeBaseline = (): Promise<void> => {
+      writes += 1
+      return Promise.resolve()
+    }
+    const gitCalls: string[] = []
+    deps.execGit = (_cwd: string, args: readonly string[]): Promise<{ stdout: string; stderr: string }> => {
+      gitCalls.push(args.join(' '))
+      return Promise.resolve({ stdout: '', stderr: '' })
+    }
+    deps.measureScore = sequenceMeasure([0.96])
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('skipped')
+    expect(writes).toBe(0)
+    expect(gitCalls.some((c) => c.startsWith('commit'))).toBe(false)
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/mutation-improve/pipeline.test.ts -t "skip"`
+Expected: FAIL — baseline stays 0.46, no add/commit calls recorded.
+
+- [ ] **Step 3: Implement ratchetVerifiedSkip**
+
+In `mutation-improve/src/pipeline.ts`, add above `skipIter`:
+
+```typescript
+// A skip means the measured score already clears the threshold while the
+// baseline floor lags behind. Ratchet the floor directly on the integration
+// branch (repoRoot) so future runs don't re-select the file and burn a full
+// mutation run rediscovering it. Only baseline.json is staged, so a dirty
+// repoRoot working tree is safe.
+async function ratchetVerifiedSkip(
+  deps: PipelineDeps,
+  baseline: BaselineMap,
+  file: string,
+  score: number,
+): Promise<void> {
+  const bumped = bumpScore(baseline, file, score)
+  if (bumped[file] === baseline[file]) return
+  await deps.writeBaseline(deps.config.repoRoot, bumped)
+  await deps.execGit(deps.config.repoRoot, ['add', 'scripts/mutation/baseline.json'])
+  await deps.execGit(deps.config.repoRoot, [
+    'commit',
+    '-m',
+    `chore(mutation): ratchet ${file} baseline to ${score} (verified at threshold)`,
+  ])
+}
+```
+
+In `runIteration`, change the skip branch:
+
+```typescript
+    const beforeScore = await deps.measureScore(worktreePath, selection.file)
+    if (beforeScore >= deps.config.threshold) {
+      deps.runState.doneSet.push(selection.file)
+      await ratchetVerifiedSkip(deps, baseline, selection.file, beforeScore)
+      return await skipIter(deps, iter, worktreePath, selection.file, beforeScore)
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run mutation-improve:test && bun run mutation-improve:typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mutation-improve/src/pipeline.ts tests/mutation-improve/pipeline.test.ts
+git commit -m "fix(mutation-improve): ratchet baseline floor on threshold-verified skips"
+```
+
+---
+
+### Task 9: Rename agentTimeoutMs → mutateTimeoutMs + docs sync (Unit D)
+
+The top-level key gates the mutation-run exec, not agents. Hard rename, no
+alias (Zod strips the unknown old key), plus sync the workspace doc.
+
+**Files:**
+- Modify: `mutation-improve/src/config.ts`
+- Modify: `mutation-improve/src/cli.ts:159`
+- Modify: `mutation-improve/config.json`, `mutation-improve/config.example.json`
+- Modify: `mutation-improve/CLAUDE.md`
+- Test: `tests/mutation-improve/config.test.ts`
+- Modify (factory renames): `tests/mutation-improve/pipeline.test.ts`, `tests/mutation-improve/finalize.test.ts`, `tests/mutation-improve/integration.test.ts`, `tests/mutation-improve/integration-git.test.ts`, `tests/mutation-improve/run-state.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `MutationImproveConfig.mutateTimeoutMs: number` (replaces
+  `agentTimeoutMs`).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/mutation-improve/config.test.ts`, inside the existing
+`MutationImproveConfigSchema applies defaults` test add:
+
+```typescript
+    expect(parsed.mutateTimeoutMs).toBe(1_800_000)
+```
+
+Append a new test in `describe('config')`:
+
+```typescript
+  test('MutationImproveConfigSchema strips the legacy agentTimeoutMs key', () => {
+    const parsed = MutationImproveConfigSchema.parse({ ...minimalValid, agentTimeoutMs: 5 })
+    expect(parsed.mutateTimeoutMs).toBe(1_800_000)
+    expect('agentTimeoutMs' in parsed).toBe(false)
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/mutation-improve/config.test.ts`
+Expected: FAIL — `parsed.mutateTimeoutMs` is `undefined`.
+
+- [ ] **Step 3: Rename everywhere**
+
+In `mutation-improve/src/config.ts`, schema line:
+
+```typescript
+  mutateTimeoutMs: z.number().int().min(0).default(1_800_000),
+```
+
+(replaces `agentTimeoutMs: z.number().int().min(0).default(1_800_000),`).
+
+In `mutation-improve/src/cli.ts:159`:
+
+```typescript
+      const exec = createShellExec(worktreePath, `${config.mutateFileCommand} ${srcFile}`, config.mutateTimeoutMs)
+```
+
+In `mutation-improve/config.json` and `mutation-improve/config.example.json`:
+rename the `"agentTimeoutMs": 1800000` key to `"mutateTimeoutMs": 1800000`.
+
+In the five test files, rename the factory key `agentTimeoutMs:` →
+`mutateTimeoutMs:` (values unchanged): `pipeline.test.ts:29`,
+`finalize.test.ts:23`, `integration.test.ts:68`, `integration-git.test.ts:89`,
+`run-state.test.ts:29`.
+
+In `mutation-improve/CLAUDE.md`:
+- `Two timeouts exist: \`agent.timeoutMs\` for agent subprocesses, top-level \`agentTimeoutMs\` for the mutation-run exec, \`buildTimeoutMs\` for the build check.` → `Three timeouts exist: \`agent.timeoutMs\` for agent subprocesses, top-level \`mutateTimeoutMs\` for the mutation-run exec, \`buildTimeoutMs\` for the build check.`
+- Purpose paragraph: `merges per-iteration worktree branches into \`base\`; a final step pushes and opens a PR via \`gh\`.` → `merges per-iteration worktree branches into the checked-out integration branch (the CLI refuses to start on \`base\` or a detached HEAD); a final step pushes that branch and opens a PR to \`base\` via \`gh\`.`
+- Pipeline step 5: `then merged to \`base\`.` → `then merged into the integration branch.`
+
+- [ ] **Step 4: Run tests + full greps to verify**
+
+Run: `bun run mutation-improve:test && bun run mutation-improve:typecheck && bun run mutation-improve:lint && bun run mutation-improve:format:check`
+Expected: PASS all four.
+
+Run: `rg agentTimeoutMs mutation-improve tests/mutation-improve`
+Expected: no matches.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mutation-improve/src/config.ts mutation-improve/src/cli.ts mutation-improve/config.json mutation-improve/config.example.json mutation-improve/CLAUDE.md tests/mutation-improve/config.test.ts tests/mutation-improve/pipeline.test.ts tests/mutation-improve/finalize.test.ts tests/mutation-improve/integration.test.ts tests/mutation-improve/integration-git.test.ts tests/mutation-improve/run-state.test.ts
+git commit -m "refactor(mutation-improve): rename agentTimeoutMs to mutateTimeoutMs"
+```
+
+---
+
+## Final verification
+
+After Task 9, from the repo root:
+
+```bash
+bun run mutation-improve:test && bun run mutation-improve:typecheck && bun run mutation-improve:lint && bun run mutation-improve:format:check
+```
+
+All four green. Then confirm the eight spec issues map to commits:
+
+| Issue | Fixed by |
+|-------|----------|
+| 1 build-gate cwd | Task 2 |
+| 2 finalize push/PR | Tasks 6, 7 |
+| 3 per-iter artifacts | Task 3 |
+| 4 state saved once | Task 5 |
+| 5 skip no-ratchet | Task 8 |
+| 6 failed lacks file | Task 4 |
+| 7 rename bypass | Task 1 |
+| 8 timeout key | Task 9 |

--- a/docs/superpowers/specs/2026-08-06-mutation-improve-runner-fixes-design.md
+++ b/docs/superpowers/specs/2026-08-06-mutation-improve-runner-fixes-design.md
@@ -1,0 +1,174 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation-Improve Runner — Gate & Finalize Fixes
+
+**Date:** 2026-08-06
+**Status:** Design — approved (pending implementation plan)
+**Type:** Tooling bugfix round; `mutation-improve/` workspace only; no papai runtime changes
+
+## Summary
+
+A code review of the landed runner (PR #222 lineage, see
+`2026-08-05-mutation-improve-runner-design.md`) surfaced eight issues. All were
+verified against the code and the original spec; three are outright deviations
+from that spec, one is a design flaw the implementation inherited. All eight are
+fixed here, bundled as one spec landing as four independent commit units.
+
+| # | Issue | Verdict |
+|---|-------|---------|
+| 1 | Build gate runs `checkCommand` with cwd = `runDir`, not the iteration worktree (`cli.ts:154-157`); the gate never sees the agent's diff | Deviation — runner spec said "run `bun check:full` **in the worktree**" |
+| 2 | Finalize pushes `config.base` then `gh pr create --base <base>` with no head (`finalize.ts:65-69`), but `mergeWorktree` merges into whatever branch `repoRoot` is checked out on | Design flaw inherited from the runner spec (push base + PR against base is contradictory) |
+| 3 | Per-iter artifact paths computed in `pipeline.ts:74,100` are dead: `cli.ts:109,130` hardcodes run-level `iter/selection.json` / `iter/result.json`, and `agentWritePath` uses only the basename — `iter/<N>/` dirs stay empty, artifacts are overwritten every iteration | Deviation — runner spec said agent writes `<runDir>/iter/i/…`; spec'd `iter/i/failure.json` was never implemented |
+| 4 | `state.json` saved only once in the `cli.ts` finally-block; a crash loses `doneSet`/`merged`/`failed`/`currentIteration`, and `--resume-run` restarts from a stale iteration | Confirmed robustness gap |
+| 5 | Skip path (`beforeScore ≥ threshold`) never ratchets the baseline floor; `doneSet` is per-run, so every future run re-selects the file and burns a full Stryker run just to skip it again | Confirmed efficiency gap |
+| 6 | `FailedEntrySchema.file` exists but `failIter` never passes it; the PR failure table can't say what was attempted | Confirmed observability gap |
+| 7 | Diff-guard parses porcelain lines by fixed slice; rename entries (`R  orig -> new`) are unparsed — `tests/a.ts -> src/b.ts` passes the guard because the line starts with an allowed prefix | Confirmed guard bypass |
+| 8 | Two timeout keys: top-level `agentTimeoutMs` actually gates the *mutation-run* exec (`cli.ts:159`), `agent.timeoutMs` gates agents — easy to tune the wrong one | Confirmed config smell |
+
+## Decisions (from brainstorm)
+
+- **Scope: all eight issues** in one spec, landing as four commit units
+  (A: gates, B: artifacts+state, C: finalize, D: skip-ratchet+config). Each unit
+  is independently testable and reviewable; a problem in one does not block the
+  others.
+- **Finalize flow: current-branch + PR, guarded.** The runner merges iterations
+  into the branch `repoRoot` is checked out on; that is now an explicit,
+  enforced contract. Finalize pushes *that* branch and opens the PR against
+  `base` with an explicit `--head`. Pushing `base` itself is removed.
+- **Ratchet + commit on skip.** A skip means the floor was stale; the runner
+  bumps `baseline.json` directly in `repoRoot` and commits just that file on the
+  integration branch. The commit rides into the summary PR.
+- **`agentTimeoutMs` → `mutateTimeoutMs` hard rename**, no alias. The config is
+  checked-in dev tooling with a single consumer.
+
+## Non-goals
+
+- No change to review-loop's `agentWritePath` basename contract or any
+  review-loop consumer. The artifact fix aligns the copy destination with the
+  prompt path inside `mutation-improve` only.
+- No change to gate order, threshold/epsilon semantics, prompt contents, or the
+  sequential-iteration model.
+- No `build-check.log` artifact: build stdout/stderr already lands in the
+  failure reason and now in `failure.json`; a separate log duplicates it.
+- No changes under `src/`, `client/`, or `plugins/`.
+
+## Unit A — Gate integrity (issues 1, 7)
+
+**Build-gate cwd.** `PipelineDeps.runBuildCheck` becomes
+`(worktreePath: string) => Promise<BuildCheckResult>`. `gatePhase` passes the
+iteration worktree path (already in scope). `cli.ts` constructs
+`createShellExec(worktreePath, config.checkCommand, config.buildTimeoutMs)` per
+invocation instead of once against `runState.runDir`. This mirrors the cwd
+pattern `measureScore` already uses (`cli.ts:158-161`), so bun's behavior in a
+fresh worktree is the same as the working mutation-run path.
+
+**Diff-guard renames.** New `parsePorcelainPaths(line: string): string[]` in
+`src/diff-guard.ts`: parses `XY path` and `XY orig -> new` (R/C statuses),
+stripping surrounding quotes per segment. `runDiffGuard` flattens all endpoints
+before `classifyDiff`; a rename is a violation if **either** endpoint escapes
+`ALLOWED_PREFIXES`. This flags `tests/… -> src/…` (smuggle) and `src/… -> tests/…`
+(source removal) while allowing `tests/… -> tests/…`.
+
+**Tests:** `pipeline.test.ts` asserts `runBuildCheck` is called with the
+worktree path; `diff-guard.test.ts` gains rename cases (both directions,
+quoted segments, plain paths unchanged).
+
+## Unit B — Artifacts & state (issues 3, 4, 6)
+
+**Per-iter artifacts.** Dep signatures gain the output path:
+`runSelectAgent(worktreePath, prompt, outputPath)` and
+`runImproveAgent(worktreePath, prompt, outputPath)`. `pipeline.ts` passes its
+existing per-iter `selectOut`/`improveOut`; the `cli.ts` closures forward that
+path to `runAgent({ outputPath })` in place of the hardcoded run-level paths.
+`runAttempt` already `mkdir`s the destination dirname, so `<runDir>/iter/<N>/`
+is populated with no extra fs work. The prompt path and the copy destination are
+the same string again (both derive from `iterDir(runDir, iter)`), so the
+basename-only `agentWritePath` behavior stays correct.
+
+**`failure.json`.** `failIter` writes `<runDir>/iter/<N>/failure.json`
+(`{iter, gate, reason, file?}`) via `node:fs/promises` — the same direct-fs
+pattern as the existing `mkdir(iterPath)` in `runIteration`. Restores the
+runner-spec artifact.
+
+**Save per iteration.** `PipelineDeps` gains
+`saveRunState(state: MutationImproveRunState): Promise<void>`; `runFrom` calls
+it after each `runIteration` completes (after `results.push`, before recursing).
+`cli.ts` wires the real `saveRunState`; the finally-block save stays as a final
+flush. Resume semantics: a crash mid-iteration loses only that iteration (its
+worktree is swept by `--reset-worktree`); a crash after merge but before save
+self-heals — resume re-selects the file, measures ≥ threshold, skips, and
+Unit D's ratchet records the floor.
+
+**File in failed entries.** `failIter` takes `file?: string`; `runIteration`
+captures `selection.file` once the selection parses and threads it into both
+the `state.json` failed entry and `failure.json`. Select-gate rejections carry
+the (invalidly picked) file; pre-selection exceptions carry none.
+
+**Tests:** integration/pipeline tests updated for the new dep signatures;
+pipeline tests assert per-iter `outputPath` forwarding, `failure.json` content,
+`saveRunState` called once per completed iteration with the latest state, and
+`file` present in failed entries where a selection existed.
+
+## Unit C — Finalize flow (issue 2)
+
+**Startup guard.** New `assertIntegrationBranch(execGit, repoRoot, base)` in
+`src/finalize.ts`, called from `runCli` immediately after config load — before
+`createRunState` makes any run directories. Fails fast when
+`git rev-parse --abbrev-ref HEAD` returns `config.base` (would merge+push
+straight onto base) or `HEAD` (detached), with a message to check out an
+integration branch first.
+
+**Push/PR refs.** `runFinalize` resolves the current branch via `execGit`, then:
+`git push <upstream> <branch>` (replacing `push <upstream> <base>`), and
+`gh pr create --base <base> --head <branch> --title … --body <table>`.
+Failure handling unchanged: write `finalize.log` with a ready-to-paste command,
+return `{ pushed: true }`. `--no-pr` unchanged: merges stay local, no push.
+
+**Tests:** `cli.test.ts` — guard aborts before run-state creation when on base
+or detached; `finalize.test.ts` — push targets the resolved branch, PR carries
+`--head`; existing `gh`-failure fallback tests keep passing.
+
+## Unit D — Skip-ratchet & config (issues 5, 8)
+
+**Skip-ratchet.** In `runIteration`'s skip path, after `beforeScore ≥ threshold`:
+compute `bumped = bumpScore(baseline, file, beforeScore)`; if
+`bumped[file] !== baseline[file]`, then in `repoRoot` (not the about-to-be-
+removed worktree): `writeBaseline(repoRoot, bumped)`,
+`git add scripts/mutation/baseline.json`,
+`git commit -m "chore(mutation): ratchet <file> baseline to <score> (verified at threshold)"`.
+Staging exactly one path keeps this safe against a dirty working tree. If the
+floor doesn't move, no commit. The `doneSet.push` and worktree removal are
+unchanged. Ordering: measure in the worktree first (correct tree), remove
+worktree, then write+commit in `repoRoot`.
+
+**Config rename.** `agentTimeoutMs` → `mutateTimeoutMs` in
+`MutationImproveConfigSchema` (`src/config.ts`), `config.json`,
+`config.example.json`, and the `measureScore` wiring in `cli.ts`. Final triple:
+`mutateTimeoutMs` (Stryker runs), `buildTimeoutMs` (check command),
+`agent.timeoutMs` (agent subprocesses).
+
+**Tests:** pipeline test — skip with a stale floor writes+commits the bump in
+`repoRoot` (assert `writeBaseline` target and the two `execGit` calls), skip
+with an accurate floor commits nothing; `config.test.ts` — schema accepts
+`mutateTimeoutMs`. The old key is not aliased: Zod's default unknown-key
+stripping silently drops it, and both checked-in configs are updated in the
+same commit, so the old key never survives in-repo.
+
+## Docs to update (Unit D tail)
+
+`mutation-improve/AGENTS.md` documents the old model and must be re-synced:
+"merges … into `base`" → merges into the checked-out integration branch
+(enforced at startup); the timeout sentence gains `mutateTimeoutMs`; the
+artifacts list already matches the Unit-B reality once implemented.
+
+## Testing & verification (all units)
+
+TDD per repo hooks (`mutation-improve/src/**` ↔ `tests/mutation-improve/**`):
+failing tests first per unit, then implementation. Each unit ends green on
+`bun run mutation-improve:test`, `:typecheck`, `:lint`, `:format:check` (run
+from the repo root). Units land as separate commits on the current branch.

--- a/mutation-improve/AGENTS.md
+++ b/mutation-improve/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/mutation-improve/CLAUDE.md
+++ b/mutation-improve/CLAUDE.md
@@ -1,0 +1,48 @@
+# mutation-improve Workspace
+
+## Purpose
+
+`mutation-improve/` is a standalone Bun workspace for the autonomous mutation-coverage improvement runner. Each iteration spawns two `opencode run` agent subprocesses (a SELECT agent that picks the highest-ROI file from `scripts/mutation/baseline.json`, then an IMPROVE agent that writes spec/plan/tests for it), gates the result, ratchets the baseline, and merges per-iteration worktree branches into `base`; a final step pushes and opens a PR via `gh`. It is local developer tooling, not a papai runtime dependency.
+
+## Pipeline
+
+`src/pipeline.ts` runs iterations strictly sequentially (each observes the prior iteration's baseline bump and `doneSet`):
+
+1. SELECT — runner reads the baseline; the agent only suggests. Picks outside the baseline or already in `doneSet` are rejected as agent mistakes.
+2. CAPTURE BEFORE — runner-measured score; already ≥ `threshold` → iteration is `skipped` and the file joins `doneSet`.
+3. IMPROVE — agent writes spec/plan/tests; its declared score is never trusted.
+4. GATES, in order: diff-guard (`src/diff-guard.ts`: agent may only touch `tests/` and `docs/superpowers/`) → build check (`checkCommand`) → runner-measured after-score via `mutateFileCommand <file>`, read from `reports/paired/<stem>.stryker-report.json` (`src/score-reader.ts`, one retry on missing/corrupt report). Below `threshold` fails unless the agent declared residuals AND the score lands within `epsilon` of it.
+5. RATCHET + MERGE — the baseline bump is committed on the iteration branch inside the worktree, then merged to `base`. A merge conflict aborts the whole run (`gate: 'merge'`) so no later iteration chains off a stale base.
+
+Outcomes per iteration: `improved` | `skipped` | `failed`. The CLI exits 1 if any iteration failed or the run aborted. `runIteration` routes every throw through the same cleanup path so worktrees/branches are not leaked; `--reset-worktree` sweeps stale `<runId>-iterN` worktrees left by a killed process.
+
+## Config & repoRoot
+
+`config.json` (shape in `config.example.json`) loads via `--config` (default: `config.json` next to this package). `repoRoot` is resolved then **snapped to the git toplevel** (`detectGitRoot` in `src/config.ts`), so `"repoRoot": "."` works even though `bun run --filter` sets the cwd to this package dir; non-git roots pass through unchanged. `workDir` resolves against the snapped root. Note `readBaseline` (`src/baseline.ts`) returns `{}` on ENOENT rather than erroring — a wrong root therefore surfaces as select-gate rejections, not a load error. Two timeouts exist: `agent.timeoutMs` for agent subprocesses, top-level `agentTimeoutMs` for the mutation-run exec, `buildTimeoutMs` for the build check.
+
+## Storage / Artifacts
+
+- `<workDir>/runs/<runId>/state.json` — persisted run state (Zod-validated on `--resume-run <runId>`).
+- `<workDir>/runs/<runId>/agent-output.log` + `iter/<N>/{selection,result}.json` — agent transcripts and structured outputs.
+- `<workDir>/worktrees/<runId>-iter<N>` on branches `mutation-improve/<runId>-iter<N>` (kept on merge conflict, removed otherwise).
+- `finalize.log` in the run dir if `gh pr create` fails (includes a re-run command).
+
+## Scripts
+
+Run workspace commands from the repo root:
+
+- `bun run mutation-improve:test`
+- `bun run mutation-improve:typecheck`
+- `bun run mutation-improve:lint`
+- `bun run mutation-improve:format:check`
+- `bun run mutation-improve:start -- [--count N] [--threshold 0..1] [--base branch] [--resume-run <runId>] [--reset-worktree] [--no-pr]`
+
+## TDD Hooks
+
+The repo TDD resolver treats `mutation-improve/src/**` as gateable implementation code and maps it to `tests/mutation-improve/**`. New work must follow the same test-first flow used under `src/`.
+
+## Dependencies
+
+- `zod` — config/run-state/agent-output validation (shared with root).
+- `review-loop/src/*` — imported by relative path (not a package dependency): agent runner, build checker, live renderer, spawn, worktree/git helpers.
+- `scripts/mutation/*` — Stryker report reading/merging for runner-side score measurement.

--- a/mutation-improve/CLAUDE.md
+++ b/mutation-improve/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-`mutation-improve/` is a standalone Bun workspace for the autonomous mutation-coverage improvement runner. Each iteration spawns two `opencode run` agent subprocesses (a SELECT agent that picks the highest-ROI file from `scripts/mutation/baseline.json`, then an IMPROVE agent that writes spec/plan/tests for it), gates the result, ratchets the baseline, and merges per-iteration worktree branches into `base`; a final step pushes and opens a PR via `gh`. It is local developer tooling, not a papai runtime dependency.
+`mutation-improve/` is a standalone Bun workspace for the autonomous mutation-coverage improvement runner. Each iteration spawns two `opencode run` agent subprocesses (a SELECT agent that picks the highest-ROI file from `scripts/mutation/baseline.json`, then an IMPROVE agent that writes spec/plan/tests for it), gates the result, ratchets the baseline, and merges per-iteration worktree branches into the checked-out integration branch (the CLI refuses to start on `base` or a detached HEAD); a final step pushes that branch and opens a PR to `base` via `gh`. It is local developer tooling, not a papai runtime dependency.
 
 ## Pipeline
 
@@ -12,13 +12,13 @@
 2. CAPTURE BEFORE — runner-measured score; already ≥ `threshold` → iteration is `skipped` and the file joins `doneSet`.
 3. IMPROVE — agent writes spec/plan/tests; its declared score is never trusted.
 4. GATES, in order: diff-guard (`src/diff-guard.ts`: agent may only touch `tests/` and `docs/superpowers/`) → build check (`checkCommand`) → runner-measured after-score via `mutateFileCommand <file>`, read from `reports/paired/<stem>.stryker-report.json` (`src/score-reader.ts`, one retry on missing/corrupt report). Below `threshold` fails unless the agent declared residuals AND the score lands within `epsilon` of it.
-5. RATCHET + MERGE — the baseline bump is committed on the iteration branch inside the worktree, then merged to `base`. A merge conflict aborts the whole run (`gate: 'merge'`) so no later iteration chains off a stale base.
+5. RATCHET + MERGE — the baseline bump is committed on the iteration branch inside the worktree, then merged into the integration branch. A merge conflict aborts the whole run (`gate: 'merge'`) so no later iteration chains off a stale base.
 
 Outcomes per iteration: `improved` | `skipped` | `failed`. The CLI exits 1 if any iteration failed or the run aborted. `runIteration` routes every throw through the same cleanup path so worktrees/branches are not leaked; `--reset-worktree` sweeps stale `<runId>-iterN` worktrees left by a killed process.
 
 ## Config & repoRoot
 
-`config.json` (shape in `config.example.json`) loads via `--config` (default: `config.json` next to this package). `repoRoot` is resolved then **snapped to the git toplevel** (`detectGitRoot` in `src/config.ts`), so `"repoRoot": "."` works even though `bun run --filter` sets the cwd to this package dir; non-git roots pass through unchanged. `workDir` resolves against the snapped root. Note `readBaseline` (`src/baseline.ts`) returns `{}` on ENOENT rather than erroring — a wrong root therefore surfaces as select-gate rejections, not a load error. Two timeouts exist: `agent.timeoutMs` for agent subprocesses, top-level `agentTimeoutMs` for the mutation-run exec, `buildTimeoutMs` for the build check.
+`config.json` (shape in `config.example.json`) loads via `--config` (default: `config.json` next to this package). `repoRoot` is resolved then **snapped to the git toplevel** (`detectGitRoot` in `src/config.ts`), so `"repoRoot": "."` works even though `bun run --filter` sets the cwd to this package dir; non-git roots pass through unchanged. `workDir` resolves against the snapped root. Note `readBaseline` (`src/baseline.ts`) returns `{}` on ENOENT rather than erroring — a wrong root therefore surfaces as select-gate rejections, not a load error. Three timeouts exist: `agent.timeoutMs` for agent subprocesses, top-level `mutateTimeoutMs` for the mutation-run exec, `buildTimeoutMs` for the build check.
 
 ## Storage / Artifacts
 

--- a/mutation-improve/config.example.json
+++ b/mutation-improve/config.example.json
@@ -6,7 +6,7 @@
   "count": 1,
   "threshold": 0.95,
   "epsilon": 0.02,
-  "agentTimeoutMs": 1800000,
+  "mutateTimeoutMs": 1800000,
   "buildTimeoutMs": 600000,
   "checkCommand": "bun check:full",
   "mutateFileCommand": "bun test:mutate:file",

--- a/mutation-improve/config.json
+++ b/mutation-improve/config.json
@@ -6,7 +6,7 @@
   "count": 10,
   "threshold": 0.9,
   "epsilon": 0.02,
-  "agentTimeoutMs": 1800000,
+  "mutateTimeoutMs": 1800000,
   "buildTimeoutMs": 600000,
   "checkCommand": "bun check:full",
   "mutateFileCommand": "bun test:mutate:file",

--- a/mutation-improve/config.json
+++ b/mutation-improve/config.json
@@ -1,0 +1,19 @@
+{
+  "repoRoot": ".",
+  "workDir": ".mutation-improve",
+  "base": "master",
+  "upstream": "origin",
+  "count": 10,
+  "threshold": 0.9,
+  "epsilon": 0.02,
+  "agentTimeoutMs": 1800000,
+  "buildTimeoutMs": 600000,
+  "checkCommand": "bun check:full",
+  "mutateFileCommand": "bun test:mutate:file",
+  "agent": {
+    "model": "zai-coding-plan/glm-5.2",
+    "extraArgs": [],
+    "timeoutMs": 1800000
+  },
+  "prBranchPrefix": "mutation-improve"
+}

--- a/mutation-improve/src/cli.ts
+++ b/mutation-improve/src/cli.ts
@@ -156,7 +156,7 @@ function buildPipelineDeps(
       return runBuildCheck({ exec: () => exec() })
     },
     measureScore: (worktreePath: string, srcFile: string) => {
-      const exec = createShellExec(worktreePath, `${config.mutateFileCommand} ${srcFile}`, config.agentTimeoutMs)
+      const exec = createShellExec(worktreePath, `${config.mutateFileCommand} ${srcFile}`, config.mutateTimeoutMs)
       return measureMutationScore({ exec: () => exec() }, path.join(worktreePath, 'reports', 'paired'), srcFile)
     },
     readBaseline,

--- a/mutation-improve/src/cli.ts
+++ b/mutation-improve/src/cli.ts
@@ -18,7 +18,7 @@ import {
 } from '../../review-loop/src/worktree.js'
 import { readBaseline, writeBaseline } from './baseline.js'
 import { type MutationImproveConfig, loadMutationImproveConfig } from './config.js'
-import { runFinalize } from './finalize.js'
+import { assertIntegrationBranch, runFinalize } from './finalize.js'
 import { type IterationResult, runPipeline, type PipelineDeps } from './pipeline.js'
 import { ResultSchema } from './result-schema.js'
 import { createRunState, loadRunState, saveRunState, type MutationImproveRunState } from './run-state.js'
@@ -208,6 +208,8 @@ export async function runCli(argv: readonly string[]): Promise<void> {
   if (args.count !== undefined) config.count = args.count
   if (args.threshold !== undefined) config.threshold = args.threshold
   if (args.base !== undefined) config.base = args.base
+
+  await assertIntegrationBranch(execGit, config.repoRoot, config.base)
 
   const runState: MutationImproveRunState =
     args.resumeRunId === undefined ? await createRunState(config) : await loadRunState(config.workDir, args.resumeRunId)

--- a/mutation-improve/src/cli.ts
+++ b/mutation-improve/src/cli.ts
@@ -100,13 +100,13 @@ function selectRunner(
   runState: MutationImproveRunState,
   log: LiveRenderer,
 ): PipelineDeps['runSelectAgent'] {
-  return (worktreePath, prompt) =>
+  return (worktreePath, prompt, outputPath) =>
     runAgent({
       spawn: realSpawn,
       model: config.agent.model,
       cwd: worktreePath,
       prompt,
-      outputPath: path.join(runState.runDir, 'iter', 'selection.json'),
+      outputPath,
       outputSchema: SelectionSchema,
       label: 'select',
       logPath: path.join(runState.runDir, 'agent-output.log'),
@@ -121,13 +121,13 @@ function improveRunner(
   runState: MutationImproveRunState,
   log: LiveRenderer,
 ): PipelineDeps['runImproveAgent'] {
-  return (worktreePath, prompt) =>
+  return (worktreePath, prompt, outputPath) =>
     runAgent({
       spawn: realSpawn,
       model: config.agent.model,
       cwd: worktreePath,
       prompt,
-      outputPath: path.join(runState.runDir, 'iter', 'result.json'),
+      outputPath,
       outputSchema: ResultSchema,
       label: 'improve',
       logPath: path.join(runState.runDir, 'agent-output.log'),

--- a/mutation-improve/src/cli.ts
+++ b/mutation-improve/src/cli.ts
@@ -151,8 +151,8 @@ function buildPipelineDeps(
     removeWorktree,
     mergeWorktree,
     execGit,
-    runBuildCheck: () => {
-      const exec = createShellExec(runState.runDir, config.checkCommand, config.buildTimeoutMs)
+    runBuildCheck: (worktreePath: string) => {
+      const exec = createShellExec(worktreePath, config.checkCommand, config.buildTimeoutMs)
       return runBuildCheck({ exec: () => exec() })
     },
     measureScore: (worktreePath: string, srcFile: string) => {

--- a/mutation-improve/src/cli.ts
+++ b/mutation-improve/src/cli.ts
@@ -163,6 +163,7 @@ function buildPipelineDeps(
     writeBaseline,
     runSelectAgent: selectRunner(config, runState, log),
     runImproveAgent: improveRunner(config, runState, log),
+    saveRunState,
     log,
   }
 }

--- a/mutation-improve/src/config.ts
+++ b/mutation-improve/src/config.ts
@@ -24,7 +24,7 @@ export const MutationImproveConfigSchema = z.object({
   count: z.number().int().positive().default(1),
   threshold: z.number().min(0).max(1).default(0.95),
   epsilon: z.number().min(0).max(1).default(0.02),
-  agentTimeoutMs: z.number().int().min(0).default(1_800_000),
+  mutateTimeoutMs: z.number().int().min(0).default(1_800_000),
   buildTimeoutMs: z.number().int().min(0).default(600_000),
   checkCommand: z.string().min(1).default('bun check:full'),
   mutateFileCommand: z.string().min(1).default('bun test:mutate:file'),

--- a/mutation-improve/src/config.ts
+++ b/mutation-improve/src/config.ts
@@ -42,13 +42,27 @@ export interface ConfigLoadInput {
   repoRoot?: string
 }
 
+// repoRoot may legitimately resolve to a subdirectory of the target repo (e.g.
+// "repoRoot": "." in mutation-improve/config.json, where `bun run --filter`
+// sets the cwd to the package dir). Snap it to the git toplevel so baseline,
+// worktree, and merge operations target the real repo; non-git roots (tests,
+// ad-hoc dirs) pass through unchanged.
+async function snapToGitRoot(resolved: string): Promise<string> {
+  try {
+    return await detectGitRoot(resolved)
+  } catch {
+    return resolved
+  }
+}
+
 export async function loadMutationImproveConfig(input: ConfigLoadInput): Promise<MutationImproveConfig> {
   const configPath = path.resolve(input.configPath)
   const raw = JSON.parse(await readFile(configPath, 'utf8')) as unknown
   const parsed = MutationImproveConfigSchema.parse(raw)
 
   const repoRootSource = input.repoRoot ?? parsed.repoRoot
-  const repoRoot = repoRootSource === undefined ? await detectGitRoot(process.cwd()) : path.resolve(repoRootSource)
+  const resolved = repoRootSource === undefined ? await detectGitRoot(process.cwd()) : path.resolve(repoRootSource)
+  const repoRoot = await snapToGitRoot(resolved)
   const workDir = path.resolve(repoRoot, parsed.workDir)
 
   await mkdir(workDir, { recursive: true })

--- a/mutation-improve/src/diff-guard.ts
+++ b/mutation-improve/src/diff-guard.ts
@@ -17,6 +17,23 @@ export function classifyDiff(paths: readonly string[]): { allowed: string[]; vio
   return { allowed, violations }
 }
 
+function unquote(p: string): string {
+  return p.replace(/^"|"$/gu, '')
+}
+
+// Porcelain v1 rename/copy entries look like `R  orig -> new` (each side
+// quoted independently when it contains special chars). Only R/C statuses use
+// the arrow form, so the status check prevents mis-splitting a quoted path
+// that merely contains ' -> '.
+export function parsePorcelainPaths(line: string): string[] {
+  const status = line.slice(0, 2)
+  const body = line.slice(3).trim()
+  if (!status.includes('R') && !status.includes('C')) return [unquote(body)]
+  const arrowIdx = body.indexOf(' -> ')
+  if (arrowIdx === -1) return [unquote(body)]
+  return [unquote(body.slice(0, arrowIdx)), unquote(body.slice(arrowIdx + 4))]
+}
+
 export async function runDiffGuard(
   execGit: ExecGitFn,
   cwd: string,
@@ -24,8 +41,8 @@ export async function runDiffGuard(
   const { stdout } = await execGit(cwd, ['status', '--porcelain', '--untracked-files=all'])
   const paths = stdout
     .split('\n')
-    .map((line) => line.slice(3).trim())
-    .map((p) => p.replace(/^"|"$/gu, ''))
+    .filter((line) => line.trim().length > 0)
+    .flatMap(parsePorcelainPaths)
     .filter((p) => p.length > 0)
   const { violations } = classifyDiff(paths)
   return violations.length === 0 ? { ok: true } : { ok: false, violations }

--- a/mutation-improve/src/failure-recorder.ts
+++ b/mutation-improve/src/failure-recorder.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { iterDir, type MutationImproveRunState } from './run-state.js'
+
+export type FailureEntry = { iter: number; gate: string; reason: string; file?: string }
+
+// Single failure sink: every failed iteration leaves a durable
+// iter/<N>/failure.json (runner-spec artifact) and a state.json entry. The
+// file is recorded when known so the summary PR can name what was attempted.
+export async function recordFailure(
+  runState: MutationImproveRunState,
+  iter: number,
+  gate: string,
+  reason: string,
+  file?: string,
+): Promise<FailureEntry> {
+  const entry: FailureEntry = file === undefined ? { iter, gate, reason } : { iter, gate, reason, file }
+  await writeFile(path.join(iterDir(runState.runDir, iter), 'failure.json'), `${JSON.stringify(entry, null, 2)}\n`)
+  runState.failed.push(entry)
+  return entry
+}

--- a/mutation-improve/src/finalize.ts
+++ b/mutation-improve/src/finalize.ts
@@ -62,11 +62,13 @@ export function buildSummaryBody(merged: readonly MergedRow[], failed: readonly 
 
 export async function runFinalize(deps: FinalizeDeps, input: FinalizeInput): Promise<FinalizeResult> {
   const { config, runState } = input
-  await deps.execGit(config.repoRoot, ['push', config.upstream, config.base])
+  const { stdout } = await deps.execGit(config.repoRoot, ['rev-parse', '--abbrev-ref', 'HEAD'])
+  const branch = stdout.trim()
+  await deps.execGit(config.repoRoot, ['push', config.upstream, branch])
   const title = `mutation-improve: ${runState.merged.map((m) => m.file).join(', ')}`
   const body = buildSummaryBody(runState.merged, runState.failed)
   const result = await deps.runGh(
-    ['pr', 'create', '--base', config.base, '--title', title, '--body', body],
+    ['pr', 'create', '--base', config.base, '--head', branch, '--title', title, '--body', body],
     config.repoRoot,
   )
   if (result.exitCode !== 0) {
@@ -74,7 +76,7 @@ export async function runFinalize(deps: FinalizeDeps, input: FinalizeInput): Pro
     await mkdir(path.dirname(logPath), { recursive: true })
     await appendFile(
       logPath,
-      `gh pr create failed (exit ${result.exitCode}): ${result.stderr}\nRe-run: gh pr create --base ${config.base} --title ${JSON.stringify(title)} --body <body>\n`,
+      `gh pr create failed (exit ${result.exitCode}): ${result.stderr}\nRe-run: gh pr create --base ${config.base} --head ${branch} --title ${JSON.stringify(title)} --body <body>\n`,
     )
     return { pushed: true }
   }

--- a/mutation-improve/src/finalize.ts
+++ b/mutation-improve/src/finalize.ts
@@ -80,3 +80,16 @@ export async function runFinalize(deps: FinalizeDeps, input: FinalizeInput): Pro
   }
   return { pushed: true, prUrl: result.stdout.trim() || undefined }
 }
+
+// Iterations merge into whatever branch repoRoot is checked out on. Starting
+// a run on base (or a detached HEAD) would merge+push straight onto base with
+// no PR, so refuse before any run state is created.
+export async function assertIntegrationBranch(execGit: ExecGitFn, repoRoot: string, base: string): Promise<void> {
+  const { stdout } = await execGit(repoRoot, ['rev-parse', '--abbrev-ref', 'HEAD'])
+  const branch = stdout.trim()
+  if (branch === base || branch === 'HEAD') {
+    throw new Error(
+      `mutation-improve merges iterations into the checked-out branch, but repoRoot is on '${branch}'. Check out a non-base integration branch first (base: ${base}).`,
+    )
+  }
+}

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -42,8 +42,8 @@ export interface PipelineDeps {
   measureScore: (worktreePath: string, srcFile: string) => Promise<number>
   readBaseline: (repoRoot: string) => Promise<BaselineMap>
   writeBaseline: (repoRoot: string, map: BaselineMap) => Promise<void>
-  runSelectAgent: (worktreePath: string, prompt: string) => Promise<AgentRunResult<Selection>>
-  runImproveAgent: (worktreePath: string, prompt: string) => Promise<AgentRunResult<Result>>
+  runSelectAgent: (worktreePath: string, prompt: string, outputPath: string) => Promise<AgentRunResult<Selection>>
+  runImproveAgent: (worktreePath: string, prompt: string, outputPath: string) => Promise<AgentRunResult<Result>>
   log: { log: (msg: string) => void; issue?: unknown }
 }
 
@@ -79,6 +79,7 @@ async function selectPhase(
       baselineSummary: JSON.stringify(baseline),
       outputPath: agentWritePath(worktreePath, selectOut),
     }),
+    selectOut,
   )
   const selection = SelectionSchema.parse(selectRes.value)
   if (deps.runState.doneSet.includes(selection.file) || baseline[selection.file] === undefined) {
@@ -107,6 +108,7 @@ async function improvePhase(
       date: new Date().toISOString().slice(0, 10),
       outputPath: agentWritePath(worktreePath, improveOut),
     }),
+    improveOut,
   )
   return ResultSchema.parse(improveRes.value)
 }

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -38,7 +38,7 @@ export interface PipelineDeps {
   removeWorktree: (repoRoot: string, worktreePath: string, runId: string, branchPrefix: string) => Promise<void>
   mergeWorktree: (repoRoot: string, branchName: string) => Promise<MergeResult>
   execGit: (cwd: string, args: readonly string[]) => Promise<{ stdout: string; stderr: string }>
-  runBuildCheck: () => Promise<{ passed: boolean; stdout: string; stderr: string }>
+  runBuildCheck: (worktreePath: string) => Promise<{ passed: boolean; stdout: string; stderr: string }>
   measureScore: (worktreePath: string, srcFile: string) => Promise<number>
   readBaseline: (repoRoot: string) => Promise<BaselineMap>
   writeBaseline: (repoRoot: string, map: BaselineMap) => Promise<void>
@@ -126,7 +126,7 @@ async function gatePhase(
   if (!diff.ok) {
     return { ok: false, gate: 'diff-scope', reason: `forbidden paths changed: ${diff.violations.join(', ')}` }
   }
-  const build = await deps.runBuildCheck()
+  const build = await deps.runBuildCheck(worktreePath)
   if (!build.passed) {
     return { ok: false, gate: 'build', reason: build.stderr || build.stdout }
   }

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -19,6 +19,7 @@ import type { MutationImproveRunState } from './run-state.js'
 import { iterDir } from './run-state.js'
 import { SelectionSchema } from './selection-schema.js'
 import type { Selection } from './selection-schema.js'
+import { ratchetVerifiedSkip } from './skip-ratchet.js'
 
 export interface IterationResult {
   iter: number
@@ -247,6 +248,7 @@ export async function runIteration(deps: PipelineDeps, iter: number): Promise<It
     const beforeScore = await deps.measureScore(worktreePath, selection.file)
     if (beforeScore >= deps.config.threshold) {
       deps.runState.doneSet.push(selection.file)
+      await ratchetVerifiedSkip(deps, baseline, selection.file, beforeScore)
       return await skipIter(deps, iter, worktreePath, selection.file, beforeScore)
     }
 

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -11,6 +11,7 @@ import type { MergeResult } from '../../review-loop/src/worktree.js'
 import { bumpScore, type BaselineMap } from './baseline.js'
 import type { MutationImproveConfig } from './config.js'
 import { runDiffGuard } from './diff-guard.js'
+import { recordFailure, type FailureEntry } from './failure-recorder.js'
 import { buildImprovePrompt, buildSelectPrompt } from './prompt-templates.js'
 import type { Result } from './result-schema.js'
 import { ResultSchema } from './result-schema.js'
@@ -48,7 +49,7 @@ export interface PipelineDeps {
 }
 
 type PhaseOk<T> = { ok: true; value: T }
-type PhaseFail = { ok: false; gate: string; reason: string }
+type PhaseFail = { ok: false; gate: string; reason: string; file?: string }
 type PhaseResult<T> = PhaseOk<T> | PhaseFail
 
 function branchFor(deps: PipelineDeps, iter: number): string {
@@ -83,7 +84,7 @@ async function selectPhase(
   )
   const selection = SelectionSchema.parse(selectRes.value)
   if (deps.runState.doneSet.includes(selection.file) || baseline[selection.file] === undefined) {
-    return { ok: false, gate: 'select', reason: 'selection file not in baseline or already done' }
+    return { ok: false, gate: 'select', reason: 'selection file not in baseline or already done', file: selection.file }
   }
   return { ok: true, value: { selection, baseline } }
 }
@@ -201,11 +202,12 @@ async function failIter(
   worktreePath: string,
   gate: string,
   reason: string,
+  file?: string,
 ): Promise<IterationResult> {
+  const entry: FailureEntry = await recordFailure(deps.runState, iter, gate, reason, file)
   await deps.resetWorktree(worktreePath)
   await deps.removeWorktree(deps.config.repoRoot, worktreePath, runIdFor(deps, iter), deps.config.prBranchPrefix)
-  deps.runState.failed.push({ iter, gate, reason })
-  return { iter, outcome: 'failed', gate, reason }
+  return { ...entry, outcome: 'failed' }
 }
 
 function skipIter(
@@ -230,13 +232,15 @@ export async function runIteration(deps: PipelineDeps, iter: number): Promise<It
   // `mutation-improve/<runId>-iterN` branch are leaked, runState.failed gains
   // no entry, and the next createWorktree for the same path fails.
   let worktreeCreated = false
+  let file: string | undefined
   try {
     await deps.createWorktree(deps.config.repoRoot, worktreePath, runIdFor(deps, iter), deps.config.prBranchPrefix)
     worktreeCreated = true
 
     const sel = await selectPhase(deps, worktreePath, iterPath)
-    if (!sel.ok) return await failIter(deps, iter, worktreePath, sel.gate, sel.reason)
+    if (!sel.ok) return await failIter(deps, iter, worktreePath, sel.gate, sel.reason, sel.file)
     const { selection, baseline } = sel.value
+    file = selection.file
 
     // ② CAPTURE BEFORE (runner-owned). Already at threshold → nothing to do.
     const beforeScore = await deps.measureScore(worktreePath, selection.file)
@@ -248,18 +252,18 @@ export async function runIteration(deps: PipelineDeps, iter: number): Promise<It
     const improved = await improvePhase(deps, worktreePath, iterPath, selection.file, beforeScore)
 
     const gate = await gatePhase(deps, worktreePath, selection.file, improved)
-    if (!gate.ok) return await failIter(deps, iter, worktreePath, gate.gate, gate.reason)
+    if (!gate.ok) return await failIter(deps, iter, worktreePath, gate.gate, gate.reason, file)
 
     return await finalizePhase(deps, iter, worktreePath, selection.file, baseline, beforeScore, gate.value, improved)
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error)
-    // If createWorktree itself threw there is nothing to reset/remove; just
-    // record the failure so the run is not silently dropped.
+    // If createWorktree itself threw there is nothing to reset/remove; record
+    // the failure (no file — selection never ran) so the run is not dropped.
     if (!worktreeCreated) {
-      deps.runState.failed.push({ iter, gate: 'exception', reason })
+      await recordFailure(deps.runState, iter, 'exception', reason)
       return { iter, outcome: 'failed', gate: 'exception', reason }
     }
-    return failIter(deps, iter, worktreePath, 'exception', reason)
+    return failIter(deps, iter, worktreePath, 'exception', reason, file)
   }
 }
 

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -6,7 +6,7 @@
 import { mkdir } from 'node:fs/promises'
 import path from 'node:path'
 
-import type { AgentRunResult } from '../../review-loop/src/agent-runner.js'
+import { agentWritePath, type AgentRunResult } from '../../review-loop/src/agent-runner.js'
 import type { MergeResult } from '../../review-loop/src/worktree.js'
 import { bumpScore, type BaselineMap } from './baseline.js'
 import type { MutationImproveConfig } from './config.js'
@@ -77,7 +77,7 @@ async function selectPhase(
     buildSelectPrompt({
       doneSet: deps.runState.doneSet,
       baselineSummary: JSON.stringify(baseline),
-      outputPath: selectOut,
+      outputPath: agentWritePath(worktreePath, selectOut),
     }),
   )
   const selection = SelectionSchema.parse(selectRes.value)
@@ -105,7 +105,7 @@ async function improvePhase(
       beforeScore,
       threshold: deps.config.threshold,
       date: new Date().toISOString().slice(0, 10),
-      outputPath: improveOut,
+      outputPath: agentWritePath(worktreePath, improveOut),
     }),
   )
   return ResultSchema.parse(improveRes.value)

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -45,6 +45,7 @@ export interface PipelineDeps {
   writeBaseline: (repoRoot: string, map: BaselineMap) => Promise<void>
   runSelectAgent: (worktreePath: string, prompt: string, outputPath: string) => Promise<AgentRunResult<Selection>>
   runImproveAgent: (worktreePath: string, prompt: string, outputPath: string) => Promise<AgentRunResult<Result>>
+  saveRunState: (state: MutationImproveRunState) => Promise<void>
   log: { log: (msg: string) => void; issue?: unknown }
 }
 
@@ -279,8 +280,10 @@ export async function runPipeline(deps: PipelineDeps): Promise<{ results: Iterat
     results.push(outcome)
     if (outcome.gate === 'merge') {
       deps.runState.status = 'aborted'
+      await deps.saveRunState(deps.runState)
       return { results, aborted: true }
     }
+    await deps.saveRunState(deps.runState)
     return runFrom(iter + 1, false)
   }
   const final = await runFrom(deps.runState.currentIteration + 1, false)

--- a/mutation-improve/src/skip-ratchet.ts
+++ b/mutation-improve/src/skip-ratchet.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { bumpScore, type BaselineMap } from './baseline.js'
+import type { PipelineDeps } from './pipeline.js'
+
+type SkipRatchetDeps = Pick<PipelineDeps, 'writeBaseline' | 'execGit'> & {
+  config: { repoRoot: string }
+}
+
+// A skip means the measured score already clears the threshold while the
+// baseline floor lags behind. Ratchet the floor directly on the integration
+// branch (repoRoot) so future runs don't re-select the file and burn a full
+// mutation run rediscovering it. Only baseline.json is staged, so a dirty
+// repoRoot working tree is safe.
+export async function ratchetVerifiedSkip(
+  deps: SkipRatchetDeps,
+  baseline: BaselineMap,
+  file: string,
+  score: number,
+): Promise<void> {
+  const bumped = bumpScore(baseline, file, score)
+  if (bumped[file] === baseline[file]) return
+  await deps.writeBaseline(deps.config.repoRoot, bumped)
+  await deps.execGit(deps.config.repoRoot, ['add', 'scripts/mutation/baseline.json'])
+  await deps.execGit(deps.config.repoRoot, [
+    'commit',
+    '-m',
+    `chore(mutation): ratchet ${file} baseline to ${score} (verified at threshold)`,
+  ])
+}

--- a/tests/mutation-improve/cli.test.ts
+++ b/tests/mutation-improve/cli.test.ts
@@ -7,11 +7,23 @@ import { afterEach, describe, expect, test } from 'bun:test'
 import { existsSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
-import { DEFAULT_CONFIG_PATH, parseCliArgs, resetRunWorktrees } from '../../mutation-improve/src/cli.js'
+import { DEFAULT_CONFIG_PATH, parseCliArgs, resetRunWorktrees, runCli } from '../../mutation-improve/src/cli.js'
 import { execGit } from '../../review-loop/src/worktree.js'
 import { cleanupTempDirs, makeTempDir } from './test-helpers'
 
 afterEach(cleanupTempDirs)
+
+async function setupRepo(): Promise<{ repoRoot: string; worktreesDir: string }> {
+  const repoRoot = makeTempDir('cli-repo-')
+  await execGit(repoRoot, ['init'])
+  await execGit(repoRoot, ['config', 'user.email', 'test@test.com'])
+  await execGit(repoRoot, ['config', 'user.name', 'Test'])
+  await execGit(repoRoot, ['checkout', '-b', 'master'])
+  writeFileSync(path.join(repoRoot, 'README.md'), 'hello')
+  await execGit(repoRoot, ['add', '.'])
+  await execGit(repoRoot, ['commit', '-m', 'init'])
+  return { repoRoot, worktreesDir: path.join(repoRoot, '.mutation-improve', 'worktrees') }
+}
 
 describe('cli parseCliArgs', () => {
   test('parses --config and requires --config (default exists)', () => {
@@ -65,18 +77,6 @@ describe('cli parseCliArgs', () => {
 })
 
 describe('resetRunWorktrees', () => {
-  async function setupRepo(): Promise<{ repoRoot: string; worktreesDir: string }> {
-    const repoRoot = makeTempDir('cli-repo-')
-    await execGit(repoRoot, ['init'])
-    await execGit(repoRoot, ['config', 'user.email', 'test@test.com'])
-    await execGit(repoRoot, ['config', 'user.name', 'Test'])
-    await execGit(repoRoot, ['checkout', '-b', 'master'])
-    writeFileSync(path.join(repoRoot, 'README.md'), 'hello')
-    await execGit(repoRoot, ['add', '.'])
-    await execGit(repoRoot, ['commit', '-m', 'init'])
-    return { repoRoot, worktreesDir: path.join(repoRoot, '.mutation-improve', 'worktrees') }
-  }
-
   test('removes only iteration worktrees and branches matching runId', async () => {
     const { repoRoot, worktreesDir } = await setupRepo()
     const sameRun1 = path.join(worktreesDir, 'r1-iter1')
@@ -100,5 +100,25 @@ describe('resetRunWorktrees', () => {
   test('no-op when no matching worktrees exist', async () => {
     const { repoRoot } = await setupRepo()
     await expect(resetRunWorktrees(repoRoot, 'r1', 'mutation-improve')).resolves.toBeUndefined()
+  })
+})
+
+describe('runCli integration-branch guard', () => {
+  test('fails fast on the base branch before creating run state', async () => {
+    const { repoRoot } = await setupRepo()
+    const configPath = path.join(repoRoot, 'cfg.json')
+    writeFileSync(configPath, JSON.stringify({ repoRoot, workDir: '.mi', agent: { model: 'm' } }))
+    await expect(runCli(['--config', configPath])).rejects.toThrow(/integration branch/u)
+    expect(existsSync(path.join(repoRoot, '.mi', 'runs'))).toBe(false)
+  })
+
+  test('fails fast on a detached HEAD', async () => {
+    const { repoRoot } = await setupRepo()
+    const { stdout: sha } = await execGit(repoRoot, ['rev-parse', 'HEAD'])
+    await execGit(repoRoot, ['checkout', sha.trim()])
+    const configPath = path.join(repoRoot, 'cfg.json')
+    writeFileSync(configPath, JSON.stringify({ repoRoot, workDir: '.mi', agent: { model: 'm' } }))
+    await expect(runCli(['--config', configPath])).rejects.toThrow(/integration branch/u)
+    expect(existsSync(path.join(repoRoot, '.mi', 'runs'))).toBe(false)
   })
 })

--- a/tests/mutation-improve/config.test.ts
+++ b/tests/mutation-improve/config.test.ts
@@ -4,7 +4,8 @@
 // See LICENSE in the project root for details.
 
 import { afterEach, describe, expect, test } from 'bun:test'
-import { writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, realpathSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
 import { MutationImproveConfigSchema, loadMutationImproveConfig } from '../../mutation-improve/src/config.js'
@@ -43,5 +44,25 @@ describe('config', () => {
     const config = await loadMutationImproveConfig({ configPath })
     expect(config.repoRoot).toBe(repoRoot)
     expect(config.workDir).toBe(path.resolve(repoRoot, '.mutation-improve'))
+  })
+
+  test('loadMutationImproveConfig snaps a repoRoot subdirectory to the git toplevel', async () => {
+    const gitRoot = makeTempDir('cfg-git-')
+    const git = (args: readonly string[], cwd: string): string =>
+      execFileSync('git', [...args], { cwd, encoding: 'utf8' })
+    git(['init', '--quiet'], gitRoot)
+    const subdir = path.join(gitRoot, 'mutation-improve')
+    mkdirSync(subdir)
+    const configPath = path.join(subdir, 'config.json')
+    writeFileSync(configPath, JSON.stringify({ ...minimalValid, repoRoot: '.' }))
+    const cwd = process.cwd()
+    process.chdir(subdir)
+    try {
+      const config = await loadMutationImproveConfig({ configPath })
+      expect(config.repoRoot).toBe(realpathSync(gitRoot))
+      expect(config.workDir).toBe(path.join(realpathSync(gitRoot), '.mutation-improve'))
+    } finally {
+      process.chdir(cwd)
+    }
   })
 })

--- a/tests/mutation-improve/config.test.ts
+++ b/tests/mutation-improve/config.test.ts
@@ -30,6 +30,13 @@ describe('config', () => {
     expect(parsed.mutateFileCommand).toBe('bun test:mutate:file')
     expect(parsed.prBranchPrefix).toBe('mutation-improve')
     expect(parsed.agent.timeoutMs).toBe(1_800_000)
+    expect(parsed.mutateTimeoutMs).toBe(1_800_000)
+  })
+
+  test('MutationImproveConfigSchema strips the legacy agentTimeoutMs key', () => {
+    const parsed = MutationImproveConfigSchema.parse({ ...minimalValid, agentTimeoutMs: 5 })
+    expect(parsed.mutateTimeoutMs).toBe(1_800_000)
+    expect('agentTimeoutMs' in parsed).toBe(false)
   })
 
   test('MutationImproveConfigSchema rejects threshold out of [0,1]', () => {

--- a/tests/mutation-improve/contracts.test.ts
+++ b/tests/mutation-improve/contracts.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, test } from 'bun:test'
 
 import { ResultSchema } from '../../mutation-improve/src/result-schema.js'
 import { SelectionSchema } from '../../mutation-improve/src/selection-schema.js'
-import { runAgent } from '../../review-loop/src/agent-runner.js'
+import { agentWritePath, runAgent } from '../../review-loop/src/agent-runner.js'
 import { createShellExec, runBuildCheck } from '../../review-loop/src/build-checker.js'
 import { LiveRenderer } from '../../review-loop/src/live-renderer.js'
 import { realSpawn } from '../../review-loop/src/spawn.js'
@@ -94,6 +94,7 @@ describe('review-loop surface contract', () => {
     // tests/review-loop/**; this asserts presence + callability so removal or
     // export-shape drift fails loudly in mutation-improve's own gate.
     expect(typeof runAgent).toBe('function')
+    expect(typeof agentWritePath).toBe('function')
     expect(typeof realSpawn).toBe('function')
     expect(typeof createWorktree).toBe('function')
     expect(typeof execGit).toBe('function')

--- a/tests/mutation-improve/diff-guard.test.ts
+++ b/tests/mutation-improve/diff-guard.test.ts
@@ -5,7 +5,12 @@
 
 import { describe, expect, test } from 'bun:test'
 
-import { ALLOWED_PREFIXES, classifyDiff, runDiffGuard } from '../../mutation-improve/src/diff-guard.js'
+import {
+  ALLOWED_PREFIXES,
+  classifyDiff,
+  parsePorcelainPaths,
+  runDiffGuard,
+} from '../../mutation-improve/src/diff-guard.js'
 
 type GitResult = { stdout: string; stderr: string }
 
@@ -52,6 +57,43 @@ describe('diff-guard', () => {
 
   test('runDiffGuard strips porcelain quotes around paths with special chars', async () => {
     const execGit = (): Promise<GitResult> => Promise.resolve({ stdout: ' M "tests/a b.test.ts"\n', stderr: '' })
+    const result = await runDiffGuard(execGit, '/repo/wt')
+    expect(result).toEqual({ ok: true })
+  })
+
+  test('parsePorcelainPaths returns a single path for non-rename entries', () => {
+    expect(parsePorcelainPaths(' M tests/a.test.ts')).toEqual(['tests/a.test.ts'])
+    expect(parsePorcelainPaths('?? "docs/superpowers/a b.md"')).toEqual(['docs/superpowers/a b.md'])
+  })
+
+  test('parsePorcelainPaths splits rename entries into both endpoints', () => {
+    expect(parsePorcelainPaths('R  tests/old.test.ts -> tests/new.test.ts')).toEqual([
+      'tests/old.test.ts',
+      'tests/new.test.ts',
+    ])
+    expect(parsePorcelainPaths('R  "tests/a b.test.ts" -> "tests/c d.test.ts"')).toEqual([
+      'tests/a b.test.ts',
+      'tests/c d.test.ts',
+    ])
+  })
+
+  test('runDiffGuard flags a rename from allowed to forbidden (smuggle)', async () => {
+    const execGit = (): Promise<GitResult> =>
+      Promise.resolve({ stdout: 'R  tests/a.test.ts -> src/foo.ts\n', stderr: '' })
+    const result = await runDiffGuard(execGit, '/repo/wt')
+    expect(result).toEqual({ ok: false, violations: ['src/foo.ts'] })
+  })
+
+  test('runDiffGuard flags a rename from forbidden to allowed (source removal)', async () => {
+    const execGit = (): Promise<GitResult> =>
+      Promise.resolve({ stdout: 'R  src/foo.ts -> tests/foo.test.ts\n', stderr: '' })
+    const result = await runDiffGuard(execGit, '/repo/wt')
+    expect(result).toEqual({ ok: false, violations: ['src/foo.ts'] })
+  })
+
+  test('runDiffGuard allows a rename within tests/', async () => {
+    const execGit = (): Promise<GitResult> =>
+      Promise.resolve({ stdout: 'R  tests/old.test.ts -> tests/new.test.ts\n', stderr: '' })
     const result = await runDiffGuard(execGit, '/repo/wt')
     expect(result).toEqual({ ok: true })
   })

--- a/tests/mutation-improve/failure-recorder.test.ts
+++ b/tests/mutation-improve/failure-recorder.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
+
+import { recordFailure } from '../../mutation-improve/src/failure-recorder.js'
+import type { MutationImproveRunState } from '../../mutation-improve/src/run-state.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+const runState = (repoRoot: string): MutationImproveRunState => ({
+  runId: 'r1',
+  repoRoot,
+  workDir: path.join(repoRoot, '.mutation-improve'),
+  runDir: path.join(repoRoot, '.mutation-improve', 'runs', 'r1'),
+  statePath: path.join(repoRoot, '.mutation-improve', 'runs', 'r1', 'state.json'),
+  base: 'master',
+  threshold: 0.95,
+  count: 1,
+  currentIteration: 0,
+  doneSet: [],
+  merged: [],
+  failed: [],
+  status: 'running',
+})
+
+describe('recordFailure', () => {
+  test('writes iter/<N>/failure.json and pushes the state entry, with file when known', async () => {
+    const state = runState(makeTempDir('fr-'))
+    await mkdir(path.join(state.runDir, 'iter', '3'), { recursive: true })
+    const entry = await recordFailure(state, 3, 'score', 'below threshold', 'src/foo.ts')
+    expect(entry).toEqual({ iter: 3, gate: 'score', reason: 'below threshold', file: 'src/foo.ts' })
+    expect(state.failed).toEqual([{ iter: 3, gate: 'score', reason: 'below threshold', file: 'src/foo.ts' }])
+    const onDisk = JSON.parse(await readFile(path.join(state.runDir, 'iter', '3', 'failure.json'), 'utf8')) as unknown
+    expect(onDisk).toEqual({ iter: 3, gate: 'score', reason: 'below threshold', file: 'src/foo.ts' })
+  })
+
+  test('omits the file key when no file is known', async () => {
+    const state = runState(makeTempDir('fr-'))
+    await mkdir(path.join(state.runDir, 'iter', '1'), { recursive: true })
+    const entry = await recordFailure(state, 1, 'exception', 'boom')
+    expect(entry).toEqual({ iter: 1, gate: 'exception', reason: 'boom' })
+    const onDisk = JSON.parse(await readFile(path.join(state.runDir, 'iter', '1', 'failure.json'), 'utf8')) as unknown
+    expect(onDisk).toEqual({ iter: 1, gate: 'exception', reason: 'boom' })
+  })
+})

--- a/tests/mutation-improve/finalize.test.ts
+++ b/tests/mutation-improve/finalize.test.ts
@@ -6,7 +6,13 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 
 import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
-import { buildSummaryBody, runFinalize, type ExecGitFn, type RunGhFn } from '../../mutation-improve/src/finalize.js'
+import {
+  assertIntegrationBranch,
+  buildSummaryBody,
+  runFinalize,
+  type ExecGitFn,
+  type RunGhFn,
+} from '../../mutation-improve/src/finalize.js'
 import type { MutationImproveRunState } from '../../mutation-improve/src/run-state.js'
 import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
 
@@ -90,5 +96,26 @@ describe('finalize', () => {
     const out = await runFinalize({ execGit, runGh }, { config: config(repoRoot), runState })
     expect(out.pushed).toBe(true)
     expect(out.prUrl).toBeUndefined()
+  })
+})
+
+describe('assertIntegrationBranch', () => {
+  const branchExec =
+    (branch: string): ExecGitFn =>
+    () =>
+      Promise.resolve({ stdout: `${branch}\n`, stderr: '' })
+
+  test('passes on a non-base branch', async () => {
+    await expect(assertIntegrationBranch(branchExec('mutation-improve-10'), '/repo', 'master')).resolves.toBeUndefined()
+  })
+
+  test('throws on the base branch', async () => {
+    await expect(assertIntegrationBranch(branchExec('master'), '/repo', 'master')).rejects.toThrow(
+      /integration branch/u,
+    )
+  })
+
+  test('throws on a detached HEAD', async () => {
+    await expect(assertIntegrationBranch(branchExec('HEAD'), '/repo', 'master')).rejects.toThrow(/integration branch/u)
   })
 })

--- a/tests/mutation-improve/finalize.test.ts
+++ b/tests/mutation-improve/finalize.test.ts
@@ -4,6 +4,7 @@
 // See LICENSE in the project root for details.
 
 import { afterEach, describe, expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
 
 import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
 import {
@@ -34,6 +35,13 @@ const config = (repoRoot: string): MutationImproveConfig => ({
   prBranchPrefix: 'mutation-improve',
 })
 
+const branchExecGit =
+  (branch: string, seen?: string[]): ExecGitFn =>
+  (_cwd, args) => {
+    seen?.push(args.join(' '))
+    return Promise.resolve({ stdout: args[0] === 'rev-parse' ? `${branch}\n` : '', stderr: '' })
+  }
+
 describe('finalize', () => {
   test('buildSummaryBody renders one row per merged file plus a failures section when present', () => {
     const body = buildSummaryBody(
@@ -63,15 +71,18 @@ describe('finalize', () => {
       status: 'completed',
     }
     const seen: string[] = []
-    const execGit: ExecGitFn = (_cwd, args) => {
-      seen.push(args.join(' '))
-      return Promise.resolve({ stdout: '', stderr: '' })
+    const execGit = branchExecGit('mutation-improve-10', seen)
+    let ghArgs: readonly string[] = []
+    const runGh: RunGhFn = (args) => {
+      ghArgs = args
+      return Promise.resolve({ exitCode: 0, stdout: 'https://github.com/x/pull/9\n', stderr: '' })
     }
-    const runGh: RunGhFn = () => Promise.resolve({ exitCode: 0, stdout: 'https://github.com/x/pull/9\n', stderr: '' })
     const out = await runFinalize({ execGit, runGh }, { config: config(repoRoot), runState })
     expect(out.pushed).toBe(true)
     expect(out.prUrl).toBe('https://github.com/x/pull/9')
-    expect(seen.some((s) => s.startsWith('push origin master'))).toBe(true)
+    expect(seen).toContain('push origin mutation-improve-10')
+    expect(ghArgs).toContain('--head')
+    expect(ghArgs[ghArgs.indexOf('--head') + 1]).toBe('mutation-improve-10')
   })
 
   test('runFinalize survives gh failure and still reports pushed=true', async () => {
@@ -91,11 +102,13 @@ describe('finalize', () => {
       failed: [],
       status: 'completed',
     }
-    const execGit: ExecGitFn = () => Promise.resolve({ stdout: '', stderr: '' })
+    const execGit = branchExecGit('mutation-improve-10')
     const runGh: RunGhFn = () => Promise.resolve({ exitCode: 1, stdout: '', stderr: 'no gh' })
     const out = await runFinalize({ execGit, runGh }, { config: config(repoRoot), runState })
     expect(out.pushed).toBe(true)
     expect(out.prUrl).toBeUndefined()
+    const log = await readFile(`${repoRoot}/.mi/runs/r/finalize.log`, 'utf8')
+    expect(log).toContain('--head mutation-improve-10')
   })
 })
 

--- a/tests/mutation-improve/finalize.test.ts
+++ b/tests/mutation-improve/finalize.test.ts
@@ -27,7 +27,7 @@ const config = (repoRoot: string): MutationImproveConfig => ({
   count: 1,
   threshold: 0.95,
   epsilon: 0.02,
-  agentTimeoutMs: 1,
+  mutateTimeoutMs: 1,
   buildTimeoutMs: 1,
   checkCommand: 'x',
   mutateFileCommand: 'x',

--- a/tests/mutation-improve/integration-git.test.ts
+++ b/tests/mutation-improve/integration-git.test.ts
@@ -86,7 +86,7 @@ describe('integration real-git', () => {
       count: 1,
       threshold: 0.95,
       epsilon: 0.02,
-      agentTimeoutMs: 1_800_000,
+      mutateTimeoutMs: 1_800_000,
       buildTimeoutMs: 600_000,
       checkCommand: 'bun check:full',
       mutateFileCommand: 'bun test:mutate:file',

--- a/tests/mutation-improve/integration-git.test.ts
+++ b/tests/mutation-improve/integration-git.test.ts
@@ -125,6 +125,7 @@ describe('integration real-git', () => {
       writeBaseline,
       runSelectAgent: () => Promise.resolve({ value: selection, usage: emptyUsage() }),
       runImproveAgent,
+      saveRunState: () => Promise.resolve(),
       log: { log: () => undefined },
     }
 

--- a/tests/mutation-improve/integration.test.ts
+++ b/tests/mutation-improve/integration.test.ts
@@ -65,7 +65,7 @@ describe('integration', () => {
       count: 1,
       threshold: 0.95,
       epsilon: 0.02,
-      agentTimeoutMs: 1_800_000,
+      mutateTimeoutMs: 1_800_000,
       buildTimeoutMs: 600_000,
       checkCommand: 'bun check:full',
       mutateFileCommand: 'bun test:mutate:file',

--- a/tests/mutation-improve/integration.test.ts
+++ b/tests/mutation-improve/integration.test.ts
@@ -104,7 +104,7 @@ describe('integration', () => {
 
     const out = await runFinalize(
       {
-        execGit: () => Promise.resolve({ stdout: '', stderr: '' }),
+        execGit: () => Promise.resolve({ stdout: 'feat\n', stderr: '' }),
         runGh: () => Promise.resolve({ exitCode: 0, stdout: 'https://github.com/x/pull/1\n', stderr: '' }),
       },
       { config, runState },

--- a/tests/mutation-improve/integration.test.ts
+++ b/tests/mutation-improve/integration.test.ts
@@ -92,6 +92,7 @@ describe('integration', () => {
       },
       runSelectAgent: () => Promise.resolve({ value: selection, usage: emptyUsage() }),
       runImproveAgent: () => Promise.resolve({ value: improvedResult, usage: emptyUsage() }),
+      saveRunState: () => Promise.resolve(),
       log: { log: () => undefined },
     }
 

--- a/tests/mutation-improve/pipeline.test.ts
+++ b/tests/mutation-improve/pipeline.test.ts
@@ -121,6 +121,7 @@ const happyDeps = (): PipelineDeps => {
     },
     runSelectAgent: () => Promise.resolve({ value: selection, usage: emptyUsage() }),
     runImproveAgent: () => Promise.resolve({ value: result, usage: emptyUsage() }),
+    saveRunState: () => Promise.resolve(),
     log: { log: () => undefined, issue: undefined },
   }
   return deps
@@ -406,5 +407,34 @@ describe('pipeline runPipeline', () => {
     expect(results[0]?.gate).toBe('merge')
     expect(deps.runState.status).toBe('aborted')
     expect(deps.runState.currentIteration).toBe(1)
+  })
+
+  test('saves run state after each iteration', async () => {
+    const deps = happyDeps()
+    deps.config = config(deps.config.repoRoot, { count: 2 })
+    deps.measureScore = sequenceMeasure([0.46, 0.97, 0.5, 0.96])
+    const picks = ['src/live-status/tool-status-labels.ts', 'src/tools/memory.ts']
+    deps.runSelectAgent = sequenceSelect(picks, selection)
+    const savedIterations: number[] = []
+    deps.saveRunState = (state: MutationImproveRunState): Promise<void> => {
+      savedIterations.push(state.currentIteration)
+      return Promise.resolve()
+    }
+    await runPipeline(deps)
+    expect(savedIterations).toEqual([1, 2])
+  })
+
+  test('merge-abort saves state with status aborted', async () => {
+    const deps = happyDeps()
+    deps.mergeWorktree = (): Promise<{ ok: false; conflictFiles: string[] }> =>
+      Promise.resolve({ ok: false, conflictFiles: ['scripts/mutation/baseline.json'] })
+    const savedStatuses: string[] = []
+    deps.saveRunState = (state: MutationImproveRunState): Promise<void> => {
+      savedStatuses.push(state.status)
+      return Promise.resolve()
+    }
+    const { aborted } = await runPipeline(deps)
+    expect(aborted).toBe(true)
+    expect(savedStatuses).toEqual(['aborted'])
   })
 })

--- a/tests/mutation-improve/pipeline.test.ts
+++ b/tests/mutation-improve/pipeline.test.ts
@@ -11,7 +11,7 @@ import { runIteration, runPipeline, type PipelineDeps } from '../../mutation-imp
 import type { Result } from '../../mutation-improve/src/result-schema.js'
 import type { MutationImproveRunState } from '../../mutation-improve/src/run-state.js'
 import type { Selection } from '../../mutation-improve/src/selection-schema.js'
-import type { AgentUsage } from '../../review-loop/src/agent-runner.js'
+import { agentWritePath, type AgentUsage } from '../../review-loop/src/agent-runner.js'
 import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
 
 afterEach(cleanupTempDirs)
@@ -142,6 +142,36 @@ describe('pipeline runIteration', () => {
     // baseline bump is runner-owned
     const bumped = await deps.readBaseline(deps.config.repoRoot)
     expect(bumped['src/live-status/tool-status-labels.ts']).toBe(0.97)
+  })
+
+  // The runner reads agent output ONLY from agentWritePath(worktree, outputPath)
+  // (<worktree>/.review-loop/<basename>); the prompt must direct the agent to
+  // that exact scratch path or the iteration dies with an exception gate (the
+  // 2026-08-05 run failed all 10 iterations this way).
+  test('select prompt directs the agent to the worktree scratch path the runner reads', async () => {
+    const deps = happyDeps()
+    let selectPrompt = ''
+    deps.runSelectAgent = (_worktreePath: string, prompt: string): Promise<{ value: Selection; usage: AgentUsage }> => {
+      selectPrompt = prompt
+      return Promise.resolve({ value: selection, usage: emptyUsage() })
+    }
+    await runIteration(deps, 1)
+    const worktreePath = path.join(deps.config.workDir, 'worktrees', 'r1-iter1')
+    const selectOut = path.join(deps.runState.runDir, 'iter', '1', 'selection.json')
+    expect(selectPrompt).toContain(agentWritePath(worktreePath, selectOut))
+  })
+
+  test('improve prompt directs the agent to the worktree scratch path the runner reads', async () => {
+    const deps = happyDeps()
+    let improvePrompt = ''
+    deps.runImproveAgent = (_worktreePath: string, prompt: string): Promise<{ value: Result; usage: AgentUsage }> => {
+      improvePrompt = prompt
+      return Promise.resolve({ value: result, usage: emptyUsage() })
+    }
+    await runIteration(deps, 1)
+    const worktreePath = path.join(deps.config.workDir, 'worktrees', 'r1-iter1')
+    const improveOut = path.join(deps.runState.runDir, 'iter', '1', 'result.json')
+    expect(improvePrompt).toContain(agentWritePath(worktreePath, improveOut))
   })
 
   test('diff-scope violation fails the iteration without merging or ratcheting', async () => {

--- a/tests/mutation-improve/pipeline.test.ts
+++ b/tests/mutation-improve/pipeline.test.ts
@@ -298,6 +298,36 @@ describe('pipeline runIteration', () => {
     await runIteration(deps, 1)
     expect(buildCwd).toBe(path.join(deps.config.workDir, 'worktrees', 'r1-iter1'))
   })
+
+  test('select agent receives the per-iteration outputPath', async () => {
+    const deps = happyDeps()
+    let seenOut = ''
+    deps.runSelectAgent = (
+      _worktreePath: string,
+      _prompt: string,
+      outputPath: string,
+    ): Promise<{ value: Selection; usage: AgentUsage }> => {
+      seenOut = outputPath
+      return Promise.resolve({ value: selection, usage: emptyUsage() })
+    }
+    await runIteration(deps, 1)
+    expect(seenOut).toBe(path.join(deps.runState.runDir, 'iter', '1', 'selection.json'))
+  })
+
+  test('improve agent receives the per-iteration outputPath', async () => {
+    const deps = happyDeps()
+    let seenOut = ''
+    deps.runImproveAgent = (
+      _worktreePath: string,
+      _prompt: string,
+      outputPath: string,
+    ): Promise<{ value: Result; usage: AgentUsage }> => {
+      seenOut = outputPath
+      return Promise.resolve({ value: result, usage: emptyUsage() })
+    }
+    await runIteration(deps, 1)
+    expect(seenOut).toBe(path.join(deps.runState.runDir, 'iter', '1', 'result.json'))
+  })
 })
 
 describe('pipeline runPipeline', () => {

--- a/tests/mutation-improve/pipeline.test.ts
+++ b/tests/mutation-improve/pipeline.test.ts
@@ -28,7 +28,7 @@ const config = (repoRoot: string, overrides: Partial<MutationImproveConfig> = {}
   count: 1,
   threshold: 0.95,
   epsilon: 0.02,
-  agentTimeoutMs: 1_800_000,
+  mutateTimeoutMs: 1_800_000,
   buildTimeoutMs: 600_000,
   checkCommand: 'bun check:full',
   mutateFileCommand: 'bun test:mutate:file',

--- a/tests/mutation-improve/pipeline.test.ts
+++ b/tests/mutation-improve/pipeline.test.ts
@@ -287,6 +287,17 @@ describe('pipeline runIteration', () => {
     expect(calls.remove).toBe(0)
     expect(deps.runState.failed).toEqual([{ iter: 1, gate: 'exception', reason: 'worktree add failed' }])
   })
+
+  test('build gate runs checkCommand inside the iteration worktree', async () => {
+    const deps = happyDeps()
+    let buildCwd = ''
+    deps.runBuildCheck = (worktreePath: string): Promise<{ passed: boolean; stdout: string; stderr: string }> => {
+      buildCwd = worktreePath
+      return Promise.resolve({ passed: true, stdout: '', stderr: '' })
+    }
+    await runIteration(deps, 1)
+    expect(buildCwd).toBe(path.join(deps.config.workDir, 'worktrees', 'r1-iter1'))
+  })
 })
 
 describe('pipeline runPipeline', () => {

--- a/tests/mutation-improve/pipeline.test.ts
+++ b/tests/mutation-improve/pipeline.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, test } from 'bun:test'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
+import type { BaselineMap } from '../../mutation-improve/src/baseline.js'
 import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
 import { runIteration, runPipeline, type PipelineDeps } from '../../mutation-improve/src/pipeline.js'
 import type { Result } from '../../mutation-improve/src/result-schema.js'
@@ -375,6 +376,49 @@ describe('pipeline runIteration', () => {
       await readFile(path.join(deps.runState.runDir, 'iter', '1', 'failure.json'), 'utf8'),
     ) as unknown
     expect(failure).toEqual({ iter: 1, gate: 'exception', reason: 'worktree add failed' })
+  })
+
+  test('skip ratchets a stale baseline floor with a baseline-only commit in repoRoot', async () => {
+    const deps = happyDeps()
+    deps.measureScore = sequenceMeasure([0.97])
+    const gitCalls: string[] = []
+    deps.execGit = (cwd: string, args: readonly string[]): Promise<{ stdout: string; stderr: string }> => {
+      gitCalls.push(`${cwd} ${args.join(' ')}`)
+      return Promise.resolve({ stdout: '', stderr: '' })
+    }
+    const outcome = await runIteration(deps, 1)
+    expect(outcome).toEqual({
+      iter: 1,
+      outcome: 'skipped',
+      file: 'src/live-status/tool-status-labels.ts',
+      beforeScore: 0.97,
+    })
+    const baseline = await deps.readBaseline(deps.config.repoRoot)
+    expect(baseline['src/live-status/tool-status-labels.ts']).toBe(0.97)
+    const repoRoot = deps.config.repoRoot
+    expect(gitCalls).toContain(`${repoRoot} add scripts/mutation/baseline.json`)
+    const commitPrefix = `${repoRoot} commit -m chore(mutation): ratchet src/live-status/tool-status-labels.ts baseline to 0.97`
+    expect(gitCalls.some((c) => c.startsWith(commitPrefix))).toBe(true)
+  })
+
+  test('skip with an accurate floor does not rewrite or commit the baseline', async () => {
+    const deps = happyDeps()
+    deps.readBaseline = (): Promise<BaselineMap> => Promise.resolve({ 'src/live-status/tool-status-labels.ts': 0.97 })
+    let writes = 0
+    deps.writeBaseline = (): Promise<void> => {
+      writes += 1
+      return Promise.resolve()
+    }
+    const gitCalls: string[] = []
+    deps.execGit = (_cwd: string, args: readonly string[]): Promise<{ stdout: string; stderr: string }> => {
+      gitCalls.push(args.join(' '))
+      return Promise.resolve({ stdout: '', stderr: '' })
+    }
+    deps.measureScore = sequenceMeasure([0.96])
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('skipped')
+    expect(writes).toBe(0)
+    expect(gitCalls.some((c) => c.startsWith('commit'))).toBe(false)
   })
 })
 

--- a/tests/mutation-improve/pipeline.test.ts
+++ b/tests/mutation-improve/pipeline.test.ts
@@ -4,6 +4,7 @@
 // See LICENSE in the project root for details.
 
 import { afterEach, describe, expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
@@ -260,7 +261,18 @@ describe('pipeline runIteration', () => {
     expect(outcome.reason).toBe('agent blew up')
     expect(calls.reset).toBe(1)
     expect(calls.remove).toBe(1)
-    expect(deps.runState.failed).toEqual([{ iter: 1, gate: 'exception', reason: 'agent blew up' }])
+    expect(deps.runState.failed).toEqual([
+      { iter: 1, gate: 'exception', reason: 'agent blew up', file: 'src/live-status/tool-status-labels.ts' },
+    ])
+    const failure = JSON.parse(
+      await readFile(path.join(deps.runState.runDir, 'iter', '1', 'failure.json'), 'utf8'),
+    ) as unknown
+    expect(failure).toEqual({
+      iter: 1,
+      gate: 'exception',
+      reason: 'agent blew up',
+      file: 'src/live-status/tool-status-labels.ts',
+    })
     expect(deps.runState.merged).toHaveLength(0)
   })
 
@@ -327,6 +339,41 @@ describe('pipeline runIteration', () => {
     }
     await runIteration(deps, 1)
     expect(seenOut).toBe(path.join(deps.runState.runDir, 'iter', '1', 'result.json'))
+  })
+
+  test('select-gate rejection records the invalidly picked file and writes failure.json', async () => {
+    const deps = happyDeps()
+    deps.runSelectAgent = (): Promise<{ value: Selection; usage: AgentUsage }> =>
+      Promise.resolve({ value: { ...selection, file: 'src/not-in-baseline.ts' }, usage: emptyUsage() })
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('select')
+    expect(deps.runState.failed[0]).toEqual({
+      iter: 1,
+      gate: 'select',
+      reason: 'selection file not in baseline or already done',
+      file: 'src/not-in-baseline.ts',
+    })
+    const failure = JSON.parse(
+      await readFile(path.join(deps.runState.runDir, 'iter', '1', 'failure.json'), 'utf8'),
+    ) as unknown
+    expect(failure).toEqual({
+      iter: 1,
+      gate: 'select',
+      reason: 'selection file not in baseline or already done',
+      file: 'src/not-in-baseline.ts',
+    })
+  })
+
+  test('createWorktree throw still writes failure.json without a file', async () => {
+    const deps = happyDeps()
+    deps.createWorktree = (): Promise<void> => Promise.reject(new Error('worktree add failed'))
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    const failure = JSON.parse(
+      await readFile(path.join(deps.runState.runDir, 'iter', '1', 'failure.json'), 'utf8'),
+    ) as unknown
+    expect(failure).toEqual({ iter: 1, gate: 'exception', reason: 'worktree add failed' })
   })
 })
 

--- a/tests/mutation-improve/run-state.test.ts
+++ b/tests/mutation-improve/run-state.test.ts
@@ -26,7 +26,7 @@ const baseConfig = (repoRoot: string, workDir: string): MutationImproveConfig =>
   count: 1,
   threshold: 0.95,
   epsilon: 0.02,
-  agentTimeoutMs: 1_800_000,
+  mutateTimeoutMs: 1_800_000,
   buildTimeoutMs: 600_000,
   checkCommand: 'bun check:full',
   mutateFileCommand: 'bun test:mutate:file',

--- a/tests/mutation-improve/skip-ratchet.test.ts
+++ b/tests/mutation-improve/skip-ratchet.test.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { ratchetVerifiedSkip } from '../../mutation-improve/src/skip-ratchet.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+describe('ratchetVerifiedSkip', () => {
+  test('stale floor: writes bumped baseline to repoRoot and commits baseline.json in repoRoot', async () => {
+    const repoRoot = makeTempDir('sr-')
+    const writes: Array<{ root: string; map: Record<string, number> }> = []
+    const gitCalls: string[] = []
+    const deps = {
+      config: { repoRoot },
+      writeBaseline: (root: string, map: Record<string, number>): Promise<void> => {
+        writes.push({ root, map })
+        return Promise.resolve()
+      },
+      execGit: (cwd: string, args: readonly string[]): Promise<{ stdout: string; stderr: string }> => {
+        gitCalls.push(`${cwd} ${args.join(' ')}`)
+        return Promise.resolve({ stdout: '', stderr: '' })
+      },
+    }
+    const baseline = { 'src/foo.ts': 0.5 }
+    await ratchetVerifiedSkip(deps, baseline, 'src/foo.ts', 0.9)
+    expect(writes).toHaveLength(1)
+    expect(writes[0]?.root).toBe(repoRoot)
+    expect(writes[0]?.map['src/foo.ts']).toBe(0.9)
+    expect(gitCalls).toContain(`${repoRoot} add scripts/mutation/baseline.json`)
+    expect(
+      gitCalls.some((c) => c.startsWith(`${repoRoot} commit -m chore(mutation): ratchet src/foo.ts baseline to 0.9`)),
+    ).toBe(true)
+  })
+
+  test('accurate floor: baseline[file] already >= score → no writes, no git calls', async () => {
+    const repoRoot = makeTempDir('sr-')
+    let writes = 0
+    const gitCalls: string[] = []
+    const deps = {
+      config: { repoRoot },
+      writeBaseline: (): Promise<void> => {
+        writes += 1
+        return Promise.resolve()
+      },
+      execGit: (_cwd: string, args: readonly string[]): Promise<{ stdout: string; stderr: string }> => {
+        gitCalls.push(args.join(' '))
+        return Promise.resolve({ stdout: '', stderr: '' })
+      },
+    }
+    const baseline = { 'src/foo.ts': 0.97 }
+    await ratchetVerifiedSkip(deps, baseline, 'src/foo.ts', 0.96)
+    expect(writes).toBe(0)
+    expect(gitCalls).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

Bugfix round on the `mutation-improve/` runner (local dev tooling, no papai runtime changes), from a code review of the landed runner. All eight issues verified against the original runner spec; three are outright deviations from it.

Spec: `docs/superpowers/specs/2026-08-06-mutation-improve-runner-fixes-design.md`
Plan: `docs/superpowers/plans/2026-08-06-mutation-improve-runner-fixes.md`

| # | Issue | Fix |
|---|-------|-----|
| 1 | Build gate ran `checkCommand` in the run dir, never seeing the agent's diff | Thread worktree path through `runBuildCheck` (c95c46110) |
| 2 | Finalize pushed `base` + PR'd with no head while merges land on the checked-out branch | Startup guard refuses base/detached (c2db6e53b); finalize pushes the integration branch with explicit `--head` (609b06f8a) |
| 3 | Per-iteration artifact paths dead (`iter/<N>/` empty, run-level files overwritten) | `outputPath` threaded through agent-runner deps (880fffc02) |
| 4 | Run state saved only at process end; crash loses progress | `saveRunState` after every iteration (5a9f4e0e7) |
| 5 | Threshold-verified skips never ratcheted the baseline floor | Ratchet + baseline-only commit in repoRoot (5a446f636) |
| 6 | Failed entries dropped the file; spec'd `failure.json` missing | `recordFailure` sink in new `failure-recorder.ts` (398548593) |
| 7 | Diff-guard mis-parsed porcelain renames (`tests/… -> src/…` smuggle) | Parse both rename endpoints (d1d460053) |
| 8 | `agentTimeoutMs` actually gated mutation runs | Renamed to `mutateTimeoutMs`, docs synced (a9794e468) |

## Execution

Subagent-driven: fresh implementer + independent reviewer per task, all 9 tasks review-clean; final whole-branch review: **ready to merge**. Two module extractions (`failure-recorder.ts`, `skip-ratchet.ts`) driven by the 300-line max-lines gate, documented in the plan.

## Verification

- `bun run mutation-improve:test` — 88/88 pass
- `mutation-improve:typecheck`, `:lint`, `:format:check` — all clean
- Real-git integration tests cover worktree merge propagation, startup guard, and baseline ratchet paths