### PR TITLE
refactor(opencode-agent): require LLM_BASE_URL, rename OPENAI_* to LLM_*

### DIFF
--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -141,9 +141,9 @@ jobs:
           # The only model credentials. One OpenAI-compatible endpoint covers
           # OpenAI, Azure-style gateways, OpenRouter and self-hosted servers, so
           # there are no provider-specific keys to keep in step.
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
-          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_BASE_URL: ${{ vars.LLM_BASE_URL }}
+          LLM_MODEL: ${{ vars.LLM_MODEL }}
 
           # Pipeline configuration — see opencode-agent/README.md.
           AGENT_SELF_LOGIN: ${{ vars.AGENT_SELF_LOGIN || github.repository_owner }}

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -387,11 +387,11 @@ cannot drift.
 
 | Variable                                   | Required | Default                                         | Purpose                                               |
 | ------------------------------------------ | -------- | ----------------------------------------------- | ----------------------------------------------------- |
-| `OPENAI_API_KEY`                           | yes      | —                                               | Model credentials                                     |
-| `OPENAI_MODEL`                             | yes      | —                                               | Model name, e.g. `gpt-5`                              |
-| `OPENAI_BASE_URL`                          | no       | `https://api.openai.com/v1`                     | Any OpenAI-compatible endpoint                        |
-| `GITHUB_TOKEN`                             | yes      | —                                               | Comments, branches, pull requests                     |
-| `GITHUB_REPOSITORY`                        | yes      | —                                               | `owner/repo`                                          |
+| `LLM_API_KEY`                              | yes      | —                                               | Model credentials                                     |
+| `LLM_MODEL`                                | yes      | —                                               | Model name, e.g. `gpt-5`                              |
+| `LLM_BASE_URL`                             | yes      | —                                               | Any OpenAI-compatible endpoint                        |
+| `GITHUB_TOKEN`                             | no       | the job's own `secrets.GITHUB_TOKEN`            | Comments, branches, pull requests; see below          |
+| `GITHUB_REPOSITORY`                        | no       | the job's own `owner/repo`                      | `owner/repo`; see below                               |
 | `AGENT_SELF_LOGIN`                         | no       | derived from the token                          | Login the agent posts as; see above                   |
 | `AGENT_WORKFLOW_NAME`                      | no       | `OpenCode Issue Agent`                          | This workflow's name, for the CI recursion guard      |
 | `AGENT_BASE_BRANCH`                        | no       | detected                                        | Branch the PR targets; see below                      |
@@ -410,9 +410,29 @@ cannot drift.
 | `AGENT_COMMIT_NAME` / `AGENT_COMMIT_EMAIL` | no       | `opencode-agent[bot]`                           | Commit identity                                       |
 | `AGENT_LOG_LEVEL`                          | no       | `info`                                          | `debug`, `info`, `warn`, `error`                      |
 
-`OPENAI_MODEL` is required rather than defaulted: with a custom base URL there is
-no model name that is right by default, and a wrong guess surfaces deep inside
-the first model call instead of at config load.
+`LLM_MODEL` and `LLM_BASE_URL` are both required rather than defaulted: with a
+model gateway that is not necessarily OpenAI's own, there is no base URL or
+model name that is right by default, and a wrong guess surfaces deep inside the
+first model call instead of at config load. A default of
+`https://api.openai.com/v1` used to stand in for `LLM_BASE_URL`, which made a
+forgotten value indistinguishable from a deliberate one; this pipeline is built
+around one arbitrary configured endpoint, not OpenAI specifically, so there is
+no endpoint that is right unless someone said so.
+
+`GITHUB_TOKEN` and `GITHUB_REPOSITORY` need no operator setup on GitHub
+Actions, unlike the variables above. `GITHUB_REPOSITORY` is one of the
+[default environment variables](https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables)
+every Actions job carries — it needs no `env:` entry to exist, and the
+workflow's `GITHUB_REPOSITORY: ${{ github.repository }}` line only makes that
+already-present value explicit. `GITHUB_TOKEN` is not a default environment
+variable — it is a secret every repository already has, and the shipped
+workflow wires it in from `secrets.GITHUB_TOKEN` (or `secrets.AGENT_GITHUB_TOKEN`
+when set) without the operator creating anything. Both stay `required()` at
+config load, because a genuinely missing value — a hand-edited workflow, or a
+local run that forgot to set one — should fail loudly rather than guess; the
+"no" above is about operator setup, not about the loader's validation. A local
+run has no Actions runtime to supply them and must set both explicitly, as
+shown under **Local runs** below.
 
 Every numeric knob is validated as an integer **and range-checked**, because
 rejecting non-integers only closes "not a number", never "a number that cannot
