### PR TITLE
mutation-improve: src/utils/scheduler.helpers.ts, review-loop/src/summary-burndown.ts, plugins/task-provider-youtrack/field-engine.ts, plugins/task-provider-youtrack/create-field-helpers.ts, src/announcements/humanize.ts, src/utils/scheduler.events.ts, plugins/task-provider-youtrack/dedicated-fields.ts

### DIFF
--- a/docs/superpowers/plans/2026-08-07-mutation-coverage-create-field-helpers.md
+++ b/docs/superpowers/plans/2026-08-07-mutation-coverage-create-field-helpers.md
@@ -1,0 +1,77 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation Coverage — `plugins/task-provider-youtrack/create-field-helpers.ts` Plan
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax for tracking. This is a test-only
+> effort; there is **no** production-code change.
+
+**Goal:** Raise the `plugins/task-provider-youtrack/create-field-helpers.ts` mutation score from
+**0.813953488372093** to **≥ 0.9** (projected **1.0**) by appending two `test()`s to the existing
+companion `tests/plugins/task-provider-youtrack/create-field-helpers.test.ts`. Spec:
+`docs/superpowers/specs/2026-08-07-mutation-coverage-create-field-helpers-design.md`.
+
+**Architecture:** `collectFieldPairs(params)` walks four optional dedicated fields
+(`status`/`priority`/`assignee`/`dueDate`) plus the generic `customFields` array, pushing a tagged
+`FieldPair` per present field. The `status`, `priority`, and generic branches are already perfectly
+covered; the `assignee` (line 35) and `dueDate` (line 36) branches are exercised by **no** test in
+the suite, so their conditional/object-literal/string-literal mutants survive. Each new test passes
+**only** the dedicated param under test so the returned array is exactly one pair, then asserts
+`toHaveLength(1)` and exact `toBe(...)` on every field.
+
+## Global Constraints
+
+- **Test-only.** Extend only `tests/plugins/task-provider-youtrack/create-field-helpers.test.ts`
+  (plus the two docs files already written). Do **not** touch `src/`, `client/`, `plugins/`,
+  `scripts/`, or `scripts/mutation/baseline.json`.
+- Runtime Bun; tests use `bun:test` (`import { describe, expect, test } from 'bun:test'`).
+- **Every new assertion is an exact `toBe(...)`** (and `toHaveLength` for the array length) — never
+  `toContain` / `startsWith` / `endsWith`. Field access (`pairs[0].source` etc.) is checked
+  per-field with `toBe`, so an `ObjectLiteral→{}` mutant makes every field `undefined`.
+- One `test()` per mutant class (one-to-one with the spec's gap table).
+- No comments added to the test file (repo convention).
+- Reuse the existing `collectFieldPairs` import already in the file (no new imports needed).
+
+## Measure (already complete)
+
+- [x] `bun test:mutate:file plugins/task-provider-youtrack/create-field-helpers.ts` → `killed=35
+      survived=2 noCoverage=6 score=0.813953488372093`; report at
+      `reports/paired/plugins__task-provider-youtrack__create-field-helpers.ts.stryker-report.json`.
+- [x] Enumerated all 8 surviving/no-coverage mutants with ids, mutators, and `line:col`.
+
+## Tasks (one per mutant class → one test each)
+
+- [ ] **Task 1 — `collectFieldPairs` assignee pair (class 1).** Append a `test()` to the existing
+      `describe('collectFieldPairs', ...)` block: call
+      `collectFieldPairs({ assignee: 'someone' })`, then assert `pairs.toHaveLength(1)`,
+      `pairs[0].source` is `toBe('dedicated')`, `pairs[0].kind` is `toBe('user')`, and
+      `pairs[0].value` is `toBe('someone')`. Kills mutants 15 (conditional→`false`, array becomes
+      empty → `toHaveLength` fails), 17 (object→`{}`, fields become `undefined` → `toBe` fails), 18
+      (`'dedicated'`→`""` → `.source` `toBe('dedicated')` fails), 19 (`'user'`→`""` → `.kind`
+      `toBe('user')` fails).
+- [ ] **Task 2 — `collectFieldPairs` dueDate pair (class 2).** Append a `test()` to the existing
+      `describe('collectFieldPairs', ...)` block: call
+      `collectFieldPairs({ dueDate: '2026-01-01' })`, then assert `pairs.toHaveLength(1)`,
+      `pairs[0].source` is `toBe('dedicated')`, `pairs[0].kind` is `toBe('date')`, and
+      `pairs[0].value` is `toBe('2026-01-01')`. Kills mutants 21 (conditional→`false`), 23
+      (object→`{}`), 24 (`'dedicated'`→`""`), 25 (`'date'`→`""`) — each via the same failure modes
+      as Task 1.
+
+## Residuals (accepted — no test can kill)
+
+None. Every one of the 8 surviving/no-coverage mutants is killed by the two tests above; no
+equivalent mutants exist in this file. (Confirmed empirically by re-measuring in the Verification
+step; the result JSON's `residuals` array is empty.)
+
+## Verification
+
+- [ ] `bun test tests/plugins/task-provider-youtrack/create-field-helpers.test.ts` → all green.
+- [ ] `bun test:mutate:file plugins/task-provider-youtrack/create-field-helpers.ts` →
+      `killed=43 score=1.0`; zero non-killed mutants in
+      `reports/paired/plugins__task-provider-youtrack__create-field-helpers.ts.stryker-report.json`.
+- [ ] `git status` shows changes only under `tests/` and `docs/superpowers/` (diff-gate), plus the
+      single `.review-loop/result.json`.

--- a/docs/superpowers/plans/2026-08-07-mutation-coverage-dedicated-fields.md
+++ b/docs/superpowers/plans/2026-08-07-mutation-coverage-dedicated-fields.md
@@ -1,0 +1,59 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Plan: mutation coverage for `plugins/task-provider-youtrack/dedicated-fields.ts`
+
+Spec: `docs/superpowers/specs/2026-08-07-mutation-coverage-dedicated-fields-design.md`.
+Target: raise Stryker score from **0.6699** to **>= 0.9** (test-only).
+
+## Global constraints
+
+- Test-only. Touch only `tests/plugins/task-provider-youtrack/dedicated-fields.test.ts`
+  (and these docs). Never edit `src/`, `client/`, `plugins/`, `scripts/`, or
+  `scripts/mutation/baseline.json`.
+- Every new assertion uses exact equality (`toBe` / `toEqual`) on fully-knowable values —
+  never `startsWith` / `endsWith` / `toContain` / regex substrings where a full string is
+  knowable. For thrown errors, `try/catch` and assert `.message` (and `.appError`) exactly.
+- Reuse the existing `field(name, typeId, bundleType?)` helper; extend it with an optional
+  `localizedName` parameter (existing 3-arg calls are unaffected).
+- One focused test per gap class C1-C13 (13 tests). Residuals R1-R8 are declared, not
+  tested.
+
+## Tasks
+
+- [ ] **C1** — state canonical disambiguation (`State` + `Статус`); kills 1,2,3.
+- [ ] **C2** — user Russian canonical (`Ответственный`); kills 6.
+- [ ] **C3** — priority Russian canonical (`Приоритет`); kills 9.
+- [ ] **C4/C9** — priority with no enum field: exact "No priority-type field exists…"
+  message + `appError` equals `providerError.validationFailed('customFields', …)`; kills
+  26, 68, 72.
+- [ ] **C5/C6** — date sole-field shortcut (with a non-date companion); kills 30,38,39,
+  40,41.
+- [ ] **C7** — localized-name disambiguation (`localizedName: 'Assignee'`); kills 44,53,
+  60.
+- [ ] **C8** — multiple-candidate exact message incl. `Name; Name` join; kills 66.
+- [ ] **C10** — candidate-filter optional-chaining over `[fieldless, named state]`;
+  kills 81. (id 79 is equivalent under schema-valid data → residual R9.)
+- [ ] **C11** — single non-canonical enum as `priority` is not auto-resolved (exact
+  "Multiple candidate fields…" message); kills 85,87.
+- [ ] **C12** — two fields both named `Assignee` throw; kills 98,99.
+- [ ] **C13** — date canonical disambiguation (`Due Date` + `Дедлайн`); kills 10,11,12.
+- [ ] Run `bun test tests/plugins/task-provider-youtrack/dedicated-fields.test.ts` green.
+- [ ] Re-run `bun test:mutate:file plugins/task-provider-youtrack/dedicated-fields.ts`;
+  confirm survivors are exactly R1-R9 (ids 43,45,51,59,63,64,79,91,101) and score >= 0.9.
+- [ ] Write `result.json` with residuals = measured survivors.
+
+## Risks / notes
+
+- The teaching-error strings use straight ASCII double quotes around the kind
+  (`for "priority"`); assertions must match byte-for-byte.
+- `id 59` (`localized !== null`) stays NoCoverage-equivalent even after the C7 test
+  because `?? undefined` on L34 structurally forbids `localized === null`; it is declared
+  residual R4.
+- If a planned kill unexpectedly survives the re-measure, either tighten that test or move
+  the id into residuals with honest reasoning — the declared `mutantIds` UNION must equal
+  the measured survivor set exactly.

--- a/docs/superpowers/plans/2026-08-07-mutation-coverage-field-engine.md
+++ b/docs/superpowers/plans/2026-08-07-mutation-coverage-field-engine.md
@@ -1,0 +1,63 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Plan: mutation coverage for `plugins/task-provider-youtrack/field-engine.ts`
+
+Implements the spec at
+`docs/superpowers/specs/2026-08-07-mutation-coverage-field-engine-design.md`.
+
+## Global constraints
+
+- **Test-only.** Edit only `tests/plugins/task-provider-youtrack/field-engine.test.ts`
+  (+ the docs + result JSON). No `src/`/`client/`/`plugins/`/`scripts/` edits.
+- Do **not** touch `scripts/mutation/baseline.json`.
+- Every new assertion uses exact equality (`toBe` / `toEqual`); no `startsWith` /
+  `endsWith` / `toContain` where a full value is knowable.
+- Keep the existing 9 tests intact; only add.
+- Use DI (the `getBundleElements` ctx), no module mocking.
+- `bun test tests/plugins/task-provider-youtrack/field-engine.test.ts` must be green
+  before finishing.
+
+## Tasks (one per mutant class)
+
+- [ ] **C1** Add a table-driven `classifyFieldType` suite asserting `kind`, `label`,
+      `singleType`, `multiType`, `multi`, `bundleSegment` for every `TYPE_TABLE` row
+      (enum/state/version/ownedField/build/user/text/string/integer/float/date/
+      date-and-time/period, single + multi variants). Covers ids 10-65.
+- [ ] **C2** Add `parseFieldTypeId` edge-input tests via `classifyFieldType`: spaced id,
+      internally-spaced base, trailing garbage, newline anchor, bracketless field,
+      missing `fieldType.id`. Covers ids 67,69,70,71,83,90.
+- [ ] **C3** Add `bundleSegment` tests for `VersionBundle` / `OwnedFieldBundle` /
+      `BuildBundle`. Covers ids 94,95,96.
+- [ ] **C4** Add classifyFieldType tests for missing `field`, missing `fieldType`,
+      unknown base, non-bundle-with-bundle, bundle-without-bundle. Covers ids
+      102,103,105,116,120.
+- [ ] **C5** Add classifyFieldType unknown-branch tests (empty base + non-empty base).
+      Covers ids 107-114.
+- [ ] **C6** Add `formatAllowed` tests: small, exact-cap (50), overflow (51). Covers
+      ids 122-125,127-130.
+- [ ] **C7** Add `capAllowedValues` tests: small, exact-cap (50), overflow (51). Covers
+      ids 133,134,138.
+- [ ] **C8** Add `normalize` test. Covers id 144.
+- [ ] **C9** Add multi-resolve tests: empty middle entry (enum), whitespace tokens
+      (user). Covers ids 146,149,151,153.
+- [ ] **C10** Add ambiguous-bundle (duplicate name) test. Covers ids 172,173.
+- [ ] **C11** Add missing-name tests (no `field`; `field` without `name`), asserting
+      `appError.field` and exact reason. Covers ids 185,187,189,190.
+- [ ] **C12** Add simple-numeric tests: string field keeps string, float field → number,
+      non-numeric string field does not throw. Covers ids 199,205,206,207.
+- [ ] **C13** Add simple-string return test. Covers ids 216,217.
+- [ ] **C14** Add `date` case test. Covers ids 218-221.
+- [ ] **C15** Add `period` case test. Covers ids 222-226.
+- [ ] **C16** Add `user` case test (single + multi). Covers ids 227-232.
+- [ ] **C17** Add bundle-guard tests (no bundle / unknown bundle type / bundle without
+      id). Covers ids 236,238,239,240,242,244,245.
+- [ ] **C18** Add `unknown` case test asserting the exact interpolated error. Covers
+      ids 249-253,255.
+- [ ] **Verify** `bun test` green, then `bun test:mutate:file` >= 0.9 and survivors ==
+      declared residuals (R1-R6: ids 78,80,99,175,181,183,254,256).
+- [ ] **Residuals** Write result JSON with exact `mutantIds` per residual loc.

--- a/docs/superpowers/plans/2026-08-07-mutation-coverage-humanize.md
+++ b/docs/superpowers/plans/2026-08-07-mutation-coverage-humanize.md
@@ -1,0 +1,71 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Plan: mutation coverage for `src/announcements/humanize.ts`
+
+Goal: mutation score **>= 0.9** (from 0.338), test-only. One task per mutant
+class. Target file under test unchanged.
+
+## Global constraints
+
+- **Test-only.** Touch only `tests/` and `docs/superpowers/` (+ the one
+  `.review-loop/result.json`). Never edit `src/`, `client/`, `plugins/`,
+  `scripts/`, or `scripts/mutation/baseline.json`.
+- **Exact equality only** for new assertions: `toBe` for scalars/strings,
+  `toEqual` only for the one fully-knowable metadata object/array. No
+  `toContain` / `startsWith` / `endsWith` where a full value is knowable.
+- **DI-first.** Use the existing `deps()` helper for all injected paths.
+- **Log observation via the multistream.** `humanize.ts` is transitively
+  preloaded (mock-reset → `src/announcements.ts`), so it is cached with the real
+  logger before any per-file `mock.module` can apply, and `tests/setup.ts` pins
+  `LOG_LEVEL=silent` before that load. So the logging tests use pino's public
+  `logMultistream.add()` extension point with a trace-level capture stream and
+  raise `logger.level = 'trace'` (pino children inherit it dynamically) — no
+  delayed import, no module mock. `setupTestDb()` runs in `beforeEach` so the
+  default-deps path's real `resolveAdminLlmConfig` sees a migrated empty
+  `llm_admin_roles` table.
+- **SPDX header** on the modified test file (already present; keep it).
+
+## Tasks
+
+- [ ] **A — classify system prompt (L27–35).** Add test capturing `opts.system`
+      on `generateStructured`; assert `toBe` against the verbatim
+      `CLASSIFY_SYSTEM_PROMPT` joined text. Kills `8,9,10,11,12,13,14,15,16`.
+- [ ] **B — write system prompt (L39–58).** Add test capturing `opts.system` on
+      `generate`; assert `toBe` against the verbatim `SYSTEM_PROMPT` joined
+      text. Kills `19,20,21,22,24,25,27,28,29,30,31,32,33,34,35,36,37`.
+- [ ] **C — empty-release sentinel (L37).** Add test asserting the returned
+      value `toBe` the hardcoded literal string (not the re-imported constant).
+      Kills `17`.
+- [ ] **D+E — not-configured warn (L14 child scope + L86–94 guard/warn).** With a
+      capture stream + `logger.level='trace'` and an `ok:false` config, assert
+      exactly one warn whose `scope` `toBe('announcements:humanize')`, metadata
+      fields exact, and `msg` `toBe('Central LLM not configured; skipping changelog humanization')`.
+      Kills `0,1,47,48,49,51,52,53,54`. (Leaves `50` — see residuals.)
+- [ ] **G — failure warn (L109).** Reject in `generateStructured`; assert the
+      captured warn's `error` `toBe('boom')`, `scope`, and `msg`
+      `toBe('Changelog humanization failed')`. Kills `66,67`.
+- [ ] **F-38 — default-deps wiring (L67).** Call `humanizeChangelog('raw')`
+      with no deps; assert it resolves to `null` (real default deps → unconfigured
+      central LLM) rather than rejecting (`{}`-mutated). Kills `38`.
+
+## Residuals (declared, not killed)
+
+- [x] **`50`** — true equivalent (ternary always-true; `config.missing` only
+      exists when `type === 'missing'`).
+- [x] **`39`,`40`** — `defaultDeps.generate` body; import-time-snapshot
+      reachability + SDK-contract forwarding.
+- [x] **`41`,`42`,`43`** — `defaultDeps.generateStructured` body + opaque
+      `Output.object` config (only the `ai` SDK reads it).
+
+## Verification gate
+
+- [x] `bun test tests/announcements/humanize.test.ts` green (16 pass).
+- [x] `bun test:mutate:file src/announcements/humanize.ts` → killed=62 survived=1
+      noCoverage=5 (0.9118), survivors == `{39,40,41,42,43,50}`.
+- [ ] `.review-loop/result.json` written; residual `mutantIds` union == measured
+      survivors.

--- a/docs/superpowers/plans/2026-08-07-mutation-coverage-scheduler.events.md
+++ b/docs/superpowers/plans/2026-08-07-mutation-coverage-scheduler.events.md
@@ -1,0 +1,87 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation Coverage Plan — `src/utils/scheduler.events.ts`
+
+**Date:** 2026-08-07
+**Spec:** `docs/superpowers/specs/2026-08-07-mutation-coverage-scheduler.events-design.md`
+**Target:** raise mutation score from `0.45` (18/40) to `>= 0.9`; achieved `0.90` (36/40).
+
+## Goal
+
+Add one test-only companion file `tests/utils/scheduler.events.test.ts` that kills 18
+of the 22 currently non-killed mutants (2 survived + 20 `NoCoverage`), leaving only the
+4 `'Unknown error'` fallback strings (ids 6, 14, 22, 30) as declared residuals. No edits
+to `src/`, `client/`, `plugins/`, `scripts/`, or `baseline.json`.
+
+## Global constraints
+
+- Test-only: create `tests/utils/scheduler.events.test.ts` only (plus this plan/spec/result.json).
+- Follow the **cache-busting logger-mock pattern** from `tests/history.test.ts` /
+  `tests/tools/search-memos.test.ts`: per-test, install a recording `logger` via
+  `mock.module('../../src/logger.js', …)` then
+  `import(\`../../src/utils/scheduler.events.js?t=${crypto.randomUUID()}\`)`. The query
+  forces a fresh module evaluation (the module is already cached from the
+  `tests/mock-reset.ts` preload via `src/scheduler.js`), so the module-scoped
+  `log = logger.child(…)` binds to the recorder.
+- The recorder uses **plain functions** (not `mock()`) returning a child logger whose
+  `error(payload, message)` records to per-test arrays. A fresh recorder is created per
+  load, so no cross-test state leaks.
+- Throw an **`Error`** (not a non-Error) in each throwing handler: `no-throw-literal` +
+  `only-throw-error` (both `error`) reject throwing any non-Error value. This makes the
+  `'Unknown error'` `else` branch unreachable from tests → mutants 6/14/22/30 are
+  residuals (see T9).
+- Narrow captured payloads via a pure `isRecord` type predicate + `requireRecord`
+  helper (no `as` — `no-unsafe-type-assertion` is `error`); read index-signature
+  properties with bracket notation (`payload['error']`) per `TS4111`. No conditionals
+  inside test bodies (`no-conditional-in-test`) — the narrowing `if` lives in
+  `requireRecord` at module scope.
+- Every assertion is `toBe(...)` against the full exact value. No `startsWith` /
+  `endsWith` / `toContain` / `toEqual` partial matching.
+- One `test()` per mutant class (5 tests total), matching the spec's Design table 1:1.
+- SPDX header on the new file; no comments in the test body.
+
+## Tasks
+
+- [x] **T0 — scaffold.** `tests/utils/scheduler.events.test.ts`: SPDX header,
+      `bun:test` imports, type-only imports of `EventEmitter` + the four handler/payload
+      types, the `isRecord`/`requireRecord` narrowing helpers, and the
+      `loadSchedulerEventsModule()` loader (recorder + cache-busting import).
+- [x] **T1 — class A (scope).** `logger.child` invoked once at import with exact scope.
+      Assert `childCalls.length === 1` and `scope['scope'] === 'scheduler:events'` (`toBe`).
+      Covers mutant ids **0, 1**.
+- [x] **T2 — class B (emitTickEvent catch, 4 of 5).** One throwing `Error` `tick` handler;
+      assert `errorCalls.length === 1`, `payload['error'] === 'handler blew up'`,
+      `payload['event'] === 'tick'`, `message === 'Event handler threw error'` (all `toBe`).
+      Covers ids **5, 7, 8, 9** (id 6 is a residual).
+- [x] **T3 — class C (emitErrorEvent catch, 4 of 5).** Same shape, `events.error`,
+      `payload['event'] === 'error'`. Covers ids **13, 15, 16, 17** (id 14 residual).
+- [x] **T4 — class D (emitRetryEvent catch, 4 of 5).** Same shape, `events.retry`,
+      `payload['event'] === 'retry'`. Covers ids **21, 23, 24, 25** (id 22 residual).
+- [x] **T5 — class E (emitFatalErrorEvent catch, 4 of 5).** Same shape, `events.fatalError`,
+      `payload['event'] === 'fatalError'`. Covers ids **29, 31, 32, 33** (id 30 residual).
+- [x] **T6 — verify isolation.** `bun test tests/utils/scheduler.events.test.ts` green (5/5).
+- [x] **T7 — verify no sibling regression.** helpers + internal + scheduler suites green (53/53).
+- [x] **T8 — re-measure.** `bun test:mutate:file src/utils/scheduler.events.ts`:
+      `killed=36 survived=0 noCoverage=4 score=0.9`; non-killed ids exactly `{6, 14, 22, 30}`.
+- [x] **T9 — residuals.** Declare the 4 `'Unknown error'` fallback strings (ids 6, 14, 22,
+      30; locs `:24`, `:38`, `:52`, `:66`) as residuals in `result.json`. They are the
+      `else` branch of `error instanceof Error ? error.message : 'Unknown error'`, only
+      reachable via a non-Error throw — which `no-throw-literal`/`only-throw-error` forbid
+      in test code. Their `mutantIds` union exactly equals the runner-measured surviving set.
+
+## Risk / notes
+
+- The cache-busting query import is load-bearing: a plain `await import` returns the
+  cached module (pre-evaluated by the `tests/mock-reset.ts` preload via `src/scheduler.js`)
+  with `log` bound to the real pino logger, so none of the recording assertions would fire.
+  Confirmed empirically — without the `?t=<uuid>` suffix, all 5 tests failed with empty
+  recorder arrays; with it, all pass.
+- Per-class coverage is 4 of 5, not 5 of 5, by design: the `'Unknown error'` string is the
+  file's tests-only ceiling. Score `0.90 = 36/40` clears the `>= 0.9` target; under the
+  default `threshold: 0.95` the iteration instead merges as `capped`, which requires the
+  declared residuals to set-equal the surviving ids (gate.ts `coversAllSurvivors`) — they do.

--- a/docs/superpowers/plans/2026-08-07-mutation-coverage-scheduler.helpers.md
+++ b/docs/superpowers/plans/2026-08-07-mutation-coverage-scheduler.helpers.md
@@ -1,0 +1,111 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation Coverage — `src/utils/scheduler.helpers.ts` Plan
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax for tracking. This is a
+> test-only effort; there is **no** production-code change.
+
+**Goal:** Raise the `src/utils/scheduler.helpers.ts` mutation score from
+**0.3333333333333333** to **≥ 0.9** (projected **1.0**) by creating a new companion
+`tests/utils/scheduler.helpers.test.ts` with exact-equality assertions. Spec:
+`docs/superpowers/specs/2026-08-07-mutation-coverage-scheduler.helpers-design.md`.
+
+**Architecture:** `src/utils/scheduler.helpers.ts` is the pure helper module for the scheduler.
+`calculateBackoff` computes `Math.floor(Math.min(2**attempt*1000, maxDelay) + jitter)` where
+`jitter = baseDelay * 0.1 * Math.random()`; `getErrorMessage`/`getErrorObject` are defensive
+extractors over `unknown`; `DEFAULT_OPTIONS`/`DEFAULT_TASK_OPTIONS` are plain object constants.
+Every surviving mutant is observable as a changed exact return value once `Math.random()` is
+pinned, so each new test asserts `toBe(...)` on a full value.
+
+## Global Constraints
+
+- **Test-only.** Create only `tests/utils/scheduler.helpers.test.ts` (plus the two docs files
+  already written). Do **not** touch `src/`, `client/`, `plugins/`, `scripts/`, or
+  `scripts/mutation/baseline.json`.
+- Runtime Bun; tests use `bun:test` (`import { afterEach, beforeEach, describe, expect, test } from 'bun:test'`).
+- **Every new assertion is an exact `toBe(...)`** — never `toContain` / `startsWith` /
+  `endsWith` where a full value is knowable. Object-identity uses reference `toBe`, and
+  `instanceof` checks use `toBeInstanceOf(Error)`. Constant objects are checked per-field with
+  `toBe` (not `toEqual`) so an `ObjectLiteral→{}` mutant makes every field `undefined`.
+- The `calculateBackoff` test stubs `Math.random` to `() => 0.5` inside a `beforeEach` and
+  restores the original in an `afterEach` (direct assignment, not a bun `mock()` spy, so the
+  global `mock.restore()` does not interfere). With this stub,
+  `calculateBackoff(0, 60000) === Math.floor(1000 * 1.05) === 1050`.
+- One `test()` per mutant class (one-to-one with the spec's gap table). Where a single
+  behaviour cleanly kills several mutants of one class, they share one `test()`.
+- No comments added to the test file (repo convention).
+- The companion resolver maps `src/utils/scheduler.helpers.ts` →
+  `tests/utils/scheduler.helpers.test.ts`; creating exactly that path makes the paired runner
+  pick it up automatically (additive with the coverage-discovered `scheduler.test.ts`).
+
+## Measure (already complete)
+
+- [x] `bun test:mutate:file src/utils/scheduler.helpers.ts` → `killed=11 survived=12
+      noCoverage=10 score=0.3333333333333333`; report at
+      `reports/paired/src__utils__scheduler.helpers.ts.stryker-report.json`.
+- [x] Enumerated all 22 surviving/no-coverage mutants with ids, mutators, and `line:col`.
+
+## Tasks (one per mutant class → one test each)
+
+- [ ] **Task 1 — `calculateBackoff` deterministic backoff.** Add a `describe` that stubs
+      `Math.random = () => 0.5` in `beforeEach` (restore in `afterEach`) and one `test()`
+      asserting `calculateBackoff(0, 60000)` is `toBe(1050)`, `calculateBackoff(0, 500)` is
+      `toBe(525)`, and `calculateBackoff(5, 60000)` is `toBe(33600)`. Mutant 6 (`Math.min`→
+      `Math.max`) yields 63000; 9 (`*0.1`→`/0.1`) yields 6000; 8 (trailing `*`→`/`) yields 1200;
+      10 (`+jitter`→`-jitter`) yields 950 — all differ from 1050. Kills mutants 6, 8, 9, 10.
+- [ ] **Task 2 — `getErrorMessage(Error)`.** Add `test()` asserting
+      `getErrorMessage(new Error('boom'))` is `toBe('boom')`. Mutants 15 (body→`{}`) returns
+      `undefined`, 17 (`if→false`) and 18 (return-block→`{}`) return `'Unknown error'`. Kills
+      mutants 15, 17, 18.
+- [ ] **Task 3 — `getErrorMessage(string)`.** Add `test()` asserting
+      `getErrorMessage('some message')` is `toBe('some message')`. Mutant 16 (`if→true`)
+      returns `undefined`; 20 (ternary→`false`), 21 (`===`→`!==`), 22 (`'string'`→`""`) all
+      return `'Unknown error'`. Kills mutants 16, 20, 21, 22.
+- [ ] **Task 4 — `getErrorMessage` fallback.** Add `test()` asserting `getErrorMessage(42)` is
+      `toBe('Unknown error')`. Mutant 19 (ternary→`true`) returns `42`; 23 (`'Unknown error'`→
+      `""`) returns `""`. Kills mutants 19, 23.
+- [ ] **Task 5 — `getErrorObject(string)`.** Add `test()` asserting the result is
+      `toBeInstanceOf(Error)` and `.message` is `toBe('hello')`. Mutant 25 (`if→true`) returns
+      the raw string (fails `toBeInstanceOf`); 29 (ternary→`false`), 30 (`===`→`!==`), 31
+      (`'string'`→`""`) wrap `'Unknown error'` (fails `.message` `toBe`). Kills mutants 25, 29,
+      30, 31.
+- [ ] **Task 6 — `getErrorObject` fallback.** Add `test()` asserting
+      `getErrorObject(42).message` is `toBe('Unknown error')`. Mutant 28 (ternary→`true`) wraps
+      the raw value (message `'42'`); 32 (`'Unknown error'`→`""`) yields message `""`. Kills
+      mutants 28, 32.
+- [ ] **Task 7 — `DEFAULT_OPTIONS` exact.** Add `test()` asserting
+      `DEFAULT_OPTIONS.unrefByDefault` is `toBe(true)`, `.defaultRetries` is `toBe(3)`,
+      `.maxRetryDelay` is `toBe(60000)`. Mutant 1 (`unrefByDefault`→`false`) flips the first
+      field. Kills mutant 1.
+- [ ] **Task 8 — `DEFAULT_TASK_OPTIONS` exact.** Add `test()` asserting
+      `DEFAULT_TASK_OPTIONS.immediate` is `toBe(false)`, `.retries` is `toBe(3)`, `.unref` is
+      `toBe(true)`. Mutant 2 (whole object→`{}`) makes every field `undefined`; 4 (`unref`→
+      `false`) flips one field. Kills mutants 2, 4.
+- [ ] **Task 9 (documentation only — no survivor) — `getErrorObject(Error)` identity.** Add
+      `test()` asserting `getErrorObject(err)` returns the identical reference (`toBe(err)`).
+      This documents the `instanceof` early-return branch; it does not kill any survivor
+      (mutants 26/27 on line 129 are already killed indirectly).
+- [ ] **Task 10 (documentation only — no survivor) — mergers.** Add one `test()` asserting
+      `mergeOptions(undefined)` and `mergeOptions({...})` per-field `toBe`, and
+      `mergeTaskOptions(...)` per-field `toBe`, including scheduler-default inheritance. These
+      duplicate coverage already provided by `scheduler.test.ts`; they make the new companion
+      self-contained. They kill no survivor (mutants 0/11/12/13/14 already killed).
+
+## Residuals (accepted — no test can kill)
+
+None. Every one of the 22 surviving/no-coverage mutants is killed by the tests above; no
+equivalent mutants exist in this file. (Confirmed empirically by re-measuring in the
+Verification step; the result JSON's `residuals` array is empty.)
+
+## Verification
+
+- [ ] `bun test tests/utils/scheduler.helpers.test.ts` → all green.
+- [ ] `bun test:mutate:file src/utils/scheduler.helpers.ts` → `killed=33 score=1.0`; zero
+      non-killed mutants in `reports/paired/src__utils__scheduler.helpers.ts.stryker-report.json`.
+- [ ] `git status` shows changes only under `tests/` and `docs/superpowers/` (diff-gate), plus
+      the single `.review-loop/result.json`.

--- a/docs/superpowers/plans/2026-08-07-mutation-coverage-summary-burndown.md
+++ b/docs/superpowers/plans/2026-08-07-mutation-coverage-summary-burndown.md
@@ -1,0 +1,47 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Plan: mutation coverage for `review-loop/src/summary-burndown.ts`
+
+Spec: `docs/superpowers/specs/2026-08-07-mutation-coverage-summary-burndown-design.md`
+Target: measured **0.74 → 0.96**; killable gap = classes A–D (mutant ids
+3, 5, 9, 15, 16, 17, 18, 19, 24, 25, 27 — eleven mutants); accepted residuals = ids 12, 33.
+
+## Global constraints
+
+- **Tests-only.** Edit only `tests/review-loop/summary-burndown.test.ts` plus this
+  spec/plan. Never touch `src/`, `client/`, `plugins/`, `scripts/`,
+  `review-loop/src/`, or `scripts/mutation/baseline.json`.
+- **Exact equality only.** Every new assertion is `toBe(...)` on the full, knowable
+  `burndownBlock` output string — no `startsWith`/`endsWith`/`toContain`.
+- **One test per killable mutant class** (A–D). Tests may incidentally kill additional
+  mutants; that is acceptable.
+- **Ground every expected string in the real formatter.** Expected block strings were
+  captured by running the production `burndownBlock` against the designed fixtures.
+- Follow the file's existing conventions: `bun:test`, `.js` import paths, the
+  `zeroMetric`/`busyMetric` helper style, no comments, BUSL-1.1 header already present.
+
+## Tasks
+
+- [ ] **A — kill the zero-total guard (ids 3, 5).** Add a test asserting the exact
+      block for a round with `newIssues = 2`, all decisions zero, so `avgFix` is `-`.
+- [ ] **B — kill the critical multiplier (id 9).** Add a test asserting the exact block
+      for a round with `reviewerSeverity = { critical: 1 }`, `newIssues = 1`, so `avgRev`
+      is `4.0`.
+- [ ] **C — kill the decidedCount addends (ids 15, 16, 17, 18, 19).** Add a test asserting
+      the exact block for a round with **all seven decision fields = 1** and
+      `fixerSeverity = { medium: 7 }`, so `decidedCount = 7` and `avgFix = 2.0`; each
+      `+addend → -addend` mutant lowers `decidedCount` to 5 (`avgFix = 2.8`).
+- [ ] **D — kill the rowIsZero short-circuit (ids 24, 25, 27).** Add a test asserting
+      the exact two-row block for `[round11 {newIssues=1, decidedCount=0},
+      round12 {newIssues=0, decidedCount=2}]`.
+- [ ] **Verify green.** `bun test tests/review-loop/summary-burndown.test.ts` passes.
+- [ ] **Re-measure.** `bun test:mutate:file review-loop/src/summary-burndown.ts` shows
+      survivors == {12, 33} and score = 0.96 (≥ 0.9); if any unexpected id survives, add a
+      targeted test (if killable) or justify it as a residual.
+- [ ] **Declare residuals.** Write `result.json` with residual mutantIds == measured
+      survivors, exactly.

--- a/docs/superpowers/plans/2026-08-07-progress-stats-renderer.md
+++ b/docs/superpowers/plans/2026-08-07-progress-stats-renderer.md
@@ -1,0 +1,1668 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Progress & Stats Renderer Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add run-level aggregate stats (tokens, est. cost, tool calls, lines added/removed, elapsed) to the live footer and end-of-run summaries of the `review-loop` and `mutation-improve` CLIs, persisted to `metrics.json` / `state.json`.
+
+**Architecture:** A pure, dependency-free `RunStats` aggregate (`review-loop/src/run-stats.ts`) accumulates per-label and total stats; the existing hand-rolled `LiveRenderer` holds an instance and renders aggregate segments in its persistent status line. Cost is estimated from a `pricing` table in each workspace's `config.json` (opencode events always report `cost: 0`). Diff stats are measured with `git diff --numstat` at each merge point. Spec: `docs/superpowers/specs/2026-08-07-progress-stats-renderer-design.md`.
+
+**Tech Stack:** Bun, TypeScript (`.js` import extensions), Zod v4, bun:test. No new runtime dependencies.
+
+## Global Constraints
+
+- No new runtime dependencies in either workspace's `package.json`.
+- Every new source file starts with the BUSL-1.1 header (hook-enforced):
+  ```ts
+  // SPDX-License-Identifier: BUSL-1.1
+  // Copyright (c) 2026 Dmitriy Lazarev
+  // Use of this software is governed by the Business Source License 1.1.
+  // See LICENSE in the project root for details.
+  ```
+- New `ProgressReporter` members MUST be optional — test fakes across both suites construct minimal reporters.
+- Error extraction idiom: `error instanceof Error ? error.message : String(error)`.
+- Tests: `bun:test`, DI-first, no wall-clock timing assertions. Run focused tests from the repo root: `bun test tests/review-loop/<file>.test.ts`.
+- Workspace checks: `bun run review-loop:typecheck && bun run review-loop:lint` (and `mutation-improve:` equivalents) from the repo root.
+- TDD is hook-enforced for `review-loop/src/**` and `mutation-improve/src/**` — write the failing test first in every task.
+
+## Spec refinements locked in this plan
+
+1. **Model resolution is per-usage-delta, not once at CLI start.** `line-handler` knows `RunAgentOptions.model` per agent call and forwards it in the usage delta; review-loop's four agent configs may use different models, so a single CLI-start model would misprice.
+2. **mutation-improve summary table columns:** file, before→after, outcome, `+a/-r` (per-iteration diff IS available, labeled `iter-N`). Per-file token columns from the spec mockup are NOT available — agent labels are role-based (`select`/`improve`), so tokens aggregate by role; the totals row carries overall tokens/cost/tools.
+
+---
+
+### Task 1: `cost.ts` — pricing table + estimation
+
+**Files:**
+- Create: `review-loop/src/cost.ts`
+- Test: `tests/review-loop/cost.test.ts`
+
+**Interfaces:**
+- Produces: `PriceEntrySchema`, `PricingTableSchema`, `PriceEntry`, `PricingTable`, `matchPrice(pricing, model): PriceEntry | undefined`, `estimateCostUsd(price, input, output): number`. Consumed by Tasks 3, 6.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { estimateCostUsd, matchPrice, PricingTableSchema } from '../../review-loop/src/cost.js'
+
+describe('matchPrice', () => {
+  const pricing = { 'claude-sonnet-*': { input: 3, output: 15 }, 'gpt-4o': { input: 2.5, output: 10 } }
+
+  test('exact match wins over glob', () => {
+    const table = { ...pricing, 'claude-sonnet-4': { input: 1, output: 1 } }
+    expect(matchPrice(table, 'claude-sonnet-4')).toEqual({ input: 1, output: 1 })
+  })
+
+  test('glob match', () => {
+    expect(matchPrice(pricing, 'claude-sonnet-4-20250514')).toEqual({ input: 3, output: 15 })
+  })
+
+  test('provider-prefixed model still globs when pattern covers it', () => {
+    expect(matchPrice({ 'anthropic/claude-*': { input: 3, output: 15 } }, 'anthropic/claude-sonnet-4')).toEqual({
+      input: 3,
+      output: 15,
+    })
+  })
+
+  test('no match returns undefined', () => {
+    expect(matchPrice(pricing, 'llama-3')).toBeUndefined()
+  })
+})
+
+describe('estimateCostUsd', () => {
+  test('computes per-1M-token pricing', () => {
+    expect(estimateCostUsd({ input: 3, output: 15 }, 100_000, 10_000)).toBeCloseTo(0.45, 10)
+  })
+})
+
+describe('PricingTableSchema', () => {
+  test('rejects negative prices', () => {
+    expect(PricingTableSchema.safeParse({ m: { input: -1, output: 1 } }).success).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/review-loop/cost.test.ts`
+Expected: FAIL — module `../../review-loop/src/cost.js` not found.
+
+- [ ] **Step 3: Implement `review-loop/src/cost.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+export const PriceEntrySchema = z.object({
+  input: z.number().nonnegative(),
+  output: z.number().nonnegative(),
+})
+export const PricingTableSchema = z.record(z.string(), PriceEntrySchema)
+export type PriceEntry = z.infer<typeof PriceEntrySchema>
+export type PricingTable = z.infer<typeof PricingTableSchema>
+
+function globToRegExp(glob: string): RegExp {
+  const escaped = glob.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '.*')
+  return new RegExp(`^${escaped}$`)
+}
+
+export function matchPrice(pricing: PricingTable, model: string): PriceEntry | undefined {
+  const exact = pricing[model]
+  if (exact !== undefined) return exact
+  for (const [pattern, entry] of Object.entries(pricing)) {
+    if (pattern.includes('*') && globToRegExp(pattern).test(model)) return entry
+  }
+  return undefined
+}
+
+export function estimateCostUsd(price: PriceEntry, input: number, output: number): number {
+  return (input / 1_000_000) * price.input + (output / 1_000_000) * price.output
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/review-loop/cost.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Typecheck, lint, commit**
+
+```bash
+bun run review-loop:typecheck && bun run review-loop:lint
+git add review-loop/src/cost.ts tests/review-loop/cost.test.ts
+git commit -m "feat(review-loop): add pricing-table cost estimation module"
+```
+
+---
+
+### Task 2: `diff-stats.ts` — numstat parsing + merge diff measurement
+
+**Files:**
+- Create: `review-loop/src/diff-stats.ts`
+- Test: `tests/review-loop/diff-stats.test.ts`
+
+**Interfaces:**
+- Produces: `DiffStats { added: number; removed: number }`, `ExecGitFn`, `parseNumstat(output): DiffStats`, `headSha(execGit, cwd): Promise<string>`, `measureDiffSince(execGit, cwd, beforeSha): Promise<DiffStats>`. Consumed by Tasks 3 (type), 7, 9.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { headSha, measureDiffSince, parseNumstat, type ExecGitFn } from '../../review-loop/src/diff-stats.js'
+
+describe('parseNumstat', () => {
+  test('sums added/removed across files', () => {
+    expect(parseNumstat('10\t2\tsrc/a.ts\n3\t0\tsrc/b.ts\n')).toEqual({ added: 13, removed: 2 })
+  })
+
+  test('binary lines (-) count as zero', () => {
+    expect(parseNumstat('-\t-\timg.png\n5\t1\tsrc/a.ts\n')).toEqual({ added: 5, removed: 1 })
+  })
+
+  test('rename lines parse', () => {
+    expect(parseNumstat('4\t2\tsrc/{old.ts => new.ts}\n')).toEqual({ added: 4, removed: 2 })
+  })
+
+  test('empty output is zero', () => {
+    expect(parseNumstat('')).toEqual({ added: 0, removed: 0 })
+  })
+})
+
+describe('headSha / measureDiffSince', () => {
+  test('headSha trims rev-parse output', async () => {
+    const execGit: ExecGitFn = (_cwd, args) => {
+      expect(args).toEqual(['rev-parse', 'HEAD'])
+      return Promise.resolve({ stdout: '  abc123\n', stderr: '' })
+    }
+    await expect(headSha(execGit, '/repo')).resolves.toBe('abc123')
+  })
+
+  test('measureDiffSince runs numstat against beforeSha..HEAD', async () => {
+    const execGit: ExecGitFn = (_cwd, args) => {
+      expect(args).toEqual(['diff', '--numstat', 'abc123..HEAD'])
+      return Promise.resolve({ stdout: '7\t3\tsrc/a.ts\n', stderr: '' })
+    }
+    await expect(measureDiffSince(execGit, '/repo', 'abc123')).resolves.toEqual({ added: 7, removed: 3 })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/review-loop/diff-stats.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `review-loop/src/diff-stats.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+export interface DiffStats {
+  added: number
+  removed: number
+}
+
+export type ExecGitFn = (cwd: string, args: readonly string[]) => Promise<{ stdout: string; stderr: string }>
+
+export function parseNumstat(output: string): DiffStats {
+  let added = 0
+  let removed = 0
+  for (const line of output.split('\n')) {
+    if (line.trim() === '') continue
+    const [a, r] = line.split('\t')
+    const addN = Number(a)
+    const remN = Number(r)
+    if (Number.isFinite(addN)) added += addN
+    if (Number.isFinite(remN)) removed += remN
+  }
+  return { added, removed }
+}
+
+export async function headSha(execGit: ExecGitFn, cwd: string): Promise<string> {
+  const { stdout } = await execGit(cwd, ['rev-parse', 'HEAD'])
+  return stdout.trim()
+}
+
+export async function measureDiffSince(execGit: ExecGitFn, cwd: string, beforeSha: string): Promise<DiffStats> {
+  const { stdout } = await execGit(cwd, ['diff', '--numstat', `${beforeSha}..HEAD`])
+  return parseNumstat(stdout)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/review-loop/diff-stats.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Typecheck, lint, commit**
+
+```bash
+bun run review-loop:typecheck && bun run review-loop:lint
+git add review-loop/src/diff-stats.ts tests/review-loop/diff-stats.test.ts
+git commit -m "feat(review-loop): add git numstat diff-stats module"
+```
+
+---
+
+### Task 3: `run-stats.ts` — the pure aggregate
+
+**Files:**
+- Create: `review-loop/src/run-stats.ts`
+- Test: `tests/review-loop/run-stats.test.ts`
+
+**Interfaces:**
+- Consumes: `matchPrice`, `estimateCostUsd`, `PricingTable` (Task 1); `DiffStats` (Task 2).
+- Produces: `LabelStats`, `StatsTotals`, `StatsSnapshot`, `PersistedStats`, `PersistedStatsSchema`, `RunStatsOptions`, `class RunStats { addUsage(label, delta: UsageInput); addToolCalls(label, n); addDiff(label, diff); snapshot(): StatsSnapshot; persist(): PersistedStats; static rehydrate(persisted, options): RunStats }`. Consumed by Tasks 4, 5, 8, 9, 10.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { RunStats } from '../../review-loop/src/run-stats.js'
+
+describe('RunStats', () => {
+  test('accumulates usage per label and in totals', () => {
+    const stats = new RunStats({ startedAt: 0, now: () => 0 })
+    stats.addUsage('select', { input: 100, output: 10, reasoning: 5 })
+    stats.addUsage('improve', { input: 200, output: 20, reasoning: 0 })
+    stats.addUsage('improve', { input: 50, output: 5, reasoning: 1 })
+    const snap = stats.snapshot()
+    expect(snap.totals.input).toBe(350)
+    expect(snap.totals.output).toBe(35)
+    expect(snap.totals.reasoning).toBe(6)
+    expect(snap.perLabel['improve']).toMatchObject({ input: 250, output: 25 })
+  })
+
+  test('clamps NaN and negative values to zero', () => {
+    const stats = new RunStats({ startedAt: 0, now: () => 0 })
+    stats.addUsage('a', { input: Number.NaN, output: -5, reasoning: 3 })
+    stats.addToolCalls('a', -2)
+    stats.addDiff('a', { added: Number.NaN, removed: -1 })
+    const snap = stats.snapshot()
+    expect(snap.totals).toMatchObject({ input: 0, output: 0, reasoning: 3, toolCalls: 0, added: 0, removed: 0 })
+  })
+
+  test('accumulates tool calls and diff per label', () => {
+    const stats = new RunStats({ startedAt: 0, now: () => 0 })
+    stats.addToolCalls('fixer-w1', 3)
+    stats.addToolCalls('fixer-w1', 2)
+    stats.addDiff('worker-1', { added: 10, removed: 4 })
+    const snap = stats.snapshot()
+    expect(snap.totals.toolCalls).toBe(5)
+    expect(snap.totals.added).toBe(10)
+    expect(snap.perLabel['fixer-w1']?.toolCalls).toBe(5)
+    expect(snap.perLabel['worker-1']).toMatchObject({ added: 10, removed: 4 })
+  })
+
+  test('estimates cost from pricing table and per-delta model', () => {
+    const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } }, startedAt: 0, now: () => 0 })
+    stats.addUsage('a', { input: 100_000, output: 10_000, reasoning: 0, model: 'm-x' })
+    expect(stats.snapshot().totals.estimatedCostUsd).toBeCloseTo(0.45, 10)
+  })
+
+  test('omits cost when no pricing entry matches', () => {
+    const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } }, startedAt: 0, now: () => 0 })
+    stats.addUsage('a', { input: 100, output: 10, reasoning: 0, model: 'other' })
+    expect(stats.snapshot().totals.estimatedCostUsd).toBeUndefined()
+  })
+
+  test('omits cost when no pricing configured', () => {
+    const stats = new RunStats({ startedAt: 0, now: () => 0 })
+    stats.addUsage('a', { input: 100, output: 10, reasoning: 0, model: 'm-x' })
+    expect(stats.snapshot().totals.estimatedCostUsd).toBeUndefined()
+  })
+
+  test('constructor model is the fallback when delta has none', () => {
+    const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } }, model: 'm-x', startedAt: 0, now: () => 0 })
+    stats.addUsage('a', { input: 1_000_000, output: 0, reasoning: 0 })
+    expect(stats.snapshot().totals.estimatedCostUsd).toBeCloseTo(3, 10)
+  })
+
+  test('snapshot returns fresh objects each call', () => {
+    const stats = new RunStats({ startedAt: 0, now: () => 0 })
+    stats.addUsage('a', { input: 1, output: 1, reasoning: 0 })
+    const first = stats.snapshot()
+    first.totals.input = 999
+    ;(first.perLabel['a'] as { input: number }).input = 999
+    expect(stats.snapshot().totals.input).toBe(1)
+    expect(stats.snapshot().perLabel['a']?.input).toBe(1)
+  })
+
+  test('elapsedMs comes from now - startedAt', () => {
+    const stats = new RunStats({ startedAt: 1000, now: () => 61_000 })
+    expect(stats.snapshot().totals.elapsedMs).toBe(60_000)
+  })
+
+  test('persist + rehydrate round-trips totals and perLabel', () => {
+    const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } }, startedAt: 0, now: () => 0 })
+    stats.addUsage('a', { input: 100_000, output: 10_000, reasoning: 0, model: 'm-x' })
+    stats.addToolCalls('a', 4)
+    stats.addDiff('iter-1', { added: 7, removed: 2 })
+    const restored = RunStats.rehydrate(stats.persist(), { pricing: { 'm-*': { input: 3, output: 15 } } })
+    const snap = restored.snapshot()
+    expect(snap.totals).toMatchObject({ input: 100_000, output: 10_000, toolCalls: 4, added: 7, removed: 2 })
+    expect(snap.totals.estimatedCostUsd).toBeCloseTo(0.45, 10)
+    expect(snap.perLabel['iter-1']).toMatchObject({ added: 7, removed: 2 })
+  })
+
+  test('rehydrate with undefined starts empty', () => {
+    const stats = RunStats.rehydrate(undefined, {})
+    expect(stats.snapshot().totals.input).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/review-loop/run-stats.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `review-loop/src/run-stats.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+import { estimateCostUsd, matchPrice, type PricingTable } from './cost.js'
+import type { DiffStats } from './diff-stats.js'
+
+export interface UsageInput {
+  input: number
+  output: number
+  reasoning: number
+  model?: string
+}
+
+export interface LabelStats {
+  input: number
+  output: number
+  reasoning: number
+  toolCalls: number
+  added: number
+  removed: number
+}
+
+export interface StatsTotals extends LabelStats {
+  estimatedCostUsd?: number
+}
+
+export interface StatsSnapshot {
+  totals: StatsTotals & { elapsedMs: number }
+  perLabel: Record<string, LabelStats>
+}
+
+export const LabelStatsSchema = z.object({
+  input: z.number(),
+  output: z.number(),
+  reasoning: z.number(),
+  toolCalls: z.number(),
+  added: z.number(),
+  removed: z.number(),
+})
+
+export const PersistedStatsSchema = z.object({
+  totals: LabelStatsSchema.extend({ estimatedCostUsd: z.number().optional() }),
+  perLabel: z.record(z.string(), LabelStatsSchema),
+})
+export type PersistedStats = z.infer<typeof PersistedStatsSchema>
+
+export interface RunStatsOptions {
+  pricing?: PricingTable
+  model?: string
+  startedAt?: number
+  now?: () => number
+}
+
+function clamp(n: number): number {
+  return Number.isFinite(n) && n > 0 ? n : 0
+}
+
+function emptyLabelStats(): LabelStats {
+  return { input: 0, output: 0, reasoning: 0, toolCalls: 0, added: 0, removed: 0 }
+}
+
+export class RunStats {
+  private readonly pricing: PricingTable | undefined
+  private readonly model: string | undefined
+  private readonly startedAt: number
+  private readonly now: () => number
+  private readonly totals: LabelStats = emptyLabelStats()
+  private readonly perLabel = new Map<string, LabelStats>()
+  private estimatedCost = 0
+  private hasCost = false
+
+  constructor(options: RunStatsOptions = {}) {
+    this.pricing = options.pricing
+    this.model = options.model
+    this.now = options.now ?? Date.now
+    this.startedAt = options.startedAt ?? this.now()
+  }
+
+  static rehydrate(persisted: PersistedStats | undefined, options: RunStatsOptions = {}): RunStats {
+    const stats = new RunStats(options)
+    if (persisted === undefined) return stats
+    for (const [label, entry] of Object.entries(persisted.perLabel)) {
+      stats.perLabel.set(label, { ...entry })
+    }
+    stats.totals.input = persisted.totals.input
+    stats.totals.output = persisted.totals.output
+    stats.totals.reasoning = persisted.totals.reasoning
+    stats.totals.toolCalls = persisted.totals.toolCalls
+    stats.totals.added = persisted.totals.added
+    stats.totals.removed = persisted.totals.removed
+    if (persisted.totals.estimatedCostUsd !== undefined) {
+      stats.estimatedCost = persisted.totals.estimatedCostUsd
+      stats.hasCost = true
+    }
+    return stats
+  }
+
+  addUsage(label: string, delta: UsageInput): void {
+    const entry = this.labelEntry(label)
+    entry.input += clamp(delta.input)
+    entry.output += clamp(delta.output)
+    entry.reasoning += clamp(delta.reasoning)
+    this.totals.input += clamp(delta.input)
+    this.totals.output += clamp(delta.output)
+    this.totals.reasoning += clamp(delta.reasoning)
+    const model = delta.model ?? this.model
+    if (this.pricing !== undefined && model !== undefined) {
+      const price = matchPrice(this.pricing, model)
+      if (price !== undefined) {
+        this.estimatedCost += estimateCostUsd(price, clamp(delta.input), clamp(delta.output))
+        this.hasCost = true
+      }
+    }
+  }
+
+  addToolCalls(label: string, n: number): void {
+    const delta = Math.floor(clamp(n))
+    this.labelEntry(label).toolCalls += delta
+    this.totals.toolCalls += delta
+  }
+
+  addDiff(label: string, diff: DiffStats): void {
+    const entry = this.labelEntry(label)
+    entry.added += clamp(diff.added)
+    entry.removed += clamp(diff.removed)
+    this.totals.added += clamp(diff.added)
+    this.totals.removed += clamp(diff.removed)
+  }
+
+  snapshot(): StatsSnapshot {
+    return {
+      totals: { ...this.totals, ...this.costField(), elapsedMs: Math.max(0, this.now() - this.startedAt) },
+      perLabel: Object.fromEntries([...this.perLabel].map(([label, entry]) => [label, { ...entry }])),
+    }
+  }
+
+  persist(): PersistedStats {
+    return {
+      totals: { ...this.totals, ...this.costField() },
+      perLabel: Object.fromEntries([...this.perLabel].map(([label, entry]) => [label, { ...entry }])),
+    }
+  }
+
+  private costField(): { estimatedCostUsd?: number } {
+    return this.hasCost ? { estimatedCostUsd: this.estimatedCost } : {}
+  }
+
+  private labelEntry(label: string): LabelStats {
+    let entry = this.perLabel.get(label)
+    if (entry === undefined) {
+      entry = emptyLabelStats()
+      this.perLabel.set(label, entry)
+    }
+    return entry
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/review-loop/run-stats.test.ts`
+Expected: PASS (11 tests).
+
+- [ ] **Step 5: Typecheck, lint, commit**
+
+```bash
+bun run review-loop:typecheck && bun run review-loop:lint
+git add review-loop/src/run-stats.ts tests/review-loop/run-stats.test.ts
+git commit -m "feat(review-loop): add RunStats aggregate with cost estimation and rehydration"
+```
+
+---
+
+### Task 4: Reporter seam + `LiveRenderer` stats wiring and footer segments
+
+**Files:**
+- Modify: `review-loop/src/progress-log.ts:13-30`
+- Modify: `review-loop/src/live-renderer.ts` (constructor L68-71, `usage` L120-126, `statusLine` L161-179)
+- Test: `tests/review-loop/live-renderer.test.ts` (extend), `tests/review-loop/progress-log.test.ts` (extend if it type-checks the interface; otherwise renderer test covers it)
+
+**Interfaces:**
+- Consumes: `RunStats` (Task 3), `DiffStats` (Task 2).
+- Produces: `UsageDelta` gains optional `label?: string; model?: string`; `ProgressReporter` gains `readonly stats?: RunStats` and `diff?(label: string, diff: DiffStats): void`; `new LiveRenderer(stream, stats?)`. Consumed by Tasks 5, 7, 8, 9.
+
+- [ ] **Step 1: Write the failing test** (append a new describe block to `tests/review-loop/live-renderer.test.ts`; `makeStream` helper already exists at the top of that file)
+
+```ts
+import { RunStats } from '../../review-loop/src/run-stats.js'
+
+describe('LiveRenderer stats', () => {
+  test('routes usage deltas into RunStats with label and model', () => {
+    const { stream } = makeStream()
+    const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } } })
+    const r = new LiveRenderer(stream, stats)
+    r.usage({ input: 100_000, output: 10_000, reasoning: 0, cost: 0, label: 'improve', model: 'm-x' })
+    expect(stats.snapshot().perLabel['improve']?.input).toBe(100_000)
+    expect(stats.snapshot().totals.estimatedCostUsd).toBeCloseTo(0.45, 10)
+  })
+
+  test('diff() routes into RunStats', () => {
+    const { stream } = makeStream()
+    const stats = new RunStats()
+    const r = new LiveRenderer(stream, stats)
+    r.diff('iter-1', { added: 12, removed: 3 })
+    expect(stats.snapshot().totals.added).toBe(12)
+  })
+
+  test('status line gains cost, tools and diff segments (TTY)', () => {
+    const { output, stream } = makeStream({ isTTY: true, columns: 300 })
+    const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } } })
+    const r = new LiveRenderer(stream, stats)
+    r.usage({ input: 100_000, output: 10_000, reasoning: 0, cost: 0, label: 'improve', model: 'm-x' })
+    stats.addToolCalls('improve', 7)
+    r.diff('iter-1', { added: 12, removed: 3 })
+    r.slot('improve', '  improve   ▶ read a.ts · 1s · 1 tool')
+    const last = output.at(-1) ?? ''
+    expect(last).toContain('in 100.0k / out 10.0k')
+    expect(last).toContain('~$0.45 est')
+    expect(last).toContain('tools 7')
+    expect(last).toContain('+12/-3')
+  })
+
+  test('cost segment hidden when no pricing matches', () => {
+    const { output, stream } = makeStream({ isTTY: true, columns: 300 })
+    const stats = new RunStats()
+    const r = new LiveRenderer(stream, stats)
+    r.usage({ input: 100_000, output: 10_000, reasoning: 0, cost: 0, label: 'improve' })
+    r.slot('improve', 'x')
+    expect(output.at(-1) ?? '').not.toContain('est')
+  })
+
+  test('works without stats (legacy single-arg construction)', () => {
+    const { output, stream } = makeStream({ isTTY: true, columns: 300 })
+    const r = new LiveRenderer(stream)
+    r.usage({ input: 5, output: 2, reasoning: 0, cost: 0 })
+    r.slot('a', 'x')
+    expect(output.at(-1) ?? '').toContain('in 5 / out 2')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/review-loop/live-renderer.test.ts`
+Expected: FAIL — `new LiveRenderer(stream, stats)` extra arg type error / `r.diff is not a function`.
+
+- [ ] **Step 3: Implement**
+
+`review-loop/src/progress-log.ts` — extend `UsageDelta` and `ProgressReporter`:
+
+```ts
+import type { DiffStats } from './diff-stats.js'
+import type { RunStats } from './run-stats.js'
+import type { Severity } from './trace-log.js'
+
+// ...IssueProgressEvent unchanged...
+
+export interface UsageDelta {
+  input: number
+  output: number
+  reasoning: number
+  cost: number
+  label?: string
+  model?: string
+}
+
+export interface ProgressReporter {
+  readonly dynamic: boolean
+  readonly stats?: RunStats
+  event(message: string): void
+  live(lines: readonly string[]): void
+  clearLive(): void
+  log(message: string): void
+  issue?(event: IssueProgressEvent): void
+  statusSuffix?(): string
+  slot?(key: string, line: string | null): void
+  usage?(delta: UsageDelta): void
+  diff?(label: string, diff: DiffStats): void
+}
+```
+
+`review-loop/src/live-renderer.ts` — constructor, `stats` property, `usage`, new `diff`, statusLine segments:
+
+```ts
+import { formatDecidedLine, formatFoundLine } from './issue-format.js'
+import { activitySummary, formatDuration, formatTokenCount, MIDDLE_DOT, truncate } from './live-format.js'
+import type { DiffStats } from './diff-stats.js'
+import type { IssueProgressEvent, ProgressReporter, UsageDelta } from './progress-log.js'
+import type { RunStats } from './run-stats.js'
+
+// in class LiveRenderer:
+  readonly stats: RunStats | undefined
+
+  constructor(stream: RendererStream, stats?: RunStats) {
+    this.stream = stream
+    this.tty = stream.isTTY === true
+    this.stats = stats
+  }
+
+  usage(delta: UsageDelta): void {
+    this.touch()
+    this.usageTotals.input += delta.input
+    this.usageTotals.output += delta.output
+    this.usageTotals.reasoning += delta.reasoning
+    this.usageTotals.cost += delta.cost
+    this.stats?.addUsage(delta.label ?? 'agent', delta)
+  }
+
+  diff(label: string, diffStats: DiffStats): void {
+    this.stats?.addDiff(label, diffStats)
+  }
+```
+
+In `statusLine()`, after the existing `in … / out …` push (L174-176), append:
+
+```ts
+    const snap = this.stats?.snapshot()
+    if (snap !== undefined) {
+      if (snap.totals.estimatedCostUsd !== undefined) {
+        parts.push(`~$${snap.totals.estimatedCostUsd.toFixed(2)} est`)
+      }
+      if (snap.totals.toolCalls > 0) parts.push(`tools ${snap.totals.toolCalls}`)
+      if (snap.totals.added > 0 || snap.totals.removed > 0) {
+        parts.push(`+${snap.totals.added}/-${snap.totals.removed}`)
+      }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/review-loop/live-renderer.test.ts tests/review-loop/progress-log.test.ts`
+Expected: PASS (old + new).
+
+- [ ] **Step 5: Typecheck, lint, commit**
+
+```bash
+bun run review-loop:typecheck && bun run review-loop:lint && bun run mutation-improve:typecheck
+git add review-loop/src/progress-log.ts review-loop/src/live-renderer.ts tests/review-loop/live-renderer.test.ts
+git commit -m "feat(review-loop): wire RunStats into LiveRenderer footer segments"
+```
+
+---
+
+### Task 5: `line-handler` forwards label/model and tool-call increments
+
+**Files:**
+- Modify: `review-loop/src/line-handler.ts` (`LiveCtx` L20-34, `applyEvent` step_finish L73-90, `createLineHandler` ctx init L96-110)
+- Test: `tests/review-loop/line-handler.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `UsageDelta.label/model` + `ProgressReporter.stats` (Task 4).
+- Produces: `LiveCtx` gains `readonly model: string` and `reportedToolCalls: number`. No external consumers beyond the handler.
+
+- [ ] **Step 1: Write the failing test** (append to `tests/review-loop/line-handler.test.ts`, inside `describe('createLineHandler reporter wiring')` which already has `makeReporter`; event JSON shapes below match the existing fixtures in this file — `step_finish` requires `part.reason`, `tool_use` uses `part.callID` + `part.state`)
+
+```ts
+  test('step_finish delta carries label/model and tool calls accumulate per step', () => {
+    const cwd = makeTempDir('line-handler-stats-')
+    const stats = new RunStats()
+    const deltas: UsageDelta[] = []
+    const reporter = makeReporter({
+      stats,
+      usage: (d) => {
+        deltas.push(d)
+      },
+    })
+    const handler = createLineHandler({ ...makeOptions(cwd, path.join(cwd, 'agent.log')), reporter })
+    const stepStart = JSON.stringify({ type: 'step_start', timestamp: 1, part: {} })
+    const stepFinish = JSON.stringify({
+      type: 'step_finish',
+      part: { reason: 'stop', tokens: { input: 5, output: 2, reasoning: 1 }, cost: 0 },
+    })
+    const tool = (id: string) =>
+      JSON.stringify({
+        type: 'tool_use',
+        part: { tool: 'read', callID: id, state: { status: 'running', input: { filePath: '/a/cli.ts' } } },
+      })
+    handler.onLine(stepStart)
+    handler.onLine(tool('c1'))
+    handler.onLine(stepFinish)
+    handler.onLine(stepStart)
+    handler.onLine(tool('c2'))
+    handler.onLine(tool('c1')) // duplicate callID from a later step must not double-count
+    handler.onLine(stepFinish)
+    expect(deltas).toEqual([
+      { input: 5, output: 2, reasoning: 1, cost: 0, label: 'drain', model: 'm' },
+      { input: 5, output: 2, reasoning: 1, cost: 0, label: 'drain', model: 'm' },
+    ])
+    expect(stats.snapshot().totals.toolCalls).toBe(2)
+    expect(stats.snapshot().perLabel['drain']?.input).toBe(10)
+  })
+```
+
+Also update the EXISTING test `step_finish forwards usage to the reporter` (line-handler.test.ts:68-84): its `toEqual([{ input: 5, output: 2, reasoning: 1, cost: 0.5 }])` assertion breaks because the delta gains `label`/`model`. Change the expectation to:
+
+```ts
+    expect(deltas).toEqual([{ input: 5, output: 2, reasoning: 1, cost: 0.5, label: 'drain', model: 'm' }])
+```
+
+Add the import at the top of the test file:
+
+```ts
+import { RunStats } from '../../review-loop/src/run-stats.js'
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/review-loop/line-handler.test.ts`
+Expected: FAIL — toolCalls 0 / deltas lack label.
+
+- [ ] **Step 3: Implement**
+
+`review-loop/src/line-handler.ts`:
+
+```ts
+export interface LiveCtx {
+  readonly label: string
+  readonly model: string
+  readonly logPath: string
+  readonly reporter: ProgressReporter | undefined
+  startedAt: number
+  toolCount: number
+  reportedToolCalls: number
+  tool: string
+  arg: string
+  readonly seenCalls: Set<string>
+  timer: ReturnType<typeof setInterval> | null
+  usage: AgentUsage
+  firstStepAt: number | null
+  logChain: Promise<void>
+}
+```
+
+In `applyEvent` `case 'step_finish':`, replace the `reporter.usage?.({...})` call with:
+
+```ts
+        reporter.usage?.({
+          input: evt.tokens.input,
+          output: evt.tokens.output,
+          reasoning: evt.tokens.reasoning,
+          cost: evt.cost,
+          label: ctx.label,
+          model: ctx.model,
+        })
+        const newToolCalls = ctx.toolCount - ctx.reportedToolCalls
+        if (newToolCalls > 0) {
+          ctx.reportedToolCalls = ctx.toolCount
+          reporter.stats?.addToolCalls(ctx.label, newToolCalls)
+        }
+```
+
+In `createLineHandler` ctx initializer add `model: options.model,` and `reportedToolCalls: 0,`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/review-loop/line-handler.test.ts tests/review-loop/agent-runner.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck, lint, commit**
+
+```bash
+bun run review-loop:typecheck && bun run review-loop:lint
+git add review-loop/src/line-handler.ts tests/review-loop/line-handler.test.ts
+git commit -m "feat(review-loop): forward label/model and tool-call increments from line handler"
+```
+
+---
+
+### Task 6: `pricing` config schema (both workspaces) + example configs
+
+**Files:**
+- Modify: `review-loop/src/config.ts:19-32`
+- Modify: `mutation-improve/src/config.ts:19-40`
+- Modify: `review-loop/config.example.json`
+- Modify: `mutation-improve/config.example.json`
+- Test: `tests/review-loop/config.test.ts` (extend), `tests/mutation-improve/config.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `PricingTableSchema` (Task 1).
+- Produces: `ReviewLoopConfig.pricing?: PricingTable`, `MutationImproveConfig.pricing?: PricingTable`. Consumed by Tasks 8, 9.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/review-loop/config.test.ts` (this suite tests the Zod schema directly — follow that pattern):
+
+```ts
+  test('accepts an optional pricing table', () => {
+    const parsed = ReviewLoopConfigSchema.parse({
+      workDir: '.review-loop',
+      reviewer: { model: 'm1' },
+      fixer: { model: 'm2' },
+      matcher: { model: 'm3' },
+      pricing: { 'm-*': { input: 3, output: 15 } },
+    })
+    expect(parsed.pricing).toEqual({ 'm-*': { input: 3, output: 15 } })
+  })
+
+  test('pricing is undefined when omitted', () => {
+    const parsed = ReviewLoopConfigSchema.parse({
+      workDir: '.review-loop',
+      reviewer: { model: 'm1' },
+      fixer: { model: 'm2' },
+      matcher: { model: 'm3' },
+    })
+    expect(parsed.pricing).toBeUndefined()
+  })
+
+  test('rejects a malformed pricing entry', () => {
+    expect(() =>
+      ReviewLoopConfigSchema.parse({
+        workDir: '.review-loop',
+        reviewer: { model: 'm1' },
+        fixer: { model: 'm2' },
+        matcher: { model: 'm3' },
+        pricing: { 'm-*': { input: 'x' } },
+      }),
+    ).toThrow()
+  })
+```
+
+Mirror the same three tests in `tests/mutation-improve/config.test.ts` against `MutationImproveConfigSchema` (use that suite's existing minimal valid config object as the base and add `pricing`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/review-loop/config.test.ts tests/mutation-improve/config.test.ts`
+Expected: FAIL — `pricing` is stripped/undefined on parse (Zod strips unknown keys), so the first assertion fails.
+
+- [ ] **Step 3: Implement**
+
+`review-loop/src/config.ts`:
+
+```ts
+import { PricingTableSchema } from './cost.js'
+
+export const ReviewLoopConfigSchema = z.object({
+  // ...existing fields...
+  matcher: AgentConfigSchema,
+  pricing: PricingTableSchema.optional(),
+})
+```
+
+`mutation-improve/src/config.ts`:
+
+```ts
+import { PricingTableSchema } from '../../review-loop/src/cost.js'
+
+export const MutationImproveConfigSchema = z.object({
+  // ...existing fields...
+  prBranchPrefix: z.string().min(1).default('mutation-improve'),
+  pricing: PricingTableSchema.optional(),
+})
+```
+
+Add to both `config.example.json` files (top-level, after the agent/agent blocks):
+
+```json
+  "pricing": {
+    "anthropic/claude-sonnet-*": { "input": 3, "output": 15 },
+    "anthropic/claude-opus-*": { "input": 15, "output": 75 }
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/review-loop/config.test.ts tests/mutation-improve/config.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck, lint, commit**
+
+```bash
+bun run review-loop:typecheck && bun run review-loop:lint && bun run mutation-improve:typecheck && bun run mutation-improve:lint
+git add review-loop/src/config.ts mutation-improve/src/config.ts review-loop/config.example.json mutation-improve/config.example.json tests/review-loop/config.test.ts tests/mutation-improve/config.test.ts
+git commit -m "feat: add optional pricing table to review-loop and mutation-improve config schemas"
+```
+
+---
+
+### Task 7: review-loop — worker-pool merge diff measurement
+
+**Files:**
+- Modify: `review-loop/src/worker-pool.ts` (`mergeWorkerIntoPrimary` L86-98, `createWorkerPool` L147-176)
+- Test: `tests/review-loop/worker-pool.test.ts` (extend; uses real temp git repos via `setupPrimary` + `createReviewLoopConfigFixture`)
+
+**Interfaces:**
+- Consumes: `headSha`, `measureDiffSince`, `DiffStats` (Task 2).
+- Produces: `WorkerPoolHooks { onMergeDiff?: (workerId: number, diff: DiffStats) => void; warn?: (message: string) => void }`; `createWorkerPool(config, runState, hooks?)`. Consumed by Task 8 (cli wiring).
+
+- [ ] **Step 1: Write the failing test** (append to `tests/review-loop/worker-pool.test.ts`; mirrors the existing temp-repo fixture style)
+
+```ts
+test('mergeWorkerIntoPrimary reports numstat diff via onMergeDiff hook', async () => {
+  const repoRoot = makeTempDir('pool-')
+  const config = createReviewLoopConfigFixture(repoRoot, { poolSize: 1 })
+  const runState = await createRunState(config, path.join(repoRoot, 'plan.md'))
+  await setupPrimary(repoRoot, runState.runId, runState.worktreePath)
+
+  const diffs: Array<{ workerId: number; added: number; removed: number }> = []
+  const pool = await createWorkerPool(config, runState, {
+    onMergeDiff: (workerId, diff) => diffs.push({ workerId, ...diff }),
+    warn: () => undefined,
+  })
+  const worker = await pool.acquire('src/a.ts')
+  writeFileSync(path.join(worker.worktreePath, 'src-a.ts'), 'line1\nline2\nline3\n')
+  await execGit(worker.worktreePath, ['add', '.'])
+  await execGit(worker.worktreePath, ['commit', '-m', 'worker change'])
+  const result = await pool.mergeWorkerIntoPrimary(worker)
+  expect(result.ok).toBe(true)
+  expect(diffs).toEqual([{ workerId: worker.id, added: 3, removed: 0 }])
+  await pool.close()
+})
+
+test('mergeWorkerIntoPrimary without hooks still merges', async () => {
+  const repoRoot = makeTempDir('pool-')
+  const config = createReviewLoopConfigFixture(repoRoot, { poolSize: 1 })
+  const runState = await createRunState(config, path.join(repoRoot, 'plan.md'))
+  await setupPrimary(repoRoot, runState.runId, runState.worktreePath)
+  const pool = await createWorkerPool(config, runState)
+  const worker = await pool.acquire('src/a.ts')
+  writeFileSync(path.join(worker.worktreePath, 'x.ts'), 'x\n')
+  await execGit(worker.worktreePath, ['add', '.'])
+  await execGit(worker.worktreePath, ['commit', '-m', 'x'])
+  expect((await pool.mergeWorkerIntoPrimary(worker)).ok).toBe(true)
+  await pool.close()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/review-loop/worker-pool.test.ts`
+Expected: FAIL — `createWorkerPool` accepts no third arg; no hook invoked (`diffs` stays empty).
+
+- [ ] **Step 3: Implement** (`review-loop/src/worker-pool.ts`)
+
+```ts
+import { headSha, measureDiffSince, type DiffStats } from './diff-stats.js'
+
+export interface WorkerPoolHooks {
+  onMergeDiff?: (workerId: number, diff: DiffStats) => void
+  warn?: (message: string) => void
+}
+
+function mergeWorkerIntoPrimary(
+  internals: PoolInternals,
+  primaryWorktreePath: string,
+  primaryBranch: string,
+  worker: Worker,
+  hooks: WorkerPoolHooks,
+): Promise<{ ok: true } | { ok: false; conflictFiles: string[] }> {
+  return withPrimaryLock(internals, async () => {
+    const rebase = await rebaseOnto(worker.worktreePath, primaryBranch, worker.branch)
+    if (!rebase.ok) return { ok: false, conflictFiles: rebase.conflictFiles }
+    const before = await headSha(execGit, primaryWorktreePath)
+    await mergeFastForward(primaryWorktreePath, worker.branch)
+    try {
+      const diff = await measureDiffSince(execGit, primaryWorktreePath, before)
+      hooks.onMergeDiff?.(worker.id, diff)
+    } catch (error) {
+      hooks.warn?.(`[worker-${worker.id}] merge diff stats failed: ${error instanceof Error ? error.message : String(error)}`)
+    }
+    return { ok: true }
+  })
+}
+
+export async function createWorkerPool(
+  config: ReviewLoopConfig,
+  runState: RunState,
+  hooks: WorkerPoolHooks = {},
+): Promise<WorkerPool> {
+  // ...unchanged body except:
+    mergeWorkerIntoPrimary: (worker: Worker) =>
+      mergeWorkerIntoPrimary(internals, primaryWorktreePath, primaryBranch, worker, hooks),
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/review-loop/worker-pool.test.ts`
+Expected: PASS (old + 2 new).
+
+- [ ] **Step 5: Typecheck, lint, commit**
+
+```bash
+bun run review-loop:typecheck && bun run review-loop:lint
+git add review-loop/src/worker-pool.ts tests/review-loop/worker-pool.test.ts
+git commit -m "feat(review-loop): report merge numstat diffs from worker pool"
+```
+
+---
+
+### Task 8: review-loop — cli wiring, summary totals line, metrics.json `runStats`, resume rehydrate
+
+**Files:**
+- Modify: `review-loop/src/summary.ts` (`MetricsJson` L26-42, `buildTimingLine` area, `buildSummary` L211-230, `buildMetricsJson` L232-258)
+- Modify: `review-loop/src/cli.ts` (`writeRunArtifacts` L164-189, `executeReviewLoop` L191-221, `runCli` L223-250)
+- Test: `tests/review-loop/summary.test.ts` (extend), `tests/review-loop/cli.test.ts` (extend for `writeRunArtifacts` + `readPersistedRunStats`)
+
+**Interfaces:**
+- Consumes: `RunStats`, `PersistedStats`, `StatsSnapshot` (Task 3); `WorkerPoolHooks` (Task 7); `config.pricing` (Task 6).
+- Produces: `MetricsJson.runStats?: PersistedStats`; `SummaryInput.stats?: StatsSnapshot`; `writeRunArtifacts(runDir, result, options)` where `options` gains `stats?: RunStats`; exported `readPersistedRunStats(runDir): Promise<PersistedStats | undefined>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/review-loop/summary.test.ts` (uses the existing `inputOf(overrides)` fixture at line 88):
+
+```ts
+test('buildSummary appends a Stats line when stats are present', () => {
+  const summary = buildSummary(
+    inputOf({
+      stats: {
+        totals: {
+          input: 228_800,
+          output: 41_200,
+          reasoning: 0,
+          toolCalls: 37,
+          added: 412,
+          removed: 87,
+          estimatedCostUsd: 1.02,
+          elapsedMs: 252_000,
+        },
+        perLabel: {},
+      },
+    }),
+  )
+  expect(summary).toContain('Stats: tools 37 · +412/-87 · ~$1.02 est')
+})
+
+test('buildSummary omits the Stats line when stats are absent', () => {
+  expect(buildSummary(inputOf())).not.toContain('Stats:')
+})
+
+test('buildMetricsJson includes runStats when provided', () => {
+  const runStats = {
+    totals: { input: 1, output: 2, reasoning: 0, toolCalls: 3, added: 4, removed: 5, estimatedCostUsd: 0.01 },
+    perLabel: {},
+  }
+  const metrics = buildMetricsJson('clean', 1, 0, [], { poolSize: 1, inspect: false }, runStats)
+  expect(metrics.runStats).toEqual(runStats)
+})
+```
+
+`tests/review-loop/cli.test.ts`:
+
+```ts
+test('writeRunArtifacts persists runStats into metrics.json and a Stats line into summary.txt', async () => {
+  const runDir = makeTempDir('rl-artifacts-')
+  const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } }, startedAt: 0, now: () => 60_000 })
+  stats.addUsage('reviewer', { input: 100_000, output: 10_000, reasoning: 0, model: 'm-x' })
+  stats.addToolCalls('reviewer', 5)
+  await writeRunArtifacts(
+    runDir,
+    { doneReason: 'clean', rounds: 1, metrics: [], ledger: { issues: {} } },
+    { poolSize: 1, inspect: false, wallMs: 60_000, stats },
+  )
+  const metrics = JSON.parse(await readFile(path.join(runDir, 'metrics.json'), 'utf8'))
+  expect(metrics.runStats.totals.toolCalls).toBe(5)
+  expect(metrics.runStats.totals.estimatedCostUsd).toBeCloseTo(0.45, 10)
+  const summary = await readFile(path.join(runDir, 'summary.txt'), 'utf8')
+  expect(summary).toContain('Stats: tools 5')
+})
+
+test('readPersistedRunStats returns undefined when metrics.json is missing or has no runStats', async () => {
+  const runDir = makeTempDir('rl-nostats-')
+  await expect(readPersistedRunStats(runDir)).resolves.toBeUndefined()
+})
+```
+
+(The `writeRunArtifacts` result fixture `{ doneReason: 'clean', rounds: 1, metrics: [], ledger: { issues: {} } }` must satisfy `ReviewLoopResult` — check `review-loop/src/loop-controller.ts` for the exact type and adjust field names if they differ. `console.log(summary)` inside `writeRunArtifacts` will print during the test; that is acceptable — existing cli tests already tolerate it.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/review-loop/summary.test.ts tests/review-loop/cli.test.ts`
+Expected: FAIL — no `stats` on SummaryInput / no 6th param / no `readPersistedRunStats` export.
+
+- [ ] **Step 3: Implement**
+
+`review-loop/src/summary.ts`:
+
+```ts
+import type { PersistedStats, StatsSnapshot } from './run-stats.js'
+
+export interface MetricsJson {
+  // ...existing fields...
+  runStats?: PersistedStats
+}
+
+export interface SummaryInput {
+  // ...existing fields...
+  stats?: StatsSnapshot
+}
+
+function buildStatsLine(stats: StatsSnapshot | undefined): string | null {
+  if (stats === undefined) return null
+  const t = stats.totals
+  const parts: string[] = []
+  if (t.toolCalls > 0) parts.push(`tools ${t.toolCalls}`)
+  if (t.added > 0 || t.removed > 0) parts.push(`+${t.added}/-${t.removed}`)
+  if (t.estimatedCostUsd !== undefined) parts.push(`~$${t.estimatedCostUsd.toFixed(2)} est`)
+  if (parts.length === 0) return null
+  return `Stats: ${parts.join(' · ')}`
+}
+```
+
+In `buildSummary`, after `const inspectorLine = …` block, add:
+
+```ts
+  const statsLine = buildStatsLine(input.stats)
+  if (statsLine !== null) lines.push(statsLine)
+```
+
+In `buildMetricsJson`, add a 6th optional parameter and field:
+
+```ts
+export function buildMetricsJson(
+  doneReason: ReviewLoopResult['doneReason'],
+  rounds: number,
+  closed: number,
+  metrics: readonly RoundMetric[],
+  options: SummaryOptions,
+  runStats?: PersistedStats,
+): MetricsJson {
+  // ...existing body...
+  return {
+    // ...existing fields...
+    ...(runStats === undefined ? {} : { runStats }),
+  }
+}
+```
+
+`review-loop/src/cli.ts`:
+
+```ts
+import { RunStats, type PersistedStats } from './run-stats.js'
+
+export async function readPersistedRunStats(runDir: string): Promise<PersistedStats | undefined> {
+  try {
+    const raw = JSON.parse(await readFile(path.join(runDir, 'metrics.json'), 'utf8')) as { runStats?: PersistedStats }
+    return raw.runStats
+  } catch {
+    return undefined
+  }
+}
+```
+
+`writeRunArtifacts` — extend options and both writes:
+
+```ts
+export async function writeRunArtifacts(
+  runDir: string,
+  result: ReviewLoopResult,
+  options: { poolSize: number; inspect: boolean; wallMs: number; stats?: RunStats },
+): Promise<void> {
+  // ...
+  const summary = buildSummary({
+    // ...existing fields...
+    stats: options.stats?.snapshot(),
+  })
+  // ...
+      JSON.stringify(
+        buildMetricsJson(result.doneReason, result.rounds, closed, result.metrics ?? [], options, options.stats?.persist()),
+        null,
+        2,
+      )
+}
+```
+
+`executeReviewLoop` — pass stats through from the reporter:
+
+```ts
+  await writeRunArtifacts(runState.runDir, result, {
+    poolSize: config.poolSize,
+    inspect,
+    wallMs: Date.now() - startedAt,
+    stats: log.stats,
+  })
+```
+
+`runCli` — construct stats with rehydration, pass into renderer and pool:
+
+```ts
+  const priorStats = args.resumeRunId === undefined ? undefined : await readPersistedRunStats(runState.runDir)
+  const stats = RunStats.rehydrate(priorStats, { pricing: config.pricing })
+  const log = new LiveRenderer(process.stdout, stats)
+  // ...
+  const pool = await createWorkerPool(config, runState, {
+    onMergeDiff: (workerId, diff) => log.diff(`worker-${workerId}`, diff),
+    warn: (message) => log.event(message),
+  })
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/review-loop/summary.test.ts tests/review-loop/cli.test.ts tests/review-loop/worker-pool.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck, lint, full review-loop suite, commit**
+
+```bash
+bun run review-loop:typecheck && bun run review-loop:lint && bun run review-loop:test
+git add review-loop/src/summary.ts review-loop/src/cli.ts tests/review-loop/summary.test.ts tests/review-loop/cli.test.ts
+git commit -m "feat(review-loop): persist run stats to metrics.json and print Stats line in summary"
+```
+
+---
+
+### Task 9: mutation-improve — state stats schema, pipeline merge diff, cli save wrap
+
+**Files:**
+- Modify: `mutation-improve/src/run-state.ts` (schema L33-44)
+- Modify: `mutation-improve/src/pipeline.ts` (`PipelineDeps.log` L53, `finalizePhase` L163-202)
+- Modify: `mutation-improve/src/cli.ts` (`buildPipelineDeps` L141-172, `runCli` L208-249)
+- Test: `tests/mutation-improve/run-state.test.ts` (extend), `tests/mutation-improve/pipeline.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `RunStats`, `PersistedStats`, `PersistedStatsSchema` (Task 3); `headSha`, `measureDiffSince`, `DiffStats` (Task 2); `config.pricing` (Task 6).
+- Produces: `PersistedRunState.stats?: PersistedStats`; `PipelineDeps.log` gains `diff?(label, diff)`; `persistStats(state, stats): void` (exported from `run-state.ts`). Consumed by Task 10.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/mutation-improve/run-state.test.ts` (uses the suite's existing `baseConfig(repoRoot, workDir)` + `makeTempDir` fixture style):
+
+```ts
+test('state.json round-trips the optional stats block', async () => {
+  const repoRoot = makeTempDir('run-state-stats-')
+  const config = baseConfig(repoRoot, path.join(repoRoot, '.mutation-improve'))
+  const state = await createRunState(config)
+  const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } } })
+  stats.addUsage('improve', { input: 100_000, output: 10_000, reasoning: 0, model: 'm-x' })
+  stats.addDiff('iter-1', { added: 301, removed: 12 })
+  persistStats(state, stats)
+  await saveRunState(state)
+  const loaded = await loadRunState(state.workDir, state.runId)
+  expect(loaded.stats?.totals.input).toBe(100_000)
+  expect(loaded.stats?.totals.estimatedCostUsd).toBeCloseTo(0.45, 10)
+  expect(loaded.stats?.perLabel['iter-1']).toMatchObject({ added: 301, removed: 12 })
+})
+
+test('state.json without a stats block loads with stats undefined', async () => {
+  const repoRoot = makeTempDir('run-state-nostats-')
+  const config = baseConfig(repoRoot, path.join(repoRoot, '.mutation-improve'))
+  const state = await createRunState(config)
+  const loaded = await loadRunState(state.workDir, state.runId)
+  expect(loaded.stats).toBeUndefined()
+})
+```
+
+(Add `persistStats` to the existing `run-state.js` import block and import `RunStats` from `../../review-loop/src/run-stats.js`.)
+
+`tests/mutation-improve/pipeline.test.ts` (uses the existing `happyDeps()` fake pattern):
+
+```ts
+test('finalize measures merge diff and reports it via log.diff', async () => {
+  const deps = happyDeps()
+  const diffs: Array<{ label: string; added: number; removed: number }> = []
+  deps.log = { log: () => undefined, diff: (label: string, d: { added: number; removed: number }) => diffs.push({ label, ...d }) }
+  deps.execGit = (_cwd: string, args: readonly string[]) => {
+    if (args[0] === 'rev-parse') return Promise.resolve({ stdout: 'abc123\n', stderr: '' })
+    if (args[0] === 'diff') return Promise.resolve({ stdout: '301\t12\ttests/x.test.ts\n', stderr: '' })
+    return Promise.resolve({ stdout: '', stderr: '' })
+  }
+  const outcome = await runIteration(deps, 1)
+  expect(outcome.outcome).toBe('improved')
+  expect(diffs).toEqual([{ label: 'iter-1', added: 301, removed: 12 }])
+})
+
+test('merge conflict reports no diff', async () => {
+  const deps = happyDeps()
+  const diffs: unknown[] = []
+  deps.log = { log: () => undefined, diff: () => diffs.push(1) }
+  deps.mergeWorktree = () => Promise.resolve({ ok: false, conflictFiles: ['scripts/mutation/baseline.json'] })
+  const outcome = await runIteration(deps, 1)
+  expect(outcome.gate).toBe('merge')
+  expect(diffs).toEqual([])
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/mutation-improve/run-state.test.ts tests/mutation-improve/pipeline.test.ts`
+Expected: FAIL — `persistStats` not exported; `log.diff` never called.
+
+- [ ] **Step 3: Implement**
+
+`mutation-improve/src/run-state.ts`:
+
+```ts
+import { PersistedStatsSchema, type PersistedStats, type RunStats } from '../../review-loop/src/run-stats.js'
+
+export const PersistedRunStateSchema = z.object({
+  // ...existing fields...
+  status: z.enum(['running', 'completed', 'aborted']),
+  stats: PersistedStatsSchema.optional(),
+})
+
+export function persistStats(state: MutationImproveRunState, stats: RunStats): void {
+  state.stats = stats.persist()
+}
+```
+
+`mutation-improve/src/pipeline.ts`:
+
+```ts
+import { headSha, measureDiffSince, type DiffStats } from '../../review-loop/src/diff-stats.js'
+
+// in PipelineDeps:
+  log: { log: (msg: string) => void; issue?: unknown; diff?: (label: string, diff: DiffStats) => void }
+
+// in finalizePhase, around the merge (current L173-185):
+  const beforeSha = await headSha(deps.execGit, deps.config.repoRoot)
+  const merge = await deps.mergeWorktree(deps.config.repoRoot, branchFor(deps, iter))
+  if (!merge.ok) {
+    return {
+      iter,
+      outcome: 'failed',
+      file,
+      beforeScore,
+      afterScore,
+      gate: 'merge',
+      reason: `conflict: ${merge.conflictFiles.join(', ')}`,
+    }
+  }
+  try {
+    const diff = await measureDiffSince(deps.execGit, deps.config.repoRoot, beforeSha)
+    deps.log.diff?.(`iter-${iter}`, diff)
+  } catch (error) {
+    deps.log.log(`[stats] merge diff unavailable: ${error instanceof Error ? error.message : String(error)}`)
+  }
+```
+
+`mutation-improve/src/cli.ts`:
+
+```ts
+import { RunStats } from '../../review-loop/src/run-stats.js'
+import { createRunState, loadRunState, persistStats, saveRunState, type MutationImproveRunState } from './run-state.js'
+
+// buildPipelineDeps gains a stats parameter and wraps saveRunState:
+function buildPipelineDeps(
+  config: MutationImproveConfig,
+  runState: MutationImproveRunState,
+  log: LiveRenderer,
+  cappedRegistry: CappedRegistryStore,
+  stats: RunStats,
+): PipelineDeps {
+  return {
+    // ...existing fields...
+    saveRunState: async (state) => {
+      persistStats(state, stats)
+      await saveRunState(state)
+    },
+    log,
+  }
+}
+
+// in runCli, replace the LiveRenderer construction + deps build:
+  const stats = RunStats.rehydrate(runState.stats, { pricing: config.pricing })
+  const log = new LiveRenderer(process.stdout, stats)
+  const deps = buildPipelineDeps(config, runState, log, cappedRegistry, stats)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/mutation-improve/run-state.test.ts tests/mutation-improve/pipeline.test.ts`
+Expected: PASS. Also run `bun test tests/mutation-improve` to confirm existing pipeline fakes tolerate the two extra `execGit` calls (the sequence fakes clamp to their last entry, and `parseNumstat` treats non-numstat output as zeros — both safe by design).
+
+- [ ] **Step 5: Typecheck, lint, commit**
+
+```bash
+bun run mutation-improve:typecheck && bun run mutation-improve:lint && bun test tests/mutation-improve
+git add mutation-improve/src/run-state.ts mutation-improve/src/pipeline.ts mutation-improve/src/cli.ts tests/mutation-improve/run-state.test.ts tests/mutation-improve/pipeline.test.ts
+git commit -m "feat(mutation-improve): persist run stats in state.json and measure merge diffs per iteration"
+```
+
+---
+
+### Task 10: mutation-improve — terminal run summary
+
+**Files:**
+- Create: `mutation-improve/src/summary.ts`
+- Modify: `mutation-improve/src/cli.ts` (`runCli` tail, L244-248)
+- Test: `tests/mutation-improve/summary.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `StatsSnapshot` (Task 3); `MutationImproveRunState` + `IterationResult`; `formatDuration`, `formatTokenCount` from `review-loop/src/live-format.js`.
+- Produces: `buildRunSummary(input: { runState: MutationImproveRunState; results: readonly IterationResult[]; stats: StatsSnapshot; aborted: boolean }): string`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import type { IterationResult } from '../../mutation-improve/src/pipeline.js'
+import type { MutationImproveRunState } from '../../mutation-improve/src/run-state.js'
+import { buildRunSummary } from '../../mutation-improve/src/summary.js'
+import { RunStats } from '../../review-loop/src/run-stats.js'
+
+function makeRunState(): MutationImproveRunState {
+  return {
+    runId: 'run-1',
+    runDir: '/tmp/x',
+    workDir: '/tmp',
+    statePath: '/tmp/x/state.json',
+    repoRoot: '/tmp',
+    base: 'master',
+    threshold: 0.95,
+    count: 2,
+    currentIteration: 2,
+    doneSet: ['src/a.ts'],
+    merged: [
+      { file: 'src/a.ts', beforeScore: 0.612, afterScore: 0.784, iter: 1 },
+      { file: 'src/b.ts', beforeScore: 0.55, afterScore: 0.667, iter: 2, capped: true },
+    ],
+    failed: [{ iter: 3, file: 'src/c.ts', gate: 'build', reason: 'tsc failed' }],
+    status: 'completed',
+  }
+}
+
+describe('buildRunSummary', () => {
+  test('renders per-file rows, failures and totals', () => {
+    const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } }, startedAt: 0, now: () => 760_000 })
+    stats.addUsage('improve', { input: 228_800, output: 41_200, reasoning: 0, model: 'm-x' })
+    stats.addToolCalls('improve', 37)
+    stats.addDiff('iter-1', { added: 301, removed: 12 })
+    const results: IterationResult[] = [
+      { iter: 1, outcome: 'improved', file: 'src/a.ts' },
+      { iter: 2, outcome: 'capped', file: 'src/b.ts' },
+      { iter: 3, outcome: 'failed', file: 'src/c.ts', gate: 'build' },
+    ]
+    const summary = buildRunSummary({ runState: makeRunState(), results, stats: stats.snapshot(), aborted: false })
+    expect(summary).toContain('src/a.ts')
+    expect(summary).toContain('61.2% → 78.4%')
+    expect(summary).toContain('improved')
+    expect(summary).toContain('+301/-12')
+    expect(summary).toContain('capped')
+    expect(summary).toContain('src/c.ts')
+    expect(summary).toContain('build')
+    expect(summary).toContain('in 228.8k / out 41.2k')
+    expect(summary).toContain('~$1.30 est')
+    expect(summary).toContain('tools 37')
+    expect(summary).toContain('12m40s')
+  })
+
+  test('omits cost when unpriced and marks aborted runs', () => {
+    const stats = new RunStats({ startedAt: 0, now: () => 1000 })
+    const summary = buildRunSummary({ runState: makeRunState(), results: [], stats: stats.snapshot(), aborted: true })
+    expect(summary).toContain('aborted')
+    expect(summary).not.toContain('est')
+  })
+})
+```
+
+(Cost arithmetic: 228_800 in × $3/1M = 0.6864; 41_200 out × $15/1M = 0.618; total 1.3044 → `~$1.30 est`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/mutation-improve/summary.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `mutation-improve/src/summary.ts`**
+
+```ts
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { formatDuration, formatTokenCount } from '../../review-loop/src/live-format.js'
+import type { StatsSnapshot } from '../../review-loop/src/run-stats.js'
+import type { IterationResult } from './pipeline.js'
+import type { MutationImproveRunState } from './run-state.js'
+
+export interface RunSummaryInput {
+  runState: MutationImproveRunState
+  results: readonly IterationResult[]
+  stats: StatsSnapshot
+  aborted: boolean
+}
+
+function pct(score: number): string {
+  return `${(score * 100).toFixed(1)}%`
+}
+
+function mergedRow(entry: MutationImproveRunState['merged'][number], stats: StatsSnapshot): string {
+  const outcome = entry.capped === true ? 'capped' : 'improved'
+  const diff = stats.perLabel[`iter-${entry.iter}`]
+  const diffPart = diff !== undefined && (diff.added > 0 || diff.removed > 0) ? `+${diff.added}/-${diff.removed}` : '-'
+  return `  ${entry.file}  ${pct(entry.beforeScore)} → ${pct(entry.afterScore)}  ${outcome}  ${diffPart}`
+}
+
+function totalsLine(stats: StatsSnapshot): string {
+  const t = stats.totals
+  const parts = [`in ${formatTokenCount(t.input)} / out ${formatTokenCount(t.output)}`]
+  if (t.estimatedCostUsd !== undefined) parts.push(`~$${t.estimatedCostUsd.toFixed(2)} est`)
+  if (t.toolCalls > 0) parts.push(`tools ${t.toolCalls}`)
+  if (t.added > 0 || t.removed > 0) parts.push(`+${t.added}/-${t.removed}`)
+  parts.push(formatDuration(t.elapsedMs))
+  return `Totals: ${parts.join(' · ')}`
+}
+
+export function buildRunSummary(input: RunSummaryInput): string {
+  const { runState, results, stats, aborted } = input
+  const status = aborted ? 'aborted' : runState.failed.length > 0 ? 'completed with failures' : 'completed'
+  const lines = [
+    `Run summary (${runState.runId}) — ${status}: ${runState.merged.length} merged, ${runState.failed.length} failed, ${results.length} iterations`,
+  ]
+  for (const entry of runState.merged) {
+    lines.push(mergedRow(entry, stats))
+  }
+  for (const f of runState.failed) {
+    lines.push(`  ${f.file ?? '(no file)'}  failed at ${f.gate}: ${f.reason}`)
+  }
+  lines.push(totalsLine(stats))
+  return lines.join('\n')
+}
+```
+
+`mutation-improve/src/cli.ts` — in `runCli`, after the `try/finally` that saves state and before the finalize/exit-code block:
+
+```ts
+  console.log(buildRunSummary({ runState, results, stats: stats.snapshot(), aborted }))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/mutation-improve/summary.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck, lint, commit**
+
+```bash
+bun run mutation-improve:typecheck && bun run mutation-improve:lint
+git add mutation-improve/src/summary.ts mutation-improve/src/cli.ts tests/mutation-improve/summary.test.ts
+git commit -m "feat(mutation-improve): print end-of-run terminal summary with aggregate stats"
+```
+
+---
+
+### Task 11: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run both full suites and all checks**
+
+```bash
+bun run review-loop:test
+bun run mutation-improve:test
+bun run review-loop:typecheck && bun run review-loop:lint && bun run review-loop:format:check
+bun run mutation-improve:typecheck && bun run mutation-improve:lint && bun run mutation-improve:format:check
+```
+
+Expected: all green. Fix any format drift with `bun run review-loop:format` / `bun run mutation-improve:format` and commit as `style: apply oxfmt`.
+
+- [ ] **Step 2: Smoke-run the live footer manually (optional, TTY only)**
+
+```bash
+bun run mutation-improve:start -- --count 1 --threshold 0
+```
+
+Expected: status line shows `in …k / out …k · ~$… est · tools N · +a/-b` segments while an iteration runs (cost segment only when `pricing` is configured in `mutation-improve/config.json`); end of run prints the `Run summary` block. `--threshold 0` makes every file already-at-threshold → exercises the skip path quickly; a full improved-path smoke can use the default threshold.
+
+- [ ] **Step 3: Commit any residual fixes**
+
+```bash
+git status --short
+git add -A && git commit -m "chore: final verification fixes for progress stats renderer"
+```

--- a/docs/superpowers/specs/2026-08-07-mutation-coverage-create-field-helpers-design.md
+++ b/docs/superpowers/specs/2026-08-07-mutation-coverage-create-field-helpers-design.md
@@ -1,0 +1,117 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation Coverage — `plugins/task-provider-youtrack/create-field-helpers.ts` Design
+
+**Date:** 2026-08-07
+**Status:** Approved for planning
+**Target file:** `plugins/task-provider-youtrack/create-field-helpers.ts` (`collectFieldPairs`, which
+tags dedicated params by field kind and flattens generic `customFields`, plus `resolveFieldPair`)
+**Before score:** 0.813953488372093 (killed=35 survived=2 noCoverage=6, total=43)
+**Target score:** ≥ 0.9
+
+## Summary
+
+`create-field-helpers.ts` has a companion test
+(`tests/plugins/task-provider-youtrack/create-field-helpers.test.ts`) that covers the `status`/`priority`
+branches of `collectFieldPairs`, the `customFields` generic branch, and the two `resolveFieldPair`
+paths (dedicated resolution + unknown-generic throw). The remaining gap is narrow but precise: the
+`assignee` (line 35) and `dueDate` (line 36) dedicated branches are **never exercised by any test in
+the suite**. Consequently the `!== undefined` conditional that always returns `false`, the pushed
+object literal (→ `{}`), and both string literals on each of those two lines all survive.
+
+This spec adds **two** focused `test()`s — one per surviving mutant class — to the existing
+companion file. Each asserts an exact `toBe(...)` on every field of the single produced pair (plus
+`toHaveLength(1)` on the array), killing all 8 non-killed mutants and raising the score to **1.0**.
+There are no accepted residuals: every survivor is observable as a changed exact value.
+
+## Why this file
+
+`collectFieldPairs` is the entry point that turns a `DedicatedParams` bag into the flat
+`FieldPair[]` consumed by `resolveFieldPair`; it is imported by the YouTrack create/update flows. A
+surviving mutant on the `assignee` or `dueDate` branch silently drops the dedicated pair, swaps its
+`kind` tag, or empties the pushed object — which would misroute field resolution for assignee/due
+date values. The function is pure and synchronous, so every behaviour is observable as an exact
+return value, making it an ideal mutation target. The `status`/`priority` lines already score
+perfectly; only `assignee` and `dueDate` are uncovered.
+
+## Non-goals
+
+- **No production-code changes.** `src/`, `client/`, `plugins/`, `scripts/` are untouched; the diff
+  gate restricts edits to `tests/` and `docs/superpowers/`.
+- **No edits to `scripts/mutation/baseline.json`** (the runner owns the ratchet).
+- The existing companion test file is **extended in place** (not replaced); the only additions are
+  the two new `test()` blocks plus the imports they need.
+- No comments added to the test file (repo convention).
+
+## Gap analysis
+
+Measured via `bun test:mutate:file plugins/task-provider-youtrack/create-field-helpers.ts`; report at
+`reports/paired/plugins__task-provider-youtrack__create-field-helpers.ts.stryker-report.json`.
+2 `Survived` + 6 `NoCoverage` = 8 non-killed mutants (score 35/43 = 0.8140). They group into two
+classes, one per uncovered dedicated branch. Mutant ids are Stryker ids from the report; locations
+are `line:col` in `plugins/task-provider-youtrack/create-field-helpers.ts`.
+
+The two relevant source lines are:
+
+```
+35:   if (params.assignee !== undefined) pairs.push({ source: 'dedicated', kind: 'user', value: params.assignee })
+36:   if (params.dueDate !== undefined) pairs.push({ source: 'dedicated', kind: 'date', value: params.dueDate })
+```
+
+| # | Class (behaviour) | Mutant ids | Loc | Root cause / why it survives |
+|---|---|---|---|---|
+| 1 | `collectFieldPairs` assignee branch — the `!== undefined` conditional (→ always `false`), the pushed object literal (→ `{}`), and the `'dedicated'` / `'user'` string literals (→ `""`) | 15, 17, 18, 19 | 35:7, 35:49, 35:59, 35:78 | No test in the suite passes `assignee` to `collectFieldPairs`, so line 35 is never taken. The `=== undefined` equality-flip (mutant 16) and the conditional-→`true` (mutant 14) are killed indirectly because they inject an *extra* `value: undefined` pair that breaks an exact-output assertion elsewhere, but nothing verifies that a *provided* `assignee` value round-trips. Conditional-→`false` (15) drops the pair entirely; object-→`{}` (17) empties it; `'dedicated'`→`""` (18) and `'user'`→`""` (19) corrupt the tags. A single test passing `assignee` and asserting the exact pair kills all four. |
+| 2 | `collectFieldPairs` dueDate branch — the `!== undefined` conditional (→ always `false`), the pushed object literal (→ `{}`), and the `'dedicated'` / `'date'` string literals (→ `""`) | 21, 23, 24, 25 | 36:7, 36:48, 36:58, 36:77 | No test passes `dueDate`, so line 36 is never taken. Identical root cause to class 1: the equality-flip (22) and conditional-→`true` (20) are killed by the extra-pair side effect, but nothing verifies a provided `dueDate` round-trips. Conditional-→`false` (21) drops the pair; object-→`{}` (23) empties it; `'dedicated'`→`""` (24) and `'date'`→`""` (25) corrupt the tags. A single test passing `dueDate` and asserting the exact pair kills all four. |
+
+Note: the only reason the `=== undefined` flip and conditional-→`true` are already `Killed` while
+conditional-→`false` survives is asymmetric observability — an *extra* element changes an exact array
+used elsewhere, whereas a *missing* element is invisible until a test specifically provides that
+param.
+
+## Design — tests to add
+
+Each class maps **one-to-one** to a single new `test()` appended to the existing
+`tests/plugins/task-provider-youtrack/create-field-helpers.test.ts`. To make each assertion a
+clean, single-element observation, each fixture passes **only** the dedicated param under test (no
+`status`/`priority`/`customFields`), so the returned array is exactly one pair. Every assertion is
+an exact `toBe(...)` (or `toHaveLength` for the array length) — never `toContain` / `startsWith` /
+`endsWith`.
+
+| Test (class #) | Fixture | Exact expected value | Kills |
+|---|---|---|---|
+| T1 (#1) `collectFieldPairs` assignee pair | `collectFieldPairs({ assignee: 'someone' })` | `toHaveLength(1)`; `pairs[0].source` is `toBe('dedicated')`, `.kind` is `toBe('user')`, `.value` is `toBe('someone')` | 15, 17, 18, 19 |
+| T2 (#2) `collectFieldPairs` dueDate pair | `collectFieldPairs({ dueDate: '2026-01-01' })` | `toHaveLength(1)`; `pairs[0].source` is `toBe('dedicated')`, `.kind` is `toBe('date')`, `.value` is `toBe('2026-01-01')` | 21, 23, 24, 25 |
+
+**Projected after-score:** killed = 35 + 8 = **43**, non-killed = 0, total = 43 →
+**score = 43/43 = 1.0** (≥ 0.9 target).
+
+Why each mutant dies under its test:
+
+- **15 / 21** (conditional → `false`): the pair is never pushed, so `toHaveLength(1)` fails (array is empty).
+- **17 / 23** (object literal → `{}`): `pairs[0]` is `{}`, so `.source`/`.kind`/`.value` are `undefined` and each `toBe(...)` fails.
+- **18 / 24** (`'dedicated'` → `""`): `.source` becomes `""`, failing `toBe('dedicated')`.
+- **19** (`'user'` → `""`): `.kind` becomes `""`, failing `toBe('user')`.
+- **25** (`'date'` → `""`): `.kind` becomes `""`, failing `toBe('date')`.
+
+## Verification
+
+1. `bun test tests/plugins/task-provider-youtrack/create-field-helpers.test.ts` is green (all
+   `test()`s, including the two new ones).
+2. `bun test:mutate:file plugins/task-provider-youtrack/create-field-helpers.ts` reports
+   `killed=43 survived=0 noCoverage=0 score=1.0`, and
+   `reports/paired/plugins__task-provider-youtrack__create-field-helpers.ts.stryker-report.json`
+   shows zero non-killed mutants.
+3. No file under `src/`, `client/`, `plugins/`, `scripts/`, or `scripts/mutation/baseline.json` is
+   modified (diff-gate); the only new/changed files are under `tests/` and `docs/superpowers/`, plus
+   the single `.review-loop/result.json`.
+
+## Accepted residuals
+
+None. Every surviving mutant in this file is observable as a changed exact value: a dropped pair
+(broken `toHaveLength`), an emptied object (broken field `toBe`), or a corrupted tag string (broken
+`toBe`). No equivalent mutants remain; the projected score is 1.0.

--- a/docs/superpowers/specs/2026-08-07-mutation-coverage-dedicated-fields-design.md
+++ b/docs/superpowers/specs/2026-08-07-mutation-coverage-dedicated-fields-design.md
@@ -1,0 +1,156 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation coverage: `plugins/task-provider-youtrack/dedicated-fields.ts`
+
+## Summary
+
+Raise the Stryker mutation score of `plugins/task-provider-youtrack/dedicated-fields.ts`
+from **0.6699** (69 killed / 103 total; 27 Survived + 7 NoCoverage) to **>= 0.9** by
+extending its companion test file `tests/plugins/task-provider-youtrack/dedicated-fields.test.ts`.
+This is a **test-only** change: no production file is touched. Every killable surviving
+mutant class is covered by exactly one focused test that asserts exact values (`toBe` /
+`toEqual`); the remaining equivalent / unreachable mutants are declared as accepted
+residuals.
+
+## Why this file
+
+`dedicated-fields.ts` resolves a dedicated param (`state` / `user` / `priority` /
+`date`) to the project's real `ProjectCustomField`: it filters fields by type, takes the
+sole candidate as a shortcut (except `priority`, which is always ambiguous because enum
+fields are non-unique), and otherwise disambiguates by a canonical English/Russian name
+before raising a teaching error. It is pure logic with no I/O, so it is an ideal
+mutation target. Its current suite (7 tests) only exercises the state/user sole-field
+shortcuts and the English `priority` / `assignee` canonical names — leaving the entire
+`date` kind, every Russian canonical name, the localized-name branch, the candidate-filter
+guards, the sole/ambiguous return guards, and the exact teaching-error text uncovered.
+
+## Non-goals
+
+- Editing anything under `src/`, `client/`, `plugins/`, or `scripts/`.
+- Editing `scripts/mutation/baseline.json` (the runner owns it).
+- Refactoring `dedicated-fields.ts` to remove dead code; equivalent / unreachable mutants
+  are declared as accepted residuals instead.
+- Changing the public export (`resolveDedicatedField`) or the `DedicatedKind` type.
+
+## Gap analysis
+
+Measured survivors come from
+`reports/paired/plugins__task-provider-youtrack__dedicated-fields.ts.stryker-report.json`.
+Each row is one mutant class (a coherent locus of survivors). The "mutant ids" column
+lists the exact Stryker `id` values in that class.
+
+| # | Class | Locus | Mutant ids | Status |
+|---|-------|-------|------------|--------|
+| C1 | `CANONICAL_NAMES.state` array + literal strings | L18 | 1,2,3 | Survived |
+| C2 | `CANONICAL_NAMES.user` Russian literal | L19 | 6 | Survived |
+| C3 | `CANONICAL_NAMES.priority` Russian literal | L20 | 9 | Survived |
+| C4 | `matchesType` priority `c.label === 'enum'` (forced true) | L27 | 26 | Survived |
+| C5 | `matchesType` user `kind === 'user'` (forced true) | L28 | 30 | Survived |
+| C6 | `matchesType` date branch (whole expression) | L29 | 38,39,40,41 | NoCoverage |
+| C7 | `matchesCanonicalName` localized-name branch (`??`, right operand) | L34,L37 | 44,53,60 | Survived/NoCov |
+| C8 | `dedicatedError` join separator `'; '` | L44 | 66 | Survived |
+| C9 | `dedicatedError` empty-candidates guard + `appError.field` | L46,L49 | 68,72 | Survived |
+| C10 | candidate-filter: drop `?.` on `f.field` (fieldless entry) | L61 | 81 | Survived |
+| C11 | sole-candidate shortcut condition + `'priority'` literal | L62 | 85,87 | Survived |
+| C12 | ambiguous named-match return: `&&`→`\|\|` + `named.length === 1` guard | L68 | 98,99 | Survived |
+| C13 | `CANONICAL_NAMES.date` array + literal strings | L21 | 10,11,12 | Survived |
+| R1 | `matchesCanonicalName` `field.field?.name` optional chaining | L33 | 43 | Survived (equivalent) |
+| R2 | `matchesCanonicalName` `field.field?.localizedName` optional chaining | L34 | 45 | Survived (equivalent) |
+| R3 | `matchesCanonicalName` `name !== undefined` (always true for candidates) | L36 | 51 | Survived (equivalent) |
+| R4 | `matchesCanonicalName` `localized !== null` (dead: `?? undefined` forbids null) | L37 | 59 | NoCoverage (equivalent) |
+| R5 | `fieldName` `field.field?.name` optional chaining | L41 | 63 | Survived (equivalent) |
+| R6 | `fieldName` `?? '(unnamed)'` fallback (dead for candidates) | L41 | 64 | NoCoverage (unreachable) |
+| R7 | sole-candidate `only !== undefined` (redundant given `length === 1`) | L64 | 91 | Survived (equivalent) |
+| R8 | ambiguous return `pick !== undefined` (redundant given `length === 1`) | L68 | 101 | Survived (equivalent) |
+| R9 | candidate-filter name guard `f.field?.name !== undefined` (redundant under valid data) | L61 | 79 | Survived (equivalent) |
+
+## Design — tests to add
+
+One focused test per killable gap class (C1-C13); residuals R1-R9 are accepted (see
+below). All assertions use exact equality (`toBe` / `toEqual`) on fully-knowable values.
+
+- **C1 → state canonical disambiguation.** Two state-typed fields where one is named
+  `State` (English) and a second scenario where one is named `Статус` (Russian); each
+  resolves the canonically-named field. Kills the `state` array, the `state` literal, and
+  the `статус` literal.
+- **C2 → user Russian canonical.** Two user-typed fields where one is named
+  `Ответственный`; it resolves. Kills the `ответственный` literal.
+- **C3 → priority Russian canonical.** Two enum fields where one is named `Приоритет`; it
+  resolves. Kills the `приоритет` literal.
+- **C4 → priority type-match forced true.** `resolveDedicatedField('priority', …)` with
+  only non-enum fields asserts the exact "No priority-type field exists…" message; under
+  the mutant those fields wrongly become candidates and the message flips. Also covers C9.
+- **C5+C6 → date kind.** A sole date field (alongside a non-date field) resolves via the
+  sole-candidate shortcut, exercising `matchesType` for both `date` (killing the whole
+  date expression) and the `user` short-circuit (the mutant diverts `date` into the
+  `c.kind === 'user'` return and the field stops matching).
+- **C7 → localized-name disambiguation.** A user field whose `name` is non-canonical but
+  whose `localizedName` is `Assignee` resolves; kills the `??` → `&&`, the localized
+  right-operand forced false, and the `localized !== null` → `=== null` mutants.
+- **C8 → multiple-candidate join separator.** Two user fields with no canonical name
+  throw, and the exact message — including the `Name; Name` join — is asserted.
+- **C9 → empty-candidates branch + appError tag.** The C4 priority-no-enum case also
+  asserts `err.appError` equals `providerError.validationFailed('customFields', …)`,
+  pinning the `candidates.length === 0` ternary and the `'customFields'` field literal.
+- **C10 → candidate-filter optional chaining.** A `state` resolve over `[fieldless,
+  named state]` resolves the named field: a field with no `field` object kills the
+  `f.field?.name` optional-chaining mutant (it would throw on `undefined.name`). (The
+  sibling "drop the name guard" mutant id 79 is equivalent under schema-valid data — see
+  R9 — because a typed `ProjectCustomField` always carries a `name`, so the guard never
+  excludes a type-matching field; it cannot be killed without zod-invalid input.)
+- **C11 → sole-candidate shortcut.** A single non-canonical enum field passed as
+  `priority` is *not* auto-resolved; it throws the exact "Multiple candidate fields…"
+  message. The mutant that forces the shortcut condition true (or blanks the `'priority'`
+  literal) would return the field instead.
+- **C12 → ambiguous named match is not silently resolved.** Two user fields both named
+  `Assignee` throw; the `&&`→`||` and `named.length === 1`-forced-true mutants would
+  return the first match.
+- **C13 → date canonical disambiguation.** Two date fields where one is named `Due Date`
+  and a second scenario where one is named `Дедлайн`; each resolves. Kills the `date`
+  array and both literals.
+
+## Verification
+
+1. `bun test tests/plugins/task-provider-youtrack/dedicated-fields.test.ts` is green.
+2. `bun test:mutate:file plugins/task-provider-youtrack/dedicated-fields.ts` reports a
+   score >= 0.9; the only remaining survivors are exactly the declared residuals (R1-R9).
+
+## Accepted residuals
+
+Equivalent or unreachable mutants that survive every possible test and therefore cannot
+be killed without editing `src/`/`plugins/`. The runner re-measures; the declared
+`mutantIds` must equal the post-test survivor set. Per-loc reasoning is recorded in the
+result JSON.
+
+- **R1 (id 43)** — `matchesCanonicalName` is only ever called on candidates, and the
+  candidate filter guarantees `f.field?.name !== undefined`, so `field.field` is always
+  defined; `field.field?.name` and `field.field.name` are observationally identical.
+- **R2 (id 45)** — same reasoning on `field.field?.localizedName`; `field.field` is always
+  present for candidates.
+- **R3 (id 51)** — `name !== undefined` is always true for candidates (the filter already
+  required it), so forcing it `true` changes nothing.
+- **R4 (id 59)** — `localized` can never be `null`: L34 `field.field?.localizedName ??
+  undefined` maps `null` to `undefined`, so `localized !== null` is perpetually `true` and
+  forcing it `true` is a no-op.
+- **R5 (id 63)** — `fieldName` is only called via `candidates.map(fieldName)`; candidates
+  always have `field.field` defined, so `field.field?.name` vs `field.field.name` coincide.
+- **R6 (id 64)** — the `?? '(unnamed)'` fallback is dead: `fieldName` only runs on
+  candidates whose name is a defined string, so the nullish arm never fires.
+- **R7 (id 91)** — `only !== undefined` is redundant: it sits inside `if
+  (candidates.length === 1)`, and a dense filter result always has a defined element at
+  index 0 when its length is 1.
+- **R8 (id 101)** — `pick !== undefined` is redundant for the same reason: `pick =
+  named[0]` and the enclosing guard requires `named.length === 1`, so `pick` is always
+  defined.
+- **R9 (id 79)** — the candidate-filter name guard `f.field?.name !== undefined` is
+  redundant under schema-valid data: `ProjectCustomFieldSchema` makes `field.name` a
+  required `string` whenever `field` is present, and a field with no `field` is already
+  rejected by `matchesType` (it classifies as `unknown`). So no schema-valid input has a
+  type-matching field whose name is `undefined`, and dropping the guard changes nothing.
+  Killing it would require zod-invalid test data, which the lint policy
+  (`no-unsafe-type-assertion`) blocks constructing.

--- a/docs/superpowers/specs/2026-08-07-mutation-coverage-field-engine-design.md
+++ b/docs/superpowers/specs/2026-08-07-mutation-coverage-field-engine-design.md
@@ -1,0 +1,156 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation coverage: `plugins/task-provider-youtrack/field-engine.ts`
+
+## Summary
+
+Raise the Stryker mutation score of `plugins/task-provider-youtrack/field-engine.ts`
+from **0.4747** (122 killed / 257 total; 90 Survived + 45 NoCoverage) to **>= 0.9**
+by extending its companion test file `tests/plugins/task-provider-youtrack/field-engine.test.ts`.
+This is a **test-only** change: no production file is touched. Every surviving mutant
+class is covered by exactly one focused test that asserts exact values (`toBe`).
+
+## Why this file
+
+`field-engine.ts` is the YouTrack custom-field resolver: it classifies a
+`ProjectCustomField` by its `fieldType.id`, looks up a `$type` + label from a static
+`TYPE_TABLE`, and resolves a raw user string into the wire payload (bundle match, user
+login list, date/period/text/simple). It is pure logic with no I/O of its own, so it is
+an ideal, high-ROI mutation target. Its current suite (9 tests) only exercises the
+state/enum bundle path, the integer numeric guard, and the text shortcut — leaving the
+majority of the `TYPE_TABLE`, the `parseFieldTypeId` regex, the cap helpers, the
+multi-value splitter, and every `switch` branch of `resolveCustomFieldValue` uncovered.
+
+## Non-goals
+
+- Editing anything under `src/`, `client/`, `plugins/`, or `scripts/`.
+- Editing `scripts/mutation/baseline.json` (the runner owns it).
+- Refactoring `field-engine.ts` to remove dead code; equivalent/unreachable mutants are
+  declared as accepted residuals instead.
+- Changing the public exports (`classifyFieldType`, `formatAllowed`,
+  `capAllowedValues`, `normalize`, `resolveCustomFieldValue`).
+
+## Gap analysis
+
+Measured survivors come from `reports/paired/plugins__task-provider-youtrack__field-engine.ts.stryker-report.json`.
+Each row is one mutant class (a coherent locus of survivors). The "mutant ids" column
+lists the exact Stryker `id` values in that class.
+
+| # | Class | Locus | Mutant ids | Status |
+|---|-------|-------|------------|--------|
+| C1 | `TYPE_TABLE` literals + entry objects not asserted | L42-63 | 10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,28,29,30,33,34,35,36,37,38,39,40,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65 | Survived |
+| C2 | `parseFieldTypeId` whole-id trim, base trim, regex anchors, multi default | L66-75 | 67,69,70,71,83,90 | Survived/NoCov |
+| C3 | `BUNDLE_SEGMENTS` value strings | L77-82 | 94,95,96 | Survived |
+| C4 | `classifyFieldType` optional-chaining + unknown branching + bundle-kind guard | L88-101 | 102,103,105,116,120 | Survived |
+| C5 | `classifyFieldType` unknown-branch return object + literals | L91-93 | 107,108,109,110,111,112,113,114 | NoCov |
+| C6 | `formatAllowed` cap boundary + overflow template | L104-107 | 122,123,124,125,127,128,129,130 | Survived/NoCov |
+| C7 | `capAllowedValues` cap boundary + slice | L109-112 | 133,134,138 | Survived |
+| C8 | `normalize` trim | L117 | 144 | Survived |
+| C9 | `splitMulti` filter + per-token trim | L119-125 | 146,149,151,153 | Survived |
+| C10 | `matchBundleValue` single-match guard | L133 | 172,173 | Survived |
+| C11 | `resolveCustomFieldValue` name guard + missing-name error | L151-152 | 185,187,189,190 | Survived/NoCov |
+| C12 | `resolveCustomFieldValue` simple numeric guard (incl. float) | L158 | 199,205,206,207 | Survived/NoCov |
+| C13 | `resolveCustomFieldValue` simple (string) return object | L165 | 216,217 | NoCov |
+| C14 | `resolveCustomFieldValue` `date` case | L167-168 | 218,219,220,221 | Survived/NoCov |
+| C15 | `resolveCustomFieldValue` `period` case | L169-170 | 222,223,224,225,226 | Survived/NoCov |
+| C16 | `resolveCustomFieldValue` `user` case | L171-174 | 227,228,229,230,231,232 | Survived/NoCov |
+| C17 | `resolveCustomFieldValue` bundle guard + no-resolvable error | L177-180 | 236,238,239,240,242,244,245 | Survived/NoCov |
+| C18 | `resolveCustomFieldValue` `unknown` case + error template | L185-189 | 249,250,251,252,253,255 | NoCov |
+| R1 | `bundleSegmentFromType` `bundleType === undefined` guard | L86 | 99 | Survived (equivalent) |
+| R2 | `matchBundleValue` `matched !== undefined` (redundant given length===1) | L133 | 175 | Survived (equivalent) |
+| R3 | `parseFieldTypeId` `match[1] ?? ''` / `match[2] ?? ''` fallbacks | L70-71 | 78,80 | NoCov (unreachable) |
+| R4 | `issueType` `resolved === undefined` throw + its message | L142 | 181,183 | Survived/NoCov (unreachable) |
+| R5 | unknown error `field.field?.fieldType` 2nd-level optional chaining | L188 | 254 | NoCov (unreachable) |
+| R6 | final `throw new Error('Unreachable…')` message | L191 | 256 | NoCov (unreachable) |
+
+## Design — tests to add
+
+One focused test per gap class (C1-C18); residuals R1-R6 are accepted (see below).
+All assertions use exact equality (`toBe` / `toEqual`) on fully-knowable values.
+
+- **C1 → `classifyFieldType` table-driven rows.** A data-driven test asserts `kind`,
+  `label`, `singleType`, `multiType`, `multi`, and `bundleSegment` for every `TYPE_TABLE`
+  key: `enum[1]`, `state[*]`, `version[1]`, `version[*]`, `ownedField[1]`,
+  `ownedField[*]`, `build[1]`, `build[*]`, `user[1]`, `user[*]`, `text`, `string`,
+  `integer`, `float`, `date`, `date and time`, `period`. Bundle rows carry a matching
+  `bundle.$type` so `bundleSegment` is exercised.
+- **C2 → parseFieldTypeId edge inputs.** Spaced id (`' state[1] '`), internally-spaced
+  base (`'State  [1]'`), trailing garbage (`'state[1]x'`), newline-anchored
+  (`'a\n[1]'`), bracketless field (`'text'`), and `fieldType.id === undefined`.
+- **C3 → bundleSegment mapping.** `classifyFieldType` on `version`/`ownedField`/`build`
+  fields whose `bundle.$type` is `VersionBundle` / `OwnedFieldBundle` / `BuildBundle`.
+- **C4 → classifyFieldType optionals.** A field with no `field` (kills `?.fieldType`),
+  a field whose `fieldType` is missing (kills `?.id`), an unknown base (kills the
+  `entry === undefined` branch), and a non-bundle kind that still carries a `bundle`
+  (kills the `entry.kind === 'bundle'` guard), plus a bundle field without a `bundle`
+  (kills `field.bundle?.$type`).
+- **C5 → unknown-branch literals.** Two classifyFieldType calls: empty base
+  (`fieldType.id` absent) asserting `label`/`kind` `'unknown'`; non-empty unknown base
+  (`'gizmo[1]'`) asserting `label` equals the base.
+- **C6 → formatAllowed boundaries.** `<=` (1 value), exact-cap (50 values), and
+  overflow (51 values) asserting the full `…and N more` string.
+- **C7 → capAllowedValues boundaries.** Small, exact-cap (50), and overflow (51)
+  asserting element count and the trailing summary element.
+- **C8 → normalize.** `normalize('  Hello  ')` is `'hello'`.
+- **C9 → splitMulti via multi resolve.** Empty middle entry (`'Open,,Fixed'`) on a
+  multi-enum, and whitespace around tokens (`' alice , bob '`) on a multi-user field.
+- **C10 → matchBundleValue ambiguity.** A bundle with two equally-named elements;
+  resolving must throw the teaching error.
+- **C11 → missing-name guard.** A field with no `field` (throws), and a field whose
+  `field` lacks `name`; asserts `appError.field === 'customFields'` and the exact
+  reason.
+- **C12 → numeric guard.** String-typed simple field given a numeric string keeps it a
+  string (`'5'`); float field `'1.5'` becomes `1.5`; non-numeric string on a string
+  field does **not** throw.
+- **C13 → simple string return.** String field resolves to
+  `{ $type: 'SimpleIssueCustomField', value: rawValue }`.
+- **C14 → date case.** Date field resolves with `$type` `'DateIssueCustomField'` and the
+  parsed timestamp.
+- **C15 → period case.** Period field resolves with `$type` `'PeriodIssueCustomField'`
+  and `{ presentation: rawValue }`.
+- **C16 → user case.** Single + multi user fields resolve to `{ login }` payloads with
+  the right `$type`.
+- **C17 → bundle guard.** A bundle field with no `bundle`, with an unknown bundle
+  `$type` (segment undefined), and with a `bundle` lacking `id`; each throws the exact
+  "no resolvable value set" message.
+- **C18 → unknown case.** An unknown-typed field throws the exact teaching error whose
+  template interpolates the `fieldType.id` (or `'unknown'` when absent).
+
+## Verification
+
+1. `bun test tests/plugins/task-provider-youtrack/field-engine.test.ts` is green.
+2. `bun test:mutate:file plugins/task-provider-youtrack/field-engine.ts` reports a score
+   >= 0.9; the only remaining survivors are exactly the declared residuals (R1-R6).
+
+## Accepted residuals
+
+Equivalent or unreachable mutants that survive every possible test and therefore cannot
+be killed without editing `src/`/`plugins/`. The runner re-measures; the declared
+`mutantIds` must equal the post-test survivor set. Per-loc reasoning is recorded in the
+result JSON.
+
+- **R1 (id 99)** — `bundleType === undefined ? undefined : BUNDLE_SEGMENTS[bundleType]`.
+  Mutating the guard to `false` always evaluates `BUNDLE_SEGMENTS[bundleType]`; for
+  `bundleType === undefined` that lookup is `undefined` too, so both branches are
+  observationally identical for every input.
+- **R2 (id 175)** — `matched !== undefined` is redundant because `matched = matches[0]`
+  and the guard already requires `matches.length === 1`; a filter-produced dense array
+  always has a defined element at index 0 when its length is 1.
+- **R3 (ids 78, 80)** — `match[1] ?? ''` / `match[2] ?? ''` nullish fallbacks inside the
+  matched branch: both capture groups are mandatory in `/^(.*)\[(1|\*)\]$/u`, so on a
+  successful match they are always defined strings; the `?? ''` arms are unreachable.
+- **R4 (ids 181, 183)** — `issueType`'s `if (resolved === undefined) throw` is dead:
+  `issueType` is only reached from the `user`/`bundle` cases, whose `singleType`/
+  `multiType` are always populated by `TYPE_TABLE`; `resolved` is never `undefined`, so
+  the condition and its message cannot be exercised.
+- **R5 (id 254)** — the second `field.field?.fieldType` optional chain in the unknown
+  error template: by the time the `unknown` case runs, the missing-name guard has
+  already guaranteed `field.field` is defined, so `field.field.fieldType` never throws.
+- **R6 (id 256)** — the terminal `throw new Error('Unreachable: unhandled field kind')`
+  sits after a switch that exhausts all seven `FieldClassification['kind']` values; no
+  value reaches it.

--- a/docs/superpowers/specs/2026-08-07-mutation-coverage-humanize-design.md
+++ b/docs/superpowers/specs/2026-08-07-mutation-coverage-humanize-design.md
@@ -1,0 +1,101 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation coverage: `src/announcements/humanize.ts`
+
+## Summary
+
+Raise the Stryker mutation score of `src/announcements/humanize.ts` from the
+measured **0.338** (killed=23, survived=40, noCoverage=5 out of 68 mutants) to
+**>= 0.9** using test-only changes. The work adds exact-equality assertions to
+the companion test file `tests/announcements/humanize.test.ts` that pin the two
+LLM system-prompt constants, the empty-release sentinel, the not-configured and
+failure log warnings, the logger child scope, and the default-deps wiring. Six
+mutants are declared as accepted residuals (one true equivalent, five at the
+test-only ceiling).
+
+## Why this file
+
+`humanize.ts` is the changelog humanizer: it classifies raw changelog lines via
+a structured LLM pass, drops entries that do not matter to end users, and turns
+the survivors into a friendly announcement via a second LLM pass. Its behavior is
+gated entirely by dependency-injected callbacks (`HumanizeChangelogDeps`), so the
+existing DI tests already cover the happy/error paths of `humanizeChangelog` —
+but they only assert *return values* and use loose `toContain` checks on the
+prompts. Almost every surviving mutant is a prompt string literal or a log call
+that a loose/absent assertion cannot distinguish.
+
+## Non-goals
+
+- Editing `src/` (or `client/`, `plugins/`, `scripts/`). This is test-only.
+- Changing `scripts/mutation/baseline.json` (the runner owns it).
+- Refactoring the production prompts or log messages.
+- Rewriting the existing DI-first tests; they stay, new assertions are added
+  alongside them.
+
+## Gap analysis
+
+Measured survivors (45 total = 40 Survived + 5 NoCoverage) group into eight
+classes. `mutantIds` are the Stryker ids from
+`reports/paired/src__announcements__humanize.ts.stryker-report.json`.
+
+| # | Class (location) | Mutants | mutator(s) | Why it survives |
+| --- | --- | --- | --- | --- |
+| A | `CLASSIFY_SYSTEM_PROMPT` array + join (L27–35) | 9 | `8` ArrayDeclaration, `9`–`15` StringLiteral, `16` StringLiteral (join `'\n'`) | No test asserts the *exact* classify `system` prompt passed to `generateStructured`; only `prompt` is loosely checked. |
+| B | `SYSTEM_PROMPT` array + join (L39–58) | 17 | `19`–`22`,`24`–`25`,`27`–`37` StringLiteral (elements + join) | Existing test uses `toContain` on three substrings of the write `system`; every other element/separator mutates unseen. |
+| C | `EMPTY_RELEASE_NOTE` literal (L37) | 1 | `17` StringLiteral | Existing test asserts `toBe(EMPTY_RELEASE_NOTE)` — comparing the constant to itself masks any value change. |
+| D | `logger.child({ scope })` (L14) | 2 | `0` ObjectLiteral, `1` StringLiteral | The child-scope argument is set at module load and never observed. |
+| E | not-configured guard + `log.warn` (L86–94) | 8 | `47`/`48` guard skipped, `49` ObjectLiteral, `50`/`51` ConditionalExpression, `52` EqualityOperator, `53`/`54` StringLiteral | Guard is masked by the downstream `catch` (skipping it still yields `null` via a thrown `config.main` access), and the warn metadata/message are never asserted. |
+| F | `defaultDeps` object + arrow bodies (L67–77) | 6 | `38` ObjectLiteral, `39`/`41` BlockStatement (NoCov), `40`/`42`/`43` ObjectLiteral (NoCov) | `defaultDeps` is never exercised — every test injects `deps(...)`. |
+| G | failure `log.warn` (L109) | 2 | `66` ObjectLiteral, `67` StringLiteral | The catch-path warn metadata/message are never asserted. |
+
+(E = 8 mutants: `47,48,49,50,51,52,53,54`. F = 6 mutants: `38,39,40,41,42,43`.)
+
+## Design — tests to add
+
+Each added test maps one-to-one onto a gap class and uses exact equality
+(`toBe` for scalars/strings; `toEqual` for the one fully-knowable metadata
+object/array, which is exact deep equality — never `toContain`/`startsWith`).
+
+| Test | Kills (class) | How |
+| --- | --- | --- |
+| `passes the exact classify system prompt to the structured pass` | A (`8`–`16`) | Capture `opts.system` on `generateStructured`; assert `toBe(CLASSIFY_SYSTEM_PROMPT_TEXT)` — the verbatim joined constant. |
+| `passes the exact write system prompt to the announcement pass` | B (`19`–`37`) | Capture `opts.system` on `generate`; assert `toBe(SYSTEM_PROMPT_TEXT)`. |
+| `returns the literal empty-release note text when nothing survives` | C (`17`) | Assert `toBe(<literal>)` against the hardcoded string, not the re-imported constant. |
+| `logs the not-configured warning with the child scope, exact metadata, and message` | D + E except `50` (`0`,`1`,`47`,`48`,`49`,`51`,`52`,`53`,`54`) | Capture the emitted warn via the logger's multistream; assert `scope` `toBe('announcements:humanize')` (kills the child-scope object/string mutants `0`/`1`), the exact metadata fields, and `msg` `toBe('Central LLM not configured; skipping changelog humanization')`. Skipping the guard (`47`/`48`) omits this warn entirely; mutating the ternary/operators (`51`/`52`/`53`) or the metadata object (`49`) or the message (`54`) breaks the exact match. |
+| `logs the humanization-failed warning with the child scope, error, and message` | G (`66`,`67`) | Reject in `generateStructured`; assert the captured warn's `error` `toBe('boom')`, `scope` `toBe('announcements:humanize')`, and `msg` `toBe('Changelog humanization failed')`. |
+| `uses the real default-deps wiring when none are passed` | F-`38` only | Call `humanizeChangelog('raw')` with no deps (over a migrated test DB); real `defaultDeps` resolves to an unconfigured central LLM and returns `null`, whereas mutating `defaultDeps` to `{}` makes `resolveConfig` undefined and the call rejects. |
+
+The companion file keeps ordinary static imports. Because `humanize.ts` is
+transitively preloaded by the global `tests/mock-reset.ts` (via
+`src/announcements.ts`), it is already cached with the real logger before any
+per-file `mock.module` could apply, and `tests/setup.ts` pins `LOG_LEVEL=silent`
+before that load — so the child logger emits nothing by default. The logging
+tests therefore observe output through pino's public `logMultistream.add()`
+extension point (a trace-level capture stream) after raising
+`logger.level = 'trace'` (pino children inherit the root level dynamically).
+`setupTestDb()` runs in `beforeEach` so the default-deps path's real
+`resolveAdminLlmConfig` sees a migrated (empty) `llm_admin_roles` table and
+returns not-configured instead of throwing. The existing DI tests are unchanged
+in behavior.
+
+## Verification
+
+- `bun test tests/announcements/humanize.test.ts` is green.
+- `bun test:mutate:file src/announcements/humanize.ts` reports
+  killed=62 survived=1 noCoverage=5 → score **0.9118** (>= 0.9), with exactly
+  the six residual ids `{39, 40, 41, 42, 43, 50}` surviving.
+
+## Accepted residuals
+
+Six survivors remain; the runner-measured surviving set must equal this union.
+
+| loc | why | mutantIds |
+| --- | --- | --- |
+| L91 `missing: config.type === 'missing' ? config.missing : undefined` (mutant `50`, ConditionalExpression → always-true) | True equivalent. `config.missing` is only present on `LlmConfigMissing` (where `type === 'missing'`); for every valid `LlmConfigResult` the always-true branch yields the same value as the original ternary. Distinguishing it requires a type-inconsistent config object (impossible input). | `["50"]` |
+| L70–73 `defaultDeps.generate` arrow body (mutants `39`,`40`) | Test-only ceiling. Only reachable through `defaultDeps`, which every consumer overrides via DI. `defaultDeps.resolveConfig`/`buildModel` are import-time snapshots of the real `resolveAdminLlmConfig`/`buildChatModel`; reaching `generate` requires a DB-seeded admin LLM config plus an `ai`-SDK `generateText` mock — the body merely forwards `result.text`, i.e. it re-tests the SDK contract, not papai logic. | `["39","40"]` |
+| L74–77 `defaultDeps.generateStructured` arrow body + `Output.object` config (mutants `41`,`42`,`43`) | Test-only ceiling. Same reachability constraint as above; additionally `42`/`43` mutate the structured-output config object (`Output.object({ schema })`) which is opaque to papai — only the external `ai` SDK reads it, so no papai return value can distinguish the mutation without asserting on what the mocked `generateText` received. | `["41","42","43"]` |

--- a/docs/superpowers/specs/2026-08-07-mutation-coverage-scheduler.events-design.md
+++ b/docs/superpowers/specs/2026-08-07-mutation-coverage-scheduler.events-design.md
@@ -1,0 +1,141 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation Coverage — `src/utils/scheduler.events.ts`
+
+**Date:** 2026-08-07
+**Status:** Accepted
+**Target file:** `src/utils/scheduler.events.ts`
+**Measured score (before):** 0.45 (18/40 mutants killed) — target `>= 0.9`
+**Measured score (after):** 0.90 (36/40 killed; 4 `NoCoverage` residuals)
+
+## Summary
+
+`src/utils/scheduler.events.ts` exports `createEmitters`, which wraps four private
+`emit*Event` helpers (`emitTickEvent`, `emitErrorEvent`, `emitRetryEvent`,
+`emitFatalErrorEvent`). Each helper iterates the matching handler `Set` in an
+`EventEmitter`, invokes each handler inside a `try/catch`, and on a throw logs an
+error via the module-scoped `log = logger.child({ scope: 'scheduler:events' })`.
+
+The measured Stryker report (`reports/paired/src__utils__scheduler.events.ts.stryker-report.json`)
+showed 40 mutants: 18 killed, 2 survived, 20 with `NoCoverage`. Every surviving and
+uncovered mutant lived in one of two places the existing `tests/utils/*.test.ts`
+suites never exercised:
+
+1. The module-scoped `logger.child({ scope: 'scheduler:events' })` call (line 14).
+2. The `catch` block body of each of the four `emit*Event` helpers (the error path).
+
+This spec adds a dedicated companion test file (`tests/utils/scheduler.events.test.ts`)
+that drives the error path of all four emitters and asserts the exact `log.error`
+payloads, plus the import-time `logger.child` scope. Every new assertion uses exact
+equality (`toBe`) on the full, knowable value. After the work, 36/40 mutants are
+killed (score `0.90`); the remaining 4 are the `'Unknown error'` fallback string in
+each catch block — a tests-only ceiling documented under **Accepted residuals**.
+
+## Why this file
+
+- The four `emit*Event` catch blocks are the scheduler's defensive boundary: a
+  misbehaving event handler must not crash the scheduling loop. The catch block is
+  currently untested — if it were silently broken (e.g. swallowed without logging, or
+  logged with the wrong event tag), no test would notice.
+- `createEmitters` is the only export and is consumed by `createScheduler`
+  (`src/utils/scheduler.ts:146`); a regression here affects every scheduled task.
+- The file is small, pure, and has no I/O — it is an ideal, cheap target for full
+  mutation coverage from tests alone.
+
+## Non-goals
+
+- Editing `src/` (or `client/`, `plugins/`, `scripts/`). This iteration is test-only.
+- Changing `scripts/mutation/baseline.json` — the runner owns it.
+- Retesting the happy path (mutants already `Killed`: the function/forEach/try block
+  bodies and the `createEmitters` wiring). Those are covered by the existing
+  `tests/utils/scheduler*.test.ts` suites.
+- The `instanceof Error ? error.message : 'Unknown error'` ternary itself — Stryker
+  emitted no mutant on that expression, so it needs no dedicated test.
+
+## Gap analysis
+
+Grouped by mutant class (each class = one structural location shared across the four
+near-identical helpers, plus the standalone scope class). Status counts are from the
+measured report.
+
+| Class | Location (lines) | Mutant ids | Status | Why it survives / is uncovered |
+| --- | --- | --- | --- | --- |
+| A. Logger scope | `log = logger.child({ scope: 'scheduler:events' })` (L14) | 0, 1 | Survived | No test captures the import-time `logger.child` call, so mutating the scope object (`{}`) or the scope string (`""`) is invisible. The logger is a no-op mock everywhere. |
+| B. `emitTickEvent` catch | L23–26 | 5, 6, 7, 8, 9 | NoCoverage | No test registers a `tick` handler that throws, so the catch block (and its `log.error` payload) never executes. |
+| C. `emitErrorEvent` catch | L37–40 | 13, 14, 15, 16, 17 | NoCoverage | Same — no throwing `error` handler. |
+| D. `emitRetryEvent` catch | L51–54 | 21, 22, 23, 24, 25 | NoCoverage | Same — no throwing `retry` handler. |
+| E. `emitFatalErrorEvent` catch | L65–68 | 29, 30, 31, 32, 33 | NoCoverage | Same — no throwing `fatalError` handler. |
+
+Within each catch class (B–E) the five mutants are structurally identical across the
+four helpers:
+
+- the catch `BlockStatement` → `{}` (mutant 5/13/21/29),
+- the `'Unknown error'` fallback string → `""` (6/14/22/30) — **accepted residual**,
+  see below,
+- the `log.error` first-arg object literal → `{}` (7/15/23/31),
+- the event-tag string (`'tick'`/`'error'`/`'retry'`/`'fatalError'`) → `""` (8/16/24/32),
+- the `'Event handler threw error'` message string → `""` (9/17/25/33).
+
+## Design — tests to add
+
+A single new companion file `tests/utils/scheduler.events.test.ts`, mapped one-to-one
+onto the gap classes above (one `test()` per class). It follows the cache-busting
+logger-mock pattern from `tests/history.test.ts` / `tests/tools/search-memos.test.ts`:
+per-test, install a recording `logger` via `mock.module`, then `import(...scheduler.events.js?t=<uuid>)`
+so the module re-evaluates and its module-scoped `log` binds to the recorder. Because
+`scheduler.events.js` is already in the import graph of the `tests/mock-reset.ts`
+preload (via `src/scheduler.js`), a plain static import would re-use the cached module
+bound to the real logger — the cache-busting query is what forces the fresh binding.
+
+| Test | Kills class | Mutant ids | How |
+| --- | --- | --- | --- |
+| `logger.child` is invoked once at import with the exact scheduler:events scope | A | 0, 1 | Capture the `child` call args; assert `childCalls.length === 1` and `scope === 'scheduler:events'` (`toBe`). Mutating the object to `{}` drops `scope` to `undefined`; mutating the string to `""` makes `scope === ""`. |
+| `emitTickEvent` logs the exact error payload when a tick handler throws | B (4 of 5) | 5, 7, 8, 9 | Register one throwing `Error` handler in `events.tick`; call `createEmitters(events).emitTick(event)`. Assert `errorCalls.length === 1`, `payload.error === 'handler blew up'`, `payload.event === 'tick'`, and `message === 'Event handler threw error'` (all `toBe`). The object-literal mutant is killed because `{}` makes `payload.error`/`payload.event` `undefined`. |
+| `emitErrorEvent` logs the exact error payload when an error handler throws | C (4 of 5) | 13, 15, 16, 17 | Same shape, `events.error`, `payload.event === 'error'`. |
+| `emitRetryEvent` logs the exact error payload when a retry handler throws | D (4 of 5) | 21, 23, 24, 25 | Same shape, `events.retry`, `payload.event === 'retry'`. |
+| `emitFatalErrorEvent` logs the exact error payload when a fatalError handler throws | E (4 of 5) | 29, 31, 32, 33 | Same shape, `events.fatalError`, `payload.event === 'fatalError'`. |
+
+The tests throw an `Error` (not a non-Error) on purpose: the repo's oxlint config
+enforces `eslint/no-throw-literal` and `typescript/only-throw-error` (both `error`),
+which reject throwing any non-Error value (literal, `any`, or `unknown`). That makes
+the `'Unknown error'` `else` branch (mutant 6/14/22/30) unreachable from lint-clean
+tests — see **Accepted residuals**.
+
+Assertion policy: every check is `toBe(...)` against the full, exact expected value.
+Object payloads are read through a pure `isRecord` type predicate narrowed via a
+`requireRecord` helper (no `as` casts — `no-unsafe-type-assertion` is enforced), and
+index-signature properties are read with bracket notation (`payload['error']`) per the
+repo's `TS4111` rule. No `startsWith`/`endsWith`/`toContain`/`toEqual` partial matching.
+
+## Verification
+
+1. `bun test tests/utils/scheduler.events.test.ts` — the new file passes in isolation (5/5).
+2. `bun run typecheck` and `bun run lint` — clean (no lint-disable / type-ignore / unsafe casts).
+3. `bun test tests/utils/scheduler.helpers.test.ts tests/utils/scheduler.internal.test.ts tests/utils/scheduler.test.ts` — no sibling regression (53/53).
+4. `bun test:mutate:file src/utils/scheduler.events.ts` — re-measured: `killed=36
+   survived=0 noCoverage=4 pending=0 score=0.9`. The non-killed set is exactly
+   `{6, 14, 22, 30}` (the `'Unknown error'` strings), which the declared residuals cover 1:1.
+
+## Accepted residuals
+
+The four `'Unknown error'` fallback strings (mutant ids **6, 14, 22, 30** — one per
+`emit*Event` catch block, at `src/utils/scheduler.events.ts:24`, `:38`, `:52`, `:66`)
+are accepted residuals.
+
+Each is the `else` branch of `error instanceof Error ? error.message : 'Unknown error'`
+and is only evaluated when the caught value is **not** an `Error`. The repo's oxlint
+config enforces `eslint/no-throw-literal` and `typescript/only-throw-error` (both
+`error` severity), which reject throwing any non-Error value in test code (string,
+object, `any`, and `unknown` were all confirmed rejected by probing the linter).
+Therefore no lint-clean test can make an event handler throw a non-Error, the branch is
+unreachable from tests, and mutating the literal to `""` has no observable effect
+(Stryker reports them `NoCoverage`). Killing any of them would require either disabling
+the lint rule or editing `src/` (e.g. typing the handler return so a non-Error throw is
+impossible, or dropping the fallback) — both outside the test-only constraint. These are
+the file's entire tests-only ceiling; the union of their `mutantIds` exactly equals the
+runner-measured surviving set.

--- a/docs/superpowers/specs/2026-08-07-mutation-coverage-scheduler.helpers-design.md
+++ b/docs/superpowers/specs/2026-08-07-mutation-coverage-scheduler.helpers-design.md
@@ -1,0 +1,121 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation Coverage — `src/utils/scheduler.helpers.ts` Design
+
+**Date:** 2026-08-07
+**Status:** Approved for planning
+**Target file:** `src/utils/scheduler.helpers.ts` (defaults, the `calculateBackoff`
+exponential-backoff-with-jitter function, the `mergeOptions`/`mergeTaskOptions` mergers, and
+the `getErrorMessage`/`getErrorObject` safe-extractors)
+**Before score:** 0.3333333333333333 (killed=11 survived=12 noCoverage=10, total=33)
+**Target score:** ≥ 0.9
+
+## Summary
+
+`src/utils/scheduler.helpers.ts` is the pure helper module for the scheduler: it owns the
+`DEFAULT_OPTIONS` / `DEFAULT_TASK_OPTIONS` constants, the deterministic parts of retry backoff
+(`calculateBackoff`), the option mergers, and the two safe-error extractors
+(`getErrorMessage` / `getErrorObject`). It has **no companion test file**: the only coverage
+comes indirectly from `tests/utils/scheduler.test.ts` (which exercises the running scheduler
+but never asserts on these helpers' exact return values). The result is that 22 of 33 mutants
+survive: every arithmetic operator in `calculateBackoff` is loose (jitter makes the result
+non-deterministic), both safe-error extractors are never called directly with non-`Error`
+inputs, and the default constants are never read for exact equality.
+
+This spec adds a **new** companion `tests/utils/scheduler.helpers.test.ts` with one focused
+`test()` per mutant class (8 tests) — each using exact `toBe(...)` equality — to raise the
+score to **1.0**. The non-deterministic `Math.random()` jitter is pinned via a scoped stub so
+the backoff result becomes an exact, assertable integer. There are no accepted residuals: every
+surviving mutant is observable as a changed return value.
+
+## Why this file
+
+The scheduler helpers are imported by `src/utils/scheduler.js` (the retry loop uses
+`calculateBackoff` and `getErrorMessage`/`getErrorObject`; task registration uses the mergers
+and defaults). A surviving mutant here silently changes retry timing or error surfacing for
+every scheduled task in the system. The file is pure and synchronous (the only external
+dependency is `Math.random()`, which is trivially stubbable), so every behaviour is observable
+as an exact return value — an ideal mutation target that nonetheless had zero direct test
+coverage.
+
+## Non-goals
+
+- **No production-code changes.** `src/`, `client/`, `plugins/`, `scripts/` are untouched; the
+  diff gate restricts edits to `tests/` and `docs/superpowers/`.
+- **No edits to `scripts/mutation/baseline.json`** (the runner owns the ratchet).
+- No edits to existing test files; a **new** companion `tests/utils/scheduler.helpers.test.ts`
+  is created (the current companion resolver maps `src/utils/scheduler.helpers.ts` to exactly
+  this path, which did not yet exist).
+- `calculateBackoff`'s real-valued randomness is **not** under test; only the deterministic
+  arithmetic is asserted, with `Math.random()` stubbed to a fixed value inside one `describe`.
+- No comments added to the test file (repo convention).
+
+## Gap analysis
+
+Measured via `bun test:mutate:file src/utils/scheduler.helpers.ts`; report at
+`reports/paired/src__utils__scheduler.helpers.ts.stryker-report.json`. 12 `Survived` + 10
+`NoCoverage` = 22 non-killed mutants (score 11/33 = 0.3333). They group into the classes below.
+Mutant ids are Stryker ids from the report; locations are `line:col` in
+`src/utils/scheduler.helpers.ts`.
+
+| # | Class (behaviour) | Mutant ids | Loc | Root cause / why it survives |
+|---|---|---|---|---|
+| 1 | `calculateBackoff` backoff arithmetic — `Math.min`→`Math.max`, `baseDelay * 0.1`→`/0.1`, trailing `* Math.random()`→`/`, `baseDelay + jitter`→`-` | 6, 8, 9, 10 | 89, 90, 91 | No test calls `calculateBackoff` at all, and even if it did the real `Math.random()` jitter makes the return a float range, so no exact assertion could pin it. Stubbing `Math.random()` to `0.5` makes `calculateBackoff(0, 60000)` return exactly `1050`; each arithmetic mutant yields a different integer (63000 / 6000 / 1200 / 950), so a single `toBe(1050)` kills all four. |
+| 2 | `getErrorMessage` for an `Error` — function body removal and the `instanceof` guard | 15, 17, 18 | 118-123, 119 | No test calls `getErrorMessage(new Error(...))`. Body→`{}` (15) returns `undefined`; `if→false` (17) and the return-block→`{}` (18) both fall through to the ternary and return `'Unknown error'`. `toBe('boom')` kills all three. |
+| 3 | `getErrorMessage` for a `string` — the `instanceof`→`true` flip and the `typeof === 'string'` ternary (conditional both ways, equality flip, `'string'` literal) | 16, 20, 21, 22 | 119, 122 | No test passes a string. `if→true` (16) returns `(<string>).message` = `undefined`; the three ternary mutants (20/21/22) all route a string to `'Unknown error'`. `toBe('some message')` kills all four. |
+| 4 | `getErrorMessage` fallback (non-string, non-`Error`) — the ternary `→true` and the `'Unknown error'` literal | 19, 23 | 122 | No test passes a non-string/non-`Error`. Ternary `→true` (19) returns the raw value (`42`); `'Unknown error'`→`""` (23) returns `""`. `toBe('Unknown error')` kills both. |
+| 5 | `getErrorObject` for a `string` — the `instanceof`→`true` flip and the ternary (both ways, equality flip, `'string'` literal) | 25, 29, 30, 31 | 129, 132 | No test calls `getErrorObject('...')`. `if→true` (25) returns the raw string (not an `Error`); the ternary mutants (29/30/31) wrap `'Unknown error'`. Asserting `instanceof Error` + `toBe('hello')` on `.message` kills all four. |
+| 6 | `getErrorObject` fallback (non-string, non-`Error`) — the ternary `→true` and the `'Unknown error'` literal | 28, 32 | 132 | No test passes a non-string/non-`Error`. Ternary `→true` (28) wraps the raw value (`new Error(42)` → message `'42'`); `'Unknown error'`→`""` (32) yields message `""`. `toBe('Unknown error')` on `.message` kills both. |
+| 7 | `DEFAULT_OPTIONS` constant — `unrefByDefault: true`→`false` | 1 | 49 | No test reads `DEFAULT_OPTIONS` for exact equality. `expect(DEFAULT_OPTIONS.unrefByDefault).toBe(true)` kills it. |
+| 8 | `DEFAULT_TASK_OPTIONS` constant — whole object→`{}` and `unref: true`→`false` | 2, 4 | 57-61, 60 | No test reads `DEFAULT_TASK_OPTIONS` for exact equality. Object→`{}` (2) makes every field `undefined`; `unref→false` (4) flips one field. Per-field `toBe(...)` assertions kill both. |
+
+## Design — tests to add
+
+Each class maps **one-to-one** to a single new `test()` in the new
+`tests/utils/scheduler.helpers.test.ts`. Every assertion is an exact `toBe(...)` (or
+`toBeInstanceOf` / reference `toBe` for object identity) — never `toContain` / `startsWith` /
+`endsWith`. Each expected value was computed from the unmutated function and (for backoff)
+re-derived under a stubbed `Math.random`.
+
+| Test (class #) | Fixture | Exact expected value | Kills |
+|---|---|---|---|
+| T1 (#1) `calculateBackoff` deterministic backoff (`Math.random` stubbed to `0.5`) | `calculateBackoff(0, 60000)`; plus capping `calculateBackoff(0, 500)` and `calculateBackoff(5, 60000)` | `1050`, `525`, `33600` | 6, 8, 9, 10 |
+| T2 (#2) `getErrorMessage(Error)` | `getErrorMessage(new Error('boom'))` | `'boom'` | 15, 17, 18 |
+| T3 (#3) `getErrorMessage(string)` | `getErrorMessage('some message')` | `'some message'` | 16, 20, 21, 22 |
+| T4 (#4) `getErrorMessage` fallback | `getErrorMessage(42)` | `'Unknown error'` | 19, 23 |
+| T5 (#5) `getErrorObject(string)` | `getErrorObject('hello')` → `instanceof Error` and `.message` | `instanceof Error` is `true`, `.message` is `'hello'` | 25, 29, 30, 31 |
+| T6 (#6) `getErrorObject` fallback | `getErrorObject(42)` → `.message` | `'Unknown error'` | 28, 32 |
+| T7 (#7) `DEFAULT_OPTIONS` exact | `DEFAULT_OPTIONS.unrefByDefault` / `.defaultRetries` / `.maxRetryDelay` | `true`, `3`, `60000` | 1 |
+| T8 (#8) `DEFAULT_TASK_OPTIONS` exact | `DEFAULT_TASK_OPTIONS.immediate` / `.retries` / `.unref` | `false`, `3`, `true` | 2, 4 |
+
+Two light documentation tests are also added that do **not** kill any survivor but keep the
+companion self-contained and exercise the `Error`-instance branches and the mergers:
+`getErrorObject(<same Error>)` returns the identical reference (`toBe`), and
+`mergeOptions` / `mergeTaskOptions` override defaults per-field (`toBe`). The latter are already
+killed indirectly by `tests/utils/scheduler.test.ts`; they are duplicated here only as a
+standalone-companion safety net.
+
+**Projected after-score:** killed = 11 + 22 = **33**, non-killed = 0, total = 33 →
+**score = 33/33 = 1.0** (≥ 0.9 target).
+
+## Verification
+
+1. `bun test tests/utils/scheduler.helpers.test.ts` is green (all new `test()`s).
+2. `bun test:mutate:file src/utils/scheduler.helpers.ts` reports `killed=33 survived=0
+   noCoverage=0 score=1.0`, and `reports/paired/src__utils__scheduler.helpers.ts.stryker-report.json`
+   shows zero non-killed mutants.
+3. No file under `src/`, `client/`, `plugins/`, `scripts/`, or `scripts/mutation/baseline.json`
+   is modified (diff-gate); the only new/changed files are under `tests/` and
+   `docs/superpowers/`, plus the single `.review-loop/result.json`.
+
+## Accepted residuals
+
+None. Every surviving mutant in this file is observable as a changed exact return value (or, for
+the constants, a changed exact field). The only source of non-determinism — `Math.random()` in
+`calculateBackoff` — is pinned with a scoped stub, so all four backoff-arithmetic mutants become
+distinguishable integers. No equivalent mutants remain.

--- a/docs/superpowers/specs/2026-08-07-mutation-coverage-summary-burndown-design.md
+++ b/docs/superpowers/specs/2026-08-07-mutation-coverage-summary-burndown-design.md
@@ -1,0 +1,114 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Mutation coverage: `review-loop/src/summary-burndown.ts`
+
+## Summary
+
+Raise the Stryker mutation score of `review-loop/src/summary-burndown.ts` from the
+measured baseline **0.74** (the value pinned in `scripts/mutation/baseline.json`) to
+**0.96** by adding four focused, exact-equality assertions to the existing companion test
+`tests/review-loop/summary-burndown.test.ts`. Eleven of the thirteen currently surviving
+mutants are behaviorally observable through `burndownBlock`'s output and are killed by the
+new tests. The remaining two are provably **equivalent** (a multiply/divide by the weight
+`1`, and a `padEnd(0)` no-op) and are declared as accepted residuals.
+
+This is a **tests-only** change: no file under `src/`, `client/`, `plugins/`,
+`scripts/`, or `review-loop/src/` is touched.
+
+## Why this file
+
+`summary-burndown.ts` renders the ASCII burndown table appended to every review-loop run
+transcript. It is a pure, side-effect-free formatter whose entire public surface is the
+string returned by `burndownBlock` — so every observable behavior is reachable through
+exact string assertions. It was the lowest-scored review-loop source in the ratchet and is
+the ideal candidate for full behavioral coverage.
+
+## Non-goals
+
+- Refactoring `summary-burndown.ts` (no `src/` edits; this iteration is test-only).
+- Killing the two equivalent mutants declared as residuals — they cannot be killed without
+  changing production code.
+- Covering `trace-log.ts` types or other review-loop modules.
+- Changing `scripts/mutation/baseline.json` (the runner owns the ratchet).
+
+## Gap analysis
+
+Measured against the **unmodified** companion test
+(`git checkout HEAD -- tests/review-loop/summary-burndown.test.ts`, then
+`bun test:mutate:file review-loop/src/summary-burndown.ts`, report
+`reports/paired/review-loop__src__summary-burndown.ts.stryker-report.json`):
+`killed=37 survived=12 noCoverage=1 pending=0 score=0.74` (scored=50).
+
+Every Survived/NoCoverage mutant, grouped into behavioral classes:
+
+| Class | Mutant ids | Loc | Mutator | Original → Mutated | Why it survives today |
+|---|---|---|---|---|---|
+| **A. avgSeverity zero-total guard** | 3 | L27 | ConditionalExpression | `if (total === 0) return '-'` → condition `false` | No fixture drives `avgSeverity(_, 0)`, so the guard is dead in the suite; forcing it off is invisible. |
+| | 5 | L27 | StringLiteral (NoCoverage) | `'-'` → `""` | Same dead branch: the `'-'` literal has zero execution coverage. |
+| **B. SEV_WEIGHT critical multiplier** | 9 | L29 | ArithmeticOperator | `counts.critical * SEV_WEIGHT.critical` → `/` | The sole fixture (`busyMetric`) has `critical = 0` in both severity sets, so `0*4 === 0/4`. |
+| **C. decidedCount sum addends** | 19 | L40 | ArithmeticOperator | `… + m.decisions.already_fixed` → `-` | `busyMetric` has `already_fixed = 0`, so `+0 === -0`. |
+| | 18 | L41 | ArithmeticOperator | `… + m.decisions.needs_human` → `-` | `needs_human = 0` ⇒ `+0 === -0`. |
+| | 17 | L42 | ArithmeticOperator | `… + m.decisions.plan_drift` → `-` | `plan_drift = 0` ⇒ `+0 === -0`. |
+| | 16 | L43 | ArithmeticOperator | `… + m.decisions.no_commit` → `-` | `no_commit = 0` ⇒ `+0 === -0`. |
+| | 15 | L44 | ArithmeticOperator | `… + m.decisions.inspector_rejected` → `-` | `inspector_rejected = 0` ⇒ `+0 === -0`. |
+| **D. rowIsZero short-circuit** | 25 | L49 | ConditionalExpression | `m.newIssues === 0` → `true` | No fixture has `newIssues > 0 && decidedCount === 0`, so flipping the left operand never changes the kept/dropped decision. |
+| | 27 | L49 | ConditionalExpression | `decidedCount(m) === 0` → `true` | No fixture has `newIssues === 0 && decidedCount > 0`, so flipping the right operand never changes the decision. |
+| | 24 | L49 | LogicalOperator | `&&` → `\|\|` | Both fixtures are either fully zero or fully non-zero, so `a && b` and `a \|\| b` agree. |
+| **E. SEV_WEIGHT low multiplier (equivalent)** | 12 | L32 | ArithmeticOperator | `counts.low * SEV_WEIGHT.low` → `/` | `SEV_WEIGHT.low === 1`, so `low*1 === low/1` for every integer. **Accepted residual.** |
+| **F. renderRow width guard (equivalent)** | 33 | L56 | ConditionalExpression | `width === 0 ? value : value.padEnd(width)` → condition `false` | Forcing the guard off routes the `width === 0` column through `value.padEnd(0)`, and `padEnd(0)` is the identity for every string; non-zero columns already take the `padEnd` branch. **Accepted residual.** |
+
+Classes **A–D** (ids 3, 5, 9, 15, 16, 17, 18, 19, 24, 25, 27 — eleven mutants) are the
+killable gaps; classes **E–F** (ids 12, 33) are the accepted residuals.
+
+## Design — tests to add
+
+All new assertions use **exact `toBe(...)` equality** on the full `burndownBlock` output
+string (the entire rendered block), which is fully knowable for a deterministic formatter.
+One test per killable class; each fixture is constructed so the targeted mutator class
+changes exactly one cell (or one row's presence) of the output, making the exact-match
+assertion fail under the mutant.
+
+- **Test A → Class A (ids 3, 5).** Round 3 with `newIssues = 2`, all decisions zero
+  (`decidedCount = 0`), so the row is kept (`newIssues > 0`) and
+  `avgFix = avgSeverity(fixerSeverity, 0)` exercises the `total === 0` guard and the `'-'`
+  literal. Mutant 3 forces the guard off → `0/0 = "NaN"`; mutant 5 returns `""`; both
+  differ from the expected `-` cell.
+- **Test B → Class B (id 9).** Round 5 with `reviewerSeverity = { critical: 1 }` and
+  `newIssues = 1`, so `avgRev = (1*4)/1 = 4.0`. Mutant 9 swaps `*4`→`/4` (≈`0.3`), ≠ `4.0`.
+- **Test C → Class C (ids 15, 16, 17, 18, 19).** Round 7 with **all seven decision fields
+  set to 1** (`decidedCount = 7`) and `fixerSeverity = { medium: 7 }` →
+  `avgFix = (7*2)/7 = 2.0`. Each `+addend → -addend` mutant reduces `decidedCount` to 5,
+  giving `avgFix = 14/5 = 2.8`, ≠ `2.0`. Setting every addend nonzero covers all five
+  surviving operators at once.
+- **Test D → Class D (ids 24, 25, 27).** Two rounds in one block: round 11 with
+  `newIssues = 1, decidedCount = 0`, and round 12 with `newIssues = 0, decidedCount = 2`
+  (decisions `fixed = 2`). Each survivor drops a different subset of rows: id 25 drops
+  round 11, id 27 drops round 12, id 24 drops both. Asserting the full two-row block fails
+  under any row loss.
+
+## Verification
+
+1. `bun test tests/review-loop/summary-burndown.test.ts` → 7 pass, 0 fail
+   (3 existing + 4 new).
+2. `bun test:mutate:file review-loop/src/summary-burndown.ts` reports
+   `killed=48 survived=2 noCoverage=0 score=0.96`, with the only survivors being ids
+   **12** and **33** — exactly the accepted residuals.
+3. The build gate `CI=true bun check:full` is unaffected (tests-only diff).
+
+## Accepted residuals
+
+- **id 12 — `counts.low * SEV_WEIGHT.low` → `/` (L32).** `SEV_WEIGHT.low === 1`, hence
+  `low * 1 === low / 1` for every non-negative integer count. No input can distinguish the
+  mutant from the original; it is mathematically equivalent. Killing it would require a
+  `src/` change (e.g. a non-unit low weight), out of scope.
+- **id 33 — `width === 0 ? value : value.padEnd(width)` condition → `false` (L56).**
+  Forcing the guard off routes the `width === 0` column through `value.padEnd(0)`, and
+  `String.prototype.padEnd(0)` is the identity for every string (ECMA-262: when
+  `targetLength ≤ string.length`, the original is returned). Non-zero-width columns already
+  evaluate to the `padEnd` branch. The mutant is output-identical for all inputs.
+  Eliminating it would need a `src/` change to the WIDTHS/padding model, out of scope.

--- a/docs/superpowers/specs/2026-08-07-progress-stats-renderer-design.md
+++ b/docs/superpowers/specs/2026-08-07-progress-stats-renderer-design.md
@@ -1,0 +1,141 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Progress & Stats Renderer Upgrade — Design
+
+Date: 2026-08-07
+Status: Approved (brainstorming)
+Workspaces: `review-loop/`, `mutation-improve/`
+
+## Problem
+
+The live progress output of both runner CLIs is not informative enough: per-step footers (`task ✓ 2s · 3 tools · in 5225 / out 113`) carry no run-level aggregates. There is no overall token i/o, tool-call total, lines added/removed, or estimated cost — and `mutation-improve` prints no end-of-run terminal summary at all (only a PR-body markdown).
+
+## Decision record (from brainstorming)
+
+| Question | Decision |
+|---|---|
+| Rendering paradigm | Upgrade the existing hand-rolled renderer (scrolling log + persistent live block). No listr2/tasuku/Ink/OpenTUI dependency. |
+| Cost | Pricing table in `config.json`; estimated cost computed from token counts; displayed as `~$X est`. (`opencode run` events always report `cost: 0`.) |
+| Diff stats | Measured at merge points via `git diff --numstat` (per iteration in mutation-improve; per worker-merge in review-loop). |
+| Persistence | Aggregates printed to terminal AND persisted (`state.json` for mutation-improve, `metrics.json` for review-loop); rehydrated on `--resume-run`. |
+| Scope | Both workspaces in one effort (renderer is shared via `review-loop/src`). |
+
+## Library research summary
+
+- **listr2** (v11, ~44M dl/wk): full task-tree runner with custom renderers (`ListrBaseRenderer`), bottom bar, persistent output. Rejected: it wants to own task orchestration; both pipelines self-orchestrate (sequential recursive iterations; worker pool), so it would be renderer-only glue against its grain.
+- **tasuku**: minimal vitest-like task list; no custom renderers/bottom bar — too thin for stats.
+- **cli-progress / spinnies**: progress bars / multi-spinners; wrong fit (runs have no % progress; spinnies unmaintained since 2023).
+- **Ink**: React-for-CLI dashboards (Copilot CLI, Wrangler). Rejected as overkill: ~50MB RAM, 32fps rerender loop, non-TTY fallback complexity, new runtime dep for local tooling.
+- **OpenTUI**: Bun+Zig native TUI (powers opencode). Rejected: native FFI dep, heaviest lift.
+- **blessed**: dated, unmaintained.
+- **Chosen**: keep the proven EPIPE-safe, TTY-aware hand-rolled renderer; the actual gap is data aggregation, not rendering primitives.
+
+## Architecture
+
+### New / changed files
+
+| File | Change |
+|---|---|
+| `review-loop/src/run-stats.ts` | **New.** Pure `RunStats` aggregate (~150 lines). No I/O, no ANSI. |
+| `review-loop/src/cost.ts` | **New.** Pricing-table lookup + `estimateCost(model, tokens)`. |
+| `review-loop/src/diff-stats.ts` | **New.** `git diff --numstat` parser; reuses existing `execGit` from `worktree.ts`. |
+| `review-loop/src/live-renderer.ts` | Extend: holds `RunStats`; status line gains aggregate segments. |
+| `review-loop/src/progress-log.ts` | `ProgressReporter` gains optional `stats?: RunStats` and `diff?(label, {added, removed})`. Optional → existing test fakes keep working. |
+| `review-loop/src/line-handler.ts` | Step end forwards `toolCount` in addition to usage. |
+| `review-loop/src/config.ts` | Zod schema gains optional `pricing` map. |
+| `review-loop/src/summary.ts` + `summary-burndown.ts` | Final report gains totals block (tokens, est. cost, tools, +a/-r). |
+| `review-loop/src/cli.ts` | Construct `RunStats`, wire model→pricing, rehydrate on resume, persist at end. |
+| `mutation-improve/src/summary.ts` | **New.** Terminal run summary (per-iteration outcome table + totals). |
+| `mutation-improve/src/run-state.ts` | `state.json` schema gains optional `stats` block. |
+| `mutation-improve/src/pipeline.ts` / `cli.ts` | Wire stats through; measure diff at ratchet commit; print summary at end. |
+
+### `RunStats` API
+
+```ts
+interface UsageDelta { inputTokens: number; outputTokens: number; reasoningTokens: number; wallMs: number }
+interface DiffStats { added: number; removed: number }
+interface StatsSnapshot {
+  totals: { input: number; output: number; reasoning: number; toolCalls: number; added: number; removed: number; estimatedCostUsd?: number; elapsedMs: number }
+  perLabel: Record<string, { input: number; output: number; toolCalls: number; added: number; removed: number }>
+}
+
+class RunStats {
+  constructor(opts: { startedAt?: number; pricing?: PricingTable; model?: string; rehydrate?: Partial<StatsSnapshot> })
+  addUsage(label: string, delta: UsageDelta): void
+  addToolCalls(label: string, n: number): void
+  addDiff(label: string, diff: DiffStats): void
+  snapshot(): StatsSnapshot   // immutable copy
+}
+```
+
+### Config addition (both workspaces' `config.json`, Zod-validated)
+
+```jsonc
+{
+  "pricing": {                       // optional; USD per 1M tokens
+    "claude-sonnet-*": { "input": 3, "output": 15 },
+    "gpt-*":           { "input": 2.5, "output": 10 }
+  }
+}
+```
+
+Matching: glob on the model string resolved once at CLI start (from agent config if present, else opencode default). No match → cost omitted everywhere; never displayed as `$0.00`.
+
+## Data flow
+
+1. **Tokens/cost/tools** — `line-handler.ts` already parses `step_finish` (tokens) and counts unique `callId`s; on step end it now also calls `stats.addUsage(label, …)` / `addToolCalls(label, n)` via the reporter. `RunStats` adds `estCost` per step when pricing matches.
+2. **Diff stats** — mutation-improve: in `finalizePhase` after the ratchet commit, `diffStats(base…iterBranch)` → `reporter.diff('iter-N', stats)`. review-loop: in `mergeWorkerIntoPrimary` after merge → `reporter.diff('worker-N', stats)`. Failed/skipped iterations contribute nothing.
+3. **Durations** — `RunStats` records run start; footer shows total elapsed; per-label elapsed unchanged.
+4. **Footer** — `LiveRenderer.statusLine()` appends aggregate segments from `stats.snapshot()`: `in <k> / out <k> · ~$X est · tools N · +a/-r`.
+5. **Persistence** — at run end: mutation-improve merges `stats.snapshot()` into `state.json` (`stats` block, optional in schema for old-run compat); review-loop adds `diffStats`, `estimatedCostUsd`, `toolCalls` to `metrics.json`. On `--resume-run`, snapshot rehydrates from the artifact so totals accumulate.
+
+## Output shape
+
+Live footer (TTY only, single persistent line):
+
+```
+  status    round 2/4 · review ×1 · fix ×2 · 4m12s · issues: 3 open · in 228.8k / out 41.2k · ~$1.02 est · tools 37 · +412/-87
+```
+
+Final summary (both CLIs; new for mutation-improve):
+
+```
+Run summary (mutation-improve-13, 3 iterations, 12m40s)
+  file                          before   after   outcome    tokens (in/out)   lines
+  src/tools/registry.ts          61.2%   78.4%   improved   98.2k / 12.1k     +301/-12
+  src/chat/router.ts             55.0%   66.7%   capped     74.1k / 9.8k      +111/-75
+  ─────────────────────────────────────────────────────────────────────────────────
+  totals                                             228.8k / 41.2k   +412/-87   ~$1.02 est
+```
+
+Non-TTY: no per-tick footer (unchanged); stats appear only in the final summary + artifacts.
+
+## Error handling
+
+- **EPIPE/broken stream**: `RunStats` accumulates independently of stream state; existing `writeSafe` permanent downgrade preserved; summary still persisted (printed best-effort).
+- **numstat failure** (missing base, detached HEAD, binary-only diff): warn via `reporter.event()`, contribute `+0/-0`, never fail merge/run. Binary numstat lines (`-\t-`) parse as zero.
+- **Pricing**: no match → cost segments omitted; malformed `pricing` → Zod startup error.
+- **Resume**: artifacts lacking stats → rehydrate as zeros.
+- **Parse gaps**: missing token fields → 0; NaN/negative clamped.
+
+## Testing (test-first per workspace TDD hooks)
+
+- `tests/review-loop/run-stats.test.ts` — accumulation, snapshot immutability, rehydrate, clamping.
+- `tests/review-loop/cost.test.ts` — glob match, no-match → undefined, accumulation, rounding.
+- `tests/review-loop/diff-stats.test.ts` — numstat parsing (normal / binary / rename), failure → zero + warn.
+- `tests/review-loop/live-renderer.test.ts` (extend) — footer segments, cost hidden when unpriced, non-TTY silence, EPIPE downgrade still accumulates.
+- `tests/review-loop/line-handler.test.ts` (extend) — step end forwards usage + toolCount.
+- `tests/mutation-improve/integration.test.ts` (extend) — `state.json` gains `stats`; terminal summary printed with totals.
+- review-loop integration — `metrics.json` gains new fields; summary includes totals.
+
+## Out of scope
+
+- No new runtime dependencies.
+- No full-screen TUI, no interactivity (keyboard), no progress bars.
+- No changes to `scripts/mutation/` output.
+- Harness elision (`[N lines elided]`) is external to these CLIs and unchanged.

--- a/docs/superpowers/specs/2026-08-07-progress-stats-renderer-design.md
+++ b/docs/superpowers/specs/2026-08-07-progress-stats-renderer-design.md
@@ -115,6 +115,8 @@ Run summary (mutation-improve-13, 3 iterations, 12m40s)
 
 Non-TTY: no per-tick footer (unchanged); stats appear only in the final summary + artifacts.
 
+The footer's leading activity segments remain CLI-specific (review-loop: `round N/M · issues: N open`; mutation-improve: `iter N/M · current phase`); only the new trailing aggregate segments (`in/out · ~$ est · tools · +a/-r`) are shared.
+
 ## Error handling
 
 - **EPIPE/broken stream**: `RunStats` accumulates independently of stream state; existing `writeSafe` permanent downgrade preserved; summary still persisted (printed best-effort).

--- a/mutation-improve/CLAUDE.md
+++ b/mutation-improve/CLAUDE.md
@@ -22,7 +22,7 @@ Outcomes per iteration: `improved` | `skipped` | `capped` | `failed`. The CLI ex
 
 ## Storage / Artifacts
 
-- `<workDir>/runs/<runId>/state.json` — persisted run state (Zod-validated on `--resume-run <runId>`).
+- `<workDir>/runs/<runId>/state.json` — persisted run state (Zod-validated on `--resume-run <runId>`); its optional `stats` block carries the run's aggregate usage/diff totals, rehydrated into the live footer on resume.
 - `<workDir>/capped.json` — cross-run registry of files merged at their tests-only ceiling; select-gate rejects them. Delete an entry to make a file eligible again (e.g. after a src refactor raised its ceiling).
 - `<workDir>/runs/<runId>/agent-output.log` + `iter/<N>/{selection,result}.json` — agent transcripts and structured outputs.
 - `iter/<N>/build-output.log` — full combined stdout+stderr of a failed build gate (the recorded reason is tail-bounded).
@@ -46,5 +46,5 @@ The repo TDD resolver treats `mutation-improve/src/**` as gateable implementatio
 ## Dependencies
 
 - `zod` — config/run-state/agent-output validation (shared with root).
-- `review-loop/src/*` — imported by relative path (not a package dependency): agent runner, build checker, live renderer, spawn, worktree/git helpers.
+- `review-loop/src/*` — imported by relative path (not a package dependency): agent runner, build checker, live renderer, run-stats/cost/diff-stats, spawn, worktree/git helpers. The optional top-level `pricing` map (same shape as review-loop's) enables estimated-cost display; each iteration's merge numstat diff is recorded via `src/merge-stats.ts`, and `src/summary.ts` prints the end-of-run terminal summary (per-file scores/outcomes/±lines + totals).
 - `scripts/mutation/*` — Stryker report reading/merging for runner-side score measurement.

--- a/mutation-improve/config.example.json
+++ b/mutation-improve/config.example.json
@@ -16,5 +16,9 @@
     "extraArgs": [],
     "timeoutMs": 1800000
   },
-  "prBranchPrefix": "mutation-improve"
+  "prBranchPrefix": "mutation-improve",
+  "pricing": {
+    "anthropic/claude-sonnet-*": { "input": 3, "output": 15 },
+    "anthropic/claude-opus-*": { "input": 15, "output": 75 }
+  }
 }

--- a/mutation-improve/src/cli.ts
+++ b/mutation-improve/src/cli.ts
@@ -8,6 +8,7 @@ import path from 'node:path'
 import { runAgent } from '../../review-loop/src/agent-runner.js'
 import { createShellExec, runBuildCheck } from '../../review-loop/src/build-checker.js'
 import { LiveRenderer } from '../../review-loop/src/live-renderer.js'
+import { RunStats } from '../../review-loop/src/run-stats.js'
 import { realSpawn } from '../../review-loop/src/spawn.js'
 import {
   createWorktree,
@@ -22,7 +23,7 @@ import { type MutationImproveConfig, loadMutationImproveConfig } from './config.
 import { assertIntegrationBranch, runFinalize } from './finalize.js'
 import { type IterationResult, runPipeline, type PipelineDeps } from './pipeline.js'
 import { ResultSchema } from './result-schema.js'
-import { createRunState, loadRunState, saveRunState, type MutationImproveRunState } from './run-state.js'
+import { createRunState, loadRunState, persistStats, saveRunState, type MutationImproveRunState } from './run-state.js'
 import { measureMutationScore } from './score-reader.js'
 import { SelectionSchema } from './selection-schema.js'
 
@@ -143,6 +144,7 @@ function buildPipelineDeps(
   runState: MutationImproveRunState,
   log: LiveRenderer,
   cappedRegistry: CappedRegistryStore,
+  stats: RunStats,
 ): PipelineDeps {
   return {
     config,
@@ -166,7 +168,10 @@ function buildPipelineDeps(
     runSelectAgent: selectRunner(config, runState, log),
     runImproveAgent: improveRunner(config, runState, log),
     cappedRegistry,
-    saveRunState,
+    saveRunState: async (state) => {
+      persistStats(state, stats)
+      await saveRunState(state)
+    },
     log,
   }
 }
@@ -226,8 +231,9 @@ export async function runCli(argv: readonly string[]): Promise<void> {
   // capped files and re-enter the re-pick loop it exists to prevent).
   const cappedRegistry = await loadCappedRegistryStore(config.workDir, runState.runId)
 
-  const log = new LiveRenderer(process.stdout)
-  const deps = buildPipelineDeps(config, runState, log, cappedRegistry)
+  const stats = RunStats.rehydrate(runState.stats, { pricing: config.pricing })
+  const log = new LiveRenderer(process.stdout, stats)
+  const deps = buildPipelineDeps(config, runState, log, cappedRegistry, stats)
   // I1: try/finally guarantees saveRunState runs even if runPipeline throws
   // (e.g. AgentRunError mid-pipeline), so --resume-run sees the last-known
   // in-memory progress instead of losing everything to a throw.

--- a/mutation-improve/src/cli.ts
+++ b/mutation-improve/src/cli.ts
@@ -26,6 +26,7 @@ import { ResultSchema } from './result-schema.js'
 import { createRunState, loadRunState, persistStats, saveRunState, type MutationImproveRunState } from './run-state.js'
 import { measureMutationScore } from './score-reader.js'
 import { SelectionSchema } from './selection-schema.js'
+import { buildRunSummary } from './summary.js'
 
 export interface CliArgs {
   configPath: string
@@ -244,8 +245,11 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     results = pipelineOut.results
     aborted = pipelineOut.aborted
   } finally {
+    persistStats(runState, stats)
     await saveRunState(runState)
   }
+
+  console.log(buildRunSummary({ runState, results, stats: stats.snapshot(), aborted }))
 
   const failed = results.filter((r) => r.outcome === 'failed')
   if (!args.noPr && runState.merged.length > 0 && !aborted) {

--- a/mutation-improve/src/config.ts
+++ b/mutation-improve/src/config.ts
@@ -8,6 +8,7 @@ import path from 'node:path'
 
 import { z } from 'zod'
 
+import { PricingTableSchema } from '../../review-loop/src/cost.js'
 import { detectGitRoot } from '../../review-loop/src/worktree.js'
 
 const AgentConfigSchema = z.object({
@@ -37,6 +38,7 @@ export const MutationImproveConfigSchema = z.object({
   mutateFileCommand: z.string().min(1).default('bun test:mutate:file'),
   agent: AgentConfigSchema,
   prBranchPrefix: z.string().min(1).default('mutation-improve'),
+  pricing: PricingTableSchema.optional(),
 })
 
 export interface MutationImproveConfig extends z.infer<typeof MutationImproveConfigSchema> {

--- a/mutation-improve/src/merge-stats.ts
+++ b/mutation-improve/src/merge-stats.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { measureDiffSince } from '../../review-loop/src/diff-stats.js'
+import type { PipelineDeps } from './pipeline.js'
+
+type MergeStatsDeps = Pick<PipelineDeps, 'execGit' | 'log'> & {
+  config: { repoRoot: string }
+}
+
+// Reports the merge diff for an iteration into the run-stats sink. Captured
+// after a successful merge against the pre-merge HEAD (beforeSha), so it
+// reflects exactly what the iteration's branch landed on the integration
+// branch. A measurement failure (e.g. a missing sha) must never abort the
+// run, so it degrades to a log line instead of throwing.
+export async function reportMergeDiff(deps: MergeStatsDeps, iter: number, beforeSha: string): Promise<void> {
+  try {
+    const diff = await measureDiffSince(deps.execGit, deps.config.repoRoot, beforeSha)
+    deps.log.diff?.(`iter-${iter}`, diff)
+  } catch (error) {
+    deps.log.log(`[stats] merge diff unavailable: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -7,20 +7,19 @@ import { mkdir } from 'node:fs/promises'
 import path from 'node:path'
 
 import { agentWritePath, type AgentRunResult } from '../../review-loop/src/agent-runner.js'
+import { headSha, type DiffStats } from '../../review-loop/src/diff-stats.js'
 import type { MergeResult } from '../../review-loop/src/worktree.js'
 import { bumpScore, type BaselineMap } from './baseline.js'
 import type { CappedRegistryStore } from './capped-registry.js'
 import type { MutationImproveConfig } from './config.js'
 import { recordFailure, type FailureEntry } from './failure-recorder.js'
 import { gatePhase, type PhaseResult } from './gate.js'
+import { reportMergeDiff } from './merge-stats.js'
 import { buildImprovePrompt, buildSelectPrompt } from './prompt-templates.js'
-import type { Result } from './result-schema.js'
-import { ResultSchema } from './result-schema.js'
-import type { MutationImproveRunState } from './run-state.js'
-import { iterDir } from './run-state.js'
+import { ResultSchema, type Result } from './result-schema.js'
+import { iterDir, type MutationImproveRunState } from './run-state.js'
 import type { MeasuredScore } from './score-reader.js'
-import { SelectionSchema } from './selection-schema.js'
-import type { Selection } from './selection-schema.js'
+import { SelectionSchema, type Selection } from './selection-schema.js'
 import { ratchetVerifiedSkip } from './skip-ratchet.js'
 
 export interface IterationResult {
@@ -50,7 +49,7 @@ export interface PipelineDeps {
   runImproveAgent: (worktreePath: string, prompt: string, outputPath: string) => Promise<AgentRunResult<Result>>
   cappedRegistry: CappedRegistryStore
   saveRunState: (state: MutationImproveRunState) => Promise<void>
-  log: { log: (msg: string) => void; issue?: unknown }
+  log: { log: (msg: string) => void; issue?: unknown; diff?: (label: string, diff: DiffStats) => void }
 }
 
 function branchFor(deps: PipelineDeps, iter: number): string {
@@ -171,6 +170,7 @@ async function finalizePhase(
 ): Promise<IterationResult> {
   const { afterScore, result } = gate
   await commitRatchet(deps, worktreePath, file, afterScore, bumpScore(baseline, file, afterScore))
+  const beforeSha = await headSha(deps.execGit, deps.config.repoRoot)
   const merge = await deps.mergeWorktree(deps.config.repoRoot, branchFor(deps, iter))
   if (!merge.ok) {
     return {
@@ -183,6 +183,7 @@ async function finalizePhase(
       reason: `conflict: ${merge.conflictFiles.join(', ')}`,
     }
   }
+  await reportMergeDiff(deps, iter, beforeSha)
   // Record the cap only after the merge landed: an aborted run keeps the bump
   // on the unmerged iteration branch, and a persisted cap would wrongly block
   // the file in later runs whose baseline never received the tests.

--- a/mutation-improve/src/run-state.ts
+++ b/mutation-improve/src/run-state.ts
@@ -9,6 +9,7 @@ import path from 'node:path'
 
 import { z } from 'zod'
 
+import { PersistedStatsSchema, type RunStats } from '../../review-loop/src/run-stats.js'
 import type { MutationImproveConfig } from './config.js'
 
 const MergedEntrySchema = z.object({
@@ -41,6 +42,7 @@ export const PersistedRunStateSchema = z.object({
   merged: z.array(MergedEntrySchema),
   failed: z.array(FailedEntrySchema),
   status: z.enum(['running', 'completed', 'aborted']),
+  stats: PersistedStatsSchema.optional(),
 })
 
 export type PersistedRunState = z.infer<typeof PersistedRunStateSchema>
@@ -92,4 +94,8 @@ export async function loadRunState(workDir: string, runId: string): Promise<Muta
 export async function saveRunState(state: MutationImproveRunState): Promise<void> {
   const persisted = PersistedRunStateSchema.parse(state)
   await writeFile(state.statePath, JSON.stringify(persisted, null, 2))
+}
+
+export function persistStats(state: MutationImproveRunState, stats: RunStats): void {
+  state.stats = stats.persist()
 }

--- a/mutation-improve/src/summary.ts
+++ b/mutation-improve/src/summary.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { formatDuration, formatTokenCount } from '../../review-loop/src/live-format.js'
+import type { StatsSnapshot } from '../../review-loop/src/run-stats.js'
+import type { IterationResult } from './pipeline.js'
+import type { MutationImproveRunState } from './run-state.js'
+
+export interface RunSummaryInput {
+  runState: MutationImproveRunState
+  results: readonly IterationResult[]
+  stats: StatsSnapshot
+  aborted: boolean
+}
+
+function pct(score: number): string {
+  return `${(score * 100).toFixed(1)}%`
+}
+
+function mergedRow(entry: MutationImproveRunState['merged'][number], stats: StatsSnapshot): string {
+  const outcome = entry.capped === true ? 'capped' : 'improved'
+  const diff = stats.perLabel[`iter-${entry.iter}`]
+  const diffPart = diff !== undefined && (diff.added > 0 || diff.removed > 0) ? `+${diff.added}/-${diff.removed}` : '-'
+  return `  ${entry.file}  ${pct(entry.beforeScore)} → ${pct(entry.afterScore)}  ${outcome}  ${diffPart}`
+}
+
+function totalsLine(stats: StatsSnapshot): string {
+  const t = stats.totals
+  const parts = [`in ${formatTokenCount(t.input)} / out ${formatTokenCount(t.output)}`]
+  if (t.estimatedCostUsd !== undefined) parts.push(`~$${t.estimatedCostUsd.toFixed(2)} est`)
+  if (t.toolCalls > 0) parts.push(`tools ${t.toolCalls}`)
+  if (t.added > 0 || t.removed > 0) parts.push(`+${t.added}/-${t.removed}`)
+  parts.push(formatDuration(t.elapsedMs))
+  return `Totals: ${parts.join(' · ')}`
+}
+
+export function buildRunSummary(input: RunSummaryInput): string {
+  const { runState, results, stats, aborted } = input
+  const status = aborted ? 'aborted' : runState.failed.length > 0 ? 'completed with failures' : 'completed'
+  const lines = [
+    `Run summary (${runState.runId}) — ${status}: ${runState.merged.length} merged, ${runState.failed.length} failed, ${results.length} iterations`,
+  ]
+  for (const entry of runState.merged) {
+    lines.push(mergedRow(entry, stats))
+  }
+  for (const f of runState.failed) {
+    lines.push(`  ${f.file ?? '(no file)'}  failed at ${f.gate}: ${f.reason}`)
+  }
+  lines.push(totalsLine(stats))
+  return lines.join('\n')
+}

--- a/review-loop/CLAUDE.md
+++ b/review-loop/CLAUDE.md
@@ -9,7 +9,11 @@
 - The default `workDir` is `.review-loop/` relative to `repoRoot` (see `config.example.json`). The directory is created on demand via `mkdir`.
 - Per-run state lives at `<workDir>/runs/<runId>/state.json` (see `src/run-state.ts`).
 - Progress logs and transcripts land alongside the run state (see `src/progress-log.ts`).
-- `config.example.json` at the workspace root documents the expected config shape; real configs are loaded from the path passed via `--config` (defaults to `.review-loop/config.json`).
+- `config.example.json` at the workspace root documents the expected config shape; real configs are loaded from the path passed via `--config` (defaults to `.review-loop/config.json`). The optional top-level `pricing` map (USD per 1M tokens, glob-matched against the agent model) enables estimated-cost display.
+
+## Run Stats
+
+`src/run-stats.ts` (pure aggregate), `src/cost.ts` (pricing lookup), and `src/diff-stats.ts` (git numstat at worker merges) feed the `LiveRenderer` footer's aggregate segments (total tokens, `~$ est`, tool calls, `+a/-r`) and the final summary's `Stats:` line. Aggregates persist to `metrics.json` (`runStats` block) and rehydrate on `--resume-run`; stats accumulation is independent of the EPIPE downgrade, and segments are hidden when zero/unpriced.
 
 ## Scripts
 

--- a/review-loop/config.example.json
+++ b/review-loop/config.example.json
@@ -25,5 +25,9 @@
     "model": "ollama-cloud/kimi-k2.6:cloud",
     "extraArgs": [],
     "timeoutMs": 1800000
+  },
+  "pricing": {
+    "anthropic/claude-sonnet-*": { "input": 3, "output": 15 },
+    "anthropic/claude-opus-*": { "input": 15, "output": 75 }
   }
 }

--- a/review-loop/src/cli.ts
+++ b/review-loop/src/cli.ts
@@ -6,6 +6,8 @@
 import { access, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
+import { z } from 'zod'
+
 import { createShellExec, runBuildCheck, type ShellExecFn } from './build-checker.js'
 import { MergeConflictError, formatBuildFailureMessage } from './cli-errors.js'
 import { loadReviewLoopConfig, type ReviewLoopConfig } from './config.js'
@@ -162,12 +164,14 @@ export async function prepareWorktree(config: ReviewLoopConfig, runState: RunSta
   }
 }
 
+const MetricsEnvelopeSchema = z.object({ runStats: PersistedStatsSchema.optional() })
+
 export async function readPersistedRunStats(runDir: string): Promise<PersistedStats | undefined> {
   try {
-    const raw: unknown = JSON.parse(await readFile(path.join(runDir, 'metrics.json'), 'utf8'))
-    const candidate = typeof raw === 'object' && raw !== null ? (raw as { runStats?: unknown }).runStats : undefined
-    const parsed = PersistedStatsSchema.safeParse(candidate)
-    return parsed.success ? parsed.data : undefined
+    const parsed = MetricsEnvelopeSchema.safeParse(
+      JSON.parse(await readFile(path.join(runDir, 'metrics.json'), 'utf8')),
+    )
+    return parsed.success ? parsed.data.runStats : undefined
   } catch {
     return undefined
   }

--- a/review-loop/src/cli.ts
+++ b/review-loop/src/cli.ts
@@ -3,7 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { access, writeFile } from 'node:fs/promises'
+import { access, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { createShellExec, runBuildCheck, type ShellExecFn } from './build-checker.js'
@@ -14,6 +14,7 @@ import { LiveRenderer } from './live-renderer.js'
 import { runReviewLoop, type ReviewLoopResult } from './loop-controller.js'
 import type { ProgressReporter } from './progress-log.js'
 import { createRunState, loadRunState, type RunState } from './run-state.js'
+import { RunStats, PersistedStatsSchema, type PersistedStats } from './run-stats.js'
 import { realSpawn } from './spawn.js'
 import { buildMetricsJson, buildSummary } from './summary.js'
 import { createFileTraceLogger, type TraceLogger } from './trace-log.js'
@@ -161,10 +162,21 @@ export async function prepareWorktree(config: ReviewLoopConfig, runState: RunSta
   }
 }
 
+export async function readPersistedRunStats(runDir: string): Promise<PersistedStats | undefined> {
+  try {
+    const raw: unknown = JSON.parse(await readFile(path.join(runDir, 'metrics.json'), 'utf8'))
+    const candidate = typeof raw === 'object' && raw !== null ? (raw as { runStats?: unknown }).runStats : undefined
+    const parsed = PersistedStatsSchema.safeParse(candidate)
+    return parsed.success ? parsed.data : undefined
+  } catch {
+    return undefined
+  }
+}
+
 export async function writeRunArtifacts(
   runDir: string,
   result: ReviewLoopResult,
-  options: { poolSize: number; inspect: boolean; wallMs: number },
+  options: { poolSize: number; inspect: boolean; wallMs: number; stats?: RunStats },
 ): Promise<void> {
   const closed = Object.values(result.ledger.issues).filter((r) => r.status === 'closed').length
   const summary = buildSummary({
@@ -175,12 +187,24 @@ export async function writeRunArtifacts(
     runDir,
     wallMs: options.wallMs,
     options: { poolSize: options.poolSize, inspect: options.inspect },
+    stats: options.stats?.snapshot(),
   })
   await writeFile(path.join(runDir, 'summary.txt'), `${summary}\n`)
   try {
     await writeFile(
       path.join(runDir, 'metrics.json'),
-      `${JSON.stringify(buildMetricsJson(result.doneReason, result.rounds, closed, result.metrics ?? [], options), null, 2)}\n`,
+      `${JSON.stringify(
+        buildMetricsJson(
+          result.doneReason,
+          result.rounds,
+          closed,
+          result.metrics ?? [],
+          options,
+          options.stats?.persist(),
+        ),
+        null,
+        2,
+      )}\n`,
     )
   } catch (error) {
     console.warn(`[review-loop] metrics.json write failed: ${error instanceof Error ? error.message : String(error)}`)
@@ -216,6 +240,7 @@ async function executeReviewLoop(
     poolSize: config.poolSize,
     inspect,
     wallMs: Date.now() - startedAt,
+    stats: log.stats,
   })
   await finalizeRun(config, runState, { exec, runBuildCheck, mergeWorktree, removeWorktree })
 }
@@ -236,11 +261,20 @@ export async function runCli(argv: readonly string[]): Promise<void> {
 
   await prepareWorktree(config, runState, args.resetWorktree)
 
-  const log = new LiveRenderer(process.stdout)
+  const priorStats = args.resumeRunId === undefined ? undefined : await readPersistedRunStats(runState.runDir)
+  const stats = RunStats.rehydrate(priorStats, { pricing: config.pricing })
+  const log = new LiveRenderer(process.stdout, stats)
   const exec = createShellExec(runState.worktreePath, config.checkCommand, config.buildTimeoutMs)
   const trace = createFileTraceLogger(runState.tracePath)
   await cleanWorkerWorktrees(runState.worktreePath, args.resumeRunId)
-  const pool = await createWorkerPool(config, runState)
+  const pool = await createWorkerPool(config, runState, {
+    onMergeDiff: (workerId, diff) => {
+      log.diff(`worker-${workerId}`, diff)
+    },
+    warn: (message) => {
+      log.event(message)
+    },
+  })
 
   try {
     await executeReviewLoop(config, runState, ledger, exec, log, trace, pool, !args.noInspect, startedAt)

--- a/review-loop/src/config.ts
+++ b/review-loop/src/config.ts
@@ -8,6 +8,7 @@ import path from 'node:path'
 
 import { z } from 'zod'
 
+import { PricingTableSchema } from './cost.js'
 import { detectGitRoot } from './worktree.js'
 
 const AgentConfigSchema = z.object({
@@ -29,6 +30,7 @@ export const ReviewLoopConfigSchema = z.object({
   fixer: AgentConfigSchema,
   inspector: AgentConfigSchema.optional(),
   matcher: AgentConfigSchema,
+  pricing: PricingTableSchema.optional(),
 })
 
 export interface ReviewLoopConfig extends z.infer<typeof ReviewLoopConfigSchema> {

--- a/review-loop/src/cost.ts
+++ b/review-loop/src/cost.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+export const PriceEntrySchema = z.object({
+  input: z.number().nonnegative(),
+  output: z.number().nonnegative(),
+})
+export const PricingTableSchema = z.record(z.string(), PriceEntrySchema)
+export type PriceEntry = z.infer<typeof PriceEntrySchema>
+export type PricingTable = z.infer<typeof PricingTableSchema>
+
+function globToRegExp(glob: string): RegExp {
+  const escaped = glob.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&').replace(/\\\*/gu, '.*')
+  return new RegExp(`^${escaped}$`, 'u')
+}
+
+export function matchPrice(pricing: PricingTable, model: string): PriceEntry | undefined {
+  const exact = pricing[model]
+  if (exact !== undefined) return exact
+  for (const [pattern, entry] of Object.entries(pricing)) {
+    if (pattern.includes('*') && globToRegExp(pattern).test(model)) return entry
+  }
+  return undefined
+}
+
+export function estimateCostUsd(price: PriceEntry, input: number, output: number): number {
+  return (input / 1_000_000) * price.input + (output / 1_000_000) * price.output
+}

--- a/review-loop/src/diff-stats.ts
+++ b/review-loop/src/diff-stats.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+export interface DiffStats {
+  added: number
+  removed: number
+}
+
+export type ExecGitFn = (cwd: string, args: readonly string[]) => Promise<{ stdout: string; stderr: string }>
+
+export function parseNumstat(output: string): DiffStats {
+  let added = 0
+  let removed = 0
+  for (const line of output.split('\n')) {
+    if (line.trim() === '') continue
+    const [a, r] = line.split('\t')
+    const addN = Number(a)
+    const remN = Number(r)
+    if (Number.isFinite(addN)) added += addN
+    if (Number.isFinite(remN)) removed += remN
+  }
+  return { added, removed }
+}
+
+export async function headSha(execGit: ExecGitFn, cwd: string): Promise<string> {
+  const { stdout } = await execGit(cwd, ['rev-parse', 'HEAD'])
+  return stdout.trim()
+}
+
+export async function measureDiffSince(execGit: ExecGitFn, cwd: string, beforeSha: string): Promise<DiffStats> {
+  const { stdout } = await execGit(cwd, ['diff', '--numstat', `${beforeSha}..HEAD`])
+  return parseNumstat(stdout)
+}

--- a/review-loop/src/line-handler.ts
+++ b/review-loop/src/line-handler.ts
@@ -19,10 +19,12 @@ export interface LineHandler {
 
 export interface LiveCtx {
   readonly label: string
+  readonly model: string
   readonly logPath: string
   readonly reporter: ProgressReporter | undefined
   startedAt: number
   toolCount: number
+  reportedToolCalls: number
   tool: string
   arg: string
   readonly seenCalls: Set<string>
@@ -45,6 +47,32 @@ function renderLive(ctx: LiveCtx): void {
   } else {
     reporter.slot(ctx.label, line)
   }
+}
+
+function applyStepFinish(evt: Extract<OpencodeEvent, { type: 'step_finish' }>, ctx: LiveCtx): void {
+  const reporter = ctx.reporter
+  ctx.usage.inputTokens += evt.tokens.input
+  ctx.usage.outputTokens += evt.tokens.output
+  ctx.usage.reasoningTokens += evt.tokens.reasoning
+  ctx.usage.costUsd += evt.cost
+  if (reporter === undefined) return
+  reporter.usage?.({
+    input: evt.tokens.input,
+    output: evt.tokens.output,
+    reasoning: evt.tokens.reasoning,
+    cost: evt.cost,
+    label: ctx.label,
+    model: ctx.model,
+  })
+  const newToolCalls = ctx.toolCount - ctx.reportedToolCalls
+  if (newToolCalls > 0) {
+    ctx.reportedToolCalls = ctx.toolCount
+    reporter.stats?.addToolCalls(ctx.label, newToolCalls)
+  }
+  reporter.clearLive()
+  reporter.event(
+    formatStepFooter(ctx.label, ctx.startedAt === 0 ? 0 : Date.now() - ctx.startedAt, ctx.toolCount, evt.tokens),
+  )
 }
 
 function applyEvent(evt: OpencodeEvent, ctx: LiveCtx): void {
@@ -71,22 +99,7 @@ function applyEvent(evt: OpencodeEvent, ctx: LiveCtx): void {
       renderLive(ctx)
       break
     case 'step_finish':
-      ctx.usage.inputTokens += evt.tokens.input
-      ctx.usage.outputTokens += evt.tokens.output
-      ctx.usage.reasoningTokens += evt.tokens.reasoning
-      ctx.usage.costUsd += evt.cost
-      if (reporter !== undefined) {
-        reporter.usage?.({
-          input: evt.tokens.input,
-          output: evt.tokens.output,
-          reasoning: evt.tokens.reasoning,
-          cost: evt.cost,
-        })
-        reporter.clearLive()
-        reporter.event(
-          formatStepFooter(ctx.label, ctx.startedAt === 0 ? 0 : Date.now() - ctx.startedAt, ctx.toolCount, evt.tokens),
-        )
-      }
+      applyStepFinish(evt, ctx)
       break
     case 'text':
       break
@@ -96,10 +109,12 @@ function applyEvent(evt: OpencodeEvent, ctx: LiveCtx): void {
 export function createLineHandler<T>(options: RunAgentOptions<T>): LineHandler {
   const ctx: LiveCtx = {
     label: options.label,
+    model: options.model,
     logPath: options.logPath,
     reporter: options.reporter,
     startedAt: 0,
     toolCount: 0,
+    reportedToolCalls: 0,
     tool: '',
     arg: '',
     seenCalls: new Set<string>(),

--- a/review-loop/src/live-renderer.ts
+++ b/review-loop/src/live-renderer.ts
@@ -3,9 +3,11 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import type { DiffStats } from './diff-stats.js'
 import { formatDecidedLine, formatFoundLine } from './issue-format.js'
 import { activitySummary, formatDuration, formatTokenCount, MIDDLE_DOT, truncate } from './live-format.js'
 import type { IssueProgressEvent, ProgressReporter, UsageDelta } from './progress-log.js'
+import type { RunStats } from './run-stats.js'
 
 const ERASE_LINE = '\u001b[2K'
 const CURSOR_DOWN = '\u001b[1B'
@@ -57,6 +59,7 @@ export class LiveRenderer implements ProgressReporter {
   private readonly tty: boolean
   private broken = false
   private readonly stream: RendererStream
+  readonly stats: RunStats | undefined
   private renderedLines = 0
   private startedAt = 0
   private round = 0
@@ -65,9 +68,10 @@ export class LiveRenderer implements ProgressReporter {
   private readonly usageTotals: UsageDelta = { input: 0, output: 0, reasoning: 0, cost: 0 }
   private readonly slots = new Map<string, string>()
 
-  constructor(stream: RendererStream) {
+  constructor(stream: RendererStream, stats?: RunStats) {
     this.stream = stream
     this.tty = stream.isTTY === true
+    this.stats = stats
   }
 
   get dynamic(): boolean {
@@ -123,6 +127,11 @@ export class LiveRenderer implements ProgressReporter {
     this.usageTotals.output += delta.output
     this.usageTotals.reasoning += delta.reasoning
     this.usageTotals.cost += delta.cost
+    this.stats?.addUsage(delta.label ?? 'agent', delta)
+  }
+
+  diff(label: string, diffStats: DiffStats): void {
+    this.stats?.addDiff(label, diffStats)
   }
 
   event(message: string): void {
@@ -173,6 +182,16 @@ export class LiveRenderer implements ProgressReporter {
     if (segments.length > 0) parts.push(`issues: ${segments.join(` ${MIDDLE_DOT} `)}`)
     if (this.usageTotals.input > 0 || this.usageTotals.output > 0) {
       parts.push(`in ${formatTokenCount(this.usageTotals.input)} / out ${formatTokenCount(this.usageTotals.output)}`)
+    }
+    const snap = this.stats?.snapshot()
+    if (snap !== undefined) {
+      if (snap.totals.estimatedCostUsd !== undefined) {
+        parts.push(`~$${snap.totals.estimatedCostUsd.toFixed(2)} est`)
+      }
+      if (snap.totals.toolCalls > 0) parts.push(`tools ${snap.totals.toolCalls}`)
+      if (snap.totals.added > 0 || snap.totals.removed > 0) {
+        parts.push(`+${snap.totals.added}/-${snap.totals.removed}`)
+      }
     }
     if (parts.length === 0) return ''
     return `  ${'status'.padEnd(10)} ${parts.join(` ${MIDDLE_DOT} `)}`

--- a/review-loop/src/progress-log.ts
+++ b/review-loop/src/progress-log.ts
@@ -3,6 +3,8 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import type { DiffStats } from './diff-stats.js'
+import type { RunStats } from './run-stats.js'
 import type { Severity } from './trace-log.js'
 
 export type IssueProgressEvent =
@@ -15,10 +17,13 @@ export interface UsageDelta {
   output: number
   reasoning: number
   cost: number
+  label?: string
+  model?: string
 }
 
 export interface ProgressReporter {
   readonly dynamic: boolean
+  readonly stats?: RunStats
   event(message: string): void
   live(lines: readonly string[]): void
   clearLive(): void
@@ -27,6 +32,7 @@ export interface ProgressReporter {
   statusSuffix?(): string
   slot?(key: string, line: string | null): void
   usage?(delta: UsageDelta): void
+  diff?(label: string, diff: DiffStats): void
 }
 
 export function emitDecision(

--- a/review-loop/src/run-stats.ts
+++ b/review-loop/src/run-stats.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+import { estimateCostUsd, matchPrice, type PricingTable } from './cost.js'
+import type { DiffStats } from './diff-stats.js'
+
+export interface UsageInput {
+  input: number
+  output: number
+  reasoning: number
+  model?: string
+}
+
+export interface LabelStats {
+  input: number
+  output: number
+  reasoning: number
+  toolCalls: number
+  added: number
+  removed: number
+}
+
+export interface StatsTotals extends LabelStats {
+  estimatedCostUsd?: number
+}
+
+export interface StatsSnapshot {
+  totals: StatsTotals & { elapsedMs: number }
+  perLabel: Record<string, LabelStats>
+}
+
+export const LabelStatsSchema = z.object({
+  input: z.number(),
+  output: z.number(),
+  reasoning: z.number(),
+  toolCalls: z.number(),
+  added: z.number(),
+  removed: z.number(),
+})
+
+export const PersistedStatsSchema = z.object({
+  totals: LabelStatsSchema.extend({ estimatedCostUsd: z.number().optional() }),
+  perLabel: z.record(z.string(), LabelStatsSchema),
+})
+export type PersistedStats = z.infer<typeof PersistedStatsSchema>
+
+export interface RunStatsOptions {
+  pricing?: PricingTable
+  model?: string
+  startedAt?: number
+  now?: () => number
+}
+
+function clamp(n: number): number {
+  return Number.isFinite(n) && n > 0 ? n : 0
+}
+
+function emptyLabelStats(): LabelStats {
+  return { input: 0, output: 0, reasoning: 0, toolCalls: 0, added: 0, removed: 0 }
+}
+
+export class RunStats {
+  private readonly pricing: PricingTable | undefined
+  private readonly model: string | undefined
+  private readonly startedAt: number
+  private readonly now: () => number
+  private readonly totals: LabelStats = emptyLabelStats()
+  private readonly perLabel = new Map<string, LabelStats>()
+  private estimatedCost = 0
+  private hasCost = false
+
+  constructor(options: RunStatsOptions = {}) {
+    this.pricing = options.pricing
+    this.model = options.model
+    this.now = options.now ?? Date.now
+    this.startedAt = options.startedAt ?? this.now()
+  }
+
+  static rehydrate(persisted: PersistedStats | undefined, options: RunStatsOptions = {}): RunStats {
+    const stats = new RunStats(options)
+    if (persisted === undefined) return stats
+    for (const [label, entry] of Object.entries(persisted.perLabel)) {
+      stats.perLabel.set(label, { ...entry })
+    }
+    stats.totals.input = persisted.totals.input
+    stats.totals.output = persisted.totals.output
+    stats.totals.reasoning = persisted.totals.reasoning
+    stats.totals.toolCalls = persisted.totals.toolCalls
+    stats.totals.added = persisted.totals.added
+    stats.totals.removed = persisted.totals.removed
+    if (persisted.totals.estimatedCostUsd !== undefined) {
+      stats.estimatedCost = persisted.totals.estimatedCostUsd
+      stats.hasCost = true
+    }
+    return stats
+  }
+
+  addUsage(label: string, delta: UsageInput): void {
+    const entry = this.labelEntry(label)
+    entry.input += clamp(delta.input)
+    entry.output += clamp(delta.output)
+    entry.reasoning += clamp(delta.reasoning)
+    this.totals.input += clamp(delta.input)
+    this.totals.output += clamp(delta.output)
+    this.totals.reasoning += clamp(delta.reasoning)
+    const model = delta.model ?? this.model
+    if (this.pricing !== undefined && model !== undefined) {
+      const price = matchPrice(this.pricing, model)
+      if (price !== undefined) {
+        this.estimatedCost += estimateCostUsd(price, clamp(delta.input), clamp(delta.output))
+        this.hasCost = true
+      }
+    }
+  }
+
+  addToolCalls(label: string, n: number): void {
+    const delta = Math.floor(clamp(n))
+    this.labelEntry(label).toolCalls += delta
+    this.totals.toolCalls += delta
+  }
+
+  addDiff(label: string, diff: DiffStats): void {
+    const entry = this.labelEntry(label)
+    entry.added += clamp(diff.added)
+    entry.removed += clamp(diff.removed)
+    this.totals.added += clamp(diff.added)
+    this.totals.removed += clamp(diff.removed)
+  }
+
+  snapshot(): StatsSnapshot {
+    return {
+      totals: { ...this.totals, ...this.costField(), elapsedMs: Math.max(0, this.now() - this.startedAt) },
+      perLabel: Object.fromEntries([...this.perLabel].map(([label, entry]) => [label, { ...entry }])),
+    }
+  }
+
+  persist(): PersistedStats {
+    return {
+      totals: { ...this.totals, ...this.costField() },
+      perLabel: Object.fromEntries([...this.perLabel].map(([label, entry]) => [label, { ...entry }])),
+    }
+  }
+
+  private costField(): { estimatedCostUsd?: number } {
+    return this.hasCost ? { estimatedCostUsd: this.estimatedCost } : {}
+  }
+
+  private labelEntry(label: string): LabelStats {
+    let entry = this.perLabel.get(label)
+    if (entry === undefined) {
+      entry = emptyLabelStats()
+      this.perLabel.set(label, entry)
+    }
+    return entry
+  }
+}

--- a/review-loop/src/summary.ts
+++ b/review-loop/src/summary.ts
@@ -14,6 +14,7 @@ import {
 import type { IssueLedgerSnapshot, LedgerIssueRecord } from './issue-ledger.js'
 import { formatDuration } from './live-format.js'
 import type { ReviewLoopResult } from './loop-controller.js'
+import type { PersistedStats, StatsSnapshot } from './run-stats.js'
 import { burndownBlock } from './summary-burndown.js'
 import type { PhaseMs, RoundMetric, UsageTotals } from './trace-log.js'
 
@@ -39,6 +40,7 @@ export interface MetricsJson {
     reopened: number
     inspectorRejected: number
   }
+  runStats?: PersistedStats
 }
 
 export interface SummaryOptions {
@@ -54,6 +56,7 @@ export interface SummaryInput {
   runDir: string
   wallMs: number
   options: SummaryOptions
+  stats?: StatsSnapshot
 }
 
 interface IssueCounts {
@@ -173,6 +176,17 @@ function buildInspectorLine(metrics: readonly RoundMetric[], options: SummaryOpt
   return `Inspector: ${runs} runs, ${rejected} rejected (${rate} reject rate)`
 }
 
+function buildStatsLine(stats: StatsSnapshot | undefined): string | null {
+  if (stats === undefined) return null
+  const t = stats.totals
+  const parts: string[] = []
+  if (t.toolCalls > 0) parts.push(`tools ${t.toolCalls}`)
+  if (t.added > 0 || t.removed > 0) parts.push(`+${t.added}/-${t.removed}`)
+  if (t.estimatedCostUsd !== undefined) parts.push(`~$${t.estimatedCostUsd.toFixed(2)} est`)
+  if (parts.length === 0) return null
+  return `Stats: ${parts.join(' · ')}`
+}
+
 function issuesBlock(ledger: IssueLedgerSnapshot): string[] {
   const records = Object.values(ledger.issues)
   if (records.length === 0) return []
@@ -219,6 +233,9 @@ export function buildSummary(input: SummaryInput): string {
   const inspectorLine = buildInspectorLine(input.metrics, input.options)
   if (inspectorLine !== null) lines.push(inspectorLine)
 
+  const statsLine = buildStatsLine(input.stats)
+  if (statsLine !== null) lines.push(statsLine)
+
   const issues = issuesBlock(input.ledger)
   if (issues.length > 0) lines.push('', ...issues)
 
@@ -235,6 +252,7 @@ export function buildMetricsJson(
   closed: number,
   metrics: readonly RoundMetric[],
   options: SummaryOptions,
+  runStats?: PersistedStats,
 ): MetricsJson {
   const lastMetric = metrics.length > 0 ? metrics[metrics.length - 1] : undefined
   const openFromMetrics = lastMetric === undefined ? 0 : lastMetric.cumulativeOpen
@@ -254,5 +272,6 @@ export function buildMetricsJson(
       reopened: 0,
       inspectorRejected: metrics.reduce((s, m) => s + m.inspector.rejected, 0),
     },
+    ...(runStats === undefined ? {} : { runStats }),
   }
 }

--- a/review-loop/src/worker-pool.ts
+++ b/review-loop/src/worker-pool.ts
@@ -6,6 +6,7 @@
 import path from 'node:path'
 
 import type { ReviewLoopConfig } from './config.js'
+import { headSha, measureDiffSince, type DiffStats } from './diff-stats.js'
 import type { RunState } from './run-state.js'
 import { execGit, rebaseOnto, mergeFastForward, removeWorktree } from './worktree.js'
 
@@ -17,6 +18,11 @@ export interface Worker {
   lockedFiles: ReadonlySet<string>
   headSha(): Promise<string>
   resetToBaseline(sha: string): Promise<void>
+}
+
+export interface WorkerPoolHooks {
+  onMergeDiff?: (workerId: number, diff: DiffStats) => void
+  warn?: (message: string) => void
 }
 
 export interface WorkerPool {
@@ -88,11 +94,21 @@ function mergeWorkerIntoPrimary(
   primaryWorktreePath: string,
   primaryBranch: string,
   worker: Worker,
+  hooks: WorkerPoolHooks,
 ): Promise<{ ok: true } | { ok: false; conflictFiles: string[] }> {
   return withPrimaryLock(internals, async () => {
     const rebase = await rebaseOnto(worker.worktreePath, primaryBranch, worker.branch)
     if (!rebase.ok) return { ok: false, conflictFiles: rebase.conflictFiles }
+    const before = await headSha(execGit, primaryWorktreePath)
     await mergeFastForward(primaryWorktreePath, worker.branch)
+    try {
+      const diff = await measureDiffSince(execGit, primaryWorktreePath, before)
+      hooks.onMergeDiff?.(worker.id, diff)
+    } catch (error) {
+      hooks.warn?.(
+        `[worker-${worker.id}] merge diff stats failed: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
     return { ok: true }
   })
 }
@@ -144,7 +160,11 @@ async function buildWorkers(
   return workers
 }
 
-export async function createWorkerPool(config: ReviewLoopConfig, runState: RunState): Promise<WorkerPool> {
+export async function createWorkerPool(
+  config: ReviewLoopConfig,
+  runState: RunState,
+  hooks: WorkerPoolHooks = {},
+): Promise<WorkerPool> {
   const repoRoot = config.repoRoot
   const primaryBranch = `review-loop/${runState.runId}`
   const primaryWorktreePath = runState.worktreePath
@@ -167,7 +187,7 @@ export async function createWorkerPool(config: ReviewLoopConfig, runState: RunSt
     },
 
     mergeWorkerIntoPrimary: (worker: Worker) =>
-      mergeWorkerIntoPrimary(internals, primaryWorktreePath, primaryBranch, worker),
+      mergeWorkerIntoPrimary(internals, primaryWorktreePath, primaryBranch, worker, hooks),
 
     workerPaths: () => internals.workers.map((w) => w.worktreePath),
 

--- a/scripts/mutation/baseline.json
+++ b/scripts/mutation/baseline.json
@@ -379,7 +379,7 @@
   "src/tools/workspace-files.ts": 0.6382978723404256,
   "src/tools/wrap-tool-execution.ts": 0.6571428571428571,
   "src/users.ts": 0.6746987951807228,
-  "src/utils/scheduler.events.ts": 0.45,
+  "src/utils/scheduler.events.ts": 0.9,
   "src/utils/scheduler.helpers.ts": 1,
   "src/utils/scheduler.ts": 1
 }

--- a/scripts/mutation/baseline.json
+++ b/scripts/mutation/baseline.json
@@ -95,7 +95,7 @@
   "plugins/task-provider-youtrack/collaboration-provider.ts": 0,
   "plugins/task-provider-youtrack/create-field-helpers.ts": 1,
   "plugins/task-provider-youtrack/custom-field-values.ts": 0,
-  "plugins/task-provider-youtrack/dedicated-fields.ts": 0.6699029126213593,
+  "plugins/task-provider-youtrack/dedicated-fields.ts": 0.912621359223301,
   "plugins/task-provider-youtrack/due-date.ts": 0.925531914893617,
   "plugins/task-provider-youtrack/entry-runtime.ts": 0,
   "plugins/task-provider-youtrack/field-engine.ts": 0.9688715953307393,

--- a/scripts/mutation/baseline.json
+++ b/scripts/mutation/baseline.json
@@ -157,7 +157,7 @@
   "review-loop/src/live-renderer.ts": 0.6678571428571428,
   "review-loop/src/loop-controller.ts": 0.6666666666666666,
   "review-loop/src/progress-log.ts": 1,
-  "review-loop/src/summary-burndown.ts": 0.74,
+  "review-loop/src/summary-burndown.ts": 0.96,
   "review-loop/src/summary.ts": 0.721030042918455,
   "review-loop/src/worktree.ts": 0.8402366863905325,
   "src/analytics/intent/classifier.ts": 0.9672727272727273,

--- a/scripts/mutation/baseline.json
+++ b/scripts/mutation/baseline.json
@@ -380,6 +380,6 @@
   "src/tools/wrap-tool-execution.ts": 0.6571428571428571,
   "src/users.ts": 0.6746987951807228,
   "src/utils/scheduler.events.ts": 0.45,
-  "src/utils/scheduler.helpers.ts": 0.3333333333333333,
+  "src/utils/scheduler.helpers.ts": 1,
   "src/utils/scheduler.ts": 1
 }

--- a/scripts/mutation/baseline.json
+++ b/scripts/mutation/baseline.json
@@ -98,7 +98,7 @@
   "plugins/task-provider-youtrack/dedicated-fields.ts": 0.6699029126213593,
   "plugins/task-provider-youtrack/due-date.ts": 0.925531914893617,
   "plugins/task-provider-youtrack/entry-runtime.ts": 0,
-  "plugins/task-provider-youtrack/field-engine.ts": 0.4280155642023346,
+  "plugins/task-provider-youtrack/field-engine.ts": 0.9688715953307393,
   "plugins/task-provider-youtrack/field-name-error.ts": 0.8,
   "plugins/task-provider-youtrack/helpers.ts": 0.7391304347826086,
   "plugins/task-provider-youtrack/identity-resolver.ts": 0.5384615384615384,

--- a/scripts/mutation/baseline.json
+++ b/scripts/mutation/baseline.json
@@ -93,7 +93,7 @@
   "plugins/task-provider-youtrack/bundle-values.ts": 0.4838709677419355,
   "plugins/task-provider-youtrack/classify-error.ts": 0.9490909090909091,
   "plugins/task-provider-youtrack/collaboration-provider.ts": 0,
-  "plugins/task-provider-youtrack/create-field-helpers.ts": 0.46511627906976744,
+  "plugins/task-provider-youtrack/create-field-helpers.ts": 1,
   "plugins/task-provider-youtrack/custom-field-values.ts": 0,
   "plugins/task-provider-youtrack/dedicated-fields.ts": 0.6699029126213593,
   "plugins/task-provider-youtrack/due-date.ts": 0.925531914893617,

--- a/scripts/mutation/baseline.json
+++ b/scripts/mutation/baseline.json
@@ -162,7 +162,7 @@
   "review-loop/src/worktree.ts": 0.8402366863905325,
   "src/analytics/intent/classifier.ts": 0.9672727272727273,
   "src/analytics/jobs/backfill.ts": 0.7741935483870968,
-  "src/announcements/humanize.ts": 0.3382352941176471,
+  "src/announcements/humanize.ts": 0.9117647058823529,
   "src/attachments/staged-download.ts": 1,
   "src/bot-attachments.ts": 0.5950413223140496,
   "src/bot-message-caching.ts": 0.9166666666666666,

--- a/tests/announcements/humanize.test.ts
+++ b/tests/announcements/humanize.test.ts
@@ -3,7 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
 import type { LanguageModel } from 'ai'
 
@@ -13,6 +13,50 @@ import {
   humanizeChangelog,
   type HumanizeChangelogDeps,
 } from '../../src/announcements/humanize.js'
+import { logger, logMultistream } from '../../src/logger.js'
+import { setupTestDb } from '../utils/test-helpers.js'
+
+// humanize.ts captures `logger.child({ scope })` once at module load, and the
+// global `tests/setup.ts` preload pins LOG_LEVEL=silent before that load, so the
+// child logger emits nothing by default. The logger is the real pino instance
+// (preloaded transitively via tests/mock-reset.ts -> src/announcements.ts), so a
+// per-file mock.module cannot replace it. Instead, attach a trace-level capture
+// stream through the public `logMultistream.add()` extension point and raise the
+// root logger level per-test (pino children inherit it dynamically). The level
+// is restored in afterEach so the mutation never leaks past this file: the serial
+// build gate (`CI=true bun check:full`) runs every file in one process.
+const captured: string[] = []
+logMultistream.add({
+  level: 'trace',
+  stream: {
+    write(raw: string): void {
+      captured.push(raw)
+    },
+  },
+})
+const originalLevel = logger.level
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
+
+const logEntries = (): Record<string, unknown>[] =>
+  captured.flatMap((line) => {
+    try {
+      const entry: unknown = JSON.parse(line)
+      return isRecord(entry) ? [entry] : []
+    } catch {
+      return []
+    }
+  })
+
+const warnEntries = (): Record<string, unknown>[] => logEntries().filter((entry) => entry['level'] === 40)
+
+const soleWarn = (): Record<string, unknown> => {
+  const warns = warnEntries()
+  expect(warns).toHaveLength(1)
+  const warn = warns[0]
+  if (warn === undefined) throw new Error('expected exactly one warn entry')
+  return warn
+}
 
 const role = (model: string): { apiKey: string; baseUrl: string; model: string; source: 'global' } => ({
   apiKey: 'k',
@@ -45,6 +89,16 @@ function deps(over: Partial<HumanizeChangelogDeps>): HumanizeChangelogDeps {
     ...over,
   }
 }
+
+beforeEach(async () => {
+  await setupTestDb()
+  logger.level = 'trace'
+  captured.length = 0
+})
+
+afterEach(() => {
+  logger.level = originalLevel
+})
 
 describe('humanizeChangelog', () => {
   test('classifies first, then writes from surviving entries only', async () => {
@@ -141,6 +195,73 @@ describe('humanizeChangelog', () => {
     expect(writeSystem).toContain('⚡ Improvements')
     expect(writeSystem).toContain('Example input')
     expect(writeSystem).toContain('benefit')
+  })
+
+  test('passes the exact classify system prompt to the structured pass', async () => {
+    let capturedSystem = ''
+    await humanizeChangelog(
+      'raw',
+      deps({
+        generateStructured: (opts) => {
+          capturedSystem = opts.system
+          return Promise.resolve(twoEntries)
+        },
+      }),
+    )
+    expect(capturedSystem).toBe(
+      'You select which software changelog entries matter to end users of a chat bot.\nRules:\n- Keep only changes a non-technical user would notice or benefit from: new capabilities, improvements to speed, reliability or usability, and bug fixes.\n- Drop internal changes: build, ci, test, chore, refactor, deps, docs, formatting, and other internal plumbing.\n- When in doubt, drop the entry.\n- For each kept entry set kind: "new" for a new capability, "improvement" when something works better or faster now, "fix" when a problem is gone.\n- Keep "text" close to the original entry. Do not rewrite for tone; that happens later.',
+    )
+  })
+
+  test('passes the exact write system prompt to the announcement pass', async () => {
+    let capturedSystem = ''
+    await humanizeChangelog(
+      'raw',
+      deps({
+        generate: (opts) => {
+          capturedSystem = opts.system
+          return Promise.resolve({ text: 'ok' })
+        },
+      }),
+    )
+    expect(capturedSystem).toBe(
+      'You turn a filtered list of changelog entries (a JSON array of {kind, text}) into a short, friendly release announcement for end users of a chat bot.\nRules:\n- Write for non-technical users. Plain, warm, concise.\n- No jargon, config keys, module names, commit hashes, or scopes in parentheses.\n- Each item is one short line framed as a benefit: what the user can now do, or what annoyance is gone.\n- Group into sections with these exact headers when content exists: "✨ New", "⚡ Improvements", "🛠 Fixes". Omit a section entirely if it has no items.\n- Output only the announcement body. No preamble, no "here is", no version number.\nExample input:\n[{"kind":"new","text":"feat(telegram): pick up edited messages and update the task"},{"kind":"improvement","text":"perf: task list loads faster for large projects"},{"kind":"fix","text":"fix(memory): recall search returns stale results after compaction"}]\nExample output:\n✨ New\n- Changed your mind? Edit your message and the bot updates the task.\n\n⚡ Improvements\n- Your task lists open faster, even in big projects.\n\n🛠 Fixes\n- The bot\'s memory search always shows fresh results again.',
+    )
+  })
+
+  test('returns the literal empty-release note text when nothing survives', async () => {
+    const result = await humanizeChangelog('raw', deps({ generateStructured: () => Promise.resolve({ entries: [] }) }))
+    expect(result).toBe('This release is all behind-the-scenes improvements — nothing new to learn.')
+  })
+
+  test('logs the not-configured warning with the child scope, exact metadata, and message', async () => {
+    const result = await humanizeChangelog(
+      'raw',
+      deps({
+        resolveConfig: () => ({ ok: false, type: 'missing', source: 'global', missing: ['main_model'] }),
+      }),
+    )
+    expect(result).toBeNull()
+    const warn = soleWarn()
+    expect(warn['scope']).toBe('announcements:humanize')
+    expect(warn['msg']).toBe('Central LLM not configured; skipping changelog humanization')
+    expect(warn['type']).toBe('missing')
+    expect(warn['source']).toBe('global')
+    expect(warn['missing']).toEqual(['main_model'])
+  })
+
+  test('logs the humanization-failed warning with the child scope, error, and message', async () => {
+    const result = await humanizeChangelog('raw', deps({ generateStructured: () => Promise.reject(new Error('boom')) }))
+    expect(result).toBeNull()
+    const warn = soleWarn()
+    expect(warn['scope']).toBe('announcements:humanize')
+    expect(warn['error']).toBe('boom')
+    expect(warn['msg']).toBe('Changelog humanization failed')
+  })
+
+  test('uses the real default-deps wiring when none are passed', async () => {
+    const result = await humanizeChangelog('raw')
+    expect(result).toBeNull()
   })
 })
 

--- a/tests/mutation-improve/config.test.ts
+++ b/tests/mutation-improve/config.test.ts
@@ -52,6 +52,28 @@ describe('config', () => {
     expect(() => MutationImproveConfigSchema.parse({ ...minimalValid, threshold: -0.1 })).toThrow()
   })
 
+  test('MutationImproveConfigSchema accepts an optional pricing table', () => {
+    const parsed = MutationImproveConfigSchema.parse({
+      ...minimalValid,
+      pricing: { 'm-*': { input: 3, output: 15 } },
+    })
+    expect(parsed.pricing).toEqual({ 'm-*': { input: 3, output: 15 } })
+  })
+
+  test('MutationImproveConfigSchema pricing is undefined when omitted', () => {
+    const parsed = MutationImproveConfigSchema.parse({ ...minimalValid })
+    expect(parsed.pricing).toBeUndefined()
+  })
+
+  test('MutationImproveConfigSchema rejects a malformed pricing entry', () => {
+    expect(() =>
+      MutationImproveConfigSchema.parse({
+        ...minimalValid,
+        pricing: { 'm-*': { input: 'x' } },
+      }),
+    ).toThrow()
+  })
+
   test('loadMutationImproveConfig resolves workDir against repoRoot and creates it', async () => {
     const repoRoot = makeTempDir('cfg-')
     const configPath = path.join(repoRoot, 'config.json')

--- a/tests/mutation-improve/merge-stats.test.ts
+++ b/tests/mutation-improve/merge-stats.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { reportMergeDiff } from '../../mutation-improve/src/merge-stats.js'
+import type { DiffStats } from '../../review-loop/src/diff-stats.js'
+
+describe('reportMergeDiff', () => {
+  test('measures the diff since beforeSha and reports it via log.diff', async () => {
+    const reported: Array<{ label: string; diff: DiffStats }> = []
+    const execGit = (): Promise<{ stdout: string; stderr: string }> =>
+      Promise.resolve({ stdout: '301\t12\ttests/x.test.ts\n', stderr: '' })
+    await reportMergeDiff(
+      {
+        execGit,
+        config: { repoRoot: '/repo' },
+        log: {
+          log: (): void => undefined,
+          diff: (label: string, diff: DiffStats): void => {
+            reported.push({ label, diff })
+          },
+        },
+      },
+      1,
+      'abc123',
+    )
+    expect(reported).toEqual([{ label: 'iter-1', diff: { added: 301, removed: 12 } }])
+  })
+
+  test('falls back to log.log when the diff measurement throws', async () => {
+    const logs: string[] = []
+    const reported: unknown[] = []
+    const execGit = (): Promise<{ stdout: string; stderr: string }> => Promise.reject(new Error('git blew up'))
+    await reportMergeDiff(
+      {
+        execGit,
+        config: { repoRoot: '/repo' },
+        log: {
+          log: (msg: string): void => {
+            logs.push(msg)
+          },
+          diff: (): void => {
+            reported.push(1)
+          },
+        },
+      },
+      1,
+      'abc123',
+    )
+    expect(reported).toEqual([])
+    expect(logs).toEqual(['[stats] merge diff unavailable: git blew up'])
+  })
+})

--- a/tests/mutation-improve/pipeline.test.ts
+++ b/tests/mutation-improve/pipeline.test.ts
@@ -132,6 +132,14 @@ const sequenceGitStatus = (statuses: readonly string[]): PipelineDeps['execGit']
   }
 }
 
+// Subcommand-keyed execGit fake: returns canned stdout for args[0] (e.g.
+// 'rev-parse'/'diff'), empty otherwise. Keeps conditionals out of test bodies
+// (no-conditional-in-test) and yields zeros for unscripted subcommands.
+const scriptedExecGit =
+  (responses: Record<string, string>): PipelineDeps['execGit'] =>
+  (_cwd: string, args: readonly string[]): Promise<{ stdout: string; stderr: string }> =>
+    Promise.resolve({ stdout: responses[args[0] ?? ''] ?? '', stderr: '' })
+
 // Sequence-based runImproveAgent fake: records each prompt into `prompts` and
 // returns results[0] on first call, etc., clamping to the last element.
 const sequenceImprove = (
@@ -289,6 +297,40 @@ describe('pipeline runIteration', () => {
     const outcome = await runIteration(deps, 1)
     expect(outcome.outcome).toBe('failed')
     expect(outcome.gate).toBe('merge')
+  })
+
+  test('finalize measures merge diff and reports it via log.diff', async () => {
+    const deps = happyDeps()
+    const diffs: Array<{ label: string; added: number; removed: number }> = []
+    deps.log = {
+      log: (): void => undefined,
+      diff: (label: string, d: { added: number; removed: number }): void => {
+        diffs.push({ label, ...d })
+      },
+    }
+    deps.execGit = scriptedExecGit({
+      'rev-parse': 'abc123\n',
+      diff: '301\t12\ttests/x.test.ts\n',
+    })
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.outcome).toBe('improved')
+    expect(diffs).toEqual([{ label: 'iter-1', added: 301, removed: 12 }])
+  })
+
+  test('merge conflict reports no diff', async () => {
+    const deps = happyDeps()
+    const diffs: unknown[] = []
+    deps.log = {
+      log: (): void => undefined,
+      diff: (): void => {
+        diffs.push(1)
+      },
+    }
+    deps.mergeWorktree = (): Promise<{ ok: false; conflictFiles: string[] }> =>
+      Promise.resolve({ ok: false, conflictFiles: ['scripts/mutation/baseline.json'] })
+    const outcome = await runIteration(deps, 1)
+    expect(outcome.gate).toBe('merge')
+    expect(diffs).toEqual([])
   })
 
   // C2: an unexpected throw mid-pipeline must route through failIter so the

--- a/tests/mutation-improve/run-state.test.ts
+++ b/tests/mutation-improve/run-state.test.ts
@@ -11,9 +11,11 @@ import {
   createRunState,
   iterDir,
   loadRunState,
+  persistStats,
   PersistedRunStateSchema,
   saveRunState,
 } from '../../mutation-improve/src/run-state.js'
+import { RunStats } from '../../review-loop/src/run-stats.js'
 import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
 
 afterEach(cleanupTempDirs)
@@ -89,5 +91,28 @@ describe('run-state', () => {
     const reloaded = await loadRunState(config.workDir, created.runId)
     expect(reloaded.merged[0]?.capped).toBe(true)
     expect(reloaded.merged[1]?.capped).toBeUndefined()
+  })
+
+  test('state.json round-trips the optional stats block', async () => {
+    const repoRoot = makeTempDir('run-state-stats-')
+    const config = baseConfig(repoRoot, path.join(repoRoot, '.mutation-improve'))
+    const state = await createRunState(config)
+    const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } } })
+    stats.addUsage('improve', { input: 100_000, output: 10_000, reasoning: 0, model: 'm-x' })
+    stats.addDiff('iter-1', { added: 301, removed: 12 })
+    persistStats(state, stats)
+    await saveRunState(state)
+    const loaded = await loadRunState(state.workDir, state.runId)
+    expect(loaded.stats?.totals.input).toBe(100_000)
+    expect(loaded.stats?.totals.estimatedCostUsd).toBeCloseTo(0.45, 10)
+    expect(loaded.stats?.perLabel['iter-1']).toMatchObject({ added: 301, removed: 12 })
+  })
+
+  test('state.json without a stats block loads with stats undefined', async () => {
+    const repoRoot = makeTempDir('run-state-nostats-')
+    const config = baseConfig(repoRoot, path.join(repoRoot, '.mutation-improve'))
+    const state = await createRunState(config)
+    const loaded = await loadRunState(state.workDir, state.runId)
+    expect(loaded.stats).toBeUndefined()
   })
 })

--- a/tests/mutation-improve/summary.test.ts
+++ b/tests/mutation-improve/summary.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import type { IterationResult } from '../../mutation-improve/src/pipeline.js'
+import type { MutationImproveRunState } from '../../mutation-improve/src/run-state.js'
+import { buildRunSummary } from '../../mutation-improve/src/summary.js'
+import { RunStats } from '../../review-loop/src/run-stats.js'
+
+function makeRunState(): MutationImproveRunState {
+  return {
+    runId: 'run-1',
+    runDir: '/tmp/x',
+    workDir: '/tmp',
+    statePath: '/tmp/x/state.json',
+    repoRoot: '/tmp',
+    base: 'master',
+    threshold: 0.95,
+    count: 2,
+    currentIteration: 2,
+    doneSet: ['src/a.ts'],
+    merged: [
+      { file: 'src/a.ts', beforeScore: 0.612, afterScore: 0.784, iter: 1 },
+      { file: 'src/b.ts', beforeScore: 0.55, afterScore: 0.667, iter: 2, capped: true },
+    ],
+    failed: [{ iter: 3, file: 'src/c.ts', gate: 'build', reason: 'tsc failed' }],
+    status: 'completed',
+  }
+}
+
+describe('buildRunSummary', () => {
+  test('renders per-file rows, failures and totals', () => {
+    const stats = new RunStats({
+      pricing: { 'm-*': { input: 3, output: 15 } },
+      startedAt: 0,
+      now: (): number => 760_000,
+    })
+    stats.addUsage('improve', { input: 228_800, output: 41_200, reasoning: 0, model: 'm-x' })
+    stats.addToolCalls('improve', 37)
+    stats.addDiff('iter-1', { added: 301, removed: 12 })
+    const results: IterationResult[] = [
+      { iter: 1, outcome: 'improved', file: 'src/a.ts' },
+      { iter: 2, outcome: 'capped', file: 'src/b.ts' },
+      { iter: 3, outcome: 'failed', file: 'src/c.ts', gate: 'build' },
+    ]
+    const summary = buildRunSummary({ runState: makeRunState(), results, stats: stats.snapshot(), aborted: false })
+    expect(summary).toContain('src/a.ts')
+    expect(summary).toContain('61.2% → 78.4%')
+    expect(summary).toContain('improved')
+    expect(summary).toContain('+301/-12')
+    expect(summary).toContain('capped')
+    expect(summary).toContain('src/c.ts')
+    expect(summary).toContain('build')
+    expect(summary).toContain('in 228.8k / out 41.2k')
+    expect(summary).toContain('~$1.30 est')
+    expect(summary).toContain('tools 37')
+    expect(summary).toContain('12m40s')
+  })
+
+  test('omits cost when unpriced and marks aborted runs', () => {
+    const stats = new RunStats({ startedAt: 0, now: (): number => 1000 })
+    const summary = buildRunSummary({ runState: makeRunState(), results: [], stats: stats.snapshot(), aborted: true })
+    expect(summary).toContain('aborted')
+    expect(summary).not.toContain('est')
+  })
+})

--- a/tests/plugins/task-provider-youtrack/create-field-helpers.test.ts
+++ b/tests/plugins/task-provider-youtrack/create-field-helpers.test.ts
@@ -27,6 +27,18 @@ describe('collectFieldPairs', () => {
     expect(pairs).toContainEqual({ source: 'dedicated', kind: 'state', value: 'Open' })
     expect(pairs).toContainEqual({ source: 'generic', name: 'URL', value: 'http://x' })
   })
+
+  test('assignee dedicated param round-trips as a single user-kind pair', () => {
+    const pairs = collectFieldPairs({ assignee: 'someone' })
+    expect(pairs).toHaveLength(1)
+    expect(pairs[0]).toEqual({ source: 'dedicated', kind: 'user', value: 'someone' })
+  })
+
+  test('dueDate dedicated param round-trips as a single date-kind pair', () => {
+    const pairs = collectFieldPairs({ dueDate: '2026-01-01' })
+    expect(pairs).toHaveLength(1)
+    expect(pairs[0]).toEqual({ source: 'dedicated', kind: 'date', value: '2026-01-01' })
+  })
 })
 
 describe('resolveFieldPair', () => {

--- a/tests/plugins/task-provider-youtrack/dedicated-fields.test.ts
+++ b/tests/plugins/task-provider-youtrack/dedicated-fields.test.ts
@@ -7,17 +7,29 @@ import { describe, expect, test } from 'bun:test'
 
 import type { z } from 'zod'
 
+import { YouTrackClassifiedError } from '../../../plugins/task-provider-youtrack/classify-error.js'
 import { resolveDedicatedField } from '../../../plugins/task-provider-youtrack/dedicated-fields.js'
 import type { ProjectCustomFieldSchema } from '../../../plugins/task-provider-youtrack/schemas/bundle.js'
+import { providerError } from '../../../src/errors.js'
 
 type PCF = z.infer<typeof ProjectCustomFieldSchema>
 
-const field = (name: string, typeId: string, bundleType?: string): PCF =>
+const field = (name: string, typeId: string, bundleType?: string, localizedName?: string): PCF =>
   ({
     $type: 'ProjectCustomField',
-    field: { name, fieldType: { id: typeId } },
+    field: { name, fieldType: { id: typeId }, ...(localizedName === undefined ? {} : { localizedName }) },
     ...(bundleType === undefined ? {} : { bundle: { id: 'b-1', $type: bundleType } }),
   }) as PCF
+
+const captureError = (fn: () => unknown): YouTrackClassifiedError => {
+  try {
+    fn()
+  } catch (e) {
+    if (e instanceof YouTrackClassifiedError) return e
+    throw e
+  }
+  throw new Error('expected resolveDedicatedField to throw')
+}
 
 const STATE = field('Cтaтус', 'state[1]', 'StateBundle')
 const USER = field('Oтветствeнный', 'user[*]', 'UserBundle')
@@ -60,5 +72,94 @@ describe('resolveDedicatedField', () => {
 
   test('no field of the requested type throws a teaching error', () => {
     expect(() => resolveDedicatedField('state', [USER, URGENCY])).toThrow(/state/iu)
+  })
+
+  test('state disambiguates by canonical name across multiple state fields', () => {
+    const english = resolveDedicatedField('state', [
+      field('State', 'state[1]', 'StateBundle'),
+      field('OldState', 'state[1]', 'StateBundle'),
+    ])
+    expect(english.field?.name).toBe('State')
+    const russian = resolveDedicatedField('state', [
+      field('Статус', 'state[1]', 'StateBundle'),
+      field('OldState', 'state[1]', 'StateBundle'),
+    ])
+    expect(russian.field?.name).toBe('Статус')
+  })
+
+  test('assignee disambiguates by the Russian canonical name "ответственный"', () => {
+    const resolved = resolveDedicatedField('user', [
+      field('Ответственный', 'user[1]', 'UserBundle'),
+      field('Other', 'user[1]', 'UserBundle'),
+    ])
+    expect(resolved.field?.name).toBe('Ответственный')
+  })
+
+  test('priority disambiguates by the Russian canonical name "приоритет"', () => {
+    const resolved = resolveDedicatedField('priority', [field('Приоритет', 'enum[1]', 'EnumBundle'), TEAM])
+    expect(resolved.field?.name).toBe('Приоритет')
+  })
+
+  test('priority with no enum field reports a no-priority-type-field error tagged customFields', () => {
+    const err = captureError(() => resolveDedicatedField('priority', [STATE, USER]))
+    expect(err.message).toBe(
+      'No priority-type field exists in this project. Use describe_project to see the fields, then set the value via customFields by name.',
+    )
+    expect(err.appError).toEqual(providerError.validationFailed('customFields', err.message))
+  })
+
+  test('date resolves the sole date-typed field via the candidate shortcut', () => {
+    const resolved = resolveDedicatedField('date', [field('StartDate', 'date[1]'), STATE])
+    expect(resolved.field?.name).toBe('StartDate')
+  })
+
+  test('disambiguates by localized name when the field name is not canonical', () => {
+    const localized = field('Foo', 'user[1]', 'UserBundle', 'Assignee')
+    const resolved = resolveDedicatedField('user', [localized, field('Bar', 'user[1]', 'UserBundle')])
+    expect(resolved.field?.name).toBe('Foo')
+  })
+
+  test('the multiple-candidate teaching error joins candidate names with "; "', () => {
+    const err = captureError(() =>
+      resolveDedicatedField('user', [
+        field('Owner', 'user[1]', 'UserBundle'),
+        field('Watcher', 'user[1]', 'UserBundle'),
+      ]),
+    )
+    expect(err.message).toBe(
+      'Multiple candidate fields for "user" (Owner; Watcher). Set the intended one explicitly via customFields by name.',
+    )
+  })
+
+  test('candidate filter skips fields that lack a field object', () => {
+    const fieldless: PCF = { $type: 'ProjectCustomField' }
+    const resolved = resolveDedicatedField('state', [fieldless, field('Foo', 'state[1]', 'StateBundle')])
+    expect(resolved.field?.name).toBe('Foo')
+  })
+
+  test('a single non-canonical enum field is not auto-resolved as priority', () => {
+    const err = captureError(() => resolveDedicatedField('priority', [URGENCY]))
+    expect(err.message).toBe(
+      'Multiple candidate fields for "priority" (Срочность). Set the intended one explicitly via customFields by name.',
+    )
+  })
+
+  test('two fields sharing one canonical name are reported as ambiguous', () => {
+    const err = captureError(() =>
+      resolveDedicatedField('user', [
+        field('Assignee', 'user[1]', 'UserBundle'),
+        field('Assignee', 'user[1]', 'UserBundle'),
+      ]),
+    )
+    expect(err.message).toBe(
+      'Multiple candidate fields for "user" (Assignee; Assignee). Set the intended one explicitly via customFields by name.',
+    )
+  })
+
+  test('date disambiguates by canonical name across multiple date fields', () => {
+    const english = resolveDedicatedField('date', [field('Due Date', 'date[1]'), field('Other', 'date[1]')])
+    expect(english.field?.name).toBe('Due Date')
+    const russian = resolveDedicatedField('date', [field('Дедлайн', 'date[1]'), field('Other', 'date[1]')])
+    expect(russian.field?.name).toBe('Дедлайн')
   })
 })

--- a/tests/plugins/task-provider-youtrack/field-engine.test.ts
+++ b/tests/plugins/task-provider-youtrack/field-engine.test.ts
@@ -5,7 +5,21 @@
 
 import { describe, expect, test } from 'bun:test'
 
-import { classifyFieldType, resolveCustomFieldValue } from '../../../plugins/task-provider-youtrack/field-engine.js'
+import type { z } from 'zod'
+
+import { YouTrackClassifiedError } from '../../../plugins/task-provider-youtrack/classify-error.js'
+import {
+  capAllowedValues,
+  classifyFieldType,
+  formatAllowed,
+  normalize,
+  resolveCustomFieldValue,
+} from '../../../plugins/task-provider-youtrack/field-engine.js'
+import type { FieldClassification } from '../../../plugins/task-provider-youtrack/field-engine.js'
+import { ProjectCustomFieldSchema } from '../../../plugins/task-provider-youtrack/schemas/bundle.js'
+import { providerError } from '../../../src/errors.js'
+
+type ProjectCustomField = z.infer<typeof ProjectCustomFieldSchema>
 
 const stateField = {
   $type: 'StateProjectCustomField',
@@ -23,6 +37,40 @@ const stateElements = [{ name: 'Open' }, { name: 'In Progress', localizedName: '
 
 const fetcher = (_segment: string, _bundleId: string): Promise<typeof stateElements> => Promise.resolve(stateElements)
 
+const noFetch = (): Promise<never> => Promise.reject(new Error('bundle fetch unexpected'))
+
+const fieldWith = (id: string, bundle?: { id: string; $type?: string }, name = 'F'): ProjectCustomField => ({
+  $type: 'X',
+  field: { name, fieldType: { id } },
+  ...(bundle === undefined ? {} : { bundle }),
+})
+
+// Resolves a TYPE_TABLE row's bundleType into a field; the conditional lives here at
+// module scope so vitest/no-conditional-in-test stays clear of the test callback.
+const fieldForTable = (id: string, bundleType: string | undefined): ProjectCustomField =>
+  bundleType === undefined ? fieldWith(id) : fieldWith(id, { id: 'b-1', $type: bundleType })
+
+// Widen-then-delete is the lint-safe way to feed a ProjectCustomField with a
+// bundle that omits `id` (oxlint no-unsafe-type-assertion blocks narrowing casts).
+const fieldWithoutBundleId = (): ProjectCustomField => {
+  const field: ProjectCustomField = {
+    $type: 'StateProjectCustomField',
+    field: { name: 'State', fieldType: { id: 'state[1]' } },
+    bundle: { id: 'sb-1', $type: 'StateBundle' },
+  }
+  delete (field.bundle! as { id?: string }).id
+  return field
+}
+
+const expectClassified = async (promise: Promise<unknown>): Promise<YouTrackClassifiedError> => {
+  const error: unknown = await promise.catch((caught: unknown) => caught)
+  expect(error).toBeInstanceOf(YouTrackClassifiedError)
+  if (!(error instanceof YouTrackClassifiedError)) {
+    throw new Error('Expected a YouTrackClassifiedError to be thrown')
+  }
+  return error
+}
+
 describe('classifyFieldType', () => {
   test('classifies a single state field', () => {
     const c = classifyFieldType(stateField)
@@ -38,6 +86,276 @@ describe('classifyFieldType', () => {
     expect(c.multi).toBe(true)
     expect(c.multiType).toBe('MultiEnumIssueCustomField')
     expect(c.bundleSegment).toBe('enum')
+  })
+
+  // C1 + C3: every TYPE_TABLE row asserts kind/label/singleType/multiType/multi/bundleSegment.
+  test.each<[string, string | undefined, FieldClassification]>([
+    [
+      'enum[1]',
+      'EnumBundle',
+      {
+        label: 'enum',
+        kind: 'bundle',
+        multi: false,
+        singleType: 'SingleEnumIssueCustomField',
+        multiType: 'MultiEnumIssueCustomField',
+        bundleSegment: 'enum',
+      },
+    ],
+    [
+      'state[1]',
+      'StateBundle',
+      {
+        label: 'state',
+        kind: 'bundle',
+        multi: false,
+        singleType: 'StateIssueCustomField',
+        multiType: 'StateIssueCustomField',
+        bundleSegment: 'state',
+      },
+    ],
+    [
+      'version[1]',
+      'VersionBundle',
+      {
+        label: 'version',
+        kind: 'bundle',
+        multi: false,
+        singleType: 'SingleVersionIssueCustomField',
+        multiType: 'MultiVersionIssueCustomField',
+        bundleSegment: 'version',
+      },
+    ],
+    [
+      'ownedfield[1]',
+      'OwnedFieldBundle',
+      {
+        label: 'ownedField',
+        kind: 'bundle',
+        multi: false,
+        singleType: 'SingleOwnedIssueCustomField',
+        multiType: 'MultiOwnedIssueCustomField',
+        bundleSegment: 'ownedField',
+      },
+    ],
+    [
+      'build[1]',
+      'BuildBundle',
+      {
+        label: 'build',
+        kind: 'bundle',
+        multi: false,
+        singleType: 'SingleBuildIssueCustomField',
+        multiType: 'MultiBuildIssueCustomField',
+        bundleSegment: 'build',
+      },
+    ],
+    [
+      'user[1]',
+      undefined,
+      {
+        label: 'user',
+        kind: 'user',
+        multi: false,
+        singleType: 'SingleUserIssueCustomField',
+        multiType: 'MultiUserIssueCustomField',
+        bundleSegment: undefined,
+      },
+    ],
+    [
+      'date[1]',
+      undefined,
+      {
+        label: 'date',
+        kind: 'date',
+        multi: false,
+        singleType: 'DateIssueCustomField',
+        multiType: 'DateIssueCustomField',
+        bundleSegment: undefined,
+      },
+    ],
+    [
+      'date and time[1]',
+      undefined,
+      {
+        label: 'date',
+        kind: 'date',
+        multi: false,
+        singleType: 'DateIssueCustomField',
+        multiType: 'DateIssueCustomField',
+        bundleSegment: undefined,
+      },
+    ],
+    [
+      'period[1]',
+      undefined,
+      {
+        label: 'period',
+        kind: 'period',
+        multi: false,
+        singleType: 'PeriodIssueCustomField',
+        multiType: 'PeriodIssueCustomField',
+        bundleSegment: undefined,
+      },
+    ],
+    [
+      'text',
+      undefined,
+      {
+        label: 'text',
+        kind: 'text',
+        multi: false,
+        singleType: 'TextIssueCustomField',
+        multiType: 'TextIssueCustomField',
+        bundleSegment: undefined,
+      },
+    ],
+    [
+      'string',
+      undefined,
+      {
+        label: 'string',
+        kind: 'simple',
+        multi: false,
+        singleType: 'SimpleIssueCustomField',
+        multiType: 'SimpleIssueCustomField',
+        bundleSegment: undefined,
+      },
+    ],
+    [
+      'integer',
+      undefined,
+      {
+        label: 'integer',
+        kind: 'simple',
+        multi: false,
+        singleType: 'SimpleIssueCustomField',
+        multiType: 'SimpleIssueCustomField',
+        bundleSegment: undefined,
+      },
+    ],
+    [
+      'float',
+      undefined,
+      {
+        label: 'float',
+        kind: 'simple',
+        multi: false,
+        singleType: 'SimpleIssueCustomField',
+        multiType: 'SimpleIssueCustomField',
+        bundleSegment: undefined,
+      },
+    ],
+  ])('classifies every TYPE_TABLE row (%s)', (id, bundleType, expected) => {
+    const c = classifyFieldType(fieldForTable(id, bundleType))
+    expect(c).toEqual(expected)
+  })
+
+  // C2: parseFieldTypeId trimming + regex anchoring.
+  test('trims surrounding whitespace from the whole fieldType id', () => {
+    const c = classifyFieldType(fieldWith(' state[1] '))
+    expect(c.kind).toBe('bundle')
+    expect(c.label).toBe('state')
+    expect(c.singleType).toBe('StateIssueCustomField')
+  })
+
+  test('trims whitespace inside the parsed base', () => {
+    const c = classifyFieldType(fieldWith('State  [1]'))
+    expect(c.kind).toBe('bundle')
+    expect(c.label).toBe('state')
+  })
+
+  test('treats a fieldType id with trailing garbage after the qualifier as unknown', () => {
+    const c = classifyFieldType(fieldWith('state[1]x'))
+    expect(c.kind).toBe('unknown')
+    expect(c.label).toBe('state[1]x')
+  })
+
+  test('anchors the qualifier match to the end of the id', () => {
+    const c = classifyFieldType(fieldWith('junk\nstate[1]'))
+    expect(c.kind).toBe('unknown')
+    expect(c.label).toBe('junk\nstate[1]')
+  })
+
+  // C4 + C5: defensive optionals + the unknown branch.
+  test('survives a missing field.field (no fieldType)', () => {
+    const c = classifyFieldType({ $type: 'X' })
+    expect(c).toEqual({ label: 'unknown', kind: 'unknown', multi: false })
+  })
+
+  test('survives a field.field without a fieldType (empty base)', () => {
+    const c = classifyFieldType({ $type: 'X', field: { name: 'N' } })
+    expect(c).toEqual({ label: 'unknown', kind: 'unknown', multi: false })
+  })
+
+  test('labels an unrecognized non-empty base with the base itself', () => {
+    const c = classifyFieldType(fieldWith('gizmo[1]'))
+    expect(c).toEqual({ label: 'gizmo', kind: 'unknown', multi: false })
+  })
+
+  test('does not compute a bundleSegment for non-bundle kinds even when a bundle is present', () => {
+    const c = classifyFieldType({
+      $type: 'X',
+      field: { name: 'Due', fieldType: { id: 'date[1]' } },
+      bundle: { id: 'b-1', $type: 'StateBundle' },
+    })
+    expect(c.kind).toBe('date')
+    expect(c.bundleSegment).toBe(undefined)
+  })
+
+  test('returns an undefined bundleSegment for a bundle field that has no bundle', () => {
+    const c = classifyFieldType(fieldWith('state[1]', undefined))
+    expect(c).toEqual({
+      label: 'state',
+      kind: 'bundle',
+      multi: false,
+      singleType: 'StateIssueCustomField',
+      multiType: 'StateIssueCustomField',
+      bundleSegment: undefined,
+    })
+  })
+})
+
+describe('formatAllowed', () => {
+  // C6
+  test('joins values under the cap with ", "', () => {
+    expect(formatAllowed(['a', 'b'])).toBe('a, b')
+  })
+
+  test('does not cap at exactly the cap boundary', () => {
+    const fifty = Array.from({ length: 50 }, (_value, index) => `v${index}`)
+    expect(formatAllowed(fifty)).toBe(fifty.join(', '))
+  })
+
+  test('caps overflow and appends an exact remainder summary', () => {
+    const fifty = Array.from({ length: 50 }, (_value, index) => `v${index}`)
+    const fiftyOne = [...fifty, 'extra']
+    expect(formatAllowed(fiftyOne)).toBe(`${fifty.join(', ')}, …and 1 more`)
+  })
+})
+
+describe('capAllowedValues', () => {
+  // C7
+  test('returns a copy of values under the cap', () => {
+    expect(capAllowedValues(['a', 'b'])).toEqual(['a', 'b'])
+  })
+
+  test('does not cap at exactly the cap boundary', () => {
+    const fifty = Array.from({ length: 50 }, (_value, index) => `v${index}`)
+    expect(capAllowedValues(fifty)).toEqual(fifty)
+  })
+
+  test('caps overflow to the first cap values plus a remainder summary element', () => {
+    const fifty = Array.from({ length: 50 }, (_value, index) => `v${index}`)
+    const fiftyOne = [...fifty, 'extra']
+    expect(capAllowedValues(fiftyOne)).toEqual([...fifty, '…and 1 more'])
+  })
+})
+
+describe('normalize', () => {
+  // C8
+  test('trims and lowercases', () => {
+    expect(normalize('  Hello  ')).toBe('hello')
   })
 })
 
@@ -91,5 +409,166 @@ describe('resolveCustomFieldValue', () => {
       getBundleElements: () => Promise.reject(new Error('no fetch')),
     })
     expect(payload).toEqual({ name: 'Story points', $type: 'SimpleIssueCustomField', value: 5 })
+  })
+
+  // C9: splitMulti trimming + empty-entry filtering.
+  test('drops empty entries when splitting a multi-value list', async () => {
+    const payload = await resolveCustomFieldValue(enumMultiField, 'Open,,Fixed', { getBundleElements: fetcher })
+    expect(payload.value).toEqual([{ name: 'Open' }, { name: 'Fixed' }])
+  })
+
+  test('trims whitespace around each token of a multi-value list', async () => {
+    const multiUser = {
+      $type: 'UserProjectCustomField',
+      field: { name: 'Assignees', fieldType: { id: 'user[*]' } },
+    }
+    const payload = await resolveCustomFieldValue(multiUser, ' alice , bob ', { getBundleElements: noFetch })
+    expect(payload).toEqual({
+      name: 'Assignees',
+      $type: 'MultiUserIssueCustomField',
+      value: [{ login: 'alice' }, { login: 'bob' }],
+    })
+  })
+
+  // C10: matchBundleValue ambiguity guard.
+  test('rejects an ambiguous bundle with two equally-named elements', async () => {
+    const dupFetcher = (): Promise<{ name: string }[]> => Promise.resolve([{ name: 'Open' }, { name: 'Open' }])
+    const err = await expectClassified(
+      resolveCustomFieldValue(
+        {
+          $type: 'EnumProjectCustomField',
+          field: { name: 'Tags', fieldType: { id: 'enum[1]' } },
+          bundle: { id: 'eb-1', $type: 'EnumBundle' },
+        },
+        'open',
+        { getBundleElements: dupFetcher },
+      ),
+    )
+    expect(err.message).toBe('Field "Tags": "open" is not a valid value. Allowed values: Open, Open')
+    expect(err.appError).toEqual(providerError.validationFailed('Tags', err.message))
+  })
+
+  // C11: missing-name guard.
+  test('throws a teaching error carrying the customFields context when the field has no name', async () => {
+    const err = await expectClassified(resolveCustomFieldValue({ $type: 'X' }, 'x', { getBundleElements: noFetch }))
+    expect(err.message).toBe('Custom field is missing a name')
+    expect(err.appError).toEqual(providerError.validationFailed('customFields', 'Custom field is missing a name'))
+  })
+
+  // C12 + C13: simple numeric guard + string passthrough.
+  test('keeps a string-typed simple field as a raw string', async () => {
+    const stringField = {
+      $type: 'SimpleProjectCustomField',
+      field: { name: 'Cost', fieldType: { id: 'string' } },
+    }
+    const payload = await resolveCustomFieldValue(stringField, 'hello', { getBundleElements: noFetch })
+    expect(payload).toEqual({ name: 'Cost', $type: 'SimpleIssueCustomField', value: 'hello' })
+  })
+
+  test('parses a float-typed simple field into a number', async () => {
+    const floatField = {
+      $type: 'SimpleProjectCustomField',
+      field: { name: 'Estimate', fieldType: { id: 'float' } },
+    }
+    const payload = await resolveCustomFieldValue(floatField, '1.5', { getBundleElements: noFetch })
+    expect(payload).toEqual({ name: 'Estimate', $type: 'SimpleIssueCustomField', value: 1.5 })
+  })
+
+  // C14: date case.
+  test('resolves a date field to a DateIssueCustomField with the parsed timestamp', async () => {
+    const dateField = {
+      $type: 'DateProjectCustomField',
+      field: { name: 'Due', fieldType: { id: 'date' } },
+    }
+    const payload = await resolveCustomFieldValue(dateField, '2026-01-15', { getBundleElements: noFetch })
+    expect(payload).toEqual({
+      name: 'Due',
+      $type: 'DateIssueCustomField',
+      value: Date.parse('2026-01-15T12:00:00.000Z'),
+    })
+  })
+
+  // C15: period case.
+  test('resolves a period field to a PeriodIssueCustomField presentation', async () => {
+    const periodField = {
+      $type: 'PeriodProjectCustomField',
+      field: { name: 'Estimate', fieldType: { id: 'period' } },
+    }
+    const payload = await resolveCustomFieldValue(periodField, '2w', { getBundleElements: noFetch })
+    expect(payload).toEqual({ name: 'Estimate', $type: 'PeriodIssueCustomField', value: { presentation: '2w' } })
+  })
+
+  // C16: user case.
+  test('resolves a single-user field to a login payload', async () => {
+    const userField = {
+      $type: 'UserProjectCustomField',
+      field: { name: 'Assignee', fieldType: { id: 'user[1]' } },
+    }
+    const payload = await resolveCustomFieldValue(userField, 'alice', { getBundleElements: noFetch })
+    expect(payload).toEqual({ name: 'Assignee', $type: 'SingleUserIssueCustomField', value: { login: 'alice' } })
+  })
+
+  // C17: bundle guard.
+  test('rejects a bundle field that has no bundle', async () => {
+    const err = await expectClassified(
+      resolveCustomFieldValue(
+        { $type: 'StateProjectCustomField', field: { name: 'State', fieldType: { id: 'state[1]' } } },
+        'Open',
+        { getBundleElements: noFetch },
+      ),
+    )
+    expect(err.message).toBe('Field "State" has no resolvable value set on this project')
+    expect(err.appError).toEqual(providerError.validationFailed('State', err.message))
+  })
+
+  test('rejects a bundle field whose bundle type yields no segment', async () => {
+    const err = await expectClassified(
+      resolveCustomFieldValue(
+        {
+          $type: 'StateProjectCustomField',
+          field: { name: 'State', fieldType: { id: 'state[1]' } },
+          bundle: { id: 'sb-1', $type: 'MysteryBundle' },
+        },
+        'Open',
+        { getBundleElements: noFetch },
+      ),
+    )
+    expect(err.message).toBe('Field "State" has no resolvable value set on this project')
+    expect(err.appError).toEqual(providerError.validationFailed('State', err.message))
+  })
+
+  test('rejects a bundle field whose bundle carries no id', async () => {
+    const err = await expectClassified(
+      resolveCustomFieldValue(fieldWithoutBundleId(), 'Open', { getBundleElements: noFetch }),
+    )
+    expect(err.message).toBe('Field "State" has no resolvable value set on this project')
+    expect(err.appError).toEqual(providerError.validationFailed('State', err.message))
+  })
+
+  // C18: unknown case.
+  test('throws a teaching error naming the unsupported type id', async () => {
+    const err = await expectClassified(
+      resolveCustomFieldValue(
+        { $type: 'FooProjectCustomField', field: { name: 'Weird', fieldType: { id: 'gizmo[1]' } } },
+        'x',
+        { getBundleElements: noFetch },
+      ),
+    )
+    expect(err.message).toBe(
+      'Field "Weird" has an unsupported type (gizmo[1]). Use describe_project to choose a settable field.',
+    )
+    expect(err.appError).toEqual(providerError.validationFailed('Weird', err.message))
+  })
+
+  test('falls back to "unknown" in the teaching error when the fieldType id is absent', async () => {
+    const err = await expectClassified(
+      resolveCustomFieldValue({ $type: 'FooProjectCustomField', field: { name: 'Weird' } }, 'x', {
+        getBundleElements: noFetch,
+      }),
+    )
+    expect(err.message).toBe(
+      'Field "Weird" has an unsupported type (unknown). Use describe_project to choose a settable field.',
+    )
+    expect(err.appError).toEqual(providerError.validationFailed('Weird', err.message))
   })
 })

--- a/tests/review-loop/cli.test.ts
+++ b/tests/review-loop/cli.test.ts
@@ -3,7 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { afterEach, describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, spyOn, test } from 'bun:test'
 import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
@@ -594,6 +594,62 @@ describe('writeRunArtifacts stats persistence', () => {
 
   test('readPersistedRunStats returns undefined when metrics.json is missing or has no runStats', async () => {
     const runDir = makeTempDir('rl-nostats-')
+    await expect(readPersistedRunStats(runDir)).resolves.toBeUndefined()
+  })
+
+  test('writeRunArtifacts without stats writes no runStats and no Stats line', async () => {
+    const runDir = makeTempDir('rl-artifacts-nostats-')
+    await writeRunArtifacts(
+      runDir,
+      { doneReason: 'clean', rounds: 1, metrics: [], ledger: { issues: {} } },
+      { poolSize: 1, inspect: false, wallMs: 1000 },
+    )
+    const metricsText = await readFile(path.join(runDir, 'metrics.json'), 'utf8')
+    expect(metricsText).not.toContain('runStats')
+    const summary = await readFile(path.join(runDir, 'summary.txt'), 'utf8')
+    expect(summary).not.toContain('Stats:')
+  })
+
+  test('writeRunArtifacts tolerates a result without metrics', async () => {
+    const runDir = makeTempDir('rl-artifacts-nometrics-')
+    await writeRunArtifacts(
+      runDir,
+      { doneReason: 'clean', rounds: 1, ledger: { issues: {} } },
+      { poolSize: 1, inspect: false, wallMs: 1000 },
+    )
+    const metricsText = await readFile(path.join(runDir, 'metrics.json'), 'utf8')
+    expect(metricsText).toContain('"inputTokens": 0')
+  })
+
+  test('writeRunArtifacts warns and still writes summary when metrics.json write fails', async () => {
+    const runDir = makeTempDir('rl-artifacts-eisdir-')
+    mkdirSync(path.join(runDir, 'metrics.json'))
+    const warn = spyOn(console, 'warn').mockImplementation(() => {})
+    await writeRunArtifacts(
+      runDir,
+      { doneReason: 'clean', rounds: 1, metrics: [], ledger: { issues: {} } },
+      { poolSize: 1, inspect: false, wallMs: 1000 },
+    )
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(String(warn.mock.calls[0]![0])).toContain('metrics.json write failed')
+    expect(existsSync(path.join(runDir, 'summary.txt'))).toBe(true)
+  })
+
+  test('readPersistedRunStats returns undefined for invalid JSON', async () => {
+    const runDir = makeTempDir('rl-badstats-json-')
+    writeFileSync(path.join(runDir, 'metrics.json'), 'not json')
+    await expect(readPersistedRunStats(runDir)).resolves.toBeUndefined()
+  })
+
+  test('readPersistedRunStats returns undefined when runStats violates the schema', async () => {
+    const runDir = makeTempDir('rl-badstats-schema-')
+    writeFileSync(path.join(runDir, 'metrics.json'), JSON.stringify({ runStats: { totals: { input: 'x' } } }))
+    await expect(readPersistedRunStats(runDir)).resolves.toBeUndefined()
+  })
+
+  test('readPersistedRunStats returns undefined when metrics.json has no runStats key', async () => {
+    const runDir = makeTempDir('rl-badstats-key-')
+    writeFileSync(path.join(runDir, 'metrics.json'), JSON.stringify({ doneReason: 'clean' }))
     await expect(readPersistedRunStats(runDir)).resolves.toBeUndefined()
   })
 })

--- a/tests/review-loop/cli.test.ts
+++ b/tests/review-loop/cli.test.ts
@@ -5,14 +5,24 @@
 
 import { afterEach, describe, expect, test } from 'bun:test'
 import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { runBuildCheck } from '../../review-loop/src/build-checker.js'
 import { MergeConflictError } from '../../review-loop/src/cli-errors.js'
-import { finalizeRun, parseCliArgs, resolvePlanPath, runCli, type FinalizeDeps } from '../../review-loop/src/cli.js'
+import {
+  finalizeRun,
+  parseCliArgs,
+  readPersistedRunStats,
+  resolvePlanPath,
+  runCli,
+  writeRunArtifacts,
+  type FinalizeDeps,
+} from '../../review-loop/src/cli.js'
 import type { ReviewLoopConfig } from '../../review-loop/src/config.js'
 import { createIssueLedger, saveIssueLedger, type IssueLedger } from '../../review-loop/src/issue-ledger.js'
 import { createRunState, PersistedRunStateSchema, type RunState } from '../../review-loop/src/run-state.js'
+import { RunStats } from '../../review-loop/src/run-stats.js'
 import { execGit } from '../../review-loop/src/worktree.js'
 import { cleanupTempDirs, createReviewLoopConfigFixture, makeTempDir } from './test-helpers.js'
 
@@ -557,5 +567,33 @@ describe('runCli', () => {
 
     const runDir = fixture.getRunDir()
     expect(existsSync(path.join(runDir, 'summary.txt'))).toBe(true)
+  })
+})
+
+describe('writeRunArtifacts stats persistence', () => {
+  test('writeRunArtifacts persists runStats into metrics.json and a Stats line into summary.txt', async () => {
+    const runDir = makeTempDir('rl-artifacts-')
+    const stats = new RunStats({
+      pricing: { 'm-*': { input: 3, output: 15 } },
+      startedAt: 0,
+      now: (): number => 60_000,
+    })
+    stats.addUsage('reviewer', { input: 100_000, output: 10_000, reasoning: 0, model: 'm-x' })
+    stats.addToolCalls('reviewer', 5)
+    await writeRunArtifacts(
+      runDir,
+      { doneReason: 'clean', rounds: 1, metrics: [], ledger: { issues: {} } },
+      { poolSize: 1, inspect: false, wallMs: 60_000, stats },
+    )
+    const persisted = await readPersistedRunStats(runDir)
+    expect(persisted?.totals.toolCalls).toBe(5)
+    expect(persisted?.totals.estimatedCostUsd).toBeCloseTo(0.45, 10)
+    const summary = await readFile(path.join(runDir, 'summary.txt'), 'utf8')
+    expect(summary).toContain('Stats: tools 5')
+  })
+
+  test('readPersistedRunStats returns undefined when metrics.json is missing or has no runStats', async () => {
+    const runDir = makeTempDir('rl-nostats-')
+    await expect(readPersistedRunStats(runDir)).resolves.toBeUndefined()
   })
 })

--- a/tests/review-loop/config.test.ts
+++ b/tests/review-loop/config.test.ts
@@ -88,6 +88,39 @@ describe('ReviewLoopConfigSchema', () => {
     })
     expect(parsed.poolSize).toBe(5)
   })
+
+  test('accepts an optional pricing table', () => {
+    const parsed = ReviewLoopConfigSchema.parse({
+      workDir: '.review-loop',
+      reviewer: { model: 'm1' },
+      fixer: { model: 'm2' },
+      matcher: { model: 'm3' },
+      pricing: { 'm-*': { input: 3, output: 15 } },
+    })
+    expect(parsed.pricing).toEqual({ 'm-*': { input: 3, output: 15 } })
+  })
+
+  test('pricing is undefined when omitted', () => {
+    const parsed = ReviewLoopConfigSchema.parse({
+      workDir: '.review-loop',
+      reviewer: { model: 'm1' },
+      fixer: { model: 'm2' },
+      matcher: { model: 'm3' },
+    })
+    expect(parsed.pricing).toBeUndefined()
+  })
+
+  test('rejects a malformed pricing entry', () => {
+    expect(() =>
+      ReviewLoopConfigSchema.parse({
+        workDir: '.review-loop',
+        reviewer: { model: 'm1' },
+        fixer: { model: 'm2' },
+        matcher: { model: 'm3' },
+        pricing: { 'm-*': { input: 'x' } },
+      }),
+    ).toThrow()
+  })
 })
 
 function writeConfig(dir: string, config: Record<string, unknown>): string {

--- a/tests/review-loop/cost.test.ts
+++ b/tests/review-loop/cost.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { estimateCostUsd, matchPrice, PricingTableSchema } from '../../review-loop/src/cost.js'
+
+describe('matchPrice', () => {
+  const pricing = { 'claude-sonnet-*': { input: 3, output: 15 }, 'gpt-4o': { input: 2.5, output: 10 } }
+
+  test('exact match wins over glob', () => {
+    const table = { ...pricing, 'claude-sonnet-4': { input: 1, output: 1 } }
+    expect(matchPrice(table, 'claude-sonnet-4')).toEqual({ input: 1, output: 1 })
+  })
+
+  test('glob match', () => {
+    expect(matchPrice(pricing, 'claude-sonnet-4-20250514')).toEqual({ input: 3, output: 15 })
+  })
+
+  test('provider-prefixed model still globs when pattern covers it', () => {
+    expect(matchPrice({ 'anthropic/claude-*': { input: 3, output: 15 } }, 'anthropic/claude-sonnet-4')).toEqual({
+      input: 3,
+      output: 15,
+    })
+  })
+
+  test('no match returns undefined', () => {
+    expect(matchPrice(pricing, 'llama-3')).toBeUndefined()
+  })
+})
+
+describe('estimateCostUsd', () => {
+  test('computes per-1M-token pricing', () => {
+    expect(estimateCostUsd({ input: 3, output: 15 }, 100_000, 10_000)).toBeCloseTo(0.45, 10)
+  })
+})
+
+describe('PricingTableSchema', () => {
+  test('rejects negative prices', () => {
+    expect(PricingTableSchema.safeParse({ m: { input: -1, output: 1 } }).success).toBe(false)
+  })
+})

--- a/tests/review-loop/diff-stats.test.ts
+++ b/tests/review-loop/diff-stats.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { headSha, measureDiffSince, parseNumstat, type ExecGitFn } from '../../review-loop/src/diff-stats.js'
+
+describe('parseNumstat', () => {
+  test('sums added/removed across files', () => {
+    expect(parseNumstat('10\t2\tsrc/a.ts\n3\t0\tsrc/b.ts\n')).toEqual({ added: 13, removed: 2 })
+  })
+
+  test('binary lines (-) count as zero', () => {
+    expect(parseNumstat('-\t-\timg.png\n5\t1\tsrc/a.ts\n')).toEqual({ added: 5, removed: 1 })
+  })
+
+  test('rename lines parse', () => {
+    expect(parseNumstat('4\t2\tsrc/{old.ts => new.ts}\n')).toEqual({ added: 4, removed: 2 })
+  })
+
+  test('empty output is zero', () => {
+    expect(parseNumstat('')).toEqual({ added: 0, removed: 0 })
+  })
+})
+
+describe('headSha / measureDiffSince', () => {
+  test('headSha trims rev-parse output', async () => {
+    const execGit: ExecGitFn = (_cwd, args) => {
+      expect(args).toEqual(['rev-parse', 'HEAD'])
+      return Promise.resolve({ stdout: '  abc123\n', stderr: '' })
+    }
+    await expect(headSha(execGit, '/repo')).resolves.toBe('abc123')
+  })
+
+  test('measureDiffSince runs numstat against beforeSha..HEAD', async () => {
+    const execGit: ExecGitFn = (_cwd, args) => {
+      expect(args).toEqual(['diff', '--numstat', 'abc123..HEAD'])
+      return Promise.resolve({ stdout: '7\t3\tsrc/a.ts\n', stderr: '' })
+    }
+    await expect(measureDiffSince(execGit, '/repo', 'abc123')).resolves.toEqual({ added: 7, removed: 3 })
+  })
+})

--- a/tests/review-loop/line-handler.test.ts
+++ b/tests/review-loop/line-handler.test.ts
@@ -12,6 +12,7 @@ import { z } from 'zod'
 import type { RunAgentOptions, SpawnResult } from '../../review-loop/src/agent-runner.js'
 import { createLineHandler, enqueueLog } from '../../review-loop/src/line-handler.js'
 import type { ProgressReporter, UsageDelta } from '../../review-loop/src/progress-log.js'
+import { RunStats } from '../../review-loop/src/run-stats.js'
 import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
 
 afterEach(cleanupTempDirs)
@@ -80,7 +81,45 @@ describe('createLineHandler reporter wiring', () => {
         part: { reason: 'stop', tokens: { input: 5, output: 2, reasoning: 1 }, cost: 0.5 },
       }),
     )
-    expect(deltas).toEqual([{ input: 5, output: 2, reasoning: 1, cost: 0.5 }])
+    expect(deltas).toEqual([{ input: 5, output: 2, reasoning: 1, cost: 0.5, label: 'drain', model: 'm' }])
+  })
+
+  test('step_finish delta carries label/model and tool calls accumulate per step', () => {
+    const cwd = makeTempDir('line-handler-stats-')
+    const stats = new RunStats()
+    const deltas: UsageDelta[] = []
+    const reporter = makeReporter({
+      stats,
+      usage: (d) => {
+        deltas.push(d)
+        stats.addUsage('drain', d)
+      },
+    })
+    const handler = createLineHandler({ ...makeOptions(cwd, path.join(cwd, 'agent.log')), reporter })
+    const stepStart = JSON.stringify({ type: 'step_start', timestamp: 1, part: {} })
+    const stepFinish = JSON.stringify({
+      type: 'step_finish',
+      part: { reason: 'stop', tokens: { input: 5, output: 2, reasoning: 1 }, cost: 0 },
+    })
+    const tool = (id: string): string =>
+      JSON.stringify({
+        type: 'tool_use',
+        part: { tool: 'read', callID: id, state: { status: 'running', input: { filePath: '/a/cli.ts' } } },
+      })
+    handler.onLine(stepStart)
+    handler.onLine(tool('c1'))
+    handler.onLine(stepFinish)
+    handler.onLine(stepStart)
+    handler.onLine(tool('c2'))
+    // duplicate callID from a later step must not double-count
+    handler.onLine(tool('c1'))
+    handler.onLine(stepFinish)
+    expect(deltas).toEqual([
+      { input: 5, output: 2, reasoning: 1, cost: 0, label: 'drain', model: 'm' },
+      { input: 5, output: 2, reasoning: 1, cost: 0, label: 'drain', model: 'm' },
+    ])
+    expect(stats.snapshot().totals.toolCalls).toBe(2)
+    expect(stats.snapshot().perLabel['drain']?.input).toBe(10)
   })
 
   test('tool progress goes to reporter.slot and dispose clears it', async () => {

--- a/tests/review-loop/live-renderer.test.ts
+++ b/tests/review-loop/live-renderer.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from 'bun:test'
 
 import { LiveRenderer, type RendererStream, withLivePhase } from '../../review-loop/src/live-renderer.js'
 import type { ProgressReporter } from '../../review-loop/src/progress-log.js'
+import { RunStats } from '../../review-loop/src/run-stats.js'
 
 function makeStream(opts: { isTTY?: boolean; columns?: number } = {}): {
   stream: RendererStream
@@ -313,5 +314,56 @@ describe('withLivePhase', () => {
     const { result } = await withLivePhase(reporter, 'build', () => Promise.resolve('done'))
     expect(result).toBe('done')
     expect(slots[slots.length - 1]).toEqual(['build', null])
+  })
+})
+
+describe('LiveRenderer stats', () => {
+  test('routes usage deltas into RunStats with label and model', () => {
+    const { stream } = makeStream()
+    const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } } })
+    const r = new LiveRenderer(stream, stats)
+    r.usage({ input: 100_000, output: 10_000, reasoning: 0, cost: 0, label: 'improve', model: 'm-x' })
+    expect(stats.snapshot().perLabel['improve']?.input).toBe(100_000)
+    expect(stats.snapshot().totals.estimatedCostUsd).toBeCloseTo(0.45, 10)
+  })
+
+  test('diff() routes into RunStats', () => {
+    const { stream } = makeStream()
+    const stats = new RunStats()
+    const r = new LiveRenderer(stream, stats)
+    r.diff('iter-1', { added: 12, removed: 3 })
+    expect(stats.snapshot().totals.added).toBe(12)
+  })
+
+  test('status line gains cost, tools and diff segments (TTY)', () => {
+    const { output, stream } = makeStream({ isTTY: true, columns: 300 })
+    const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } } })
+    const r = new LiveRenderer(stream, stats)
+    r.usage({ input: 100_000, output: 10_000, reasoning: 0, cost: 0, label: 'improve', model: 'm-x' })
+    stats.addToolCalls('improve', 7)
+    r.diff('iter-1', { added: 12, removed: 3 })
+    r.slot('improve', '  improve   ▶ read a.ts · 1s · 1 tool')
+    const last = output[output.length - 1]!
+    expect(last).toContain('in 100.0k / out 10.0k')
+    expect(last).toContain('~$0.45 est')
+    expect(last).toContain('tools 7')
+    expect(last).toContain('+12/-3')
+  })
+
+  test('cost segment hidden when no pricing matches', () => {
+    const { output, stream } = makeStream({ isTTY: true, columns: 300 })
+    const stats = new RunStats()
+    const r = new LiveRenderer(stream, stats)
+    r.usage({ input: 100_000, output: 10_000, reasoning: 0, cost: 0, label: 'improve' })
+    r.slot('improve', 'x')
+    expect(output[output.length - 1]!).not.toContain('est')
+  })
+
+  test('works without stats (legacy single-arg construction)', () => {
+    const { output, stream } = makeStream({ isTTY: true, columns: 300 })
+    const r = new LiveRenderer(stream)
+    r.usage({ input: 5, output: 2, reasoning: 0, cost: 0 })
+    r.slot('a', 'x')
+    expect(output[output.length - 1]!).toContain('in 5 / out 2')
   })
 })

--- a/tests/review-loop/live-renderer.test.ts
+++ b/tests/review-loop/live-renderer.test.ts
@@ -366,4 +366,41 @@ describe('LiveRenderer stats', () => {
     r.slot('a', 'x')
     expect(output[output.length - 1]!).toContain('in 5 / out 2')
   })
+
+  test('usage without a label accumulates under agent', () => {
+    const { stream } = makeStream()
+    const stats = new RunStats()
+    const r = new LiveRenderer(stream, stats)
+    r.usage({ input: 5, output: 2, reasoning: 0, cost: 0 })
+    expect(stats.snapshot().perLabel['agent']?.input).toBe(5)
+    expect(stats.snapshot().perLabel['']).toBeUndefined()
+  })
+
+  test('diff without stats is a no-op', () => {
+    const { stream } = makeStream()
+    const r = new LiveRenderer(stream)
+    expect(() => r.diff('iter-1', { added: 1, removed: 0 })).not.toThrow()
+  })
+
+  test('status line hides tools and diff segments at zero (TTY)', () => {
+    const { output, stream } = makeStream({ isTTY: true, columns: 300 })
+    const stats = new RunStats()
+    const r = new LiveRenderer(stream, stats)
+    r.usage({ input: 100, output: 10, reasoning: 0, cost: 0, label: 'a' })
+    r.slot('a', 'x')
+    const last = output[output.length - 1]!
+    expect(last).toContain('in 100 / out 10')
+    expect(last).not.toContain('tools')
+    expect(last).not.toContain('+0/-0')
+  })
+
+  test('status line shows diff segment when only added is positive (TTY)', () => {
+    const { output, stream } = makeStream({ isTTY: true, columns: 300 })
+    const stats = new RunStats()
+    const r = new LiveRenderer(stream, stats)
+    r.usage({ input: 1, output: 1, reasoning: 0, cost: 0, label: 'a' })
+    r.diff('iter-1', { added: 5, removed: 0 })
+    r.slot('a', 'x')
+    expect(output[output.length - 1]!).toContain('+5/-0')
+  })
 })

--- a/tests/review-loop/run-stats.test.ts
+++ b/tests/review-loop/run-stats.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { RunStats } from '../../review-loop/src/run-stats.js'
+
+describe('RunStats', () => {
+  test('accumulates usage per label and in totals', () => {
+    const stats = new RunStats({ startedAt: 0, now: (): number => 0 })
+    stats.addUsage('select', { input: 100, output: 10, reasoning: 5 })
+    stats.addUsage('improve', { input: 200, output: 20, reasoning: 0 })
+    stats.addUsage('improve', { input: 50, output: 5, reasoning: 1 })
+    const snap = stats.snapshot()
+    expect(snap.totals.input).toBe(350)
+    expect(snap.totals.output).toBe(35)
+    expect(snap.totals.reasoning).toBe(6)
+    expect(snap.perLabel['improve']).toMatchObject({ input: 250, output: 25 })
+  })
+
+  test('clamps NaN and negative values to zero', () => {
+    const stats = new RunStats({ startedAt: 0, now: (): number => 0 })
+    stats.addUsage('a', { input: Number.NaN, output: -5, reasoning: 3 })
+    stats.addToolCalls('a', -2)
+    stats.addDiff('a', { added: Number.NaN, removed: -1 })
+    const snap = stats.snapshot()
+    expect(snap.totals).toMatchObject({ input: 0, output: 0, reasoning: 3, toolCalls: 0, added: 0, removed: 0 })
+  })
+
+  test('accumulates tool calls and diff per label', () => {
+    const stats = new RunStats({ startedAt: 0, now: (): number => 0 })
+    stats.addToolCalls('fixer-w1', 3)
+    stats.addToolCalls('fixer-w1', 2)
+    stats.addDiff('worker-1', { added: 10, removed: 4 })
+    const snap = stats.snapshot()
+    expect(snap.totals.toolCalls).toBe(5)
+    expect(snap.totals.added).toBe(10)
+    expect(snap.perLabel['fixer-w1']?.toolCalls).toBe(5)
+    expect(snap.perLabel['worker-1']).toMatchObject({ added: 10, removed: 4 })
+  })
+
+  test('estimates cost from pricing table and per-delta model', () => {
+    const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } }, startedAt: 0, now: (): number => 0 })
+    stats.addUsage('a', { input: 100_000, output: 10_000, reasoning: 0, model: 'm-x' })
+    expect(stats.snapshot().totals.estimatedCostUsd).toBeCloseTo(0.45, 10)
+  })
+
+  test('omits cost when no pricing entry matches', () => {
+    const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } }, startedAt: 0, now: (): number => 0 })
+    stats.addUsage('a', { input: 100, output: 10, reasoning: 0, model: 'other' })
+    expect(stats.snapshot().totals.estimatedCostUsd).toBeUndefined()
+  })
+
+  test('omits cost when no pricing configured', () => {
+    const stats = new RunStats({ startedAt: 0, now: (): number => 0 })
+    stats.addUsage('a', { input: 100, output: 10, reasoning: 0, model: 'm-x' })
+    expect(stats.snapshot().totals.estimatedCostUsd).toBeUndefined()
+  })
+
+  test('constructor model is the fallback when delta has none', () => {
+    const stats = new RunStats({
+      pricing: { 'm-*': { input: 3, output: 15 } },
+      model: 'm-x',
+      startedAt: 0,
+      now: (): number => 0,
+    })
+    stats.addUsage('a', { input: 1_000_000, output: 0, reasoning: 0 })
+    expect(stats.snapshot().totals.estimatedCostUsd).toBeCloseTo(3, 10)
+  })
+
+  test('snapshot returns fresh objects each call', () => {
+    const stats = new RunStats({ startedAt: 0, now: (): number => 0 })
+    stats.addUsage('a', { input: 1, output: 1, reasoning: 0 })
+    const first = stats.snapshot()
+    first.totals.input = 999
+    first.perLabel['a']!.input = 999
+    expect(stats.snapshot().totals.input).toBe(1)
+    expect(stats.snapshot().perLabel['a']?.input).toBe(1)
+  })
+
+  test('elapsedMs comes from now - startedAt', () => {
+    const stats = new RunStats({ startedAt: 1000, now: (): number => 61_000 })
+    expect(stats.snapshot().totals.elapsedMs).toBe(60_000)
+  })
+
+  test('persist + rehydrate round-trips totals and perLabel', () => {
+    const stats = new RunStats({ pricing: { 'm-*': { input: 3, output: 15 } }, startedAt: 0, now: (): number => 0 })
+    stats.addUsage('a', { input: 100_000, output: 10_000, reasoning: 0, model: 'm-x' })
+    stats.addToolCalls('a', 4)
+    stats.addDiff('iter-1', { added: 7, removed: 2 })
+    const restored = RunStats.rehydrate(stats.persist(), { pricing: { 'm-*': { input: 3, output: 15 } } })
+    const snap = restored.snapshot()
+    expect(snap.totals).toMatchObject({ input: 100_000, output: 10_000, toolCalls: 4, added: 7, removed: 2 })
+    expect(snap.totals.estimatedCostUsd).toBeCloseTo(0.45, 10)
+    expect(snap.perLabel['iter-1']).toMatchObject({ added: 7, removed: 2 })
+  })
+
+  test('rehydrate with undefined starts empty', () => {
+    const stats = RunStats.rehydrate(undefined, {})
+    expect(stats.snapshot().totals.input).toBe(0)
+  })
+})

