### PR TITLE
mutation-improve: src/analytics/intent/classifier.ts, plugins/task-provider-youtrack/due-date.ts, plugins/task-provider-youtrack/classify-error.ts, review-loop/src/live-format.ts, plugins/task-provider-youtrack/query-builder.ts

### DIFF
--- a/docs/architecture/commands.md
+++ b/docs/architecture/commands.md
@@ -22,7 +22,7 @@ See LICENSE in the project root for details.
 - `bun test:mutate:changed` — paired mutation run vs `origin/master`; this is what CI uses.
 - `bun test:mutate:seed --scores=PATH [--fresh-base=SHA]` — re-apply a persisted per-file scores snapshot to `scripts/mutation/baseline.json` via `seedMerge` without re-running Stryker; the CI `mutation-baseline` commit step loops over this when master moves mid-run (`--fresh-base` drops scores for files changed on master since the run's checkout).
 - `bun test:mutate:file <paths...>` — fast per-file paired run (`ignoreStatic:false` + companion tests), bypasses the static-bucket artifact.
-- `bun check` — staged-file lint/typecheck/format; `bun check:full` runs `scripts/check.sh`.
+- `bun check` — staged-file lint/typecheck/format; `bun check:full` runs `scripts/check.sh`. The full-mode license-headers check enumerates `git ls-files --cached --others --exclude-standard` (tracked **plus** untracked non-ignored files) so brand-new files in a worktree are header-checked before commit, matching what the pre-commit hook's `--staged` mode will enforce.
 - `bun check:bundle-isolation` — asserts the dev-only `client/stories/**` harness never leaked into production bundles.
 
 Analytics operator CLIs (full operator flows: `docs/operations/analytics-runbook.md`):

--- a/docs/superpowers/plans/2026-08-06-mutation-coverage-classifier.md
+++ b/docs/superpowers/plans/2026-08-06-mutation-coverage-classifier.md
@@ -1,0 +1,187 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# `classifier.ts` Mutation Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Raise the paired mutation score of
+`src/analytics/intent/classifier.ts` from **0.4582** to **≥ 0.90** by
+extending `tests/analytics/intent/classifier.test.ts`. No production
+changes.
+
+**Architecture:** Test-only. All eight new tests append to the existing
+`describe('deterministic A+B classifiers', …)` block. Two new imports are
+needed: `STRUCTURED_SIGNAL_BY_INTENT` and `TOOL_BY_INTENT` (both already
+exported from `src/analytics/intent/classifier.js`). The classifier is a
+set of pure functions over in-memory data — no DB, no mocks, no DI.
+
+**Tech Stack:** Bun test runner (`bun:test`), Stryker via
+`bun test:mutate:file`.
+
+**Spec:** `docs/superpowers/specs/2026-08-06-mutation-coverage-classifier-design.md`
+
+## Global Constraints
+
+- Runtime is **Bun**; tests use `bun:test` (no Jest/Vitest).
+- Strict TypeScript; use `.js` extension in all import paths.
+- **No lint-disable or type-ignore comments** — the write hook blocks them.
+- **No comments in test code.**
+- **Every new assertion uses exact equality** — `toBe(...)` for scalars /
+  full strings, `toEqual(...)` for arrays/objects. Never
+  `startsWith`/`endsWith`/`toContain` where a full string is knowable.
+- **One `test(...)` per mutant class** (eight tests total, one per gap row
+  in the spec).
+- No production source changes anywhere. No edit to
+  `scripts/mutation/baseline.json`.
+- The standard red-step of TDD does not apply: the production code is
+  correct and the new tests pass immediately. The quality gate is the
+  **mutation score** in Task 7, not test redness.
+- Commit message style: conventional, e.g.
+  `test: lock classifier vocabulary and return-path shapes`.
+
+## File Structure
+
+- **Modify** `tests/analytics/intent/classifier.test.ts` — extend the
+  import to add `STRUCTURED_SIGNAL_BY_INTENT` and `TOOL_BY_INTENT`, then
+  append eight tests inside the existing `describe` block.
+
+---
+
+### Task 1: Extend imports
+
+**Files:**
+- Modify: `tests/analytics/intent/classifier.test.ts`
+
+- [ ] **Step 1: Add the two table exports to the import**
+
+Extend the existing import from `../../../src/analytics/intent/classifier.js`
+to also import `STRUCTURED_SIGNAL_BY_INTENT` and `TOOL_BY_INTENT` (both are
+already `export const`). No other import changes.
+
+- [ ] **Step 2: Run the file**
+
+Run: `bun test tests/analytics/intent/classifier.test.ts`
+Expected: PASS — 13 tests, 0 failures (no new tests yet).
+
+---
+
+### Task 2: Tests T1–T8 (one per mutant class)
+
+**Files:**
+- Modify: `tests/analytics/intent/classifier.test.ts` (append eight tests
+  inside the existing `describe('deterministic A+B classifiers', …)` block,
+  before its closing `})`).
+
+**Interfaces:**
+- Consumes: `classifyToolTrace`, `classifyMetadata`, `classifyHybrid`,
+  `toClassifierToolSlug`, `STRUCTURED_SIGNAL_BY_INTENT`, `TOOL_BY_INTENT`,
+  `inputOf`.
+
+- [ ] **Step 1: T1 — structured feature signals map each intent to its primary**
+
+Loop over every entry of `STRUCTURED_SIGNAL_BY_INTENT`; for each
+`[intent, signal]` assert
+`classifyMetadata(inputOf({ feature_events: [signal] })).primary` is `toBe`
+the intent. (Kills class C1.)
+
+- [ ] **Step 2: T2 — a meta-tool alongside a mapped goal tool does not mask the goal**
+
+For each meta-tool in `['search_tools', 'load_tool', 'expand_result']`,
+classify `[{tool_slug: meta}, {tool_slug: 'create_task'}]` and assert
+`primary` is `toBe('task.create')`, `abstained` is `toBe(false)`, and
+`tool_evidence_conflict` is `toBe(false)`. (Kills class C2.)
+
+- [ ] **Step 3: T3 — runtime tool slugs translate exhaustively to classifier vocabulary**
+
+Define a `Record<string, string>` mapping every runtime slug from
+`RUNTIME_SLUGS_BY_INTENT` to its classifier slug
+(`TOOL_BY_INTENT[intent]`); iterate and assert
+`toClassifierToolSlug(slug)` is `toBe` the expected classifier slug. Also
+assert `toClassifierToolSlug('external_other')` is `toBe('external_other')`
+(unmapped passthrough). (Kills class C3 — all 110 non-residual runtime
+mutants.)
+
+- [ ] **Step 4: T4 — abstention predictions carry an empty goal list**
+
+Assert `classifyToolTrace(inputOf({})).goals` `toEqual([])`. (Kills C4.)
+
+- [ ] **Step 5: T5 — prediction-from-goals marks tool_evidence_conflict false**
+
+Assert `classifyToolTrace(inputOf({ tool_trace: [{ tool_slug: 'create_task' }] })).tool_evidence_conflict` `toBe(false)`. (Kills C5.)
+
+- [ ] **Step 6: T6 — every classifier path reports its deterministic strategy**
+
+Assert `.strategy`:
+- tool-trace empty → `toBe('tool_trace_v1')`
+- tool-trace mapped (`create_task`) → `toBe('tool_trace_v1')`
+- tool-trace unmapped-only (`external_other`) → `toBe('tool_trace_v1')`
+- metadata signal (`provider:task:create`) → `toBe('metadata_v1')`
+- `command_family: 'help'` → `toBe('metadata_v1')`
+- `command_family: 'config'` → `toBe('metadata_v1')`
+- `command_family: 'stop'` → `toBe('metadata_v1')`
+- unsupported-goal signal → `toBe('metadata_v1')`
+- metadata empty → `toBe('metadata_v1')`
+
+(Kills class C6 — nine strategy StringLiteral mutants.)
+
+- [ ] **Step 7: T7 — stop and unsupported-goal paths report no conflict and empty goals**
+
+Assert stop `tool_evidence_conflict` `toBe(false)`; assert unsupported-goal
+`tool_evidence_conflict` `toBe(false)` and `goals` `toEqual([])`.
+(Kills class C7.)
+
+- [ ] **Step 8: T8 — hybrid with no evidence reports no tool evidence conflict**
+
+Assert `classifyHybrid(inputOf({})).tool_evidence_conflict` `toBe(false)`.
+(Kills class C8.)
+
+- [ ] **Step 9: Run the file**
+
+Run: `bun test tests/analytics/intent/classifier.test.ts`
+Expected: PASS — 21 tests, 0 failures.
+
+---
+
+### Task 3: Mutation verification
+
+**Files:** None modified (measurement only), unless a survivor above the
+accepted residuals appears.
+
+- [ ] **Step 1: Run the paired mutation measurement**
+
+Run: `bun test:mutate:file src/analytics/intent/classifier.ts`
+Expected: score **≥ 0.90** (target ≈ 0.98; previous baseline 0.4582).
+
+- [ ] **Step 2: Triage any survivors above the accepted residuals**
+
+Accepted residuals (documented in the spec — do not chase):
+- L96 `task.change_state: []` (no runtime slug maps to it).
+- L188 `help_context: []` (reached via `command_family`, not a slug).
+- L92 `task.create: ['create_task']` array + `'create_task'` string, L94
+  `'get_task'` string, L117 `task.delete: ['delete_task']` array +
+  `'delete_task'` string — fixed-point entries where the runtime slug
+  equals its classifier slug, so the mapping is a no-op whether present or
+  absent.
+- L218 `ordered.length === 0` left-operand (private helper, callers guard).
+- L242 `goals.length === 0` (empty path delegates to an identical
+  abstention).
+
+Any other survivor means a missing assertion — extend the relevant test,
+re-run `bun test tests/analytics/intent/classifier.test.ts`, then re-run
+Step 1.
+
+- [ ] **Step 3: Full local verification**
+
+Run: `bun test tests/analytics/intent/classifier.test.ts`
+Expected: PASS — all green.
+Run lint and typecheck per the repo's `package.json` scripts.
+Expected: clean.
+
+- [ ] **Step 4: Do NOT edit `scripts/mutation/baseline.json`**
+
+The floor ratchets via the runner; no commit touches it.

--- a/docs/superpowers/plans/2026-08-06-mutation-coverage-classify-error.md
+++ b/docs/superpowers/plans/2026-08-06-mutation-coverage-classify-error.md
@@ -1,0 +1,114 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Plan — Mutation Coverage for classify-error.ts
+
+**Date:** 2026-08-06
+**Spec:** `docs/superpowers/specs/2026-08-06-mutation-coverage-classify-error-design.md`
+**Target file:** `plugins/task-provider-youtrack/classify-error.ts`
+**Companion test:** `tests/plugins/task-provider-youtrack/classify-error.test.ts`
+**Starting score:** 0.618 · **Target:** ≥ 0.9
+
+## Global constraints
+
+- **Test-only.** Edit only the companion test file and the docs/spec/result
+  JSON. No edits under `src/`, `client/`, `plugins/`, or `scripts/`.
+- Do not touch `scripts/mutation/baseline.json` (runner-owned ratchet).
+- Every new assertion uses exact equality: `toBe(...)` for scalars/strings,
+  `toEqual(...)` for the full `requiredFields` array. No
+  `startsWith` / `endsWith` / `toContain` where a full value is knowable.
+- All inputs flow through the public `classifyYouTrackError` export; no
+  private helper is imported.
+- Each new test targets exactly one mutant class from the spec's gap table.
+- SPDX header preserved/added on any new file; emoji copied verbatim from
+  source (none introduced here).
+
+## Tasks (one per mutant class)
+
+- [ ] **A — `isYouTrackErrorBody` invalid-body guards (L38/L41/L42).**
+  Add tests asserting a 500 error with `{ error: 123 }` and with `null`
+  falls back to the constructor message without throwing.
+- [ ] **B — foreign-key loop (L40/L41).** Add a test with
+  `{ error: 'ok', extra: 9 }` asserting the body stays valid.
+- [ ] **C — `extractYouTrackErrorMessage` undefined-body arm (L49/L50).**
+  Covered by task A's `{ error: 123 }` case; add an explicit comment-free
+  assertion that `result.message` equals the constructor message.
+- [ ] **D — `normalizeFieldName` cleaning (L59–L62).** Add tests for
+  whitespace-trim, quote-strip, and double-space collapse, asserting exact
+  `requiredFields` arrays.
+- [ ] **D/E — empty-after-trim (L63).** Add a test where the captured name
+  trims to empty and assert `requiredFields.length` is `0`.
+- [ ] **E — stopword filter (L64/L65).** Add four tests (one per stopword)
+  plus one mixed-case `Field` test, each asserting length `0`.
+- [ ] **F — ` and ` rewrite (L70).** Add `Alpha and Beta` test asserting
+  exactly two distinct names.
+- [ ] **G — candidate wiring (L79/L81/L82).** Add `error_rule_name`-only
+  workflow test asserting the rule-name candidate is harvested.
+- [ ] **H — "requires these custom fields:" regex (L84/L85).** Add test
+  asserting `[{ URL }, { Name }]`.
+- [ ] **I — "required field(s):" regex (L89/L90).** Add singular and plural
+  tests.
+- [ ] **J — "field X is required" regex (L94–L98).** Add unquoted
+  `field URL is required` test.
+- [ ] **K — fallback skip + undefined guard (L102/L105/L110/L112).** Add the
+  `Primary. Fill "Extra"` test and the no-`error_description` quoted test.
+- [ ] **M — workflow `projectId` (L129).** Assert preserved value and
+  `'unknown'` fallback.
+- [ ] **N — 400 invalid body (L154).** Assert `validation-failed` without
+  throwing.
+- [ ] **O — 404 context fallbacks (L168/L172/L176/L180/L184).** Assert
+  `'unknown'` for project/comment/label/saved-query ids.
+- [ ] **P — `YouTrackClassifiedError.name` (L18).** Assert `.name`.
+
+## Residuals (equivalent mutants — documented, not killed)
+
+Final measured set after the test pass (14 survivors, score 0.9491). Each is
+a true equivalent given the data-flow invariants of the module:
+
+- [x] **L38:24** `ConditionalExpression => false` (`typeof body !== 'object'`
+      guard). Redundant with the `body === null` short-circuit: every
+      non-null primitive body proceeds to `Object.entries`, whose property
+      access on a boxed primitive returns `undefined` and falls through to the
+      same extracted message.
+- [x] **L59:19** `MethodExpression => rawName` (`.trim()` removed). The
+      immediately-following regex `/^["'\s]+|["'\s]+$/gu` already strips all
+      leading/trailing whitespace, so the prior `.trim()` is a no-op.
+- [x] **L79:23 / L79:48 / L79:61** `OptionalChaining` on
+      `body?.error_description|error|error_rule_name`.
+      `extractRequiredFields` is only called from
+      `classifyWorkflowValidationError`, which is only reached when
+      `body?.error_type === 'workflow'` — i.e. `body` is guaranteed defined,
+      so `body?.X` ≡ `body.X`.
+- [x] **L94:44** `Regex` `\s+` → `\s` (both whitespace groups in the
+      `field … is required` pattern). Any extra space absorbed by the
+      single-`\s` mutant lands at the start/end of the capture group and is
+      removed by `normalizeFieldName`'s trim/strip, so the cleaned name is
+      identical.
+- [x] **L96:11 / L110:11** `ConditionalExpression => false` on
+      `if (fieldName === undefined) continue`. The capturing groups
+      `([^"':.;]+?)` and `([^"…"]+)` require ≥1 char, so `match[1]` is never
+      `undefined` when a match exists; the guard is dead code.
+- [x] **L103:28** `OptionalChaining` on `body?.error_description`. Same
+      invariant as L79: `body` is always defined in this scope.
+- [x] **L114:11** `ConditionalExpression => true|false` and
+      `EqualityOperator` (`names.size >= 0` / `<= 0`) on
+      `if (names.size > 0) break`. In the fallback scope the two candidates
+      are `body?.error_description` and `message`, and
+      `message === body?.error_description` whenever the description is
+      present (it wins the `??` chain in `extractYouTrackErrorMessage`);
+      when it is absent the first candidate is `undefined` and skipped.
+      Either way the second candidate cannot add names the first did not, so
+      the early-break is a no-op.
+
+## Verification steps
+
+1. `bun test tests/plugins/task-provider-youtrack/classify-error.test.ts`
+   → green.
+2. `bun test:mutate:file plugins/task-provider-youtrack/classify-error.ts`
+   → score ≥ 0.9 (residuals enumerated above).
+3. `git diff --name-only` shows only `tests/`, `docs/superpowers/`, and the
+   result JSON.

--- a/docs/superpowers/plans/2026-08-06-mutation-coverage-due-date.md
+++ b/docs/superpowers/plans/2026-08-06-mutation-coverage-due-date.md
@@ -1,0 +1,110 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation Coverage — `due-date.ts` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Raise the Stryker mutation score of
+`plugins/task-provider-youtrack/due-date.ts` from **0.6915** (65/94) to
+**≥ 0.9** (target 87/94 ≈ 0.9255) by extending
+`tests/plugins/task-provider-youtrack/due-date.test.ts` only.
+
+**Design doc:** `docs/superpowers/specs/2026-08-06-mutation-coverage-due-date-design.md`
+— read it first; the gap table and per-class reasoning are authoritative.
+
+**Tech stack:** Bun, `bun:test`, Zod v4. Test-only — no edits under `src/`,
+`client/`, `plugins/`, or `scripts/`.
+
+---
+
+## Global constraints
+
+- **Test-only.** The only modified source file is
+  `tests/plugins/task-provider-youtrack/due-date.test.ts`. New docs live under
+  `docs/superpowers/`. The single result artifact is
+  `.review-loop/result.json`. Nothing else may be created or changed.
+- **Never touch `scripts/mutation/baseline.json`** — the runner owns it.
+- **Exact equality only.** Every new assertion uses `toBe(...)` on a
+  fully-knowable value. No `startsWith` / `endsWith` / `toContain`. Error
+  assertions pin `message` and each scalar field of `appError`
+  (`type`, `code`, `field`, `reason`) individually.
+- **One test per mutant class** (classes A–J from the design doc). Do not
+  combine two classes into one test body.
+- **Preserve the existing 4 happy-path tests verbatim** (apart from adding the
+  two new imports: `DueDateCustomFieldSchema`, `YouTrackClassifiedError`).
+- **SPDX license header** is already present in the test file; do not duplicate.
+- All asserted timestamp/`slice`/`appError` literals are taken from the design
+  doc and were verified against live runtime probing (see design *Design*).
+
+## Reference
+
+| File (unchanged)                                  | What's there                          | Used for                                  |
+| ------------------------------------------------- | ------------------------------------- | ----------------------------------------- |
+| `plugins/task-provider-youtrack/due-date.ts`      | Functions under test                  | Read-only reference                       |
+| `plugins/task-provider-youtrack/classify-error.ts`| `YouTrackClassifiedError` class       | Import for typed `appError` access        |
+| `src/providers/errors.ts` (L88)                   | `validationFailed` → `{type,code,field,reason}` | Exact `appError` field values |
+
+---
+
+## Tasks
+
+Each task = one class = one `test(...)` block. Check a box only after the test
+is written and passes on the unmutated source.
+
+- [ ] **Setup — imports.** Add `DueDateCustomFieldSchema` to the existing
+  `due-date.js` import block; add a new import line for `YouTrackClassifiedError`
+  from `../../../plugins/task-provider-youtrack/classify-error.js`. Add a small
+  `captureClassification(fn)` helper that runs `fn`, returns the thrown
+  `Error`, and throws if `fn` did not throw — used by the error-asserting tests.
+- [ ] **Class A — schema object literal (id 0).**
+  `DueDateCustomFieldSchema.safeParse({}).success` `toBe(false)`.
+- [ ] **Class B — final fallback (ids 2, 58, 63, 64, 65).**
+  `parseDueDateValue('abc2024-03-15')` throws; assert `message` and all four
+  `appError` scalars (`reason` =
+  `Expected YYYY-MM-DD or an ISO datetime with timezone information`).
+- [ ] **Class C — ISO `^` anchor (id 11).**
+  `parseDueDateValue('abc2024-03-15T23:45:00+02:00')` throws; assert `message`
+  and the same `appError` shape as B.
+- [ ] **Class D — ISO `$` anchor (id 12).**
+  `parseDueDateValue('2024-03-15T23:45:00+02:00abc')` throws; assert `message`
+  and the same `appError` shape as B.
+- [ ] **Class E — ISO optional seconds (id 23).**
+  `parseDueDateValue('2024-03-15T23:45+02:00')`
+  `toBe(Date.parse('2024-03-15T12:00:00.000Z'))`.
+- [ ] **Class F — ISO fractional seconds (ids 27, 28).**
+  `parseDueDateValue('2024-03-15T23:45:00.123+02:00')`
+  `toBe(Date.parse('2024-03-15T12:00:00.000Z'))`.
+- [ ] **Class G — calendar-reality check (ids 40, 42, 44, 53, 54, 55, 56, 57).**
+  `parseDueDateValue('2024-02-30')` throws; assert `message` and all four
+  `appError` scalars (`reason` =
+  `Expected a real calendar date in YYYY-MM-DD format`).
+- [ ] **Class H — nullish guard (id 72).**
+  `mapYouTrackDueDateValue(null)` `toBe(undefined)` **and**
+  `mapYouTrackDueDateValue(undefined)` `toBe(undefined)`.
+- [ ] **Class I — filter undefined guard (id 81).**
+  `normalizeYouTrackListTaskParams({}).dueAfter` `toBe(undefined)`.
+- [ ] **Class J — filter date-regex `^` (id 83).**
+  `normalizeYouTrackListTaskParams({ dueAfter: 'abc2024-03-15' }).dueAfter`
+  `toBe('abc2024-03')`.
+
+## Verification gate
+
+- [ ] `bun test tests/plugins/task-provider-youtrack/due-date.test.ts` → 16 pass, 0 fail.
+- [ ] `bun test:mutate:file plugins/task-provider-youtrack/due-date.ts` →
+      score ≥ 0.9; residual survivors are exactly ids
+      `{37, 85, 86, 87, 88, 89, 90}` (7 equivalent).
+- [ ] `git diff --stat` shows changes only under `tests/` and
+      `docs/superpowers/` (plus the single `.review-loop/result.json`).
+
+## Residuals (accepted, do NOT write tests for)
+
+- id 37 — L23 guard (equivalent; see design doc).
+- ids 85–90 — L61 date-regex char-class/quantifier (equivalent; see design doc).
+
+These are recorded in `.review-loop/result.json` `residuals[]` with per-loc
+reasoning so the runner's residual tolerance can admit the final score.

--- a/docs/superpowers/plans/2026-08-06-mutation-coverage-live-format.md
+++ b/docs/superpowers/plans/2026-08-06-mutation-coverage-live-format.md
@@ -1,0 +1,122 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation Coverage — `review-loop/src/live-format.ts` Plan
+
+> **For agentic workers:** Test-only change. Implement task-by-task; each task maps 1:1 to a gap class in the spec (`docs/superpowers/specs/2026-08-06-mutation-coverage-live-format-design.md`). Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Raise the paired mutation score of `review-loop/src/live-format.ts` from **0.75** to **≥ 0.9** (measured **0.9872**) by adding exact-equality assertions to the companion test file only.
+
+**Architecture:** No source changes. All edits land in `tests/review-loop/live-format.test.ts`. Each new test targets one surviving-mutant class from the measured paired report.
+
+**Tech Stack:** Bun, TypeScript (strict), `bun:test`.
+
+## Global Constraints
+
+- **Test-only.** Edit nothing under `src/`, `client/`, `plugins/`, `scripts/`, or `review-loop/`. Do not touch `scripts/mutation/baseline.json`.
+- **Exact equality only** for new assertions: `expect(...).toBe(...)`. No `startsWith`/`endsWith`/`toContain`/`toMatch` where a full string is knowable.
+- **One test per gap class** (16 tests → 16 classes).
+- **Glyphs verbatim from source** via `\u` escapes: `\u25B6` (▶ ARROW), `\u00B7` (· MIDDLE_DOT), `\u2713` (✓ CHECK), `\u00D7` (× TIMES).
+- Use `.js` extension in the import path; keep the existing `bun:test` import style.
+- Never add lint-disable / type-ignore comments.
+- Expected strings were cross-checked against the live module before writing (see spec Verification).
+
+## Baseline (measured)
+
+`reports/paired/review-loop__src__live-format.ts.stryker-report.json`: 156 mutants — 117 Killed, 37 Survived, 2 NoCoverage. Score `117/156 = 0.75`.
+
+---
+
+### Task 1 — `formatDuration` 60s boundary (class 1, mutant 10)
+
+- [ ] Add test: `expect(formatDuration(60_000)).toBe('1m00s')` inside `describe('formatDuration')`.
+- Kills: `id 10` (`totalSeconds < 60` → `<=`).
+
+### Task 2 — `truncate` non-positive max guard (class 2, mutants 20, 21, NoCov 23, 24)
+
+- [ ] Add `describe('truncate')` (import `truncate`): `truncate('abc', 0) === ''`, `truncate('abc', -2) === ''`.
+- Kills: `id 20` (cond→false), `id 21` (`<=`→`<`); converts NoCoverage `id 23` (block→`{}`) and `id 24` (`""`→Stryker) to Killed.
+
+### Task 3 — `truncate` exact-length boundary (class 3, mutant 27)
+
+- [ ] In `describe('truncate')`: `truncate('abcd', 4) === 'abcd'`, `truncate('abc', 3) === 'abc'`.
+- Kills: `id 27` (`value.length <= max` → `<`).
+
+### Task 4 — `pickString` empty-value skip (class 4, mutants 41, 42)
+
+- [ ] In `describe('formatToolArg')`: `formatToolArg('task', { description: '', subagent_type: 'explore' }) === 'explore'`.
+- Kills: `id 41` (`value.length > 0` → true), `id 42` (`>` → `>=`).
+
+### Task 5 — `firstStringValue` type/length guard (class 5, mutants 48, 50, 51, 54, 55)
+
+- [ ] In `describe('formatToolArg')`: `formatToolArg('custom', { a: '', b: 'world' }) === 'world'` AND `formatToolArg('custom', { a: [1], b: 'world' }) === 'world'`.
+- Kills: 48/50/54/55 via empty-first; 51 via array-first.
+
+### Task 6 — `isRecord` narrows to objects (class 6, mutants 60, 62, 63, 65)
+
+- [ ] In `describe('formatToolArg')`: `formatToolArg('custom', 'hello') === ''` AND `formatToolArg('custom', null) === ''`.
+- Kills: 60/62/65 via string; 63 via `null` (mutant throws on `Object.values(null)`).
+
+### Task 7 — read/write dispatch + empty-path handling (class 7, mutant 72)
+
+- [ ] In `describe('formatToolArg')`: `formatToolArg('write', { filePath: '/a/b/x.ts' }) === 'x.ts'` AND `formatToolArg('read', { filePath: '' }) === ''`.
+- Kills: `id 72` (`case 'write'` → `case ''`). The `read { filePath: "" }` assertion documents graceful empty-path handling; the two L64 literals (`id 78`, `id 80`) are equivalent residuals (see Verification).
+
+### Task 8 — `bash` dispatch key specificity (class 8, mutant 83)
+
+- [ ] In `describe('formatToolArg')`: `formatToolArg('bash', { a: 'firstval', command: 'echo hi' }) === 'echo hi'`.
+- Kills: `id 83` (`case 'bash'` → `case ''`).
+
+### Task 9 — `grep`/`glob` dispatch key specificity (class 9, mutants 86, 88)
+
+- [ ] In `describe('formatToolArg')`: grep and glob with a leading non-`pattern` string value, asserting the `pattern`.
+- Kills: `id 86`, `id 88` (`case 'grep'`/`case 'glob'` → `case ''`).
+
+### Task 10 — `task` description priority (class 10, mutants 91, 92)
+
+- [ ] In `describe('formatToolArg')`: `formatToolArg('task', { subagent_type: 'explore', description: 'find files' }) === 'find files'`.
+- Kills: `id 91` (task-body fallthrough to default), `id 92` (`case 'task'` → `case ''`).
+
+### Task 11 — `formatLiveLine` empty-arg branch (class 11, mutants 104, 106)
+
+- [ ] In `describe('formatLiveLine')`: exact `formatLiveLine('fixer', 'edit', '', 5000, 2)` → `` `  fixer      \u25B6 edit \u00B7 5s \u00B7 2 tools` ``.
+- Kills: `id 104` (`arg === ''` → false), `id 106` (`""` → Stryker).
+
+### Task 12 — `formatLiveLine` singular count, exact full line (class 12, mutants 110, 112)
+
+- [ ] In `describe('formatLiveLine')`: exact `formatLiveLine('reviewer', 'read', 'a.ts', 1000, 1)` → `` `  reviewer   \u25B6 read a.ts \u00B7 1s \u00B7 1 tool` ``.
+- [ ] Remove the now-redundant loose `toContain('1 tool')` singular test it supersedes.
+- Kills: `id 110` (`toolCount === 1` → false), `id 112` (`""` → Stryker).
+
+### Task 13 — `formatStepFooter` exact render + singular (class 13, mutants 2, 118, 120)
+
+- [ ] In `describe('formatStepFooter')`: exact `formatStepFooter('reviewer', 18000, 1, { input: 13373, output: 31 })` → `` `  reviewer \u2713 18s \u00B7 1 tool \u00B7 in 13373 / out 31` ``.
+- Kills: `id 2` (`CHECK` → `""`), `id 118` (singular cond → false), `id 120` (`""` → Stryker).
+
+### Task 14 — `formatTokenCount` million boundary (class 14, mutant 130)
+
+- [ ] In `describe('formatTokenCount')`: `formatTokenCount(1_000_000) === '1.00M'`.
+- Kills: `id 130` (`n < 1_000_000` → `<=`).
+
+### Task 15 — `activitySummary` verb dictionary (class 15, mutants 138, 140, 141)
+
+- [ ] Add `describe('activitySummary')` (import `activitySummary`): `['matcher']→'match'`, `['inspector']→'inspect'`, `['build']→'build'`, `['fixer']→'fix'`, `['reviewer']→'review'`.
+- Kills: `id 138`, `id 140`, `id 141` (ACTIVITY_VERB value → `""`).
+
+### Task 16 — `activitySummary` parts/singular/join (class 16, mutants 149, 152, 155)
+
+- [ ] In `describe('activitySummary')`: `[]→''`, single→bare verb, `['reviewer','fixer']→'review+fix'`, `['reviewer','reviewer','fixer']→'review×2+fix'` (`` `review\u00D72+fix` ``), unknown base→itself.
+- Kills: `id 149` (`[]` → `[Stryker]`), `id 152` (`n === 1` → false), `id 155` (`'+'` → `""`).
+
+---
+
+## Verification checklist
+
+- [ ] `bun test tests/review-loop/live-format.test.ts` green.
+- [ ] `bun test:mutate:file review-loop/src/live-format.ts` reports killed ≥ 141 (**measured: 154 / survived 2 / score 0.9872**).
+- [ ] No files changed outside `tests/` and `docs/superpowers/` (plus the single result JSON).
+- [ ] Residuals `id 78` and `id 80` documented (equivalent; both on L64, `path.basename("") === ""` and the `"Stryker was here"` comparison operand is unreachable from `pickString`).

--- a/docs/superpowers/plans/2026-08-06-mutation-coverage-query-builder.md
+++ b/docs/superpowers/plans/2026-08-06-mutation-coverage-query-builder.md
@@ -1,0 +1,61 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Plan: mutation coverage for `plugins/task-provider-youtrack/query-builder.ts`
+
+Date: 2026-08-06
+Target: 0.80 → **≥ 0.9** (predicted **1.0**)
+Companion spec: `docs/superpowers/specs/2026-08-06-mutation-coverage-query-builder-design.md`
+
+## Global constraints
+
+- **Test-only.** No edits under `src/`, `client/`, `plugins/`, `scripts/`, and
+  no edit to `scripts/mutation/baseline.json`. Touch only the new companion test
+  file and the two `docs/superpowers/` artifacts.
+- **New file, not a refactor.** Create
+  `tests/plugins/task-provider-youtrack/query-builder.test.ts`; leave the
+  existing query case in `task-helpers.test.ts` untouched (it stays a regression
+  anchor and the coverage map keeps it in scope).
+- **Pure unit.** `buildYouTrackQuery` is synchronous and side-effect-free. No
+  `mock.module`, no `setMockFetch`, no `setupTestDb` — import the function
+  directly from `../../../plugins/task-provider-youtrack/query-builder.js`.
+- **Exact oracles only.** Every assertion is a full-string `toBe(...)` on the
+  returned query. No `toContain` / `startsWith` / `endsWith` / `toMatch`.
+- **One test per mutant class.** Names mirror spec classes A–D.
+- **SPDX header** on the new file (BUSL-1.1), matching the source.
+
+## Task checklist (one per mutant class)
+
+- [ ] **Class A — `dueAfter`-only branch.** Add test passing
+      `{ dueAfter: '2026-01-01' }` → assert
+      `'project: {DEMO} Due date: >2026-01-01'`. Kills mutants 33, 34, 30, 24.
+- [ ] **Class B — `dueBefore`-only branch.** Add test passing
+      `{ dueBefore: '2026-01-31' }` → assert
+      `'project: {DEMO} Due date: <2026-01-31'`. Kills mutants 39, 40, 36.
+- [ ] **Class C — `sortBy: 'createdAt'` → `'created'`.** Add test passing
+      `{ sortBy: 'createdAt', sortOrder: 'desc' }` → assert
+      `'project: {DEMO} sort by: created desc'` (explicit `desc` so it does not
+      also cover class D). Kills mutants 47, 49, 50.
+- [ ] **Class D — default `'asc'` sort order.** Add test passing
+      `{ sortBy: 'priority' }` (no `sortOrder`) → assert
+      `'project: {DEMO} sort by: priority asc'`. Kills mutant 53.
+
+## Verification steps
+
+- [ ] `bun test tests/plugins/task-provider-youtrack/query-builder.test.ts` —
+      all four cases green.
+- [ ] `bun test:mutate:file plugins/task-provider-youtrack/query-builder.ts` —
+      `killed=55 survived=0 noCoverage=0 score=1.0`.
+- [ ] `bun check:full` — lint + typecheck clean (new file only).
+- [ ] Write `.review-loop/result.json` (schema: `specPath`, `planPath`,
+      `testPaths`, `residuals`, `notes`). Residuals empty — no equivalent
+      survivors identified.
+
+## Residuals
+
+None expected. All 11 survivors are killed by the four classes above; per-loc
+equivalence reasoning is recorded in the spec's "Accepted residuals" section.

--- a/docs/superpowers/specs/2026-08-06-mutation-coverage-classifier-design.md
+++ b/docs/superpowers/specs/2026-08-06-mutation-coverage-classifier-design.md
@@ -1,0 +1,148 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation coverage: `src/analytics/intent/classifier.ts`
+
+Date: 2026-08-06
+Status: approved
+
+## Summary
+
+Raise the paired mutation score of `src/analytics/intent/classifier.ts` —
+measured **0.4582** (126 killed / 149 survived / 5 runtime-error of 280
+mutants) — to **≥ 0.90** by extending the existing companion test file
+`tests/analytics/intent/classifier.test.ts` with vocabulary- and
+shape-locking assertions. No production changes.
+
+## Why this file
+
+- **Frozen vocabulary module.** `classifier.ts` is the deterministic A+B
+  intent classifier promoted from the PoC. Its three lookup tables
+  (`TOOL_BY_INTENT`, `STRUCTURED_SIGNAL_BY_INTENT`,
+  `RUNTIME_SLUGS_BY_INTENT`) and the `META_TOOLS` set are pure data: a
+  single wrong string silently reroutes an intent. Almost every surviving
+  mutant is a `StringLiteral → ""` or `ArrayDeclaration → []` inside these
+  tables, meaning the vocabulary is effectively unverified today.
+- **Highest bad-mutant density in this run.** 149 survivors concentrate in
+  one small (293-line) file; the existing 13 tests sample only a handful of
+  the ~100 mapped slugs/signals.
+- **Real behavior at stake.** The runtime-slug adapter
+  (`toClassifierToolSlug`) gates which tool traces the classifier can ever
+  recognize; an unmapped slug fails closed to abstention. A regression here
+  silently degrades classification for entire intent families (collaborate,
+  project-schema, recurring, attachment, coding, …).
+
+## Non-goals
+
+- No change to `src/`, `client/`, `plugins/`, or `scripts/` — test-only.
+- No edit to `scripts/mutation/baseline.json` (the runner owns it).
+- No refactor of the classifier. The frozen `intent.v1` strings are
+  asserted verbatim; this work locks them, not redesigns them.
+- Not chasing the four accepted equivalent residuals (see Accepted
+  residuals).
+
+## Gap analysis
+
+Run: `bun test:mutate:file src/analytics/intent/classifier.ts`
+Report: `reports/paired/src__analytics__intent__classifier.ts.stryker-report.json`
+(126 killed / 149 survived / 5 runtime-error; score 0.4582).
+
+The 149 survivors cluster into eight classes. One row per class:
+
+| # | Class | Loc range | Mutator(s) | Count | Why it survives today |
+| --- | --- | --- | --- | --- | --- |
+| C1 | `STRUCTURED_SIGNAL_BY_INTENT` signal values | L62–76 | StringLiteral→`""` | 15 | Only `provider:task:create` is fed to `classifyMetadata`; the other 15 feature signals are never exercised, so blanking a value just makes that signal unmapped with no observable assertion. |
+| C2 | `META_TOOLS` set + the skip conditional | L89, L233 | ArrayDeclaration→`[]`, StringLiteral→`""`, ConditionalExpression→`false` | 5 | The meta-tool test uses meta-tools *alone*; with no mapped goal alongside, skipping vs. not-skipping both abstain with `conflict=false`, so the skip is observationally equivalent on that input. |
+| C3 | `RUNTIME_SLUGS_BY_INTENT` vocabulary | L92–186 | StringLiteral→`""`, ArrayDeclaration→`[]` | 110 | `toClassifierToolSlug` is asserted for only 4 of ~70 runtime slugs; the other ~66 slugs and their parent arrays are unverified, so blanking any one passes through unchanged. (Excludes the 2 empty-array residuals in C-residual.) |
+| C4 | `abstention()` goals array | L205 | ArrayDeclaration→`["Stryker was here"]` | 1 | No test asserts `goals` on an abstention path, so a garbage element is invisible. |
+| C5 | `predictionFromGoals` conflict flag | L225 | BooleanLiteral false→true | 1 | No test asserts `tool_evidence_conflict === false` on a successful (non-abstained) goal prediction. |
+| C6 | Strategy labels on every return path | L241,242,254,256,259,263,273,281 | StringLiteral→`""` | 9 | `strategy` is asserted only on the hybrid path; the `tool_trace_v1` / `metadata_v1` labels on the seven other return paths are unchecked. |
+| C7 | `no_action` / unsupported-goal conflict + goals | L268, L275, L278 | BooleanLiteral false→true, ArrayDeclaration→`["Stryker was here"]` | 3 | The stop and unsupported-goal tests assert `primary`/`abstained`/`confidence` but not `tool_evidence_conflict` (→true survives) nor the `goals: []` shape (→garbage survives). |
+| C8 | Hybrid conflict OR-shortcut | L291 | ConditionalExpression→`true` | 1 | The hybrid no-evidence path is not asserted for `tool_evidence_conflict`, so forcing it to `true` is invisible. |
+
+**Kill budget.** 149 survived. Nine are accepted equivalent residuals
+(below). Killing the other 140 yields `(126+140)/(126+140+9) = 266/275 =
+0.967`, comfortably above 0.90. The minimum needed to clear 0.90 is 122
+kills. (Note: the runtime-slug class C3 excludes five fixed-point entries
+— `create_task`, `get_task`, `delete_task` slug/array at L92/94/117 —
+where the runtime slug equals its classifier slug so the mapping is a
+no-op; those join the empty-array lookups as accepted residuals.)
+
+## Design — tests to add
+
+All eight new tests are appended to the existing `describe('deterministic
+A+B classifiers', …)` block in `tests/analytics/intent/classifier.test.ts`.
+Each test maps 1:1 onto one gap class and uses exact equality
+(`toBe` / `toEqual`) throughout — no `startsWith`/`endsWith`/`toContain`
+where a full string is knowable.
+
+| Test (new) | Kills class | Mechanism |
+| --- | --- | --- |
+| T1 structured feature signals map each intent's signal to its primary | C1 | Loop over the exported `STRUCTURED_SIGNAL_BY_INTENT`; for each `[intent, signal]` assert `classifyMetadata({feature_events:[signal]}).primary === intent`. Blank any value → that signal unmapped → abstention → assertion fails. |
+| T2 a meta-tool alongside a mapped goal tool does not mask the goal | C2 | For each of `search_tools`/`load_tool`/`expand_result`, assert `classifyToolTrace([{tool_slug: meta}, {tool_slug: 'create_task'}])` yields `primary === 'task.create'`, `abstained === false`, `tool_evidence_conflict === false`. If the meta is not skipped it becomes an unmapped goal tool → abstention-with-conflict → fail. |
+| T3 runtime tool slugs translate exhaustively to classifier vocabulary | C3 | A `Record<string, string>` of every runtime slug → its classifier slug (`TOOL_BY_INTENT[intent]`), iterated with `expect(toClassifierToolSlug(slug)).toBe(expected)`. Blank any value or array → the slug passes through unchanged → fail. Also asserts a known unmapped slug passes through. |
+| T4 abstention predictions carry an empty goal list | C4 | `expect(classifyToolTrace(inputOf({})).goals).toEqual([])`. |
+| T5 prediction-from-goals marks tool_evidence_conflict false | C5 | `expect(classifyToolTrace(inputOf({tool_trace:[{tool_slug:'create_task'}]})).tool_evidence_conflict).toBe(false)`. |
+| T6 every classifier path reports its deterministic strategy | C6 | Assert `.strategy` is `'tool_trace_v1'` on tool-trace empty / mapped / unmapped paths and `'metadata_v1'` on the signal / help / config / stop / unsupported-goal / metadata-abstention paths. |
+| T7 stop and unsupported-goal paths report no conflict and empty goals | C7 | stop: `tool_evidence_conflict === false`; unsupported-goal: `tool_evidence_conflict === false` and `goals` toEqual `[]`. |
+| T8 hybrid with no evidence reports no tool evidence conflict | C8 | `expect(classifyHybrid(inputOf({})).tool_evidence_conflict).toBe(false)` (tool abstains clean, metadata abstains clean → OR must be false). |
+
+## Verification
+
+1. `bun test tests/analytics/intent/classifier.test.ts` — green (existing
+   13 + 8 new).
+2. `bun test:mutate:file src/analytics/intent/classifier.ts` — score
+   **≥ 0.90** (target ≈ 0.98).
+3. Repo lint / typecheck via the standard scripts.
+4. No manual `scripts/mutation/baseline.json` edit — the runner ratchets it.
+
+## Accepted residuals
+
+The final paired run leaves **9 survivors** (score **0.9673**, 266 killed /
+9 survived of 275 scoring mutants). All nine are genuinely unobservable
+through the public API — killing them would require either exporting a
+private helper or asserting on Stryker's `"Stryker was here"` sentinel
+(which tests the mutator, not real behavior):
+
+**Empty-array lookups (the `[] → ["Stryker was here"]` mutator):**
+
+- **L96 `task.change_state: []`** — `task.change_state` has no runtime
+  slugs by design; no real slug ever maps to `change_task_state`. The
+  intent is reached via the classifier-vocabulary slug directly, never the
+  runtime adapter.
+- **L188 `help_context: []`** — symmetric: `help_context` has no runtime
+  slugs; the intent is reached via `command_family: 'help'`, never a tool
+  slug. Only the sentinel string would be affected.
+
+**Fixed-point runtime-slug entries (runtime slug === classifier slug, so the
+mapping is a no-op whether present or absent):**
+
+- **L92 `task.create: ['create_task']`** (array→`[]`) and
+  **L92 `'create_task'`** (string→`""`) — the runtime slug `create_task`
+  equals its classifier slug `create_task`; `toClassifierToolSlug` returns
+  the same string mapped or unmapped, and `classifyToolTrace` resolves
+  `create_task` via `TOOL_TO_INTENT`, not the runtime table.
+- **L94 `'get_task'`** (string→`""`) — runtime slug `get_task` equals
+  classifier slug `get_task`. (The sibling `get_task_history → get_task`
+  mapping is non-trivial and IS killed by T3.)
+- **L117 `task.delete: ['delete_task']`** (array→`[]`) and
+  **L117 `'delete_task'`** (string→`""`) — runtime slug `delete_task`
+  equals classifier slug `delete_task`.
+
+**Equivalent control-flow in private helpers:**
+
+- **L218 `ordered.length === 0` (left operand) → `false`** —
+  `predictionFromGoals` is module-private and every caller guards empty
+  goals (`classifyToolTrace` checks `goals.length === 0`; `classifyMetadata`
+  checks `goals.length > 0` or passes a literal single-goal array). After
+  `sortGoals` dedup, a non-empty input cannot become empty, so the
+  sub-condition is never true; replacing it with `false` is equivalent.
+- **L242 `goals.length === 0` → `false`** — with empty goals the original
+  returns `abstention('tool_trace_v1')`; the mutant delegates to
+  `predictionFromGoals('tool_trace_v1', [], 0.99)`, whose first line
+  (`ordered.length === 0`) routes back to `abstention('tool_trace_v1')`.
+  The two paths produce byte-identical predictions.

--- a/docs/superpowers/specs/2026-08-06-mutation-coverage-classify-error-design.md
+++ b/docs/superpowers/specs/2026-08-06-mutation-coverage-classify-error-design.md
@@ -1,0 +1,157 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation Coverage — classify-error.ts Design
+
+**Date:** 2026-08-06
+**Status:** Proposed
+**Scope:** Test-only improvements to `tests/plugins/task-provider-youtrack/classify-error.test.ts`
+**Target file:** `plugins/task-provider-youtrack/classify-error.ts`
+
+## Summary
+
+The YouTrack error classifier (`classifyYouTrackError`) maps raw
+`YouTrackApiError` / `Error` / unknown values onto a typed
+`YouTrackClassifiedError` carrying a standardised `AppError`. Its companion
+test suite covers the happy-path status branches but leaves the internal
+helpers (`isYouTrackErrorBody`, `normalizeFieldName`, `appendFieldNames`,
+`extractRequiredFields`, and the context-fallback wiring) weakly exercised.
+Stryker reports **170 killed / 275 total → score 0.618**, far below the 0.9
+gate. This spec adds targeted, exact-equality assertions — one logical test
+per surviving mutant class — to raise the score to ≥ 0.9 without touching
+production code.
+
+## Why this file
+
+`classify-error.ts` is the single translation layer between YouTrack's
+free-form error envelopes and papai's structured `AppError` taxonomy. Every
+workflow-validation field-extraction rule, every 404 resource routing
+branch, and every network/auth heuristic lives here. Surviving mutants in
+this file are silent: a flipped regex or a dropped `?? 'unknown'` fallback
+still produces *a* classified error, just the wrong one, which then misleads
+the LLM tool loop and the analytics classifier. Killing them with
+behavioural assertions is high-ROI because each assertion pins a real
+user-facing contract.
+
+## Non-goals
+
+- Refactoring `classify-error.ts` or any production file (hard constraint:
+  test-only).
+- Raising coverage of the Kaneo classifier (`classify-error.test.ts` under
+  `task-provider-kaneo`) — out of scope.
+- Killing genuinely equivalent mutants (see *Accepted residuals*); those are
+  documented, not chased.
+- Editing `scripts/mutation/baseline.json` (the runner owns the ratchet).
+
+## Gap analysis
+
+Measured with `bun test:mutate:file plugins/task-provider-youtrack/classify-error.ts`.
+83 survived + 22 no-coverage mutants remain. They collapse into the classes
+below. Each row names the source location band, the mutant flavour, and the
+observable contract that distinguishes the mutant from the original.
+
+| # | Mutant class (locations) | Flavour | Why it survives today | Contract that kills it |
+|---|--------------------------|---------|-----------------------|------------------------|
+| A | `isYouTrackErrorBody` validation — L38–L42 | `ConditionalExpression`, `LogicalOperator`, `BooleanLiteral`, `ArrayDeclaration`, `StringLiteral`, `BlockStatement` | No test feeds a body whose known key holds a non-string value, nor a `null`/non-object body; the guard therefore looks dead | A 500 error with `{ error: 123 }` must fall back to `error.message`; `null` body must not throw |
+| B | `isYouTrackErrorBody` per-key loop — L40/L41 | `ConditionalExpression(true)`, includes-array mutants | No test mixes a valid known key with a *foreign* key carrying a non-string value, so "always validate every key" looks harmless | A 500 error with `{ error: 'ok', extra: 9 }` must still treat the body as valid |
+| C | `extractYouTrackErrorMessage` body-undefined branch — L49/L50 | `BlockStatement`, `ConditionalExpression` | No test reaches the "body failed validation → return `error.message`" arm through an HTTP path | 500 error with invalid body yields `result.message === error.message` (mutant crashes) |
+| D | `normalizeFieldName` cleaning — L59–L64 | `MethodExpression`, `Regex`, `StringLiteral`, `ConditionalExpression` | No test asserts the *exact* cleaned field name, so trim/quote/collapse/empty differences pass unseen | Workflow error with quoted/whitespace/double-space field names asserts exact `requiredFields` |
+| E | `normalizeFieldName` keyword filter — L64/L65 | `MethodExpression`, `ConditionalExpression`, `LogicalOperator`, `StringLiteral` | The four stopwords (`field`, `fields`, `custom field`, `custom fields`) are never fed in, nor a mixed-case variant | Each stopword (and `Field`) yields an empty `requiredFields` |
+| F | `appendFieldNames` — L69–L73 | `Regex`, `StringLiteral`, `BlockStatement`, `ConditionalExpression` | The ` and ` → `,` rewrite is never exercised | `required fields: Alpha and Beta` yields exactly `[{Alpha},{Beta}]` |
+| G | `extractRequiredFields` candidate wiring — L79/L81/L82 | `ArrayDeclaration`, `OptionalChaining`, `BlockStatement`, `ConditionalExpression` | Candidates array and loop entry are only hit indirectly; empty/undefined candidates look equivalent | A workflow error whose only signal is in `error_rule_name`, plus the primary-pattern test, distinguish the mutants |
+| H | `extractRequiredFields` "requires these custom fields:" regex — L84/L85 | `Regex` (4 variants), `ConditionalExpression` | The list pattern is never matched in tests | Exact capture from `requires these custom fields: URL, Name` |
+| I | `extractRequiredFields` "required field(s):" regex — L89/L90 | `Regex` (4 variants), `ConditionalExpression` | Singular/plural required-fields pattern never matched | Exact capture from `required field: X` and `required fields: A, B` |
+| J | `extractRequiredFields` "field X is required" regex — L94–L98 | `Regex` (8 variants), `ConditionalExpression`, `EqualityOperator` | The per-field assertion pattern never matched (unquoted + quoted) | Exact capture from `field URL is required` |
+| K | Fallback quoted extraction — L102/L105/L110/L112 | `ConditionalExpression`, `OptionalChaining` | The "skip fallback when primary matched" guard and the undefined-candidate guard are untested | Primary match that ends before a quoted token must NOT absorb the quoted token |
+| L | Fallback quoted extraction — L106–L114 | (covered by existing smart-quote tests + K) | — | Existing tests + K |
+| M | `classifyWorkflowValidationError` context — L129 | `LogicalOperator`, `StringLiteral` | Existing workflow test passes a `projectId` but never asserts its value | Assert `projectId` preserved AND fallback `'unknown'` |
+| N | `classifyApiError` 400 body access — L154 | `OptionalChaining` | No 400 error with an *invalid* body reaches the `body?.error_type` read | 400 error with `{ error_description: 123 }` classifies as `validation-failed` without throwing |
+| O | `classifyNotFoundError` context fallbacks — L168/L172/L176/L180/L184 | `StringLiteral`, `OptionalChaining` | Only the `taskId` "unknown" fallback is asserted; project/comment/label/saved-query fallbacks and the no-context saved-query crash are not | Each 404 resource type without context asserts the exact `'unknown'` id (or `resourceId`) |
+| P | `YouTrackClassifiedError.name` — L18 | `StringLiteral` | No test asserts `.name` | `expect(result.name).toBe('YouTrackClassifiedError')` |
+
+## Design — tests to add
+
+Each test below maps 1:1 onto a gap-class row above and uses exact equality
+(`toBe` for scalars, `toEqual` for the full `requiredFields` array). All
+inputs flow through the public `classifyYouTrackError` export so no helper
+is imported directly.
+
+- **A/C — `isYouTrackErrorBody` rejects invalid bodies (HTTP path)**
+  - 500 + `{ error: 123 }` ⇒ `result.message` is the constructor message.
+  - 500 + `null` body ⇒ does not throw; `result.message` is the constructor
+    message; `result.appError.code` is `'unexpected'`.
+- **B — foreign non-string key is ignored**
+  - 500 + `{ error: 'BodyMsg', extra: 9 }` ⇒ `result.message` is `'BodyMsg'`.
+- **C — invalid body short-circuits to `error.message`**
+  - 500 + `{ error: 123 }` already covers the `body === undefined` arm.
+- **D — `normalizeFieldName` cleaning**
+  - `required field:    Spaced   ` ⇒ `[{ name: 'Spaced' }]`.
+  - `required field: "Quoted"` ⇒ `[{ name: 'Quoted' }]`.
+  - `required field: double  space` ⇒ `[{ name: 'double space' }]`.
+- **D/E — empty-after-trim returns null**
+  - `required fields: ` ⇒ `requiredFields` length `0`.
+- **E — stopword filter (each keyword)**
+  - `required field: field` / `: fields` / `: custom field` / `: custom fields`
+    ⇒ length `0` for each.
+  - `required field: Field` (mixed case, kills `toLowerCase` mutant) ⇒ length `0`.
+- **F — ` and ` separator rewrite**
+  - `required fields: Alpha and Beta` ⇒ `[{ name: 'Alpha' }, { name: 'Beta' }]`.
+- **G — `error_rule_name` candidate**
+  - body `{ error_rule_name: 'required field: FromRule', error_type: 'workflow' }`
+    ⇒ `[{ name: 'FromRule' }]`.
+- **H — "requires these custom fields:" pattern**
+  - `requires these custom fields: URL, Name` ⇒ `[{ URL }, { Name }]`.
+- **I — "required field:" / "required fields:" patterns**
+  - `required field: Solo` ⇒ `[{ Solo }]`.
+  - `required fields: A, B` ⇒ `[{ A }, { B }]`.
+- **J — "field X is required" pattern**
+  - `field URL is required` ⇒ `[{ URL }]` (unquoted, kills `["']?`→`["']`).
+- **K — fallback is skipped once a primary pattern matched**
+  - `requires these custom fields: Primary. Fill "Extra"` ⇒ `[{ Primary }]`
+    (mutant that always runs the fallback would also add `Extra`).
+- **K — fallback tolerates an undefined candidate**
+  - 400 + `{ error_type: 'workflow' }` + message `fill "Msg"` ⇒ `[{ Msg }]`
+    (mutant that drops the `undefined` guard crashes).
+- **M — workflow context**
+  - workflow error with `{ projectId: 'PROJ-9' }` ⇒ `appError.projectId`
+    is `'PROJ-9'`.
+  - workflow error with no context ⇒ `appError.projectId` is `'unknown'`.
+- **N — 400 with invalid body**
+  - 400 + `{ error_description: 123 }` ⇒ `appError.code` is
+    `'validation-failed'` (does not throw).
+- **O — 404 context fallbacks**
+  - 404 `project not found` (no ctx) ⇒ `projectId` is `'unknown'`.
+  - 404 `comment not found` (no ctx) ⇒ `commentId` is `'unknown'`.
+  - 404 `tag not found` (no ctx) ⇒ `labelName` is `'unknown'`.
+  - 404 `saved query not found` (no ctx) ⇒ `resourceId` is `'unknown'`
+    (mutant that drops `context?.queryId` crashes).
+- **P — classified-error name**
+  - any classified result ⇒ `result.name` is `'YouTrackClassifiedError'`.
+
+## Verification
+
+1. `bun test tests/plugins/task-provider-youtrack/classify-error.test.ts`
+   is green.
+2. `bun test:mutate:file plugins/task-provider-youtrack/classify-error.ts`
+   reports a score ≥ 0.9.
+3. No file under `src/`, `client/`, `plugins/`, or `scripts/` is modified
+   (diff-guard). `scripts/mutation/baseline.json` is untouched.
+
+## Accepted residuals
+
+Equivalent mutants that survive because of data-flow invariants or redundant
+guards; each is enumerated in the plan's *Residuals* section with per-loc
+reasoning. Representative examples: the `typeof body !== 'object'` guard
+(L38:24) is redundant with the `body === null` short-circuit for every
+primitive body (property access on a boxed primitive returns `undefined` and
+falls through to the same message); `body?.X` optional-chaining inside
+`extractRequiredFields` (L79/L103) is equivalent because `body` is
+guaranteed defined at every call site; the `if (names.size > 0) break`
+optimisation (L114) is equivalent because the two fallback candidates are
+always byte-identical or one is `undefined`; `.trim()` before the
+quote/whitespace strip regex (L59) is redundant. These are documented, not
+pursued.

--- a/docs/superpowers/specs/2026-08-06-mutation-coverage-due-date-design.md
+++ b/docs/superpowers/specs/2026-08-06-mutation-coverage-due-date-design.md
@@ -1,0 +1,150 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation Coverage — `plugins/task-provider-youtrack/due-date.ts` Design
+
+**Date:** 2026-08-06
+**Status:** Proposed
+**Scope:** Test-only mutation-score recovery for `plugins/task-provider-youtrack/due-date.ts`
+**Target file:** `plugins/task-provider-youtrack/due-date.ts` (67 LOC)
+**Companion test:** `tests/plugins/task-provider-youtrack/due-date.test.ts`
+
+## Summary
+
+`due-date.ts` parses / normalizes YouTrack "Due Date" custom-field values
+between three representations: bare `YYYY-MM-DD` calendar dates, ISO-8601
+datetimes with timezone, and millisecond timestamps. It also filters list-task
+`dueAfter` / `dueBefore` params down to a 10-character date prefix. The file is
+small but branch-dense (four regexes, three throw sites, two ternary chains), so
+its mutation score is sensitive to missing edge-case assertions.
+
+The current Stryker run measures **0.6915** (65 killed / 94 total). Seven
+mutants are `NoCoverage` (unreached code) and twenty-two `Survived`. This spec
+adds ten focused tests — one per surviving mutant *class* — to raise the score
+to **≈ 0.9255** (87 killed / 94), accepting seven genuinely-equivalent
+residuals.
+
+## Why this file
+
+`due-date.ts` is the single conversion chokepoint for every due-date value
+flowing in and out of the YouTrack provider. A mutated regex anchor or a
+mutated calendar-reality guard silently corrupts task due dates (wrong day,
+`NaN` timestamps, or a misleading validation message) without breaking the
+happy path that the existing tests exercise. The file was selected by the
+mutation-improve runner as the highest-ROI target under the baseline ratchet.
+
+## Non-goals
+
+- No change to `plugins/`, `src/`, `client/`, or `scripts/` — this iteration is
+  strictly test-only (diff-guard enforced).
+- No reformatting or restyling of the existing four happy-path tests beyond the
+  minimal edits needed to add imports.
+- No attempt to kill the seven accepted-equivalent residuals (see *Accepted
+  residuals*); they are documented with per-loc reasoning, not pursued.
+- No change to `scripts/mutation/baseline.json` — the runner owns the ratchet.
+
+## Gap analysis
+
+Stryker `reports/paired/plugins__task-provider-youtrack__due-date.ts.stryker-report.json`,
+94 mutants total: **65 Killed, 7 NoCoverage, 22 Survived**. The 29 survivors
+collapse into the classes below. Each row lists the mutant ids at that location
+and *why* the existing suite misses them.
+
+| # | Class (loc)                                       | Mutant ids            | Mutator / replacement (representative)                                  | Why it survives today                                                                                                        |
+| - | ------------------------------------------------- | --------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| A | `DueDateCustomFieldSchema` object literal (L12)   | 0                     | `ObjectLiteral` → `{}`                                                  | Schema is exported but never imported by any test; empty-object mutation accepts anything.                                   |
+| B | `parseDueDateValue` final fallback (L17 / L40 / L44-47) | 2, 58, 63, 64, 65 | Regex `^` dropped; `isIsoDateTimeValue` cond → `true`; throw block NoCoverage | No test feeds a value that is neither a calendar date nor an ISO datetime, so the final `throw` (L44-47) is never reached and the `^` anchor / ISO guard are never contradicted. |
+| C | `isIsoDateTimeValue` leading anchor `^` (L20)     | 11                    | Regex `^` dropped                                                       | The one ISO test value is prefix-free, so dropping `^` is observationally identical.                                         |
+| D | `isIsoDateTimeValue` trailing anchor `$` (L20)    | 12                    | Regex `$` dropped                                                       | The one ISO test value is suffix-free, so dropping `$` is observationally identical.                                         |
+| E | `isIsoDateTimeValue` optional-seconds `?` (L20)   | 23                    | `(?::\d{2}(\.\d…)?)?` → seconds required                                | The one ISO test value includes seconds; the "minutes-only" form is never exercised.                                         |
+| F | `isIsoDateTimeValue` fractional-seconds group (L20) | 27, 28              | `\d{1,3}` → `\d`; `\d` → `\D`                                           | No test value carries a sub-second component.                                                                                |
+| G | `isValidDateOnlyValue` calendar-reality check (L23-26, L33-37) | 40, 42, 44, 53, 54, 55, 56, 57 | cond → `true`; `&&` → `||`; `isDateOnlyValue` cond → `false`; throw block NoCoverage | No test feeds a *date-shaped but non-calendar* value (e.g. `2024-02-30`); the reality check + L34 throw are never contradicted/executed. |
+| H | `mapYouTrackDueDateValue` nullish guard (L51)     | 72                    | cond → `false`                                                          | Only a numeric timestamp is tested; `null`/`undefined` never reach the ternary.                                              |
+| I | `normalizeYouTrackDueDateFilter` undefined guard (L61) | 81                | cond → `false`                                                          | Both filter fields are always supplied in the existing test; `undefined` never reaches the ternary.                          |
+| J | `normalizeYouTrackDueDateFilter` date-regex `^` (L61) | 83                 | Regex `^` dropped                                                       | The supplied filter values are either a clean 10-char date (`slice===value`) or already non-matching; the `^` anchor is never contradicted. |
+| — | `isValidDateOnlyValue` guard (L23)                | 37                    | `!isDateOnlyValue` cond → `false`                                       | **Equivalent** — see *Accepted residuals*.                                                                                  |
+| — | `normalizeYouTrackDueDateFilter` date-regex body (L61) | 85, 86, 87, 88, 89, 90 | `\d{4}`→`\d` / `\D{4}`; `\d{2}`→`\d`/`\D{2}` (month/day)        | **Equivalent** — see *Accepted residuals*.                                                                                  |
+
+Classes A–J are killable (22 mutants); the two `—` rows are the 7 accepted
+equivalent residuals.
+
+## Design — tests to add
+
+One test per class (A–J), each mapped one-to-one onto a gap-analysis row. Every
+assertion uses exact equality (`toBe`) on a fully-knowable value — no
+`startsWith` / `endsWith` / `toContain`. Error tests catch the thrown error and
+pin `message` plus every scalar field of `appError` (`type`, `code`, `field`,
+`reason`) individually with `toBe`, which simultaneously kills the
+`StringLiteral`→`""` mutants living inside each throw.
+
+| Class | New test (title)                                                                          | Input / call                                                                 | Exact assertion(s)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ----- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| A     | `DueDateCustomFieldSchema rejects an object missing name`                                 | `DueDateCustomFieldSchema.safeParse({}).success`                             | `toBe(false)`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| B     | `parseDueDateValue rejects input that is neither a calendar date nor an ISO datetime`     | `parseDueDateValue('abc2024-03-15')`                                         | throws; `message` `toBe('Invalid dueDate: abc2024-03-15')`; `appError` `{type:'provider', code:'validation-failed', field:'dueDate', reason:'Expected YYYY-MM-DD or an ISO datetime with timezone information'}` (each field via `toBe`)                                                                                                                                                                                                                                                                                                                                                                       |
+| C     | `parseDueDateValue rejects an ISO datetime with a non-date prefix`                        | `parseDueDateValue('abc2024-03-15T23:45:00+02:00')`                          | throws (same `appError` shape as B with the matching `message`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| D     | `parseDueDateValue rejects an ISO datetime with a trailing suffix`                        | `parseDueDateValue('2024-03-15T23:45:00+02:00abc')`                          | throws (same `appError` shape as B with the matching `message`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| E     | `parseDueDateValue accepts an ISO datetime without seconds`                               | `parseDueDateValue('2024-03-15T23:45+02:00')`                                | `toBe(Date.parse('2024-03-15T12:00:00.000Z'))`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| F     | `parseDueDateValue accepts an ISO datetime with three-digit fractional seconds`           | `parseDueDateValue('2024-03-15T23:45:00.123+02:00')`                         | `toBe(Date.parse('2024-03-15T12:00:00.000Z'))`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| G     | `parseDueDateValue rejects a date-shaped but non-calendar value`                          | `parseDueDateValue('2024-02-30')`                                            | throws; `message` `toBe('Invalid dueDate: 2024-02-30')`; `appError` `{type:'provider', code:'validation-failed', field:'dueDate', reason:'Expected a real calendar date in YYYY-MM-DD format'}` (each field via `toBe`)                                                                                                                                                                                                                                                                                                                                                                                         |
+| H     | `mapYouTrackDueDateValue returns undefined for null and undefined`                        | `mapYouTrackDueDateValue(null)`, `mapYouTrackDueDateValue(undefined)`        | `toBe(undefined)` (each)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| I     | `normalizeYouTrackListTaskParams leaves undefined filters undefined`                      | `normalizeYouTrackListTaskParams({}).dueAfter`                               | `toBe(undefined)`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| J     | `normalizeYouTrackListTaskParams slices a prefixed filter that is not a clean date`       | `normalizeYouTrackListTaskParams({ dueAfter: 'abc2024-03-15' }).dueAfter`    | `toBe('abc2024-03')`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+
+### How each class's mutants are killed
+
+- **B** `'abc2024-03-15'` is neither calendar-date nor ISO, so it reaches the
+  L44 throw (covers NoCoverage 63/64/65). Mutating the L17 `^` anchor (id 2)
+  makes `isDateOnlyValue` true, diverting to the L34 throw whose `appError`
+  `reason` differs → assertion fails. Mutating the L40 conditional to `true`
+  (id 58) returns a number instead of throwing → assertion fails.
+- **G** `'2024-02-30'` is date-shaped (`isDateOnlyValue` true) but
+  `new Date('2024-02-30T12:00:00.000Z')` rolls to `2024-03-01`, so the
+  round-trip check is false and L34 throws (covers NoCoverage 54/55/56/57).
+  Mutating any of the L25 operands (`&&`→`||` id 42, cond → `true` ids 40/44)
+  flips the reality check to true → returns a number; mutating the L33 guard
+  to `false` (id 53) diverts to the L44 throw whose `reason` differs → fail.
+- **C/D/E/F** each feed a single discriminating ISO value: prefix (C, kills
+  id 11), suffix (D, id 12), no-seconds (E, id 23), `.123` fraction (F, ids
+  27 & 28). Originals either parse to a known timestamp or throw with a known
+  `appError`; the mutant inverts parse↔throw, breaking the `toBe`.
+- **H/I/J** directly contradict the mutated ternary/regex via `null` /
+  `undefined` / prefixed inputs whose exact output is fully knowable.
+
+## Verification
+
+1. `bun test tests/plugins/task-provider-youtrack/due-date.test.ts` → all green
+   (existing 6 + new 10).
+2. `bun test:mutate:file plugins/task-provider-youtrack/due-date.ts` → measured
+   score ≥ 0.9 (target 87/94 ≈ 0.9255). The runner reads
+   `reports/paired/plugins__task-provider-youtrack__due-date.ts.stryker-report.json`.
+3. Expected post-state: 87 Killed, 0 NoCoverage, 7 Survived (the residuals
+   below). No new `Survived` / `NoCoverage` classes introduced.
+
+## Accepted residuals
+
+Seven surviving mutants are accepted as equivalent and left in place (per-loc
+reasoning repeated in the result `residuals` array):
+
+- **id 37 — L23 `if (!isDateOnlyValue(value)) return false` → `if (false)`.**
+  Equivalent. The guard short-circuits non-date-shaped input to `false`.
+  Without it the function continues, but the `&&` chain still returns `false`
+  for every non-date input: if `new Date(value+'T12:00:00.000Z')` is invalid,
+  `!Number.isNaN(getTime())` is `false` and short-circuits before
+  `.toISOString()` can throw; if the date is valid, the round-trip
+  `parsed.toISOString().slice(0,10) === value` can equal `value` only when
+  `value` is exactly `YYYY-MM-DD` — which is precisely the case
+  `isDateOnlyValue` already admits. There is therefore no input on which the
+  observable result of `isValidDateOnlyValue` (and hence `parseDueDateValue`)
+  differs.
+- **ids 85, 86, 87, 88, 89, 90 — L61 date-regex char-class / quantifier
+  mutations** (`\d{4}`→`\d`/`\D{4}`; month/day `\d{2}`→`\d`/`\D{2}`).
+  Equivalent. The L61 regex only selects between *return `value` as-is* and
+  *return `value.slice(0,10)`*. For any string ≤ 10 chars, `value.slice(0,10)
+  === value`, so the two branches coincide; and every one of these mutated
+  patterns is anchored `^…$` and matches at most 10 characters, so no >10-char
+  string can ever match. The selection is therefore observationally identical
+  for all inputs. (Only the un-anchored variant id 83 — class J — is killable.)

--- a/docs/superpowers/specs/2026-08-06-mutation-coverage-live-format-design.md
+++ b/docs/superpowers/specs/2026-08-06-mutation-coverage-live-format-design.md
@@ -1,0 +1,127 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation Coverage — `review-loop/src/live-format.ts` Design
+
+**Date:** 2026-08-06
+**Status:** Test-only improvement (no source changes)
+**Target file:** `review-loop/src/live-format.ts`
+**Companion test:** `tests/review-loop/live-format.test.ts`
+**Score formula:** `(killed + timeout) / (killed + survived + noCoverage + timeout)` (see `scripts/mutation/score-merger.ts`)
+
+## Summary
+
+`review-loop/src/live-format.ts` is a pure formatting module (durations, tool args,
+live status lines, token counts, activity summaries) for the review-loop live renderer.
+The paired mutation run reports a **0.75** score (117 killed / 156 total; 37 survived,
+2 no-coverage). This spec adds **exact-equality** assertions to the companion test file
+that kill 35 of the 37 surviving mutants and exercise both no-coverage mutants, raising
+the score to **154/156 = 0.9872** (verified). Two mutants on L64 (`id 78` condition
+`filePath === ""` → `false`, and `id 80` the compared literal `""` → `"Stryker was
+here"`) are accepted as equivalent residuals.
+
+## Why this file
+
+`live-format.ts` is small (120 lines), fully pure, fully deterministic, and already has
+a companion test — yet its mutation score is low because the existing tests assert shape
+via `toContain`/`toHaveLength` rather than full exact strings, and several branches
+(`truncate`, `activitySummary`, switch-case routing, type guards) are only exercised on
+the "happy" input. Pure formatting functions are the ideal target for exact-string
+mutation kills: every output is fully knowable, so every surviving mutant is either a
+genuine gap in the asserted string or an equivalent.
+
+## Non-goals
+
+- **No changes to `src/`, `client/`, `plugins/`, `scripts/`, or `review-loop/src/`.** The
+  source module is correct; only the companion test gains assertions.
+- **No change to `scripts/mutation/baseline.json`** (the runner owns it).
+- **No new test files.** All new assertions live in the existing
+  `tests/review-loop/live-format.test.ts`.
+- **No loosening** of existing assertions. New assertions are `toBe(...)` exact only.
+- **No attempt to kill the two equivalent mutants (`id 78`, `id 80`)** — see Accepted residuals.
+
+## Gap analysis
+
+Measured from the fresh paired report
+`reports/paired/review-loop__src__live-format.ts.stryker-report.json` (156 mutants:
+117 Killed, 37 Survived, 2 NoCoverage). Survivors grouped into classes; one row per
+class. `id`s are Stryker mutant ids; line refs are `live-format.ts`.
+
+| # | Gap class (surviving mutant ids) | Location | Mutator / replacement | Why it survives | Killed by (test) |
+|---|---|---|---|---|---|
+| 1 | `formatDuration` 60s boundary (10) | L16 `totalSeconds < 60` | Equality `<= 60` | No test at exactly 60000 ms | `formatDuration(60_000) === '1m00s'` |
+| 2 | `truncate` non-positive max guard (20, 21) + NoCov (23, 24) | L25 `max <= 0`, L26 `return ""` block | Cond→`false`, `<=`→`<`, Block→`{}`, `""`→Stryker | `truncate` never called with `max <= 0` | `truncate("abc", 0/-2) === ""` |
+| 3 | `truncate` exact-length boundary (27) | L28 `value.length <= max` | Equality `< max` | No test where `value.length === max` | `truncate("abcd", 4) === "abcd"` |
+| 4 | `pickString` skips empty values (41, 42) | L37 `value.length > 0` | Cond→`true`, `>`→`>=` | No empty-first-key + later-non-empty input | `formatToolArg('task', { description: "", subagent_type: "explore" }) === "explore"` |
+| 5 | `firstStringValue` type/length guard (48, 50, 51, 54, 55) | L46 `typeof value === "string" && value.length > 0` | Cond→`true`, `&&`→`||`, LHS→`true`, RHS→`true`, `>`→`>=` | Default-case fallback only tested with a leading non-empty string | empty-first and array-first custom inputs |
+| 6 | `isRecord` narrows to objects (60, 62, 63, 65) | L54 `value !== null && typeof value === "object"` | Cond→`true`, `&&`→`||`, LHS→`true`, RHS→`true` | `formatToolArg` never fed a non-record / `null` | `formatToolArg('custom', "hello"/null) === ""` |
+| 7 | read/write dispatch + empty-path basename (72) | L62 `case "write"`, L64 `filePath === "" ? ""` | StrLit `case ""` | `write` case untested; empty-`filePath` path untested | `formatToolArg('write', …)`; `('read', { filePath: "" })` documents graceful `""` (L64 literals are residual — see below) |
+| 8 | `bash` dispatch uses `command` key (83) | L66 `case "bash"` | StrLit `case ""` | `bash` only tested with `command` as the sole value | `formatToolArg('bash', { a: "x", command: "echo hi" }) === "echo hi"` |
+| 9 | `grep`/`glob` dispatch use `pattern` key (86, 88) | L68/L69 `case "grep"`/`case "glob"` | StrLit `case ""` | `pattern` always the sole value in tests | custom-first value + `pattern` |
+| 10 | `task` dispatch prioritizes `description` (91, 92) | L71 `case "task"`, L72 return | Cond fallthrough, StrLit `case ""` | `description` never tested alongside an earlier `subagent_type` | `formatToolArg('task', { subagent_type: "explore", description: "find files" }) === "find files"` |
+| 11 | `formatLiveLine` empty-arg branch (104, 106) | L79 `arg === ""` | Cond→`false`, `""`→Stryker | No test with tool set AND `arg === ""` | exact `formatLiveLine('fixer','edit','',5000,2)` |
+| 12 | `formatLiveLine` singular count + full line (110, 112) | L80 `toolCount === 1 ? "" : "s"` | Cond→`false`, `""`→Stryker | Singular case asserted via `toContain("1 tool")`, which also matches `"1 tools"` | exact full line with `toolCount === 1` |
+| 13 | `formatStepFooter` full render + singular (2, 118, 120) | L10 `CHECK`, L90 singular | StrLit `CHECK`→`""`, Cond→`false`, `""`→Stryker | Footer asserted via `toContain`, never as an exact string | exact footer with `toolCount === 1` |
+| 14 | `formatTokenCount` million boundary (130) | L96 `n < 1_000_000` | Equality `<= 1_000_000` | No test at exactly 1 000 000 | `formatTokenCount(1_000_000) === "1.00M"` |
+| 15 | `activitySummary` verb dictionary (138, 140, 141) | L102/L104/L105 ACTIVITY_VERB values | StrLit `""` | `activitySummary` entirely untested | `activitySummary(['matcher'/'inspector'/'build'])` |
+| 16 | `activitySummary` parts/singular/join (149, 152, 155) | L115 `[]`, L117 `n === 1`, L119 `"+"` | Array→`[Stryker]`, Cond→`false`, StrLit `""` | `activitySummary` entirely untested | empty / single / multi / count assertions |
+
+**Equivalent (not in a kill class):** `id 78` and `id 80` — both on L64 of the
+read/edit/write branch. See Accepted residuals.
+
+## Design — tests to add
+
+Each new test maps one-to-one onto a gap-analysis row. Every assertion is `toBe(...)`
+with a fully-knowable string (no `startsWith`/`endsWith`/`toContain` for new assertions).
+Glyphs are copied verbatim from source via `\u` escapes (`\u25B6` ▶, `\u00B7` ·,
+`\u2713` ✓, `\u00D7` ×) so expected strings are byte-exact.
+
+- **T1 — `formatDuration` 60s boundary (class 1):** assert `formatDuration(60_000) === "1m00s"`.
+- **T2 — `truncate` non-positive max (class 2):** `truncate("abc", 0) === ""`, `truncate("abc", -2) === ""`.
+- **T3 — `truncate` exact length (class 3):** `truncate("abcd", 4) === "abcd"`, `truncate("abc", 3) === "abc"`.
+- **T4 — `pickString` empty skip (class 4):** `formatToolArg('task', { description: "", subagent_type: "explore" }) === "explore"`.
+- **T5 — `firstStringValue` guard (class 5):** `formatToolArg('custom', { a: "", b: "world" }) === "world"` AND `formatToolArg('custom', { a: [1], b: "world" }) === "world"` (empty-first kills 48/50/54/55; array-first kills 51).
+- **T6 — `isRecord` guard (class 6):** `formatToolArg('custom', "hello") === ""` (kills 60/62/65) AND `formatToolArg('custom', null) === ""` (kills 63 via throw under mutation).
+- **T7 — read/write dispatch (class 7):** `formatToolArg('write', { filePath: "/a/b/x.ts" }) === "x.ts"` (kills 72) AND `formatToolArg('read', { filePath: "" }) === ""` (documents graceful empty-path handling; both L64 literals are equivalent, see residuals).
+- **T8 — `bash` key specificity (class 8):** `formatToolArg('bash', { a: "firstval", command: "echo hi" }) === "echo hi"`.
+- **T9 — `grep`/`glob` key specificity (class 9):** `formatToolArg('grep', { a: "firstval", pattern: "TODO" }) === "TODO"` AND `formatToolArg('glob', { a: "firstval", pattern: "**/*.ts" }) === "**/*.ts"`.
+- **T10 — `task` description priority (class 10):** `formatToolArg('task', { subagent_type: "explore", description: "find files" }) === "find files"`.
+- **T11 — `formatLiveLine` empty-arg (class 11):** exact `formatLiveLine('fixer', 'edit', '', 5000, 2)`.
+- **T12 — `formatLiveLine` singular exact (class 12):** exact `formatLiveLine('reviewer', 'read', 'a.ts', 1000, 1)` (also drops the now-redundant loose `toContain("1 tool")` test it supersedes).
+- **T13 — `formatStepFooter` exact singular (class 13):** exact `formatStepFooter('reviewer', 18000, 1, { input: 13373, output: 31 })`.
+- **T14 — `formatTokenCount` million boundary (class 14):** `formatTokenCount(1_000_000) === "1.00M"`.
+- **T15 — `activitySummary` verbs (class 15):** `['matcher']→"match"`, `['inspector']→"inspect"`, `['build']→"build"`, `['fixer']→"fix"`, `['reviewer']→"review"`.
+- **T16 — `activitySummary` structure (class 16):** `[]→""`, single→bare verb, `['reviewer','fixer']→"review+fix"`, `['reviewer','reviewer','fixer']→"review×2+fix"`, unknown base→itself.
+
+## Verification
+
+1. `bun test tests/review-loop/live-format.test.ts` is green on the unmodified source
+   (every expected value was cross-checked against the live module before commit).
+2. `bun test:mutate:file review-loop/src/live-format.ts` — **measured post-change counts:**
+   killed = **154**, survived = **2** (residuals `id 78`, `id 80`), no-coverage = **0**,
+   score = **154/156 = 0.9872 ≥ 0.9**.
+3. Margin: only 24 additional kills are required to clear 0.9 (141/156); the plan
+   delivers 37 (35 survived + 2 no-coverage), so even partial attrition stays well above threshold.
+
+## Accepted residuals
+
+- **`id 78` — `review-loop/src/live-format.ts:64`, `filePath === ""` → `false`.**
+  The expression is `return filePath === "" ? "" : path.basename(filePath)`. Mutating the
+  condition to `false` forces `path.basename(filePath)` unconditionally. Because
+  `path.basename("") === ""`, both branches produce identical output for every reachable
+  `filePath`: `""` (the only value `pickString` yields when no path is present) yields `""`
+  on both branches, and any non-empty path yields its basename on both branches. There is
+  no reachable input that distinguishes original from mutant, so it is a true equivalent.
+- **`id 80` — `review-loop/src/live-format.ts:64`, the compared literal `""` → `"Stryker was here"`.**
+  This mutates the *comparison operand* of `filePath === ""`, producing
+  `filePath === "Stryker was here"`. For the condition's truth value to change, `filePath`
+  would have to be either `""` (original true, mutant false) or exactly `"Stryker was
+  here"` (original false, mutant true). The latter is unreachable: `filePath` is the
+  return of `pickString(obj, ["filePath", "path"])`, which can only yield a caller-provided
+  path string or `""` — never the sentinel. And for `filePath === ""` the two ternary
+  branches coincide because `path.basename("") === ""`. Hence no reachable input
+  distinguishes original from mutant; it is a true equivalent.

--- a/docs/superpowers/specs/2026-08-06-mutation-coverage-query-builder-design.md
+++ b/docs/superpowers/specs/2026-08-06-mutation-coverage-query-builder-design.md
@@ -1,0 +1,159 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation coverage: `plugins/task-provider-youtrack/query-builder.ts`
+
+Date: 2026-08-06
+Status: approved
+
+## Summary
+
+Raise the mutation score of `plugins/task-provider-youtrack/query-builder.ts`
+from **0.80** (44 killed / 5 survived / 6 no-coverage, 55 mutants — measured by
+`bun test:mutate:file` 2026-08-06) to **≥ 0.9** (predicted **1.0**) by adding a
+dedicated companion test file. No source changes. The entire gap is uncovered
+`else if` due-date branches and the sort-field/sort-order mapping in a pure
+string-building function, so every survivor is killable with one exact-output
+`toBe(...)` assertion per missing input class.
+
+## Why this file
+
+- **Genuine, fully killable gap.** `buildYouTrackQuery` is a 19-line pure
+  function (no fetch, no store, no DI, no clock). All 11 surviving mutants are
+  observable through the returned query string; none is structural/IO.
+- **Thin existing coverage.** The only covering test today is a single case in
+  `tests/plugins/task-provider-youtrack/task-helpers.test.ts` that exercises
+  exactly one combination (every filter set + `sortBy: 'priority'`). It leaves
+  three input classes entirely unreached: a `dueAfter`-only filter, a
+  `dueBefore`-only filter, and `sortBy: 'createdAt'` (the only value that is
+  *rewritten* rather than passed through) plus the default-`'asc'` fallback.
+- **No companion exists.** The mirror path
+  `tests/plugins/task-provider-youtrack/query-builder.test.ts` does not exist;
+  the paired runner's companion resolver discovers it automatically once added
+  (no `overrides.json` edit), and the coverage map union heuristic keeps the
+  existing `task-helpers.test.ts` in scope too.
+- **Real consumer.** `buildYouTrackQuery` is the sole builder for YouTrack
+  issue-search queries (used by the list-tasks operation). A surviving mutant
+  here silently emits a malformed query — e.g. a spurious `Due date:
+  <undefined>`, or `sort by: createdAt` instead of `sort by: created` — that
+  YouTrack interprets as a different (or empty) result set.
+
+## Non-goals
+
+- **No edits to `query-builder.ts` or any `src/`/`client/`/`plugins/`/`scripts/`
+  code.** This is test-only; the implementation is already correct.
+- **No change to `scripts/mutation/baseline.json`.** The runner owns the floor;
+  the CI re-seed job raises it on master.
+- **No refactor of the existing `task-helpers.test.ts` query case.** It stays as
+  a regression anchor; the new companion adds the missing classes alongside it.
+- **No table-driven `test.each` matrix.** One named test per mutant class keeps
+  the spec↔test mapping explicit and the gap analysis diffable, per the
+  one-test-per-class brief.
+- **No integration through the list-tasks operation.** The operation needs the
+  client/field harness to kill the same pure-function mutants; the direct
+  unit path is the documented entry contract.
+
+## Gap analysis
+
+Measured survivors (`reports/paired/plugins__task-provider-youtrack__query-builder.ts.stryker-report.json`,
+paired run 2026-08-06): 5 `Survived` + 6 `NoCoverage` = **11**. They collapse
+into **4 missing-input classes**, one row each:
+
+| # | Class (missing input) | Mutants in the class (id · mutator · loc · status) | Why it survives |
+| --- | --- | --- | --- |
+| A | `dueAfter` set, `dueBefore` unset | **33** BlockStatement `else if` body L17–L19 (NoCoverage); **34** StringLiteral `` `Due date: >${params.dueAfter}` `` L18 (NoCoverage); **30** ConditionalExpression `params?.dueAfter !== undefined` → `false` L17:14–L17:44 (Survived); **24** ConditionalExpression `params.dueBefore !== undefined` → `true` L14:41–L14:71 (Survived) | No test passes `dueAfter` without `dueBefore`. With no such input the `else if` body is never entered (33/34 uncovered), the else-if guard is never the deciding branch (30 survives), and the both-branch `dueBefore` operand only diverges from `true` on exactly this input (24 survives — every other path either takes the both-branch by default or short-circuits before evaluating it). |
+| B | `dueBefore` set, `dueAfter` unset | **39** BlockStatement `else if` body L19–L21 (NoCoverage); **40** StringLiteral `` `Due date: <${params.dueBefore}` `` L20 (NoCoverage); **36** ConditionalExpression `params?.dueBefore !== undefined` → `false` L19:14–L19:45 (Survived) | No test passes `dueBefore` without `dueAfter`. The second `else if` body is never entered (39/40 uncovered) and its guard is never the deciding branch (36 survives). |
+| C | `sortBy: 'createdAt'` (rewritten to `'created'`) | **47** ConditionalExpression `params.sortBy === 'createdAt'` → `false` L23:23–L23:52 (Survived); **49** StringLiteral `'createdAt'` (right operand of `===`) → `""` L23:41–L23:52 (Survived); **50** StringLiteral `'created'` (ternary true branch) → `""` L23:55–L23:64 (NoCoverage) | The only covering test uses `sortBy: 'priority'`, which takes the ternary's *false* branch (`sortField = params.sortBy`). The `'createdAt' → 'created'` rewrite is never exercised: the true-branch literal is uncovered (50) and the `=== 'createdAt'` comparison is never the deciding branch (47/49 survive — with a non-`createdAt` value the mutant and original agree). |
+| D | `sortBy` set, `sortOrder` unset (default `'asc'`) | **53** StringLiteral `'asc'` (`?? 'asc'` fallback) → `""` L24:66–L24:71 (NoCoverage) | The only covering test passes `sortOrder: 'desc'`, so the `?? 'asc'` fallback never evaluates. The literal is uncovered (53). |
+
+Net: 11 survivors across 4 classes. Killing all four classes lands every
+survivor. No mutant class falls outside these four.
+
+## Design — tests to add
+
+New companion file
+`tests/plugins/task-provider-youtrack/query-builder.test.ts`. Plain `bun:test`,
+no harness (the function is pure and synchronous). Each test imports
+`buildYouTrackQuery` directly from
+`../../../plugins/task-provider-youtrack/query-builder.js` and asserts the
+**entire** returned string with `toBe(...)` — exact equality is mandatory and
+sufficient here because the full query string is fully knowable from the input,
+and any string-literal / operand mutant that survives changes exactly that
+string. One test per class, mapped one-to-one onto the gap table:
+
+1. **Class A — `dueAfter` only.**
+   `buildYouTrackQuery({ dueAfter: '2026-01-01' }, 'DEMO')`
+   → `toBe('project: {DEMO} Due date: >2026-01-01')`.
+   *Kills 33* (the `else if` body now executes), *34* (the literal appears and
+   any change breaks `toBe`), *30* (mutant `→ false` skips the body, dropping
+   the clause → string differs), *24* (mutant `→ true` routes to the both-branch
+   and appends `Due date: <undefined>` → string differs).
+2. **Class B — `dueBefore` only.**
+   `buildYouTrackQuery({ dueBefore: '2026-01-31' }, 'DEMO')`
+   → `toBe('project: {DEMO} Due date: <2026-01-31')`.
+   *Kills 39, 40, 36* by the same mechanisms as class A mirrored to the second
+   `else if`.
+3. **Class C — `sortBy: 'createdAt'` with an explicit `sortOrder`.**
+   `buildYouTrackQuery({ sortBy: 'createdAt', sortOrder: 'desc' }, 'DEMO')`
+   → `toBe('project: {DEMO} sort by: created desc')`.
+   *Kills 50* (the `'created'` literal is now reached and asserted), *47*
+   (mutant `→ false` makes `sortField = 'createdAt'` → `sort by: createdAt desc`
+   → differs), *49* (mutant `'createdAt'→""` makes the `===` false → same
+   `createdAt` output → differs). An explicit `sortOrder: 'desc'` is used so
+   this test does *not* also cover class D, keeping the one-to-one mapping clean.
+4. **Class D — `sortBy` set, `sortOrder` unset.**
+   `buildYouTrackQuery({ sortBy: 'priority' }, 'DEMO')`
+   → `toBe('project: {DEMO} sort by: priority asc')`.
+   *Kills 53* (the `?? 'asc'` fallback now evaluates; mutant `'asc'→""` yields
+   `sort by: priority ` with a trailing space → differs from `... priority asc`).
+
+### Expected outcome
+
+Predicted killed: **55/55 → score 1.0**. Every mutant in the inventory (44
+already killed + the 11 above) is reached by at least one case with a
+discriminating exact-string oracle. Pre-analysis found **no equivalent-mutant
+class** among the 11: each survivor's mutated value flows unchanged into a query
+clause or comparison whose effect is visible in the returned string for the
+class's defining input (see Accepted residuals).
+
+## Verification
+
+1. `bun test tests/plugins/task-provider-youtrack/query-builder.test.ts` — the
+   four new cases pass.
+2. `bun test:mutate:file plugins/task-provider-youtrack/query-builder.ts` —
+   confirm `killed=55 survived=0 noCoverage=0 score=1.0`; investigate any
+   unexpected survivor before declaring done.
+3. No `baseline.json` edit in the PR: the CI `mutation-baseline` job re-seeds
+   the floor on master (per-key max) from the changed-files run; the gate is
+   regression-only, so the improved score can only raise the floor.
+4. Lint/typecheck via the repo's `bun check:full` — no existing suite is
+   modified (new file, no shared mocks, no `mock.module`).
+
+## Accepted residuals
+
+None. All 11 surviving mutants are behaviorally observable through the returned
+query string and are killed by the four cases above; no equivalent mutant was
+identified. Per-loc reasoning that none is equivalent:
+
+- **L17 `params?.dueAfter !== undefined` (30), L17–L19 body (33), L18 literal
+  (34), L14 `params.dueBefore !== undefined` (24):** on a `dueAfter`-only input
+  the original emits exactly one `Due date: >…` clause; every one of these
+  mutants changes that emission (drops it, or adds a spurious `Due date:
+  <undefined>`). Observable → not equivalent.
+- **L19 `params?.dueBefore !== undefined` (36), L19–L21 body (39), L20 literal
+  (40):** mirrored to a `dueBefore`-only input; the original emits exactly one
+  `Due date: <…` clause and each mutant changes it. Observable → not equivalent.
+- **L23 `params.sortBy === 'createdAt'` (47), L23 `'createdAt'` literal (49),
+  L23 `'created'` literal (50):** on `sortBy: 'createdAt'` the original rewrites
+  to `created`; each mutant yields `createdAt` (or empty). Observable → not
+  equivalent.
+- **L24 `'asc'` fallback literal (53):** on a `sortOrder`-unset input the
+  original appends ` asc`; the mutant appends an empty string. Observable → not
+  equivalent.
+
+If a future run surfaces a survivor outside these four classes, it would be a
+new mutator on already-killed lines and must be triaged then.

--- a/mutation-improve/CLAUDE.md
+++ b/mutation-improve/CLAUDE.md
@@ -8,13 +8,13 @@
 
 `src/pipeline.ts` runs iterations strictly sequentially (each observes the prior iteration's baseline bump and `doneSet`):
 
-1. SELECT — runner reads the baseline; the agent only suggests. Picks outside the baseline or already in `doneSet` are rejected as agent mistakes.
+1. SELECT — runner reads the baseline; the agent only suggests. Picks outside the baseline, already in `doneSet`, already failed this run, or present in the cross-run capped registry (`<workDir>/capped.json`) are rejected as agent mistakes.
 2. CAPTURE BEFORE — runner-measured score; already ≥ `threshold` → iteration is `skipped` and the file joins `doneSet`.
-3. IMPROVE — agent writes spec/plan/tests; its declared score is never trusted.
-4. GATES, in order: diff-guard (`src/diff-guard.ts`: agent may only touch `tests/` and `docs/superpowers/`) → build check (`checkCommand`) → runner-measured after-score via `mutateFileCommand <file>`, read from `reports/paired/<stem>.stryker-report.json` (`src/score-reader.ts`, one retry on missing/corrupt report). Below `threshold` fails unless the agent declared residuals AND the score lands within `epsilon` of it. A failed build check does NOT fail the iteration outright: the failed check output is fed back to the agent (`buildFixAttempts` times, default 2; diff-guard re-runs after each fix) before the iteration is failed at the build gate. A failed build check does NOT fail the iteration outright: the failed check output is fed back to the agent (`buildFixAttempts` times, default 2; diff-guard re-runs after each fix) before the iteration is failed at the build gate.
+3. IMPROVE — agent writes spec/plan/tests; its declared score is never trusted. Residual declarations must name the Stryker mutant ids they cover (`mutantIds`).
+4. GATES, in order: diff-guard (`src/diff-guard.ts`: agent may only touch `tests/` and `docs/superpowers/`) → build check (`checkCommand`) → runner-measured after-score via `mutateFileCommand <file>`, read from `reports/paired/<stem>.stryker-report.json` (`src/score-reader.ts`, one retry on missing/corrupt report). Below `threshold` there are three outcomes: the residual escape hatch passes as `improved` when residuals are declared AND the score lands within `epsilon` of the threshold; otherwise the iteration merges as `capped` when the score improved AND the declared residual `mutantIds` exactly equal the runner-measured surviving ids (the file is at its tests-only ceiling — baseline ratchets to the measured score and the file enters the capped registry); otherwise it fails. A failed build check does NOT fail the iteration outright: the failed check output is fed back to the agent (`buildFixAttempts` times, default 2; diff-guard re-runs after each fix) before the iteration is failed at the build gate.
 5. RATCHET + MERGE — the baseline bump is committed on the iteration branch inside the worktree, then merged into the integration branch. A merge conflict aborts the whole run (`gate: 'merge'`) so no later iteration chains off a stale base.
 
-Outcomes per iteration: `improved` | `skipped` | `failed`. The CLI exits 1 if any iteration failed or the run aborted. `runIteration` routes every throw through the same cleanup path so worktrees/branches are not leaked; `--reset-worktree` sweeps stale `<runId>-iterN` worktrees left by a killed process.
+Outcomes per iteration: `improved` | `skipped` | `capped` | `failed`. The CLI exits 1 if any iteration failed or the run aborted (`capped` is a merge, not a failure). `runIteration` routes every throw through the same cleanup path so worktrees/branches are not leaked; `--reset-worktree` sweeps stale `<runId>-iterN` worktrees left by a killed process.
 
 ## Config & repoRoot
 
@@ -23,6 +23,7 @@ Outcomes per iteration: `improved` | `skipped` | `failed`. The CLI exits 1 if an
 ## Storage / Artifacts
 
 - `<workDir>/runs/<runId>/state.json` — persisted run state (Zod-validated on `--resume-run <runId>`).
+- `<workDir>/capped.json` — cross-run registry of files merged at their tests-only ceiling; select-gate rejects them. Delete an entry to make a file eligible again (e.g. after a src refactor raised its ceiling).
 - `<workDir>/runs/<runId>/agent-output.log` + `iter/<N>/{selection,result}.json` — agent transcripts and structured outputs.
 - `iter/<N>/build-output.log` — full combined stdout+stderr of a failed build gate (the recorded reason is tail-bounded).
 - `<workDir>/worktrees/<runId>-iter<N>` on branches `mutation-improve/<runId>-iter<N>` (kept on merge conflict, removed otherwise).

--- a/mutation-improve/src/capped-registry.ts
+++ b/mutation-improve/src/capped-registry.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { z } from 'zod'
+
+const CappedEntrySchema = z.object({
+  score: z.number(),
+  cappedAt: z.string(),
+  runId: z.string(),
+})
+
+const CappedRegistrySchema = z.record(z.string(), CappedEntrySchema)
+
+type CappedRegistry = z.infer<typeof CappedRegistrySchema>
+
+export interface CappedEntry {
+  readonly file: string
+  readonly score: number
+  readonly cappedAt: string
+  readonly runId: string
+}
+
+export interface CappedRegistryStore {
+  readonly entries: readonly CappedEntry[]
+  readonly record: (file: string, score: number) => Promise<void>
+}
+
+export const cappedRegistryPath = (workDir: string): string => path.join(workDir, 'capped.json')
+
+const isEnoent = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && 'code' in error && (error as { code: unknown }).code === 'ENOENT'
+
+// Cross-run memory of files whose tests-only mutation-score ceiling landed
+// below the threshold. A capped file was merged at its ceiling once already,
+// so re-selecting it can only re-discover the same ceiling — the select gate
+// rejects these picks. Missing file means "nothing capped yet" ({}); a corrupt
+// file throws so cross-run memory is never silently dropped.
+export async function loadCappedRegistryStore(workDir: string, runId: string): Promise<CappedRegistryStore> {
+  const filePath = cappedRegistryPath(workDir)
+  let registry: CappedRegistry = {}
+  try {
+    registry = CappedRegistrySchema.parse(JSON.parse(await readFile(filePath, 'utf8')))
+  } catch (error) {
+    if (!isEnoent(error)) throw error
+  }
+  let entries: readonly CappedEntry[] = Object.entries(registry).map(([file, entry]) => ({ file, ...entry }))
+  return {
+    get entries() {
+      return entries
+    },
+    record: async (file: string, score: number): Promise<void> => {
+      const entry = { score, cappedAt: new Date().toISOString(), runId }
+      registry = { ...registry, [file]: entry }
+      entries = [...entries.filter((e) => e.file !== file), { file, ...entry }]
+      await mkdir(workDir, { recursive: true })
+      await writeFile(filePath, JSON.stringify(registry, null, 2))
+    },
+  }
+}

--- a/mutation-improve/src/cli.ts
+++ b/mutation-improve/src/cli.ts
@@ -17,6 +17,7 @@ import {
   resetWorktree,
 } from '../../review-loop/src/worktree.js'
 import { readBaseline, writeBaseline } from './baseline.js'
+import { type CappedRegistryStore, loadCappedRegistryStore } from './capped-registry.js'
 import { type MutationImproveConfig, loadMutationImproveConfig } from './config.js'
 import { assertIntegrationBranch, runFinalize } from './finalize.js'
 import { type IterationResult, runPipeline, type PipelineDeps } from './pipeline.js'
@@ -141,6 +142,7 @@ function buildPipelineDeps(
   config: MutationImproveConfig,
   runState: MutationImproveRunState,
   log: LiveRenderer,
+  cappedRegistry: CappedRegistryStore,
 ): PipelineDeps {
   return {
     config,
@@ -163,6 +165,7 @@ function buildPipelineDeps(
     writeBaseline,
     runSelectAgent: selectRunner(config, runState, log),
     runImproveAgent: improveRunner(config, runState, log),
+    cappedRegistry,
     saveRunState,
     log,
   }
@@ -218,8 +221,13 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     await resetRunWorktrees(config.repoRoot, runState.runId, config.prBranchPrefix)
   }
 
+  // Loaded before the pipeline so a corrupt registry fails fast instead of
+  // being discovered mid-run (or worse, silently reset, which would re-allow
+  // capped files and re-enter the re-pick loop it exists to prevent).
+  const cappedRegistry = await loadCappedRegistryStore(config.workDir, runState.runId)
+
   const log = new LiveRenderer(process.stdout)
-  const deps = buildPipelineDeps(config, runState, log)
+  const deps = buildPipelineDeps(config, runState, log, cappedRegistry)
   // I1: try/finally guarantees saveRunState runs even if runPipeline throws
   // (e.g. AgentRunError mid-pipeline), so --resume-run sees the last-known
   // in-memory progress instead of losing everything to a throw.

--- a/mutation-improve/src/gate.ts
+++ b/mutation-improve/src/gate.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { runBuildGateWithRetries } from './build-gate.js'
+import { runDiffGuard } from './diff-guard.js'
+import type { PipelineDeps } from './pipeline.js'
+import type { Result } from './result-schema.js'
+
+export type PhaseOk<T> = { ok: true; value: T }
+export type PhaseFail = { ok: false; gate: string; reason: string; file?: string }
+export type PhaseResult<T> = PhaseOk<T> | PhaseFail
+
+export interface GateOutcome {
+  afterScore: number
+  result: Result
+  capped: boolean
+}
+
+// Set equality, not subset: a declared id that is not an actual survivor means
+// the agent's bookkeeping is wrong (or padded) — fail closed. An empty
+// surviving set can never cap (a below-threshold score implies survivors).
+function coversAllSurvivors(result: Result, survivingMutantIds: readonly string[]): boolean {
+  const declared = new Set(result.residuals.flatMap((r) => r.mutantIds))
+  const surviving = new Set(survivingMutantIds)
+  return surviving.size > 0 && declared.size === surviving.size && [...declared].every((id) => surviving.has(id))
+}
+
+// ④a DIFF-GUARD → ④b BUILD → ⑤ VERIFY. Diff-guard runs BEFORE verify so any agent
+// attempt to edit baseline.json or src/ is caught before the runner spends a
+// mutation-score run on tampered inputs. The after-score is runner-measured.
+// Three below-threshold outcomes:
+//   - residual escape hatch (unchanged): residuals declared AND score within
+//     epsilon of the threshold → passes as 'improved'.
+//   - capped: score improved AND the declared residual mutant ids exactly equal
+//     the runner-measured surviving ids → merges at the measured ceiling as
+//     'capped' (the file is provably at its tests-only limit; failing would
+//     discard real coverage gains and invite endless re-picks).
+//   - otherwise the iteration fails the score gate.
+// Build-gate failures are fed back to the agent for up to config.buildFixAttempts
+// fix-and-re-gate cycles (see runBuildGateWithRetries in build-gate.ts) before
+// failing.
+export async function gatePhase(
+  deps: PipelineDeps,
+  iterPath: string,
+  worktreePath: string,
+  file: string,
+  beforeScore: number,
+  improved: Result,
+): Promise<PhaseResult<GateOutcome>> {
+  const diff = await runDiffGuard(deps.execGit, worktreePath)
+  if (!diff.ok) {
+    return { ok: false, gate: 'diff-scope', reason: `forbidden paths changed: ${diff.violations.join(', ')}` }
+  }
+  const buildGate = await runBuildGateWithRetries(
+    { execGit: deps.execGit, runBuildCheck: deps.runBuildCheck, runImproveAgent: deps.runImproveAgent, log: deps.log },
+    { iterPath, worktreePath, file, attempt: 1, maxAttempts: deps.config.buildFixAttempts, improved },
+  )
+  if (!buildGate.ok) return buildGate
+  const result = buildGate.value
+  const measured = await deps.measureScore(worktreePath, file)
+  const afterScore = measured.score
+  const justified = result.residuals.length > 0 && afterScore >= deps.config.threshold - deps.config.epsilon
+  if (afterScore >= deps.config.threshold || justified) {
+    return { ok: true, value: { afterScore, result, capped: false } }
+  }
+  if (afterScore > beforeScore && coversAllSurvivors(result, measured.survivingMutantIds)) {
+    return { ok: true, value: { afterScore, result, capped: true } }
+  }
+  return { ok: false, gate: 'score', reason: `afterScore ${afterScore} < threshold ${deps.config.threshold}` }
+}

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -9,22 +9,23 @@ import path from 'node:path'
 import { agentWritePath, type AgentRunResult } from '../../review-loop/src/agent-runner.js'
 import type { MergeResult } from '../../review-loop/src/worktree.js'
 import { bumpScore, type BaselineMap } from './baseline.js'
-import { runBuildGateWithRetries } from './build-gate.js'
+import type { CappedRegistryStore } from './capped-registry.js'
 import type { MutationImproveConfig } from './config.js'
-import { runDiffGuard } from './diff-guard.js'
 import { recordFailure, type FailureEntry } from './failure-recorder.js'
+import { gatePhase, type PhaseResult } from './gate.js'
 import { buildImprovePrompt, buildSelectPrompt } from './prompt-templates.js'
 import type { Result } from './result-schema.js'
 import { ResultSchema } from './result-schema.js'
 import type { MutationImproveRunState } from './run-state.js'
 import { iterDir } from './run-state.js'
+import type { MeasuredScore } from './score-reader.js'
 import { SelectionSchema } from './selection-schema.js'
 import type { Selection } from './selection-schema.js'
 import { ratchetVerifiedSkip } from './skip-ratchet.js'
 
 export interface IterationResult {
   iter: number
-  outcome: 'improved' | 'skipped' | 'failed'
+  outcome: 'improved' | 'skipped' | 'failed' | 'capped'
   file?: string
   beforeScore?: number
   afterScore?: number
@@ -42,18 +43,15 @@ export interface PipelineDeps {
   mergeWorktree: (repoRoot: string, branchName: string) => Promise<MergeResult>
   execGit: (cwd: string, args: readonly string[]) => Promise<{ stdout: string; stderr: string }>
   runBuildCheck: (worktreePath: string) => Promise<{ passed: boolean; stdout: string; stderr: string }>
-  measureScore: (worktreePath: string, srcFile: string) => Promise<number>
+  measureScore: (worktreePath: string, srcFile: string) => Promise<MeasuredScore>
   readBaseline: (repoRoot: string) => Promise<BaselineMap>
   writeBaseline: (repoRoot: string, map: BaselineMap) => Promise<void>
   runSelectAgent: (worktreePath: string, prompt: string, outputPath: string) => Promise<AgentRunResult<Selection>>
   runImproveAgent: (worktreePath: string, prompt: string, outputPath: string) => Promise<AgentRunResult<Result>>
+  cappedRegistry: CappedRegistryStore
   saveRunState: (state: MutationImproveRunState) => Promise<void>
   log: { log: (msg: string) => void; issue?: unknown }
 }
-
-type PhaseOk<T> = { ok: true; value: T }
-type PhaseFail = { ok: false; gate: string; reason: string; file?: string }
-type PhaseResult<T> = PhaseOk<T> | PhaseFail
 
 function branchFor(deps: PipelineDeps, iter: number): string {
   return `${deps.config.prBranchPrefix}/${deps.runState.runId}-iter${iter}`
@@ -68,18 +66,24 @@ function runIdFor(deps: PipelineDeps, iter: number): string {
 }
 
 // ① SELECT — runner reads baseline; agent only suggests. Reject picks not in baseline
-// (nothing to improve) or already done (would re-do work). Both are agent mistakes.
+// (nothing to improve), already done (would re-do work), already failed this run
+// (same gates, same model — a re-pick almost certainly re-fails and burns an
+// iteration), or capped by an earlier run (its tests-only ceiling is already
+// merged; re-picking can only re-discover it). All four are agent mistakes.
 async function selectPhase(
   deps: PipelineDeps,
   worktreePath: string,
   iterPath: string,
 ): Promise<PhaseResult<{ selection: Selection; baseline: BaselineMap }>> {
   const baseline = await deps.readBaseline(deps.config.repoRoot)
+  const failedFiles = deps.runState.failed.flatMap((f) => (f.file === undefined ? [] : [f.file]))
   const selectOut = path.join(iterPath, 'selection.json')
   const selectRes = await deps.runSelectAgent(
     worktreePath,
     buildSelectPrompt({
       doneSet: deps.runState.doneSet,
+      failedFiles,
+      cappedFiles: deps.cappedRegistry.entries,
       baselineSummary: JSON.stringify(baseline),
       outputPath: agentWritePath(worktreePath, selectOut),
     }),
@@ -88,6 +92,17 @@ async function selectPhase(
   const selection = SelectionSchema.parse(selectRes.value)
   if (deps.runState.doneSet.includes(selection.file) || baseline[selection.file] === undefined) {
     return { ok: false, gate: 'select', reason: 'selection file not in baseline or already done', file: selection.file }
+  }
+  if (failedFiles.includes(selection.file)) {
+    return { ok: false, gate: 'select', reason: 'selection file already failed this run', file: selection.file }
+  }
+  if (deps.cappedRegistry.entries.some((e) => e.file === selection.file)) {
+    return {
+      ok: false,
+      gate: 'select',
+      reason: 'selection file already capped at its declared residual ceiling',
+      file: selection.file,
+    }
   }
   return { ok: true, value: { selection, baseline } }
 }
@@ -117,35 +132,26 @@ async function improvePhase(
   return ResultSchema.parse(improveRes.value)
 }
 
-// ④a DIFF-GUARD → ④b BUILD → ⑤ VERIFY. Diff-guard runs BEFORE verify so any agent
-// attempt to edit baseline.json or src/ is caught before the runner spends a
-// mutation-score run on tampered inputs. The after-score is runner-measured;
-// the residual escape hatch only opens when the agent declared residuals AND
-// the measured score lands within epsilon of the threshold. Build-gate failures
-// are fed back to the agent for up to config.buildFixAttempts fix-and-re-gate
-// cycles (see runBuildGateWithRetries in build-gate.ts) before failing.
-async function gatePhase(
+// C1: write the baseline bump into the WORKTREE (not repoRoot) and commit the
+// agent's spec/plan/test outputs together with the bump on the worktree
+// branch BEFORE mergeWorktree. Without this, mergeWorktree merges an empty
+// branch ("Already up to date"), writeBaseline never propagates to base, and
+// removeWorktree --force discards the agent's uncommitted files.
+async function commitRatchet(
   deps: PipelineDeps,
-  iterPath: string,
   worktreePath: string,
   file: string,
-  improved: Result,
-): Promise<PhaseResult<{ afterScore: number; result: Result }>> {
-  const diff = await runDiffGuard(deps.execGit, worktreePath)
-  if (!diff.ok) {
-    return { ok: false, gate: 'diff-scope', reason: `forbidden paths changed: ${diff.violations.join(', ')}` }
-  }
-  const buildGate = await runBuildGateWithRetries(
-    { execGit: deps.execGit, runBuildCheck: deps.runBuildCheck, runImproveAgent: deps.runImproveAgent, log: deps.log },
-    { iterPath, worktreePath, file, attempt: 1, maxAttempts: deps.config.buildFixAttempts, improved },
-  )
-  if (!buildGate.ok) return buildGate
-  const afterScore = await deps.measureScore(worktreePath, file)
-  const justified = buildGate.value.residuals.length > 0 && afterScore >= deps.config.threshold - deps.config.epsilon
-  if (afterScore < deps.config.threshold && !justified) {
-    return { ok: false, gate: 'score', reason: `afterScore ${afterScore} < threshold ${deps.config.threshold}` }
-  }
-  return { ok: true, value: { afterScore, result: buildGate.value } }
+  afterScore: number,
+  bumped: BaselineMap,
+): Promise<void> {
+  await deps.writeBaseline(worktreePath, bumped)
+  await deps.execGit(worktreePath, ['add', '-A'])
+  await deps.execGit(worktreePath, [
+    'commit',
+    '--allow-empty',
+    '-m',
+    `chore(mutation): ratchet ${file} baseline to ${afterScore}`,
+  ])
 }
 
 // ⑥ RATCHET (runner-owned) → ⑦ MERGE. The baseline bump is written into the
@@ -161,23 +167,10 @@ async function finalizePhase(
   file: string,
   baseline: BaselineMap,
   beforeScore: number,
-  gate: { afterScore: number; result: Result },
+  gate: { afterScore: number; result: Result; capped: boolean },
 ): Promise<IterationResult> {
   const { afterScore, result } = gate
-  const bumped = bumpScore(baseline, file, afterScore)
-  // C1: write the baseline bump into the WORKTREE (not repoRoot) and commit the
-  // agent's spec/plan/test outputs together with the bump on the worktree
-  // branch BEFORE mergeWorktree. Without this, mergeWorktree merges an empty
-  // branch ("Already up to date"), writeBaseline never propagates to base, and
-  // removeWorktree --force discards the agent's uncommitted files.
-  await deps.writeBaseline(worktreePath, bumped)
-  await deps.execGit(worktreePath, ['add', '-A'])
-  await deps.execGit(worktreePath, [
-    'commit',
-    '--allow-empty',
-    '-m',
-    `chore(mutation): ratchet ${file} baseline to ${afterScore}`,
-  ])
+  await commitRatchet(deps, worktreePath, file, afterScore, bumpScore(baseline, file, afterScore))
   const merge = await deps.mergeWorktree(deps.config.repoRoot, branchFor(deps, iter))
   if (!merge.ok) {
     return {
@@ -190,6 +183,10 @@ async function finalizePhase(
       reason: `conflict: ${merge.conflictFiles.join(', ')}`,
     }
   }
+  // Record the cap only after the merge landed: an aborted run keeps the bump
+  // on the unmerged iteration branch, and a persisted cap would wrongly block
+  // the file in later runs whose baseline never received the tests.
+  if (gate.capped) await deps.cappedRegistry.record(file, afterScore)
   await deps.removeWorktree(deps.config.repoRoot, worktreePath, runIdFor(deps, iter), deps.config.prBranchPrefix)
   deps.runState.doneSet.push(file)
   deps.runState.merged.push({
@@ -199,8 +196,9 @@ async function finalizePhase(
     iter,
     specPath: result.specPath,
     planPath: result.planPath,
+    ...(gate.capped ? { capped: true } : {}),
   })
-  return { iter, outcome: 'improved', file, beforeScore, afterScore }
+  return { iter, outcome: gate.capped ? 'capped' : 'improved', file, beforeScore, afterScore }
 }
 
 async function failIter(
@@ -250,7 +248,8 @@ export async function runIteration(deps: PipelineDeps, iter: number): Promise<It
     file = selection.file
 
     // ② CAPTURE BEFORE (runner-owned). Already at threshold → nothing to do.
-    const beforeScore = await deps.measureScore(worktreePath, selection.file)
+    const before = await deps.measureScore(worktreePath, selection.file)
+    const beforeScore = before.score
     if (beforeScore >= deps.config.threshold) {
       deps.runState.doneSet.push(selection.file)
       await ratchetVerifiedSkip(deps, baseline, selection.file, beforeScore)
@@ -259,7 +258,7 @@ export async function runIteration(deps: PipelineDeps, iter: number): Promise<It
 
     const improved = await improvePhase(deps, worktreePath, iterPath, selection.file, beforeScore)
 
-    const gate = await gatePhase(deps, iterPath, worktreePath, selection.file, improved)
+    const gate = await gatePhase(deps, iterPath, worktreePath, selection.file, beforeScore, improved)
     if (!gate.ok) return await failIter(deps, iter, worktreePath, gate.gate, gate.reason, file)
 
     return await finalizePhase(deps, iter, worktreePath, selection.file, baseline, beforeScore, gate.value)

--- a/mutation-improve/src/prompt-templates.ts
+++ b/mutation-improve/src/prompt-templates.ts
@@ -5,17 +5,45 @@
 
 import path from 'node:path'
 
+import type { CappedEntry } from './capped-registry.js'
+
 const stemFrom = (file: string): string => {
   const base = path.basename(file).replace(/\.ts$/u, '')
   return base
 }
 
+const RESULT_SCHEMA_LINE =
+  'Schema: { specPath: string, planPath: string, testPaths: string[] (>=1),\n' +
+  'residuals: [{loc, why, mutantIds: string[]}], notes: string }.'
+
+// Both header forms spelled out verbatim: agents default to the // style they
+// see in source, but check.sh requires the HTML-comment form for docs/*.md and
+// rejects anything else at the pre-commit hook.
+const LICENSE_HEADER_LINES = [
+  '- SPDX license headers on any new file; emoji copied verbatim from source.',
+  '  Header styles: .ts files use `// SPDX-License-Identifier: BUSL-1.1` (plus copyright lines);',
+  '  .md files MUST use the HTML-comment form as the first lines of the file:',
+  '  <!--',
+  '  SPDX-License-Identifier: BUSL-1.1',
+  '  Copyright (c) 2026 Dmitriy Lazarev',
+  '  Use of this software is governed by the Business Source License 1.1.',
+  '  See LICENSE in the project root for details.',
+  '  -->',
+]
+
 export function buildSelectPrompt(input: {
   doneSet: readonly string[]
+  failedFiles: readonly string[]
+  cappedFiles: readonly CappedEntry[]
   baselineSummary: string
   outputPath: string
 }): string {
   const excluded = input.doneSet.length === 0 ? '(none)' : input.doneSet.join(', ')
+  const failed = input.failedFiles.length === 0 ? '(none)' : input.failedFiles.join(', ')
+  const capped =
+    input.cappedFiles.length === 0
+      ? '(none)'
+      : input.cappedFiles.map((e) => `${e.file} (ceiling ${e.score})`).join(', ')
   return [
     'You are the SELECT phase of an autonomous mutation-coverage improvement runner.',
     '',
@@ -31,6 +59,8 @@ export function buildSelectPrompt(input: {
     '- Files whose companion test cannot exercise the behaviour without a full chat/LLM runtime.',
     '',
     `Files already improved in this run (DO NOT pick): ${excluded}`,
+    `Files already attempted and FAILED this run (DO NOT pick; same gates, same model — a retry re-fails): ${failed}`,
+    `Files capped at their tests-only ceiling by earlier runs (DO NOT pick; the ceiling is already merged): ${capped}`,
     '',
     `baseline.json contents: ${input.baselineSummary}`,
     '',
@@ -69,8 +99,7 @@ export function buildFixPrompt(input: {
     '  below - do not create copies of it anywhere else.',
     '',
     `When done, REWRITE your result JSON to this ABSOLUTE path: ${input.outputPath}`,
-    'Schema: { specPath: string, planPath: string, testPaths: string[] (>=1),',
-    'residuals: [{loc, why}], notes: string }.',
+    RESULT_SCHEMA_LINE,
   ].join('\n')
 }
 
@@ -100,11 +129,19 @@ export function buildImprovePrompt(input: {
     '   MUST use exact equality toBe(...) - never startsWith/endsWith/toContain where a full string is',
     '   knowable. One test per mutant class.',
     '5. RESIDUALS. Enumerate equivalent mutants that survive and genuinely cannot be killed, with per-loc',
-    '   reasoning.',
+    '   reasoning. Each entry MUST list the Stryker mutant ids it covers (mutantIds: string[]) exactly as',
+    '   they appear in your measured report (reports/paired/<stem>.stryker-report.json, "id" fields with',
+    '   status Survived or NoCoverage). The runner re-measures and set-matches the UNION of your mutantIds',
+    '   against its own surviving ids: they must be EQUAL — every survivor declared, nothing extra.',
+    '',
+    'CAPPED PATH. If the file\u2019s tests-only ceiling lands below the target (equivalent mutants / dead code',
+    'that only a src/ edit could remove), a full residual declaration still counts as success: the runner',
+    'merges your tests, ratchets the baseline to the measured score, and marks the file capped (outcome',
+    "'capped'), provided the score improved AND your declared mutantIds exactly cover every survivor.",
+    'A file below target with incomplete or padded mutantIds FAILS and all work is discarded.',
     '',
     `Write your result as JSON to this ABSOLUTE path (note the hidden .review-loop/ parent dir): ${input.outputPath}`,
-    'Schema: { specPath: string, planPath: string, testPaths: string[] (>=1),',
-    'residuals: [{loc, why}], notes: string }.',
+    RESULT_SCHEMA_LINE,
     '',
     'HARD CONSTRAINTS (the runner verifies these and REJECTS the iteration if violated):',
     '- MUST NOT edit anything under src/, client/, plugins/, or scripts/. Test-only.',
@@ -113,6 +150,6 @@ export function buildImprovePrompt(input: {
     '  above - do not create copies of it anywhere else. Any other new or changed file,',
     '  including under review-loop/ or mutation-improve/, fails the diff gate.',
     '- Run `bun test tests/<companion>` green before finishing.',
-    '- SPDX license headers on any new file; emoji copied verbatim from source.',
+    ...LICENSE_HEADER_LINES,
   ].join('\n')
 }

--- a/mutation-improve/src/result-schema.ts
+++ b/mutation-improve/src/result-schema.ts
@@ -5,9 +5,13 @@
 
 import { z } from 'zod'
 
+// mutantIds names the Stryker mutant ids (from reports/paired/<stem>.stryker-report.json)
+// this residual covers. The runner set-matches their union against its own
+// measured surviving ids to open the capped gate; omitted means "covers nothing".
 const ResidualSchema = z.object({
   loc: z.string(),
   why: z.string(),
+  mutantIds: z.array(z.string().min(1)).default([]),
 })
 
 export const ResultSchema = z.object({

--- a/mutation-improve/src/run-state.ts
+++ b/mutation-improve/src/run-state.ts
@@ -18,6 +18,9 @@ const MergedEntrySchema = z.object({
   iter: z.number().int(),
   specPath: z.string().optional(),
   planPath: z.string().optional(),
+  // true when the iteration merged below threshold at its declared residual
+  // ceiling (outcome 'capped'); absent/false on fully-threshold-passing merges.
+  capped: z.boolean().optional(),
 })
 
 const FailedEntrySchema = z.object({

--- a/mutation-improve/src/score-reader.ts
+++ b/mutation-improve/src/score-reader.ts
@@ -4,7 +4,7 @@
 // See LICENSE in the project root for details.
 
 import { ReportReadError, readStrykerReport } from '../../scripts/mutation/json-readers.js'
-import { mergeReports, type StrykerReport } from '../../scripts/mutation/score-merger.js'
+import { mergeReports, survivingMutantIds, type StrykerReport } from '../../scripts/mutation/score-merger.js'
 
 export const safeFileStem = (srcFile: string): string => srcFile.replaceAll(/[^a-zA-Z0-9._-]+/gu, '__')
 
@@ -16,6 +16,14 @@ export interface MeasureDeps {
   readReport?: (reportPath: string) => StrykerReport
 }
 
+// survivingMutantIds rides along with the score so the pipeline's capped-gate
+// can set-match the improve agent's declared residual mutant ids against the
+// runner-measured survivors without re-running the mutation command.
+export interface MeasuredScore {
+  readonly score: number
+  readonly survivingMutantIds: readonly string[]
+}
+
 function isRetryable(error: unknown): boolean {
   if (error instanceof ReportReadError) return true
   return (
@@ -23,15 +31,20 @@ function isRetryable(error: unknown): boolean {
   )
 }
 
-export async function measureMutationScore(deps: MeasureDeps, reportDir: string, srcFile: string): Promise<number> {
+export async function measureMutationScore(
+  deps: MeasureDeps,
+  reportDir: string,
+  srcFile: string,
+): Promise<MeasuredScore> {
   const read = deps.readReport ?? readStrykerReport
   const reportPath = reportPathFor(reportDir, srcFile)
-  const attempt = async (): Promise<number> => {
+  const attempt = async (): Promise<MeasuredScore> => {
     const result = await deps.exec()
     if (result.exitCode !== 0) {
       throw new Error(`mutation run failed (exit ${result.exitCode}): ${result.stderr}`)
     }
-    return mergeReports([read(reportPath)]).score
+    const report = read(reportPath)
+    return { score: mergeReports([report]).score, survivingMutantIds: survivingMutantIds(report) }
   }
   try {
     const score = await attempt()

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -329,13 +329,18 @@ else
       exit_code=0
       if [ "$check" = "license-headers" ]; then
         header_checked_files=()
+        # --cached --others --exclude-standard: tracked files PLUS untracked
+        # (not gitignored) ones. A consumer's gate may run full mode on a
+        # worktree containing brand-new, never-added files (agent-authored
+        # docs/tests); tracked-only enumeration would miss them here and let
+        # the pre-commit hook's --staged mode reject them later at git commit.
         while IFS= read -r file; do
           [ -n "$file" ] || continue
           [ -f "$file" ] || continue
           if is_license_header_file "$file"; then
             header_checked_files+=("$file")
           fi
-        done < <(git ls-files 2>/dev/null || true)
+        done < <(git ls-files --cached --others --exclude-standard 2>/dev/null || true)
         run_license_header_check "$TMPDIR/$fname.out" "${header_checked_files[@]+${header_checked_files[@]}}" || exit_code=$?
       elif [ "$check" = "test" ]; then
         # CI runners (4 vCPU, all checks already running concurrently) get

--- a/scripts/mutation/baseline.json
+++ b/scripts/mutation/baseline.json
@@ -96,7 +96,7 @@
   "plugins/task-provider-youtrack/create-field-helpers.ts": 0.46511627906976744,
   "plugins/task-provider-youtrack/custom-field-values.ts": 0,
   "plugins/task-provider-youtrack/dedicated-fields.ts": 0.6699029126213593,
-  "plugins/task-provider-youtrack/due-date.ts": 0.6595744680851063,
+  "plugins/task-provider-youtrack/due-date.ts": 0.925531914893617,
   "plugins/task-provider-youtrack/entry-runtime.ts": 0,
   "plugins/task-provider-youtrack/field-engine.ts": 0.4280155642023346,
   "plugins/task-provider-youtrack/field-name-error.ts": 0.8,

--- a/scripts/mutation/baseline.json
+++ b/scripts/mutation/baseline.json
@@ -91,7 +91,7 @@
   "plugins/task-provider-kaneo/validation-error.ts": 0,
   "plugins/task-provider-youtrack/bundle-cache.ts": 0.6067415730337079,
   "plugins/task-provider-youtrack/bundle-values.ts": 0.4838709677419355,
-  "plugins/task-provider-youtrack/classify-error.ts": 0.6036363636363636,
+  "plugins/task-provider-youtrack/classify-error.ts": 0.9490909090909091,
   "plugins/task-provider-youtrack/collaboration-provider.ts": 0,
   "plugins/task-provider-youtrack/create-field-helpers.ts": 0.46511627906976744,
   "plugins/task-provider-youtrack/custom-field-values.ts": 0,

--- a/scripts/mutation/baseline.json
+++ b/scripts/mutation/baseline.json
@@ -125,7 +125,7 @@
   "plugins/task-provider-youtrack/phase-five-provider.ts": 0,
   "plugins/task-provider-youtrack/prompt-addendum.ts": 0.7222222222222222,
   "plugins/task-provider-youtrack/provider.ts": 0.46,
-  "plugins/task-provider-youtrack/query-builder.ts": 0.4727272727272727,
+  "plugins/task-provider-youtrack/query-builder.ts": 1,
   "plugins/task-provider-youtrack/relations.ts": 0.6037735849056604,
   "plugins/task-provider-youtrack/schemas/activity.ts": 1,
   "plugins/task-provider-youtrack/schemas/agile.ts": 1,

--- a/scripts/mutation/baseline.json
+++ b/scripts/mutation/baseline.json
@@ -160,7 +160,7 @@
   "review-loop/src/summary-burndown.ts": 0.74,
   "review-loop/src/summary.ts": 0.721030042918455,
   "review-loop/src/worktree.ts": 0.8402366863905325,
-  "src/analytics/intent/classifier.ts": 0.4581818181818182,
+  "src/analytics/intent/classifier.ts": 0.9672727272727273,
   "src/analytics/jobs/backfill.ts": 0.7741935483870968,
   "src/announcements/humanize.ts": 0.3382352941176471,
   "src/attachments/staged-download.ts": 1,

--- a/scripts/mutation/baseline.json
+++ b/scripts/mutation/baseline.json
@@ -153,7 +153,7 @@
   "review-loop/src/issue-processor-attempts.ts": 0.6993006993006993,
   "review-loop/src/issue-processor.ts": 0.696969696969697,
   "review-loop/src/line-handler.ts": 0.5421686746987951,
-  "review-loop/src/live-format.ts": 0.7435897435897436,
+  "review-loop/src/live-format.ts": 0.9871794871794872,
   "review-loop/src/live-renderer.ts": 0.6678571428571428,
   "review-loop/src/loop-controller.ts": 0.6666666666666666,
   "review-loop/src/progress-log.ts": 1,

--- a/scripts/mutation/baseline.json
+++ b/scripts/mutation/baseline.json
@@ -211,7 +211,7 @@
   "src/group-settings/registry.ts": 0.6962025316455697,
   "src/history.ts": 1,
   "src/instances/encryption.ts": 1,
-  "src/live-status/tool-status-labels.ts": 0.46190476190476193,
+  "src/live-status/tool-status-labels.ts": 0.9714285714285714,
   "src/llm-orchestrator-attachments.ts": 0.5727272727272728,
   "src/llm-orchestrator-invoke.ts": 0.691358024691358,
   "src/llm-orchestrator-tools.ts": 0.5409836065573771,

--- a/scripts/mutation/score-merger.ts
+++ b/scripts/mutation/score-merger.ts
@@ -83,3 +83,15 @@ export const mergeReports = (reports: readonly StrykerReport[]): MergedScore => 
     score: scored === 0 ? 0 : (counts.killed + counts.timeout) / scored,
   }
 }
+
+// Ids of mutants that count AGAINST the mutation score: Survived and NoCoverage
+// both sit in the `scored` denominator without contributing kills, so a residual
+// declaration must cover both buckets. Mutants without a string id are dropped:
+// they can never be set-matched against an agent's declared residual ids, and
+// keeping them would make a full-coverage check silently unverifiable.
+export const survivingMutantIds = (report: StrykerReport): string[] =>
+  reportMutants(report).flatMap((mutant) =>
+    (mutant.status === 'Survived' || mutant.status === 'NoCoverage') && typeof mutant.id === 'string'
+      ? [mutant.id]
+      : [],
+  )

--- a/tests/analytics/intent/classifier.test.ts
+++ b/tests/analytics/intent/classifier.test.ts
@@ -12,6 +12,7 @@ import {
   toClassifierToolSlug,
   type IntentClassifierInput,
 } from '../../../src/analytics/intent/classifier.js'
+import type { CoreIntent } from '../../../src/analytics/intent/taxonomy.js'
 
 const inputOf = (partial: Partial<IntentClassifierInput>): IntentClassifierInput => ({
   tool_trace: [],
@@ -143,5 +144,193 @@ describe('deterministic A+B classifiers', () => {
     expect(toClassifierToolSlug('load_tool')).toBe('load_tool')
     expect(toClassifierToolSlug('external_other')).toBe('external_other')
     expect(toClassifierToolSlug('apply_youtrack_command')).toBe('apply_youtrack_command')
+  })
+
+  test('structured feature signals map each intent signal to its primary', () => {
+    const assertSignal = (intent: CoreIntent, signal: string): void => {
+      const prediction = classifyMetadata(inputOf({ feature_events: [signal] }))
+      expect(prediction.primary).toBe(intent)
+      expect(prediction.abstained).toBe(false)
+      expect(prediction.strategy).toBe('metadata_v1')
+    }
+    assertSignal('task.create', 'provider:task:create')
+    assertSignal('task.find_list', 'provider:task:search')
+    assertSignal('task.read_detail', 'provider:task:read_detail')
+    assertSignal('task.update_fields', 'provider:task:update_fields')
+    assertSignal('task.change_state', 'provider:task:change_state')
+    assertSignal('task.collaborate', 'provider:task:collaborate')
+    assertSignal('task.delete', 'provider:task:delete')
+    assertSignal('project_schema.manage', 'feature:project_schema:manage')
+    assertSignal('recurring.manage', 'feature:recurring:manage')
+    assertSignal('deferred.manage', 'feature:deferred:manage')
+    assertSignal('memory_memo.write', 'feature:memory:write')
+    assertSignal('memory_memo.find', 'feature:memory:find')
+    assertSignal('attachment.manage', 'feature:attachment:manage')
+    assertSignal('web.retrieve', 'feature:web:retrieve')
+    assertSignal('identity_participant.manage', 'feature:identity:manage')
+    assertSignal('coding.start_review', 'feature:coding:start_review')
+    assertSignal('coding.monitor_control', 'feature:coding:monitor_control')
+    assertSignal('coding.continue_publish', 'feature:coding:continue_publish')
+    assertSignal('configuration_permissions', 'feature:configuration:permissions')
+    assertSignal('help_context', 'command:help_context')
+  })
+
+  test('a meta-tool alongside a mapped goal tool does not mask the goal', () => {
+    for (const metaSlug of ['search_tools', 'load_tool', 'expand_result']) {
+      const prediction = classifyToolTrace(
+        inputOf({ tool_trace: [{ tool_slug: metaSlug }, { tool_slug: 'create_task' }] }),
+      )
+      expect(prediction.primary).toBe('task.create')
+      expect(prediction.abstained).toBe(false)
+      expect(prediction.tool_evidence_conflict).toBe(false)
+      expect(prediction.strategy).toBe('tool_trace_v1')
+    }
+  })
+
+  test('runtime tool slugs translate exhaustively to classifier vocabulary', () => {
+    const expected: Record<string, string> = {
+      create_task: 'create_task',
+      list_tasks: 'find_tasks',
+      search_tasks: 'find_tasks',
+      count_tasks: 'find_tasks',
+      get_task: 'get_task',
+      get_task_history: 'get_task',
+      update_task: 'update_task_fields',
+      add_task_label: 'update_task_fields',
+      remove_task_label: 'update_task_fields',
+      add_comment: 'comment_or_assign_task',
+      update_comment: 'comment_or_assign_task',
+      remove_comment: 'comment_or_assign_task',
+      add_comment_reaction: 'comment_or_assign_task',
+      remove_comment_reaction: 'comment_or_assign_task',
+      get_comments: 'comment_or_assign_task',
+      add_task_relation: 'comment_or_assign_task',
+      remove_task_relation: 'comment_or_assign_task',
+      add_vote: 'comment_or_assign_task',
+      remove_vote: 'comment_or_assign_task',
+      add_watcher: 'comment_or_assign_task',
+      remove_watcher: 'comment_or_assign_task',
+      list_watchers: 'comment_or_assign_task',
+      log_work: 'comment_or_assign_task',
+      update_work: 'comment_or_assign_task',
+      remove_work: 'comment_or_assign_task',
+      list_work: 'comment_or_assign_task',
+      assign_task_to_sprint: 'comment_or_assign_task',
+      delete_task: 'delete_task',
+      create_project: 'manage_project_schema',
+      update_project: 'manage_project_schema',
+      delete_project: 'manage_project_schema',
+      get_project: 'manage_project_schema',
+      list_projects: 'manage_project_schema',
+      create_label: 'manage_project_schema',
+      update_label: 'manage_project_schema',
+      remove_label: 'manage_project_schema',
+      list_labels: 'manage_project_schema',
+      create_status: 'manage_project_schema',
+      update_status: 'manage_project_schema',
+      delete_status: 'manage_project_schema',
+      list_statuses: 'manage_project_schema',
+      reorder_statuses: 'manage_project_schema',
+      create_sprint: 'manage_project_schema',
+      update_sprint: 'manage_project_schema',
+      list_sprints: 'manage_project_schema',
+      list_agiles: 'manage_project_schema',
+      add_project_member: 'manage_project_schema',
+      remove_project_member: 'manage_project_schema',
+      list_project_team: 'manage_project_schema',
+      list_saved_queries: 'manage_project_schema',
+      create_recurring_task: 'manage_recurring_task',
+      update_recurring_task: 'manage_recurring_task',
+      delete_recurring_task: 'manage_recurring_task',
+      list_recurring_tasks: 'manage_recurring_task',
+      pause_recurring_task: 'manage_recurring_task',
+      resume_recurring_task: 'manage_recurring_task',
+      skip_recurring_task: 'manage_recurring_task',
+      create_reminder: 'manage_deferred_prompt',
+      create_alert: 'manage_deferred_prompt',
+      update_reminder: 'manage_deferred_prompt',
+      cancel_reminder: 'manage_deferred_prompt',
+      get_reminder: 'manage_deferred_prompt',
+      list_reminders: 'manage_deferred_prompt',
+      save_memo: 'write_memo',
+      archive_memos: 'write_memo',
+      promote_memo: 'write_memo',
+      remember_memory: 'write_memo',
+      forget_memory: 'write_memo',
+      list_memos: 'find_memo',
+      search_memos: 'find_memo',
+      list_memory: 'find_memo',
+      search_memory: 'find_memo',
+      list_attachments: 'manage_attachment',
+      upload_attachment: 'manage_attachment',
+      remove_attachment: 'manage_attachment',
+      delete_file: 'manage_attachment',
+      list_files: 'manage_attachment',
+      resolve_staged_file: 'manage_attachment',
+      search_staged_files: 'manage_attachment',
+      fetch_chat_link: 'manage_attachment',
+      web_fetch: 'fetch_public_web_page',
+      plugin_synthetic_web_search__search: 'fetch_public_web_page',
+      find_user: 'resolve_participant_identity',
+      resolve_chat_participant: 'resolve_participant_identity',
+      set_my_identity: 'resolve_participant_identity',
+      clear_my_identity: 'resolve_participant_identity',
+      get_current_user: 'resolve_participant_identity',
+      plugin_acp__start_session: 'start_coding_or_review',
+      plugin_acp__list_projects: 'start_coding_or_review',
+      plugin_acp__list_agents: 'start_coding_or_review',
+      plugin_acp__session_status: 'control_coding_session',
+      plugin_acp__list_sessions: 'control_coding_session',
+      plugin_acp__cancel_session: 'control_coding_session',
+      plugin_acp__answer_permission: 'control_coding_session',
+      plugin_acp__continue_session: 'continue_or_publish_coding_session',
+      plugin_acp__finish_session: 'continue_or_publish_coding_session',
+      set_visibility: 'configure_tool_permissions',
+    }
+    expect(Object.keys(expected).length).toBe(97)
+    for (const [runtimeSlug, classifierSlug] of Object.entries(expected)) {
+      expect(toClassifierToolSlug(runtimeSlug)).toBe(classifierSlug)
+    }
+    expect(toClassifierToolSlug('external_other')).toBe('external_other')
+    expect(toClassifierToolSlug('apply_youtrack_command')).toBe('apply_youtrack_command')
+  })
+
+  test('abstention predictions carry an empty goal list', () => {
+    expect(classifyToolTrace(inputOf({})).goals).toEqual([])
+    expect(classifyMetadata(inputOf({})).goals).toEqual([])
+  })
+
+  test('prediction-from-goals marks tool_evidence_conflict false', () => {
+    const prediction = classifyToolTrace(inputOf({ tool_trace: [{ tool_slug: 'create_task' }] }))
+    expect(prediction.tool_evidence_conflict).toBe(false)
+    expect(prediction.abstained).toBe(false)
+  })
+
+  test('every classifier path reports its deterministic strategy', () => {
+    expect(classifyToolTrace(inputOf({})).strategy).toBe('tool_trace_v1')
+    expect(classifyToolTrace(inputOf({ tool_trace: [{ tool_slug: 'create_task' }] })).strategy).toBe('tool_trace_v1')
+    expect(classifyToolTrace(inputOf({ tool_trace: [{ tool_slug: 'external_other' }] })).strategy).toBe('tool_trace_v1')
+    expect(classifyMetadata(inputOf({ feature_events: ['provider:task:create'] })).strategy).toBe('metadata_v1')
+    expect(classifyMetadata(inputOf({ command_family: 'help' })).strategy).toBe('metadata_v1')
+    expect(classifyMetadata(inputOf({ command_family: 'config' })).strategy).toBe('metadata_v1')
+    expect(classifyMetadata(inputOf({ command_family: 'stop' })).strategy).toBe('metadata_v1')
+    expect(classifyMetadata(inputOf({ feature_events: ['turn:unsupported_goal'] })).strategy).toBe('metadata_v1')
+    expect(classifyMetadata(inputOf({})).strategy).toBe('metadata_v1')
+  })
+
+  test('stop and unsupported-goal paths report no conflict and empty goals', () => {
+    const stop = classifyMetadata(inputOf({ command_family: 'stop' }))
+    expect(stop.tool_evidence_conflict).toBe(false)
+    expect(stop.goals).toEqual(['no_action'])
+    const unsupported = classifyMetadata(inputOf({ feature_events: ['turn:unsupported_goal'] }))
+    expect(unsupported.tool_evidence_conflict).toBe(false)
+    expect(unsupported.goals).toEqual([])
+  })
+
+  test('hybrid with no evidence reports no tool evidence conflict', () => {
+    const prediction = classifyHybrid(inputOf({}))
+    expect(prediction.tool_evidence_conflict).toBe(false)
+    expect(prediction.abstained).toBe(true)
+    expect(prediction.strategy).toBe('hybrid_v1')
   })
 })

--- a/tests/mutation-improve/capped-registry.test.ts
+++ b/tests/mutation-improve/capped-registry.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { cappedRegistryPath, loadCappedRegistryStore } from '../../mutation-improve/src/capped-registry.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+describe('capped-registry', () => {
+  test('loads an empty registry when capped.json does not exist', async () => {
+    const workDir = makeTempDir('capped-')
+    const store = await loadCappedRegistryStore(workDir, 'run-1')
+    expect(store.entries).toEqual([])
+  })
+
+  test('record persists an entry that a fresh load returns', async () => {
+    const workDir = makeTempDir('capped-')
+    const store = await loadCappedRegistryStore(workDir, 'run-1')
+    await store.record('plugins/task-provider-kaneo/mappers.ts', 0.857)
+
+    const reloaded = await loadCappedRegistryStore(workDir, 'run-2')
+    expect(reloaded.entries).toHaveLength(1)
+    const entry = reloaded.entries[0]
+    expect(entry?.file).toBe('plugins/task-provider-kaneo/mappers.ts')
+    expect(entry?.score).toBe(0.857)
+    expect(entry?.runId).toBe('run-1')
+    expect(entry?.cappedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/u)
+  })
+
+  test('entries reflect record immediately, without a reload', async () => {
+    const workDir = makeTempDir('capped-')
+    const store = await loadCappedRegistryStore(workDir, 'run-1')
+    await store.record('src/a.ts', 0.8)
+    expect(store.entries.map((e) => e.file)).toEqual(['src/a.ts'])
+  })
+
+  test('recording the same file twice overwrites the earlier entry', async () => {
+    const workDir = makeTempDir('capped-')
+    const store = await loadCappedRegistryStore(workDir, 'run-1')
+    await store.record('src/a.ts', 0.8)
+    await store.record('src/a.ts', 0.85)
+    expect(store.entries).toHaveLength(1)
+    expect(store.entries[0]?.score).toBe(0.85)
+    const reloaded = await loadCappedRegistryStore(workDir, 'run-1')
+    expect(reloaded.entries).toHaveLength(1)
+    expect(reloaded.entries[0]?.score).toBe(0.85)
+  })
+
+  test('load throws on a corrupt registry rather than silently dropping cross-run memory', async () => {
+    const workDir = makeTempDir('capped-')
+    await writeFile(cappedRegistryPath(workDir), JSON.stringify({ 'src/a.ts': { score: 'high' } }))
+    await expect(loadCappedRegistryStore(workDir, 'run-1')).rejects.toThrow()
+  })
+
+  test('registry file lives at <workDir>/capped.json', () => {
+    expect(cappedRegistryPath('/w')).toBe(path.join('/w', 'capped.json'))
+  })
+})

--- a/tests/mutation-improve/cli.test.ts
+++ b/tests/mutation-improve/cli.test.ts
@@ -4,7 +4,7 @@
 // See LICENSE in the project root for details.
 
 import { afterEach, describe, expect, test } from 'bun:test'
-import { existsSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
 import { DEFAULT_CONFIG_PATH, parseCliArgs, resetRunWorktrees, runCli } from '../../mutation-improve/src/cli.js'
@@ -120,5 +120,21 @@ describe('runCli integration-branch guard', () => {
     writeFileSync(configPath, JSON.stringify({ repoRoot, workDir: '.mi', agent: { model: 'm' } }))
     await expect(runCli(['--config', configPath])).rejects.toThrow(/integration branch/u)
     expect(existsSync(path.join(repoRoot, '.mi', 'runs'))).toBe(false)
+  })
+
+  // The capped registry is cross-run memory: silently resetting a corrupt one
+  // would re-allow capped files and re-enter the re-pick loop. runCli must load
+  // it up front and surface the corruption instead of starting the pipeline.
+  test('rejects on a corrupt capped registry before the pipeline starts', async () => {
+    const { repoRoot } = await setupRepo()
+    await execGit(repoRoot, ['checkout', '-b', 'integr'])
+    const configPath = path.join(repoRoot, 'cfg.json')
+    writeFileSync(
+      configPath,
+      JSON.stringify({ repoRoot, workDir: '.mi', count: 1, agent: { model: 'm', timeoutMs: 1000 } }),
+    )
+    mkdirSync(path.join(repoRoot, '.mi'), { recursive: true })
+    writeFileSync(path.join(repoRoot, '.mi', 'capped.json'), 'not json')
+    await expect(runCli(['--config', configPath, '--no-pr'])).rejects.toThrow(SyntaxError)
   })
 })

--- a/tests/mutation-improve/contracts.test.ts
+++ b/tests/mutation-improve/contracts.test.ts
@@ -65,6 +65,39 @@ describe('contracts', () => {
     expect(() => ResultSchema.parse(base)).toThrow()
     expect(() => ResultSchema.parse({ ...base, testPaths: ['tests/x.test.ts'] })).not.toThrow()
   })
+
+  test('ResultSchema residual entries carry the Stryker mutant ids they cover', () => {
+    const parsed = ResultSchema.parse({
+      specPath: 'd.md',
+      planPath: 'p.md',
+      testPaths: ['tests/x.test.ts'],
+      residuals: [{ loc: 'src/x.ts:24', why: 'equivalent guard', mutantIds: ['2', '3', '4'] }],
+    })
+    expect(parsed.residuals[0]?.mutantIds).toEqual(['2', '3', '4'])
+  })
+
+  // Old agent outputs (and resumed runs) predate mutantIds; they must still
+  // parse — the capped gate treats a missing list as "covers nothing", which
+  // fails closed to the pre-change behaviour (iteration fails the score gate).
+  test('ResultSchema defaults residual mutantIds to empty when omitted', () => {
+    const parsed = ResultSchema.parse({
+      specPath: 'd.md',
+      planPath: 'p.md',
+      testPaths: ['tests/x.test.ts'],
+      residuals: [{ loc: 'src/x.ts:24', why: 'equivalent guard' }],
+    })
+    expect(parsed.residuals[0]?.mutantIds).toEqual([])
+  })
+
+  test('ResultSchema rejects non-string residual mutantIds', () => {
+    const base = {
+      specPath: 'd.md',
+      planPath: 'p.md',
+      testPaths: ['tests/x.test.ts'],
+      residuals: [{ loc: 'src/x.ts:24', why: 'equivalent guard', mutantIds: [2, 3] }],
+    }
+    expect(() => ResultSchema.parse(base)).toThrow()
+  })
 })
 
 describe('review-loop surface contract', () => {

--- a/tests/mutation-improve/gate.test.ts
+++ b/tests/mutation-improve/gate.test.ts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdirSync } from 'node:fs'
+import path from 'node:path'
+
+import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
+import { gatePhase } from '../../mutation-improve/src/gate.js'
+import type { GateOutcome, PhaseFail, PhaseOk, PhaseResult } from '../../mutation-improve/src/gate.js'
+import type { PipelineDeps } from '../../mutation-improve/src/pipeline.js'
+import type { Result } from '../../mutation-improve/src/result-schema.js'
+import type { MutationImproveRunState } from '../../mutation-improve/src/run-state.js'
+import type { MeasuredScore } from '../../mutation-improve/src/score-reader.js'
+import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
+
+afterEach(cleanupTempDirs)
+
+const expectFail = (outcome: PhaseResult<GateOutcome>): PhaseFail => {
+  if (outcome.ok) throw new Error('expected a gate failure, got ok')
+  return outcome
+}
+
+const expectOk = (outcome: PhaseResult<GateOutcome>): PhaseOk<GateOutcome> => {
+  if (!outcome.ok) throw new Error(`expected ok, got gate ${outcome.gate}: ${outcome.reason}`)
+  return outcome
+}
+
+const baseResult: Result = {
+  specPath: 'docs/superpowers/specs/x-design.md',
+  planPath: 'docs/superpowers/plans/x.md',
+  testPaths: ['tests/x.test.ts'],
+  residuals: [],
+  notes: '',
+}
+
+const withResiduals = (residuals: Result['residuals']): Result => ({ ...baseResult, residuals })
+
+interface GateFake {
+  deps: PipelineDeps
+  calls: { builds: number; measures: number }
+  iterPath: string
+  worktreePath: string
+}
+
+const gateDeps = (
+  overrides: { gitStatus?: string; buildPassed?: boolean; measured?: MeasuredScore } = {},
+): GateFake => {
+  const repoRoot = makeTempDir('gate-')
+  const worktreePath = path.join(repoRoot, 'wt')
+  const iterPath = path.join(repoRoot, 'iter', '1')
+  // recordBuildFailure writes build-output.log into iterPath on any build failure
+  mkdirSync(iterPath, { recursive: true })
+  const calls = { builds: 0, measures: 0 }
+  const config: MutationImproveConfig = {
+    repoRoot,
+    workDir: path.join(repoRoot, '.mutation-improve'),
+    base: 'master',
+    upstream: 'origin',
+    count: 1,
+    threshold: 0.95,
+    epsilon: 0.02,
+    mutateTimeoutMs: 1_800_000,
+    buildTimeoutMs: 600_000,
+    buildFixAttempts: 0,
+    checkCommand: 'bun check:full',
+    mutateFileCommand: 'bun test:mutate:file',
+    agent: { model: 'm', extraArgs: [], timeoutMs: 1_800_000 },
+    prBranchPrefix: 'mutation-improve',
+  }
+  const runState: MutationImproveRunState = {
+    runId: 'r1',
+    repoRoot,
+    workDir: config.workDir,
+    runDir: path.join(config.workDir, 'runs', 'r1'),
+    statePath: path.join(config.workDir, 'runs', 'r1', 'state.json'),
+    base: 'master',
+    threshold: 0.95,
+    count: 1,
+    currentIteration: 0,
+    doneSet: [],
+    merged: [],
+    failed: [],
+    status: 'running',
+  }
+  const deps: PipelineDeps = {
+    config,
+    runState,
+    spawn: () => Promise.resolve({ exitCode: 0, stdout: '', stderr: '' }),
+    createWorktree: () => Promise.resolve(),
+    resetWorktree: () => Promise.resolve(),
+    removeWorktree: () => Promise.resolve(),
+    mergeWorktree: () => Promise.resolve({ ok: true }),
+    execGit: () => Promise.resolve({ stdout: overrides.gitStatus ?? ' M tests/x.test.ts\n', stderr: '' }),
+    runBuildCheck: () => {
+      calls.builds += 1
+      return Promise.resolve({ passed: overrides.buildPassed ?? true, stdout: '', stderr: '' })
+    },
+    measureScore: () => {
+      calls.measures += 1
+      return Promise.resolve(overrides.measured ?? { score: 0.97, survivingMutantIds: [] })
+    },
+    readBaseline: () => Promise.resolve({}),
+    writeBaseline: () => Promise.resolve(),
+    runSelectAgent: () => Promise.reject(new Error('unused in gate')),
+    runImproveAgent: () =>
+      Promise.resolve({
+        value: baseResult,
+        usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0, wallMs: 0 },
+      }),
+    cappedRegistry: { entries: [], record: () => Promise.resolve() },
+    saveRunState: () => Promise.resolve(),
+    log: { log: () => undefined, issue: undefined },
+  }
+  return { deps, calls, iterPath, worktreePath }
+}
+
+describe('gatePhase', () => {
+  test('diff-scope violation short-circuits before the build check and the score run', async () => {
+    const { deps, calls, iterPath, worktreePath } = gateDeps({ gitStatus: ' M src/foo.ts\n' })
+    const outcome = await gatePhase(deps, iterPath, worktreePath, 'src/foo.ts', 0.4, baseResult)
+    const fail = expectFail(outcome)
+    expect(fail.gate).toBe('diff-scope')
+    expect(fail.reason).toBe('forbidden paths changed: src/foo.ts')
+    expect(calls.builds).toBe(0)
+    expect(calls.measures).toBe(0)
+  })
+
+  test('build-gate failure short-circuits before the score run', async () => {
+    const { deps, calls, iterPath, worktreePath } = gateDeps({ buildPassed: false })
+    const outcome = await gatePhase(deps, iterPath, worktreePath, 'src/foo.ts', 0.4, baseResult)
+    expect(expectFail(outcome).gate).toBe('build')
+    expect(calls.measures).toBe(0)
+  })
+
+  test('caps when the score improved and declared mutant ids equal the surviving set', async () => {
+    const { deps, iterPath, worktreePath } = gateDeps({
+      measured: { score: 0.85, survivingMutantIds: ['s1', 's2'] },
+    })
+    const improved = withResiduals([{ loc: 'src/foo.ts:1', why: 'equivalent', mutantIds: ['s1', 's2'] }])
+    const outcome = await gatePhase(deps, iterPath, worktreePath, 'src/foo.ts', 0.4, improved)
+    expect(expectOk(outcome).value).toEqual({ afterScore: 0.85, result: improved, capped: true })
+  })
+
+  test('fails the score gate when declared ids are a strict subset of survivors', async () => {
+    const { deps, iterPath, worktreePath } = gateDeps({
+      measured: { score: 0.85, survivingMutantIds: ['s1', 's2'] },
+    })
+    const improved = withResiduals([{ loc: 'src/foo.ts:1', why: 'equivalent', mutantIds: ['s1'] }])
+    const outcome = await gatePhase(deps, iterPath, worktreePath, 'src/foo.ts', 0.4, improved)
+    expect(expectFail(outcome).gate).toBe('score')
+  })
+
+  test('does not cap when the score did not improve, even with full coverage', async () => {
+    const { deps, iterPath, worktreePath } = gateDeps({
+      measured: { score: 0.85, survivingMutantIds: ['s1'] },
+    })
+    const improved = withResiduals([{ loc: 'src/foo.ts:1', why: 'equivalent', mutantIds: ['s1'] }])
+    const outcome = await gatePhase(deps, iterPath, worktreePath, 'src/foo.ts', 0.85, improved)
+    expect(expectFail(outcome).gate).toBe('score')
+  })
+
+  test('at-threshold score passes uncapped even with full residual coverage', async () => {
+    const { deps, iterPath, worktreePath } = gateDeps({
+      measured: { score: 0.97, survivingMutantIds: ['s1'] },
+    })
+    const improved = withResiduals([{ loc: 'src/foo.ts:1', why: 'equivalent', mutantIds: ['s1'] }])
+    const outcome = await gatePhase(deps, iterPath, worktreePath, 'src/foo.ts', 0.4, improved)
+    expect(expectOk(outcome).value).toEqual({ afterScore: 0.97, result: improved, capped: false })
+  })
+})

--- a/tests/mutation-improve/integration-git.test.ts
+++ b/tests/mutation-improve/integration-git.test.ts
@@ -12,6 +12,7 @@ import type { MutationImproveConfig } from '../../mutation-improve/src/config.js
 import { runPipeline, type PipelineDeps } from '../../mutation-improve/src/pipeline.js'
 import type { Result } from '../../mutation-improve/src/result-schema.js'
 import { createRunState } from '../../mutation-improve/src/run-state.js'
+import type { MeasuredScore } from '../../mutation-improve/src/score-reader.js'
 import type { Selection } from '../../mutation-improve/src/selection-schema.js'
 import type { AgentUsage } from '../../review-loop/src/agent-runner.js'
 import {
@@ -47,10 +48,10 @@ const improvedResult: Result = {
 // lives inside a test body (vitest/no-conditional-tests).
 const sequenceMeasure = (scores: readonly number[]): PipelineDeps['measureScore'] => {
   let calls = 0
-  return (): Promise<number> => {
+  return (): Promise<MeasuredScore> => {
     calls += 1
     const idx = Math.min(calls - 1, scores.length - 1)
-    return Promise.resolve(scores[idx] ?? 0)
+    return Promise.resolve({ score: scores[idx] ?? 0, survivingMutantIds: [] })
   }
 }
 
@@ -126,6 +127,7 @@ describe('integration real-git', () => {
       writeBaseline,
       runSelectAgent: () => Promise.resolve({ value: selection, usage: emptyUsage() }),
       runImproveAgent,
+      cappedRegistry: { entries: [], record: () => Promise.resolve() },
       saveRunState: () => Promise.resolve(),
       log: { log: () => undefined },
     }

--- a/tests/mutation-improve/integration.test.ts
+++ b/tests/mutation-improve/integration.test.ts
@@ -12,6 +12,7 @@ import { runFinalize } from '../../mutation-improve/src/finalize.js'
 import { runPipeline, type PipelineDeps } from '../../mutation-improve/src/pipeline.js'
 import type { Result } from '../../mutation-improve/src/result-schema.js'
 import { createRunState } from '../../mutation-improve/src/run-state.js'
+import type { MeasuredScore } from '../../mutation-improve/src/score-reader.js'
 import type { Selection } from '../../mutation-improve/src/selection-schema.js'
 import type { AgentUsage } from '../../review-loop/src/agent-runner.js'
 import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
@@ -40,10 +41,10 @@ const improvedResult: Result = {
 // (above threshold so the iteration ratchets and merges).
 const sequenceMeasure = (scores: readonly number[]): PipelineDeps['measureScore'] => {
   let calls = 0
-  return (): Promise<number> => {
+  return (): Promise<MeasuredScore> => {
     calls += 1
     const idx = Math.min(calls - 1, scores.length - 1)
-    return Promise.resolve(scores[idx] ?? 0)
+    return Promise.resolve({ score: scores[idx] ?? 0, survivingMutantIds: [] })
   }
 }
 
@@ -93,6 +94,7 @@ describe('integration', () => {
       },
       runSelectAgent: () => Promise.resolve({ value: selection, usage: emptyUsage() }),
       runImproveAgent: () => Promise.resolve({ value: improvedResult, usage: emptyUsage() }),
+      cappedRegistry: { entries: [], record: () => Promise.resolve() },
       saveRunState: () => Promise.resolve(),
       log: { log: () => undefined },
     }

--- a/tests/mutation-improve/pipeline.test.ts
+++ b/tests/mutation-improve/pipeline.test.ts
@@ -8,10 +8,12 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import type { BaselineMap } from '../../mutation-improve/src/baseline.js'
+import type { CappedEntry } from '../../mutation-improve/src/capped-registry.js'
 import type { MutationImproveConfig } from '../../mutation-improve/src/config.js'
 import { runIteration, runPipeline, type PipelineDeps } from '../../mutation-improve/src/pipeline.js'
 import type { Result } from '../../mutation-improve/src/result-schema.js'
 import type { MutationImproveRunState } from '../../mutation-improve/src/run-state.js'
+import type { MeasuredScore } from '../../mutation-improve/src/score-reader.js'
 import type { Selection } from '../../mutation-improve/src/selection-schema.js'
 import { agentWritePath, type AgentUsage } from '../../review-loop/src/agent-runner.js'
 import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
@@ -74,15 +76,23 @@ const result: Result = {
 // second, etc. The impl calls measureScore twice per iteration (before/after), so
 // a 2-element array covers one iteration; chaining uses a 4-element array. We
 // clamp to the last element past the end (avoids `??` inside test bodies, which
-// trips vitest/no-conditional-in-test).
-const sequenceMeasure = (scores: readonly number[]): PipelineDeps['measureScore'] => {
+// trips vitest/no-conditional-in-test). Plain numbers map to empty surviving ids.
+const measured = (score: number, survivingMutantIds: readonly string[] = []): MeasuredScore => ({
+  score,
+  survivingMutantIds,
+})
+
+const sequenceMeasureDetailed = (steps: readonly MeasuredScore[]): PipelineDeps['measureScore'] => {
   let calls = 0
-  return (): Promise<number> => {
+  return (): Promise<MeasuredScore> => {
     calls += 1
-    const idx = Math.min(calls - 1, scores.length - 1)
-    return Promise.resolve(scores[idx] ?? 0)
+    const idx = Math.min(calls - 1, steps.length - 1)
+    return Promise.resolve(steps[idx] ?? measured(0))
   }
 }
+
+const sequenceMeasure = (scores: readonly number[]): PipelineDeps['measureScore'] =>
+  sequenceMeasureDetailed(scores.map((score) => measured(score)))
 
 // Sequence-based runSelectAgent fake: returns picks[0] on first call, picks[1] on
 // second, etc. Clamps past the end so we never produce `file: string | undefined`.
@@ -160,6 +170,7 @@ const happyDeps = (): PipelineDeps => {
     },
     runSelectAgent: () => Promise.resolve({ value: selection, usage: emptyUsage() }),
     runImproveAgent: () => Promise.resolve({ value: result, usage: emptyUsage() }),
+    cappedRegistry: { entries: [], record: () => Promise.resolve() },
     saveRunState: () => Promise.resolve(),
     log: { log: () => undefined, issue: undefined },
   }
@@ -245,7 +256,7 @@ describe('pipeline runIteration', () => {
     deps.measureScore = sequenceMeasure([0.46, 0.94])
     deps.runImproveAgent = (): Promise<{ value: Result; usage: AgentUsage }> =>
       Promise.resolve({
-        value: { ...result, residuals: [{ loc: 'L21', why: 'equivalent' }] },
+        value: { ...result, residuals: [{ loc: 'L21', why: 'equivalent', mutantIds: [] }] },
         usage: emptyUsage(),
       })
     const outcome = await runIteration(deps, 1)
@@ -498,6 +509,156 @@ describe('pipeline runIteration', () => {
   })
 })
 
+describe('pipeline capped gate', () => {
+  // The 2026-08-06 mappers.ts pattern: a file whose tests-only ceiling sits
+  // below threshold − ε was attempted 3x in one run, each attempt merged
+  // nothing and forced exit 1. With full residual coverage the runner now
+  // merges at the measured ceiling ('capped') instead of discarding the work.
+  const cappedDeps = (
+    after: MeasuredScore,
+    residuals: Result['residuals'],
+  ): { deps: PipelineDeps; recorded: [string, number][] } => {
+    const deps = happyDeps()
+    deps.measureScore = sequenceMeasureDetailed([measured(0.46), after])
+    deps.runImproveAgent = (): Promise<{ value: Result; usage: AgentUsage }> =>
+      Promise.resolve({ value: { ...result, residuals }, usage: emptyUsage() })
+    const recorded: [string, number][] = []
+    deps.cappedRegistry = {
+      entries: [],
+      record: (file: string, score: number): Promise<void> => {
+        recorded.push([file, score])
+        return Promise.resolve()
+      },
+    }
+    return { deps, recorded }
+  }
+
+  test('below-hatch score with full residual coverage merges as capped and records the cap', async () => {
+    const { deps, recorded } = cappedDeps(measured(0.85, ['s1', 's2']), [
+      { loc: 'src/x.ts:24', why: 'equivalent guard', mutantIds: ['s1', 's2'] },
+    ])
+    const outcome = await runIteration(deps, 1)
+    expect(outcome).toEqual({
+      iter: 1,
+      outcome: 'capped',
+      file: 'src/live-status/tool-status-labels.ts',
+      beforeScore: 0.46,
+      afterScore: 0.85,
+    })
+    expect(deps.runState.merged[0]?.capped).toBe(true)
+    expect(deps.runState.doneSet).toContain('src/live-status/tool-status-labels.ts')
+    expect(deps.runState.failed).toHaveLength(0)
+    const bumped = await deps.readBaseline(deps.config.repoRoot)
+    expect(bumped['src/live-status/tool-status-labels.ts']).toBe(0.85)
+    expect(recorded).toEqual([['src/live-status/tool-status-labels.ts', 0.85]])
+  })
+
+  // The real mappers.ts result.json grouped 9 mutants into 3 per-loc entries;
+  // the union across entries is what must equal the surviving set.
+  test('grouped residual entries cap when their union equals the surviving set', async () => {
+    const { deps } = cappedDeps(measured(0.857, ['2', '3', '4', '6', '16', '17', '18', '20', '37']), [
+      { loc: 'mappers.ts:24', why: 'equivalent null guard', mutantIds: ['2', '3', '4', '6'] },
+      { loc: 'mappers.ts:31', why: 'equivalent null guard', mutantIds: ['16', '17', '18', '20'] },
+      { loc: 'mappers.ts:92', why: 'unreachable fallback', mutantIds: ['37'] },
+    ])
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('capped')
+  })
+
+  test('epsilon-hatch pass stays improved and does NOT record a cap', async () => {
+    const { deps, recorded } = cappedDeps(measured(0.94), [{ loc: 'L21', why: 'equivalent', mutantIds: ['s1'] }])
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('improved')
+    expect(deps.runState.merged[0]?.capped).toBeUndefined()
+    expect(recorded).toEqual([])
+  })
+
+  test('partial residual coverage fails the score gate (not capped)', async () => {
+    const { deps, recorded } = cappedDeps(measured(0.85, ['s1', 's2']), [
+      { loc: 'src/x.ts:24', why: 'equivalent guard', mutantIds: ['s1'] },
+    ])
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('score')
+    expect(deps.runState.merged).toHaveLength(0)
+    expect(recorded).toEqual([])
+  })
+
+  // Set equality, not subset: a declared id that is not an actual survivor
+  // means the agent's bookkeeping is wrong (or padded) — fail closed.
+  test('declared ids naming a non-survivor fail the score gate', async () => {
+    const { deps } = cappedDeps(measured(0.85, ['s1']), [
+      { loc: 'src/x.ts:24', why: 'equivalent guard', mutantIds: ['s1', 's999'] },
+    ])
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('score')
+  })
+
+  // Without the improvement guard an agent could declare residuals over every
+  // survivor of a no-op run and "merge" spec docs that changed nothing.
+  test('full coverage without a score improvement fails the score gate', async () => {
+    const deps = happyDeps()
+    deps.measureScore = sequenceMeasureDetailed([measured(0.85, ['s1']), measured(0.85, ['s1'])])
+    deps.runImproveAgent = (): Promise<{ value: Result; usage: AgentUsage }> =>
+      Promise.resolve({
+        value: { ...result, residuals: [{ loc: 'src/x.ts:24', why: 'equivalent', mutantIds: ['s1'] }] },
+        usage: emptyUsage(),
+      })
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('score')
+  })
+})
+
+describe('pipeline select exclusions', () => {
+  const cappedEntry = (file: string): CappedEntry => ({
+    file,
+    score: 0.85,
+    cappedAt: '2026-08-06T00:00:00.000Z',
+    runId: 'r0',
+  })
+
+  test('select prompt lists this run’s failed files and the capped registry as do-not-pick', async () => {
+    const deps = happyDeps()
+    deps.runState.failed = [{ iter: 1, gate: 'score', reason: 'x', file: 'src/tools/memory.ts' }]
+    deps.cappedRegistry = { entries: [cappedEntry('src/capped.ts')], record: (): Promise<void> => Promise.resolve() }
+    let selectPrompt = ''
+    deps.runSelectAgent = (_worktreePath: string, prompt: string): Promise<{ value: Selection; usage: AgentUsage }> => {
+      selectPrompt = prompt
+      return Promise.resolve({ value: selection, usage: emptyUsage() })
+    }
+    await runIteration(deps, 1)
+    expect(selectPrompt).toContain('src/tools/memory.ts')
+    expect(selectPrompt).toContain('src/capped.ts')
+  })
+
+  test('picking a file that already failed this run is rejected at the select gate', async () => {
+    const deps = happyDeps()
+    deps.runState.failed = [{ iter: 1, gate: 'score', reason: 'x', file: 'src/tools/memory.ts' }]
+    deps.runSelectAgent = (): Promise<{ value: Selection; usage: AgentUsage }> =>
+      Promise.resolve({ value: { ...selection, file: 'src/tools/memory.ts' }, usage: emptyUsage() })
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('select')
+    expect(outcome.reason).toContain('already failed this run')
+  })
+
+  test('picking a capped-registry file is rejected at the select gate', async () => {
+    const deps = happyDeps()
+    deps.cappedRegistry = {
+      entries: [cappedEntry('src/tools/memory.ts')],
+      record: (): Promise<void> => Promise.resolve(),
+    }
+    deps.runSelectAgent = (): Promise<{ value: Selection; usage: AgentUsage }> =>
+      Promise.resolve({ value: { ...selection, file: 'src/tools/memory.ts' }, usage: emptyUsage() })
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('failed')
+    expect(outcome.gate).toBe('select')
+    expect(outcome.reason).toContain('capped')
+  })
+})
+
 describe('pipeline build-fix retry', () => {
   // A failed check:full (e.g. oxfmt on an agent-authored test file) used to burn
   // the whole iteration. The runner now feeds the failed check output back to
@@ -625,6 +786,22 @@ describe('pipeline runPipeline', () => {
     expect(results[0]?.gate).toBe('merge')
     expect(deps.runState.status).toBe('aborted')
     expect(deps.runState.currentIteration).toBe(1)
+  })
+
+  test('capped iteration completes the run without aborting or recording a failure', async () => {
+    const deps = happyDeps()
+    deps.measureScore = sequenceMeasureDetailed([measured(0.46), measured(0.85, ['s1'])])
+    deps.runImproveAgent = (): Promise<{ value: Result; usage: AgentUsage }> =>
+      Promise.resolve({
+        value: { ...result, residuals: [{ loc: 'src/x.ts:24', why: 'equivalent', mutantIds: ['s1'] }] },
+        usage: emptyUsage(),
+      })
+    const { results, aborted } = await runPipeline(deps)
+    expect(aborted).toBe(false)
+    expect(results).toHaveLength(1)
+    expect(results[0]?.outcome).toBe('capped')
+    expect(deps.runState.status).toBe('completed')
+    expect(deps.runState.failed).toHaveLength(0)
   })
 
   test('saves run state after each iteration', async () => {

--- a/tests/mutation-improve/prompt-templates.test.ts
+++ b/tests/mutation-improve/prompt-templates.test.ts
@@ -11,6 +11,8 @@ describe('prompt-templates', () => {
   test('buildSelectPrompt names the output path, the done-set, and the rejection rules', () => {
     const prompt = buildSelectPrompt({
       doneSet: ['src/a.ts'],
+      failedFiles: [],
+      cappedFiles: [],
       baselineSummary: '{"src/b.ts":0.2}',
       outputPath: '/run/iter/1/selection.json',
     })
@@ -18,6 +20,20 @@ describe('prompt-templates', () => {
     expect(prompt).toContain('src/a.ts')
     expect(prompt).toContain('Math.random')
     expect(prompt).toContain('baseline.json')
+  })
+
+  test('buildSelectPrompt lists failed-this-run and capped files as do-not-pick, with ceilings', () => {
+    const prompt = buildSelectPrompt({
+      doneSet: [],
+      failedFiles: ['src/failed.ts'],
+      cappedFiles: [{ file: 'src/capped.ts', score: 0.857, cappedAt: '2026-08-06T00:00:00.000Z', runId: 'r0' }],
+      baselineSummary: '{"src/failed.ts":0.2,"src/capped.ts":0.8}',
+      outputPath: '/run/iter/1/selection.json',
+    })
+    expect(prompt).toContain('src/failed.ts')
+    expect(prompt).toContain('attempted and FAILED this run')
+    expect(prompt).toContain('src/capped.ts')
+    expect(prompt).toContain('0.857')
   })
 
   test('buildImprovePrompt states the no-src and no-baseline hard constraints and the exact-equality discipline', () => {
@@ -66,5 +82,47 @@ describe('prompt-templates', () => {
     expect(prompt).toContain('MUST NOT edit anything under src/')
     expect(prompt).toContain('ONLY under tests/ and docs/superpowers/')
     expect(prompt).toContain('/wt/.review-loop/result.json')
+  })
+
+  // Without mutantIds the runner cannot set-match declared residuals against
+  // its own measured survivors, so a structurally-capped file keeps failing
+  // the score gate and being re-picked (the 2026-08-06 mappers.ts loop).
+  test('buildImprovePrompt requires residual mutantIds and explains the capped path', () => {
+    const prompt = buildImprovePrompt({
+      file: 'src/foo.ts',
+      beforeScore: 0.3,
+      threshold: 0.95,
+      date: '2026-08-05',
+      outputPath: '/run/iter/1/result.json',
+    })
+    expect(prompt).toContain('mutantIds')
+    expect(prompt).toContain('capped')
+  })
+
+  test('buildFixPrompt result schema line includes mutantIds', () => {
+    const prompt = buildFixPrompt({
+      file: 'src/foo.ts',
+      attempt: 1,
+      maxAttempts: 2,
+      buildOutput: '✗ test failed',
+      outputPath: '/wt/.review-loop/result.json',
+    })
+    expect(prompt).toContain('mutantIds')
+  })
+
+  // The 2026-08-06 iter-8 work was discarded at the ratchet commit because the
+  // agent's spec/plan .md files lacked the HTML-comment header — the prompt
+  // only said "SPDX headers" and the agent guessed the // style.
+  test('buildImprovePrompt spells out the HTML-comment license header for .md files', () => {
+    const prompt = buildImprovePrompt({
+      file: 'src/foo.ts',
+      beforeScore: 0.3,
+      threshold: 0.95,
+      date: '2026-08-05',
+      outputPath: '/run/iter/1/result.json',
+    })
+    expect(prompt).toContain('<!--')
+    expect(prompt).toContain('SPDX-License-Identifier: BUSL-1.1')
+    expect(prompt).toContain('-->')
   })
 })

--- a/tests/mutation-improve/run-state.test.ts
+++ b/tests/mutation-improve/run-state.test.ts
@@ -71,4 +71,23 @@ describe('run-state', () => {
     expect(() => PersistedRunStateSchema.parse(valid)).not.toThrow()
     expect(() => PersistedRunStateSchema.parse({ ...valid, status: 'bogus' })).toThrow()
   })
+
+  test('merged entries round-trip the optional capped flag; absent on pre-capped states', async () => {
+    const entry = {
+      file: 'src/a.ts',
+      beforeScore: 0.3,
+      afterScore: 0.85,
+      iter: 1,
+      specPath: 's.md',
+      planPath: 'p.md',
+    }
+    const repoRoot = makeTempDir('rs-')
+    const config = baseConfig(repoRoot, path.join(repoRoot, '.mutation-improve'))
+    const created = await createRunState(config)
+    created.merged = [{ ...entry, capped: true }, entry]
+    await saveRunState(created)
+    const reloaded = await loadRunState(config.workDir, created.runId)
+    expect(reloaded.merged[0]?.capped).toBe(true)
+    expect(reloaded.merged[1]?.capped).toBeUndefined()
+  })
 })

--- a/tests/mutation-improve/score-reader.test.ts
+++ b/tests/mutation-improve/score-reader.test.ts
@@ -15,10 +15,10 @@ const reportWith = (killed: number, survived: number, noCoverage = 0, timeout = 
   files: {
     'src/foo.ts': {
       mutants: [
-        ...Array.from({ length: killed }, () => ({ status: 'Killed' })),
-        ...Array.from({ length: survived }, () => ({ status: 'Survived' })),
-        ...Array.from({ length: noCoverage }, () => ({ status: 'NoCoverage' })),
-        ...Array.from({ length: timeout }, () => ({ status: 'Timeout' })),
+        ...Array.from({ length: killed }, (_, i) => ({ id: `k${i}`, status: 'Killed' })),
+        ...Array.from({ length: survived }, (_, i) => ({ id: `s${i}`, status: 'Survived' })),
+        ...Array.from({ length: noCoverage }, (_, i) => ({ id: `n${i}`, status: 'NoCoverage' })),
+        ...Array.from({ length: timeout }, (_, i) => ({ id: `t${i}`, status: 'Timeout' })),
       ],
     },
   },
@@ -36,16 +36,27 @@ describe('score-reader', () => {
     )
   })
 
-  test('measureMutationScore reads the report after exec and returns (killed+timeout)/scored', async () => {
+  test('measureMutationScore reads the report after exec and returns (killed+timeout)/scored plus surviving ids', async () => {
     // 8 killed / (8+2) scored = 0.8
     const exec = mock(successfulExec)
-    const score = await measureMutationScore(
+    const measured = await measureMutationScore(
       { exec, readReport: () => reportWith(8, 2) },
       'reports/paired',
       'src/foo.ts',
     )
     expect(exec).toHaveBeenCalledTimes(1)
-    expect(score).toBeCloseTo(0.8, 5)
+    expect(measured.score).toBeCloseTo(0.8, 5)
+    expect(measured.survivingMutantIds).toEqual(['s0', 's1'])
+  })
+
+  test('measureMutationScore includes NoCoverage ids among the surviving ids', async () => {
+    const measured = await measureMutationScore(
+      { exec: successfulExec, readReport: () => reportWith(7, 1, 2) },
+      'reports/paired',
+      'src/foo.ts',
+    )
+    expect(measured.score).toBeCloseTo(0.7, 5)
+    expect(measured.survivingMutantIds).toEqual(['s0', 'n0', 'n1'])
   })
 
   test('measureMutationScore retries exec once when the report read throws ReportReadError, then succeeds', async () => {
@@ -53,9 +64,10 @@ describe('score-reader', () => {
     const readReport = mock((): StrykerReport => reportWith(10, 0)).mockImplementationOnce((): StrykerReport => {
       throw new ReportReadError('shape')
     })
-    const score = await measureMutationScore({ exec, readReport }, 'reports/paired', 'src/foo.ts')
+    const measured = await measureMutationScore({ exec, readReport }, 'reports/paired', 'src/foo.ts')
     expect(exec).toHaveBeenCalledTimes(2)
-    expect(score).toBe(1)
+    expect(measured.score).toBe(1)
+    expect(measured.survivingMutantIds).toEqual([])
   })
 
   test('measureMutationScore throws when exec exits non-zero, even if a stale report exists', async () => {
@@ -91,9 +103,9 @@ describe('score-reader', () => {
     const readReport = mock((): StrykerReport => reportWith(6, 0)).mockImplementationOnce((): StrykerReport => {
       throw enoent
     })
-    const score = await measureMutationScore({ exec, readReport }, 'reports/paired', 'src/foo.ts')
+    const measured = await measureMutationScore({ exec, readReport }, 'reports/paired', 'src/foo.ts')
     expect(exec).toHaveBeenCalledTimes(2)
-    expect(score).toBe(1)
+    expect(measured.score).toBe(1)
   })
 
   test('measureMutationScore does NOT retry on a plain (non-typed, non-ENOENT) error and propagates it', async () => {

--- a/tests/plugins/task-provider-youtrack/classify-error.test.ts
+++ b/tests/plugins/task-provider-youtrack/classify-error.test.ts
@@ -282,4 +282,341 @@ describe('classifyYouTrackError', () => {
       expect(result.appError).toEqual(systemError.networkError('fetch failed'))
     })
   })
+
+  describe('isYouTrackErrorBody body validation', () => {
+    test('falls back to constructor message when a known key holds a non-string value', () => {
+      const error = new YouTrackApiError('Constructor message', 500, { error: 123 })
+      const result = classifyYouTrackError(error)
+      expect(result.message).toBe('Constructor message')
+      expect(result.appError.code).toBe('unexpected')
+    })
+
+    test('does not throw and falls back when body is null', () => {
+      const error = new YouTrackApiError('Constructor message', 500, null)
+      const result = classifyYouTrackError(error)
+      expect(result.message).toBe('Constructor message')
+      expect(result.appError.code).toBe('unexpected')
+    })
+
+    test('keeps a body valid when a foreign key holds a non-string value', () => {
+      const error = new YouTrackApiError('Constructor message', 500, { error: 'Body message', extra: 9 })
+      const result = classifyYouTrackError(error)
+      expect(result.message).toBe('Body message')
+    })
+
+    test('prefers error_description over error and constructor message', () => {
+      const error = new YouTrackApiError('Constructor message', 401, {
+        error_description: 'Descriptive message',
+        error: 'Short error',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.message).toBe('Descriptive message')
+    })
+
+    test('falls back to error when error_description is absent', () => {
+      const error = new YouTrackApiError('Constructor message', 401, { error: 'Short error' })
+      const result = classifyYouTrackError(error)
+      expect(result.message).toBe('Short error')
+    })
+
+    test('treats a non-string error_description value as an invalid body', () => {
+      const error = new YouTrackApiError('Constructor message', 500, { error_description: 123 })
+      const result = classifyYouTrackError(error)
+      expect(result.message).toBe('Constructor message')
+    })
+
+    test('uses error when error_description is explicitly undefined', () => {
+      const error = new YouTrackApiError('Constructor message', 500, {
+        error_description: undefined,
+        error: 'Body error',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.message).toBe('Body error')
+    })
+
+    test('treats a non-string error_type value as an invalid body even when error is present', () => {
+      const error = new YouTrackApiError('Constructor message', 500, {
+        error_type: 123,
+        error: 'Body message',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.message).toBe('Constructor message')
+    })
+
+    test('treats a non-string error_rule_name value as an invalid body on the 400 path', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_type: 'workflow',
+        error_rule_name: 123,
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError.code).toBe('validation-failed')
+    })
+  })
+
+  describe('normalizeFieldName cleaning', () => {
+    test('trims surrounding whitespace from a field name', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'required field:    Spaced    ',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [{ name: 'Spaced' }])
+    })
+
+    test('strips surrounding quotes from a field name', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'required field: "Quoted"',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [{ name: 'Quoted' }])
+    })
+
+    test('strips every layer of surrounding quotes and whitespace', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: "required fields: ''URL''",
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [{ name: 'URL' }])
+    })
+
+    test('collapses internal double spaces to a single space', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'required field: double  space',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [{ name: 'double space' }])
+    })
+
+    test('drops a name that is empty after trimming', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'required fields:    ',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [])
+    })
+  })
+
+  describe('normalizeFieldName stopword filter', () => {
+    test('drops the stopword "field"', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'required field: field',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [])
+    })
+
+    test('drops the stopword "fields"', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'required field: fields',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [])
+    })
+
+    test('drops the stopword "custom field"', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'required field: custom field',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [])
+    })
+
+    test('drops the stopword "custom fields"', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'required field: custom fields',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [])
+    })
+
+    test('matches stopwords case-insensitively via toLowerCase', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'required field: Field',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [])
+    })
+  })
+
+  describe('appendFieldNames separator rewrite', () => {
+    test('splits a list joined by " and " into separate names', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'required fields: Alpha and Beta',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [{ name: 'Alpha' }, { name: 'Beta' }])
+    })
+  })
+
+  describe('extractRequiredFields pattern matching', () => {
+    test('harvests fields from the error_rule_name candidate', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_rule_name: 'required field: FromRule',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [{ name: 'FromRule' }])
+    })
+
+    test('matches the "requires these custom fields:" list pattern', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'requires these custom fields: URL, Name',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [{ name: 'URL' }, { name: 'Name' }])
+    })
+
+    test('matches the "requires these custom fields:" list with no space after the colon', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'requires these custom fields:URL, Name',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [{ name: 'URL' }, { name: 'Name' }])
+    })
+
+    test('matches the singular "required field:" pattern', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'required field: Solo',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [{ name: 'Solo' }])
+    })
+
+    test('matches the singular "required field:" pattern with no space after the colon', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'required field:Solo',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [{ name: 'Solo' }])
+    })
+
+    test('matches the plural "required fields:" pattern', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'required fields: Aaa, Bbb',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [{ name: 'Aaa' }, { name: 'Bbb' }])
+    })
+
+    test('matches the unquoted "field X is required" pattern', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'field URL is required',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [{ name: 'URL' }])
+    })
+
+    test('does not run the quoted fallback once a primary pattern matched', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'requires these custom fields: Primary. Fill "Extra"',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [{ name: 'Primary' }])
+    })
+
+    test('quoted fallback tolerates an absent error_description candidate', () => {
+      const error = new YouTrackApiError('fill "Msg"', 400, { error_type: 'workflow' })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [{ name: 'Msg' }])
+    })
+
+    test('field-is-required path drops a captured stopword name', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'field custom field is required',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [])
+    })
+
+    test('quoted fallback drops a captured stopword name', () => {
+      const error = new YouTrackApiError('fill "field" please', 400, { error_type: 'workflow' })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('requiredFields', [])
+    })
+  })
+
+  describe('classifyWorkflowValidationError context', () => {
+    test('preserves the provided projectId', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'requires these custom fields: X',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error, { projectId: 'PROJ-9' })
+      expect(result.appError).toHaveProperty('projectId', 'PROJ-9')
+    })
+
+    test('falls back to projectId "unknown" when no context is given', () => {
+      const error = new YouTrackApiError('Bad request', 400, {
+        error_description: 'requires these custom fields: X',
+        error_type: 'workflow',
+      })
+      const result = classifyYouTrackError(error)
+      expect(result.appError).toHaveProperty('projectId', 'unknown')
+    })
+  })
+
+  describe('classifyApiError 400 invalid body', () => {
+    test('classifies a 400 with an invalid body as validation-failed without throwing', () => {
+      const error = new YouTrackApiError('Bad request', 400, { error_description: 123 })
+      const result = classifyYouTrackError(error)
+      expect(result.appError.code).toBe('validation-failed')
+    })
+  })
+
+  describe('classifyNotFoundError context fallbacks', () => {
+    test('falls back to projectId "unknown" when no context is given', () => {
+      const error = new YouTrackApiError('Project not found', 404, {})
+      const result = classifyYouTrackError(error)
+      expect(result.appError.code).toBe('project-not-found')
+      expect(result.appError).toHaveProperty('projectId', 'unknown')
+    })
+
+    test('falls back to commentId "unknown" when no context is given', () => {
+      const error = new YouTrackApiError('Comment not found', 404, {})
+      const result = classifyYouTrackError(error)
+      expect(result.appError.code).toBe('comment-not-found')
+      expect(result.appError).toHaveProperty('commentId', 'unknown')
+    })
+
+    test('falls back to labelName "unknown" when no context is given', () => {
+      const error = new YouTrackApiError('Tag not found', 404, {})
+      const result = classifyYouTrackError(error)
+      expect(result.appError.code).toBe('label-not-found')
+      expect(result.appError).toHaveProperty('labelName', 'unknown')
+    })
+
+    test('falls back to resourceId "unknown" for a saved query without context', () => {
+      const error = new YouTrackApiError('saved query not found', 404, {})
+      const result = classifyYouTrackError(error)
+      expect(result.appError.code).toBe('not-found')
+      expect(result.appError).toHaveProperty('resourceType', 'Saved query')
+      expect(result.appError).toHaveProperty('resourceId', 'unknown')
+    })
+  })
+
+  describe('YouTrackClassifiedError name', () => {
+    test('sets the error name to YouTrackClassifiedError', () => {
+      const error = new YouTrackApiError('Issue not found', 404, {})
+      const result = classifyYouTrackError(error, { taskId: 'T-1' })
+      expect(result.name).toBe('YouTrackClassifiedError')
+    })
+  })
 })