@@ -471,15 +491,17 @@ both are 26–28 KB and neither applies to a single-session CI run.
 
 ## Setup
 
-1. Repository secret `OPENAI_API_KEY`.
-2. Repository variable `OPENAI_MODEL` (and `OPENAI_BASE_URL` for a non-OpenAI
-   endpoint).
+1. Repository secret `LLM_API_KEY`.
+2. Repository variables `LLM_MODEL` and `LLM_BASE_URL`.
 3. Repository variable `AGENT_SELF_LOGIN` — the login the agent comments under.
    Optional for a PAT, but required for a GitHub App token, which cannot report
    its own identity.
 4. Optionally `AGENT_GITHUB_TOKEN`, a GitHub App installation token. Without it
    the agent's pushes do not trigger CI, so the CI-fix path never runs.
 5. Actions needs write access to contents, issues and pull requests.
+
+Nothing to configure for `GITHUB_TOKEN` or `GITHUB_REPOSITORY` — see
+**Configuration** above for why the Actions runtime already supplies both.
 
 The workflow lives at `.github/workflows/agent-pipeline.yml`.
 
@@ -488,8 +510,9 @@ The workflow lives at `.github/workflows/agent-pipeline.yml`.
 ```bash
 GITHUB_REPOSITORY=acme/widgets \
 GITHUB_TOKEN=ghp_… \
-OPENAI_API_KEY=sk-… \
-OPENAI_MODEL=gpt-5 \
+LLM_API_KEY=sk-… \
+LLM_MODEL=gpt-5 \
+LLM_BASE_URL=https://api.openai.com/v1 \
 AGENT_SELF_LOGIN=opencode-agent \
 bun run opencode-agent/src/index.ts \
   --event-path ./fixtures/issue-opened.json \

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -93,6 +93,36 @@ cannot produce the shape twice will not produce it on the fifth attempt, and the
 job has its own timeout. A second bad reply fails the phase as before, with the
 raw text in the failure comment.
 
+## A worked example
+
+1. A maintainer opens issue #42: "Add retries to the HTTP client. Requests
+   should retry twice on 5xx." The `issues.opened` event fires the workflow;
+   the guardrails check the sender's `author_association` and let it through.
+2. The agent runs `INIT_OR_CLARIFY`: reads the issue and explores the repo,
+   then posts a design spec and parks in `DESIGN_SPEC`.
+3. The maintainer replies `/changes only retry on 502 and 503`. The agent
+   rewrites the spec from that feedback and posts it again, still in
+   `DESIGN_SPEC`.
+4. The maintainer replies `/approve`. The agent moves to `EXECUTION_PLAN`,
+   cuts `agent/issue-42` from the default branch, and posts a step-by-step
+   plan; `PLAN_REVIEW` waits for another `/approve`.
+5. Once approved, `REVIEW_AND_MUTATE` implements the plan, runs this
+   repository's own `review-loop/` workspace against the diff, and pushes to
+   `agent/issue-42`.
+6. `PR_DELIVERY` opens a pull request carrying `Closes #42`.
+7. CI runs on the branch — only if `AGENT_GITHUB_TOKEN` is configured, see
+   **Red pull requests** below — and comes back red. The `workflow_run` event
+   brings the agent back into `CI_FIX`: it checks out the branch, reproduces
+   the failing checks locally, hands the real output to the model, and
+   pushes a fix. This repeats, bounded by `AGENT_CI_FIX_MAX_ROUNDS` and
+   `AGENT_MAX_CI_ATTEMPTS`, until CI is green or the budget runs out.
+8. A maintainer merges the pull request like any other. `COMPLETE` stays
+   re-enterable from `CI_FIX`, in case a later push retriggers a check.
+
+A plain reply with no command — "why retry only on 502/503?" — is answered
+without moving the state machine at any of the waiting steps above, and
+`/cancel` stops the run for good from anywhere but `COMPLETE`.
+
 ## Red pull requests
 
 When the `CI` workflow concludes `failure` on `agent/issue-<n>`, the agent comes