--- a/tests/review-loop/summary-burndown.test.ts
+++ b/tests/review-loop/summary-burndown.test.ts
@@ -63,4 +63,55 @@ describe('burndownBlock', () => {
     expect(lines).toHaveLength(3)
     expect(block).not.toContain('  2     0')
   })
+
+  test('renders "-" avgFix when decidedCount is zero (zero-total guard)', () => {
+    const metric = zeroMetric(3)
+    metric.newIssues = 2
+    metric.cumulativeOpen = 5
+    metric.reviewerSeverity = { critical: 0, high: 0, medium: 2, low: 0 }
+    expect(burndownBlock([metric])).toBe(`Burndown:
+  round new open fixed rejected needs_human plan_drift insp_rej avgRev avgFix
+  3     2   5    0     0        0           0          0        2.0    -`)
+  })
+
+  test('weighs reviewerSeverity.critical by SEV_WEIGHT.critical (avgRev=4.0)', () => {
+    const metric = zeroMetric(5)
+    metric.newIssues = 1
+    metric.cumulativeOpen = 1
+    metric.reviewerSeverity = { critical: 1, high: 0, medium: 0, low: 0 }
+    expect(burndownBlock([metric])).toBe(`Burndown:
+  round new open fixed rejected needs_human plan_drift insp_rej avgRev avgFix
+  5     1   1    0     0        0           0          0        4.0    -`)
+  })
+
+  test('counts every decision addend in decidedCount (avgFix=2.0)', () => {
+    const metric = zeroMetric(7)
+    metric.newIssues = 3
+    metric.cumulativeOpen = 9
+    metric.decisions.fixed = 1
+    metric.decisions.invalid = 1
+    metric.decisions.already_fixed = 1
+    metric.decisions.needs_human = 1
+    metric.decisions.plan_drift = 1
+    metric.decisions.no_commit = 1
+    metric.decisions.inspector_rejected = 1
+    metric.fixerSeverity = { critical: 0, high: 0, medium: 7, low: 0 }
+    expect(burndownBlock([metric])).toBe(`Burndown:
+  round new open fixed rejected needs_human plan_drift insp_rej avgRev avgFix
+  7     3   9    1     1        1           1          1        0.0    2.0`)
+  })
+
+  test('keeps rows where exactly one of newIssues/decidedCount is zero', () => {
+    const onlyNew = zeroMetric(11)
+    onlyNew.newIssues = 1
+    onlyNew.cumulativeOpen = 1
+    onlyNew.reviewerSeverity = { critical: 0, high: 0, medium: 1, low: 0 }
+    const onlyDecided = zeroMetric(12)
+    onlyDecided.decisions.fixed = 2
+    onlyDecided.fixerSeverity = { critical: 0, high: 1, medium: 0, low: 0 }
+    expect(burndownBlock([onlyNew, onlyDecided])).toBe(`Burndown:
+  round new open fixed rejected needs_human plan_drift insp_rej avgRev avgFix
+  11    1   1    0     0        0           0          0        2.0    -
+  12    0   0    2     0        0           0          0        -      1.5`)
+  })
 })