--- a/tests/plugins/task-provider-youtrack/due-date.test.ts
+++ b/tests/plugins/task-provider-youtrack/due-date.test.ts
@@ -5,14 +5,37 @@
 
 import { describe, expect, test } from 'bun:test'
 
+import { YouTrackClassifiedError } from '../../../plugins/task-provider-youtrack/classify-error.js'
 import {
+  DueDateCustomFieldSchema,
   mapYouTrackDueDateValue,
   normalizeYouTrackDueDateInput,
   normalizeYouTrackListTaskParams,
   parseDueDateValue,
 } from '../../../plugins/task-provider-youtrack/due-date.js'
 
+const captureValidationFailure = (fn: () => unknown): { message: string; field: string; reason: string } => {
+  try {
+    fn()
+  } catch (error) {
+    if (!(error instanceof YouTrackClassifiedError)) throw error
+    const appError = error.appError
+    if (appError.code !== 'validation-failed') {
+      throw new Error(`expected validation-failed appError, got ${appError.code}`, { cause: error })
+    }
+    return { message: error.message, field: appError.field, reason: appError.reason }
+  }
+  throw new Error('expected parseDueDateValue to throw YouTrackClassifiedError')
+}
+
 describe('YouTrack due-date helpers', () => {
+  describe('DueDateCustomFieldSchema', () => {
+    test('rejects an object missing name', () => {
+      const result = DueDateCustomFieldSchema.safeParse({})
+      expect(result.success).toBe(false)
+    })
+  })
+
   describe('normalizeYouTrackDueDateInput', () => {
     test('returns date-only', () => {
       const result = normalizeYouTrackDueDateInput({ date: '2024-03-15', time: '14:30' })
@@ -30,6 +53,11 @@ describe('YouTrack due-date helpers', () => {
       const result = mapYouTrackDueDateValue(Date.parse('2024-03-15T12:00:00.000Z'))
       expect(result).toBe('2024-03-15')
     })
+
+    test('returns undefined for null and undefined', () => {
+      expect(mapYouTrackDueDateValue(null)).toBe(undefined)
+      expect(mapYouTrackDueDateValue(undefined)).toBe(undefined)
+    })
   })
 
   describe('parseDueDateValue', () => {
@@ -42,6 +70,44 @@ describe('YouTrack due-date helpers', () => {
       const result = parseDueDateValue('2024-03-15T23:45:00+02:00')
       expect(new Date(result).toISOString()).toBe('2024-03-15T12:00:00.000Z')
     })
+
+    test('rejects input that is neither a calendar date nor an ISO datetime', () => {
+      const failure = captureValidationFailure(() => parseDueDateValue('abc2024-03-15'))
+      expect(failure.message).toBe('Invalid dueDate: abc2024-03-15')
+      expect(failure.field).toBe('dueDate')
+      expect(failure.reason).toBe('Expected YYYY-MM-DD or an ISO datetime with timezone information')
+    })
+
+    test('rejects an ISO datetime with a non-date prefix', () => {
+      const failure = captureValidationFailure(() => parseDueDateValue('abc2024-03-15T23:45:00+02:00'))
+      expect(failure.message).toBe('Invalid dueDate: abc2024-03-15T23:45:00+02:00')
+      expect(failure.field).toBe('dueDate')
+      expect(failure.reason).toBe('Expected YYYY-MM-DD or an ISO datetime with timezone information')
+    })
+
+    test('rejects an ISO datetime with a trailing suffix', () => {
+      const failure = captureValidationFailure(() => parseDueDateValue('2024-03-15T23:45:00+02:00abc'))
+      expect(failure.message).toBe('Invalid dueDate: 2024-03-15T23:45:00+02:00abc')
+      expect(failure.field).toBe('dueDate')
+      expect(failure.reason).toBe('Expected YYYY-MM-DD or an ISO datetime with timezone information')
+    })
+
+    test('accepts an ISO datetime without seconds', () => {
+      const result = parseDueDateValue('2024-03-15T23:45+02:00')
+      expect(result).toBe(Date.parse('2024-03-15T12:00:00.000Z'))
+    })
+
+    test('accepts an ISO datetime with three-digit fractional seconds', () => {
+      const result = parseDueDateValue('2024-03-15T23:45:00.123+02:00')
+      expect(result).toBe(Date.parse('2024-03-15T12:00:00.000Z'))
+    })
+
+    test('rejects a date-shaped but non-calendar value', () => {
+      const failure = captureValidationFailure(() => parseDueDateValue('2024-02-30'))
+      expect(failure.message).toBe('Invalid dueDate: 2024-02-30')
+      expect(failure.field).toBe('dueDate')
+      expect(failure.reason).toBe('Expected a real calendar date in YYYY-MM-DD format')
+    })
   })
 
   describe('normalizeYouTrackListTaskParams', () => {
@@ -52,6 +118,17 @@ describe('YouTrack due-date helpers', () => {
       })
       expect(result.dueAfter).toBe('2024-03-15')
       expect(result.dueBefore).toBe('2024-03-20')
+    })
+
+    test('leaves undefined filters undefined', () => {
+      const result = normalizeYouTrackListTaskParams({})
+      expect(result.dueAfter).toBe(undefined)
+      expect(result.dueBefore).toBe(undefined)
+    })
+
+    test('slices a prefixed filter that is not a clean date', () => {
+      const result = normalizeYouTrackListTaskParams({ dueAfter: 'abc2024-03-15' })
+      expect(result.dueAfter).toBe('abc2024-03')
     })
   })
 })