--- a/opencode-agent/ROADMAP.md
+++ b/opencode-agent/ROADMAP.md
@@ -617,7 +617,7 @@ accepted `acme / widgets` (owner `"acme "`, with the space), `acme/wid gets`,
 ` acme/widgets`, `acme/widgets\n`, `-acme/widgets`, `acme/widgets?x=1`,
 `acme/wi%2fdgets` and `üñí/repo`. Every one of those parses here and then
 surfaces far away as an opaque 404 from the REST API mid-run — precisely the
-failure mode `OPENAI_MODEL` is required to avoid._
+failure mode `LLM_MODEL` is required to avoid._
 
 _Fixed by matching both halves against GitHub's own naming rules
 (`OWNER_PATTERN` / `REPO_PATTERN`, with their 39- and 100-character caps) instead
@@ -865,7 +865,7 @@ Every process the model starts with `bash` inherits that variable, so
 `echo $OPENCODE_CONFIG_CONTENT` was a complete credential disclosure. The
 environment scrub from S3-2 cannot help: the SDK sets the variable on the child,
 after the scrub. Verified by reading `/proc/<pid>/environ` of a real spawned
-server — with `OPENAI_API_KEY` already removed from this process, the key was
+server — with `LLM_API_KEY` already removed from this process, the key was
 still there, under `OPENCODE_CONFIG_CONTENT`._
 
 _Fixed by never giving OpenCode the credential. `provider-proxy.ts` runs a
@@ -984,7 +984,7 @@ Every process the model starts with `bash` inherits that variable, so
 `echo $OPENCODE_CONFIG_CONTENT` was a complete credential disclosure. The
 environment scrub from S3-2 cannot help: the SDK sets the variable on the child,
 after the scrub. Verified by reading `/proc/<pid>/environ` of a real spawned
-server — with `OPENAI_API_KEY` already removed from this process, the key was
+server — with `LLM_API_KEY` already removed from this process, the key was
 still there, under `OPENCODE_CONFIG_CONTENT`._
 
 _Fixed by never giving OpenCode the credential. `provider-proxy.ts` runs a