--- a/tests/review-loop/summary.test.ts
+++ b/tests/review-loop/summary.test.ts
@@ -223,6 +223,33 @@ describe('buildSummary artifacts', () => {
   })
 })
 
+describe('buildSummary stats line', () => {
+  test('buildSummary appends a Stats line when stats are present', () => {
+    const summary = buildSummary(
+      inputOf({
+        stats: {
+          totals: {
+            input: 228_800,
+            output: 41_200,
+            reasoning: 0,
+            toolCalls: 37,
+            added: 412,
+            removed: 87,
+            estimatedCostUsd: 1.02,
+            elapsedMs: 252_000,
+          },
+          perLabel: {},
+        },
+      }),
+    )
+    expect(summary).toContain('Stats: tools 37 · +412/-87 · ~$1.02 est')
+  })
+
+  test('buildSummary omits the Stats line when stats are absent', () => {
+    expect(buildSummary(inputOf())).not.toContain('Stats:')
+  })
+})
+
 describe('buildMetricsJson', () => {
   test('keeps the existing shape', () => {
     const json = buildMetricsJson('max_rounds', 2, 1, [busyMetric(1)], { poolSize: 1, inspect: false })
@@ -230,5 +257,14 @@ describe('buildMetricsJson', () => {
     expect(json.rounds).toBe(2)
     expect(json.totals.closed).toBe(1)
     expect(json.usage.inputTokens).toBe(120_000)
+  })
+
+  test('buildMetricsJson includes runStats when provided', () => {
+    const runStats = {
+      totals: { input: 1, output: 2, reasoning: 0, toolCalls: 3, added: 4, removed: 5, estimatedCostUsd: 0.01 },
+      perLabel: {},
+    }
+    const metrics = buildMetricsJson('clean', 1, 0, [], { poolSize: 1, inspect: false }, runStats)
+    expect(metrics.runStats).toEqual(runStats)
   })
 })

--- a/tests/review-loop/summary.test.ts
+++ b/tests/review-loop/summary.test.ts
@@ -248,6 +248,31 @@ describe('buildSummary stats line', () => {
   test('buildSummary omits the Stats line when stats are absent', () => {
     expect(buildSummary(inputOf())).not.toContain('Stats:')
   })
+
+  test('buildSummary omits the Stats line when all totals are zero', () => {
+    const summary = buildSummary(
+      inputOf({
+        stats: {
+          totals: { input: 0, output: 0, reasoning: 0, toolCalls: 0, added: 0, removed: 0, elapsedMs: 1000 },
+          perLabel: {},
+        },
+      }),
+    )
+    expect(summary).not.toContain('Stats:')
+  })
+
+  test('buildSummary Stats line shows only non-zero segments', () => {
+    const summary = buildSummary(
+      inputOf({
+        stats: {
+          totals: { input: 0, output: 0, reasoning: 0, toolCalls: 0, added: 5, removed: 0, elapsedMs: 1000 },
+          perLabel: {},
+        },
+      }),
+    )
+    expect(summary).toContain('Stats: +5/-0')
+    expect(summary).not.toContain('tools 0')
+  })
 })
 
 describe('buildMetricsJson', () => {

--- a/tests/review-loop/worker-pool.test.ts
+++ b/tests/review-loop/worker-pool.test.ts
@@ -181,3 +181,40 @@ describe('WorkerPool', () => {
     await pool.close()
   })
 })
+
+test('mergeWorkerIntoPrimary reports numstat diff via onMergeDiff hook', async () => {
+  const repoRoot = makeTempDir('pool-')
+  const config = createReviewLoopConfigFixture(repoRoot, { poolSize: 1 })
+  const runState = await createRunState(config, path.join(repoRoot, 'plan.md'))
+  await setupPrimary(repoRoot, runState.runId, runState.worktreePath)
+
+  const diffs: Array<{ workerId: number; added: number; removed: number }> = []
+  const pool = await createWorkerPool(config, runState, {
+    onMergeDiff: (workerId, diff) => {
+      diffs.push({ workerId, ...diff })
+    },
+    warn: () => undefined,
+  })
+  const worker = await pool.acquire('src/a.ts')
+  writeFileSync(path.join(worker.worktreePath, 'src-a.ts'), 'line1\nline2\nline3\n')
+  await execGit(worker.worktreePath, ['add', '.'])
+  await execGit(worker.worktreePath, ['commit', '-m', 'worker change'])
+  const result = await pool.mergeWorkerIntoPrimary(worker)
+  expect(result.ok).toBe(true)
+  expect(diffs).toEqual([{ workerId: worker.id, added: 3, removed: 0 }])
+  await pool.close()
+})
+
+test('mergeWorkerIntoPrimary without hooks still merges', async () => {
+  const repoRoot = makeTempDir('pool-')
+  const config = createReviewLoopConfigFixture(repoRoot, { poolSize: 1 })
+  const runState = await createRunState(config, path.join(repoRoot, 'plan.md'))
+  await setupPrimary(repoRoot, runState.runId, runState.worktreePath)
+  const pool = await createWorkerPool(config, runState)
+  const worker = await pool.acquire('src/a.ts')
+  writeFileSync(path.join(worker.worktreePath, 'x.ts'), 'x\n')
+  await execGit(worker.worktreePath, ['add', '.'])
+  await execGit(worker.worktreePath, ['commit', '-m', 'x'])
+  expect((await pool.mergeWorkerIntoPrimary(worker)).ok).toBe(true)
+  await pool.close()
+})

--- a/tests/utils/scheduler.events.test.ts
+++ b/tests/utils/scheduler.events.test.ts
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, mock, test } from 'bun:test'
+
+import type { EventEmitter } from '../../src/utils/scheduler.helpers.js'
+import type {
+  ErrorHandler,
+  ErrorEvent,
+  FatalErrorHandler,
+  FatalErrorEvent,
+  RetryHandler,
+  RetryEvent,
+  TickHandler,
+  TickEvent,
+} from '../../src/utils/scheduler.types.js'
+
+type SchedulerEventsModule = typeof import('../../src/utils/scheduler.events.js')
+
+const isSchedulerEventsModule = (value: unknown): value is SchedulerEventsModule =>
+  typeof value === 'object' && value !== null && typeof Reflect.get(value, 'createEmitters') === 'function'
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
+
+const requireRecord = (value: unknown): Record<string, unknown> => {
+  if (!isRecord(value)) {
+    throw new Error('expected a record value')
+  }
+  return value
+}
+
+interface Recorder {
+  readonly childCalls: readonly unknown[][]
+  readonly errorCalls: ReadonlyArray<{ payload: unknown; message: unknown }>
+}
+
+async function loadSchedulerEventsModule(): Promise<{ eventsModule: SchedulerEventsModule; recorder: Recorder }> {
+  const childCalls: unknown[][] = []
+  const errorCalls: Array<{ payload: unknown; message: unknown }> = []
+  const childLogger = {
+    debug: (): void => {},
+    info: (): void => {},
+    warn: (): void => {},
+    error: (payload: unknown, message: unknown): void => {
+      errorCalls.push({ payload, message })
+    },
+  }
+  const logger = {
+    debug: (): void => {},
+    info: (): void => {},
+    warn: (): void => {},
+    error: (): void => {},
+    child: (...args: unknown[]): typeof childLogger => {
+      childCalls.push(args)
+      return childLogger
+    },
+  }
+  void mock.module('../../src/logger.js', () => ({ logger }))
+  const loaded: unknown = await import(`../../src/utils/scheduler.events.js?t=${crypto.randomUUID()}`)
+  if (!isSchedulerEventsModule(loaded)) {
+    throw new Error('scheduler.events module did not export expected shape')
+  }
+  return { eventsModule: loaded, recorder: { childCalls, errorCalls } }
+}
+
+const throwingHandler = (): void => {
+  throw new Error('handler blew up')
+}
+
+const eventsFor = (slot: 'tick' | 'error' | 'retry' | 'fatalError'): EventEmitter => {
+  const events: EventEmitter = {
+    tick: new Set<TickHandler>(),
+    error: new Set<ErrorHandler>(),
+    retry: new Set<RetryHandler>(),
+    fatalError: new Set<FatalErrorHandler>(),
+  }
+  if (slot === 'tick') events.tick.add(throwingHandler)
+  else if (slot === 'error') events.error.add(throwingHandler)
+  else if (slot === 'retry') events.retry.add(throwingHandler)
+  else events.fatalError.add(throwingHandler)
+  return events
+}
+
+const fixedTimestamp = new Date(0)
+
+describe('createEmitters', () => {
+  test('binds the module logger to the scheduler:events scope at import time', async () => {
+    const { recorder } = await loadSchedulerEventsModule()
+
+    expect(recorder.childCalls.length).toBe(1)
+    const scopeArg = requireRecord(recorder.childCalls[0]?.[0])
+    expect(scopeArg['scope']).toBe('scheduler:events')
+  })
+
+  test('logs the exact payload when a tick handler throws', async () => {
+    const {
+      eventsModule: { createEmitters },
+      recorder,
+    } = await loadSchedulerEventsModule()
+
+    const tickEvent: TickEvent = { name: 'tick-task', duration: 7, timestamp: fixedTimestamp }
+    createEmitters(eventsFor('tick')).emitTick(tickEvent)
+
+    expect(recorder.errorCalls.length).toBe(1)
+    const payload = requireRecord(recorder.errorCalls[0]?.payload)
+    expect(payload['error']).toBe('handler blew up')
+    expect(payload['event']).toBe('tick')
+    expect(recorder.errorCalls[0]?.message).toBe('Event handler threw error')
+  })
+
+  test('logs the exact payload when an error handler throws', async () => {
+    const {
+      eventsModule: { createEmitters },
+      recorder,
+    } = await loadSchedulerEventsModule()
+
+    const errorEvent: ErrorEvent = {
+      name: 'error-task',
+      error: new Error('boom'),
+      attempt: 2,
+      timestamp: fixedTimestamp,
+    }
+    createEmitters(eventsFor('error')).emitError(errorEvent)
+
+    expect(recorder.errorCalls.length).toBe(1)
+    const payload = requireRecord(recorder.errorCalls[0]?.payload)
+    expect(payload['error']).toBe('handler blew up')
+    expect(payload['event']).toBe('error')
+    expect(recorder.errorCalls[0]?.message).toBe('Event handler threw error')
+  })
+
+  test('logs the exact payload when a retry handler throws', async () => {
+    const {
+      eventsModule: { createEmitters },
+      recorder,
+    } = await loadSchedulerEventsModule()
+
+    const retryEvent: RetryEvent = {
+      name: 'retry-task',
+      attempt: 3,
+      delay: 250,
+      timestamp: fixedTimestamp,
+    }
+    createEmitters(eventsFor('retry')).emitRetry(retryEvent)
+
+    expect(recorder.errorCalls.length).toBe(1)
+    const payload = requireRecord(recorder.errorCalls[0]?.payload)
+    expect(payload['error']).toBe('handler blew up')
+    expect(payload['event']).toBe('retry')
+    expect(recorder.errorCalls[0]?.message).toBe('Event handler threw error')
+  })
+
+  test('logs the exact payload when a fatalError handler throws', async () => {
+    const {
+      eventsModule: { createEmitters },
+      recorder,
+    } = await loadSchedulerEventsModule()
+
+    const fatalErrorEvent: FatalErrorEvent = {
+      name: 'fatal-task',
+      error: new Error('boom'),
+      timestamp: fixedTimestamp,
+    }
+    createEmitters(eventsFor('fatalError')).emitFatalError(fatalErrorEvent)
+
+    expect(recorder.errorCalls.length).toBe(1)
+    const payload = requireRecord(recorder.errorCalls[0]?.payload)
+    expect(payload['error']).toBe('handler blew up')
+    expect(payload['event']).toBe('fatalError')
+    expect(recorder.errorCalls[0]?.message).toBe('Event handler threw error')
+  })
+})

--- a/tests/utils/scheduler.helpers.test.ts
+++ b/tests/utils/scheduler.helpers.test.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import {
+  DEFAULT_OPTIONS,
+  DEFAULT_TASK_OPTIONS,
+  calculateBackoff,
+  getErrorObject,
+  getErrorMessage,
+  mergeOptions,
+  mergeTaskOptions,
+} from '../../src/utils/scheduler.helpers.js'
+
+describe('calculateBackoff', () => {
+  let originalRandom: () => number = Math.random
+
+  beforeEach(() => {
+    originalRandom = Math.random
+    Math.random = (): number => 0.5
+  })
+
+  afterEach(() => {
+    Math.random = originalRandom
+  })
+
+  test('computes exponential backoff with deterministic jitter when Math.random is pinned to 0.5', () => {
+    expect(calculateBackoff(0, 60000)).toBe(1050)
+    expect(calculateBackoff(0, 500)).toBe(525)
+    expect(calculateBackoff(5, 60000)).toBe(33600)
+  })
+})
+
+describe('getErrorMessage', () => {
+  test('returns the message of an Error instance', () => {
+    expect(getErrorMessage(new Error('boom'))).toBe('boom')
+  })
+
+  test('returns a string argument unchanged', () => {
+    expect(getErrorMessage('some message')).toBe('some message')
+  })
+
+  test('returns the fallback message for a non-string, non-Error value', () => {
+    expect(getErrorMessage(42)).toBe('Unknown error')
+  })
+})
+
+describe('getErrorObject', () => {
+  test('returns the identical reference for an Error instance', () => {
+    const err = new Error('boom')
+    expect(getErrorObject(err)).toBe(err)
+  })
+
+  test('wraps a string argument in a new Error carrying that message', () => {
+    const result = getErrorObject('hello')
+    expect(result).toBeInstanceOf(Error)
+    expect(result.message).toBe('hello')
+  })
+
+  test('wraps a non-string, non-Error value in a new Error carrying the fallback message', () => {
+    expect(getErrorObject(42).message).toBe('Unknown error')
+  })
+})
+
+describe('DEFAULT_OPTIONS', () => {
+  test('exposes the exact default scheduler options', () => {
+    expect(DEFAULT_OPTIONS.unrefByDefault).toBe(true)
+    expect(DEFAULT_OPTIONS.defaultRetries).toBe(3)
+    expect(DEFAULT_OPTIONS.maxRetryDelay).toBe(60000)
+  })
+})
+
+describe('DEFAULT_TASK_OPTIONS', () => {
+  test('exposes the exact default task options', () => {
+    expect(DEFAULT_TASK_OPTIONS.immediate).toBe(false)
+    expect(DEFAULT_TASK_OPTIONS.retries).toBe(3)
+    expect(DEFAULT_TASK_OPTIONS.unref).toBe(true)
+  })
+})
+
+describe('mergeOptions', () => {
+  test('returns the defaults when no options are given', () => {
+    const merged = mergeOptions(undefined)
+    expect(merged.unrefByDefault).toBe(true)
+    expect(merged.defaultRetries).toBe(3)
+    expect(merged.maxRetryDelay).toBe(60000)
+  })
+
+  test('overrides individual defaults while keeping the rest', () => {
+    const merged = mergeOptions({ defaultRetries: 7 })
+    expect(merged.defaultRetries).toBe(7)
+    expect(merged.unrefByDefault).toBe(true)
+    expect(merged.maxRetryDelay).toBe(60000)
+  })
+})
+
+describe('mergeTaskOptions', () => {
+  test('inherits retries and unref from scheduler defaults', () => {
+    const merged = mergeTaskOptions(undefined, DEFAULT_OPTIONS)
+    expect(merged.immediate).toBe(false)
+    expect(merged.retries).toBe(3)
+    expect(merged.unref).toBe(true)
+  })
+
+  test('lets explicit task options override scheduler defaults', () => {
+    const merged = mergeTaskOptions(
+      { immediate: true, retries: 5, unref: false },
+      { unrefByDefault: true, defaultRetries: 3, maxRetryDelay: 60000 },
+    )
+    expect(merged.immediate).toBe(true)
+    expect(merged.retries).toBe(5)
+    expect(merged.unref).toBe(false)
+  })
+})


### PR DESCRIPTION
## mutation-improve

| File | Before | After | Spec | Plan |
|---|---|---|---|---|
| src/utils/scheduler.helpers.ts | 0.3333333333333333 | 1 | docs/superpowers/specs/2026-08-07-mutation-coverage-scheduler.helpers-design.md | docs/superpowers/plans/2026-08-07-mutation-coverage-scheduler.helpers.md |
| review-loop/src/summary-burndown.ts | 0.76 | 0.96 | docs/superpowers/specs/2026-08-07-mutation-coverage-summary-burndown-design.md | docs/superpowers/plans/2026-08-07-mutation-coverage-summary-burndown.md |
| plugins/task-provider-youtrack/field-engine.ts | 0.47470817120622566 | 0.9688715953307393 | docs/superpowers/specs/2026-08-07-mutation-coverage-field-engine-design.md | docs/superpowers/plans/2026-08-07-mutation-coverage-field-engine.md |
| plugins/task-provider-youtrack/create-field-helpers.ts | 0.813953488372093 | 1 | docs/superpowers/specs/2026-08-07-mutation-coverage-create-field-helpers-design.md | docs/superpowers/plans/2026-08-07-mutation-coverage-create-field-helpers.md |
| src/announcements/humanize.ts | 0.3382352941176471 | 0.9117647058823529 | docs/superpowers/specs/2026-08-07-mutation-coverage-humanize-design.md | docs/superpowers/plans/2026-08-07-mutation-coverage-humanize.md |
| src/utils/scheduler.events.ts | 0.45 | 0.9 | docs/superpowers/specs/2026-08-07-mutation-coverage-scheduler.events-design.md | docs/superpowers/plans/2026-08-07-mutation-coverage-scheduler.events.md |
| plugins/task-provider-youtrack/dedicated-fields.ts | 0.6699029126213593 | 0.912621359223301 | docs/superpowers/specs/2026-08-07-mutation-coverage-dedicated-fields-design.md | docs/superpowers/plans/2026-08-07-mutation-coverage-dedicated-fields.md |

## Failed iterations

| Iter | Gate | Reason |
|---|---|---|
| 1 | exception | improve exited with code 1: Process timed out after 1800000ms
 |
| 2 | exception | improve exited with code 1: Process timed out after 1800000ms
 |
| 4 | exception | improve exited with code 1: Process timed out after 1800000ms
 |

---

## progress & stats renderer upgrade (feature work riding on this branch)

Spec: `docs/superpowers/specs/2026-08-07-progress-stats-renderer-design.md` · Plan: `docs/superpowers/plans/2026-08-07-progress-stats-renderer.md`

Run-level aggregate stats for the `review-loop` and `mutation-improve` CLIs: the live footer now shows total tokens, estimated cost, tool calls, and lines added/removed; end-of-run summaries print the aggregates; stats persist to `metrics.json` / `state.json` and rehydrate on `--resume-run`.

- New pure modules in `review-loop/src`: `cost.ts` (pricing-table cost estimation — `opencode run` events always report `cost: 0`, so cost is estimated from a `pricing` table in each workspace's `config.json`), `diff-stats.ts` (`git diff --numstat` measurement at merge points), `run-stats.ts` (per-label + totals aggregate, persist/rehydrate).
- `LiveRenderer` footer gains `~$X.XX est · tools N · +a/-r` segments (TTY-only, EPIPE-safe, hidden when zero/unpriced); `ProgressReporter` gains optional `stats`/`diff` members; line handler forwards per-agent label/model and tool-call increments.
- review-loop: worker pool reports each worker merge's numstat diff via hooks; `metrics.json` gains `runStats`; summary gains a `Stats:` line.
- mutation-improve: `state.json` gains a `stats` block (persisted on every save), per-iteration merge diffs, and its first end-of-run terminal summary (`Run summary …` with per-file score/outcome/±lines rows and a totals line).
- No new runtime dependencies. 497 tests green (354 review-loop + 143 mutation-improve), typecheck/lint/format clean both workspaces.