--- a/tests/plugins/task-provider-youtrack/query-builder.test.ts
+++ b/tests/plugins/task-provider-youtrack/query-builder.test.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { buildYouTrackQuery } from '../../../plugins/task-provider-youtrack/query-builder.js'
+
+describe('buildYouTrackQuery', () => {
+  test('emits only a lower due-date bound when dueAfter is set without dueBefore', () => {
+    expect(buildYouTrackQuery({ dueAfter: '2026-01-01' }, 'DEMO')).toBe('project: {DEMO} Due date: >2026-01-01')
+  })
+
+  test('emits only an upper due-date bound when dueBefore is set without dueAfter', () => {
+    expect(buildYouTrackQuery({ dueBefore: '2026-01-31' }, 'DEMO')).toBe('project: {DEMO} Due date: <2026-01-31')
+  })
+
+  test('rewrites a createdAt sort field to the YouTrack created field', () => {
+    expect(buildYouTrackQuery({ sortBy: 'createdAt', sortOrder: 'desc' }, 'DEMO')).toBe(
+      'project: {DEMO} sort by: created desc',
+    )
+  })
+
+  test('defaults the sort order to asc when sortBy is set without sortOrder', () => {
+    expect(buildYouTrackQuery({ sortBy: 'priority' }, 'DEMO')).toBe('project: {DEMO} sort by: priority asc')
+  })
+})