--- a/opencode-agent/src/config.ts
+++ b/opencode-agent/src/config.ts
@@ -105,14 +105,18 @@ const safeJson = (raw: string): unknown => {
 /**
  * Reads the single model endpoint.
  *
- * `OPENAI_MODEL` is required rather than defaulted: with a custom base URL
- * there is no model name that is right by default, and a wrong guess surfaces
- * deep inside the first model call instead of here.
+ * `LLM_MODEL` is required rather than defaulted: with a custom base URL there
+ * is no model name that is right by default, and a wrong guess surfaces deep
+ * inside the first model call instead of here. `LLM_BASE_URL` is required for
+ * the same reason: defaulting it to OpenAI's own endpoint made a missing
+ * value look like a deliberate choice instead of a misconfiguration, and this
+ * pipeline is built around one arbitrary configured endpoint, not OpenAI
+ * specifically.
  */
 export const loadOpenAiSettings = (env: Env): OpenAiSettings => ({
-  apiKey: required(env, 'OPENAI_API_KEY'),
-  baseUrl: optional(env, 'OPENAI_BASE_URL', 'https://api.openai.com/v1'),
-  model: required(env, 'OPENAI_MODEL'),
+  apiKey: required(env, 'LLM_API_KEY'),
+  baseUrl: required(env, 'LLM_BASE_URL'),
+  model: required(env, 'LLM_MODEL'),
 })
 
 /** Skill roots searched in order; the vendored superpowers checkout wins. */

--- a/opencode-agent/src/openai-config.ts
+++ b/opencode-agent/src/openai-config.ts
@@ -22,7 +22,7 @@ export const OPENAI_PROVIDER_ID = 'openai'
 
 /**
  * The AI SDK package OpenCode loads for this provider. The `openai-compatible`
- * driver — not the first-party `openai` one — is what makes `OPENAI_BASE_URL`
+ * driver — not the first-party `openai` one — is what makes `LLM_BASE_URL`
  * meaningful for non-OpenAI endpoints.
  */
 const PROVIDER_NPM = '@ai-sdk/openai-compatible'

--- a/opencode-agent/src/repository.ts
+++ b/opencode-agent/src/repository.ts
@@ -26,7 +26,7 @@ const isRepoName = (candidate: string): boolean => REPO_PATTERN.test(candidate) 
  * that is not: `acme / widgets`, a value with the trailing newline a shell
  * heredoc leaves behind, `acme/widgets?x=1`. Each of those parses, then surfaces
  * far away as an opaque 404 from the REST API in the middle of a run — the same
- * argument `OPENAI_MODEL` is required for.
+ * argument `LLM_MODEL` is required for.
  *
  * The raw value is quoted with `JSON.stringify` so invisible characters, which
  * are the likeliest cause, are visible in the error.

--- a/tests/opencode-agent/adapters.test.ts
+++ b/tests/opencode-agent/adapters.test.ts
@@ -1049,11 +1049,12 @@ describe('config', () => {
   const baseEnv: Env = {
     GITHUB_REPOSITORY: 'acme/widgets',
     GITHUB_TOKEN: 'tok',
-    OPENAI_API_KEY: 'sk-test',
-    OPENAI_MODEL: 'gpt-5',
+    LLM_API_KEY: 'sk-test',
+    LLM_MODEL: 'gpt-5',
+    LLM_BASE_URL: 'https://api.openai.com/v1',
   }
 
-  test('reads the single OpenAI endpoint', () => {
+  test('reads the single model endpoint', () => {
     expect(loadConfig(baseEnv, '/repo').openai).toEqual({
       apiKey: 'sk-test',
       baseUrl: 'https://api.openai.com/v1',
@@ -1062,12 +1063,12 @@ describe('config', () => {
   })
 
   test('honours a custom base URL', () => {
-    const config = loadConfig({ ...baseEnv, OPENAI_BASE_URL: 'https://gateway.test/v1' }, '/repo')
+    const config = loadConfig({ ...baseEnv, LLM_BASE_URL: 'https://gateway.test/v1' }, '/repo')
 
     expect(config.openai.baseUrl).toBe('https://gateway.test/v1')
   })
 
-  test.each(['OPENAI_API_KEY', 'OPENAI_MODEL', 'GITHUB_TOKEN', 'GITHUB_REPOSITORY'])('requires %s', (key) => {
+  test.each(['LLM_API_KEY', 'LLM_MODEL', 'LLM_BASE_URL', 'GITHUB_TOKEN', 'GITHUB_REPOSITORY'])('requires %s', (key) => {
     const env: Env = Object.fromEntries(Object.entries(baseEnv).filter(([name]) => name !== key))
 
     expect(() => loadConfig(env, '/repo')).toThrow(key)
@@ -1232,9 +1233,9 @@ describe('scrubSecrets / redactSecrets', () => {
     // `createOpencodeServer` spawns `opencode serve` with `{ ...process.env }`
     // and takes no env option, so anything left here is one `echo $VAR` away
     // from the model.
-    const env: Env = { GITHUB_TOKEN: TOKEN, OPENAI_API_KEY: KEY, PATH: '/usr/bin' }
+    const env: Env = { GITHUB_TOKEN: TOKEN, LLM_API_KEY: KEY, PATH: '/usr/bin' }
 
-    expect(scrubSecrets(env, [TOKEN, KEY]).sort()).toEqual(['GITHUB_TOKEN', 'OPENAI_API_KEY'])
+    expect(scrubSecrets(env, [TOKEN, KEY]).sort()).toEqual(['GITHUB_TOKEN', 'LLM_API_KEY'])
     expect(env).toEqual({ PATH: '/usr/bin' })
   })
 

--- a/tests/opencode-agent/cli.test.ts
+++ b/tests/opencode-agent/cli.test.ts
@@ -198,8 +198,9 @@ describe('runCli', () => {
   const env = {
     GITHUB_REPOSITORY: 'acme/widgets',
     GITHUB_TOKEN: 'tok',
-    OPENAI_API_KEY: 'sk-test',
-    OPENAI_MODEL: 'gpt-5',
+    LLM_API_KEY: 'sk-test',
+    LLM_MODEL: 'gpt-5',
+    LLM_BASE_URL: 'https://api.openai.com/v1',
     AGENT_SELF_LOGIN: 'agent-bot',
   }
 
@@ -234,7 +235,7 @@ describe('runCli', () => {
     const live = {
       ...env,
       GITHUB_TOKEN: 'ghp_0123456789abcdefghij',
-      OPENAI_API_KEY: 'sk-0123456789abcdefghij',
+      LLM_API_KEY: 'sk-0123456789abcdefghij',
       GH_TOKEN: 'ghp_0123456789abcdefghij',
       PATH: '/usr/bin',
     }
@@ -246,7 +247,7 @@ describe('runCli', () => {
     })
 
     expect(Object.hasOwn(live, 'GITHUB_TOKEN')).toBe(false)
-    expect(Object.hasOwn(live, 'OPENAI_API_KEY')).toBe(false)
+    expect(Object.hasOwn(live, 'LLM_API_KEY')).toBe(false)
     expect(Object.hasOwn(live, 'GH_TOKEN')).toBe(false)
     expect(live.PATH).toBe('/usr/bin')
   })
@@ -352,13 +353,13 @@ describe('runCli', () => {
     expect(result.status).toBe('skipped')
   })
 
-  test('requires the OpenAI model, rather than guessing one', async () => {
+  test('requires the model name, rather than guessing one', async () => {
     const eventPath = await writeEvent('nomodel', {
       action: 'opened',
       sender: { login: 'maintainer', type: 'User' },
       issue: { number: 1, title: 't', body: 'b', author_association: 'OWNER' },
     })
-    const { OPENAI_MODEL: _unused, ...withoutModel } = env
+    const { LLM_MODEL: _unused, ...withoutModel } = env
 
     const attempt = runCli({
       argv: ['--event-path', eventPath, '--event-name', 'issues'],
@@ -366,7 +367,7 @@ describe('runCli', () => {
       logger: silentLogger,
     })
 
-    await expect(attempt).rejects.toThrow('OPENAI_MODEL')
+    await expect(attempt).rejects.toThrow('LLM_MODEL')
   })
 
   test('fails loudly when the event file is missing', async () => {

--- a/tests/opencode-agent/workflow.test.ts
+++ b/tests/opencode-agent/workflow.test.ts
@@ -219,12 +219,12 @@ describe('steps', () => {
     expect(step('opencode cli').run).toContain('opencode-ai')
   })
 
-  test('passes only OpenAI credentials to the pipeline', () => {
+  test('passes only the single LLM endpoint credentials to the pipeline', () => {
     const env = step('agent pipeline').env
 
-    expect(Object.keys(env)).toContain('OPENAI_API_KEY')
-    expect(Object.keys(env)).toContain('OPENAI_BASE_URL')
-    expect(Object.keys(env)).toContain('OPENAI_MODEL')
+    expect(Object.keys(env)).toContain('LLM_API_KEY')
+    expect(Object.keys(env)).toContain('LLM_BASE_URL')
+    expect(Object.keys(env)).toContain('LLM_MODEL')
     expect(Object.keys(env).join(' ')).not.toContain('ANTHROPIC')
     expect(Object.keys(env).join(' ')).not.toContain('OPENCODE_API_KEY')
   })


### PR DESCRIPTION
LLM_BASE_URL now has no default: this pipeline targets one arbitrary
OpenAI-compatible endpoint, not OpenAI's own, so a missing base URL should
fail at config load rather than silently pointing at api.openai.com.

OPENAI_API_KEY/OPENAI_MODEL/OPENAI_BASE_URL are renamed to
LLM_API_KEY/LLM_MODEL/LLM_BASE_URL throughout the workspace, its workflow
and its tests. The internal `OpenAiSettings` type and OpenCode's own
"openai" provider id are unchanged — they describe the wire protocol, not
the operator-facing env var names.

Documents that GITHUB_TOKEN and GITHUB_REPOSITORY need no operator setup
on GitHub Actions: GITHUB_REPOSITORY is a default Actions environment
variable present on every job, and GITHUB_TOKEN is wired from the
repository's always-present secrets.GITHUB_TOKEN by the shipped workflow.
Both stay required() at config load so a genuinely missing value (a
hand-edited workflow, a local run) still fails loudly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XM4mDynCqTMJ2thU7fC5EW