--- a/tests/review-loop/live-format.test.ts
+++ b/tests/review-loop/live-format.test.ts
@@ -6,11 +6,13 @@
 import { describe, expect, test } from 'bun:test'
 
 import {
+  activitySummary,
   formatDuration,
   formatLiveLine,
   formatStepFooter,
   formatTokenCount,
   formatToolArg,
+  truncate,
 } from '../../review-loop/src/live-format.js'
 
 describe('formatDuration', () => {
@@ -21,6 +23,20 @@ describe('formatDuration', () => {
   test('formats minutes and seconds', () => {
     expect(formatDuration(125000)).toBe('2m05s')
   })
+  test('60s boundary uses minute format', () => {
+    expect(formatDuration(60_000)).toBe('1m00s')
+  })
+})
+
+describe('truncate', () => {
+  test('non-positive max returns empty', () => {
+    expect(truncate('abc', 0)).toBe('')
+    expect(truncate('abc', -2)).toBe('')
+  })
+  test('value at exactly max length is returned unchanged', () => {
+    expect(truncate('abcd', 4)).toBe('abcd')
+    expect(truncate('abc', 3)).toBe('abc')
+  })
 })
 
 describe('formatToolArg', () => {
@@ -28,20 +44,53 @@ describe('formatToolArg', () => {
     expect(formatToolArg('read', { filePath: '/a/b/cli.ts' })).toBe('cli.ts')
     expect(formatToolArg('edit', { path: '/a/b/src/x.ts' })).toBe('x.ts')
   })
+  test('write resolves filePath basename', () => {
+    expect(formatToolArg('write', { filePath: '/a/b/x.ts' })).toBe('x.ts')
+  })
+  test('read returns empty when filePath resolves to empty', () => {
+    expect(formatToolArg('read', { filePath: '' })).toBe('')
+  })
   test('bash truncates command', () => {
     expect(formatToolArg('bash', { command: 'echo hi' })).toBe('echo hi')
     const long = 'x'.repeat(60)
     expect(formatToolArg('bash', { command: long })).toHaveLength(40)
   })
+  test('bash ignores non-command string values', () => {
+    expect(formatToolArg('bash', { a: 'firstval', command: 'echo hi' })).toBe('echo hi')
+  })
   test('grep/glob use pattern', () => {
     expect(formatToolArg('grep', { pattern: 'TODO' })).toBe('TODO')
+  })
+  test('grep ignores non-pattern string values', () => {
+    expect(formatToolArg('grep', { a: 'firstval', pattern: 'TODO' })).toBe('TODO')
+  })
+  test('glob ignores non-pattern string values', () => {
+    expect(formatToolArg('glob', { a: 'firstval', pattern: '**/*.ts' })).toBe('**/*.ts')
   })
   test('task uses description then subagent_type', () => {
     expect(formatToolArg('task', { description: 'find files' })).toBe('find files')
     expect(formatToolArg('task', { subagent_type: 'explore' })).toBe('explore')
   })
+  test('task prioritizes description over an earlier subagent_type', () => {
+    expect(formatToolArg('task', { subagent_type: 'explore', description: 'find files' })).toBe('find files')
+  })
+  test('task skips empty description and falls back to subagent_type', () => {
+    expect(formatToolArg('task', { description: '', subagent_type: 'explore' })).toBe('explore')
+  })
   test('fallback uses first string value', () => {
     expect(formatToolArg('custom', { a: 'hello', b: 'world' })).toBe('hello')
+  })
+  test('fallback skips empty first value', () => {
+    expect(formatToolArg('custom', { a: '', b: 'world' })).toBe('world')
+  })
+  test('fallback skips non-string first value', () => {
+    expect(formatToolArg('custom', { a: [1], b: 'world' })).toBe('world')
+  })
+  test('non-record input falls back to empty', () => {
+    expect(formatToolArg('custom', 'hello')).toBe('')
+  })
+  test('null input does not throw and falls back to empty', () => {
+    expect(formatToolArg('custom', null)).toBe('')
   })
   test('empty input yields empty string', () => {
     expect(formatToolArg('read', {})).toBe('')
@@ -57,11 +106,16 @@ describe('formatLiveLine', () => {
     expect(line).toContain('42s')
     expect(line).toContain('3 tools')
   })
-  test('singular tool count', () => {
-    expect(formatLiveLine('reviewer', 'read', 'a.ts', 1000, 1)).toContain('1 tool')
-  })
   test('no tool yet shows thinking', () => {
     expect(formatLiveLine('reviewer', '', '', 2000, 0)).toContain('thinking')
+  })
+  test('renders exact line with singular tool count', () => {
+    expect(formatLiveLine('reviewer', 'read', 'a.ts', 1000, 1)).toBe(
+      `  reviewer   \u25B6 read a.ts \u00B7 1s \u00B7 1 tool`,
+    )
+  })
+  test('renders exact line when arg is empty', () => {
+    expect(formatLiveLine('fixer', 'edit', '', 5000, 2)).toBe(`  fixer      \u25B6 edit \u00B7 5s \u00B7 2 tools`)
   })
 })
 
@@ -73,6 +127,11 @@ describe('formatStepFooter', () => {
     expect(footer).toContain('4 tools')
     expect(footer).toContain('in 13373 / out 31')
   })
+  test('renders exact footer with singular tool count', () => {
+    expect(formatStepFooter('reviewer', 18000, 1, { input: 13373, output: 31 })).toBe(
+      `  reviewer \u2713 18s \u00B7 1 tool \u00B7 in 13373 / out 31`,
+    )
+  })
 })
 
 describe('formatTokenCount', () => {
@@ -82,5 +141,30 @@ describe('formatTokenCount', () => {
     expect(formatTokenCount(9824)).toBe('9.8k')
     expect(formatTokenCount(228819)).toBe('228.8k')
     expect(formatTokenCount(1500000)).toBe('1.50M')
+  })
+  test('million boundary uses M suffix', () => {
+    expect(formatTokenCount(1_000_000)).toBe('1.00M')
+  })
+})
+
+describe('activitySummary', () => {
+  test('empty input returns empty string', () => {
+    expect(activitySummary([])).toBe('')
+  })
+  test('maps known role bases to verbs', () => {
+    expect(activitySummary(['reviewer'])).toBe('review')
+    expect(activitySummary(['matcher'])).toBe('match')
+    expect(activitySummary(['fixer'])).toBe('fix')
+    expect(activitySummary(['inspector'])).toBe('inspect')
+    expect(activitySummary(['build'])).toBe('build')
+  })
+  test('multiple occurrences append a count', () => {
+    expect(activitySummary(['reviewer', 'reviewer', 'fixer'])).toBe(`review\u00D72+fix`)
+  })
+  test('joins distinct verbs with plus', () => {
+    expect(activitySummary(['reviewer', 'fixer'])).toBe('review+fix')
+  })
+  test('unknown base uses the base itself', () => {
+    expect(activitySummary(['unknownrole'])).toBe('unknownrole')
   })
 })

--- a/tests/scripts/check.test.ts
+++ b/tests/scripts/check.test.ts
@@ -302,6 +302,73 @@ describe('check.sh --skip-tests', () => {
 })
 
 describe('check.sh full mode', () => {
+  // The mutation-improve build gate runs full mode in a worktree where the
+  // agent's spec/plan/test files are NEW (untracked). Enumerating only
+  // `git ls-files` (tracked) made them invisible until the pre-commit hook's
+  // --staged mode rejected them at `git commit`, discarding passed iterations.
+  test('flags headerless untracked docs files (the worktree new-file gap)', () => {
+    const { repoDir, binDir, logFile } = createTempRepo()
+
+    try {
+      mkdirSync(path.join(repoDir, 'docs'), { recursive: true })
+      writeFileSync(path.join(repoDir, 'docs', 'new-doc.md'), '# Doc without a license header\n')
+
+      const env = createEnv({
+        PATH: `${binDir}:${basePath}`,
+        CHECK_LOG_FILE: logFile,
+      })
+      const result = runCommand(repoDir, ['bash', 'scripts/check.sh'], env)
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stdout).toContain('Missing BUSL-1.1 license header')
+      expect(result.stdout).toContain('docs/new-doc.md')
+    } finally {
+      rmSync(repoDir, { recursive: true, force: true })
+    }
+  })
+
+  test('still flags headerless tracked docs files', () => {
+    const { repoDir, binDir, logFile } = createTempRepo()
+
+    try {
+      mkdirSync(path.join(repoDir, 'docs'), { recursive: true })
+      writeFileSync(path.join(repoDir, 'docs', 'tracked.md'), '# Doc without a license header\n')
+      expectSuccess(runCommand(repoDir, ['git', 'add', 'docs/tracked.md']))
+
+      const env = createEnv({
+        PATH: `${binDir}:${basePath}`,
+        CHECK_LOG_FILE: logFile,
+      })
+      const result = runCommand(repoDir, ['bash', 'scripts/check.sh'], env)
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stdout).toContain('docs/tracked.md')
+    } finally {
+      rmSync(repoDir, { recursive: true, force: true })
+    }
+  })
+
+  test('does not flag gitignored untracked files', () => {
+    const { repoDir, binDir, logFile } = createTempRepo()
+
+    try {
+      writeFileSync(path.join(repoDir, '.gitignore'), 'docs/ignored.md\n')
+      mkdirSync(path.join(repoDir, 'docs'), { recursive: true })
+      writeFileSync(path.join(repoDir, 'docs', 'ignored.md'), '# Generated doc without a license header\n')
+
+      const env = createEnv({
+        PATH: `${binDir}:${basePath}`,
+        CHECK_LOG_FILE: logFile,
+      })
+      const result = runCommand(repoDir, ['bash', 'scripts/check.sh'], env)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).not.toContain('docs/ignored.md')
+    } finally {
+      rmSync(repoDir, { recursive: true, force: true })
+    }
+  })
+
   test('runs the server test suite serially when CI=true', () => {
     const { repoDir, binDir, logFile } = createTempRepo()
 

--- a/tests/scripts/mutation/score-merger.test.ts
+++ b/tests/scripts/mutation/score-merger.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, test } from 'bun:test'
 
-import { mergeReports } from '../../../scripts/mutation/score-merger.js'
+import { mergeReports, survivingMutantIds } from '../../../scripts/mutation/score-merger.js'
 import type { StrykerReport } from '../../../scripts/mutation/score-merger.js'
 
 const makeReport = (statuses: string[]): StrykerReport => ({
@@ -97,5 +97,43 @@ describe('mergeReports', () => {
     const out = mergeReports([makeReport(['Killed', 'WeirdNewBucket'])])
     expect(out.killed).toBe(1)
     expect(out.runtimeError).toBe(1)
+  })
+})
+
+describe('survivingMutantIds', () => {
+  test('returns ids of Survived and NoCoverage mutants only, since both count against the score', () => {
+    const ids = survivingMutantIds(makeReport(['Killed', 'Survived', 'NoCoverage', 'Timeout', 'Ignored']))
+    expect(ids).toEqual(['m1', 'm2'])
+  })
+
+  test('unions ids across all files in the report', () => {
+    const report: StrykerReport = {
+      files: {
+        'src/a.ts': { mutants: [{ id: 'a1', status: 'Survived' }] },
+        'src/b.ts': {
+          mutants: [
+            { id: 'b1', status: 'NoCoverage' },
+            { id: 'b2', status: 'Killed' },
+          ],
+        },
+      },
+    }
+    expect(survivingMutantIds(report)).toEqual(['a1', 'b1'])
+  })
+
+  test('returns an empty list for missing fields, empty reports, and all-killed reports', () => {
+    expect(survivingMutantIds({})).toEqual([])
+    expect(survivingMutantIds({ files: { 'src/x.ts': {} } })).toEqual([])
+    expect(survivingMutantIds(makeReport(['Killed', 'Timeout']))).toEqual([])
+  })
+
+  // A survivor without an id can never be matched against an agent-declared
+  // residual, so it must be excluded here; the pipeline's set-equality check
+  // then fails closed (not capped) instead of silently ignoring it.
+  test('skips mutants without a string id', () => {
+    const report: StrykerReport = {
+      files: { 'src/x.ts': { mutants: [{ status: 'Survived' }, { id: 'x1', status: 'Survived' }] } },
+    }
+    expect(survivingMutantIds(report)).toEqual(['x1'])
   })
 })


### PR DESCRIPTION
## mutation-improve

| File | Before | After | Spec | Plan |
|---|---|---|---|---|
| src/analytics/intent/classifier.ts | 0.4581818181818182 | 0.9672727272727273 | docs/superpowers/specs/2026-08-06-mutation-coverage-classifier-design.md | docs/superpowers/plans/2026-08-06-mutation-coverage-classifier.md |
| plugins/task-provider-youtrack/due-date.ts | 0.6914893617021277 | 0.925531914893617 | docs/superpowers/specs/2026-08-06-mutation-coverage-due-date-design.md | docs/superpowers/plans/2026-08-06-mutation-coverage-due-date.md |
| plugins/task-provider-youtrack/classify-error.ts | 0.6181818181818182 | 0.9490909090909091 | docs/superpowers/specs/2026-08-06-mutation-coverage-classify-error-design.md | docs/superpowers/plans/2026-08-06-mutation-coverage-classify-error.md |
| review-loop/src/live-format.ts | 0.75 | 0.9871794871794872 | docs/superpowers/specs/2026-08-06-mutation-coverage-live-format-design.md | docs/superpowers/plans/2026-08-06-mutation-coverage-live-format.md |
| plugins/task-provider-youtrack/query-builder.ts | 0.8 | 1 | docs/superpowers/specs/2026-08-06-mutation-coverage-query-builder-design.md | docs/superpowers/plans/2026-08-06-mutation-coverage-query-builder.md |

## Failed iterations

| Iter | Gate | Reason |
|---|---|---|
| 4 | score | afterScore 0.8571428571428571 < threshold 0.9 |
| 7 | score | afterScore 0.8571428571428571 < threshold 0.9 |
| 8 | exception | Command failed: git commit --allow-empty -m chore(mutation): ratchet src/recurring-utils.ts baseline to 0.9636363636363636
ℹ Checking staged files: docs/superpowers/plans/2026-08-06-mutation-coverage-recurring-utils.md docs/superpowers/specs/2026-08-06-mutation-coverage-recurring-utils-design.md scripts/mutation/baseline.json tests/recurring-utils.test.ts

✗ license-headers failed (exit code 1):
---
Missing BUSL-1.1 license header in file(s):
  docs/superpowers/plans/2026-08-06-mutation-coverage-recurring-utils.md
  docs/superpowers/specs/2026-08-06-mutation-coverage-recurring-utils-design.md

Add this header to the top of each file:
  // SPDX-License-Identifier: BUSL-1.1
  // Copyright (c) 2026 Dmitriy Lazarev
  // Use of this software is governed by the Business Source License 1.1.
  // See LICENSE in the project root for details.

For .md files, use this HTML-comment style header:
  <!--
  SPDX-License-Identifier: BUSL-1.1
  Copyright (c) 2026 Dmitriy Lazarev
  Use of this software is governed by the Business Source License 1.1.
  See LICENSE in the project root for details.
  -->

Or run: bun license:headers
---

Summary of executed checks:
✓ lint
✓ typecheck
✓ format:check
✗ license-headers

3/4 checks passed, 1 failed
 |
| 10 | score | afterScore 0.8571428571428571 < threshold 0.9 |