### PR TITLE
docs(opencode-agent): plan the issue status-feedback UX

### DIFF
--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -109,9 +109,19 @@ jobs:
           # like somebody's issue.
           if [ "${#number}" -gt 16 ]; then number=''; fi
           if [ -n "$number" ]; then
-            # `10#` so a leading zero is read as decimal, not octal, and so the
-            # value printed matches the integer the pipeline would have parsed.
-            number=$((10#$number))
+            # Leading zeros stripped so the value printed matches the integer
+            # `issueNumberFromBranch` would have parsed — `agent/issue-007` is
+            # issue 7, and the differential test below compares the two.
+            #
+            # `sed` rather than the shorter `$((10#$number))`. That arithmetic
+            # form crashes Semgrep's `gha-curl-pipe-shell` rule with a
+            # MatchingError, and `--strict` turns one crashed rule into a failed
+            # security scan for the whole repository. Bisected to this line.
+            # `test` is safe to compare with directly: unlike `$(( ))` it reads a
+            # leading zero as decimal, so the strip is about the printed value,
+            # not about the comparison.
+            number="$(printf '%s' "$number" | sed 's/^0*//')"
+            number="${number:-0}"
             if [ "$number" -le 0 ] || [ "$number" -gt 9007199254740991 ]; then number=''; fi
           fi
           echo "number=$number" >> "$GITHUB_OUTPUT"
@@ -319,9 +329,11 @@ jobs:
           # every writer on it, or the knob is a half-truth.
           LABEL_PREFIX: ${{ vars.AGENT_LABEL_PREFIX }}
         run: |
-          shopt -s extglob
-          prefix="${LABEL_PREFIX##+([[:space:]])}"
-          prefix="${prefix%%+([[:space:]])}"
+          # `sed` rather than the shorter `${VAR##+([[:space:]])}`: extglob is
+          # the one construct in this file Semgrep's bash grammar cannot parse,
+          # and `--strict` fails the whole security scan on a single unparsed
+          # line — so an unscannable workflow costs more than a spawned process.
+          prefix="$(printf '%s' "$LABEL_PREFIX" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
           prefix="${prefix:-agent:}"
 
           if [ "${prefix,,}" = 'none' ]; then
@@ -337,5 +349,8 @@ jobs:
           # which state the issue is parked in, and this step has no idea which
           # that is. Only the marker that claims a run is in flight is this
           # step's to contradict.
-          gh issue edit "$ISSUE_NUMBER" --remove-label "${prefix}working" \
-            || echo "Could not remove ${prefix}working; the next run's reconcile takes it off."
+          # One statement, not a `\`-continued `||`: that continuation is the
+          # second thing Semgrep's bash grammar gives up on here.
+          if ! gh issue edit "$ISSUE_NUMBER" --remove-label "${prefix}working"; then
+            echo "Could not remove ${prefix}working; the next run's reconcile takes it off."
+          fi

--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -269,6 +269,13 @@ jobs:
       #     is a run somebody cancels, and that is exactly when the issue must
       #     not fall silent. `failure()` is false for a cancelled job, so it was
       #     never covered.
+      #
+      # The heading followed `cancelled()` in: it read "Agent job failed", which
+      # is now wrong for half of what this step speaks for. Telling a maintainer
+      # who cancelled a run that it failed is a small lie the comment has no
+      # need to tell, and "did not finish" is true of a crash, a runner timeout
+      # and a cancellation alike — which is exactly the set the `reported` gate
+      # leaves for this step.
       - name: Report an infrastructure failure on the issue
         if: (failure() || cancelled()) && steps.issue.outputs.number && steps.pipeline.outputs.reported != 'true'
         env:
@@ -277,7 +284,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           printf '%s\n\n%s\n\n%s\n' \
-            '### Agent job failed' \
+            '### Agent job did not finish' \
             "The workflow run failed or was cancelled before or during the pipeline. Logs: $RUN_URL" \
             'The issue state is unchanged; reply `/retry` once the cause is addressed.' \
             > /tmp/agent-failure.md

--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -178,6 +178,10 @@ jobs:
           AGENT_MAX_ATTEMPTS: ${{ vars.AGENT_MAX_ATTEMPTS }}
           AGENT_TIMEOUT_MS: ${{ vars.AGENT_TIMEOUT_MS }}
           AGENT_MAX_TOKENS: ${{ vars.AGENT_MAX_TOKENS }}
+          # The namespace the status labels live under, or `none` to switch
+          # them off. Forwarded like the other knobs because a repository with
+          # its own label conventions is the ordinary case, not the exception.
+          AGENT_LABEL_PREFIX: ${{ vars.AGENT_LABEL_PREFIX }}
           AGENT_LOG_LEVEL: ${{ vars.AGENT_LOG_LEVEL || 'info' }}
         run: |
           bun run opencode-agent/src/index.ts \

--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -69,6 +69,53 @@ jobs:
        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.issue.author_association))
 
     steps:
+      # Which issue this run belongs to, resolved once and read by both feedback
+      # steps at the bottom of the job. First, before the checkout, because that
+      # is the point: a run that dies in `bun install`, or is cancelled while the
+      # model is thinking, must still know where to post — so this step may not
+      # depend on anything that can fail.
+      #
+      # Two sources, because the two event kinds carry different things.
+      # `github.event.issue.number` is the issue-triggered path and is empty on a
+      # `workflow_run` event, which knows only the branch that went red. That gap
+      # is not cosmetic: the fallback step below was gated on the issue number
+      # alone, so a runner that died during a CI-fix run posted nothing anywhere.
+      # `agent/issue-<n>` is the one link from a branch back to the conversation
+      # that started it, and `issueNumberFromBranch` in opencode-agent/src/git.ts
+      # already parses exactly that shape. The two must agree, so
+      # tests/opencode-agent/workflow.test.ts runs *this script* against *that
+      # function* over a corpus of branch names rather than trusting two
+      # hand-written parsers to stay in step.
+      - name: Resolve the issue number this run belongs to
+        id: issue
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          number="$ISSUE_NUMBER"
+          if [ -z "$number" ]; then
+            case "$HEAD_BRANCH" in
+              # Anchored at both ends like BRANCH_PATTERN is: a suffix carrying
+              # anything but digits — `agent/issue-12/nested`, `agent/issue-x` —
+              # is not a branch this pipeline owns, and a branch that merely
+              # contains the prefix is not one either.
+              agent/issue-*[!0-9]*) ;;
+              agent/issue-?*) number="${HEAD_BRANCH#agent/issue-}" ;;
+            esac
+          fi
+          # The same bounds `issueNumberFromBranch` applies: positive, and inside
+          # the safe-integer range. The length test comes first so an absurd
+          # suffix cannot wrap in the arithmetic below into a number that looks
+          # like somebody's issue.
+          if [ "${#number}" -gt 16 ]; then number=''; fi
+          if [ -n "$number" ]; then
+            # `10#` so a leading zero is read as decimal, not octal, and so the
+            # value printed matches the integer the pipeline would have parsed.
+            number=$((10#$number))
+            if [ "$number" -le 0 ] || [ "$number" -gt 9007199254740991 ]; then number=''; fi
+          fi
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -189,7 +236,7 @@ jobs:
             --event-name "$GITHUB_EVENT_NAME" \
             --repo-root "$GITHUB_WORKSPACE"
 
-      # For a job that died with nothing on the issue: an install failure, a
+      # For a job that stopped with nothing on the issue: an install failure, a
       # runner timeout, a cancelled job, a config error thrown before the first
       # comment could be posted, a crash.
       #
@@ -208,16 +255,80 @@ jobs:
       # runner processes a step's file commands in a `finally` around the
       # handler, so the marker survives that same step exiting 1. The job stays
       # red either way — the exit code is real signal.
+      #
+      # That gate is the part that works and it is unchanged. The other two
+      # conditions were the ones still too narrow, and both widenings sit
+      # *inside* it so neither can bring the double comment back:
+      #
+      #   - the issue number now comes from the resolve step, so the accident
+      #     above stops cutting both ways. A CI-fix runner that dies used to be
+      #     spared the duplicate and denied the report; it gets the report now,
+      #     and the `reported` gate is what keeps the duplicate away.
+      #   - `cancelled()` joins `failure()`. A cancelled job is the documented
+      #     consequence of a run with no visible progress: a run that looks hung
+      #     is a run somebody cancels, and that is exactly when the issue must
+      #     not fall silent. `failure()` is false for a cancelled job, so it was
+      #     never covered.
       - name: Report an infrastructure failure on the issue
-        if: failure() && github.event.issue.number && steps.pipeline.outputs.reported != 'true'
+        if: (failure() || cancelled()) && steps.issue.outputs.number && steps.pipeline.outputs.reported != 'true'
         env:
           GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           printf '%s\n\n%s\n\n%s\n' \
             '### Agent job failed' \
-            "The workflow run itself failed before or during the pipeline. Logs: $RUN_URL" \
+            "The workflow run failed or was cancelled before or during the pipeline. Logs: $RUN_URL" \
             'The issue state is unchanged; reply `/retry` once the cause is addressed.' \
             > /tmp/agent-failure.md
           gh issue comment "$ISSUE_NUMBER" --body-file /tmp/agent-failure.md
+
+      # The second half of the `agent:working` mitigation, and it has to live
+      # here rather than in the pipeline. The in-run reconcile in
+      # opencode-agent/src/labels.ts takes the marker off at the end of every run
+      # that reaches its end — and the one failure mode the marker has is a run
+      # that never does: a runner killed by `timeout-minutes`, a cancelled job,
+      # an out-of-memory kill. Neither mitigation covers the other. This step
+      # cannot repair a label somebody edited by hand and cannot know which
+      # labels the state implies; the reconcile cannot run in a process that is
+      # already gone. So an issue is left claiming an agent is working on it
+      # until somebody happens to trigger another run, which is the state a list
+      # view is least able to argue with.
+      #
+      # Best-effort like every other feedback write, per the rule labels.ts
+      # states: a job whose only red step is this one has reported a failure that
+      # did not happen. Note that a failure here is the *ordinary* case on a
+      # healthy run — the reconcile already removed the label, and removing a
+      # label an issue does not carry is a 404.
+      - name: Take the working label off the issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          # Read exactly the way `labelPrefix()` in src/config-values.ts reads
+          # it: trimmed, defaulted, and `none` compared case-insensitively. A
+          # repository that switched labelling off must not have this step reach
+          # for its labels either — opting out of a channel has to opt out of
+          # every writer on it, or the knob is a half-truth.
+          LABEL_PREFIX: ${{ vars.AGENT_LABEL_PREFIX }}
+        run: |
+          shopt -s extglob
+          prefix="${LABEL_PREFIX##+([[:space:]])}"
+          prefix="${prefix%%+([[:space:]])}"
+          prefix="${prefix:-agent:}"
+
+          if [ "${prefix,,}" = 'none' ]; then
+            echo 'AGENT_LABEL_PREFIX=none: labelling is switched off, leaving the labels alone.'
+            exit 0
+          fi
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo 'No issue number for this run; there is nothing to clean up.'
+            exit 0
+          fi
+
+          # One label, never a clear-and-reapply: every other agent label states
+          # which state the issue is parked in, and this step has no idea which
+          # that is. Only the marker that claims a run is in flight is this
+          # step's to contradict.
+          gh issue edit "$ISSUE_NUMBER" --remove-label "${prefix}working" \
+            || echo "Could not remove ${prefix}working; the next run's reconcile takes it off."

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -13,10 +13,11 @@ findings: `ROADMAP.md`.
 - One CI job = one call to `runCli`. State lives in hidden blocks on the issue,
   not on disk: `AGENT_STATE` for the machine, `AGENT_SPEC` / `AGENT_PLAN` /
   `AGENT_REPORT` for the artefacts.
-- `src/triggers.ts` decides _whether and where_ an event moves the state, with
-  the red-CI half in `src/ci-trigger.ts` and the shared outcome shape in
-  `src/trigger-outcome.ts`; `src/orchestrator.ts` drives the phase cascade once
-  that decision is made;
+- `src/triggers.ts` decides _whether and where_ an event moves the state — it
+  keeps the slash commands and the dispatch — with the red-CI half in
+  `src/ci-trigger.ts`, the plain-comment half in `src/comment-intent.ts`, and the
+  shared outcome shape plus `moveOrSkip` in `src/trigger-outcome.ts`;
+  `src/orchestrator.ts` drives the phase cascade once that decision is made;
   `src/token-budget.ts` decides whether the cascade may afford another step.
   Phase handlers in `src/phases/` return a `TransitionSignal`, a comment body and
   optional artefact blocks, and never write state or decide the next phase

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -18,10 +18,17 @@ findings: `ROADMAP.md`.
   `src/ci-trigger.ts`, the plain-comment half in `src/comment-intent.ts`, and the
   shared outcome shape plus `moveOrSkip` in `src/trigger-outcome.ts`;
   `src/orchestrator.ts` drives the phase cascade once that decision is made;
-  `src/token-budget.ts` decides whether the cascade may afford another step.
+  `src/token-budget.ts` decides whether the cascade may afford another step, and
+  `src/phase-failure.ts` decides what a run that broke is left looking like.
   Phase handlers in `src/phases/` return a `TransitionSignal`, a comment body and
   optional artefact blocks, and never write state or decide the next phase
   themselves.
+- Feedback on the issue that is not a comment lives apart from the machine that
+  causes it: `src/presentation.ts` owns the one glyph/label/headline table every
+  renderer reads, `src/feedback.ts` the reaction channel, and `src/labels.ts` the
+  label reconcile over `src/github-labels.ts`'s endpoints. Each channel has
+  exactly one function that talks to GitHub, because "best-effort" has to be a
+  property of one function rather than a convention at each call site.
 - Every external boundary is an injected interface (`GitHubApi`, `Git`,
   `CheckRunner`, `RunReview`, `OpenCodeAgent`, `ReadSkillFile`).
 

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -25,10 +25,14 @@ findings: `ROADMAP.md`.
   themselves.
 - Feedback on the issue that is not a comment lives apart from the machine that
   causes it: `src/presentation.ts` owns the one glyph/label/headline table every
-  renderer reads, `src/feedback.ts` the reaction channel, and `src/labels.ts` the
-  label reconcile over `src/github-labels.ts`'s endpoints. Each channel has
-  exactly one function that talks to GitHub, because "best-effort" has to be a
-  property of one function rather than a convention at each call site.
+  renderer reads, `src/feedback.ts` the reaction channel, `src/labels.ts` the
+  label reconcile over `src/github-labels.ts`'s endpoints, and
+  `src/status-reporter.ts` the run's live status comment over the body
+  `src/status-comment.ts` renders. Each channel has exactly one function that
+  talks to GitHub, because "best-effort" has to be a property of one function
+  rather than a convention at each call site. `src/state-persist.ts` is the same
+  shape for a write that is not feedback at all: rewriting the state block in
+  place, so a run that posts nothing can still record what it spent.
 - Every external boundary is an injected interface (`GitHubApi`, `Git`,
   `CheckRunner`, `RunReview`, `OpenCodeAgent`, `ReadSkillFile`).
 
@@ -174,12 +178,14 @@ findings: `ROADMAP.md`.
 - **Do not pay to classify a comment the budget cannot act on.** `applyIntent`
   asks `withinBudget` before `classifyComment` and routes an over-budget comment
   to the answer path, where the cascade's one stop reports it. The classifier is
-  the single model turn whose spend cannot be recorded — its `none` branch posts
-  nothing, and this pipeline persists state only by posting — so the ceiling has
+  the single model turn that posts nothing — its `none` branch deliberately
+  stays quiet, and this pipeline persists state by posting — so the ceiling has
   to stop the turn rather than count it. A run **under** budget that classifies
-  `none` still leaks that turn; the known cost of not replying to every "thanks!",
-  and not to be papered over with an `updateComment`-style write without deciding
-  that larger question first.
+  `none` used to leak that turn outright and no longer does: `readAndSkip`
+  records it through `state-persist.ts`, which rewrites the newest state block in
+  place instead of appending a comment. That write is best-effort like every
+  other one this pipeline added, so a refused rewrite reports the figure the
+  issue actually carries rather than the one the run hoped to write.
 - **`INIT_OR_CLARIFY` classifies with the default inverted.** `applyClarifyIntent`
   skips a comment only when the classifier positively reports `none`; every other
   reading re-runs triage, which is what the phase used to do for every comment —

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -12,7 +12,9 @@ findings: `ROADMAP.md`.
 
 - One CI job = one call to `runCli`. State lives in hidden blocks on the issue,
   not on disk: `AGENT_STATE` for the machine, `AGENT_SPEC` / `AGENT_PLAN` /
-  `AGENT_REPORT` for the artefacts.
+  `AGENT_REPORT` for the artefacts. `AGENT_STATUS` is the odd one out — it marks
+  the run's live status comment so `renderThread` can leave it out of a prompt,
+  and it is read by nothing else.
 - `src/triggers.ts` decides _whether and where_ an event moves the state — it
   keeps the slash commands and the dispatch — with the red-CI half in
   `src/ci-trigger.ts`, the plain-comment half in `src/comment-intent.ts`, and the
@@ -30,9 +32,16 @@ findings: `ROADMAP.md`.
   `src/status-reporter.ts` the run's live status comment over the body
   `src/status-comment.ts` renders. Each channel has exactly one function that
   talks to GitHub, because "best-effort" has to be a property of one function
-  rather than a convention at each call site. `src/state-persist.ts` is the same
-  shape for a write that is not feedback at all: rewriting the state block in
-  place, so a run that posts nothing can still record what it spent.
+  rather than a convention at each call site. The status comment carries an
+  `AGENT_STATUS` block — never `AGENT_STATE`, which would give the restore scan a
+  second source of truth — so that `prompt-budget.ts` can drop it before the
+  twenty-comment window is taken; without that, every previous run's progress
+  table would take a slot from the conversation triage, answering and the
+  classifier are being asked to read. Filter that channel by **marker**, never by
+  author: the agent writes the spec, the plan and every report too.
+  `src/state-persist.ts` is the same shape for a write that is not feedback at
+  all: rewriting the state block in place, so a run that posts nothing can still
+  record what it spent.
 - Every external boundary is an injected interface (`GitHubApi`, `Git`,
   `CheckRunner`, `RunReview`, `OpenCodeAgent`, `ReadSkillFile`).
 

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -149,22 +149,68 @@ findings: `ROADMAP.md`.
   the reset to the refresh path: same branch, same commits, same checks that
   spent the rounds, and a clean slate there is one broken branch bouncing off the
   agent for as long as anyone keeps replying `/retry`.
+- **A feedback channel has exactly one door, and that door swallows
+  everything.** `react` in `feedback.ts`, `reconcileLabels` in `labels.ts`,
+  `attempt` in `status-reporter.ts` and `persistState` in `state-persist.ts` are
+  each the only function in their module that calls GitHub, and each catches
+  every rejection and degrades it to a `warn`; a caller reaches the same
+  `RunResult` and the same **persisted state** it would have reached with the
+  channel absent. One door rather than a `try` per call site because best-effort
+  has to be a property of a function, not a convention: every write these
+  channels make is decoration on work that matters and a fresh way to break a
+  pipeline that used to work — a token without `issues: write`, a fork run, an
+  organisation restricting who may create a label, a secondary rate limit — and a
+  convention honoured at five call sites is honoured at four the day somebody
+  adds a sixth. Adapters do **not** anticipate the rule: `github-labels.ts`
+  rejects a 403 like any other transport, and only swallows the 422 that means
+  "this label already exists", because that is idempotence at the layer where an
+  HTTP status still exists. The accepted cost is stated at the catch in
+  `labels.ts` and is not an oversight: a `TypeError` from inside the reconcile
+  degrades to exactly the same `warn` as a 403, so a bug in a channel is
+  invisible to anyone not reading the log. It has been paid once already — a
+  stubbed transport answered the label read with the wrong shape,
+  `name.startsWith` threw into that catch, and the suite stayed green having
+  reconciled nothing. Sorting an `unknown` at the catch into "mine" and "theirs"
+  is how that gets fragile, so do not add the discrimination; add a test that
+  asserts the write. The workflow's `if: always()` label cleanup obeys the same
+  rule in YAML, with `|| echo`: a job whose only red step is the one taking a
+  label off has reported a failure that did not happen.
 - **A run says whether it reported, and the workflow reads that.** `RunResult`
   carries `reported`, and `step-output.ts` turns it into a `reported=true` line
-  in `$GITHUB_OUTPUT`; the workflow's fallback "Agent job failed" comment is
-  gated on `steps.pipeline.outputs.reported != 'true'`. It used to be gated on
+  in `$GITHUB_OUTPUT`; the workflow's fallback "Agent job did not finish" comment
+  is gated on `steps.pipeline.outputs.reported != 'true'`. It used to be gated on
   `if: failure()` alone, which selects **every** red job — and six paths exit 1
   only after posting their own report (`failRun`, `failAnswer`, both over-budget
   stops, `refuseExhausted`, the CI-budget notice), so every genuine failure drew
   a second comment claiming "the issue state is unchanged" beside a block that
   had just moved to `FAILED`. Only CI runs escaped, by accident:
-  `github.event.issue.number` is empty on a `workflow_run` event. Set `reported`
-  on any new terminal path from what that path **posted**, never from its status
+  `github.event.issue.number` is empty on a `workflow_run` event — which is why
+  the workflow now resolves the number from `workflow_run.head_branch` too, and
+  why that widening had to sit _inside_ the `reported` gate. Set `reported` on
+  any new terminal path from what that path **posted**, never from its status
   — `failed` covers both a reported failure and a crash, and `skipped` covers
   both a silent guardrail drop and a refused command that answered on the issue.
   A throw is deliberately unmarked: that is the crash the fallback comment is
   for. Writing the marker is best-effort and must never throw — `GITHUB_OUTPUT`
   is absent on every `--event-path` run.
+- **`reported` means an account of what happened, so a status comment never sets
+  it.** The live status comment is what makes that distinction load-bearing
+  rather than pedantic: a run killed mid-phase leaves "🛠️ Writing and reviewing
+  the code — run in progress" on the issue, which is precisely the silence the
+  fallback comment exists to explain, and nothing ever corrects it — the process
+  that owned that comment is gone, and the next run opens its own. Marking it
+  reported would suppress the only comment that would have said why the issue
+  stopped. So `StatusReporter.finish` takes the `RunResult` and returns `void`:
+  the flag is **unreachable** from the channel, not merely left alone by habit,
+  and an edit that wanted to set it would have to change the interface first.
+  Keep it that way, and keep `finish` unable to _reject_: `runAccepted` awaits it
+  on the way out with the result already decided, so a channel that could throw
+  there would turn a finished run into a failed one. The rule above is what makes
+  that impossible. The finalising edit on a _returning_ path does not set the
+  flag either, though it safely could: the paths that report already do, and two
+  writers of one flag is how it drifts. Reactions and labels are the same
+  argument one step shorter — an emoji is not an account of anything, and
+  neither is a label.
 - **The token budget is per issue and persisted.** `tokensSpent` lives in the
   state block; the orchestrator checks it before each phase. Budget on
   **tokens**, never on `cost`: token counts come

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -21,10 +21,16 @@ Every step runs in its own short-lived job; nothing long-polls.
 An Actions job has no memory of the previous one, so state lives on the issue in
 hidden HTML blocks:
 
-- `<!-- AGENT_STATE: … -->` — phase and counters. Rewritten on every comment.
+- `<!-- AGENT_STATE: … -->` — phase and counters. Written afresh with every
+  comment the pipeline posts, and rewritten **in place** by a run that spent
+  model tokens and had nothing to post.
 - `<!-- AGENT_SPEC: … -->` — the current design spec.
 - `<!-- AGENT_PLAN: … -->` — the current execution plan.
 - `<!-- AGENT_REPORT: … -->` — the implementation report.
+- `<!-- AGENT_STATUS: … -->` — the odd one out: it marks a run's live status
+  comment so the prompt layer can leave that comment out, and nothing else reads
+  it. It is deliberately not `AGENT_STATE`, or the restore scan would have two
+  sources of truth.
 
 Artefacts get their own blocks rather than being scraped back out of the visible
 markdown. That is not a style preference: a spec is model-written markdown full
@@ -323,23 +329,264 @@ exactly how an issue comes back for another expensive round. A failure that
 recorded nothing let an issue burn the ceiling and then hand the next runner a
 clean slate, round after round.
 
-Three things it cannot see: the review loop's `opencode run` subprocesses, which
-have their own sessions; any spend before the first prompt of a job; and the turn
-that classifies a plain maintainer comment as needing no action. That last one is
-a deliberate residual. Classification happens before any phase runs, and when it
-answers "no action" the run posts nothing — replying to every "thanks!" would be
-spam — so there is no comment for a state block to ride on. What the agent does
-instead is refuse to pay for it: once an issue is over budget the comment skips
-the classifier entirely and goes to the path that reports the ceiling without a
-model turn — the answer path on a waiting phase, triage's own stop in
-`INIT_OR_CLARIFY` — so a maxed-out issue stops buying a classification per
-comment.
+Classifying a plain comment used to be the hole in that. Classification happens
+before any phase runs, and when it answers "no action" the run posts nothing —
+replying to every "thanks!" would be spam — so there was no comment for a state
+block to ride on, and an issue could buy one classification per comment for as
+long as anybody kept commenting. It is closed now, from both ends. Over budget,
+the comment skips the classifier entirely and goes to the path that reports the
+ceiling without a model turn — the answer path on a waiting phase, triage's own
+stop in `INIT_OR_CLARIFY`. Under budget, the skip **rewrites the newest state
+block in place** rather than appending a comment, so the turn is written down
+without anything being said. That fix waited on an `updateComment` the pipeline
+had no other use for; the live status comment needed one anyway.
+
+The in-place rewrite targets the comment the restore scan itself selected, not
+the newest in the thread, so that comment stays the newest-with-a-block and the
+scan is unaffected — and it re-serializes through the same `renderBlock`
+escaping, because a rewrite that assembled the block by hand would reintroduce
+the forged-terminator bug on a new surface. It is best-effort like every other
+write this pipeline added: a refused rewrite reports the figure the issue
+actually carries, rather than one no reader will ever find.
+
+Two things the counter still cannot see: the review loop's `opencode run`
+subprocesses, which have their own sessions, and any spend before the first
+prompt of a job, since the running total comes from the job's own session and
+that session does not exist yet.
 
 ## Watching a run
 
-A phase that runs for twenty minutes emitting nothing is, in a CI log,
-indistinguishable from a hang — and the usual response to a job that looks hung
-is to cancel it. So the log says what is happening:
+**The issue is the surface; the Actions log is the deep dive.** This section
+used to teach the opposite, and that was the bug. A phase can run for tens of
+minutes emitting nothing, and for that whole window an issue where the agent is
+working looks exactly like an issue where the workflow never fired — which is a
+real outcome, because a guardrail can drop the event. A log nobody has a link to
+does not close that gap, and the usual response to a job that looks hung is to
+cancel it.
+
+Four things now speak on the issue itself: a reaction, a pair of labels, one
+live comment, and a link to the job in every comment a maintainer reads when
+something has gone wrong. Between them they cost **one** extra comment per run;
+everything else is a reaction, a label, or an edit to that same comment.
+
+Every one of them is best-effort by construction. Each channel has exactly one
+function that talks to GitHub and that function swallows every rejection into a
+`log.warn`, so a repository whose token cannot write labels, a fork run, or an
+organisation policy on reactions all reach the same result and the same
+persisted state as a run with no feedback at all. Nothing here can fail a
+pipeline that used to work.
+
+### Reactions — the instant acknowledgement
+
+One API call, no thread noise, and it lands on the comment you just typed, so it
+is already where you are looking.
+
+| What the run concluded                      | Reaction |
+| ------------------------------------------- | -------- |
+| Trigger accepted; work is starting          | 👀       |
+| Comment read, nothing to do about it        | 👍       |
+| Sender has no write access on the repo      | 😕       |
+| Command unknown, or not valid in this phase | 😕       |
+| A pull request was opened or refreshed      | 🚀       |
+
+They stack, because the first row happens before the run has decided anything: a
+refused `/approve` ends up wearing 👀 😕, a delivery 👀 🚀. The rejected outsider
+is the exception — the guardrails turn that event away before the 👀, so it gets
+only the 😕.
+
+A reaction lands on the comment that triggered the run, or on the issue itself
+for `issues.opened`, which has no comment to address. A red-CI `workflow_run`
+event gets nothing at all: nobody typed it and nobody is waiting on an answer to
+it, so the log line is the whole of the right record. That decision lives in one
+function (`reactionTarget`), not in a check at each call site.
+
+👍 is the one worth understanding, because it is the only trace four paths leave
+anywhere but the log: an empty comment, a comment the classifier read as chatter
+on a waiting phase, the same reading in `INIT_OR_CLARIFY`, and a plain comment on
+a phase that is not waiting for one at all. A comment would be the wrong
+instrument for any of them — answering "I have decided to do nothing" to every
+"thanks!" is exactly the noise the one-comment budget exists to prevent — but
+silence left no way to tell a comment the agent read and set aside from a
+workflow that never ran. All four go through one function, because a fix that
+acknowledged three of them is the close-the-instance-leave-the-class defect this
+workspace keeps re-opening.
+
+### Labels — the state, from a list view
+
+The phase lives in a hidden HTML block, so "which of my twelve agent issues are
+waiting on me" used to mean opening each one and reading the last comment's
+prose. A label is the only thing an issue list, a project board and a
+notification all carry.
+
+| The issue is                   | Label                | Colour |
+| ------------------------------ | -------------------- | ------ |
+| Being read for the first time  | `agent:triaging`     | blue   |
+| Waiting on your answers        | `agent:clarifying`   | amber  |
+| Parked on a design spec review | `agent:spec-review`  | amber  |
+| Being broken into steps        | `agent:planning`     | blue   |
+| Parked on a plan review        | `agent:plan-review`  | amber  |
+| Being written and reviewed     | `agent:implementing` | blue   |
+| Being delivered                | `agent:delivering`   | blue   |
+| Having its red checks repaired | `agent:ci-fixing`    | blue   |
+| Delivered                      | `agent:done`         | green  |
+| Stopped — cancelled, no PR     | `agent:stopped`      | grey   |
+| Parked in `FAILED`             | `agent:failed`       | red    |
+
+Two more carry the filtering value, and they are the part worth having even if
+the per-phase set were dropped, because each answers a question a phase name
+does not:
+
+- **`agent:working`** — a run is holding this issue right now. That is "is
+  anything actually happening", answerable from a list view.
+- **`agent:needs-you`** — the run ended and the next move is yours. That is
+  "which of my issues am I blocking", which is the one that costs a maintainer
+  time.
+
+They are mutually exclusive by construction: while the agent holds the issue it
+is not waiting on anybody, so a run in flight must not also appear in the filter
+it is busy clearing. `agent:needs-you` goes on exactly the amber and red rows
+above.
+
+Labels are reconciled at most **twice per run**, not per phase move: once when a
+run is about to do real work, and once when it ends, whatever the outcome — a
+run that only skipped gets the closing one alone. The live detail in between is
+the status comment's job, below. Each reconcile is a diff — the desired set is
+computed and only the difference issued — so a run that moved nothing writes
+nothing, rather than clearing and reapplying and costing two timeline entries
+and a visible flicker per phase.
+
+Each reconcile is also a **repair**, which is the half that is easy to leave
+out. Any `agent:*` label the state does not imply is removed, so an issue
+whose labels were edited by hand and an issue left carrying `agent:working` by a
+killed runner both heal on the next event. Labels outside the prefix are never
+touched in either direction: they are the repository's own, and removing one is
+the worst thing this channel could do.
+
+A killed runner is the one failure mode the marker has, so it has two
+mitigations and neither covers the other. The reconcile above repairs it on the
+next event; an `if: always()` workflow step takes `<prefix>working` off as the
+job exits, including a job that was cancelled or timed out. That step cannot
+know which labels the state implies and cannot repair a hand edit; the reconcile
+cannot run in a process that is already gone.
+
+`AGENT_LABEL_PREFIX` namespaces the lot — a repository with its own label
+conventions is the ordinary case, not the exception. Set it to `none` and the
+channel is off: the pipeline reconciles nothing and the workflow's cleanup step
+reads the same variable the same way and leaves the issue's labels alone, since
+opting out of a channel has to opt out of every writer on it.
+
+### The live status comment
+
+One comment per run, created when the run is about to do work, edited as it
+moves, finalised when it ends. It is the only comment any of this adds, and the
+only surface that can say "still working" without posting again — every other
+comment in this pipeline is written from a finished phase outcome and is
+terminal by construction.
+
+```markdown
+### 🛠️ Writing and reviewing the code — run in progress
+
+**Job:** [this run](https://github.com/acme/widgets/actions/runs/1482) · started 14:02 UTC
+**Branch:** `agent/issue-42` · **Pull request:** _not opened yet_
+
+| Phase             |                 |
+| ----------------- | --------------- |
+| 🔍 Triage         | ✅              |
+| 📋 Design spec    | ✅ · revision 2 |
+| 🗺️ Execution plan | ✅ · revision 1 |
+| 🛠️ Implementation | ⏳ **now**      |
+| 📦 Pull request   | ⬜              |
+
+**Doing:** read (running) · 34 tool calls
+**Budget:** 218,400 of 5,000,000 tokens · attempt 1 of 3
+```
+
+Five milestones rather than a row per phase: `PLAN_REVIEW` is the execution plan
+waiting for you rather than a sixth thing that happens, and `CI_FIX` is repair
+work on the pull request row. The question it answers is "how far along is my
+issue", not "draw me the state machine". The spec and plan rows print
+`specRevision` and `planRevision` and never recount them — the two counters were
+split apart precisely because one number could not honestly label two artefacts.
+In `CI_FIX` the budget line says "attempt 2 of 3 **on this pull request**",
+because that budget is per pull request and reading it as per-issue would have
+you conclude the agent had given up when it had not started.
+
+There is deliberately no "6m elapsed". A figure that changes every minute
+changes the whole body every minute, and the whole body changing every minute
+defeats the rule below. A start time and GitHub's own "edited N minutes ago"
+answer the same question between them and cost nothing.
+
+Two bounds on the cost, because this is the only sustained writer the pipeline
+has: an edit is skipped outright when the rendered body has not changed, and
+otherwise at most one edit is issued per minute. A 90-minute run costs about 90
+edits, comfortably inside GitHub's secondary rate limit on content-mutating
+requests, and a quiet stretch costs nothing. The closing edit is the one caller
+allowed to skip the clock — a run that ends inside the window would otherwise
+leave "run in progress" on the issue for good — but it still skips an unchanged
+body, and the body is never unchanged, because ending the run is what takes "run
+in progress" out of the heading.
+
+Three things it deliberately is not:
+
+- **It is not a state channel.** It carries no `AGENT_STATE` block, so the
+  restore scan cannot see it and there is no second source of truth. It does
+  carry an `AGENT_STATUS` block of its own — markers are matched exactly, so the
+  two cannot be confused — and that marker is what keeps it out of the model's
+  prompt. `renderThread` hands the model the last twenty comments, and dropping
+  status comments **before** that window is taken is the difference between the
+  model reading the conversation and reading a quarter-window of its own
+  previous runs' progress tables. Filtered by marker, never by author: the agent
+  writes the spec, the plan and every report too.
+- **It is not a report.** It never sets `reported`, so a run killed mid-phase
+  leaves "run in progress" on the issue _and_ still draws the workflow's
+  fallback comment — which is the case that comment exists for. Marking it
+  reported would suppress the one comment that explains the silence.
+- **It is not required.** A local `--event-path` run has no job to link to, so
+  the channel is a no-op there; and if creating the comment fails, every later
+  edit is a no-op too and the run reports exactly as it did before this existed.
+
+### Where the run link is
+
+`GITHUB_RUN_ID`, `GITHUB_RUN_ATTEMPT`, `GITHUB_SERVER_URL` and
+`GITHUB_REPOSITORY` are in every step's environment already, so the link needed
+no workflow change — only a nullable `runUrl` in the config, absent on a local
+run, where the line is omitted rather than left pointing nowhere. The attempt
+segment is appended only above 1, because a re-run's logs live under the attempt
+path and a job on attempt 3 linking `/attempts/1` would point you at the run it
+superseded.
+
+It appears in four places: the status comment's first line, the failure comment
+("The job that failed"), the CI-fix report, and the workflow's own fallback
+comment. The CI-fix report is the one that changed meaning — it names **two**
+runs now, "Red run I am repairing" and "This repair ran in", which until now
+were the same word.
+
+### One vocabulary for the glyphs
+
+Every glyph above comes from `presentation.ts`, which holds two closed tables: a
+phase table (where the issue is) and an outcome table (what just happened to
+this run). Both are `Record`s over a closed union, so a phase added later fails
+to compile until it has been given a row, and a renderer cannot invent a glyph
+locally — `run-report.ts` builds every heading through one of two helpers, and a
+test asserts no `###` literal survives in that file. The distinction the two
+tables buy is worth stating: ❌ means the work **broke**, ⛔ means a **bound was
+reached** and nothing broke at all, and ⚠️ is a failed _answer_, where nothing
+moved and no attempt was spent.
+
+The phase handlers' own artefact comments — `### Design spec (revision 1)`,
+`### Execution plan (revision 1)`, `### Implementation report`, `### Answer` —
+are outside that table and carry no glyph. They name an artefact rather than a
+state, and there is nothing for the label beside them to disagree with.
+
+The glyph is decoration and never the only carrier of meaning. The headline sits
+next to it in every rendering and the label name is plain text, so a screen
+reader that announces "clipboard, design spec is waiting for you" loses nothing
+by dropping the first word.
+
+### The Actions log
+
+Still the deep dive, and the only place that says what the model is doing
+second by second:
 
 ```
 Model tool call        { tool: "read", status: "running", call: "call_1" }
@@ -352,18 +599,23 @@ Two halves, answering different questions. OpenCode's event stream says **what**
 the model is doing, and only fires when something happens. The heartbeat, once a
 minute while a turn is outstanding, says it is **still** doing it — which is the
 only thing that distinguishes slow from dead during a single long model call
-that uses no tools.
+that uses no tools. That same heartbeat is what feeds the status comment's
+**Doing:** line, so the two surfaces cannot disagree about what is running.
 
 **Progress never carries content.** Not tool input, not tool output, not the
 model's text, not the provider's error message on a retry — only names, statuses
 and counts. That is enforced by the decoding schemas rather than by care: they
 name the scalar fields they want and drop everything else, so there is nowhere
-for a `bash` command or a file's contents to land. It matters more here than
-elsewhere: a CI log is world-readable on a public repository and is **not**
-covered by the outbound redaction that guards issue comments.
+for a `bash` command or a file's contents to land. It mattered here because a CI
+log is world-readable on a public repository and is **not** covered by the
+outbound redaction that guards issue comments — and it matters twice over now
+that the same snapshot is published to the issue. The status comment satisfies
+the rule by construction rather than by care: everything it can say about the
+model is a name, a status or a count, because that is all a `ProgressSnapshot`
+holds.
 
-Token and cost totals ride along, per step and in every heartbeat. That is
-visibility, not a ceiling — see `ROADMAP.md` S5-6.
+Token and cost totals ride along, per step and in every heartbeat, and the token
+half is now a ceiling as well as a reading — see **What bounds a run** above.
 
 ## Guardrails
 
@@ -596,6 +848,15 @@ is a positive integer that removes the bound the knob exists to impose. A
 rejection names the range, so a legitimate need for a wider one is not a
 guessing game.
 
+`AGENT_LABEL_PREFIX` is validated at load for the same reason: at most 32
+characters, and only letters, digits and `-_./: `. That is narrower than what
+GitHub itself accepts on a label, deliberately — the prefix is what decides by
+`startsWith` which of an issue's labels this pipeline owns and may remove, so it
+has to be a plain, predictable string. A comma splits a label list in half of
+GitHub's own UI, and a leading or trailing space makes two labels that look
+identical. Checking it here turns a bad value into a message naming the
+variable, rather than a 422 inside a best-effort path that swallows it.
+
 `AGENT_BASE_BRANCH` has no literal default for the same reason. It used to
 default to `main`, which is wrong for the repository this spike lives in — its
 default branch is `master` — so every local run died on `fatal: couldn't find
@@ -659,11 +920,11 @@ Nothing to configure for `GITHUB_TOKEN` or `GITHUB_REPOSITORY` — see
 
 The workflow lives at `.github/workflows/agent-pipeline.yml`.
 
-### The fallback failure comment
+### The fallback comment for a job that never spoke
 
-The workflow's last step posts an "Agent job failed" comment saying the issue
-state is unchanged and inviting a `/retry`. That is only ever true for a job
-that died with nothing on the issue: an install failure, a runner timeout, a
+The workflow posts an "Agent job did not finish" comment saying the issue state
+is unchanged and inviting a `/retry`. That is only ever true for a job that
+stopped with nothing on the issue: an install failure, a runner timeout, a
 cancelled job, a config error thrown before the first comment, a crash.
 
 It cannot be gated on `if: failure()` alone, which is what it used to be:
@@ -678,6 +939,28 @@ to `$GITHUB_OUTPUT` for every exit that posted; the fallback step is gated on
 `steps.pipeline.outputs.reported != 'true'`. The marker survives the run step's
 own exit 1 — the runner processes a step's file commands in a `finally` around
 the handler — and the job still goes red, because the exit code is real signal.
+
+Two conditions beside that gate were still too narrow, and both widenings sit
+**inside** it, so neither can bring the double comment back:
+
+- The issue number comes from a resolve step that runs **first**, before the
+  checkout, because a run that dies in `bun install` must still know where to
+  post. It reads `github.event.issue.number`, and falls back to the
+  `agent/issue-<n>` suffix of `workflow_run.head_branch` — which is empty on one
+  event kind and present on the other. Gating on the payload field alone meant a
+  runner that died mid-CI-repair posted nothing anywhere. The shell parse and
+  `issueNumberFromBranch` must agree, so `workflow.test.ts` runs _that script_
+  against _that function_ over a corpus of branch names rather than trusting two
+  hand-written parsers to stay in step.
+- `cancelled()` joins `failure()`, which does not select a cancelled job. A run
+  that looks hung is a run somebody cancels, and that is precisely the moment
+  the issue must not fall silent. The heading followed: "Agent job failed" is
+  not true of a cancellation, and "did not finish" is true of every job this
+  step now speaks for.
+
+A second `if: always()` step takes the `agent:working` label off, and the
+comment above it explains why that has to live in YAML rather than in the
+pipeline — see **Watching a run**.
 
 ## Local runs
 
@@ -737,6 +1020,10 @@ under **Setup** is simply not written. Nothing else changes.
 | `src/triggers.ts`                             | Turning a command or comment into the state move to make               |
 | `src/ci-trigger.ts`                           | Whether a red check run buys a fix round, a notice, or nothing         |
 | `src/run-report.ts`                           | Everything the orchestrator writes back to the issue                   |
+| `src/presentation.ts`                         | One glyph, label, headline and whose-turn per state an issue can be in |
+| `src/feedback.ts` / `src/labels.ts`           | The reaction channel, and the label reconcile                          |
+| `src/status-comment.ts` / `-reporter.ts`      | What the run's live comment says, and when it is edited                |
+| `src/state-persist.ts`                        | Recording what a run spent without posting a comment                   |
 | `src/step-output.ts`                          | The one thing a run tells the rest of its own workflow job             |
 | `src/token-budget.ts`                         | The per-issue token ceiling, and how a run over it parks in `FAILED`   |
 | `src/state-manager.ts`                        | Transition table and the `AGENT_STATE` block                           |
@@ -787,7 +1074,22 @@ network.
 - Bumping `STATE_VERSION` strands in-flight issues — old blocks fail validation,
   and the scan walks back to an older valid one or to a fresh state. Drain before
   bumping, or write a migration.
-- No cost ceiling beyond the round caps and the job timeout.
+- Spend is bounded in **tokens per issue** (`AGENT_MAX_TOKENS`), never in
+  currency, for the reason given under **What bounds a run**. That ceiling
+  cannot see the review loop's `opencode run` subprocesses, so a repository
+  whose review loop is the expensive half is bounded by the round caps and the
+  job timeout rather than by the token budget.
+- A run killed mid-phase leaves its status comment reading "run in progress",
+  and nothing ever corrects it: the process that owned that comment is gone, and
+  the next run opens its own. The workflow's fallback comment is what explains
+  the silence — the stale status comment is deliberately not treated as one, or
+  it would suppress it. `agent:working` is the labelling half of the same
+  problem and does get repaired, twice over.
+- Feedback is best-effort in one function per channel, which means a channel
+  that is broken — a token without `issues: write`, an organisation policy, or a
+  bug inside the reconcile — degrades to a `log.warn` and nothing else. The run
+  is unaffected, which is the point, but nobody finds out without reading the
+  Actions log.
 - Capability containment is config-level (see above), not process-level: there is
-  no container or network boundary around the model, and the repository token is
-  still in `.git/config` — see `ROADMAP.md` S3-7.
+  no container or network boundary around the model — the last direction of
+  `ROADMAP.md` S3-2 still open.

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -558,6 +558,7 @@ cannot drift.
 | `AGENT_TIMEOUT_MS`                         | no       | `1800000`                                       | Timeout for one model turn, and for each subprocess   |
 | `AGENT_MAX_TOKENS`                         | no       | `5000000`                                       | Model tokens one issue may spend, across all its jobs |
 | `AGENT_COMMIT_NAME` / `AGENT_COMMIT_EMAIL` | no       | `opencode-agent[bot]`                           | Commit identity                                       |
+| `AGENT_LABEL_PREFIX`                       | no       | `agent:`                                        | Namespace for the status labels; `none` disables them |
 | `AGENT_LOG_LEVEL`                          | no       | `info`                                          | `debug`, `info`, `warn`, `error`                      |
 
 `LLM_MODEL` and `LLM_BASE_URL` are both required rather than defaulted: with a

--- a/opencode-agent/ROADMAP.md
+++ b/opencode-agent/ROADMAP.md
@@ -14,7 +14,21 @@ See LICENSE in the project root for details.
 > out of larger findings rather than left implied and were the last two open. What
 > remains in S3 is the boundary S3-2 names in its closing note: containment is
 > config-level, not process-level, so there is no container or network boundary
-> around the model. **S4** onwards is untouched.
+> around the model.
+>
+> **S4** is closed too — all ten items, five of which unrelated work had already
+> closed without anyone marking them. **S5** is closed apart from S5-5, whose
+> premise has been overtaken twice, and S5-10, which is accepted rather than
+> fixed. **S6** is where the real remainder is: S6-5 (the mutation ratchet has
+> never seen this workspace) and S6-7 (`check.sh`'s full list omits it). Both,
+> with what they cost and what fixing them costs, are evaluated in
+> [`docs/remaining-findings-evaluation.md`](docs/remaining-findings-evaluation.md).
+>
+> That paragraph replaces "**S4** onwards is untouched", which was false when it
+> was written and stayed in this blurb through a correction of the sentence beside
+> it — the same way S3-7 and S3-8 came to be listed as open. A status line nobody
+> re-derives is the most reliably wrong part of any long document, which is why
+> what remains is now named positively rather than by omission.
 >
 > A recurring pattern is worth stating once: several items marked `[FIXED]` were
 > re-opened on inspection because the fix had closed the _instance_ and left the

--- a/opencode-agent/ROADMAP.md
+++ b/opencode-agent/ROADMAP.md
@@ -9,11 +9,12 @@ See LICENSE in the project root for details.
 
 > **Status.** This began as a report-only audit; much of it has since been fixed.
 > Resolved items are marked **[FIXED]** inline, each with what was verified and —
-> where it applies — what the first attempt at the fix got wrong. All of **S1**
-> and **S2** are closed, as is **S3** apart from **S3-7** (the repository token
-> still lives in `.git/config`) and **S3-8** (the logger redacts by field name
-> rather than by value), which were split out of larger findings rather than left
-> implied. **S4** onwards is untouched.
+> where it applies — what the first attempt at the fix got wrong. All of **S1**,
+> **S2** and **S3** are closed, including **S3-7** and **S3-8**, which were split
+> out of larger findings rather than left implied and were the last two open. What
+> remains in S3 is the boundary S3-2 names in its closing note: containment is
+> config-level, not process-level, so there is no container or network boundary
+> around the model. **S4** onwards is untouched.
 >
 > A recurring pattern is worth stating once: several items marked `[FIXED]` were
 > re-opened on inspection because the fix had closed the _instance_ and left the
@@ -971,89 +972,6 @@ throw is not redacted. It cannot be — a config failure happens before any secr
 is known. The realistic exposure is low, since phase failures are caught and
 reported inside the pipeline, and an Octokit error carries the URL but not the
 header._
-
-### S3-9 The provider key reaches the model through `OPENCODE_CONFIG_CONTENT` — verified — **[FIXED]**
-
-_Found while checking whether S3-7 had closed its class, and it had not. The
-GitHub token was carefully removed from every place the model could read it while
-the **OpenAI key** sat in plain sight._
-
-_`createOpencodeServer` spawns `opencode serve` with `OPENCODE_CONFIG_CONTENT`
-set to the serialized config — and the config is where the provider key lives.
-Every process the model starts with `bash` inherits that variable, so
-`echo $OPENCODE_CONFIG_CONTENT` was a complete credential disclosure. The
-environment scrub from S3-2 cannot help: the SDK sets the variable on the child,
-after the scrub. Verified by reading `/proc/<pid>/environ` of a real spawned
-server — with `LLM_API_KEY` already removed from this process, the key was
-still there, under `OPENCODE_CONFIG_CONTENT`._
-
-_Fixed by never giving OpenCode the credential. `provider-proxy.ts` runs a
-loopback proxy that holds the key; OpenCode is configured with
-`PLACEHOLDER_API_KEY` and the proxy's URL, and the real `Authorization` is
-swapped in on the way out. The key stays in the parent process, which the model
-has no handle on. Both consumers are covered — the in-process session and the
-review loop's `opencode run` subprocesses read the same generated config._
-
-_Verified end to end, not just in unit tests: the live check now drives a real
-`opencode serve` through the proxy to a stub upstream and asserts the upstream
-saw `Bearer <real key>` while the config OpenCode held carried only the
-placeholder. That is also the only proof that a **streamed** completion survives
-the extra hop._
-
-_This is containment, not authentication: anything that can already run code on
-the runner can call the proxy. It removes the credential from the places an
-**injected prompt** can read, which is the threat S3-2 is about._
-
-_Mutation-checked ten ways. Two survived the first pass and both taught
-something. Dropping `authorization` from the copied-header deny-list killed
-nothing — because the unconditional `set` after the copy loop already overwrites
-it, making the deny-list entry unreachable. It read as a second defence while
-being dead, so it is gone rather than kept for looks. And replacing the contained
-config with the raw one killed nothing, because every test exercised the proxy
-module directly — the adapter can be perfect and never be wired in, exactly the
-gap S3-3 hit. `contain` is exported and tested now._
-
-### S3-3 Check output and git stderr are published verbatim to a public issue — verified — **[FIXED]**
-
-_Verified on the wire with the transport recorder: a comment body carrying a
-token went out to `POST /repos/acme/widgets/issues/42/comments` byte for byte._
-
-_Redaction lives at the **GitHub adapter**, not in the renderers. A comment body
-is assembled from check output, git stderr, review summaries, model prose and the
-hidden state block's `lastError`, and every one of those is a place a future
-renderer could forget. `createOctokitApi` strips secrets from every outbound
-body — comments, new pull requests, refreshed ones — so nothing leaves the module
-unredacted, and `OctokitApiOptions.secrets` is **required** so a new construction
-site has to decide rather than default to silence._
-
-_Keyed on **values**, not names, and the reason is sharper than for the
-environment scrub: the logger redacts by field name, which only works when a
-secret arrives in a field somebody named. Check output and git stderr are free
-text — a token inside them has no key at all. Branch names are left alone; they
-are computed by this pipeline, and redacting them could corrupt a `head`._
-
-_`pipelineSecrets(config)` is the single list both consumers read, so a
-credential added to the config cannot be wired into the scrub and forgotten by
-the redaction._
-
-_A mutation survived the first pass and mattered: replacing the wired list with
-`[]` killed nothing, because every redaction test built the adapter directly. The
-adapter can be perfect and still be handed nothing. `MainOptions.fetch` now
-carries the transport into `runCli`, and a `/cancel` run — which reaches a posted
-comment without booting a model — asserts end to end that a body posted by the
-**real** pipeline carries no credential. That test kills the mutant._
-
-_Mutation-checked nine ways in total: un-redacting each of the three outbound
-paths, replacing only the first occurrence, stopping after the first secret,
-dropping the minimum-length guard, passing an empty list from `runCli`, and
-dropping either credential from `pipelineSecrets`._
-
-_Not covered: the logger still redacts by key name. That is a smaller exposure —
-GitHub masks registered secrets in Actions logs, and it does not mask issue
-comments — but it is name-based, so a token inside a logged free-text error
-message survives. Recorded as S3-8._
-
-### S3-8 The logger redacts by field name, so a secret inside a message survives
 
 `src/logger.ts` walks metadata keys against `REDACT_KEYS`. A credential that
 arrives inside a free-text `error` message — the same shape S3-3 fixed for issue

--- a/opencode-agent/docs/remaining-findings-evaluation.md
+++ b/opencode-agent/docs/remaining-findings-evaluation.md
@@ -1,0 +1,232 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# What is still open in `ROADMAP.md`, and what it is worth
+
+Every finding that is not marked `[FIXED]`, re-checked against the tree at
+`422c915` rather than trusted from its marker — because two markers in this file
+have already been wrong, in both directions.
+
+Verdict first:
+
+| Finding                     | Real state after checking          | Fix it?                    | Effort               |
+| --------------------------- | ---------------------------------- | -------------------------- | -------------------- |
+| **S6-5** Stryker blind spot | genuinely open                     | **yes** — highest value    | half a day           |
+| **S6-7** `check.sh` gap     | genuinely open                     | **yes** — do it alongside  | ~15 minutes          |
+| Stale markers               | four wrong, one of them mine       | **yes** — now              | ~20 minutes          |
+| **S6-6** coverage floor     | **closed by measurement** (below)  | no — record the number     | done here            |
+| **S5-5** job timeout        | premise overtaken twice            | no — reword                | ~5 minutes           |
+| **S6-2** delivery fake      | closed by S1-2, marker never moved | no — marker only           | in the above         |
+| **S5-10** billable no-ops   | real, and the fix is worse         | **no** — record and accept | n/a                  |
+| **S3-8** residuals          | one unfixable, one one-line        | **no** — correctly noted   | n/a                  |
+| **S3-2** process isolation  | genuinely open, genuinely big      | **not now** — see below    | weeks, and CI-shaped |
+
+---
+
+## The two worth doing
+
+### S6-5 — the mutation ratchet has never seen this workspace
+
+**Verified open.** `stryker.config.json`'s `mutate` globs are
+`src/providers/**`, `src/tools/**` and `plugins/task-provider-*/**`. There is no
+`opencode-agent/**` entry, so the repo's strongest quality gate — a per-file
+mutation ratchet that blocks CI — does not look at **8,897 lines** of this
+workspace.
+
+**Effect of leaving it open, concretely.** This is not theoretical, and this
+session is the evidence in both directions. Five stages of work were
+mutation-checked _by hand_, and that hand process repeatedly found real gaps:
+the `/ask`-counts-as-work mutant survived its first pass and needed a test
+written for it; the "presentation ignores the stance" and "markers no longer
+exclusive" mutants killed 2 and 18 tests respectively only because someone
+thought to try them. It worked — and none of it is enforced or repeatable. The
+next contributor gets a suite that looks comprehensive (894 tests) with no
+mechanism telling them which of those tests actually constrain behaviour. The
+workspace that runs a mutation loop for other people's code is the one place the
+ratchet cannot see, which is the irony the finding already names.
+
+**Effort: half a day, and the risk is CI time, not correctness.** The config
+change is four lines. The real work is:
+
+1. Add `opencode-agent/src/**/*.ts` to `mutate`, with the same
+   `!**/index.ts`-style exclusions the other globs use.
+2. Seed `scripts/mutation/baseline.json` on master — the documented path is
+   `test:mutate:changed --base=HEAD~1 --update-baseline` / `seedMerge`. Without
+   this every file arrives as "first measurement, seeded" and enforces nothing.
+3. **Measure the added CI time before committing to it.** 8,897 lines is a
+   large addition to a paired mutation run, and `test:mutate:changed` only
+   mutates changed files on a PR — so the steady-state cost is small, but the
+   baseline seeding run is not. This is the step that decides whether the change
+   is half a day or a week.
+
+Do (3) first. If the seeding run is prohibitive, the fallback is to add the
+globs but scope the ratchet to the files this workspace changes most —
+`orchestrator.ts`, `triggers.ts`, `state-manager.ts`, `token-budget.ts`,
+the feedback modules — rather than all 59.
+
+### S6-7 — `check.sh`'s full list omits the workspace
+
+**Verified, and narrower than the finding says.** `scripts/check.sh` already
+routes `opencode-agent/src/*` in its staged-file dispatch (lines 38 and 51). What
+is missing is the **full** check list at line 296, which names
+`review-loop:lint`, `review-loop:typecheck`, `review-loop:format:check` and
+`review-loop:test` but no `opencode-agent:*` equivalents.
+
+**Effect.** Low but non-zero. Root `lint`/`typecheck`/`test` cover the workspace
+transitively, so this is not a hole — it is an asymmetry that will mislead. The
+concrete cost showed up in this session: `opencode-agent:format:check` covers
+only `src` and `tests` and **does not see markdown**, so a doc-only change passed
+the workspace gate and broke the root `format:check`. Somebody running "the
+workspace's checks" reasonably believes they have run the workspace's checks.
+
+**Effort: ~15 minutes.** Four entries in the `checks=(…)` array plus the
+`test`-style special-casing at line 301, mirroring `review-loop:test`.
+
+---
+
+## The one that is bigger than it looks
+
+### S3-2 remainder — containment is config-level, not process-level
+
+**Genuinely open, and correctly described.** There is no container or network
+boundary around the model. What exists is good and does most of the work:
+capabilities are deny-by-default per agent profile, `scrubSecrets` strips
+credentials from the environment before anything spawns, the provider key never
+reaches OpenCode (`provider-proxy.ts`), and the repository token is not in
+`.git/config`.
+
+**What is actually at risk if an injected prompt defeats the capability config.**
+Worth being precise, because the honest answer is narrower than "no sandbox"
+sounds:
+
+- Provider and repository credentials are already out of reach — that is S3-2's
+  own closed half plus S3-7 and S3-9.
+- The `build` profile can run `bash`, so it has the checkout and the network. On
+  a **public** repository the checkout is public, so the exfiltration prize is
+  small.
+- On a **private** repository it is not small, and that is the case that should
+  gate this decision.
+- The provider proxy listens on loopback holding the real key. Anything already
+  running code on the runner can call it — stated in S3-9 as containment, not
+  authentication, which is the right framing but does mean the proxy is a
+  credential-shaped target for exactly this threat.
+
+**Effort: weeks, and the shape fights the platform.** Real isolation means either
+running the OpenCode server in a container inside an Actions job
+(container-in-container, with the checkout bind-mounted and egress filtered) or
+moving the whole pipeline to a self-hosted runner with a network policy. Both
+are infrastructure projects, not a patch. The SDK spawns and manages the server
+process itself, so the boundary has to go around the job rather than around the
+call.
+
+**Recommendation: not now, and the trigger for revisiting is explicit.** Do it
+when this pipeline is pointed at a private repository whose contents matter, or
+when it is given a token with access beyond the repository it runs in. Until
+then the capability and credential boundaries are the ones carrying the weight,
+and they are closed. The limitation is already stated in the README and in the
+blurb, which is the correct treatment for a risk that is accepted rather than
+overlooked.
+
+---
+
+## Closed by checking — no work needed beyond the marker
+
+### S6-6 — the coverage floor, measured
+
+The finding says "eight of the spike's files sit below the floor" and "should be
+checked before merge". **Checked:** `bun test tests/opencode-agent --coverage`
+reports the workspace at **93.6% functions / 95.2% lines** across 59 files —
+above the aggregate 90/90 floor in `scripts/coverage/floor.json`, so the
+workspace _raises_ the aggregate rather than dragging it. The risk the finding
+flagged did not materialise, largely because the work since then arrived with
+tests. Record the number and close it.
+
+### S5-5 — the job timeout, overtaken twice
+
+The finding cites `timeout-minutes: 45` at `agent-pipeline.yml:31`. The file now
+says **90**, at line 52. More importantly its harm clause — "a job that is merely
+slow across several turns still dies **silently**" — is no longer true: stage 4
+widened the fallback comment to `cancelled()` and to `workflow_run` events, and a
+runner killed by `timeout-minutes` is one of the cases that step's own comment
+now names. The job can still die at 90 minutes; it can no longer do so in
+silence. Reword to what remains: the ceiling is a guess, and nothing has measured
+a real implement-plus-review run against it.
+
+### S6-2 — closed by S1-2, marker never moved
+
+S1-2's `[FIXED]` narrative states it: a `hostileGit()` fake that throws on every
+operation drives a full resume, and both new tests were mutation-checked. The S6
+list at line 1584 was never updated. Marker only.
+
+---
+
+## Real, and the fix would be worse
+
+### S5-10 — a comment mentioning `/approve` boots a runner that then skips
+
+**Still true.** The workflow deliberately carries no comment-body filter, because
+S1-3 established that the clarification loop needs plain replies to reach the
+pipeline. So any maintainer comment starts a job; the in-process guardrails then
+skip it cheaply.
+
+**Effect: billable, not harmful** — and less bad than when the finding was
+written, because such a run now leaves a 👍 or 😕 reaction rather than nothing, so
+the boot is at least visible to the person who caused it. Cost is roughly a
+runner-minute per non-actionable comment.
+
+**Why not to fix it:** the only workflow-level filters available are the ones
+S1-3 removed. Gating on "the issue carries a state block" would need the
+workflow to read issue comments in an `if:` expression, which it cannot do.
+Reintroducing a slash-command filter would re-break the clarification loop — a
+closed S1 traded for a cost measured in pennies. Record it as accepted.
+
+### S3-8 residuals — one unfixable, one not worth a harness
+
+- **`main`'s `process.stderr.write` on an escaped throw is unredacted.** It
+  cannot be fixed: a config failure happens _before_ any secret is known, so
+  there is no list to redact against. Correctly recorded as unfixable rather than
+  as a to-do.
+- **The single line in `runCli` that chooses the logger factory** is a review
+  surface no test can hold short of capturing stdout through a full run. The
+  finding's own framing — "a one-line review surface, not a silent hole" — is the
+  right call. Building a stdout-capture harness to cover one line is a poor
+  trade.
+
+---
+
+## Doc staleness — do this now, it has already caused two errors
+
+The blurb has now been wrong twice, and the second time I wrote it.
+
+1. **"S4 onwards is untouched"** — false, and I preserved it in `422c915` while
+   correcting the sentence beside it. **S4 is entirely `[FIXED]`** (all ten
+   items, five of which were closed by unrelated work and never marked). S5 is
+   fixed apart from S5-5's reworded remainder and S5-10. This is my error and
+   should be corrected in the same place I introduced it.
+2. **S6-2** shows as open; S1-2 closed it.
+3. **S6-6** shows as an unmeasured risk; it is measured above.
+4. **S5-5** cites a line number and a value that are both stale.
+
+**Effect of leaving them:** exactly what happened here — a reader trusts a marker
+and reaches a wrong conclusion. That is not hypothetical for this file; it is its
+recurring failure mode, and the duplication fixed in `422c915` was the same
+disease. The blurb is load-bearing precisely because it is the part people read
+instead of the 1,600 lines below it.
+
+**Effort: ~20 minutes**, all in `ROADMAP.md`.
+
+---
+
+## Suggested order
+
+1. **Doc staleness** (~20 min) — cheapest, and it stops the file misleading the
+   person who does the rest.
+2. **S6-7** (~15 min) — trivial, and it makes the workspace's own gate honest.
+3. **S6-5 step 3 only**: measure the mutation seeding cost. That measurement
+   decides whether step 1–2 of S6-5 is a half-day or a project.
+4. **S6-5 proper**, if the measurement allows.
+5. **S3-2**, only on the trigger stated above.

--- a/opencode-agent/docs/status-feedback-plan.md
+++ b/opencode-agent/docs/status-feedback-plan.md
@@ -14,6 +14,14 @@ Audit of the pipeline as it stands on `claude/opencode-agent-feedback-ux-mr89ep`
 then a staged plan. Nothing here is implemented yet; this is the design and the
 reasoning behind it, in the shape the rest of this workspace records decisions.
 
+**Re-anchored** against `origin/master` at `07b2586`, after nine state-machine
+fixes landed under this document. Three of them moved ground it stands on: a
+refused slash command now answers on the issue, `RunResult.reported` gave the
+pipeline a way to tell its own workflow whether it spoke, and the token-budget
+stop learned to park somewhere `/retry` can reach. What each one closed, left
+open, or made newly possible is recorded per finding below and summarised in the
+Drift Log at the end.
+
 ---
 
 ## 1. What a maintainer can see today
@@ -65,19 +73,32 @@ Answering "which of my twelve agent issues are waiting on me" means opening
 each one and reading the last comment's prose. An issue list, a project board, a
 notification — none of them carry a thing.
 
-**G4 — rejections are silent.** Every one of these produces a log line and
-nothing else:
+**G4 — rejections are silent — half closed upstream.** The premise was that a
+typo'd slash command and a broken pipeline look identical from the issue.
+`7d6958c` proved it the expensive way: a mis-set `AGENT_SELF_LOGIN` meant the
+agent could not read back its own state block, so every `/changes` was refused
+against a freshly-restarted state — and because refusals were silent, the bug was
+invisible for as long as nobody opened the Actions log. That commit closed the
+loudest half by adding `renderRefusedCommand`, which answers on the issue and
+lists what the current phase _does_ accept, derived from the transition table so
+it cannot drift from what the machine will take.
 
-| Path                                                      | What the maintainer typed                      |
-| --------------------------------------------------------- | ---------------------------------------------- |
-| `guardrails.ts` deny `NOT_MAINTAINER`                     | anything, from an account without write access |
-| `triggers.ts` `moveOrSkip` catch                          | `/approve` while in `REVIEW_AND_MUTATE`        |
-| `applyCommand` unknown command                            | `/aprove` — a typo                             |
-| `applyTrigger` `No actionable command while in ${phase}`  | a plain comment on a non-waiting phase         |
-| `applyIntent` `Comment needs no action` / `Empty comment` | a comment the classifier read as chatter       |
+What is still silent:
 
-A typo'd slash command and a broken pipeline look **exactly the same** from the
-issue. This is the cheapest gap to close and probably the most damaging one open.
+| Path                                                      | What the maintainer typed                      | Now                       |
+| --------------------------------------------------------- | ---------------------------------------------- | ------------------------- |
+| `triggers.ts` `moveOrSkip` catch → `refuseCommand`        | `/approve` while in `REVIEW_AND_MUTATE`        | **posts** a comment       |
+| `applyCommand` unknown command → `refuseCommand`          | `/aprove` — a typo                             | **posts** a comment       |
+| `guardrails.ts` deny `NOT_MAINTAINER`                     | anything, from an account without write access | silent                    |
+| `applyTrigger` `No actionable command while in ${phase}`  | a plain comment on a non-waiting phase         | silent                    |
+| `applyIntent` `Comment needs no action` / `Empty comment` | a comment the classifier read as chatter       | silent                    |
+| `ci-trigger.ts` `refuseUnfixablePhase` / settled PR       | nothing — a machine event                      | `warn`, silent on purpose |
+
+The three remaining human-facing rows are the ones where a comment would be the
+wrong instrument: a rejected outsider, and two readings of "this comment asked
+for nothing". Each still leaves a maintainer with no signal that the agent even
+saw them, which is what §4.1 is for — and the argument is now narrower and
+better, because the loud cases have a comment and these do not need one.
 
 **G5 — no live surface.** Comments are terminal by construction: `postAndAppend`
 is called with a finished `PhaseOutcome`. Nothing exists that can say "round 2 of
@@ -85,28 +106,60 @@ is called with a finished `PhaseOutcome`. Nothing exists that can say "round 2 o
 obviously wrong. The heartbeat that already knows all of this writes to a log
 nobody has a link to (G2).
 
-**G6 — no consistent visual vocabulary.** Emoji appear in exactly two places —
-`implement.ts`'s `REVIEW_LINE` (`✅ clean` / `❌ exited N` / `— not configured`)
-and `ci-fix.ts`'s check line — and nowhere else. Headings vary in register:
-`### Done`, `### Stopped`, `### Giving up`, `### Run failed in EXECUTION_PLAN`,
-`### Waiting`. There is no per-phase glyph, so nothing is scannable.
+**G6 — no consistent visual vocabulary — and it grew.** Emoji still appear in
+exactly two places: `implement.ts`'s `REVIEW_LINE` (`✅ clean` / `❌ exited N` /
+`— not configured`) and `ci-fix.ts`'s check line. `run-report.ts` went from six
+exported renderers to nine and carries **zero** — the new ones are
+`renderRefusedCommand`, `renderAnswerFailure` and `renderAnswerOverBudget`. So
+the register spread rather than settled: `### Done`, `### Stopped`,
+`### Giving up`, `### Waiting`, `### Run failed in EXECUTION_PLAN`,
+`### I could not answer that`, ``### `/approve` does not apply right now``,
+`### Token budget spent`. Every one of them is well-written and none of them is
+scannable as a class. Nine renderers is also past the point where a phase→glyph
+mapping can be added by hand without missing one, which is rule 5's whole
+argument.
 
-**G7 — spend is invisible until it is fatal.** `tokensSpent` is persisted and
-checked before every phase, and the only time it reaches the issue is
-`renderOverBudget`, at which point the issue is dead and `/retry` is explicitly a
-lie. A maintainer cannot see the burn approaching.
+**G7 — spend is invisible until it is fatal.** Still true, and the notice around
+it got much better without touching the gap. `af57837` made the over-budget stop
+park in `FAILED` with `resumeFrom`, and `renderOverBudget` now names the phase it
+parked, so "raise `AGENT_MAX_TOKENS`, reply `/retry`" is finally advice that
+works. `b3d4d3a` made every path that writes state record spend through one
+`recordSpend` seam, so the figure is no longer zero on the failure path. All of
+which improves what the issue says **at the wall** — none of it tells a
+maintainer they are approaching one. `tokensSpent` is read before every phase and
+surfaces to a human exactly once: when it is too late to act on.
 
 **G8 — the waiting comment says nothing useful.** `renderSettled` for a
 non-terminal phase renders `### Waiting\n\nParked in \`PLAN_REVIEW\`.` — the
 phase name, and no statement of what would move it. Every other waiting comment
 in the codebase carries a "What now?" block; this one does not.
 
-**G9 — the infrastructure fallback misses half its cases.** The workflow's
-`Report an infrastructure failure on the issue` step is gated on
-`failure() && github.event.issue.number`. A `workflow_run` event carries no
-`issue.number`, so a runner that dies during a CI-fix run posts **nothing**
-anywhere. `cancelled()` is not covered either, and a cancelled job is the
-documented consequence of G1 — a run that looks hung is a run someone cancels.
+**G9 — the infrastructure fallback misses two cases — narrowed.** This finding
+originally had two halves and the larger one is fixed. `04a324b` gave
+`RunResult` a required `reported` flag, wrote `reported=true` to `$GITHUB_OUTPUT`
+via `step-output.ts`, and gated the fallback step on it — so the six pipeline
+paths that exit 1 _after_ posting their own report no longer draw a second
+comment contradicting the first. That was the serious defect, and the fix is
+better than what this document would have proposed: the pipeline knows which of
+its exits spoke, so it says so, rather than the workflow guessing from a status
+that cannot distinguish them.
+
+What remains is coverage, on the line that commit deliberately left alone:
+
+```yaml
+if: failure() && github.event.issue.number && steps.pipeline.outputs.reported != 'true'
+```
+
+- `github.event.issue.number` is empty on a `workflow_run` event, so a runner
+  that dies during a **CI-fix** run still posts nothing anywhere. `04a324b`'s own
+  message names this — CI runs escaped the double-comment bug "by accident" —
+  which is the same fact seen from the side where it helps.
+- `cancelled()` is still not selected, and a cancelled job is the documented
+  consequence of G1: a run that looks hung is a run someone cancels.
+
+Kept here rather than split out, because both cases are the same failure this
+whole document is about — work happening, or stopping, with nothing on the issue
+to say so.
 
 ---
 
@@ -140,11 +193,21 @@ obvious designs.
    source of truth. Testable invariant, and worth pinning as one.
 5. **One place per vocabulary.** The recurring defect in this workspace is a fix
    that closes an instance and leaves the class open. A phase→emoji mapping
-   spread across five renderers is that defect waiting to happen; it goes in one
+   spread across nine renderers is that defect waiting to happen; it goes in one
    `Record<Phase, …>` so a phase added later fails to compile until it is named.
 6. **Comment budget.** More feedback fails by becoming noise. Hard budget: **at
    most one new comment per run** beyond the artefact comments that already
    exist. Everything else is a reaction, a label, or an edit.
+7. **A status comment is not a report.** `RunResult.reported` means "the issue
+   carries this run's account of what happened", and the workflow's fallback
+   comment is gated on it. A live status comment must therefore **never** set the
+   flag: a run killed mid-phase leaves "🛠️ Implementing — run in progress" on the
+   issue, which is the precise case the fallback exists for, and marking it
+   reported would suppress the one comment that would have explained the silence.
+   Finalising the status comment on a **returning** path is a different question
+   and still does not set it — the paths that report already do, and two writers
+   of one flag is how it drifts. The flag is required on every terminal path, so
+   a new one has to decide; this rule is what it decides.
 
 ---
 
@@ -205,17 +268,25 @@ label set is the papai-specific hardcoding S2-4 was reopened for.
 
 ### 4.1 Reactions — instant, zero-noise acknowledgement
 
-Closes **G1** and **G4**, and it is the cheapest thing in this document: one API
-call, no thread noise, and it lands on the comment the maintainer just wrote, so
-it is already where they are looking.
+Closes **G1** and what is left of **G4**, and it is the cheapest thing in this
+document: one API call, no thread noise, and it lands on the comment the
+maintainer just wrote, so it is already where they are looking.
 
 | Situation                                 | Reaction | Where                       |
 | ----------------------------------------- | -------- | --------------------------- |
 | Trigger accepted, work starting           | 👀       | triggering comment or issue |
 | Comment understood, nothing to do         | 👍       | triggering comment          |
-| Command rejected — wrong phase, unknown   | 😕       | triggering comment          |
 | Sender lacks maintainer rights            | 😕       | triggering comment          |
+| Command rejected — wrong phase, unknown   | 😕       | triggering comment          |
 | Run finished and delivered a pull request | 🚀       | triggering comment          |
+
+The fourth row is now **redundancy rather than the fix**: `refuseCommand` posts a
+comment naming the accepted commands, and that is the better answer. Keeping the
+reaction is still worth one call — it lands instantly, before the run has done
+anything, whereas the comment arrives after `postAndAppend` — but if the row has
+to be cut for noise, cut this one first. The rows that carry the argument now are
+the first two: 👀 is the only acknowledgement any trigger gets, and 👍 is the only
+trace a `Comment needs no action` classification leaves anywhere but the log.
 
 Silent on purpose, still: bot senders, self-recursion, pull-request targets and
 CI events. Those are machine noise with no human waiting on them, and the
@@ -269,6 +340,14 @@ entire comment budget from rule 6.
 **Budget:** 218k of 5,000,000 tokens · attempt 1 of 3
 ```
 
+The spec and plan rows carry their own revision numbers now — `418c1ad` split the
+shared `revision` counter into `specRevision` and `planRevision` precisely
+because one number could not honestly label two artefacts, and this table is the
+second place that would have gone wrong. It reads them, it does not recount.
+Likewise the CI budget line, when `CI_FIX` is the live phase, says "attempt 2 of
+3 **on this pull request**": `ciAttempts` is per pull request since `c4a43bd`,
+cleared when `handleDeliver` opens a new one.
+
 Design decisions worth recording, because each had a plausible alternative:
 
 - **One per run, not one per issue.** A single long-lived status comment edited
@@ -291,6 +370,39 @@ Design decisions worth recording, because each had a plausible alternative:
   grows an optional `onTick`; the log half is unchanged.
 - **A failed edit is a warning, not a failure** (rule 1), and a failed _create_
   degrades the run to today's behaviour exactly.
+- **It never sets `reported`** (rule 7). A stale "in progress" status is the
+  fallback comment's reason for existing, not a substitute for it.
+
+#### What `updateComment` also unlocks — and this plan now owns
+
+`applyIntent` records a leak it chose not to close: classification is the one
+model turn in the pipeline whose spend can never be written down, because state
+is persisted only by posting a comment and the `none` branch deliberately posts
+nothing. The comment names the fix — "a way to persist state without posting — an
+`updateComment` on the last state block" — and calls it a larger design change
+than a few thousand stray tokens justified. Stage 3 builds exactly that call for
+its own reasons, so the objection no longer holds, and the plan takes the fix on
+rather than leaving a documented leak beside the mechanism that closes it.
+
+This widens the goal by one sentence, deliberately: the plan is about feedback,
+and this is budget correctness. It is in scope because the cost of _not_ doing it
+once `updateComment` exists is a rule in three documents (the code comment,
+`CLAUDE.md`, the README) explaining why something is hard, next to the thing that
+made it easy.
+
+The mechanism is a `persistState` that rewrites the `AGENT_STATE` block in the
+comment that already carries the newest one, rather than appending. Two things it
+must respect, both already load-bearing:
+
+- **`findLatestState` scans newest-first for the newest agent comment with a
+  valid block.** Rewriting in place keeps that comment newest-with-a-block, so
+  the scan is unaffected. Rewriting the _wrong_ comment is the failure mode; the
+  target is the comment `findLatestState` itself selected, not the last comment
+  in the thread.
+- **The block escaping in `blocks.ts` is what makes this safe at all** —
+  `renderBlock` escapes every `<` and `>` so a payload cannot forge its own
+  terminator (S1-4). An in-place rewrite re-serialises through the same path or
+  it reintroduces that bug on a new surface.
 
 Shape: a `StatusReporter` interface on `PhaseDeps` — `start(state)`,
 `enter(phase)`, `tick(snapshot)`, `finish(result)` — with a no-op implementation
@@ -317,23 +429,32 @@ absent for local runs. Once it exists:
 Every skip path, with the decision. This table is the deliverable for **G4** —
 the point is that no row is left as "log only" by omission.
 
-| Path                                       | Today   | Proposed                                             |
-| ------------------------------------------ | ------- | ---------------------------------------------------- |
-| `NOT_MAINTAINER`                           | log     | 😕 reaction                                          |
-| `PULL_REQUEST` / `BOT_SENDER` / `SELF_*`   | log     | log — machine noise, nobody is waiting               |
-| `UNSUPPORTED_EVENT` / `UNSUPPORTED_ACTION` | log     | log                                                  |
-| `CI_*` denials                             | log     | log — no human triggered them                        |
-| Unknown command (`/aprove`)                | log     | 😕 reaction                                          |
-| Command invalid in phase                   | log     | 😕 reaction; the status comment lists valid commands |
-| Plain comment, non-waiting phase           | log     | 👍 reaction                                          |
-| `Comment needs no action` / empty          | log     | 👍 reaction                                          |
-| Retry / token / CI budget exhausted        | comment | unchanged — these are already right                  |
+| Path                                                    | Today       | Proposed                                   |
+| ------------------------------------------------------- | ----------- | ------------------------------------------ |
+| `NOT_MAINTAINER`                                        | log         | 😕 reaction                                |
+| `PULL_REQUEST` / `BOT_SENDER` / `SELF_*`                | log         | log — machine noise, nobody is waiting     |
+| `UNSUPPORTED_EVENT` / `UNSUPPORTED_ACTION`              | log         | log                                        |
+| `CI_*` guardrail denials                                | log         | log — no human triggered them              |
+| `refuseUnfixablePhase` (red run, no fixable phase)      | `warn`      | log — argued out in `ci-trigger.ts`        |
+| `settledPullRequest` (red run, merged/closed/absent PR) | log         | log — CI fires per push; a comment is spam |
+| Unknown command (`/aprove`)                             | **comment** | keep; add 😕 reaction as instant echo      |
+| Command invalid in phase                                | **comment** | keep; add 😕 reaction as instant echo      |
+| Plain comment, non-waiting phase                        | log         | 👍 reaction                                |
+| `Comment needs no action` / empty                       | log         | 👍 reaction                                |
+| Retry / token / CI budget exhausted                     | comment     | unchanged — these are already right        |
 
-Reaction rather than comment for the rejections, deliberately. A wrong-phase
-`/approve` is usually followed by a second attempt; a comment per attempt turns
-one confused maintainer into a thread of bot replies. The reaction says "seen and
-declined" and the status comment — which states the valid commands for the
-current phase — says why.
+Four rows changed since the first draft and all four moved the same way: toward
+the pipeline already doing the right thing. The two command refusals now post
+`renderRefusedCommand`, which is strictly better than the reaction this document
+proposed — it names the commands the phase accepts, from the transition table, so
+it cannot go stale. The two CI rows are silent by an argument written out at
+length in `ci-trigger.ts`, and it is a better argument than "add feedback here"
+would be: a red run fires on every push and re-run, the phases that refuse are
+ones where either nothing is pushed yet or the issue is already parked under a
+failure comment saying what to do.
+
+That leaves three genuinely silent human-facing rows, and the reaction channel is
+sized to exactly those.
 
 And **G8**: `renderSettled`'s non-terminal branch gains the same "What now?"
 block every other waiting comment carries, read from the presentation table.
@@ -342,13 +463,16 @@ block every other waiting comment carries, read from the presentation table.
 
 ## 6. Workflow changes
 
-Small, and only two of them matter.
+Smaller than they were — `04a324b` did the hard half.
 
-- **Fix the infrastructure fallback (G9).** Resolve the issue number from
+- **Finish the infrastructure fallback (G9).** Keep the
+  `steps.pipeline.outputs.reported != 'true'` gate exactly as it is; it is the
+  part that works. Widen the other two conditions: resolve the issue number from
   `github.event.issue.number` **or** the `workflow_run.head_branch`'s
-  `agent/issue-<n>` suffix, and fire on `failure() || cancelled()`. A cancelled
-  job is the documented consequence of a run that looks hung, and it currently
-  leaves the issue mid-phase with no explanation at all.
+  `agent/issue-<n>` suffix (`issueNumberFromBranch` already does this in
+  `git.ts`, so the workflow expression and the pipeline agree on the shape), and
+  fire on `failure() || cancelled()`. Both additions are inside the `reported`
+  gate, so neither can bring back the double comment.
 - **Add an `if: always()` label cleanup step** removing `agent:working`, so a
   killed runner cannot strand the marker (belt to the in-run reconcile's braces).
 - Optionally surface `AGENT_LABEL_PREFIX` alongside the other `vars.AGENT_*`
@@ -357,6 +481,10 @@ Small, and only two of them matter.
 No permission change: `issues: write` already covers labels, reactions and
 comment edits.
 
+`workflow.test.ts` already parses the workflow and pins its trigger surface,
+including that the fallback's `if:` names the same output key `step-output.ts`
+writes — so both changes here land in a file that is asserted, not assumed.
+
 ---
 
 ## 7. Sequencing
@@ -364,13 +492,18 @@ comment edits.
 Each stage is independently shippable and independently useful. Stage 1 alone
 closes the two worst gaps.
 
-| Stage | Contents                                                                                                                                                  | Closes                  |
-| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| **1** | `runUrl` in config; `commentId` on `IssueTriggerEvent`; `addReaction`; acknowledgement + rejection reactions; run link in the failure and CI-fix comments | G1, G2, G4              |
-| **2** | `presentation.ts`; label reconciler; `AGENT_LABEL_PREFIX`; `renderSettled` gains next steps                                                               | G3, G6, G8              |
-| **3** | `StatusReporter`; `updateComment`; the live status comment; heartbeat `onTick`; budget line                                                               | G5, G7, and G2 properly |
-| **4** | Workflow fallback and cleanup fixes                                                                                                                       | G9                      |
-| **5** | README "Watching a run" rewritten around the issue rather than the log; a `CLAUDE.md` local rule for the feedback-is-best-effort invariant                | —                       |
+| Stage | Contents                                                                                                                                                                                         | Closes                  |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- |
+| **1** | `runUrl` in config; `commentId` on `IssueTriggerEvent`; `addReaction`; acknowledgement + remaining-silence reactions; run link in the failure and CI-fix comments                                | G1, G2, G4 remainder    |
+| **2** | `presentation.ts`; label reconciler; `AGENT_LABEL_PREFIX`; `renderSettled` gains next steps                                                                                                      | G3, G6, G8              |
+| **3** | `StatusReporter`; `updateComment`; the live status comment; heartbeat `onTick`; budget line; **`persistState` closing the classifier's accounting leak** (§4.3)                                  | G5, G7, and G2 properly |
+| **4** | Workflow fallback widened to `workflow_run` and `cancelled()`, inside the existing `reported` gate; `if: always()` label cleanup                                                                 | G9 remainder            |
+| **5** | README "Watching a run" rewritten around the issue rather than the log; `CLAUDE.md` local rules for rule 1 (best-effort) and rule 7 (`reported`); the three notes on the classifier leak retired | —                       |
+
+Stage 1 is unchanged in size but no longer the only thing standing between a
+maintainer and a silent refusal — `refuseCommand` shipped that. It is still where
+the acknowledgement and the run link live, which are the two things nothing else
+covers.
 
 ---
 
@@ -400,9 +533,21 @@ Following `tests/CLAUDE.md` and this workspace's own habits.
   new path rather than trusted to it.
 - **Rate limiting.** An injected clock proves a second `tick` inside the window
   issues no request, and that an unchanged body issues none regardless.
+- **`reported` stays false for a status comment** (rule 7). A run killed after
+  the status comment exists but before any report must still leave the flag
+  unset, so the workflow's fallback fires. `RunResult.reported` is required, so
+  the compiler catches a new terminal path that forgets to decide — but not one
+  that decides wrongly, which is what this test is for.
+- **`persistState` rewrites the right comment.** State restored after an in-place
+  rewrite equals the state written; the target is the comment `findLatestState`
+  selected, not the newest in the thread; and a payload containing `-->` survives
+  the round trip, because an in-place rewrite that bypasses `renderBlock`'s
+  escaping reintroduces S1-4 on a new surface.
 - Mutation-check hints for the reviewer: empty the reaction map; make the
   reconcile clear-and-reapply; drop the unchanged-body guard; let a thrown label
-  error propagate. Each should kill the test that names it.
+  error propagate; set `reported: true` when the status comment is created; point
+  `persistState` at the last comment instead of the selected one. Each should
+  kill the test that names it.
 
 ---
 
@@ -422,3 +567,23 @@ Following `tests/CLAUDE.md` and this workspace's own habits.
   text, not the agent's), GitHub Checks or Deployments as a status surface (a
   much larger integration for the same information), project-board automation,
   and any notification channel outside the issue.
+
+---
+
+## Drift Log
+
+Append-only. Each row is a reconciliation decision, not a change to the code.
+
+| Date       | Category               | Item                                                                                                    | Decision                                                                                                                   |
+| ---------- | ---------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| 2026-08-07 | Base moved             | Rebased `069f96e` → `07b2586` (nine opencode-agent fixes)                                               | Plan re-anchored; every claim below re-verified against the tree at `07b2586`                                              |
+| 2026-08-07 | In-plan, partial       | **G4** — `7d6958c` added `renderRefusedCommand`                                                         | Rewritten: 2 of 5 rows closed by a comment. §4.1 and §5 narrowed to the three remaining silent rows                        |
+| 2026-08-07 | In-plan, partial       | **G9** — `04a324b` added `RunResult.reported` + `step-output.ts` + the gate                             | Narrowed to `workflow_run` coverage and `cancelled()`; the double-comment half recorded as fixed, and better than proposed |
+| 2026-08-07 | In-plan, stale framing | **G7** — `af57837`, `b3d4d3a` fixed the over-budget park and spend recording                            | Gap unchanged, framing rewritten: the notices at the wall are now right, the approach to it is still invisible             |
+| 2026-08-07 | In-plan, accurate      | **G6** — `run-report.ts` 6 → 9 renderers, still zero emoji                                              | Strengthened; nine renderers is past hand-maintainable, which is rule 5's argument                                         |
+| 2026-08-07 | In-plan, accurate      | **G1, G2, G3, G5, G8** — untouched by the nine fixes                                                    | Kept verbatim; `renderSettled` re-read and is byte-identical                                                               |
+| 2026-08-07 | Out-of-plan, on-goal   | `RunResult.reported` semantics vs. a live status comment                                                | **User: add.** New design rule 7 — a status comment never sets the flag; test row and mutation hint added                  |
+| 2026-08-07 | Out-of-plan, on-goal   | `applyIntent`'s documented accounting leak, whose stated fix is `updateComment`                         | **User: add as an explicit stage-3 task.** §4.3 gains `persistState`; goal widened by one sentence, stated in place        |
+| 2026-08-07 | In-plan, stale anchors | `triggers.ts` split; `ci-trigger.ts`, `token-budget.ts`, `trigger-outcome.ts`, `step-output.ts` are new | All module references refreshed; `skip()` now takes a `reported` argument stage 1 must pass                                |
+| 2026-08-07 | Out-of-plan, on-goal   | `specRevision` / `planRevision` split; `ciAttempts` now per pull request                                | Folded into the §4.3 status-comment spec — it reads both, and must not recount either                                      |
+| 2026-08-07 | No plan claim          | `identity.ts`, `deps.ts`, `prompts.ts`, `phases/*`, `state-manager.ts`, tests                           | No plan change. `identity.ts`'s bug is cited under G4 as evidence the audit's premise was real                             |

--- a/opencode-agent/docs/status-feedback-plan.md
+++ b/opencode-agent/docs/status-feedback-plan.md
@@ -1,0 +1,424 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Status feedback UX — audit and plan
+
+How a maintainer finds out what the agent is doing, in what state their issue
+is, and where the job that is doing it lives.
+
+Audit of the pipeline as it stands on `claude/opencode-agent-feedback-ux-mr89ep`,
+then a staged plan. Nothing here is implemented yet; this is the design and the
+reasoning behind it, in the shape the rest of this workspace records decisions.
+
+---
+
+## 1. What a maintainer can see today
+
+Three surfaces exist, and only one of them is durable.
+
+| Surface            | Written by                                           | When                        | Seen by                  |
+| ------------------ | ---------------------------------------------------- | --------------------------- | ------------------------ |
+| Issue comments     | `run-report.ts` `postAndAppend`, from phase handlers | **only when a phase ends**  | everyone                 |
+| Actions job log    | `progress.ts` events + heartbeat                     | continuously, once a minute | whoever opens it         |
+| Hidden state block | `state-manager.ts` `renderStateComment`              | with every comment          | nobody — it is a comment |
+
+That is the whole of it. There are no labels, no reactions, no issue-title
+decoration, no link from the issue to the run doing the work, and no surface
+that is updated _while_ a phase runs.
+
+Verified absences, not assumptions:
+
+- `grep -rn 'GITHUB_RUN\|run_id\|runUrl' src/` finds `runUrl` only on
+  `CiTriggerEvent` — the URL of the **red run that triggered** a CI fix. The
+  pipeline never learns the URL of its _own_ run. The one place it exists is the
+  workflow's failure fallback step, which builds `RUN_URL` in YAML and only ever
+  posts it when the job itself dies.
+- `grep -rni 'label\|reaction' src/` finds four unrelated hits (an
+  `activity.ts` comment, `prompts.ts`'s envelope `label`). `GitHubApi` has seven
+  methods; none of them touches a label or a reaction.
+- `issuePayloadSchema` parses `comment.id`, and `parseIssueEvent` **drops it** —
+  so the pipeline currently cannot address the comment that triggered it even if
+  it wanted to.
+
+### The nine gaps
+
+**G1 — nothing acknowledges a trigger.** A maintainer types `/approve` and the
+next thing that appears on the issue is the finished artefact, up to
+`AGENT_TIMEOUT_MS` (default 30 minutes) later; `REVIEW_AND_MUTATE` also runs the
+whole `review-loop/` workspace inside that silence, under a 90-minute job
+timeout. For that entire window the issue is indistinguishable from one where
+the workflow never fired at all — which is also a real outcome, since a
+guardrail can drop the event.
+
+**G2 — no link to the running job.** The one question a maintainer has during
+the silence in G1 is "is something actually running, and where do I look". The
+answer exists (`GITHUB_RUN_ID` is in the runner environment of every step) and is
+never wired anywhere. Even the CI-fix comment, which _does_ post a run URL, posts
+the red run's — not the agent run repairing it.
+
+**G3 — the state is invisible at a glance.** The phase lives in an HTML comment.
+Answering "which of my twelve agent issues are waiting on me" means opening
+each one and reading the last comment's prose. An issue list, a project board, a
+notification — none of them carry a thing.
+
+**G4 — rejections are silent.** Every one of these produces a log line and
+nothing else:
+
+| Path                                                      | What the maintainer typed                      |
+| --------------------------------------------------------- | ---------------------------------------------- |
+| `guardrails.ts` deny `NOT_MAINTAINER`                     | anything, from an account without write access |
+| `triggers.ts` `moveOrSkip` catch                          | `/approve` while in `REVIEW_AND_MUTATE`        |
+| `applyCommand` unknown command                            | `/aprove` — a typo                             |
+| `applyTrigger` `No actionable command while in ${phase}`  | a plain comment on a non-waiting phase         |
+| `applyIntent` `Comment needs no action` / `Empty comment` | a comment the classifier read as chatter       |
+
+A typo'd slash command and a broken pipeline look **exactly the same** from the
+issue. This is the cheapest gap to close and probably the most damaging one open.
+
+**G5 — no live surface.** Comments are terminal by construction: `postAndAppend`
+is called with a finished `PhaseOutcome`. Nothing exists that can say "round 2 of
+4" or "still working" without adding a comment, and adding a comment per tick is
+obviously wrong. The heartbeat that already knows all of this writes to a log
+nobody has a link to (G2).
+
+**G6 — no consistent visual vocabulary.** Emoji appear in exactly two places —
+`implement.ts`'s `REVIEW_LINE` (`✅ clean` / `❌ exited N` / `— not configured`)
+and `ci-fix.ts`'s check line — and nowhere else. Headings vary in register:
+`### Done`, `### Stopped`, `### Giving up`, `### Run failed in EXECUTION_PLAN`,
+`### Waiting`. There is no per-phase glyph, so nothing is scannable.
+
+**G7 — spend is invisible until it is fatal.** `tokensSpent` is persisted and
+checked before every phase, and the only time it reaches the issue is
+`renderOverBudget`, at which point the issue is dead and `/retry` is explicitly a
+lie. A maintainer cannot see the burn approaching.
+
+**G8 — the waiting comment says nothing useful.** `renderSettled` for a
+non-terminal phase renders `### Waiting\n\nParked in \`PLAN_REVIEW\`.` — the
+phase name, and no statement of what would move it. Every other waiting comment
+in the codebase carries a "What now?" block; this one does not.
+
+**G9 — the infrastructure fallback misses half its cases.** The workflow's
+`Report an infrastructure failure on the issue` step is gated on
+`failure() && github.event.issue.number`. A `workflow_run` event carries no
+`issue.number`, so a runner that dies during a CI-fix run posts **nothing**
+anywhere. `cancelled()` is not covered either, and a cancelled job is the
+documented consequence of G1 — a run that looks hung is a run someone cancels.
+
+---
+
+## 2. Design rules this has to obey
+
+The workspace's existing rules constrain the solution more than the solution
+constrains itself. Stating them up front because two of them kill otherwise
+obvious designs.
+
+1. **Feedback must never fail a run.** Every write added here is decoration on
+   work that matters. A 403 on a label (a token without `issues: write`, a fork
+   run, an org policy) must degrade to `log.warn`, never to a failed phase. This
+   is the single most important rule in the plan, because every new call is a new
+   way to break a pipeline that used to work.
+2. **Never send free text through a new `GitHubApi` method without `clean`.**
+   `CLAUDE.md` states it; `github.ts` enforces it by making `secrets` required.
+   `updateComment` carries free text and must be redacted exactly like
+   `createComment`. Label names and reaction contents are pipeline-computed
+   constants, so they are treated like `head`/`base` branch names — passed
+   through untouched, and that exemption is stated in code rather than implied.
+3. **Progress carries names, statuses and counts only.** `activity.ts` decodes
+   through schemas that give tool input, tool output and model text nowhere to
+   land. An issue comment _is_ covered by outbound redaction, unlike the log — but
+   the rule still holds when piping activity to the issue, because a redaction
+   list only knows the secrets the pipeline loaded, and a status line is not the
+   place to relax that.
+4. **The state block is the durability channel and must stay untouched.**
+   `findLatestState` restores from the newest agent comment carrying a valid
+   block. Any new comment this plan introduces must **not** carry an
+   `AGENT_STATE` block, or an edited status comment becomes a second, competing
+   source of truth. Testable invariant, and worth pinning as one.
+5. **One place per vocabulary.** The recurring defect in this workspace is a fix
+   that closes an instance and leaves the class open. A phase→emoji mapping
+   spread across five renderers is that defect waiting to happen; it goes in one
+   `Record<Phase, …>` so a phase added later fails to compile until it is named.
+6. **Comment budget.** More feedback fails by becoming noise. Hard budget: **at
+   most one new comment per run** beyond the artefact comments that already
+   exist. Everything else is a reaction, a label, or an edit.
+
+---
+
+## 3. The vocabulary
+
+One module, `src/presentation.ts`, owning a total `Record<Phase, PhasePresentation>`.
+Every renderer, the label reconciler and the status comment read from it.
+
+| Phase               | Glyph | Label                | Whose turn | Headline                       |
+| ------------------- | ----- | -------------------- | ---------- | ------------------------------ |
+| `INIT_OR_CLARIFY`   | 🔍    | `agent:triaging`     | agent      | Reading the issue              |
+| `INIT_OR_CLARIFY`\* | ❓    | `agent:clarifying`   | **you**    | Waiting on your answers        |
+| `DESIGN_SPEC`       | 📋    | `agent:spec-review`  | **you**    | Design spec is waiting for you |
+| `EXECUTION_PLAN`    | 🗺️    | `agent:planning`     | agent      | Breaking the spec into steps   |
+| `PLAN_REVIEW`       | 🧭    | `agent:plan-review`  | **you**    | Plan is waiting for you        |
+| `REVIEW_AND_MUTATE` | 🛠️    | `agent:implementing` | agent      | Writing and reviewing the code |
+| `PR_DELIVERY`       | 📦    | `agent:delivering`   | agent      | Opening the pull request       |
+| `CI_FIX`            | 🚑    | `agent:ci-fixing`    | agent      | Repairing red checks           |
+| `COMPLETE` + PR     | ✅    | `agent:done`         | —          | Delivered                      |
+| `COMPLETE`, no PR   | 🛑    | `agent:stopped`      | —          | Stopped                        |
+| `FAILED`            | ❌    | `agent:failed`       | **you**    | Run failed                     |
+
+\* `INIT_OR_CLARIFY` is the one phase that is both a working state and a waiting
+state — it is where the agent sits after asking questions. The presentation is
+therefore keyed on `(phase, whether the last signal was NEEDS_CLARIFICATION)`,
+not on the phase alone. Handling that by hand in each renderer is precisely the
+class of bug rule 5 exists to prevent, so it belongs in the table's key.
+
+Two orthogonal markers carry the actual filtering value, and they are the part
+worth shipping even if the per-phase labels are dropped:
+
+- **`agent:working`** — set at the start of a run, removed when it ends,
+  whatever the outcome. "Is something happening right now", answerable from a
+  list view.
+- **`agent:needs-you`** — set in every **you** row above. "Which of my issues are
+  blocked on me", which is the question that actually costs a maintainer time.
+
+`agent:working` has one failure mode: a runner killed mid-flight leaves it stuck
+on. Two mitigations, both needed, because either alone leaves a hole — an
+`if: always()` cleanup step in the workflow, **and** a reconcile at the top of
+every run that computes the desired label set from the restored state and
+removes any `agent:*` label the state does not imply. The reconcile is the one
+that also repairs an issue whose labels were edited by hand.
+
+**Accessibility.** The glyph is decoration and never the only carrier of
+meaning: the phase word sits next to it in every rendering, and the label name is
+plain text. A screen reader that announces "clipboard, design spec is waiting for
+you" loses nothing by dropping the first word.
+
+**Namespacing.** `AGENT_LABEL_PREFIX` defaults to `agent:`; setting it to `none`
+disables labelling entirely. Same shape as `AGENT_REVIEW_COMMAND` — the pipeline
+already knows it runs in repositories with their own conventions, and a hardcoded
+label set is the papai-specific hardcoding S2-4 was reopened for.
+
+---
+
+## 4. The four channels, and what each one is for
+
+### 4.1 Reactions — instant, zero-noise acknowledgement
+
+Closes **G1** and **G4**, and it is the cheapest thing in this document: one API
+call, no thread noise, and it lands on the comment the maintainer just wrote, so
+it is already where they are looking.
+
+| Situation                                 | Reaction | Where                       |
+| ----------------------------------------- | -------- | --------------------------- |
+| Trigger accepted, work starting           | 👀       | triggering comment or issue |
+| Comment understood, nothing to do         | 👍       | triggering comment          |
+| Command rejected — wrong phase, unknown   | 😕       | triggering comment          |
+| Sender lacks maintainer rights            | 😕       | triggering comment          |
+| Run finished and delivered a pull request | 🚀       | triggering comment          |
+
+Silent on purpose, still: bot senders, self-recursion, pull-request targets and
+CI events. Those are machine noise with no human waiting on them, and the
+existing log line is the right amount of record.
+
+Wiring needed: carry `comment.id` out of `parseIssueEvent` (the schema already
+parses it and throws it away), and add `addReaction` to `GitHubApi`. Reactions
+are idempotent server-side — a repeat returns the existing one — so no
+bookkeeping is required.
+
+The one judgement call: reacting to a `NOT_MAINTAINER` comment is a write
+triggered by someone without write access. It is bounded (one reaction per
+comment, no content, no notification storm), and the alternative is that an
+outside contributor's comment vanishes into a log they cannot read.
+
+### 4.2 Labels — the at-a-glance state
+
+Closes **G3**. Reconciled once per run and once more at the end, computing the
+desired set from state and issuing the minimal add/remove diff — not a
+clear-and-reapply, which would produce two timeline entries per phase and a
+visible flicker.
+
+Labels are created on demand with a fixed palette (blue for agent-owned states,
+amber for `needs-you`, green for done, red for failed, grey for stopped), and a
+422 from `createLabel` means it already exists and is ignored. Per rule 1, every
+label call is best-effort.
+
+### 4.3 The live status comment — what is happening right now
+
+Closes **G2**, **G5**, **G7** and **G8**. This is the substantial piece.
+
+One comment per **run**, created when the run starts, edited as it progresses,
+finalised when it ends. It is the only comment this plan adds, which is the
+entire comment budget from rule 6.
+
+```markdown
+### 🛠️ Implementing — run in progress
+
+**Job:** [run #1482, attempt 1](https://github.com/o/r/actions/runs/1482) · started 14:02 UTC · 6m elapsed
+**Branch:** `agent/issue-42` · **Pull request:** _not opened yet_
+
+| Phase             |             |
+| ----------------- | ----------- |
+| 🔍 Triage         | ✅          |
+| 📋 Design spec    | ✅ approved |
+| 🗺️ Execution plan | ✅ approved |
+| 🛠️ Implementation | ⏳ **now**  |
+| 📦 Pull request   | ⬜          |
+
+**Doing:** `bash` (running) · 34 tool calls · 218k tokens
+**Budget:** 218k of 5,000,000 tokens · attempt 1 of 3
+```
+
+Design decisions worth recording, because each had a plausible alternative:
+
+- **One per run, not one per issue.** A single long-lived status comment edited
+  forever ends up hundreds of comments above the thing the maintainer just
+  typed, which defeats the purpose. Per-run keeps it at the bottom where the
+  conversation is, gives every run a permanent record, and — usefully — needs no
+  `AgentState` field at all in v1, since the id lives only for the life of the
+  process that created it.
+- **It carries no `AGENT_STATE` block** (rule 4). The phase-end comments remain
+  the sole state channel, so the durability path this plan touches is _none of
+  it_. Worth an explicit test: the state restored from a thread containing status
+  comments must equal the state restored from the same thread without them.
+- **Edits are rate-limited to one per 60 s and skipped when the rendered body is
+  unchanged.** A 90-minute run then costs at most ~90 edits, comfortably inside
+  the secondary rate limit on content-mutating requests, and unchanged-body
+  suppression means a quiet stretch costs nothing.
+- **The activity line comes from the existing `ProgressSnapshot`**, which already
+  carries exactly `lastAction`, `toolCalls`, `tokens`, `cost` and nothing else —
+  so rule 3 is satisfied by construction rather than by care. `HeartbeatOptions`
+  grows an optional `onTick`; the log half is unchanged.
+- **A failed edit is a warning, not a failure** (rule 1), and a failed _create_
+  degrades the run to today's behaviour exactly.
+
+Shape: a `StatusReporter` interface on `PhaseDeps` — `start(state)`,
+`enter(phase)`, `tick(snapshot)`, `finish(result)` — with a no-op implementation
+used by every existing test and by local `--event-path` runs that have no run
+URL. Injected like every other boundary in this workspace.
+
+### 4.4 Run links everywhere else
+
+`GITHUB_RUN_ID` / `GITHUB_RUN_ATTEMPT` / `GITHUB_SERVER_URL` /
+`GITHUB_REPOSITORY` are present in every step's environment (GitHub sets them;
+`scrubSecrets` matches by _value_, so they survive it), which means the run URL
+needs **no workflow change** — only a nullable `runUrl` on `PipelineConfig`,
+absent for local runs. Once it exists:
+
+- the failure comment says which run failed, so `/retry` is not the only lead;
+- the CI-fix comment distinguishes "the red run I am fixing" from "the run
+  fixing it", which today are the same word;
+- the pull request body links the run that produced it.
+
+---
+
+## 5. Breaking the remaining silences
+
+Every skip path, with the decision. This table is the deliverable for **G4** —
+the point is that no row is left as "log only" by omission.
+
+| Path                                       | Today   | Proposed                                             |
+| ------------------------------------------ | ------- | ---------------------------------------------------- |
+| `NOT_MAINTAINER`                           | log     | 😕 reaction                                          |
+| `PULL_REQUEST` / `BOT_SENDER` / `SELF_*`   | log     | log — machine noise, nobody is waiting               |
+| `UNSUPPORTED_EVENT` / `UNSUPPORTED_ACTION` | log     | log                                                  |
+| `CI_*` denials                             | log     | log — no human triggered them                        |
+| Unknown command (`/aprove`)                | log     | 😕 reaction                                          |
+| Command invalid in phase                   | log     | 😕 reaction; the status comment lists valid commands |
+| Plain comment, non-waiting phase           | log     | 👍 reaction                                          |
+| `Comment needs no action` / empty          | log     | 👍 reaction                                          |
+| Retry / token / CI budget exhausted        | comment | unchanged — these are already right                  |
+
+Reaction rather than comment for the rejections, deliberately. A wrong-phase
+`/approve` is usually followed by a second attempt; a comment per attempt turns
+one confused maintainer into a thread of bot replies. The reaction says "seen and
+declined" and the status comment — which states the valid commands for the
+current phase — says why.
+
+And **G8**: `renderSettled`'s non-terminal branch gains the same "What now?"
+block every other waiting comment carries, read from the presentation table.
+
+---
+
+## 6. Workflow changes
+
+Small, and only two of them matter.
+
+- **Fix the infrastructure fallback (G9).** Resolve the issue number from
+  `github.event.issue.number` **or** the `workflow_run.head_branch`'s
+  `agent/issue-<n>` suffix, and fire on `failure() || cancelled()`. A cancelled
+  job is the documented consequence of a run that looks hung, and it currently
+  leaves the issue mid-phase with no explanation at all.
+- **Add an `if: always()` label cleanup step** removing `agent:working`, so a
+  killed runner cannot strand the marker (belt to the in-run reconcile's braces).
+- Optionally surface `AGENT_LABEL_PREFIX` alongside the other `vars.AGENT_*`
+  knobs.
+
+No permission change: `issues: write` already covers labels, reactions and
+comment edits.
+
+---
+
+## 7. Sequencing
+
+Each stage is independently shippable and independently useful. Stage 1 alone
+closes the two worst gaps.
+
+| Stage | Contents                                                                                                                                                  | Closes                  |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| **1** | `runUrl` in config; `commentId` on `IssueTriggerEvent`; `addReaction`; acknowledgement + rejection reactions; run link in the failure and CI-fix comments | G1, G2, G4              |
+| **2** | `presentation.ts`; label reconciler; `AGENT_LABEL_PREFIX`; `renderSettled` gains next steps                                                               | G3, G6, G8              |
+| **3** | `StatusReporter`; `updateComment`; the live status comment; heartbeat `onTick`; budget line                                                               | G5, G7, and G2 properly |
+| **4** | Workflow fallback and cleanup fixes                                                                                                                       | G9                      |
+| **5** | README "Watching a run" rewritten around the issue rather than the log; a `CLAUDE.md` local rule for the feedback-is-best-effort invariant                | —                       |
+
+---
+
+## 8. Test plan
+
+Following `tests/CLAUDE.md` and this workspace's own habits.
+
+- **Presentation is total.** `Record<Phase, …>` makes a missing phase a compile
+  error; a test asserts every `PHASES` entry resolves and that no two phases
+  share a label.
+- **Label reconcile is a diff.** Unchanged state issues zero calls; a phase move
+  issues exactly one add and one remove; an issue carrying a hand-added
+  `agent:*` label is repaired.
+- **The state channel is untouched.** `findLatestState` over a thread with status
+  comments interleaved equals the same call without them — the invariant from
+  rule 4, and the one that would be expensive to discover later.
+- **Feedback failures are not run failures.** A `GitHubApi` fake that throws on
+  every label, reaction and edit call still drives a full pipeline to the same
+  `RunResult` and the same **persisted state**. This is the rule-1 test and it is
+  the most important one here.
+- **Transport-level assertions for the new methods**, through the existing
+  `fetch` seam. This workspace's recorded lesson (S2-6, S3-3, S3-8, S3-9) is that
+  a correct adapter which is never wired in passes every phase test; `contain`
+  and `assembleDeps` must be exercised, not just the modules.
+- **Redaction covers `updateComment`.** A status body carrying a credential goes
+  out clean — the same assertion `createComment` already carries, extended to the
+  new path rather than trusted to it.
+- **Rate limiting.** An injected clock proves a second `tick` inside the window
+  issues no request, and that an unchanged body issues none regardless.
+- Mutation-check hints for the reviewer: empty the reaction map; make the
+  reconcile clear-and-reapply; drop the unchanged-body guard; let a thrown label
+  error propagate. Each should kill the test that names it.
+
+---
+
+## 9. Risks and non-goals
+
+- **Noise is the failure mode.** Rule 6's one-comment budget is the mitigation,
+  and it is worth re-checking against a real long conversation before stage 3
+  ships.
+- **Label churn in a repository with its own conventions.** Namespaced and
+  disableable; the prefix knob is not optional polish.
+- **API budget.** A run costs roughly 10–40 extra calls against 5,000/hour. The
+  status edits are the only sustained writer and are capped at 1/minute.
+- **A public issue is a public surface.** Everything new goes through the
+  outbound redaction in `github.ts`, and the status comment carries only the
+  scalar `ProgressSnapshot` fields — no tool input, no model text.
+- **Explicitly not in scope:** editing the issue title or body (the maintainer's
+  text, not the agent's), GitHub Checks or Deployments as a status surface (a
+  much larger integration for the same information), project-board automation,
+  and any notification channel outside the issue.

--- a/opencode-agent/src/blocks.ts
+++ b/opencode-agent/src/blocks.ts
@@ -85,17 +85,31 @@ export const readBlock = (body: string, marker: string): unknown => {
   return found
 }
 
+/** A block, and the comment it was read out of. */
+export interface BlockLocation {
+  comment: IssueComment
+  block: unknown
+}
+
 /**
  * Walks the thread newest-first and returns the first block written by the
- * agent itself. Author filtering is the whole security model here: anyone can
- * paste a block into a comment, but only the agent's own comments are read.
+ * agent itself, **with the comment carrying it**. Author filtering is the whole
+ * security model here: anyone can paste a block into a comment, but only the
+ * agent's own comments are read.
+ *
+ * The comment is returned rather than only the payload because rewriting a
+ * block in place has to address the comment the *reader* selected. Two scans —
+ * one to read the state and another to find something to rewrite — can disagree
+ * whenever the thread has more than one candidate, and rewriting the wrong
+ * comment is the failure mode of an in-place update. One scan, and every caller
+ * derived from it, makes them agree by construction.
  */
-export const findLatestBlock = (
+export const locateLatestBlock = (
   thread: readonly IssueComment[],
   agentLogin: string,
   marker: string,
   accept: (block: unknown) => boolean = (): boolean => true,
-): unknown => {
+): BlockLocation | null => {
   const normalizedAgent = agentLogin.toLowerCase()
 
   for (let index = thread.length - 1; index >= 0; index -= 1) {
@@ -107,10 +121,43 @@ export const findLatestBlock = (
     // A block the caller rejects is walked past, not surrendered to. Returning
     // the newest *readable* block and letting the caller validate afterwards
     // meant one corrupt or foreign block masked every good one behind it.
-    if (block !== undefined && accept(block)) return block
+    if (block !== undefined && accept(block)) return { comment, block }
   }
 
-  return undefined
+  return null
+}
+
+/** The payload half of {@link locateLatestBlock}, for callers with no comment to rewrite. */
+export const findLatestBlock = (
+  thread: readonly IssueComment[],
+  agentLogin: string,
+  marker: string,
+  accept: (block: unknown) => boolean = (): boolean => true,
+): unknown => {
+  const found = locateLatestBlock(thread, agentLogin, marker, accept)
+  return found === null ? undefined : found.block
+}
+
+/**
+ * Rewrites a body's block with a new payload, or `null` when it carries none.
+ *
+ * Through {@link renderBlock} rather than by patching the JSON inside the
+ * delimiters, and that is the whole point of the function existing at all:
+ * `renderBlock` escapes every `<` and `>` so a payload cannot forge its own
+ * terminator, which a mermaid diagram (`A --> B`) and half the compiler
+ * diagnostics that land in `lastError` routinely would. An in-place rewrite that
+ * assembled the block itself would reintroduce that bug on a new surface, where
+ * the original test suite is not looking.
+ *
+ * The **last** block with this marker is the one replaced, because that is the
+ * one {@link readBlock} reads back. Rewriting an earlier one would leave the
+ * body parsing to whatever it said before.
+ */
+export const replaceBlock = (body: string, marker: string, payload: unknown): string | null => {
+  const last = [...body.matchAll(blockPattern(marker))].at(-1)
+  if (last === undefined || last.index === undefined) return null
+
+  return `${body.slice(0, last.index)}${renderBlock(marker, payload)}${body.slice(last.index + last[0].length)}`
 }
 
 /**

--- a/opencode-agent/src/commands.ts
+++ b/opencode-agent/src/commands.ts
@@ -3,6 +3,9 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import { canTransition } from './state-manager.js'
+import type { Phase, TransitionSignal } from './types.js'
+
 /** Slash commands a maintainer can issue from an issue comment. */
 export const SLASH_COMMANDS = ['/approve', '/changes', '/ask', '/retry', '/cancel'] as const
 
@@ -77,3 +80,34 @@ export const parseSlashCommand = (body: string | null): ParsedCommand | null => 
 export const COMMENT_INTENTS = ['question', 'changes', 'approve', 'none'] as const
 
 export type CommentIntent = (typeof COMMENT_INTENTS)[number]
+
+/**
+ * Slash commands, mapped to the signal they inject before handlers run.
+ *
+ * Here rather than in `triggers.ts`, which applies them, because two callers now
+ * need to ask what a phase accepts: the refusal comment, and the waiting comment
+ * in `run-report.ts`. `triggers.ts` imports `run-report.ts`, so the derivation
+ * cannot live in either of them without a cycle — the reason `moveOrSkip` moved
+ * to `trigger-outcome.ts`. It belongs beside {@link SLASH_COMMANDS} anyway: this
+ * module is the command vocabulary, and what each command *means* to the machine
+ * is part of it.
+ */
+export const COMMAND_SIGNALS: Record<string, TransitionSignal> = {
+  '/approve': 'APPROVED',
+  '/changes': 'CHANGES_REQUESTED',
+  '/retry': 'RETRY',
+  '/cancel': 'CANCELLED',
+}
+
+/**
+ * The commands `phase` would actually accept, straight from the transition
+ * table, so a list shown to a maintainer cannot drift from what the machine will
+ * take. `/ask` is appended unconditionally: answering asks nothing of the state
+ * machine, so there is no phase in which it is refused.
+ */
+export const acceptedCommands = (phase: Phase): readonly string[] => [
+  ...Object.entries(COMMAND_SIGNALS)
+    .filter(([, signal]) => canTransition(phase, signal))
+    .map(([command]) => command),
+  '/ask',
+]

--- a/opencode-agent/src/comment-intent.ts
+++ b/opencode-agent/src/comment-intent.ts
@@ -6,10 +6,11 @@
 import { react } from './feedback.js'
 import { classifyComment } from './intent.js'
 import type { PhaseInput } from './phase-context.js'
+import { persistState } from './state-persist.js'
 import { totalTokens, withinBudget } from './token-budget.js'
 import { moveOrSkip, skip } from './trigger-outcome.js'
 import type { TriggerOutcome } from './trigger-outcome.js'
-import type { TransitionSignal } from './types.js'
+import type { AgentState, TransitionSignal } from './types.js'
 
 /**
  * What a plain maintainer comment — one carrying no slash command — means, and
@@ -44,34 +45,62 @@ import type { TransitionSignal } from './types.js'
  */
 export const readAndSkip = async (input: PhaseInput, reason: string): Promise<TriggerOutcome> => {
   await react(input.deps, input.trigger, '+1')
+  const state = await recordSkippedSpend(input)
 
-  return { state: input.state, halt: skip(input.state, reason), answer: false }
+  return { state, halt: skip(state, reason), answer: false }
+}
+
+/**
+ * Writes down what a skip cost, without posting.
+ *
+ * These are the paths that spend a model turn and then say nothing, which used
+ * to mean spending it and then *recording* nothing: this pipeline persists state
+ * only by posting a comment, so the classification that decided a comment needed
+ * no action vanished with the runner. An issue could buy one per comment for as
+ * long as anybody kept commenting, against a ceiling that never noticed.
+ *
+ * Here rather than in the `none` branches that pay for it, because
+ * {@link readAndSkip} is where "this comment asked for nothing" is decided for
+ * all three of them, and a fix that covered two would be this workspace's
+ * recurring defect exactly. The paths that spent nothing cost nothing to include
+ * — the total is unchanged, so there is no rewrite to issue.
+ *
+ * A failed rewrite reports the figure the issue actually carries, not the one
+ * this run hoped to write: `persistState` is best-effort, so the alternative is
+ * a `RunResult` claiming a total no reader will ever find.
+ */
+const recordSkippedSpend = async (input: PhaseInput): Promise<AgentState> => {
+  const { deps, state, thread } = input
+
+  const spent = await totalTokens(deps, state.tokensSpent)
+  if (spent === state.tokensSpent) return state
+
+  return (await persistState(deps, thread, { ...state, tokensSpent: spent })) ?? state
 }
 
 /**
  * Reads a plain comment as an intent, and decides first whether that reading is
  * affordable.
  *
- * Classifying costs a model turn, and it is the one turn in the pipeline whose
- * spend can never be written down. State is persisted only by posting a comment,
- * and the `none` branch below deliberately posts nothing — replying to every
- * "thanks!" would be spam — so a session that reported 40,000 tokens for the
- * classification vanishes with the runner. The ceiling is therefore asked
- * *before* the turn rather than after it: over budget there is nothing any
- * classification could buy, since every branch here leads either to a handler or
- * to the answer path and `stopIfOverBudget` refuses both. Handing the comment
- * straight to the answer path lets that one check report it, in the wording it
- * already has, without a second stop in this layer and without paying to learn
- * what to say — otherwise a maxed-out issue keeps buying a classification per
- * comment for as long as anyone keeps commenting on it.
+ * Classifying costs a model turn, and it is the one turn in the pipeline that
+ * posts nothing: state is persisted by posting a comment, and the `none` branch
+ * below deliberately posts none — replying to every "thanks!" would be spam. The
+ * ceiling is therefore asked *before* the turn rather than after it: over budget
+ * there is nothing any classification could buy, since every branch here leads
+ * either to a handler or to the answer path and `stopIfOverBudget` refuses both.
+ * Handing the comment straight to the answer path lets that one check report it,
+ * in the wording it already has, without a second stop in this layer and without
+ * paying to learn what to say — otherwise a maxed-out issue keeps buying a
+ * classification per comment for as long as anyone keeps commenting on it.
  *
- * That leaves one leak, knowingly: a run **under** budget whose classifier
- * answers `none` still spends a turn nothing records. Closing it needs a way to
- * persist state without posting — an `updateComment` on the last state block —
- * which is a larger design change than a stray few thousand tokens per no-op
- * comment justifies. The bound it erodes is per issue and human-paced, and every
- * other branch folds the classification in, because `deps.tokensUsed()` reports
- * the whole job's session and whatever the run goes on to post writes that total.
+ * A run **under** budget that classifies `none` used to leak that turn outright,
+ * and no longer does: {@link readAndSkip} records the spend by rewriting the
+ * state block in place instead of posting. That fix waited on an
+ * `updateComment` the pipeline had no other use for; the live status comment
+ * needed one anyway, so what was once the whole cost of closing this is now
+ * already paid for. Every other branch folds the classification in for free,
+ * because `deps.tokensUsed()` reports the whole job's session and whatever the
+ * run goes on to post writes that total.
  */
 export const applyIntent = async (input: PhaseInput): Promise<TriggerOutcome> => {
   const { state, trigger, deps } = input

--- a/opencode-agent/src/comment-intent.ts
+++ b/opencode-agent/src/comment-intent.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { react } from './feedback.js'
+import { classifyComment } from './intent.js'
+import type { PhaseInput } from './phase-context.js'
+import { totalTokens, withinBudget } from './token-budget.js'
+import { moveOrSkip, skip } from './trigger-outcome.js'
+import type { TriggerOutcome } from './trigger-outcome.js'
+import type { TransitionSignal } from './types.js'
+
+/**
+ * What a plain maintainer comment — one carrying no slash command — means, and
+ * what it buys.
+ *
+ * Split out of `triggers.ts` when acknowledging the third silent skip pushed
+ * that file past `max-lines`, and split rather than squeezed because the seam
+ * was already there: `triggers.ts` now owns commands and the dispatch that
+ * chooses between them, this file owns reading prose. The red-CI half went the
+ * same way, into `ci-trigger.ts`, for the same reason.
+ *
+ * Two phases classify and they want **opposite defaults**, which is why both
+ * live here rather than sharing one function — see each of them.
+ */
+
+/**
+ * Skips a comment the machine has nothing to do with, having said so.
+ *
+ * The 👍 is the only trace these paths leave anywhere but the log, and a comment
+ * would be the wrong instrument: the maintainer said something the pipeline
+ * correctly read as needing no action, and answering "I have decided to do
+ * nothing" to every "thanks!" is the noise this channel exists to avoid. What
+ * the reaction buys is the distinction that was missing — between a comment the
+ * agent read and set aside, and a workflow that never fired at all.
+ *
+ * Used by **every** silent human-facing skip, not by some of them: the two
+ * readings of "this comment asked for nothing" below, and the non-waiting-phase
+ * skip in `triggers.ts`. Reacting on a subset would be this workspace's
+ * recurring defect exactly — the fix that closes the instance and leaves the
+ * class open — and the one left out would have been `INIT_OR_CLARIFY`, the phase
+ * where a maintainer is most likely to be mid-conversation.
+ */
+export const readAndSkip = async (input: PhaseInput, reason: string): Promise<TriggerOutcome> => {
+  await react(input.deps, input.trigger, '+1')
+
+  return { state: input.state, halt: skip(input.state, reason), answer: false }
+}
+
+/**
+ * Reads a plain comment as an intent, and decides first whether that reading is
+ * affordable.
+ *
+ * Classifying costs a model turn, and it is the one turn in the pipeline whose
+ * spend can never be written down. State is persisted only by posting a comment,
+ * and the `none` branch below deliberately posts nothing — replying to every
+ * "thanks!" would be spam — so a session that reported 40,000 tokens for the
+ * classification vanishes with the runner. The ceiling is therefore asked
+ * *before* the turn rather than after it: over budget there is nothing any
+ * classification could buy, since every branch here leads either to a handler or
+ * to the answer path and `stopIfOverBudget` refuses both. Handing the comment
+ * straight to the answer path lets that one check report it, in the wording it
+ * already has, without a second stop in this layer and without paying to learn
+ * what to say — otherwise a maxed-out issue keeps buying a classification per
+ * comment for as long as anyone keeps commenting on it.
+ *
+ * That leaves one leak, knowingly: a run **under** budget whose classifier
+ * answers `none` still spends a turn nothing records. Closing it needs a way to
+ * persist state without posting — an `updateComment` on the last state block —
+ * which is a larger design change than a stray few thousand tokens per no-op
+ * comment justifies. The bound it erodes is per issue and human-paced, and every
+ * other branch folds the classification in, because `deps.tokensUsed()` reports
+ * the whole job's session and whatever the run goes on to post writes that total.
+ */
+export const applyIntent = async (input: PhaseInput): Promise<TriggerOutcome> => {
+  const { state, trigger, deps } = input
+  const body = trigger.kind === 'issue' ? trigger.commentBody : null
+  if (body === null || body.trim().length === 0) return readAndSkip(input, 'Empty comment')
+
+  const spent = await totalTokens(deps, state.tokensSpent)
+  if (!withinBudget(spent, deps.config)) {
+    deps.log.warn(
+      { issue: state.issueId, phase: state.phase, spent, limit: deps.config.maxTokens },
+      'Over budget: not paying to classify the comment',
+    )
+    return { state, halt: null, answer: true }
+  }
+
+  const intent = await classifyComment({ body, phase: state.phase, deps, state })
+  deps.log.info({ intent, phase: state.phase }, 'Classified maintainer comment')
+
+  if (intent === 'none') return readAndSkip(input, 'Comment needs no action')
+  if (intent === 'question') return { state, halt: null, answer: true }
+
+  const signal: TransitionSignal = intent === 'approve' ? 'APPROVED' : 'CHANGES_REQUESTED'
+  return moveOrSkip(state, signal, deps, `an implied ${intent}`)
+}
+
+/**
+ * Reads a plain comment that arrived while the agent is waiting for answers to
+ * its own clarifying questions, and lets through everything the classifier does
+ * not positively call chatter.
+ *
+ * This phase used to skip classification altogether and hand every comment
+ * straight to triage. That is a whole triage turn — the model re-reads the
+ * issue, the whole thread and the repository, then writes a fresh design spec or
+ * another round of questions — bought by a "thanks", a 👍, or one maintainer's
+ * aside to another while the agent waits. Cheap to say, expensive to answer.
+ *
+ * The fix cannot be to route this phase through {@link applyIntent}, because
+ * that function's default points the wrong way here. `classifyComment` resolves
+ * every failure and every ambiguity to `question`, chosen for the waiting phases
+ * where answering costs one reply while re-planning discards an approved
+ * artefact. There is no approved artefact in `INIT_OR_CLARIFY`, and the cost is
+ * reversed: a maintainer's answer misread as a question gets *answered* instead
+ * of acted on, so the agent replies about its own questions, stays parked, and
+ * the maintainer has to say the same thing a second time. So the default is
+ * inverted rather than borrowed — `none` is the only verdict that skips, and
+ * every other reading, including the one the classifier falls back to when it
+ * breaks, re-runs triage exactly as before.
+ *
+ * `question` is deliberately **not** admitted as a skip-to-answer, even though a
+ * maintainer really can ask "why do you need that?" mid-clarification. In this
+ * phase it is not a verdict: it is also the bucket a failed model call, an
+ * unparsable reply and a genuinely ambiguous comment all land in, so honouring
+ * it would route every one of those into an answer turn — precisely the stall
+ * above, on exactly the comments least able to survive it. `none` is the one
+ * reading the classifier has to actively choose, so `none` is the one that acts.
+ * The price of leaving `question` out is a wasted triage turn on a real
+ * mid-clarification question; the price of letting it in is a dropped answer,
+ * and only the first of those is recoverable without the maintainer noticing.
+ *
+ * Two comments never reach the classifier at all, and both fall through to
+ * triage rather than skipping. An **absent or blank** body is the
+ * `issues.opened` event that starts every issue — there is no comment to read,
+ * and skipping it would mean the agent never runs at all. **Over budget** is the
+ * rule {@link applyIntent} sets out at length: the classifier is the one turn
+ * whose spend can never be written down, so the ceiling has to stop it rather
+ * than count it. Falling through costs nothing, because the cascade's own stop
+ * fires before `handleTriage` and reports the ceiling on the issue — the same
+ * notice a maintainer would have got anyway, one model turn cheaper.
+ */
+export const applyClarifyIntent = async (input: PhaseInput): Promise<TriggerOutcome> => {
+  const { state, trigger, deps } = input
+  const retriage: TriggerOutcome = { state, halt: null, answer: false }
+
+  const body = trigger.kind === 'issue' ? trigger.commentBody : null
+  if (body === null || body.trim().length === 0) return retriage
+
+  const spent = await totalTokens(deps, state.tokensSpent)
+  if (!withinBudget(spent, deps.config)) {
+    deps.log.warn(
+      { issue: state.issueId, phase: state.phase, spent, limit: deps.config.maxTokens },
+      'Over budget: not paying to classify a comment while clarifying',
+    )
+    return retriage
+  }
+
+  const intent = await classifyComment({ body, phase: state.phase, deps, state })
+  deps.log.info({ intent, phase: state.phase }, 'Classified a maintainer comment while clarifying')
+
+  if (intent !== 'none') return retriage
+
+  // Through {@link readAndSkip}, like the other two readings of "this comment
+  // asked for nothing". They are one class, not three call sites: same reason
+  // string, same silence, same person waiting — and this is the phase a
+  // maintainer is *most* likely to be typing in, since it is where the agent
+  // waits for answers to its own questions.
+  return readAndSkip(input, 'Comment needs no action')
+}

--- a/opencode-agent/src/config-values.ts
+++ b/opencode-agent/src/config-values.ts
@@ -93,6 +93,49 @@ export const POOL_RANGE: IntRange = { min: 1, max: 16 }
  */
 export const TOKEN_RANGE: IntRange = { min: 50_000, max: 1_000_000_000 }
 
+/**
+ * Longest prefix accepted, and it is not arbitrary: GitHub caps a label name at
+ * 50 characters, and the longest suffix in `presentation.ts` is `implementing`.
+ */
+const PREFIX_MAX_LENGTH = 32
+
+/**
+ * Characters a label name may carry here.
+ *
+ * Deliberately narrower than GitHub's own rules. A prefix is compared with
+ * `startsWith` to decide which of an issue's labels this pipeline owns and may
+ * remove, so it has to be a plain, predictable string — a comma splits a label
+ * list in half of GitHub's own UI, and leading or trailing whitespace makes two
+ * labels that look identical.
+ */
+const PREFIX_PATTERN = /^[\w\-./: ]+$/u
+
+/**
+ * Reads the label namespace, or `null` when labelling is switched off.
+ *
+ * Same shape as `AGENT_REVIEW_COMMAND`, and for the same reason: this pipeline
+ * runs in repositories with their own label conventions, so a hardcoded
+ * `agent:` set is exactly the papai-specific hardcoding S2-4 was re-opened for.
+ * `none` disables the channel outright rather than making an operator find a
+ * prefix nothing collides with.
+ *
+ * The value is validated at load, where a bad one is a message naming the
+ * variable, rather than at the first API call, where it is a 422 inside a
+ * best-effort path that swallows it.
+ */
+export const labelPrefix = (env: Env, key: string, fallback: string): string | null => {
+  const configured = optional(env, key, fallback)
+  if (configured.toLowerCase() === 'none') return null
+
+  if (configured.length > PREFIX_MAX_LENGTH) {
+    throw new ConfigError(`${key} must be at most ${PREFIX_MAX_LENGTH} characters, got ${configured.length}`)
+  }
+  if (!PREFIX_PATTERN.test(configured)) {
+    throw new ConfigError(`${key} may only contain letters, digits and \`-_./: \`, got ${JSON.stringify(configured)}`)
+  }
+  return configured
+}
+
 /** Reads an integer knob, rejecting both malformed values and unusable ones. */
 export const boundedInt = (env: Env, key: string, fallback: number, range: IntRange): number => {
   const raw = env[key]

--- a/opencode-agent/src/config.ts
+++ b/opencode-agent/src/config.ts
@@ -83,6 +83,14 @@ export interface PipelineConfig {
    * own host, and a header scoped to the wrong one is silently not sent.
    */
   gitRemoteBase: string
+  /**
+   * The Actions run executing this pipeline, or `null` when there is not one.
+   *
+   * Nullable rather than required because a local `--event-path` run is an
+   * ordinary way to use this CLI, not a misconfiguration — so every renderer
+   * that takes this has to be able to say nothing rather than link nowhere.
+   */
+  runUrl: string | null
   skillRoots: readonly string[]
 }
 
@@ -197,9 +205,36 @@ export const resolveBaseBranch = async (env: Env, sources: BaseBranchSources): P
   )
 }
 
+/**
+ * Builds the URL of the run this process is executing in.
+ *
+ * No workflow change is needed for any of it: GitHub sets `GITHUB_RUN_ID`,
+ * `GITHUB_RUN_ATTEMPT`, `GITHUB_SERVER_URL` and `GITHUB_REPOSITORY` in the
+ * environment of every step, and `scrubSecrets` matches by *value*, so none of
+ * them is stripped on the way past. `serverBase` is the same value
+ * `gitRemoteBase` carries, for the same reason it is configurable at all — an
+ * Enterprise Server install answers on its own host.
+ *
+ * The attempt segment is appended only above 1. GitHub's own run link omits it
+ * on a first attempt, and a re-run's logs live under the attempt path, so a job
+ * on attempt 3 linking `/attempts/1` would point a maintainer at the logs of the
+ * run it superseded. An unparseable attempt is treated as a first one rather
+ * than rejected: this is a link, and a config error over decoration would fail
+ * the run the link exists to explain.
+ */
+const buildRunUrl = (env: Env, serverBase: string, owner: string, repo: string): string | null => {
+  const runId = optionalOrNull(env, 'GITHUB_RUN_ID')
+  if (runId === null) return null
+
+  const attempt = Number.parseInt(optional(env, 'GITHUB_RUN_ATTEMPT', '1'), 10)
+  const suffix = Number.isSafeInteger(attempt) && attempt > 1 ? `/attempts/${attempt}` : ''
+  return `${serverBase}${owner}/${repo}/actions/runs/${runId}${suffix}`
+}
+
 /** Builds the pipeline config from the runner environment. */
 export const loadConfig = (env: Env, repoRoot: string): PipelineConfig => {
   const { owner, repo } = parseRepository(required(env, 'GITHUB_REPOSITORY'))
+  const gitRemoteBase = optional(env, 'GITHUB_SERVER_URL', 'https://github.com').replace(/\/*$/u, '/')
 
   return {
     repoRoot,
@@ -209,7 +244,8 @@ export const loadConfig = (env: Env, repoRoot: string): PipelineConfig => {
     selfLoginOverride: optionalOrNull(env, 'AGENT_SELF_LOGIN'),
     selfWorkflowName: optional(env, 'AGENT_WORKFLOW_NAME', 'OpenCode Issue Agent'),
     openai: loadOpenAiSettings(env),
-    gitRemoteBase: optional(env, 'GITHUB_SERVER_URL', 'https://github.com').replace(/\/*$/u, '/'),
+    gitRemoteBase,
+    runUrl: buildRunUrl(env, gitRemoteBase, owner, repo),
     commitAuthorName: optional(env, 'AGENT_COMMIT_NAME', 'opencode-agent[bot]'),
     commitAuthorEmail: optional(env, 'AGENT_COMMIT_EMAIL', 'opencode-agent@users.noreply.github.com'),
     checkCommand: optional(env, 'AGENT_CHECK_COMMAND', 'bun run lint && bun run typecheck && bun test'),

--- a/opencode-agent/src/config.ts
+++ b/opencode-agent/src/config.ts
@@ -105,8 +105,15 @@ export interface PipelineConfig {
   skillRoots: readonly string[]
 }
 
-/** The namespace labels take when the operator names none. */
-const DEFAULT_LABEL_PREFIX = 'agent:'
+/**
+ * The namespace labels take when the operator names none.
+ *
+ * Exported for the same reason `REPORTED_OUTPUT` is: the workflow's label
+ * cleanup step has to default the prefix in shell, where it cannot import
+ * anything, so `tests/opencode-agent/workflow.test.ts` pins that literal against
+ * this one rather than letting two spellings of the default drift apart.
+ */
+export const DEFAULT_LABEL_PREFIX = 'agent:'
 
 export const parseChecks = (raw: string | undefined): readonly CheckSpec[] => {
   if (raw === undefined || raw.trim().length === 0) return DEFAULT_CHECKS

--- a/opencode-agent/src/config.ts
+++ b/opencode-agent/src/config.ts
@@ -13,6 +13,7 @@ import {
   boundedInt,
   ConfigError,
   FILES_RANGE,
+  labelPrefix,
   LINES_RANGE,
   optional,
   optionalOrNull,
@@ -91,8 +92,21 @@ export interface PipelineConfig {
    * that takes this has to be able to say nothing rather than link nowhere.
    */
   runUrl: string | null
+  /**
+   * Namespace every label this pipeline writes lives under, or `null` when
+   * `AGENT_LABEL_PREFIX=none` switches labelling off.
+   *
+   * Nullable rather than an empty string: an empty prefix would make *every*
+   * label on the issue look agent-owned to the reconcile, which removes any it
+   * cannot account for — so the one value that reads as "no namespace" is the
+   * one value that must never reach it.
+   */
+  labelPrefix: string | null
   skillRoots: readonly string[]
 }
+
+/** The namespace labels take when the operator names none. */
+const DEFAULT_LABEL_PREFIX = 'agent:'
 
 export const parseChecks = (raw: string | undefined): readonly CheckSpec[] => {
   if (raw === undefined || raw.trim().length === 0) return DEFAULT_CHECKS
@@ -246,6 +260,7 @@ export const loadConfig = (env: Env, repoRoot: string): PipelineConfig => {
     openai: loadOpenAiSettings(env),
     gitRemoteBase,
     runUrl: buildRunUrl(env, gitRemoteBase, owner, repo),
+    labelPrefix: labelPrefix(env, 'AGENT_LABEL_PREFIX', DEFAULT_LABEL_PREFIX),
     commitAuthorName: optional(env, 'AGENT_COMMIT_NAME', 'opencode-agent[bot]'),
     commitAuthorEmail: optional(env, 'AGENT_COMMIT_EMAIL', 'opencode-agent@users.noreply.github.com'),
     checkCommand: optional(env, 'AGENT_CHECK_COMMAND', 'bun run lint && bun run typecheck && bun test'),

--- a/opencode-agent/src/deps.ts
+++ b/opencode-agent/src/deps.ts
@@ -7,8 +7,7 @@ import type { CheckRunner } from './check-loop.js'
 import { resolveBaseBranch } from './config.js'
 import type { Env, PipelineConfig } from './config.js'
 import { createGit } from './git.js'
-import { createOctokitApi } from './github.js'
-import type { FetchLike } from './github.js'
+import type { GitHubApi } from './github.js'
 import type { TriggerEvent } from './guardrails.js'
 import { resolveSelfLogin } from './identity.js'
 import type { AgentHandle } from './index.js'
@@ -19,6 +18,7 @@ import { opencodeConfigEnv } from './openai-config.js'
 import type { PhaseDeps, RunReview } from './phase-context.js'
 import { runReviewLoop } from './review-runner.js'
 import type { CommandRunner } from './shell.js'
+import type { StatusReporter } from './status-reporter.js'
 import type { Phase } from './types.js'
 
 /**
@@ -83,10 +83,29 @@ export interface DepsInput {
   run: CommandRunner
   log: Logger
   agent: AgentHandle
-  fetch?: FetchLike
+  /**
+   * Built by `contain` rather than here, unlike every other boundary below.
+   *
+   * The status reporter needs it, and the OpenCode session needs the *reporter*
+   * — its heartbeat is what feeds the live status comment — so the session
+   * cannot be built before both. One of the three has to be assembled outside
+   * this function, and the GitHub adapter is the one with no other dependency.
+   */
+  github: GitHubApi
+  status: StatusReporter
 }
 
-export const assembleDeps = ({ config, secrets, event, env, run, log, agent, fetch }: DepsInput): PhaseDeps => {
+export const assembleDeps = ({
+  config,
+  secrets,
+  event,
+  env,
+  run,
+  log,
+  agent,
+  github,
+  status,
+}: DepsInput): PhaseDeps => {
   const git = createGit({
     run,
     cwd: config.repoRoot,
@@ -96,16 +115,10 @@ export const assembleDeps = ({ config, secrets, event, env, run, log, agent, fet
     secrets,
     credential: { remote: config.gitRemoteBase, token: config.githubToken },
   })
-  const github = createOctokitApi({
-    token: config.githubToken,
-    owner: config.owner,
-    repo: config.repo,
-    secrets,
-    fetch,
-  })
 
   return {
     github,
+    status,
     git,
     runCheck: makeCheckRunner(run, config),
     runReview: makeReviewRunner(run, config, log),

--- a/opencode-agent/src/feedback.ts
+++ b/opencode-agent/src/feedback.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { GitHubApi, ReactionContent, ReactionTarget } from './github.js'
+import type { TriggerEvent } from './guardrails.js'
+import type { Logger } from './logger.js'
+import { errorMessage } from './types.js'
+
+/**
+ * The reaction channel — the pipeline's only instant acknowledgement.
+ *
+ * A maintainer types `/approve` and the next thing that appears on the issue is
+ * the finished artefact, up to `AGENT_TIMEOUT_MS` later; for that whole window
+ * the issue is indistinguishable from one where the workflow never fired, which
+ * is also a real outcome because a guardrail can drop the event. A reaction
+ * costs one API call, lands on the comment the maintainer just wrote, and adds
+ * nothing to the thread — so it can be placed on paths where a comment would be
+ * noise, which is exactly the set of paths that were silent.
+ *
+ * One rule governs everything here: **feedback must never fail a run.** Every
+ * write in this module is decoration on work that matters, and every one of them
+ * is a new way to break a pipeline that used to work — a token without
+ * `issues: write`, a fork run, an org policy on reactions. So a rejection
+ * degrades to a `warn` and the caller carries on to the same result and the same
+ * persisted state it would have reached with no reaction channel at all.
+ *
+ * Placing one is deliberately *not* reporting. `RunResult.reported` means "the
+ * issue carries this run's account of what happened", and the workflow's
+ * fallback comment is gated on it; an emoji is not an account of anything, so no
+ * caller here touches the flag.
+ */
+
+/**
+ * What reacting needs.
+ *
+ * Narrower than `PhaseDeps` on purpose: the guardrail denial is reacted to
+ * before any phase input exists, and a structural type lets that path use the
+ * same function as the trigger layer without assembling one.
+ */
+export interface ReactionDeps {
+  github: GitHubApi
+  log: Logger
+}
+
+/**
+ * Where a reaction for this trigger belongs, or `null` when nothing should be
+ * reacted to at all.
+ *
+ * A CI event is the `null` case, and it is the design rather than an oversight:
+ * a `workflow_run` payload names no comment, nobody typed it, and nobody is
+ * waiting on an answer to it — the existing log line is the right amount of
+ * record. `issues.opened` has no comment either but very much has someone
+ * waiting, so it falls back to the issue itself.
+ */
+export const reactionTarget = (trigger: TriggerEvent): ReactionTarget | null => {
+  if (trigger.kind !== 'issue') return null
+
+  return trigger.commentId === null
+    ? { kind: 'issue', number: trigger.issueNumber }
+    : { kind: 'comment', id: trigger.commentId }
+}
+
+/**
+ * Places a reaction, and swallows every way that can fail.
+ *
+ * The `catch` is the whole point of the function, not defensive padding: it is
+ * what makes the rule above true at the only place it can be enforced, and it is
+ * why no caller is allowed to reach for `deps.github.addReaction` directly.
+ */
+export const react = async (deps: ReactionDeps, trigger: TriggerEvent, content: ReactionContent): Promise<void> => {
+  const target = reactionTarget(trigger)
+  if (target === null) return
+
+  try {
+    await deps.github.addReaction(target, content)
+    deps.log.debug({ target, content }, 'Reacted to the trigger')
+  } catch (error) {
+    deps.log.warn({ target, content, error: errorMessage(error) }, 'Could not react to the trigger')
+  }
+}

--- a/opencode-agent/src/github-labels.ts
+++ b/opencode-agent/src/github-labels.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { Octokit } from '@octokit/rest'
+
+/**
+ * The label half of the GitHub surface.
+ *
+ * Split out of `github.ts` when the four methods here pushed that file past
+ * `max-lines`, along the seam that was already there: labels are one endpoint
+ * family with semantics none of the other calls have. They are created on
+ * demand, "it already exists" is a success rather than a failure, and — unlike a
+ * comment or a pull request body — they carry no free text, so the redaction
+ * `github.ts` applies at its boundary has nothing to do here.
+ *
+ * That last point is the exemption stated rather than implied, exactly as
+ * `ReactionContent` and the `head`/`base` branch names state it: every name that
+ * reaches these methods is `AGENT_LABEL_PREFIX` — validated at load — followed by
+ * a suffix out of `presentation.ts`'s closed table, and a value the pipeline
+ * assembles from two of its own constants has nowhere for a credential to hide.
+ *
+ * Nothing here is best-effort. A rejection is reported to the caller like any
+ * other, because "a failed label must never fail a run" is a decision about the
+ * pipeline and lives in `labels.ts`, at the one door to this API — the same
+ * division `github.ts` and `feedback.ts` already draw for reactions.
+ */
+export interface LabelApi {
+  /** Every label currently on the issue, agent-owned or not, by name. */
+  listLabels(issueNumber: number): Promise<string[]>
+  /** Adds labels, leaving the ones already there alone. */
+  addLabels(issueNumber: number, names: readonly string[]): Promise<void>
+  /** Removes one label from the issue; the label itself survives in the repo. */
+  removeLabel(issueNumber: number, name: string): Promise<void>
+  /**
+   * Creates a repository label, treating "it already exists" as success.
+   *
+   * Idempotence at the transport layer, where the HTTP status still exists: a
+   * repeat create answers 422, and by the time that reaches a caller it is an
+   * `Error` message indistinguishable from a real refusal. This is *not* the
+   * best-effort rule — a 403 from a token without `issues: write` still rejects
+   * here and is swallowed one layer up, where that decision belongs.
+   */
+  createLabel(name: string, color: string): Promise<void>
+}
+
+/** Status of a rejected Octokit call, when it carried one. */
+const statusOf = (error: unknown): number | null =>
+  typeof error === 'object' && error !== null && 'status' in error && typeof error.status === 'number'
+    ? error.status
+    : null
+
+/** GitHub's answer to creating a label that is already there. */
+const ALREADY_EXISTS = 422
+
+const createLabel = async (octokit: Octokit, repo: RepoRef, name: string, color: string): Promise<void> => {
+  try {
+    await octokit.rest.issues.createLabel({ ...repo, name, color })
+  } catch (error) {
+    if (statusOf(error) !== ALREADY_EXISTS) throw error
+  }
+}
+
+/**
+ * The owner/repo pair every endpoint is scoped to.
+ *
+ * Declared here and structurally identical to `github.ts`'s own, so that file
+ * can pass its `Repo` straight through without either module importing a type
+ * from the other — which for a file split out of the one that calls it is how an
+ * import cycle starts.
+ */
+interface RepoRef {
+  owner: string
+  repo: string
+}
+
+/** Builds the label endpoints against an already-authenticated Octokit. */
+export const createLabelEndpoints = (octokit: Octokit, repo: RepoRef): LabelApi => ({
+  listLabels: async (issueNumber): Promise<string[]> => {
+    const labels = await octokit.paginate(octokit.rest.issues.listLabelsOnIssue, {
+      ...repo,
+      issue_number: issueNumber,
+      per_page: 100,
+    })
+    return labels.map((label) => label.name)
+  },
+
+  addLabels: async (issueNumber, names): Promise<void> => {
+    await octokit.rest.issues.addLabels({ ...repo, issue_number: issueNumber, labels: [...names] })
+  },
+
+  // A label removed between the read and this call answers 404. It is not
+  // special-cased: the reconcile that issued it is best-effort, so the warning
+  // it degrades to is the right amount of noise for a race whose only
+  // consequence is that the next event repairs what this one could not.
+  removeLabel: async (issueNumber, name): Promise<void> => {
+    await octokit.rest.issues.removeLabel({ ...repo, issue_number: issueNumber, name })
+  },
+
+  createLabel: (name, color): Promise<void> => createLabel(octokit, repo, name, color),
+})

--- a/opencode-agent/src/github.ts
+++ b/opencode-agent/src/github.ts
@@ -56,6 +56,31 @@ export interface PullRequestStatus extends PullRequestRef {
 }
 
 /**
+ * The reactions this pipeline places, as a closed union rather than free text.
+ *
+ * That closure is what exempts it from `clean`. Outbound redaction exists
+ * because a comment body is assembled from check output, git stderr, review
+ * summaries and model prose, and any of those can carry a credential; a value
+ * drawn from four literals the pipeline picks itself has nowhere for one to
+ * hide. It is the same exemption the `head`/`base` branch names take in
+ * {@link PullRequestInput} — computed here, so passed through untouched — and it
+ * is stated rather than implied, because "a new `GitHubApi` method that sends
+ * free text must redact it" is a rule a silent exception erodes.
+ */
+export type ReactionContent = 'eyes' | '+1' | 'confused' | 'rocket'
+
+/**
+ * What a reaction lands on.
+ *
+ * One discriminated shape rather than an `addIssueReaction` and an
+ * `addCommentReaction`: the two REST endpoints differ only in the path segment
+ * they address — `issues/{n}/reactions` against `issues/comments/{id}/reactions`
+ * — and the callers all hold one id or the other without caring which endpoint
+ * that makes it. Two methods would put that mapping in every call site.
+ */
+export type ReactionTarget = { kind: 'issue'; number: number } | { kind: 'comment'; id: number }
+
+/**
  * The narrow GitHub surface the pipeline needs. Everything downstream depends on
  * this interface rather than Octokit, so phase handlers are testable without an
  * HTTP stub layer.
@@ -70,6 +95,15 @@ export interface GitHubApi {
   findPullRequest(head: string): Promise<PullRequestStatus | null>
   createPullRequest(input: PullRequestInput): Promise<PullRequestRef>
   updatePullRequest(number: number, patch: PullRequestPresentation): Promise<void>
+  /**
+   * Places one reaction. Rejects like any other call — `feedback.ts` owns the
+   * rule that a rejection here can never fail a run, because that is a decision
+   * about the pipeline, not about the transport.
+   *
+   * Idempotent server-side: a repeated reaction returns the existing one, so no
+   * caller has to record what it has already placed.
+   */
+  addReaction(target: ReactionTarget, content: ReactionContent): Promise<void>
 }
 
 export interface OctokitApiOptions {
@@ -155,6 +189,20 @@ const findPullRequest = async (octokit: Octokit, repo: Repo, head: string): Prom
 
 const closedOrOpen = (state: string): PullRequestState => (state === 'open' ? 'open' : 'closed')
 
+/** Routes to whichever of the two reaction endpoints the target names. */
+const addReaction = async (
+  octokit: Octokit,
+  repo: Repo,
+  target: ReactionTarget,
+  content: ReactionContent,
+): Promise<void> => {
+  if (target.kind === 'comment') {
+    await octokit.rest.reactions.createForIssueComment({ ...repo, comment_id: target.id, content })
+    return
+  }
+  await octokit.rest.reactions.createForIssue({ ...repo, issue_number: target.number, content })
+}
+
 /** Builds a {@link GitHubApi} backed by `@octokit/rest`. */
 export const createOctokitApi = (options: OctokitApiOptions): GitHubApi => {
   const repo: Repo = { owner: options.owner, repo: options.repo }
@@ -166,6 +214,9 @@ export const createOctokitApi = (options: OctokitApiOptions): GitHubApi => {
   return {
     listIssueComments: (issueNumber) => listIssueComments(octokit, repo, issueNumber),
     findPullRequest: (head) => findPullRequest(octokit, repo, head),
+    // No `clean`: the content is a member of a four-value union this pipeline
+    // picks, exactly like the `head`/`base` branch names above.
+    addReaction: (target, content) => addReaction(octokit, repo, target, content),
 
     createComment: async (issueNumber, body) => {
       const { data } = await octokit.rest.issues.createComment({

--- a/opencode-agent/src/github.ts
+++ b/opencode-agent/src/github.ts
@@ -6,6 +6,8 @@
 import { Octokit } from '@octokit/rest'
 
 import type { IssueComment } from './blocks.js'
+import { createLabelEndpoints } from './github-labels.js'
+import type { LabelApi } from './github-labels.js'
 import type { IssueContext } from './phase-context.js'
 import { redactSecrets } from './secrets.js'
 
@@ -84,8 +86,13 @@ export type ReactionTarget = { kind: 'issue'; number: number } | { kind: 'commen
  * The narrow GitHub surface the pipeline needs. Everything downstream depends on
  * this interface rather than Octokit, so phase handlers are testable without an
  * HTTP stub layer.
+ *
+ * The label endpoints arrive through {@link LabelApi} rather than being written
+ * out again here: extending it is what keeps a fake that satisfies `GitHubApi`
+ * unable to leave one of them out, which is the property the whole interface
+ * exists for.
  */
-export interface GitHubApi {
+export interface GitHubApi extends LabelApi {
   listIssueComments(issueNumber: number): Promise<IssueComment[]>
   /** Returns the created comment, including the author GitHub recorded. */
   createComment(issueNumber: number, body: string): Promise<PostedComment>
@@ -217,6 +224,9 @@ export const createOctokitApi = (options: OctokitApiOptions): GitHubApi => {
     // No `clean`: the content is a member of a four-value union this pipeline
     // picks, exactly like the `head`/`base` branch names above.
     addReaction: (target, content) => addReaction(octokit, repo, target, content),
+    // Nor here, and for the same reason — a label name is this pipeline's own
+    // prefix followed by a suffix from a closed table. See `github-labels.ts`.
+    ...createLabelEndpoints(octokit, repo),
 
     createComment: async (issueNumber, body) => {
       const { data } = await octokit.rest.issues.createComment({

--- a/opencode-agent/src/github.ts
+++ b/opencode-agent/src/github.ts
@@ -96,6 +96,21 @@ export interface GitHubApi extends LabelApi {
   listIssueComments(issueNumber: number): Promise<IssueComment[]>
   /** Returns the created comment, including the author GitHub recorded. */
   createComment(issueNumber: number, body: string): Promise<PostedComment>
+  /**
+   * Rewrites a comment this pipeline already posted.
+   *
+   * The second method that carries free text, and so the second that must be
+   * redacted — the rule is that a new `GitHubApi` method sending free text
+   * passes through `clean`, and this one carries a live status body assembled
+   * from the same activity summaries and state fields a comment is. It takes no
+   * exemption: unlike a reaction content or a label name, nothing here is drawn
+   * from a closed table the pipeline picks from.
+   *
+   * Two callers, both best-effort one layer up: `status-reporter.ts` edits the
+   * run's live status, and `state-persist.ts` rewrites a state block without
+   * posting. Neither rule lives here — this is the transport.
+   */
+  updateComment(commentId: number, body: string): Promise<void>
   getIssue(issueNumber: number): Promise<IssueContext>
   getAuthenticatedLogin(): Promise<string>
   /** The newest pull request from `head`, whatever became of it. */
@@ -235,6 +250,10 @@ export const createOctokitApi = (options: OctokitApiOptions): GitHubApi => {
         body: clean(body),
       })
       return { id: data.id, url: data.html_url, authorLogin: data.user?.login ?? '' }
+    },
+
+    updateComment: async (commentId, body) => {
+      await octokit.rest.issues.updateComment({ ...repo, comment_id: commentId, body: clean(body) })
     },
 
     getIssue: async (issueNumber) => {

--- a/opencode-agent/src/guardrails.ts
+++ b/opencode-agent/src/guardrails.ts
@@ -23,6 +23,16 @@ export interface IssueTriggerEvent {
   issueBody: string
   isPullRequest: boolean
   commentBody: string | null
+  /**
+   * Id of the comment that raised this run; `null` for `issues.opened`, which
+   * has no comment to address.
+   *
+   * The schema below has always parsed it and this function always threw it
+   * away, which left the pipeline unable to address the one place the person
+   * waiting is actually looking. Carried now so feedback can land there rather
+   * than on the issue as a whole.
+   */
+  commentId: number | null
   repositoryOwner: string | null
   /** `repository.default_branch`; `null` when the payload omitted it. */
   defaultBranch: string | null
@@ -117,6 +127,7 @@ const parseIssueEvent = (eventName: string, payload: unknown): IssueTriggerEvent
     issueBody: issue.body ?? '',
     isPullRequest: issue.pull_request !== undefined && issue.pull_request !== null,
     commentBody: comment === undefined ? null : comment.body,
+    commentId: comment === undefined ? null : comment.id,
     repositoryOwner: repository === undefined ? null : repository.owner.login,
     defaultBranch: repository?.default_branch ?? null,
   }

--- a/opencode-agent/src/index.ts
+++ b/opencode-agent/src/index.ts
@@ -11,6 +11,7 @@ import { pathToFileURL } from 'node:url'
 import { loadConfig } from './config.js'
 import type { PipelineConfig } from './config.js'
 import { assembleDeps } from './deps.js'
+import { createOctokitApi } from './github.js'
 import type { FetchLike } from './github.js'
 import { parseTriggerEvent } from './guardrails.js'
 import type { TriggerEvent } from './guardrails.js'
@@ -25,6 +26,7 @@ import type { ProviderProxy } from './provider-proxy.js'
 import { pipelineSecrets, scrubSecrets } from './secrets.js'
 import { runCommand } from './shell.js'
 import type { CommandRunner } from './shell.js'
+import { createStatusReporter } from './status-reporter.js'
 import { recordReport } from './step-output.js'
 import { errorMessage } from './types.js'
 import type { RunResult } from './types.js'
@@ -174,6 +176,19 @@ export const contain = ({ config, event, log, run, options, createAgent }: Conta
   const contained: PipelineConfig = { ...config, openai: proxiedSettings(config.openai, proxy) }
   const create = createAgent ?? createOpenCodeAgent
 
+  // In this order because each needs the one before it: the status comment is
+  // written through the GitHub adapter, and the session's heartbeat is what
+  // keeps the status comment current, so the session is built last and handed
+  // the reporter's tick.
+  const github = createOctokitApi({
+    token: config.githubToken,
+    owner: config.owner,
+    repo: config.repo,
+    secrets,
+    fetch: options.fetch,
+  })
+  const status = createStatusReporter({ github, log, config: contained, now: () => Date.now() })
+
   const agent = memoizeAgent(() =>
     create({
       directory: contained.repoRoot,
@@ -181,13 +196,17 @@ export const contain = ({ config, event, log, run, options, createAgent }: Conta
       sessionTitle: `issue-${event.issueNumber}`,
       timeoutMs: contained.agentTimeoutMs,
       log,
+      // Not awaited, and it never rejects: reporting must not be able to fail
+      // the turn it is reporting on, and a heartbeat that waited on an HTTP
+      // round trip would no longer be a heartbeat.
+      onTick: (snapshot) => void status.tick(snapshot),
     }),
   )
 
   return {
     proxy,
     agent,
-    deps: assembleDeps({ config: contained, secrets, event, env: options.env, run, log, agent, fetch: options.fetch }),
+    deps: assembleDeps({ config: contained, secrets, event, env: options.env, run, log, agent, github, status }),
   }
 }
 

--- a/opencode-agent/src/labels.ts
+++ b/opencode-agent/src/labels.ts
@@ -111,6 +111,16 @@ export const reconcileLabels = async (deps: LabelDeps, state: AgentState, stance
   try {
     await applyDiff(deps, prefix, state, stance)
   } catch (error) {
+    // Everything, and that includes a bug in this module: a `TypeError` from
+    // `applyDiff` degrades to exactly the same `warn` as a 403, so a broken
+    // reconcile is invisible unless somebody reads the log. That is the accepted
+    // cost of the rule rather than an oversight — a channel that re-throws on
+    // some classes of error is not best-effort any more, and deciding which is
+    // which *here*, on an `unknown`, is how that gets fragile. It is worth
+    // knowing how it will be found: this exact case appeared while writing the
+    // stage's tests, when a stubbed transport answered the label read with the
+    // wrong shape and `name.startsWith` threw into this catch, leaving a green
+    // suite that had never reconciled a thing.
     deps.log.warn(
       { issue: state.issueId, phase: state.phase, stance, error: errorMessage(error) },
       'Could not reconcile the issue labels',

--- a/opencode-agent/src/labels.ts
+++ b/opencode-agent/src/labels.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { PipelineConfig } from './config.js'
+import type { LabelApi } from './github-labels.js'
+import type { Logger } from './logger.js'
+import { NEEDS_YOU_LABEL, presentationFor, WORKING_LABEL } from './presentation.js'
+import type { LabelSpec, RunStance, WhoseTurn } from './presentation.js'
+import { mapSeries } from './sequence.js'
+import { errorMessage } from './types.js'
+import type { AgentState, RunResult } from './types.js'
+
+/**
+ * The label channel — what the issue says about itself from a list view.
+ *
+ * The phase lives in an HTML comment, so answering "which of my twelve agent
+ * issues are waiting on me" means opening each one and reading the last
+ * comment's prose. A label is the only surface an issue list, a project board
+ * and a notification all carry.
+ *
+ * Two rules shape everything here.
+ *
+ * **Feedback must never fail a run.** Every write in this module is decoration
+ * on work that matters, and each one is a new way to break a pipeline that used
+ * to work — a token without `issues: write`, a fork run, an organisation that
+ * restricts who may create a label. So {@link reconcileLabels} is the single
+ * door to the label API and it swallows everything, the way `feedback.ts` does
+ * for reactions: a rejection degrades to a `warn` and the caller reaches the
+ * same `RunResult` and the same persisted state it would have reached with no
+ * label channel at all. That is a property of one function, not a convention
+ * observed at each call site.
+ *
+ * **A diff, never a clear-and-reapply.** Removing every agent label and adding
+ * the current set back is one line shorter and wrong twice: it writes two
+ * timeline entries per phase for a state that usually did not change, and the
+ * issue visibly flickers through "no state" in between. So the desired set is
+ * computed and the difference issued — which, for a run that moved nothing,
+ * means no write at all.
+ *
+ * Reconciling is deliberately *not* reporting. `RunResult.reported` means the
+ * issue carries this run's account of what happened, and the workflow's fallback
+ * comment is gated on it; a label is not an account of anything.
+ */
+
+export interface LabelDeps {
+  /**
+   * Narrower than `PhaseDeps` on purpose, the way `ReactionDeps` is: this module
+   * touches four endpoints, and a structural type lets a test drive it without
+   * standing up the rest of the GitHub surface to reach them.
+   */
+  github: LabelApi
+  log: Logger
+  /** Only the prefix is read, so a caller need not assemble a whole config. */
+  config: Pick<PipelineConfig, 'labelPrefix'>
+}
+
+/**
+ * A label as GitHub knows it: the prefix already applied.
+ *
+ * A type of its own rather than a {@link LabelSpec} whose `suffix` has quietly
+ * become a whole name — the two are compared against what the issue carries, and
+ * one field meaning both things is how a prefix ends up applied twice or not at
+ * all.
+ */
+export interface QualifiedLabel {
+  name: string
+  color: string
+}
+
+/** The markers a stance implies, on top of the phase's own label. */
+const markersFor = (stance: RunStance, whoseTurn: WhoseTurn): readonly LabelSpec[] => {
+  // Mutually exclusive by construction, and that is the point: while the agent
+  // holds the issue it is not waiting on anybody, so a run in flight must not
+  // also show up in the "blocked on me" filter it is busy clearing.
+  if (stance === 'working') return [WORKING_LABEL]
+  return whoseTurn === 'you' ? [NEEDS_YOU_LABEL] : []
+}
+
+/**
+ * Every label this state implies, fully qualified. Pure — nothing here talks to
+ * GitHub, so the interesting half of the reconcile is testable as a value.
+ */
+export const desiredLabels = (state: AgentState, stance: RunStance, prefix: string): readonly QualifiedLabel[] => {
+  const presentation = presentationFor(state, stance)
+
+  return [presentation.label, ...markersFor(stance, presentation.whoseTurn)].map((spec) => ({
+    name: `${prefix}${spec.suffix}`,
+    color: spec.color,
+  }))
+}
+
+/**
+ * Brings the issue's labels in line with the state, best-effort.
+ *
+ * Also a repair, which is the half that is easy to leave out. Any `agent:*`
+ * label the state does not imply is removed, so an issue whose labels were
+ * edited by hand and a run whose runner was killed mid-flight — leaving
+ * `agent:working` stranded on an issue nothing is working — both heal on the
+ * next event rather than needing anybody to notice.
+ *
+ * Labels outside the prefix are never touched, in either direction. They are the
+ * repository's own, this pipeline did not put them there, and removing one is
+ * the worst thing this module could do.
+ */
+export const reconcileLabels = async (deps: LabelDeps, state: AgentState, stance: RunStance): Promise<void> => {
+  const prefix = deps.config.labelPrefix
+  if (prefix === null) return
+
+  try {
+    await applyDiff(deps, prefix, state, stance)
+  } catch (error) {
+    deps.log.warn(
+      { issue: state.issueId, phase: state.phase, stance, error: errorMessage(error) },
+      'Could not reconcile the issue labels',
+    )
+  }
+}
+
+/**
+ * The end-of-run reconcile, as a pass-through.
+ *
+ * Here rather than at each of the orchestrator's exits so that "the run is over,
+ * whatever the outcome" is stated once: `agent:working` comes off a failed run,
+ * a refused command and a delivered pull request alike. `fallback` covers the
+ * skips that carry no state of their own — reconciling the restored one is still
+ * the repair, and is what takes a stranded marker off an issue whose only event
+ * this hour was somebody typing "thanks".
+ */
+export const settleLabels = async (deps: LabelDeps, result: RunResult, fallback: AgentState): Promise<RunResult> => {
+  await reconcileLabels(deps, result.state ?? fallback, 'waiting')
+  return result
+}
+
+const applyDiff = async (deps: LabelDeps, prefix: string, state: AgentState, stance: RunStance): Promise<void> => {
+  const current = await deps.github.listLabels(state.issueId)
+  const desired = desiredLabels(state, stance, prefix)
+
+  const missing = desired.filter((label) => !current.includes(label.name))
+  const stale = current.filter((name) => name.startsWith(prefix) && !desired.some((label) => label.name === name))
+  if (missing.length === 0 && stale.length === 0) return
+
+  await addLabels(deps, state.issueId, missing)
+  // One at a time: there is no bulk delete, and the repo forbids awaiting in a
+  // loop body.
+  await mapSeries(stale, (name) => deps.github.removeLabel(state.issueId, name))
+
+  deps.log.debug(
+    { issue: state.issueId, added: missing.map((label) => label.name), removed: stale },
+    'Reconciled the issue labels',
+  )
+}
+
+/**
+ * Adds labels, creating any the repository does not have yet.
+ *
+ * Created explicitly rather than left to the add call, because that is the only
+ * way the palette is applied: a label GitHub invents on an issue gets a random
+ * colour, and a colour per meaning — blue while the agent works, amber while it
+ * waits on you, red for a failure — is most of what makes a list view readable
+ * at a glance.
+ */
+const addLabels = async (deps: LabelDeps, issueNumber: number, missing: readonly QualifiedLabel[]): Promise<void> => {
+  if (missing.length === 0) return
+
+  await mapSeries(missing, (label) => deps.github.createLabel(label.name, label.color))
+  await deps.github.addLabels(
+    issueNumber,
+    missing.map((label) => label.name),
+  )
+}

--- a/opencode-agent/src/opencode-adapter.ts
+++ b/opencode-agent/src/opencode-adapter.ts
@@ -13,7 +13,7 @@ import type { Logger } from './logger.js'
 import { buildOpencodeConfig, modelRef } from './openai-config.js'
 import type { OpenAiSettings } from './openai-config.js'
 import { createProgressTracker, followEvents, withHeartbeat } from './progress.js'
-import type { EventFollower, ProgressTracker } from './progress.js'
+import type { EventFollower, ProgressSnapshot, ProgressTracker } from './progress.js'
 import { buildBody, decodeReply, decodeSessionId, decodeSessionUsage, parseModelRef } from './sdk-contract.js'
 import type { SdkPromptBody, SessionUsage } from './sdk-contract.js'
 
@@ -86,6 +86,16 @@ export interface OpenCodeAgentOptions {
   log: Logger
   /** Heartbeat period while a turn is outstanding. `0` disables it. */
   heartbeatMs?: number
+  /**
+   * Where each heartbeat goes besides the log.
+   *
+   * The adapter is the only layer that can see a turn in flight, and the live
+   * status comment on the issue is the only surface a maintainer has a link to
+   * — so the snapshot has to be handed out from here or the two never meet.
+   * Optional because most runs have nowhere to send it: a local `--event-path`
+   * run has no status comment at all.
+   */
+  onTick?: (snapshot: ProgressSnapshot) => void
   /** Injection seam for tests. Defaults to the real SDK server + client. */
   connect?: () => Promise<OpenCodeConnection>
 }
@@ -275,5 +285,10 @@ const bounded = (work: Promise<unknown>, options: OpenCodeAgentOptions, tracker:
         `The model did not answer within ${elapsed}ms (AGENT_TIMEOUT_MS). Raise it, or narrow the phase's work.`,
       ),
     ),
-    { everyMs: options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS, log: options.log, snapshot: tracker.snapshot },
+    {
+      everyMs: options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS,
+      log: options.log,
+      snapshot: tracker.snapshot,
+      onTick: options.onTick,
+    },
   )

--- a/opencode-agent/src/orchestrator.ts
+++ b/opencode-agent/src/orchestrator.ts
@@ -111,7 +111,13 @@ const runAccepted = async (event: TriggerEvent, deps: PhaseDeps): Promise<RunRes
   // nothing adds the marker and takes it off again within the second, which is
   // two timeline entries on an issue where the agent did nothing, and precisely
   // the churn a diff instead of a clear-and-reapply exists to avoid.
-  if (willWork(entry)) await reconcileLabels(deps, entry.state, 'working')
+  // The status comment is opened on the same condition and for the same reason:
+  // it is the whole comment budget this plan allows itself, and spending it on a
+  // run that is about to do nothing is the noise the budget exists to prevent.
+  if (willWork(entry)) {
+    await reconcileLabels(deps, entry.state, 'working')
+    await deps.status.start(entry.state)
+  }
 
   const result = await driveMachine({
     ...base,
@@ -123,6 +129,12 @@ const runAccepted = async (event: TriggerEvent, deps: PhaseDeps): Promise<RunRes
     // adding it to each phase's own would count the earlier phases again.
     carriedTokens: restored.tokensSpent,
   })
+
+  // Finalising the status comment is deliberately not reporting: `finish`
+  // returns nothing, so this cannot touch `result.reported` even by accident. A
+  // run that died before reaching this line leaves "run in progress" on the
+  // issue, which is exactly what the workflow's fallback comment is for.
+  await deps.status.finish(result)
 
   return settleLabels(deps, result, entry.state)
 }
@@ -189,6 +201,10 @@ const driveMachine = async (input: MachineInput): Promise<RunResult> => {
   // place used to leave the issue in a phase no trigger re-enters.
   const stopped = await stopIfOverBudget(input)
   if (stopped !== null) return stopped
+
+  // After the budget stop, so a run that cannot afford this phase does not
+  // announce it as the one in flight.
+  await input.deps.status.enter(state)
 
   const attempt = await runHandler(handler, input)
   if (!attempt.ok) return input.answer ? failAnswer(input, attempt.error) : failRun(input, attempt.error)

--- a/opencode-agent/src/orchestrator.ts
+++ b/opencode-agent/src/orchestrator.ts
@@ -4,6 +4,7 @@
 // See LICENSE in the project root for details.
 
 import { parseSlashCommand } from './commands.js'
+import { react } from './feedback.js'
 import { evaluateGuardrails } from './guardrails.js'
 import type { TriggerEvent } from './guardrails.js'
 import type { IssueContext, MachineInput, PhaseDeps, PhaseHandler, PhaseInput, PhaseOutcome } from './phase-context.js'
@@ -58,10 +59,26 @@ export const runPipeline = async (options: RunOptions): Promise<RunResult> => {
   })
   if (!guard.allowed) {
     deps.log.warn({ code: guard.code, event: event.eventName }, 'Trigger rejected by guardrails')
-    // `reported: false` and it has to stay that way: a rejection here is
-    // deliberately silent, so the issue carries nothing about this run.
+    // The one denial with a person behind it. Every other code here is machine
+    // noise — a bot, the agent's own comment, a pull request, an event shape
+    // this pipeline does not handle — and reacting to those would be talking to
+    // nobody. `NOT_MAINTAINER` is a write triggered by an account without write
+    // access, which is the judgement call: it is bounded to one reaction on one
+    // comment with no content and no notification storm, and the alternative is
+    // that an outside contributor's comment vanishes into a log they cannot
+    // read.
+    if (guard.code === 'NOT_MAINTAINER') await react(deps, event, 'confused')
+    // `reported: false` and it has to stay that way: a reaction is not an
+    // account of what happened, so the issue still carries nothing about this
+    // run and the workflow's fallback comment must stay in scope.
     return { status: 'skipped', reason: guard.reason, state: null, reported: false }
   }
+
+  // Every accepted trigger, before anything else this run does — a reaction that
+  // arrives after the work is worth much less than one that arrives before it,
+  // and this is the only acknowledgement any trigger gets. CI events fall
+  // through it silently; `reactionTarget` decides that, not this call site.
+  await react(deps, event, 'eyes')
 
   const thread = await deps.github.listIssueComments(event.issueNumber)
   const restored = findLatestState(thread, await deps.selfLogin(), event.issueNumber) ?? initialState(event.issueNumber)
@@ -212,7 +229,8 @@ const failRun = async (input: MachineInput, error: unknown): Promise<RunResult> 
   deps.log.error({ issue: state.issueId, phase: state.phase, error: message }, 'Phase handler failed')
 
   const failed = transition(state, 'FAILED', await recordSpend(input, { lastError: message }))
-  await postAndAppend(thread, input, renderFailure(state.phase, message, failed, deps.config.maxAttempts), failed)
+  const report = renderFailure(state.phase, message, failed, deps.config.maxAttempts, deps.config.runUrl)
+  await postAndAppend(thread, input, report, failed)
 
   // The comment above is what the workflow's fallback step would otherwise
   // duplicate, contradicting it: this run has moved the issue to `FAILED`, so

--- a/opencode-agent/src/orchestrator.ts
+++ b/opencode-agent/src/orchestrator.ts
@@ -19,6 +19,7 @@ import { handleTriage } from './phases/triage.js'
 import { postAndAppend, renderSettled } from './run-report.js'
 import { findLatestState, initialState, transition } from './state-manager.js'
 import { recordSpend, stopIfOverBudget } from './token-budget.js'
+import type { TriggerOutcome } from './trigger-outcome.js'
 import { applyTrigger } from './triggers.js'
 import type { AgentState, Phase, RunResult, TransitionSignal } from './types.js'
 
@@ -103,14 +104,14 @@ const runAccepted = async (event: TriggerEvent, deps: PhaseDeps): Promise<RunRes
 
   const base: PhaseInput = { state: restored, issue, trigger: event, command, thread, deps }
   const entry = await applyTrigger(base)
-  // A trigger that moved nothing gets the closing reconcile and not the opening
-  // one. Marking a run that is about to skip as working would add the marker and
-  // remove it again within the second — two timeline entries on an issue where
-  // nothing happened, which is the noise this whole channel is sized to avoid.
-  // The closing one still runs, because it is also the repair.
   if (entry.halt !== null) return settleLabels(deps, entry.halt, restored)
 
-  await reconcileLabels(deps, entry.state, 'working')
+  // Only when something is actually going to run. The closing reconcile happens
+  // either way — it is also the repair — but marking a run that is about to do
+  // nothing adds the marker and takes it off again within the second, which is
+  // two timeline entries on an issue where the agent did nothing, and precisely
+  // the churn a diff instead of a clear-and-reapply exists to avoid.
+  if (willWork(entry)) await reconcileLabels(deps, entry.state, 'working')
 
   const result = await driveMachine({
     ...base,
@@ -125,6 +126,17 @@ const runAccepted = async (event: TriggerEvent, deps: PhaseDeps): Promise<RunRes
 
   return settleLabels(deps, result, entry.state)
 }
+
+/**
+ * Whether the cascade will actually run a handler for this entry.
+ *
+ * The two cases where it will not are a trigger that moved into a waiting phase
+ * and `/cancel`, which reaches `COMPLETE` — both of them state moves with no
+ * work behind them, and `agent:working` on either is a claim that nothing is
+ * happening. Asked of the same `HANDLERS` table {@link driveMachine} looks the
+ * phase up in, so the marker cannot disagree with what the machine does next.
+ */
+const willWork = (entry: TriggerOutcome): boolean => entry.answer || HANDLERS[entry.state.phase] !== undefined
 
 /** The issue's title and body, from the payload when present, else the API. */
 const resolveIssue = (event: TriggerEvent, deps: PhaseDeps): Promise<IssueContext> => {

--- a/opencode-agent/src/orchestrator.ts
+++ b/opencode-agent/src/orchestrator.ts
@@ -7,18 +7,19 @@ import { parseSlashCommand } from './commands.js'
 import { react } from './feedback.js'
 import { evaluateGuardrails } from './guardrails.js'
 import type { TriggerEvent } from './guardrails.js'
+import { reconcileLabels, settleLabels } from './labels.js'
 import type { IssueContext, MachineInput, PhaseDeps, PhaseHandler, PhaseInput, PhaseOutcome } from './phase-context.js'
+import { failAnswer, failRun } from './phase-failure.js'
 import { handleAnswer } from './phases/answer.js'
 import { handleCiFix } from './phases/ci-fix.js'
 import { handleDeliver } from './phases/deliver.js'
 import { handleImplement } from './phases/implement.js'
 import { handlePlan } from './phases/plan.js'
 import { handleTriage } from './phases/triage.js'
-import { postAndAppend, renderAnswerFailure, renderFailure, renderSettled } from './run-report.js'
+import { postAndAppend, renderSettled } from './run-report.js'
 import { findLatestState, initialState, transition } from './state-manager.js'
 import { recordSpend, stopIfOverBudget } from './token-budget.js'
 import { applyTrigger } from './triggers.js'
-import { errorMessage } from './types.js'
 import type { AgentState, Phase, RunResult, TransitionSignal } from './types.js'
 
 /**
@@ -80,6 +81,21 @@ export const runPipeline = async (options: RunOptions): Promise<RunResult> => {
   // through it silently; `reactionTarget` decides that, not this call site.
   await react(deps, event, 'eyes')
 
+  return runAccepted(event, deps)
+}
+
+/**
+ * Everything a trigger the guardrails let through does.
+ *
+ * Split from {@link runPipeline}, which is now the guardrail and the
+ * acknowledgement, because the two halves answer different questions and the
+ * function was already at the length limit before the label reconciles arrived.
+ *
+ * Both of those reconciles live here rather than deeper down, because both are
+ * statements about the *run*: one marker goes on when work starts and comes off
+ * when it ends, whatever the outcome, and neither fact is known to a phase.
+ */
+const runAccepted = async (event: TriggerEvent, deps: PhaseDeps): Promise<RunResult> => {
   const thread = await deps.github.listIssueComments(event.issueNumber)
   const restored = findLatestState(thread, await deps.selfLogin(), event.issueNumber) ?? initialState(event.issueNumber)
   const issue = await resolveIssue(event, deps)
@@ -87,9 +103,16 @@ export const runPipeline = async (options: RunOptions): Promise<RunResult> => {
 
   const base: PhaseInput = { state: restored, issue, trigger: event, command, thread, deps }
   const entry = await applyTrigger(base)
-  if (entry.halt !== null) return entry.halt
+  // A trigger that moved nothing gets the closing reconcile and not the opening
+  // one. Marking a run that is about to skip as working would add the marker and
+  // remove it again within the second — two timeline entries on an issue where
+  // nothing happened, which is the noise this whole channel is sized to avoid.
+  // The closing one still runs, because it is also the repair.
+  if (entry.halt !== null) return settleLabels(deps, entry.halt, restored)
 
-  return driveMachine({
+  await reconcileLabels(deps, entry.state, 'working')
+
+  const result = await driveMachine({
     ...base,
     state: entry.state,
     answer: entry.answer,
@@ -99,6 +122,8 @@ export const runPipeline = async (options: RunOptions): Promise<RunResult> => {
     // adding it to each phase's own would count the earlier phases again.
     carriedTokens: restored.tokensSpent,
   })
+
+  return settleLabels(deps, result, entry.state)
 }
 
 /** The issue's title and body, from the payload when present, else the API. */
@@ -209,68 +234,4 @@ const runHandler = async (handler: PhaseHandler, input: MachineInput): Promise<H
   } catch (error) {
     return { ok: false, error }
   }
-}
-
-/**
- * Records the failure on the issue and parks the state in FAILED with
- * `resumeFrom` set, so `/retry` re-enters the exact phase that broke instead of
- * replaying the whole pipeline.
- *
- * Through `recordSpend`, exactly as the success path is. A failing phase spends
- * what it spent — the model turn is paid for long before the parse that rejects
- * its reply — and this used to write `lastError` and nothing else, so the tokens
- * went unrecorded and the next runner read `0`. That is the one path the ceiling
- * most needs to see: the state it parks in is `FAILED`, and `/retry` out of
- * `FAILED` is how an issue comes back for another expensive round.
- */
-const failRun = async (input: MachineInput, error: unknown): Promise<RunResult> => {
-  const { state, deps, thread } = input
-  const message = errorMessage(error)
-  deps.log.error({ issue: state.issueId, phase: state.phase, error: message }, 'Phase handler failed')
-
-  const failed = transition(state, 'FAILED', await recordSpend(input, { lastError: message }))
-  const report = renderFailure(state.phase, message, failed, deps.config.maxAttempts, deps.config.runUrl)
-  await postAndAppend(thread, input, report, failed)
-
-  // The comment above is what the workflow's fallback step would otherwise
-  // duplicate, contradicting it: this run has moved the issue to `FAILED`, so
-  // "the issue state is unchanged" is false the moment `postAndAppend` returns.
-  return { status: 'failed', reason: message, state: failed, reported: true }
-}
-
-/**
- * Reports a failed answer without moving the machine, and without spending an
- * attempt.
- *
- * A question is a side conversation about work that lives elsewhere: the phase
- * records where the *work* is, so parking a delivered pull request or an
- * in-flight implementation in FAILED because a model turn about it broke is a
- * lie about what happened. In COMPLETE it was not even reachable — the FAILED
- * guard in `canTransition` refuses that move — so {@link failRun}'s own
- * `transition` threw and took the whole runner with it.
- *
- * The retry budget is left alone for the same reason: `attempts` counts
- * consecutive failures to make progress on the issue, and a question makes
- * none either way. Leaving `resumeFrom` alone is what makes the notice honest.
- * Answering in a waiting phase used to record `resumeFrom: 'DESIGN_SPEC'`, and
- * the `/retry` the failure comment invited then resumed into a phase with no
- * handler and re-parked with "Parked in `DESIGN_SPEC`" — one attempt poorer for
- * a round trip that did nothing.
- *
- * Moving nothing is not the same as recording nothing, which is the distinction
- * this path missed: it posted the restored state verbatim, so a question that
- * reached the model and then failed on a deadline or a rejected request handed
- * the next job a total with that turn missing from it. The spend is the one
- * thing a failed answer really does change, and it is written the way every
- * other state block writes it — see {@link recordSpend}.
- */
-const failAnswer = async (input: MachineInput, error: unknown): Promise<RunResult> => {
-  const { state, deps, thread } = input
-  const message = errorMessage(error)
-  deps.log.error({ issue: state.issueId, phase: state.phase, error: message }, 'Answering a question failed')
-
-  const carried = { ...state, ...(await recordSpend(input)) }
-  await postAndAppend(thread, input, renderAnswerFailure(state.phase, message), carried)
-
-  return { status: 'failed', reason: message, state: carried, reported: true }
 }

--- a/opencode-agent/src/phase-context.ts
+++ b/opencode-agent/src/phase-context.ts
@@ -14,6 +14,7 @@ import type { Logger } from './logger.js'
 import type { SkillDocument } from './obra-skills.js'
 import type { OpenCodeAgent } from './opencode-adapter.js'
 import type { ReviewRunResult } from './review-runner.js'
+import type { StatusReporter } from './status-reporter.js'
 import type { AgentState, Phase } from './types.js'
 
 /** The issue a run is about, however the run was triggered. */
@@ -60,6 +61,14 @@ export interface PhaseDeps {
    * and artefacts are read back through, not just the recursion guard.
    */
   selfLogin: () => Promise<string>
+  /**
+   * The run's live status comment, as an injected boundary like every other.
+   *
+   * Required rather than optional so a caller has to decide, and
+   * `noopStatusReporter()` is a decision: a local run with no job to link to
+   * says nothing, and says so once, in `deps.ts`.
+   */
+  status: StatusReporter
   config: PipelineConfig
   log: Logger
 }

--- a/opencode-agent/src/phase-failure.ts
+++ b/opencode-agent/src/phase-failure.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { MachineInput } from './phase-context.js'
+import { postAndAppend, renderAnswerFailure, renderFailure } from './run-report.js'
+import { transition } from './state-manager.js'
+import { recordSpend } from './token-budget.js'
+import { errorMessage } from './types.js'
+import type { RunResult } from './types.js'
+
+/**
+ * Where the cascade parks a run that broke, and what it says about it.
+ *
+ * Split from `orchestrator.ts` when that file reached its length limit, along
+ * the seam `token-budget.ts` already sits on: the orchestrator decides *which*
+ * handler runs next, and a module beside it decides what a state that cannot go
+ * on is left looking like. These two are the failure half of that, and they
+ * belong together because the whole point of having two is the difference
+ * between them — a broken phase parks the issue, a broken answer must not.
+ */
+
+/**
+ * Records the failure on the issue and parks the state in FAILED with
+ * `resumeFrom` set, so `/retry` re-enters the exact phase that broke instead of
+ * replaying the whole pipeline.
+ *
+ * Through `recordSpend`, exactly as the success path is. A failing phase spends
+ * what it spent — the model turn is paid for long before the parse that rejects
+ * its reply — and this used to write `lastError` and nothing else, so the tokens
+ * went unrecorded and the next runner read `0`. That is the one path the ceiling
+ * most needs to see: the state it parks in is `FAILED`, and `/retry` out of
+ * `FAILED` is how an issue comes back for another expensive round.
+ */
+export const failRun = async (input: MachineInput, error: unknown): Promise<RunResult> => {
+  const { state, deps, thread } = input
+  const message = errorMessage(error)
+  deps.log.error({ issue: state.issueId, phase: state.phase, error: message }, 'Phase handler failed')
+
+  const failed = transition(state, 'FAILED', await recordSpend(input, { lastError: message }))
+  const report = renderFailure(state.phase, message, failed, deps.config.maxAttempts, deps.config.runUrl)
+  await postAndAppend(thread, input, report, failed)
+
+  // The comment above is what the workflow's fallback step would otherwise
+  // duplicate, contradicting it: this run has moved the issue to `FAILED`, so
+  // "the issue state is unchanged" is false the moment `postAndAppend` returns.
+  return { status: 'failed', reason: message, state: failed, reported: true }
+}
+
+/**
+ * Reports a failed answer without moving the machine, and without spending an
+ * attempt.
+ *
+ * A question is a side conversation about work that lives elsewhere: the phase
+ * records where the *work* is, so parking a delivered pull request or an
+ * in-flight implementation in FAILED because a model turn about it broke is a
+ * lie about what happened. In COMPLETE it was not even reachable — the FAILED
+ * guard in `canTransition` refuses that move — so {@link failRun}'s own
+ * `transition` threw and took the whole runner with it.
+ *
+ * The retry budget is left alone for the same reason: `attempts` counts
+ * consecutive failures to make progress on the issue, and a question makes
+ * none either way. Leaving `resumeFrom` alone is what makes the notice honest.
+ * Answering in a waiting phase used to record `resumeFrom: 'DESIGN_SPEC'`, and
+ * the `/retry` the failure comment invited then resumed into a phase with no
+ * handler and re-parked with "Parked in `DESIGN_SPEC`" — one attempt poorer for
+ * a round trip that did nothing.
+ *
+ * Moving nothing is not the same as recording nothing, which is the distinction
+ * this path missed: it posted the restored state verbatim, so a question that
+ * reached the model and then failed on a deadline or a rejected request handed
+ * the next job a total with that turn missing from it. The spend is the one
+ * thing a failed answer really does change, and it is written the way every
+ * other state block writes it — see {@link recordSpend}.
+ */
+export const failAnswer = async (input: MachineInput, error: unknown): Promise<RunResult> => {
+  const { state, deps, thread } = input
+  const message = errorMessage(error)
+  deps.log.error({ issue: state.issueId, phase: state.phase, error: message }, 'Answering a question failed')
+
+  const carried = { ...state, ...(await recordSpend(input)) }
+  await postAndAppend(thread, input, renderAnswerFailure(state.phase, message), carried)
+
+  return { status: 'failed', reason: message, state: carried, reported: true }
+}

--- a/opencode-agent/src/phases/ci-fix.ts
+++ b/opencode-agent/src/phases/ci-fix.ts
@@ -58,7 +58,7 @@ export const handleCiFix: PhaseHandler = async (input): Promise<PhaseOutcome> =>
   const pushed = await commitAndPush(input, branch)
   deps.log.info({ issue: state.issueId, branch, passed: outcome.passed, pushed }, 'CI fix round finished')
 
-  return { signal: 'CI_FIXED', comment: renderCiReport(input, outcome, pushed) }
+  return { signal: 'CI_FIXED', comment: renderCiReport(input, outcome, pushed, deps.config.runUrl) }
 }
 
 const commitAndPush = async (input: PhaseInput, branch: string): Promise<boolean> => {
@@ -71,18 +71,38 @@ const commitAndPush = async (input: PhaseInput, branch: string): Promise<boolean
   return true
 }
 
-const runUrl = (input: PhaseInput): string | null => (input.trigger.kind === 'ci' ? input.trigger.runUrl : null)
+/** The red run that brought the pipeline here; absent unless CI triggered it. */
+const redRunUrl = (input: PhaseInput): string | null => (input.trigger.kind === 'ci' ? input.trigger.runUrl : null)
 
-const renderCiReport = (input: PhaseInput, outcome: CheckLoopResult, pushed: boolean): string => {
+/**
+ * The two runs this comment is about, told apart.
+ *
+ * There have always been two — the red one being repaired and the agent one
+ * doing the repairing — and this comment used to print only the first, under the
+ * bare word "run". A maintainer reading it had no way to tell which was meant,
+ * and no link at all to the job whose log would say what the repair actually
+ * did. Both come in as arguments: the red one is a fact about the event, the
+ * agent one a fact about the environment, and neither is a renderer's to fetch.
+ */
+const runLines = (red: string | null, agent: string | null): readonly string[] => [
+  ...(red === null ? [] : [`- Red run I am repairing: ${red}`]),
+  ...(agent === null ? [] : [`- This repair ran in: ${agent}`]),
+]
+
+const renderCiReport = (
+  input: PhaseInput,
+  outcome: CheckLoopResult,
+  pushed: boolean,
+  agentRunUrl: string | null,
+): string => {
   const { state, deps } = input
-  const url = runUrl(input)
   const lines = [
     `### CI fix attempt ${state.ciAttempts} of ${deps.config.maxCiAttempts}`,
     '',
-    url === null ? '' : `Triggered by a red run: ${url}`,
+    ...runLines(redRunUrl(input), agentRunUrl),
     `- Local checks: ${outcome.passed ? '✅ green' : '❌ still red'} after ${outcome.rounds} round(s)`,
     `- Pushed a fix: ${pushed ? 'yes' : 'no — nothing changed'}`,
-  ].filter((line) => line !== '')
+  ]
 
   if (!outcome.passed) {
     lines.push(

--- a/opencode-agent/src/phases/deliver.ts
+++ b/opencode-agent/src/phases/deliver.ts
@@ -4,6 +4,7 @@
 // See LICENSE in the project root for details.
 
 import { findArtifact, REPORT_MARKER } from '../artifacts.js'
+import { react } from '../feedback.js'
 import { branchNameFor } from '../git.js'
 import type { PullRequestPresentation, PullRequestRef, PullRequestStatus } from '../github.js'
 import type { PhaseHandler, PhaseInput, PhaseOutcome } from '../phase-context.js'
@@ -39,6 +40,15 @@ export const handleDeliver: PhaseHandler = async (input): Promise<PhaseOutcome> 
       : await refresh(input, existing, presentation)
 
   deps.log.info({ issue: state.issueId, branch, pr: pr.number, reused: existing !== null }, 'Pull request ready')
+
+  // 🚀 here rather than at the end of the run, because here is the only place
+  // that knows the difference between a delivery and a stand-down: the settled
+  // branch above reports the same `PR_OPENED` signal and reaches the same
+  // `COMPLETE`, having opened and refreshed nothing. Both live paths below it
+  // have produced a pull request, and the cascade goes straight to `COMPLETE`
+  // from here, so "a run that finished having delivered one" is exactly this
+  // line. Best-effort like every reaction — `react` cannot throw.
+  await react(deps, input.trigger, 'rocket')
 
   return {
     signal: 'PR_OPENED',

--- a/opencode-agent/src/presentation.ts
+++ b/opencode-agent/src/presentation.ts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { AgentState } from './types.js'
+
+/**
+ * How the pipeline presents itself: one glyph, one label, one headline and one
+ * statement of whose turn it is, per state a maintainer can find an issue in.
+ *
+ * One table, because the recurring defect in this workspace is a fix that closes
+ * an instance and leaves the class open, and a phase→glyph mapping written out
+ * by hand in each of nine renderers is that defect waiting to happen. Everything
+ * that speaks about a phase — the label reconciler, the waiting comment, and the
+ * status comment when it lands — reads from here, so a phase added to `PHASES`
+ * later fails to compile until it has been given a row.
+ *
+ * The glyph is decoration and never the only carrier of meaning: the headline
+ * sits beside it in every rendering and the label is plain text, so a screen
+ * reader that announces "clipboard, design spec is waiting for you" loses
+ * nothing by dropping the first word.
+ */
+
+/**
+ * Who the issue is waiting on.
+ *
+ * `nobody` is not "no answer": a delivered or cancelled issue is finished, and
+ * saying so is what keeps it out of the `needs-you` filter.
+ */
+export type WhoseTurn = 'agent' | 'you' | 'nobody'
+
+/**
+ * Whether the agent is working on this state or has handed it back.
+ *
+ * The second half of the key, and it exists because `INIT_OR_CLARIFY` is both a
+ * working state and a waiting state — it is where the agent sits after asking
+ * clarifying questions. Keying on the phase alone would force every reader to
+ * re-derive that distinction, which is the class of bug this table exists to
+ * prevent, so it goes in the key instead.
+ */
+export type RunStance = 'working' | 'waiting'
+
+/**
+ * A label this pipeline owns, named by its suffix.
+ *
+ * The suffix rather than the whole name, because `AGENT_LABEL_PREFIX` is
+ * configurable: this pipeline runs in repositories with their own label
+ * conventions, so a row cannot own the part of the name the operator chooses.
+ * `labels.ts` qualifies these; nothing here knows the prefix.
+ */
+export interface LabelSpec {
+  suffix: string
+  /** Six hex digits, no `#` — the shape GitHub's label API takes. */
+  color: string
+}
+
+export interface PhasePresentation {
+  glyph: string
+  label: LabelSpec
+  whoseTurn: WhoseTurn
+  headline: string
+}
+
+/** Blue for the states the agent owns, amber for the ones waiting on a human. */
+const BLUE = '1d76db'
+const AMBER = 'd4a72c'
+const GREEN = '0e8a16'
+const RED = 'd73a4a'
+const GREY = '6a737d'
+
+/**
+ * The two orthogonal markers, and the part worth shipping even if the per-phase
+ * labels were dropped.
+ *
+ * They answer the two questions a list view is actually asked — "is something
+ * happening right now" and "which of my issues are blocked on me" — neither of
+ * which a per-phase label answers without the reader knowing the state machine.
+ */
+export const WORKING_LABEL: LabelSpec = { suffix: 'working', color: BLUE }
+export const NEEDS_YOU_LABEL: LabelSpec = { suffix: 'needs-you', color: AMBER }
+
+/**
+ * Every row of the table, as a closed union.
+ *
+ * Two phases carry a suffix because two phases are genuinely two states:
+ * `INIT_OR_CLARIFY` splits on whether the agent is reading the issue or waiting
+ * on the answers it asked for, and `COMPLETE` splits on `state.prUrl` exactly as
+ * `renderClosing` already does — a delivered issue and a cancelled one are not
+ * the same outcome and must not carry the same label.
+ */
+export const PRESENTATION_KEYS = [
+  'INIT_OR_CLARIFY:working',
+  'INIT_OR_CLARIFY:waiting',
+  'DESIGN_SPEC',
+  'EXECUTION_PLAN',
+  'PLAN_REVIEW',
+  'REVIEW_AND_MUTATE',
+  'PR_DELIVERY',
+  'CI_FIX',
+  'COMPLETE:delivered',
+  'COMPLETE:cancelled',
+  'FAILED',
+] as const
+
+export type PresentationKey = (typeof PRESENTATION_KEYS)[number]
+
+/** A `Record` over the closed union, so a row that is missing cannot compile. */
+export const PRESENTATION: Record<PresentationKey, PhasePresentation> = {
+  'INIT_OR_CLARIFY:working': {
+    glyph: '🔍',
+    label: { suffix: 'triaging', color: BLUE },
+    whoseTurn: 'agent',
+    headline: 'Reading the issue',
+  },
+  'INIT_OR_CLARIFY:waiting': {
+    glyph: '❓',
+    label: { suffix: 'clarifying', color: AMBER },
+    whoseTurn: 'you',
+    headline: 'Waiting on your answers',
+  },
+  DESIGN_SPEC: {
+    glyph: '📋',
+    label: { suffix: 'spec-review', color: AMBER },
+    whoseTurn: 'you',
+    headline: 'Design spec is waiting for you',
+  },
+  EXECUTION_PLAN: {
+    glyph: '🗺️',
+    label: { suffix: 'planning', color: BLUE },
+    whoseTurn: 'agent',
+    headline: 'Breaking the spec into steps',
+  },
+  PLAN_REVIEW: {
+    glyph: '🧭',
+    label: { suffix: 'plan-review', color: AMBER },
+    whoseTurn: 'you',
+    headline: 'Plan is waiting for you',
+  },
+  REVIEW_AND_MUTATE: {
+    glyph: '🛠️',
+    label: { suffix: 'implementing', color: BLUE },
+    whoseTurn: 'agent',
+    headline: 'Writing and reviewing the code',
+  },
+  PR_DELIVERY: {
+    glyph: '📦',
+    label: { suffix: 'delivering', color: BLUE },
+    whoseTurn: 'agent',
+    headline: 'Opening the pull request',
+  },
+  CI_FIX: {
+    glyph: '🚑',
+    label: { suffix: 'ci-fixing', color: BLUE },
+    whoseTurn: 'agent',
+    headline: 'Repairing red checks',
+  },
+  'COMPLETE:delivered': {
+    glyph: '✅',
+    label: { suffix: 'done', color: GREEN },
+    whoseTurn: 'nobody',
+    headline: 'Delivered',
+  },
+  'COMPLETE:cancelled': {
+    glyph: '🛑',
+    label: { suffix: 'stopped', color: GREY },
+    whoseTurn: 'nobody',
+    headline: 'Stopped',
+  },
+  // Whose turn is **you**: a failed run is parked with a resume point and stays
+  // there until somebody replies `/retry` or `/cancel`. The same is true of an
+  // over-budget stop, which parks in this very phase.
+  FAILED: {
+    glyph: '❌',
+    label: { suffix: 'failed', color: RED },
+    whoseTurn: 'you',
+    headline: 'Run failed',
+  },
+}
+
+/**
+ * The row a state and a stance name.
+ *
+ * The fall-through is the load-bearing line: once the two splitting phases are
+ * narrowed away, `state.phase` is the remaining union of `Phase`, and it only
+ * satisfies {@link PresentationKey} while every one of those literals has a row.
+ * A phase added to `PHASES` and forgotten here is therefore a compile error at
+ * this `return`, not a lookup that quietly hands back `undefined` at run time.
+ */
+export const presentationKey = (state: AgentState, stance: RunStance): PresentationKey => {
+  if (state.phase === 'INIT_OR_CLARIFY') {
+    return stance === 'working' ? 'INIT_OR_CLARIFY:working' : 'INIT_OR_CLARIFY:waiting'
+  }
+  if (state.phase === 'COMPLETE') return state.prUrl === null ? 'COMPLETE:cancelled' : 'COMPLETE:delivered'
+
+  return state.phase
+}
+
+/** How this state should be presented right now. Total by construction. */
+export const presentationFor = (state: AgentState, stance: RunStance): PhasePresentation =>
+  PRESENTATION[presentationKey(state, stance)]

--- a/opencode-agent/src/presentation.ts
+++ b/opencode-agent/src/presentation.ts
@@ -199,3 +199,74 @@ export const presentationKey = (state: AgentState, stance: RunStance): Presentat
 /** How this state should be presented right now. Total by construction. */
 export const presentationFor = (state: AgentState, stance: RunStance): PhasePresentation =>
   PRESENTATION[presentationKey(state, stance)]
+
+/**
+ * The second vocabulary: what just happened to this **run**.
+ *
+ * Deliberately not the table above, and not folded into it. That one is keyed on
+ * a *phase* — where the issue is — while "the retry budget is spent", "I could
+ * not answer that" and "that command does not apply here" are keyed on an
+ * outcome, and every one of them can happen in several phases and leave the
+ * phase exactly where it was. Forcing them through a phase key would either
+ * invent phases that do not exist or make one row mean two things, which is the
+ * failure the phase table is itself built to avoid.
+ *
+ * Two renderers are deliberately **absent** and read the phase table instead:
+ * `renderClosing`'s delivered and cancelled headings are `COMPLETE:delivered`
+ * and `COMPLETE:cancelled` — the same two states the label reconciler is naming
+ * on the same comment, so a second copy of ✅ and 🛑 here could only ever drift
+ * away from the label sitting beside them.
+ */
+export const OUTCOME_KEYS = [
+  'RUN_FAILED',
+  'ANSWER_FAILED',
+  'RETRIES_SPENT',
+  'TOKENS_SPENT',
+  'ANSWER_TOKENS_SPENT',
+  'CI_GAVE_UP',
+  'COMMAND_REFUSED',
+] as const
+
+export type OutcomeKey = (typeof OUTCOME_KEYS)[number]
+
+/**
+ * A `Record` over the closed union, for the reason {@link PRESENTATION} is one.
+ *
+ * The distinctions here are the point, not the glyphs:
+ *
+ * - ❌ means the work **broke**. ⛔ means a **bound was reached** and nothing
+ *   broke at all — which is the whole argument for the budget notices being
+ *   separate renderers in the first place, and it would be undone by giving a
+ *   spent ceiling the same glyph as a crash.
+ * - ⚠️ is a failed *answer*: the model turn broke but nothing moved, no attempt
+ *   was spent and the issue is exactly where it was. ❌ there would tell a
+ *   maintainer their delivered pull request had failed.
+ * - 🚑 is `CI_FIX`'s own glyph from the phase table, reused on purpose: this is
+ *   that story ending, and the maintainer has been watching 🚑 on the issue for
+ *   however many rounds it took to give up.
+ * - 😕 matches the reaction `refuseCommand` places on the very same comment, so
+ *   the emoji on the maintainer's comment and the heading of the reply agree.
+ */
+export const OUTCOME_GLYPHS: Record<OutcomeKey, string> = {
+  RUN_FAILED: '❌',
+  ANSWER_FAILED: '⚠️',
+  RETRIES_SPENT: '⛔',
+  TOKENS_SPENT: '⛔',
+  ANSWER_TOKENS_SPENT: '⛔',
+  CI_GAVE_UP: '🚑',
+  COMMAND_REFUSED: '😕',
+}
+
+/**
+ * The heading of a comment, glyph included.
+ *
+ * Every renderer builds its first line through this or through
+ * {@link phaseHeading}, so writing a glyph inline is not something a new one
+ * falls into by accident — it has to go out of its way, past a function that is
+ * already imported, to invent a vocabulary of its own.
+ */
+export const outcomeHeading = (key: OutcomeKey, text: string): string => `### ${OUTCOME_GLYPHS[key]} ${text}`
+
+/** The same, for a comment that speaks about where the issue is. */
+export const phaseHeading = (state: AgentState, stance: RunStance, text: string): string =>
+  `### ${presentationFor(state, stance).glyph} ${text}`

--- a/opencode-agent/src/progress.ts
+++ b/opencode-agent/src/progress.ts
@@ -127,6 +127,20 @@ export interface HeartbeatOptions {
   snapshot: () => ProgressSnapshot
   /** Injected so a test does not spend real minutes proving this ticks. */
   schedule?: (tick: () => void, everyMs: number) => { cancel: () => void }
+  /**
+   * A second reader of the same tick, when one is wired.
+   *
+   * The heartbeat already knows everything a live status surface wants to say
+   * and, until now, said it only into a log nobody has a link to. Routing the
+   * snapshot rather than duplicating the timer keeps one clock in the pipeline,
+   * and keeps the two readers from ever disagreeing about what a turn has done.
+   *
+   * The log half is unchanged and stays first: a reader that throws or hangs
+   * must not cost the line that was already being written. Nothing here awaits
+   * it either — the heartbeat's job is to fire on time, not to wait for whatever
+   * the tick is being reported to.
+   */
+  onTick?: (snapshot: ProgressSnapshot) => void
 }
 
 const realSchedule = (tick: () => void, everyMs: number): { cancel: () => void } => {
@@ -164,6 +178,7 @@ export const withHeartbeat = async <T>(work: Promise<T>, options: HeartbeatOptio
       { elapsedMs: Date.now() - started, ...progress },
       'Still waiting on the model; the job is not stuck',
     )
+    if (options.onTick !== undefined) options.onTick(progress)
   }, options.everyMs)
 
   try {

--- a/opencode-agent/src/prompt-budget.ts
+++ b/opencode-agent/src/prompt-budget.ts
@@ -3,9 +3,10 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { stripBlocks } from './blocks.js'
+import { readBlock, stripBlocks } from './blocks.js'
 import type { IssueComment } from './blocks.js'
 import type { UntrustedEnvelope } from './prompts.js'
+import { STATUS_MARKER } from './status-comment.js'
 
 /**
  * How much text a prompt is allowed to carry, and which text loses when it does
@@ -34,6 +35,16 @@ const authorAttribute = (login: string): string => {
 }
 
 /**
+ * Whether a comment is the pipeline's own progress reporting.
+ *
+ * By **marker**, never by author. The agent writes the design spec, the
+ * execution plan and every phase report as well, and those are precisely what
+ * the model is being asked to read — so filtering on the login would blind it to
+ * its own artefacts, which is a much quieter version of the bug this prevents.
+ */
+const isStatusComment = (comment: IssueComment): boolean => readBlock(comment.body, STATUS_MARKER) !== undefined
+
+/**
  * Renders the issue thread for prompt context, newest last.
  *
  * **Each comment gets its own envelope**, with its author in the `source`
@@ -48,6 +59,13 @@ const authorAttribute = (login: string): string => {
  *
  * Hidden blocks are stripped: they are the pipeline's own bookkeeping, they are
  * large, and showing the model its own state schema invites it to write one.
+ *
+ * The run's live status comment is dropped outright rather than stripped, and
+ * **before** the window is taken, not after: it is one comment per run, so a
+ * conversation spanning five runs would otherwise spend a quarter of the twenty
+ * slots on progress tables the model has no use for — and the phases that read
+ * the thread are triage, answering and the classifier, which is to say the ones
+ * whose whole job is understanding what the humans said.
  */
 export const renderThread = (
   envelope: UntrustedEnvelope,
@@ -56,6 +74,7 @@ export const renderThread = (
   budget = THREAD_BUDGET,
 ): string => {
   const rendered = thread
+    .filter((comment) => !isStatusComment(comment))
     .slice(-limit)
     .map((comment) => wrapWithin(envelope, authorAttribute(comment.authorLogin), stripBlocks(comment.body), budget))
   if (rendered.length === 0) return '(no comments yet)'

--- a/opencode-agent/src/run-report.ts
+++ b/opencode-agent/src/run-report.ts
@@ -4,9 +4,11 @@
 // See LICENSE in the project root for details.
 
 import type { IssueComment } from './blocks.js'
+import { acceptedCommands } from './commands.js'
 import { reportIdentityDrift } from './identity.js'
 import { fence } from './markdown.js'
 import type { PhaseInput } from './phase-context.js'
+import { presentationFor } from './presentation.js'
 import { renderStateComment } from './state-manager.js'
 import type { AgentState, Phase } from './types.js'
 
@@ -66,8 +68,45 @@ export const renderClosing = (state: AgentState): string =>
         'If that pull request goes red I will still pick it up and push a fix.',
       ].join('\n')
 
+/**
+ * What a maintainer can type from here, named from the transition table.
+ *
+ * Shared by the two comments that have to answer that question — a refused
+ * command and a parked phase — because they are the same sentence and were on
+ * their way to being two.
+ */
+const acceptedLine = (accepted: readonly string[]): string =>
+  accepted.length === 0
+    ? 'No command moves this issue on from here.'
+    : `What works here: ${accepted.map((name) => `\`${name}\``).join(', ')}.`
+
+/**
+ * The comment that ends a run at a phase with no handler.
+ *
+ * It used to render `### Waiting` over `Parked in \`PLAN_REVIEW\`.` and stop
+ * there — the phase name, and no statement of what would move it, while every
+ * other waiting comment in this file carries a "what now". A maintainer reading
+ * it learned only that the agent had stopped, in a vocabulary (`PLAN_REVIEW`)
+ * that means nothing to anyone who has not read the state machine.
+ *
+ * Both halves are derived rather than written: the headline and glyph come from
+ * the presentation table, and the commands from the same `acceptedCommands` the
+ * refusal comment uses, so neither can drift from what the machine will take.
+ */
+const renderWaiting = (state: AgentState): string => {
+  const { glyph, headline } = presentationFor(state, 'waiting')
+
+  return [
+    `### ${glyph} ${headline}`,
+    '',
+    `Parked in \`${state.phase}\`, and nothing moves until you say so.`,
+    '',
+    acceptedLine(acceptedCommands(state.phase)),
+  ].join('\n')
+}
+
 export const renderSettled = (state: AgentState): string =>
-  state.phase === 'COMPLETE' ? renderClosing(state) : `### Waiting\n\nParked in \`${state.phase}\`.`
+  state.phase === 'COMPLETE' ? renderClosing(state) : renderWaiting(state)
 
 /**
  * The reply to a slash command the current phase cannot accept.
@@ -87,9 +126,7 @@ export const renderRefusedCommand = (command: string, phase: Phase, accepted: re
     '',
     `I am parked in \`${phase}\`, which does not accept it, so nothing has changed.`,
     '',
-    accepted.length === 0
-      ? 'No command moves this issue on from here.'
-      : `What works here: ${accepted.map((name) => `\`${name}\``).join(', ')}.`,
+    acceptedLine(accepted),
   ].join('\n')
 
 /**

--- a/opencode-agent/src/run-report.ts
+++ b/opencode-agent/src/run-report.ts
@@ -8,7 +8,7 @@ import { acceptedCommands } from './commands.js'
 import { reportIdentityDrift } from './identity.js'
 import { fence } from './markdown.js'
 import type { PhaseInput } from './phase-context.js'
-import { presentationFor } from './presentation.js'
+import { outcomeHeading, phaseHeading, presentationFor } from './presentation.js'
 import { renderStateComment } from './state-manager.js'
 import type { AgentState, Phase } from './types.js'
 
@@ -55,13 +55,18 @@ export const postAndAppend = async (
 export const renderClosing = (state: AgentState): string =>
   state.prUrl === null
     ? [
-        '### Stopped',
+        // Through the *phase* table rather than the outcome one: these two
+        // headings are `COMPLETE:cancelled` and `COMPLETE:delivered`, the same
+        // two states the label reconciler is naming on this very comment, and a
+        // second copy of the glyph could only ever drift from the label beside
+        // it.
+        phaseHeading(state, 'waiting', 'Stopped'),
         '',
         'I am no longer working on this issue, and further comments here will not restart me.',
         'Open a new issue if you want this picked up again.',
       ].join('\n')
     : [
-        '### Done',
+        phaseHeading(state, 'waiting', 'Done'),
         '',
         `The work is in ${state.prUrl}.`,
         '',
@@ -94,10 +99,10 @@ const acceptedLine = (accepted: readonly string[]): string =>
  * refusal comment uses, so neither can drift from what the machine will take.
  */
 const renderWaiting = (state: AgentState): string => {
-  const { glyph, headline } = presentationFor(state, 'waiting')
+  const { headline } = presentationFor(state, 'waiting')
 
   return [
-    `### ${glyph} ${headline}`,
+    phaseHeading(state, 'waiting', headline),
     '',
     `Parked in \`${state.phase}\`, and nothing moves until you say so.`,
     '',
@@ -122,7 +127,7 @@ export const renderSettled = (state: AgentState): string =>
  */
 export const renderRefusedCommand = (command: string, phase: Phase, accepted: readonly string[]): string =>
   [
-    `### \`${command}\` does not apply right now`,
+    outcomeHeading('COMMAND_REFUSED', `\`${command}\` does not apply right now`),
     '',
     `I am parked in \`${phase}\`, which does not accept it, so nothing has changed.`,
     '',
@@ -142,7 +147,7 @@ export const renderRefusedCommand = (command: string, phase: Phase, accepted: re
  */
 export const renderExhausted = (reason: string): string =>
   [
-    '### Giving up',
+    outcomeHeading('RETRIES_SPENT', 'Giving up'),
     '',
     reason,
     '',
@@ -160,7 +165,7 @@ export const renderExhausted = (reason: string): string =>
  */
 export const renderCiExhausted = (reason: string, prUrl: string | null): string =>
   [
-    '### I have stopped trying to fix CI',
+    outcomeHeading('CI_GAVE_UP', 'I have stopped trying to fix CI'),
     '',
     reason,
     '',
@@ -188,7 +193,7 @@ export const renderFailure = (
   runUrl: string | null,
 ): string =>
   [
-    `### Run failed in ${phase}`,
+    outcomeHeading('RUN_FAILED', `Run failed in ${phase}`),
     '',
     // The message carries raw model output, which usually contains fences.
     fence(message),
@@ -214,7 +219,7 @@ export const renderFailure = (
  */
 export const renderAnswerFailure = (phase: Phase, message: string): string =>
   [
-    '### I could not answer that',
+    outcomeHeading('ANSWER_FAILED', 'I could not answer that'),
     '',
     // The message carries raw model output, which usually contains fences.
     fence(message),
@@ -250,7 +255,7 @@ const tokenLine = (spent: number, limit: number): string =>
  */
 export const renderOverBudget = (spent: number, limit: number, resumeFrom: Phase): string =>
   [
-    '### Token budget spent',
+    outcomeHeading('TOKENS_SPENT', 'Token budget spent'),
     '',
     tokenLine(spent, limit),
     '',
@@ -272,7 +277,7 @@ export const renderOverBudget = (spent: number, limit: number, resumeFrom: Phase
  */
 export const renderAnswerOverBudget = (spent: number, limit: number, phase: Phase): string =>
   [
-    '### Token budget spent',
+    outcomeHeading('ANSWER_TOKENS_SPENT', 'Token budget spent'),
     '',
     `${tokenLine(spent, limit)} I did not put that question to the model.`,
     '',

--- a/opencode-agent/src/run-report.ts
+++ b/opencode-agent/src/run-report.ts
@@ -131,12 +131,34 @@ export const renderCiExhausted = (reason: string, prUrl: string | null): string 
     'Its checks are red and I will not attempt another fix — take a look, or push a fix yourself.',
   ].join('\n')
 
-export const renderFailure = (phase: Phase, message: string, next: AgentState, maxAttempts: number): string =>
+/**
+ * A link to the job, for the comments a maintainer reads when something has
+ * gone wrong.
+ *
+ * Rendered as nothing at all when there is no run: a local `--event-path` run is
+ * an ordinary way to drive this CLI, and an empty "Job:" label is worse than a
+ * missing line. The URL arrives as an argument rather than being read from
+ * config here, so a renderer stays a function of what it is handed.
+ */
+const jobLink = (runUrl: string | null, label: string): readonly string[] =>
+  runUrl === null ? [] : ['', `${label}: ${runUrl}`]
+
+export const renderFailure = (
+  phase: Phase,
+  message: string,
+  next: AgentState,
+  maxAttempts: number,
+  runUrl: string | null,
+): string =>
   [
     `### Run failed in ${phase}`,
     '',
     // The message carries raw model output, which usually contains fences.
     fence(message),
+    // Until now the only lead a maintainer had from this comment was `/retry`.
+    // The job that produced the message above has the rest of the story in it,
+    // and nothing on the issue said where to find it.
+    ...jobLink(runUrl, 'The job that failed'),
     '',
     `Attempt ${next.attempts} of ${maxAttempts}. Reply **\`/retry\`** to resume from \`${phase}\`, ` +
       'or **`/cancel`** to stop.',

--- a/opencode-agent/src/state-manager.ts
+++ b/opencode-agent/src/state-manager.ts
@@ -3,7 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { findLatestBlock, readBlock, renderBlock } from './blocks.js'
+import { locateLatestBlock, readBlock, renderBlock } from './blocks.js'
 import type { IssueComment } from './blocks.js'
 import { agentStateSchema, InvalidTransitionError, STATE_VERSION } from './types.js'
 import type { AgentState, Phase, TransitionSignal } from './types.js'
@@ -118,7 +118,38 @@ export const findLatestState = (
   comments: readonly IssueComment[],
   agentLogin: string,
   issueId: number,
-): AgentState | null => toState(findLatestBlock(comments, agentLogin, STATE_MARKER, ownedBy(issueId)))
+): AgentState | null => {
+  const found = findLatestStateComment(comments, agentLogin, issueId)
+  return found === null ? null : found.state
+}
+
+/** The restored state, together with the comment it was restored from. */
+export interface StateComment {
+  comment: IssueComment
+  state: AgentState
+}
+
+/**
+ * The same scan as {@link findLatestState}, keeping the comment it selected.
+ *
+ * `state-persist.ts` rewrites that comment's block in place instead of posting a
+ * new one. Both functions come off one scan on purpose: the target of a rewrite
+ * has to be the comment the *reader* will look at next, and two independent
+ * scans agreeing is a coincidence rather than a property.
+ */
+export const findLatestStateComment = (
+  comments: readonly IssueComment[],
+  agentLogin: string,
+  issueId: number,
+): StateComment | null => {
+  const found = locateLatestBlock(comments, agentLogin, STATE_MARKER, ownedBy(issueId))
+  if (found === null) return null
+
+  const state = toState(found.block)
+  // `ownedBy` already parsed it, so this cannot be null; narrowing rather than
+  // asserting keeps that true if the acceptance predicate ever loosens.
+  return state === null ? null : { comment: found.comment, state }
+}
 
 const ownedBy =
   (issueId: number) =>

--- a/opencode-agent/src/state-persist.ts
+++ b/opencode-agent/src/state-persist.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { replaceBlock } from './blocks.js'
+import type { IssueComment } from './blocks.js'
+import type { GitHubApi } from './github.js'
+import type { Logger } from './logger.js'
+import { findLatestStateComment, STATE_MARKER } from './state-manager.js'
+import { errorMessage } from './types.js'
+import type { AgentState } from './types.js'
+
+/**
+ * Writing the state block down **without posting a comment**.
+ *
+ * This pipeline persists state only by posting, which leaves exactly one hole:
+ * classifying a plain comment is a model turn, and the `none` branch of that
+ * classification deliberately posts nothing — answering "I have decided to do
+ * nothing" to every "thanks!" is the noise the whole feedback plan is sized to
+ * avoid. So a run that spent a few thousand tokens deciding a comment needed no
+ * action handed the next runner a clean slate. `comment-intent.ts` recorded that
+ * leak and named this as the fix, declining it as a larger design change than
+ * the tokens justified; the live status comment needed `updateComment` anyway,
+ * so what was once the whole cost of the fix is now already paid for.
+ *
+ * Two things this has to respect, both already load-bearing:
+ *
+ * - **The target is the comment `findLatestState` selected**, not the newest
+ *   comment in the thread. Rewriting in place keeps that comment the
+ *   newest-with-a-block, so the restore scan is unaffected; rewriting any other
+ *   one leaves the reader looking at the figure this call was trying to replace.
+ *   Both come off {@link findLatestStateComment}, so they cannot pick differently.
+ * - **The block is re-serialised through `renderBlock`**, which escapes every
+ *   `<` and `>` so a payload cannot forge its own terminator. `lastError` carries
+ *   compiler output verbatim and `-->` is ordinary in it, so an in-place rewrite
+ *   that assembled the block itself would reintroduce that bug on a surface the
+ *   original fix never touched. `replaceBlock` is the one door to that.
+ *
+ * And one rule borrowed from the feedback channels next door: **this must never
+ * fail a run.** Failing a phase because a few thousand tokens could not be
+ * written down would be a worse outcome than the leak it closes, so every way
+ * this can fail degrades to a `warn` — enforced in {@link persistState}, which
+ * is the only function here that talks to GitHub.
+ */
+
+export interface StatePersistDeps {
+  /** Narrower than `PhaseDeps`, the way `ReactionDeps` and `LabelDeps` are. */
+  github: Pick<GitHubApi, 'updateComment'>
+  log: Logger
+  /** The author filter the state block is read back through. */
+  selfLogin: () => Promise<string>
+}
+
+/**
+ * Rewrites the newest state block in place, returning the state that is now on
+ * the issue — or `null` when it could not be written, so a caller reports the
+ * figure the thread actually carries rather than the one it hoped for.
+ */
+export const persistState = async (
+  deps: StatePersistDeps,
+  thread: readonly IssueComment[],
+  state: AgentState,
+): Promise<AgentState | null> => {
+  const target = findLatestStateComment(thread, await deps.selfLogin(), state.issueId)
+  if (target === null) {
+    // A first event on a fresh issue has no agent comment to rewrite. Nothing is
+    // lost that was not already lost: there is no earlier figure to carry, and
+    // the first comment this issue posts will record the total from scratch.
+    deps.log.debug({ issue: state.issueId }, 'No state block to rewrite; nothing to persist')
+    return null
+  }
+
+  const body = replaceBlock(target.comment.body, STATE_MARKER, state)
+  if (body === null) {
+    deps.log.warn({ issue: state.issueId, comment: target.comment.id }, 'The selected comment carries no state block')
+    return null
+  }
+
+  try {
+    await deps.github.updateComment(target.comment.id, body)
+    deps.log.debug({ issue: state.issueId, comment: target.comment.id }, 'Rewrote the state block in place')
+    return state
+  } catch (error) {
+    deps.log.warn(
+      { issue: state.issueId, comment: target.comment.id, error: errorMessage(error) },
+      'Could not rewrite the state block; this run’s spend is not recorded',
+    )
+    return null
+  }
+}

--- a/opencode-agent/src/status-comment.ts
+++ b/opencode-agent/src/status-comment.ts
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { PipelineConfig } from './config.js'
+import { branchNameFor } from './git.js'
+import { phaseHeading, PRESENTATION, presentationFor } from './presentation.js'
+import type { PresentationKey, RunStance } from './presentation.js'
+import type { ProgressSnapshot } from './progress.js'
+import type { AgentState, Phase } from './types.js'
+
+/**
+ * What the run's live status comment says. Pure: every input arrives as an
+ * argument, including the clock, so the whole rendering is testable as a value
+ * and the channel that edits it has nothing to decide but *when*.
+ *
+ * Comments in this pipeline are terminal by construction — they are written from
+ * a finished `PhaseOutcome` — so nothing could ever say "round 2 of 4" or "still
+ * working" without adding a comment per tick. This is the one surface that can,
+ * and it is the entire comment budget the feedback plan allows itself: one
+ * comment per run, edited, never a second.
+ *
+ * It deliberately carries **no `AGENT_STATE` block**. `findLatestState` restores
+ * from the newest agent comment carrying one, so a second writer of that block
+ * is a second source of truth; the phase-end comments stay the only state
+ * channel, and this comment is invisible to the restore scan.
+ *
+ * It also carries no free model text. Every field here is a phase, a count or a
+ * status: the activity line comes from `ProgressSnapshot`, which has nowhere for
+ * tool input, tool output or model prose to land, so the rule that progress
+ * reporting carries names and counts only holds by construction rather than by
+ * care — and this surface is a public issue, not a log.
+ */
+
+/** One row of the progress table. */
+interface RunStep {
+  title: string
+  /** Whose glyph the row wears. Never a glyph of its own — see the note below. */
+  key: PresentationKey
+}
+
+/**
+ * The run, as five milestones.
+ *
+ * Fewer rows than there are phases, on purpose: `PLAN_REVIEW` is the execution
+ * plan waiting to be approved rather than a sixth thing that happens, and
+ * `CI_FIX` is repair work on the pull request row. A table with a row per phase
+ * would be a state-machine diagram, and the question this answers is "how far
+ * along is my issue".
+ *
+ * The titles live here rather than in `presentation.ts` because this is their
+ * only reader, so this *is* the one place — and the glyphs beside them are read
+ * back out of `PRESENTATION`, so no phase acquires a second face here.
+ */
+const RUN_STEPS: readonly RunStep[] = [
+  { title: 'Triage', key: 'INIT_OR_CLARIFY:working' },
+  { title: 'Design spec', key: 'DESIGN_SPEC' },
+  { title: 'Execution plan', key: 'EXECUTION_PLAN' },
+  { title: 'Implementation', key: 'REVIEW_AND_MUTATE' },
+  { title: 'Pull request', key: 'PR_DELIVERY' },
+]
+
+/** Rows that carry an artefact revision, by index into {@link RUN_STEPS}. */
+const SPEC_STEP = 1
+const PLAN_STEP = 2
+
+/**
+ * Which row a phase sits on. `null` for the two phases that are not a step —
+ * `COMPLETE` is past the end and `FAILED` is wherever it broke.
+ *
+ * A `Record<Phase, …>` so a phase added later fails to compile until it has been
+ * placed, the same property `PRESENTATION` has.
+ */
+const STEP_OF: Record<Phase, number | null> = {
+  INIT_OR_CLARIFY: 0,
+  DESIGN_SPEC: 1,
+  EXECUTION_PLAN: 2,
+  PLAN_REVIEW: 2,
+  REVIEW_AND_MUTATE: 3,
+  PR_DELIVERY: 4,
+  CI_FIX: 4,
+  COMPLETE: null,
+  FAILED: null,
+}
+
+/** Everything the status comment is a function of. */
+export interface StatusView {
+  state: AgentState
+  /** What the model is doing, or `null` before a heartbeat has said. */
+  progress: ProgressSnapshot | null
+  /** Whether the run still holds the issue. False once it has ended. */
+  live: boolean
+  runUrl: string
+  startedMs: number
+  /** What this issue had spent before the job started — see {@link spentTokens}. */
+  carriedTokens: number
+  config: Pick<PipelineConfig, 'maxTokens' | 'maxAttempts' | 'maxCiAttempts'>
+}
+
+/**
+ * How far the run has got, as an index into {@link RUN_STEPS}.
+ *
+ * A cancelled `COMPLETE` is the awkward case: the phase says only that the
+ * conversation is over, not where it stopped. The artefacts do say — a plan
+ * exists or it does not — so the row it stops on is read off those rather than
+ * claiming every step finished on an issue somebody cancelled during triage.
+ */
+const stepIndex = (state: AgentState): number => {
+  const direct = STEP_OF[state.phase]
+  if (direct !== null) return direct
+  if (state.phase === 'FAILED') return STEP_OF[state.resumeFrom ?? 'INIT_OR_CLARIFY'] ?? 0
+  if (state.prUrl !== null) return RUN_STEPS.length
+
+  if (state.planRevision > 0) return PLAN_STEP
+  return state.specRevision > 0 ? SPEC_STEP : 0
+}
+
+/**
+ * Behind, on, or ahead of the current step.
+ *
+ * The three marks are this table's own vocabulary and have no row in
+ * `presentation.ts`, because "a step that is behind us" is not a state an issue
+ * can be found in. The mark on the row the run *stopped* on is the exception and
+ * is read from there — ❌ for a failure, 🛑 for a cancelled issue, the waiting
+ * phase's own glyph for a run parked in front of a human — so the status comment
+ * and the label sitting on the issue beside it cannot say different things.
+ */
+const stepMark = (index: number, current: number, view: StatusView): string => {
+  if (index < current) return '✅'
+  if (index > current) return '⬜'
+  return view.live ? '⏳ **now**' : presentationFor(view.state, 'waiting').glyph
+}
+
+/**
+ * The revision this row's artefact is on.
+ *
+ * Read from `specRevision` and `planRevision`, never recounted: the two counters
+ * were split apart precisely because one number could not honestly label two
+ * artefacts, and a table that re-derived them would be the second place that
+ * went wrong.
+ */
+const revisionNote = (index: number, state: AgentState): string => {
+  if (index === SPEC_STEP && state.specRevision > 0) return ` · revision ${state.specRevision}`
+  if (index === PLAN_STEP && state.planRevision > 0) return ` · revision ${state.planRevision}`
+  return ''
+}
+
+const table = (view: StatusView): readonly string[] => {
+  const current = stepIndex(view.state)
+
+  return [
+    '| Phase | |',
+    '| --- | --- |',
+    ...RUN_STEPS.map(
+      (step, index) =>
+        `| ${PRESENTATION[step.key].glyph} ${step.title} | ${stepMark(index, current, view)}${revisionNote(index, view.state)} |`,
+    ),
+  ]
+}
+
+const count = (value: number): string => value.toLocaleString('en-US')
+
+/** `HH:MM`, in UTC, because a runner's local time is not the reader's. */
+const clockUtc = (ms: number): string => new Date(ms).toISOString().slice(11, 16)
+
+/**
+ * When the run started, and where to watch it.
+ *
+ * Deliberately *not* "6m elapsed", which the plan's sketch carried: a figure
+ * that changes every minute changes the whole body every minute, and the same
+ * section asks for edits to be skipped when the body has not changed. The two
+ * cannot both be had — a quiet twenty-minute model call would cost twenty edits
+ * saying nothing but a new minute count, which is precisely the case the
+ * suppression exists for. A start time and GitHub's own "edited N minutes ago"
+ * answer "how long has this been going" between them, and cost nothing.
+ */
+const jobLine = (view: StatusView): string =>
+  `**Job:** [this run](${view.runUrl}) · started ${clockUtc(view.startedMs)} UTC`
+
+const branchLine = (state: AgentState): string =>
+  `**Branch:** \`${branchNameFor(state.issueId)}\` · **Pull request:** ${state.prUrl ?? '_not opened yet_'}`
+
+/**
+ * What the issue has spent, live.
+ *
+ * `tokensSpent` is authoritative but only moves when a comment is posted, and
+ * the point of this surface is the stretch *between* two comments — so the
+ * heartbeat's running total, added to what the issue carried into this job, is
+ * the fresher figure for exactly as long as no phase has ended. Whichever is
+ * larger is the one that has seen more of the run; neither can double-count the
+ * other, because `carriedTokens` is captured once, before this job spends
+ * anything.
+ */
+const spentTokens = (view: StatusView): number => {
+  const observed = view.progress
+  if (observed === null) return view.state.tokensSpent
+
+  return Math.max(view.state.tokensSpent, view.carriedTokens + observed.tokens)
+}
+
+/**
+ * Which budget the run is working against.
+ *
+ * `ciAttempts` is counted per pull request rather than per issue, so the CI line
+ * has to say so: the same "attempt 2 of 3" on a second pull request would be a
+ * different two attempts, and a maintainer reading it as a per-issue count would
+ * conclude the agent had given up when it had not started.
+ */
+const attemptLine = (view: StatusView): string => {
+  const { state, config } = view
+  if (state.phase === 'CI_FIX') {
+    return `attempt ${state.ciAttempts} of ${config.maxCiAttempts} on this pull request`
+  }
+  // `attempts` counts failures already suffered, so the run in flight is the
+  // next one — which is the number the failure comment would print if it broke
+  // here.
+  return `attempt ${state.attempts + 1} of ${config.maxAttempts}`
+}
+
+const budgetLine = (view: StatusView): string =>
+  `**Budget:** ${count(spentTokens(view))} of ${count(view.config.maxTokens)} tokens · ${attemptLine(view)}`
+
+const doingLine = (progress: ProgressSnapshot): string =>
+  `**Doing:** ${progress.lastAction} · ${progress.toolCalls} tool calls`
+
+/**
+ * The whole comment.
+ *
+ * The heading's glyph and headline come from the presentation table and nothing
+ * else: "🛠️ Implementing" would be a third name for a phase that already has a
+ * label suffix and a headline, and inventing one per renderer is the defect that
+ * table exists to prevent.
+ */
+export const renderStatus = (view: StatusView): string => {
+  const stance: RunStance = view.live ? 'working' : 'waiting'
+  const { headline } = presentationFor(view.state, stance)
+  const activity = view.live && view.progress !== null ? [doingLine(view.progress)] : []
+
+  return [
+    phaseHeading(view.state, stance, view.live ? `${headline} — run in progress` : headline),
+    '',
+    jobLine(view),
+    branchLine(view.state),
+    '',
+    ...table(view),
+    '',
+    ...activity,
+    budgetLine(view),
+  ].join('\n')
+}

--- a/opencode-agent/src/status-comment.ts
+++ b/opencode-agent/src/status-comment.ts
@@ -3,6 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import { renderBlock } from './blocks.js'
 import type { PipelineConfig } from './config.js'
 import { branchNameFor } from './git.js'
 import { phaseHeading, PRESENTATION, presentationFor } from './presentation.js'
@@ -26,12 +27,33 @@ import type { AgentState, Phase } from './types.js'
  * is a second source of truth; the phase-end comments stay the only state
  * channel, and this comment is invisible to the restore scan.
  *
+ * It does carry a block of its own, under {@link STATUS_MARKER}, and that is not
+ * a hedge on the rule above — `findLatestBlock` matches a marker exactly, so
+ * `AGENT_STATUS` cannot be mistaken for `AGENT_STATE` by the scan or by
+ * `readBlock`. The marker exists because this comment must be kept out of the
+ * *prompt*: `renderThread` hands the model the last twenty comments of the
+ * thread, so from the next job onward every previous run's progress table would
+ * take a slot from the conversation the model is being asked to read, and a
+ * feedback channel that quietly makes the agent worse at reading its own issue
+ * is the wrong trade. Marked rather than filtered by author, because the agent
+ * writes the spec and the plan too and blinding the model to those would be a
+ * much subtler version of the same mistake.
+ *
  * It also carries no free model text. Every field here is a phase, a count or a
  * status: the activity line comes from `ProgressSnapshot`, which has nowhere for
  * tool input, tool output or model prose to land, so the rule that progress
  * reporting carries names and counts only holds by construction rather than by
  * care — and this surface is a public issue, not a log.
  */
+
+/**
+ * Marks a comment as this pipeline's own progress reporting.
+ *
+ * Deliberately **not** `AGENT_STATE`, and deliberately not a variant of it: the
+ * restore scan matches a marker exactly, and the two are read by different
+ * layers for opposite reasons — one to be believed, one to be left out.
+ */
+export const STATUS_MARKER = 'AGENT_STATUS'
 
 /** One row of the progress table. */
 interface RunStep {
@@ -247,5 +269,9 @@ export const renderStatus = (view: StatusView): string => {
     '',
     ...activity,
     budgetLine(view),
+    '',
+    // The marker the prompt layer leaves out, carrying the run it belongs to so
+    // a reader of the raw thread can tell two runs' status comments apart.
+    renderBlock(STATUS_MARKER, { run: view.runUrl }),
   ].join('\n')
 }

--- a/opencode-agent/src/status-reporter.ts
+++ b/opencode-agent/src/status-reporter.ts
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { PipelineConfig } from './config.js'
+import type { GitHubApi } from './github.js'
+import type { Logger } from './logger.js'
+import type { ProgressSnapshot } from './progress.js'
+import { renderStatus } from './status-comment.js'
+import type { StatusView } from './status-comment.js'
+import { errorMessage } from './types.js'
+import type { AgentState, RunResult } from './types.js'
+
+/**
+ * The live status channel: one comment per run, opened when the run starts,
+ * edited as it moves, finalised when it ends.
+ *
+ * The same two rules the reaction and label channels are built on, for the same
+ * reasons.
+ *
+ * **Feedback must never fail a run.** Every write here is decoration on work
+ * that matters, and each is a new way to break a pipeline that used to work — a
+ * token without `issues: write`, a fork run, a secondary rate limit. So
+ * {@link attempt} is the only place this module touches GitHub and it swallows
+ * everything: a failed edit is a `warn`, and a failed *create* leaves
+ * `commentId` null so every later call is a no-op and the run degrades to
+ * exactly the behaviour it had before this channel existed.
+ *
+ * **A status comment is not a report.** `RunResult.reported` means the issue
+ * carries this run's account of what happened, and the workflow's fallback
+ * comment is gated on it. A run killed mid-phase leaves "run in progress" on the
+ * issue — which is *precisely* the case that fallback exists for — so marking it
+ * reported would suppress the one comment that would have explained the silence.
+ * {@link StatusReporter.finish} therefore takes the result and returns nothing:
+ * the flag is unreachable from here, rather than merely left alone by habit.
+ *
+ * Cost is bounded twice over, because a status comment is the only sustained
+ * writer this pipeline has: an edit is skipped when the rendered body has not
+ * changed, and otherwise at most one is issued per minute. A 90-minute run costs
+ * ~90 edits, comfortably inside the secondary rate limit on content-mutating
+ * requests, and a quiet stretch costs nothing at all. The clock is injected, so
+ * neither bound is proved by waiting.
+ */
+
+export interface StatusReporter {
+  /** Opens the comment. Called once, and only when a run is about to do work. */
+  start(state: AgentState): Promise<void>
+  /** The cascade is about to run a handler for this state. */
+  enter(state: AgentState): Promise<void>
+  /** A heartbeat's account of the turn in flight. */
+  tick(snapshot: ProgressSnapshot): Promise<void>
+  /** The run is over. Returns nothing, deliberately — see the note above. */
+  finish(result: RunResult): Promise<void>
+}
+
+export interface StatusDeps {
+  /** Narrower than `PhaseDeps`, the way `ReactionDeps` and `LabelDeps` are. */
+  github: Pick<GitHubApi, 'createComment' | 'updateComment'>
+  log: Logger
+  config: PipelineConfig
+  /**
+   * The clock, injected.
+   *
+   * Nothing in this module reads `Date.now()`: the rate limit is the property
+   * most worth testing here and the least affordable to test by waiting a
+   * minute for it.
+   */
+  now: () => number
+}
+
+/** At most one edit a minute, whatever happens in between. */
+export const MIN_EDIT_INTERVAL_MS = 60_000
+
+/**
+ * Everything one run's status comment remembers.
+ *
+ * A record passed to module-level functions rather than a closure over a dozen
+ * `let`s: the same fields, and the file stays readable at the length the rules
+ * above cost to state.
+ */
+interface RunStatus {
+  deps: StatusDeps
+  runUrl: string
+  startedMs: number
+  /** `null` until the comment exists, and for ever if opening it failed. */
+  commentId: number | null
+  state: AgentState | null
+  /** What the issue had spent before this job started. Captured once. */
+  carriedTokens: number
+  progress: ProgressSnapshot | null
+  live: boolean
+  /** The body GitHub currently holds, so an unchanged render costs nothing. */
+  lastBody: string | null
+  lastEditMs: number
+}
+
+/** The only place this module talks to GitHub, and so the only place it can fail. */
+const attempt = async <T>(run: RunStatus, action: () => Promise<T>, message: string): Promise<T | null> => {
+  try {
+    return await action()
+  } catch (error) {
+    run.deps.log.warn({ issue: run.state === null ? null : run.state.issueId, error: errorMessage(error) }, message)
+    return null
+  }
+}
+
+const viewOf = (run: RunStatus, state: AgentState): StatusView => ({
+  state,
+  progress: run.progress,
+  live: run.live,
+  runUrl: run.runUrl,
+  startedMs: run.startedMs,
+  carriedTokens: run.carriedTokens,
+  config: run.deps.config,
+})
+
+/**
+ * Edits the comment, subject to both bounds.
+ *
+ * `force` skips the clock, never the unchanged-body check, and exactly one
+ * caller passes it: the final edit. A tick dropped inside the window is picked
+ * up by the next one a minute later, and a phase move dropped by it is picked up
+ * the same way — but a run that ends inside the window would otherwise leave
+ * "run in progress" on the issue for ever, which is the one state this comment
+ * must never be left in by an ordinary exit.
+ */
+const publish = async (run: RunStatus, force: boolean): Promise<void> => {
+  const id = run.commentId
+  const state = run.state
+  if (id === null || state === null) return
+
+  const body = renderStatus(viewOf(run, state))
+  if (body === run.lastBody) return
+  if (!force && run.deps.now() - run.lastEditMs < MIN_EDIT_INTERVAL_MS) return
+
+  // Stamped before the call, not after it: a refused edit has still spent the
+  // request the bound is protecting, and retrying it every tick is how a
+  // rate-limited run stays rate-limited.
+  run.lastEditMs = run.deps.now()
+  const written = await attempt(
+    run,
+    async () => {
+      await run.deps.github.updateComment(id, body)
+      return body
+    },
+    'Could not update the status comment',
+  )
+  // Only what GitHub accepted, so a failed edit is retried rather than believed.
+  if (written !== null) run.lastBody = written
+}
+
+/**
+ * Opens the comment for a run.
+ *
+ * Everything a previous run left behind is cleared here rather than assumed
+ * absent, so the contract is "one run at a time" rather than "construct one per
+ * run and hope". A process drives exactly one run, so in production this clears
+ * nothing — but a reporter that quietly stayed finished, and so rendered its
+ * second run's opening comment as though it had already ended, is a trap worth
+ * four lines to close. `startedMs` is deliberately not among them: the job
+ * started when the process did, which is what the comment's first line claims.
+ */
+const open = async (run: RunStatus, state: AgentState): Promise<void> => {
+  run.state = state
+  run.carriedTokens = state.tokensSpent
+  run.commentId = null
+  run.lastBody = null
+  run.lastEditMs = 0
+  run.progress = null
+  run.live = true
+
+  const body = renderStatus(viewOf(run, state))
+  const posted = await attempt(
+    run,
+    () => run.deps.github.createComment(state.issueId, body),
+    'Could not open the status comment; this run reports only when it ends',
+  )
+  if (posted === null) return
+
+  run.commentId = posted.id
+  run.lastBody = body
+  run.lastEditMs = run.deps.now()
+}
+
+const finalise = async (run: RunStatus, result: RunResult): Promise<void> => {
+  run.live = false
+  // A guardrail skip carries no state, and no status comment was opened for one
+  // either — but a halted run does carry the state it halted on, and that is the
+  // state the comment should end on.
+  if (result.state !== null) run.state = result.state
+  await publish(run, true)
+}
+
+/**
+ * A reporter that says nothing.
+ *
+ * Used by every test that is not about this channel, and by local
+ * `--event-path` runs, which have no run to link to: the comment's first line is
+ * a link to the job doing the work, and a status comment that cannot say where
+ * the work is happening is most of the value gone. That decision lives in
+ * {@link createStatusReporter}, so no caller has to make it twice.
+ */
+export const noopStatusReporter = (): StatusReporter => ({
+  start: (): Promise<void> => Promise.resolve(),
+  enter: (): Promise<void> => Promise.resolve(),
+  tick: (): Promise<void> => Promise.resolve(),
+  finish: (): Promise<void> => Promise.resolve(),
+})
+
+export const createStatusReporter = (deps: StatusDeps): StatusReporter => {
+  const runUrl = deps.config.runUrl
+  if (runUrl === null) return noopStatusReporter()
+
+  const run: RunStatus = {
+    deps,
+    runUrl,
+    startedMs: deps.now(),
+    commentId: null,
+    state: null,
+    carriedTokens: 0,
+    progress: null,
+    live: true,
+    lastBody: null,
+    lastEditMs: 0,
+  }
+
+  return {
+    start: (state): Promise<void> => open(run, state),
+    enter: async (state): Promise<void> => {
+      run.state = state
+      await publish(run, false)
+    },
+    tick: async (snapshot): Promise<void> => {
+      run.progress = snapshot
+      await publish(run, false)
+    },
+    finish: (result): Promise<void> => finalise(run, result),
+  }
+}

--- a/opencode-agent/src/trigger-outcome.ts
+++ b/opencode-agent/src/trigger-outcome.ts
@@ -3,12 +3,16 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import type { AgentState, RunResult } from './types.js'
+import type { PhaseDeps } from './phase-context.js'
+import { transition } from './state-manager.js'
+import { errorMessage } from './types.js'
+import type { AgentState, RunResult, TransitionSignal } from './types.js'
 
 /**
- * What the trigger layer concluded, shared by `triggers.ts` and `ci-trigger.ts`.
+ * What the trigger layer concluded, shared by `triggers.ts`, `ci-trigger.ts` and
+ * `comment-intent.ts`.
  *
- * In its own module for the reason `MachineInput` is: two modules now decide
+ * In its own module for the reason `MachineInput` is: three modules now decide
  * trigger outcomes, and a shape owned by the file one of them lives in is how an
  * import cycle starts.
  */
@@ -40,3 +44,35 @@ export const skip = (state: AgentState, reason: string, reported = false): RunRe
   state,
   reported,
 })
+
+/**
+ * Applies a signal, or turns the refusal into a skip the caller can report on.
+ *
+ * Here rather than in `triggers.ts` because both halves of the trigger layer
+ * need it: the command half calls it for a slash command, and the plain-comment
+ * half in `comment-intent.ts` calls it for a classified approve or change
+ * request. Importing it from one of those into the other is the cycle this
+ * module exists to prevent.
+ *
+ * `ci-trigger.ts` deliberately does *not* use it, and says why at length: it
+ * asks `canTransition` first, so a throw there would mean the gate and the table
+ * disagree, and swallowing that into a silent skip is what hid a missing row.
+ */
+export const moveOrSkip = (
+  state: AgentState,
+  signal: TransitionSignal,
+  deps: PhaseDeps,
+  source: string,
+): TriggerOutcome => {
+  try {
+    const next = transition(state, signal)
+    deps.log.info({ source, signal, from: state.phase, to: next.phase }, 'Applied trigger')
+    return { state: next, halt: null, answer: false }
+  } catch (error) {
+    return {
+      state,
+      halt: skip(state, `${source} is not valid in ${state.phase}: ${errorMessage(error)}`),
+      answer: false,
+    }
+  }
+}

--- a/opencode-agent/src/triggers.ts
+++ b/opencode-agent/src/triggers.ts
@@ -4,6 +4,7 @@
 // See LICENSE in the project root for details.
 
 import { applyCiTrigger } from './ci-trigger.js'
+import { acceptedCommands, COMMAND_SIGNALS } from './commands.js'
 import type { ParsedCommand } from './commands.js'
 import { applyClarifyIntent, applyIntent, readAndSkip } from './comment-intent.js'
 import { react } from './feedback.js'
@@ -13,7 +14,6 @@ import { canTransition } from './state-manager.js'
 import { moveOrSkip, skip } from './trigger-outcome.js'
 import type { TriggerOutcome } from './trigger-outcome.js'
 import { WAITING_PHASES } from './types.js'
-import type { Phase, TransitionSignal } from './types.js'
 
 /**
  * Turning a trigger — a slash command, a plain comment, a red CI run — into the
@@ -24,17 +24,12 @@ import type { Phase, TransitionSignal } from './types.js'
  * one drives the handlers once the decision is made. Two halves have since gone
  * the same way, each time this file reached the length limit and each time along
  * a seam that was already there: the red-CI path into `ci-trigger.ts`, and
- * reading plain prose into `comment-intent.ts`. What is left here is the
- * commands and the dispatch that picks between the three.
+ * reading plain prose into `comment-intent.ts`. What is left here is applying a
+ * command and the dispatch that picks between the three — the command *table*
+ * moved to `commands.ts` once the waiting comment needed to read it too, since
+ * this file imports `run-report.ts` and a shared derivation in either of them is
+ * a cycle.
  */
-
-/** Slash commands, mapped to the signal they inject before handlers run. */
-const COMMAND_SIGNALS: Record<string, TransitionSignal> = {
-  '/approve': 'APPROVED',
-  '/changes': 'CHANGES_REQUESTED',
-  '/retry': 'RETRY',
-  '/cancel': 'CANCELLED',
-}
 
 /**
  * Turns the trigger into a state move.
@@ -142,11 +137,3 @@ const refuseExhausted = async (input: PhaseInput): Promise<TriggerOutcome> => {
 
   return { state, halt: { status: 'failed', reason, state, reported: true }, answer: false }
 }
-
-/** The commands `phase` would actually accept, straight from the transition table. */
-const acceptedCommands = (phase: Phase): readonly string[] => [
-  ...Object.entries(COMMAND_SIGNALS)
-    .filter(([, signal]) => canTransition(phase, signal))
-    .map(([command]) => command),
-  '/ask',
-]

--- a/opencode-agent/src/triggers.ts
+++ b/opencode-agent/src/triggers.ts
@@ -5,15 +5,15 @@
 
 import { applyCiTrigger } from './ci-trigger.js'
 import type { ParsedCommand } from './commands.js'
-import { classifyComment } from './intent.js'
-import type { PhaseDeps, PhaseInput } from './phase-context.js'
+import { applyClarifyIntent, applyIntent, readAndSkip } from './comment-intent.js'
+import { react } from './feedback.js'
+import type { PhaseInput } from './phase-context.js'
 import { postAndAppend, renderExhausted, renderRefusedCommand } from './run-report.js'
-import { canTransition, transition } from './state-manager.js'
-import { totalTokens, withinBudget } from './token-budget.js'
-import { skip } from './trigger-outcome.js'
+import { canTransition } from './state-manager.js'
+import { moveOrSkip, skip } from './trigger-outcome.js'
 import type { TriggerOutcome } from './trigger-outcome.js'
-import { errorMessage, WAITING_PHASES } from './types.js'
-import type { AgentState, Phase, TransitionSignal } from './types.js'
+import { WAITING_PHASES } from './types.js'
+import type { Phase, TransitionSignal } from './types.js'
 
 /**
  * Turning a trigger — a slash command, a plain comment, a red CI run — into the
@@ -21,8 +21,11 @@ import type { AgentState, Phase, TransitionSignal } from './types.js'
  *
  * Split out of `orchestrator.ts`, which now owns only the phase cascade. The two
  * answer different questions: this one decides *whether and where* to go, that
- * one drives the handlers once the decision is made. The CI half went the same
- * way, into `ci-trigger.ts`, when this file reached the length limit.
+ * one drives the handlers once the decision is made. Two halves have since gone
+ * the same way, each time this file reached the length limit and each time along
+ * a seam that was already there: the red-CI path into `ci-trigger.ts`, and
+ * reading plain prose into `comment-intent.ts`. What is left here is the
+ * commands and the dispatch that picks between the three.
  */
 
 /** Slash commands, mapped to the signal they inject before handlers run. */
@@ -51,9 +54,7 @@ export const applyTrigger = (input: PhaseInput): Promise<TriggerOutcome> => {
   if (trigger.kind === 'ci') return applyCiTrigger(input)
   if (command !== null) return applyCommand(input, command)
   if (state.phase === 'INIT_OR_CLARIFY') return applyClarifyIntent(input)
-  if (!WAITING_PHASES.has(state.phase)) {
-    return Promise.resolve({ state, halt: skip(state, `No actionable command while in ${state.phase}`), answer: false })
-  }
+  if (!WAITING_PHASES.has(state.phase)) return readAndSkip(input, `No actionable command while in ${state.phase}`)
 
   return applyIntent(input)
 }
@@ -98,6 +99,11 @@ const refuseCommand = async (input: PhaseInput, command: string, reason: string)
   const { state, thread, deps } = input
   deps.log.warn({ issue: state.issueId, phase: state.phase, command }, 'Refused a slash command')
 
+  // Redundancy rather than the fix, and worth one call for the timing alone:
+  // the comment below is the better answer — it names what the phase *does*
+  // accept, from the transition table — but it arrives after `postAndAppend`,
+  // while the reaction lands before the run has done anything at all.
+  await react(deps, input.trigger, 'confused')
   await postAndAppend(thread, input, renderRefusedCommand(command, state.phase, acceptedCommands(state.phase)), state)
 
   return { state, halt: skip(state, reason, true), answer: false }
@@ -144,136 +150,3 @@ const acceptedCommands = (phase: Phase): readonly string[] => [
     .map(([command]) => command),
   '/ask',
 ]
-
-/**
- * Reads a plain comment as an intent, and decides first whether that reading is
- * affordable.
- *
- * Classifying costs a model turn, and it is the one turn in the pipeline whose
- * spend can never be written down. State is persisted only by posting a comment,
- * and the `none` branch below deliberately posts nothing — replying to every
- * "thanks!" would be spam — so a session that reported 40,000 tokens for the
- * classification vanishes with the runner. The ceiling is therefore asked
- * *before* the turn rather than after it: over budget there is nothing any
- * classification could buy, since every branch here leads either to a handler or
- * to the answer path and `stopIfOverBudget` refuses both. Handing the comment
- * straight to the answer path lets that one check report it, in the wording it
- * already has, without a second stop in this layer and without paying to learn
- * what to say — otherwise a maxed-out issue keeps buying a classification per
- * comment for as long as anyone keeps commenting on it.
- *
- * That leaves one leak, knowingly: a run **under** budget whose classifier
- * answers `none` still spends a turn nothing records. Closing it needs a way to
- * persist state without posting — an `updateComment` on the last state block —
- * which is a larger design change than a stray few thousand tokens per no-op
- * comment justifies. The bound it erodes is per issue and human-paced, and every
- * other branch folds the classification in, because `deps.tokensUsed()` reports
- * the whole job's session and whatever the run goes on to post writes that total.
- */
-const applyIntent = async (input: PhaseInput): Promise<TriggerOutcome> => {
-  const { state, trigger, deps } = input
-  const body = trigger.kind === 'issue' ? trigger.commentBody : null
-  if (body === null || body.trim().length === 0) {
-    return { state, halt: skip(state, 'Empty comment'), answer: false }
-  }
-
-  const spent = await totalTokens(deps, state.tokensSpent)
-  if (!withinBudget(spent, deps.config)) {
-    deps.log.warn(
-      { issue: state.issueId, phase: state.phase, spent, limit: deps.config.maxTokens },
-      'Over budget: not paying to classify the comment',
-    )
-    return { state, halt: null, answer: true }
-  }
-
-  const intent = await classifyComment({ body, phase: state.phase, deps, state })
-  deps.log.info({ intent, phase: state.phase }, 'Classified maintainer comment')
-
-  if (intent === 'none') return { state, halt: skip(state, 'Comment needs no action'), answer: false }
-  if (intent === 'question') return { state, halt: null, answer: true }
-
-  const signal: TransitionSignal = intent === 'approve' ? 'APPROVED' : 'CHANGES_REQUESTED'
-  return moveOrSkip(state, signal, deps, `an implied ${intent}`)
-}
-
-/**
- * Reads a plain comment that arrived while the agent is waiting for answers to
- * its own clarifying questions, and lets through everything the classifier does
- * not positively call chatter.
- *
- * This phase used to skip classification altogether and hand every comment
- * straight to triage. That is a whole triage turn — the model re-reads the
- * issue, the whole thread and the repository, then writes a fresh design spec or
- * another round of questions — bought by a "thanks", a 👍, or one maintainer's
- * aside to another while the agent waits. Cheap to say, expensive to answer.
- *
- * The fix cannot be to route this phase through {@link applyIntent}, because
- * that function's default points the wrong way here. `classifyComment` resolves
- * every failure and every ambiguity to `question`, chosen for the waiting phases
- * where answering costs one reply while re-planning discards an approved
- * artefact. There is no approved artefact in `INIT_OR_CLARIFY`, and the cost is
- * reversed: a maintainer's answer misread as a question gets *answered* instead
- * of acted on, so the agent replies about its own questions, stays parked, and
- * the maintainer has to say the same thing a second time. So the default is
- * inverted rather than borrowed — `none` is the only verdict that skips, and
- * every other reading, including the one the classifier falls back to when it
- * breaks, re-runs triage exactly as before.
- *
- * `question` is deliberately **not** admitted as a skip-to-answer, even though a
- * maintainer really can ask "why do you need that?" mid-clarification. In this
- * phase it is not a verdict: it is also the bucket a failed model call, an
- * unparsable reply and a genuinely ambiguous comment all land in, so honouring
- * it would route every one of those into an answer turn — precisely the stall
- * above, on exactly the comments least able to survive it. `none` is the one
- * reading the classifier has to actively choose, so `none` is the one that acts.
- * The price of leaving `question` out is a wasted triage turn on a real
- * mid-clarification question; the price of letting it in is a dropped answer,
- * and only the first of those is recoverable without the maintainer noticing.
- *
- * Two comments never reach the classifier at all, and both fall through to
- * triage rather than skipping. An **absent or blank** body is the
- * `issues.opened` event that starts every issue — there is no comment to read,
- * and skipping it would mean the agent never runs at all. **Over budget** is the
- * rule {@link applyIntent} sets out at length: the classifier is the one turn
- * whose spend can never be written down, so the ceiling has to stop it rather
- * than count it. Falling through costs nothing, because the cascade's own stop
- * fires before `handleTriage` and reports the ceiling on the issue — the same
- * notice a maintainer would have got anyway, one model turn cheaper.
- */
-const applyClarifyIntent = async (input: PhaseInput): Promise<TriggerOutcome> => {
-  const { state, trigger, deps } = input
-  const retriage: TriggerOutcome = { state, halt: null, answer: false }
-
-  const body = trigger.kind === 'issue' ? trigger.commentBody : null
-  if (body === null || body.trim().length === 0) return retriage
-
-  const spent = await totalTokens(deps, state.tokensSpent)
-  if (!withinBudget(spent, deps.config)) {
-    deps.log.warn(
-      { issue: state.issueId, phase: state.phase, spent, limit: deps.config.maxTokens },
-      'Over budget: not paying to classify a comment while clarifying',
-    )
-    return retriage
-  }
-
-  const intent = await classifyComment({ body, phase: state.phase, deps, state })
-  deps.log.info({ intent, phase: state.phase }, 'Classified a maintainer comment while clarifying')
-
-  if (intent !== 'none') return retriage
-
-  return { state, halt: skip(state, 'Comment needs no action'), answer: false }
-}
-
-const moveOrSkip = (state: AgentState, signal: TransitionSignal, deps: PhaseDeps, source: string): TriggerOutcome => {
-  try {
-    const next = transition(state, signal)
-    deps.log.info({ source, signal, from: state.phase, to: next.phase }, 'Applied trigger')
-    return { state: next, halt: null, answer: false }
-  } catch (error) {
-    return {
-      state,
-      halt: skip(state, `${source} is not valid in ${state.phase}: ${errorMessage(error)}`),
-      answer: false,
-    }
-  }
-}

--- a/tests/opencode-agent/adapters.test.ts
+++ b/tests/opencode-agent/adapters.test.ts
@@ -1224,6 +1224,33 @@ describe('config', () => {
     expect(loadConfig(enterprise, '/repo').runUrl).toBe('https://git.acme.internal/acme/widgets/actions/runs/7')
   })
 
+  test('labels live under `agent:` unless the repository says otherwise', () => {
+    expect(loadConfig(baseEnv, '/repo').labelPrefix).toBe('agent:')
+  })
+
+  test('a repository with its own conventions can name the namespace', () => {
+    // The same shape as `AGENT_REVIEW_COMMAND`, and for the same reason: a
+    // hardcoded label set is the papai-specific hardcoding S2-4 was re-opened
+    // for.
+    expect(loadConfig({ ...baseEnv, AGENT_LABEL_PREFIX: 'bot/' }, '/repo').labelPrefix).toBe('bot/')
+  })
+
+  test.each(['none', 'NONE', ' none '])('%p switches labelling off entirely', (raw) => {
+    expect(loadConfig({ ...baseEnv, AGENT_LABEL_PREFIX: raw }, '/repo').labelPrefix).toBeNull()
+  })
+
+  test.each(['a,b', 'ag\tent', 'x'.repeat(33)])('rejects the prefix %p at load', (raw) => {
+    // At load, where the message names the variable — not at the first API
+    // call, which is inside a best-effort path that swallows what it is told.
+    expect(() => loadConfig({ ...baseEnv, AGENT_LABEL_PREFIX: raw }, '/repo')).toThrow('AGENT_LABEL_PREFIX')
+  })
+
+  test('a blank prefix means unset, not an empty namespace', () => {
+    // An empty prefix would make every label on the issue look agent-owned to
+    // the reconcile, which removes any it cannot account for.
+    expect(loadConfig({ ...baseEnv, AGENT_LABEL_PREFIX: '   ' }, '/repo').labelPrefix).toBe('agent:')
+  })
+
   test('parseChecks falls back to the defaults', () => {
     expect(parseChecks(undefined).map((check) => check.name)).toEqual(['lint', 'typecheck', 'test'])
   })
@@ -1474,6 +1501,83 @@ describe('createOctokitApi', () => {
     await recordingApi(captured, PR_JSON, ['rocket']).addReaction({ kind: 'issue', number: 42 }, 'rocket')
 
     expect(captured[0]?.body).toEqual({ content: 'rocket' })
+  })
+
+  test('reads the labels the issue carries', async () => {
+    const captured: CapturedRequest[] = []
+
+    const names = await recordingApi(captured, [{ name: 'bug' }, { name: 'agent:working' }]).listLabels(42)
+
+    expect(names).toEqual(['bug', 'agent:working'])
+    expect(captured[0]?.method).toBe('GET')
+    expect(captured[0]?.url).toContain('/repos/acme/widgets/issues/42/labels')
+    // Paginated: an issue with more than a page of labels would otherwise look
+    // to the reconcile like one whose labels it does not own, and it would add
+    // its own back on every run.
+    expect(captured[0]?.url).toContain('per_page=100')
+  })
+
+  test('adds labels in one request rather than one apiece', async () => {
+    const captured: CapturedRequest[] = []
+
+    await recordingApi(captured).addLabels(42, ['agent:implementing', 'agent:working'])
+
+    expect(captured[0]?.method).toBe('POST')
+    expect(captured[0]?.url).toContain('/repos/acme/widgets/issues/42/labels')
+    expect(captured[0]?.body).toEqual({ labels: ['agent:implementing', 'agent:working'] })
+  })
+
+  test('removes one label from the issue, not from the repository', async () => {
+    // `DELETE /issues/{n}/labels/{name}` takes it off this issue;
+    // `DELETE /labels/{name}` deletes it everywhere, which would strip the
+    // label off every other issue that carries it.
+    const captured: CapturedRequest[] = []
+
+    await recordingApi(captured).removeLabel(42, 'agent:working')
+
+    expect(captured[0]?.method).toBe('DELETE')
+    expect(captured[0]?.url).toContain('/repos/acme/widgets/issues/42/labels/agent%3Aworking')
+  })
+
+  test('creates a label with the colour the palette gave it', async () => {
+    const captured: CapturedRequest[] = []
+
+    await recordingApi(captured).createLabel('agent:needs-you', 'd4a72c')
+
+    expect(captured[0]?.method).toBe('POST')
+    expect(captured[0]?.url).toContain('/repos/acme/widgets/labels')
+    expect(captured[0]?.body).toEqual({ name: 'agent:needs-you', color: 'd4a72c' })
+  })
+
+  test('treats a label that already exists as created', async () => {
+    // Creation is unconditional — the alternative is listing every repository
+    // label on every run — so the second run onwards answers 422. Swallowed
+    // here, where the HTTP status still exists: one layer up it is an `Error`
+    // message indistinguishable from a real refusal.
+    const api = createOctokitApi({
+      token: 'tok',
+      owner: 'acme',
+      repo: 'widgets',
+      secrets: [],
+      fetch: () => Promise.resolve(new Response('{"message":"Validation Failed"}', { status: 422 })),
+    })
+
+    expect(await api.createLabel('agent:done', '0e8a16')).toBeUndefined()
+  })
+
+  test('still reports a refusal that is not "it already exists"', async () => {
+    // A token without `issues: write` answers 403 here, and swallowing that
+    // would make the reconcile believe a label it cannot write exists.
+    const api = createOctokitApi({
+      token: 'tok',
+      owner: 'acme',
+      repo: 'widgets',
+      secrets: [],
+      fetch: () =>
+        Promise.resolve(new Response('{"message":"Resource not accessible by integration"}', { status: 403 })),
+    })
+
+    await expect(api.createLabel('agent:done', '0e8a16')).rejects.toThrow()
   })
 
   test('asks for pull requests in every state, so a merged one is not invisible', async () => {

--- a/tests/opencode-agent/adapters.test.ts
+++ b/tests/opencode-agent/adapters.test.ts
@@ -35,6 +35,7 @@ import { collectText, decodeReply, decodeSessionId, decodeSessionUsage } from '.
 import type { SessionUsage } from '../../opencode-agent/src/sdk-contract.js'
 import { redactSecrets, scrubSecrets } from '../../opencode-agent/src/secrets.js'
 import type { CommandRunner } from '../../opencode-agent/src/shell.js'
+import { STATUS_MARKER } from '../../opencode-agent/src/status-comment.js'
 import { PHASES } from '../../opencode-agent/src/types.js'
 
 describe('collectText', () => {
@@ -873,6 +874,9 @@ describe('untrusted envelope', () => {
 describe('renderThread', () => {
   const envelope = createEnvelope('abc123')
   const at = (id: number, authorLogin: string, body: string): IssueComment => ({ id, body, authorLogin })
+  /** One run's status comment, as the pipeline posts it: marked, agent-authored. */
+  const statusAt = (id: number): IssueComment =>
+    at(id, 'agent', `### 🛠️ Working\n\n${renderBlock(STATUS_MARKER, { run: `https://run/${id}` })}`)
 
   test('renders the tail of a long thread', () => {
     const thread = Array.from({ length: 30 }, (_unused, index) => at(index, 'maintainer', `comment ${index}`))
@@ -923,6 +927,39 @@ describe('renderThread', () => {
 
     expect(rendered).toContain('Visible.')
     expect(rendered).not.toContain('AGENT_STATE')
+  })
+
+  test('leaves the run’s status comments out of the prompt entirely', () => {
+    // Stage 3 put one status comment on the issue per run, and this renderer
+    // hands the model the tail of the thread regardless of who wrote it. A
+    // conversation spanning several runs would spend its window on progress
+    // tables, degrading exactly the phases that read the thread — triage,
+    // answering, and the classifier.
+    const conversation = [at(1, 'maintainer', 'Please add retries.'), at(2, 'agent', 'Here is the spec.')]
+    const withStatus = [statusAt(9), ...conversation, statusAt(10)]
+
+    expect(renderThread(envelope, withStatus)).toBe(renderThread(envelope, conversation))
+  })
+
+  test('spends the whole window on real conversation, not on progress tables', () => {
+    // Dropped before the window is taken, not after: filtering afterwards would
+    // still let a status comment consume one of the twenty slots.
+    const thread = [0, 2, 4].flatMap((index) => [at(index, 'maintainer', `comment ${index}`), statusAt(index + 1)])
+
+    const rendered = renderThread(envelope, thread, 3)
+
+    expect(rendered).toContain('comment 0')
+    expect(rendered).toContain('comment 2')
+    expect(rendered).toContain('comment 4')
+  })
+
+  test('keeps the artefact comments the agent wrote, which are the point', () => {
+    // The reason the filter is by marker and not by author: the spec, the plan
+    // and every phase report carry the same login as the status comment, and
+    // they are what the model is being asked to read.
+    const rendered = renderThread(envelope, [at(1, 'agent', 'Here is the design spec.')])
+
+    expect(rendered).toContain('Here is the design spec.')
   })
 
   test('caps the rendered size regardless of comment count', () => {

--- a/tests/opencode-agent/adapters.test.ts
+++ b/tests/opencode-agent/adapters.test.ts
@@ -1503,6 +1503,19 @@ describe('createOctokitApi', () => {
     expect(captured[0]?.body).toEqual({ content: 'rocket' })
   })
 
+  test('edits an existing comment rather than posting a new one', async () => {
+    // The distinction the whole one-comment budget rests on: a status comment
+    // that POSTed on every tick would be a comment a minute.
+    const captured: CapturedRequest[] = []
+
+    await recordingApi(captured).updateComment(9, 'still working')
+
+    const [request] = captured
+    expect(request?.method).toBe('PATCH')
+    expect(request?.url).toContain('/repos/acme/widgets/issues/comments/9')
+    expect(request?.body).toEqual({ body: 'still working' })
+  })
+
   test('reads the labels the issue carries', async () => {
     const captured: CapturedRequest[] = []
 
@@ -1606,6 +1619,10 @@ describe('createOctokitApi', () => {
 
   test.each([
     ['an issue comment', (api: GitHubApi): Promise<unknown> => api.createComment(42, `FAIL token=${LEAKED}`)],
+    // The second method that carries free text, and so the second that has to
+    // redact it. A status body is assembled from the same activity summaries and
+    // state fields a comment is, and an edit is no less public than a post.
+    ['an edited comment', (api: GitHubApi): Promise<unknown> => api.updateComment(9, `status token=${LEAKED}`)],
     [
       'a new pull request body',
       (api: GitHubApi): Promise<unknown> =>

--- a/tests/opencode-agent/adapters.test.ts
+++ b/tests/opencode-agent/adapters.test.ts
@@ -1185,6 +1185,45 @@ describe('config', () => {
     expect(loadConfig({ ...baseEnv, AGENT_MAX_ATTEMPTS: raw }, '/repo').maxAttempts).toBe(3)
   })
 
+  test('builds the URL of the run doing the work', () => {
+    // Every one of these is set by GitHub in the environment of every step, and
+    // `scrubSecrets` matches by value, so none of them is stripped on the way
+    // past — which is why the run link needs no workflow change at all.
+    const config = loadConfig({ ...baseEnv, GITHUB_RUN_ID: '1482' }, '/repo')
+
+    expect(config.runUrl).toBe('https://github.com/acme/widgets/actions/runs/1482')
+  })
+
+  test('points a re-run at its own attempt', () => {
+    // A re-run's logs live under the attempt path. Linking the run without it
+    // from a job on attempt 3 points a maintainer at the run it superseded.
+    const config = loadConfig({ ...baseEnv, GITHUB_RUN_ID: '1482', GITHUB_RUN_ATTEMPT: '3' }, '/repo')
+
+    expect(config.runUrl).toBe('https://github.com/acme/widgets/actions/runs/1482/attempts/3')
+  })
+
+  test.each(['1', '', 'lots', undefined])('leaves the attempt off a first attempt (%p)', (attempt) => {
+    // GitHub's own run link omits it, and an unparseable value is a link
+    // problem, not a reason to refuse to start.
+    const config = loadConfig({ ...baseEnv, GITHUB_RUN_ID: '1482', GITHUB_RUN_ATTEMPT: attempt }, '/repo')
+
+    expect(config.runUrl).toBe('https://github.com/acme/widgets/actions/runs/1482')
+  })
+
+  test('has no run URL when there is no run', () => {
+    // A local `--event-path` run is an ordinary way to drive this CLI, not a
+    // misconfiguration, so this is `null` rather than a throw or a broken link.
+    expect(loadConfig(baseEnv, '/repo').runUrl).toBeNull()
+  })
+
+  test('links the run on the host the rest of the pipeline talks to', () => {
+    // Same reason `gitRemoteBase` is configurable: an Enterprise Server install
+    // answers on its own host, and github.com has none of its runs.
+    const enterprise = { ...baseEnv, GITHUB_SERVER_URL: 'https://git.acme.internal', GITHUB_RUN_ID: '7' }
+
+    expect(loadConfig(enterprise, '/repo').runUrl).toBe('https://git.acme.internal/acme/widgets/actions/runs/7')
+  })
+
   test('parseChecks falls back to the defaults', () => {
     expect(parseChecks(undefined).map((check) => check.name)).toEqual(['lint', 'typecheck', 'test'])
   })
@@ -1395,6 +1434,46 @@ describe('createOctokitApi', () => {
     expect(request?.method).toBe('PATCH')
     expect(request?.url).toContain('/repos/acme/widgets/pulls/3')
     expect(request?.body).toEqual({ title: 'Renamed (#42)', body: 'Closes #42' })
+  })
+
+  test('reacts on the comment that raised the run', async () => {
+    // The two reaction endpoints differ only in the path they address, and the
+    // adapter is the only layer that knows which is which: a phase test asserts
+    // the target the pipeline chose, never the URL that carried it.
+    const captured: CapturedRequest[] = []
+
+    await recordingApi(captured).addReaction({ kind: 'comment', id: 8811 }, 'eyes')
+
+    const [request] = captured
+    expect(request?.method).toBe('POST')
+    expect(request?.url).toContain('/repos/acme/widgets/issues/comments/8811/reactions')
+    expect(request?.body).toEqual({ content: 'eyes' })
+  })
+
+  test('reacts on the issue itself when no comment raised the run', async () => {
+    const captured: CapturedRequest[] = []
+
+    await recordingApi(captured).addReaction({ kind: 'issue', number: 42 }, 'confused')
+
+    const [request] = captured
+    expect(request?.method).toBe('POST')
+    expect(request?.url).toContain('/repos/acme/widgets/issues/42/reactions')
+    // Not `/issues/comments/42/reactions`: the same number means two different
+    // things to the two endpoints, and reacting to comment 42 would land on a
+    // stranger's comment in some other issue entirely.
+    expect(request?.url).not.toContain('/issues/comments/')
+    expect(request?.body).toEqual({ content: 'confused' })
+  })
+
+  test('leaves the reaction content alone, as it does the branch names', async () => {
+    // A four-value union the pipeline picks itself has nowhere for a credential
+    // to hide, so it takes the same exemption from `clean` that `head`/`base` do
+    // — and a redactor that rewrote it would send GitHub a content it rejects.
+    const captured: CapturedRequest[] = []
+
+    await recordingApi(captured, PR_JSON, ['rocket']).addReaction({ kind: 'issue', number: 42 }, 'rocket')
+
+    expect(captured[0]?.body).toEqual({ content: 'rocket' })
   })
 
   test('asks for pull requests in every state, so a merged one is not invisible', async () => {

--- a/tests/opencode-agent/cli.test.ts
+++ b/tests/opencode-agent/cli.test.ts
@@ -183,6 +183,13 @@ interface PostRecorder {
    * "posted exactly one comment" assertion in this file into a lie.
    */
   labelCalls: { method: string; url: string; body: string }[]
+  /**
+   * Comment *edits*, kept apart from `posted` for the reason the label writes
+   * are: an edit is not a comment, and folding the two together would let the
+   * status channel — which edits once a minute — read as a run that posted
+   * once a minute, which is the whole one-comment budget seen from the wire.
+   */
+  edits: { url: string; body: string }[]
   fetch: FetchLike
 }
 
@@ -197,6 +204,7 @@ const recordPosts = (thread: unknown): PostRecorder => {
   const posted: string[] = []
   const reactions: { url: string; body: string }[] = []
   const labelCalls: { method: string; url: string; body: string }[] = []
+  const edits: { url: string; body: string }[] = []
   const json = (payload: unknown, status: number): Response =>
     new Response(JSON.stringify(payload), { status, headers: { 'content-type': 'application/json' } })
 
@@ -206,6 +214,10 @@ const recordPosts = (thread: unknown): PostRecorder => {
     if (url.includes('/reactions')) {
       reactions.push({ url, body })
       return json({ id: 5, content: 'eyes' }, 201)
+    }
+    if (method === 'PATCH' && url.includes('/issues/comments/')) {
+      edits.push({ url, body })
+      return json({ id: 9, html_url: 'https://example.test/c/9' }, 200)
     }
     if (isLabelCall(url)) {
       labelCalls.push({ method, url, body })
@@ -232,6 +244,7 @@ const recordPosts = (thread: unknown): PostRecorder => {
     posted,
     reactions,
     labelCalls,
+    edits,
     fetch: (url, init) => {
       const method = init?.method ?? 'GET'
       return Promise.resolve((byMethod[method] ?? read)(method, url, bodyOf(init?.body)))
@@ -461,6 +474,88 @@ describe('runCli', () => {
     // And none of it became a comment: the label writes go to their own
     // endpoints, not through `createComment`.
     expect(github.posted).toHaveLength(1)
+  })
+
+  test('a real run opens a live status comment, links its job, and finalises it', async () => {
+    // Same lesson as the reaction and the labels above (ROADMAP S2-6, S3-3,
+    // S3-9): a correct channel that `contain` and `assembleDeps` never hand
+    // anything passes every phase test. A low ceiling reaches the answer path's
+    // budget stop, which posts and returns without ever booting a model.
+    const prior = [
+      {
+        id: 1,
+        user: { login: 'agent-bot' },
+        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({
+          v: 2,
+          phase: 'DESIGN_SPEC',
+          issueId: 42,
+          tokensSpent: 60_000,
+        })} -->`,
+      },
+    ]
+    const eventPath = await writeEvent('status', {
+      action: 'created',
+      sender: { login: 'maintainer', type: 'User' },
+      issue: { number: 42, title: 't', body: 'b', author_association: 'OWNER' },
+      comment: { id: 8811, body: '/ask why that file?', author_association: 'OWNER' },
+      repository: { owner: { login: 'acme' }, name: 'widgets', default_branch: 'master' },
+    })
+
+    const github = recordPosts(prior)
+    const result = await runCli({
+      argv: ['--event-path', eventPath, '--event-name', 'issue_comment'],
+      env: { ...env, GITHUB_RUN_ID: '1482', AGENT_MAX_TOKENS: '50000' },
+      logger: silentLogger,
+      fetch: github.fetch,
+    })
+
+    expect(result.status).toBe('failed')
+    // Two comments and no more: the run's status comment, and the notice that
+    // ended it. Everything in between is an edit.
+    expect(github.posted).toHaveLength(2)
+    expect(github.posted[0]).toContain('[this run](https://github.com/acme/widgets/actions/runs/1482)')
+    // Rule 4, at the wire: the state channel gains no second writer.
+    expect(github.posted[0]).not.toContain('AGENT_STATE')
+    expect(github.edits).toHaveLength(1)
+    expect(github.edits[0]?.url).toContain('/repos/acme/widgets/issues/comments/9')
+    expect(github.edits[0]?.body).not.toContain('run in progress')
+  })
+
+  test('a local run with no job to link to opens no status comment', async () => {
+    // The no-op reporter, from the outside: `--event-path` without a run is an
+    // ordinary way to drive this CLI, and every other test in this file relies
+    // on it posting nothing.
+    const prior = [
+      {
+        id: 1,
+        user: { login: 'agent-bot' },
+        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({
+          v: 2,
+          phase: 'DESIGN_SPEC',
+          issueId: 42,
+          tokensSpent: 60_000,
+        })} -->`,
+      },
+    ]
+    const eventPath = await writeEvent('status-local', {
+      action: 'created',
+      sender: { login: 'maintainer', type: 'User' },
+      issue: { number: 42, title: 't', body: 'b', author_association: 'OWNER' },
+      comment: { id: 8811, body: '/ask why that file?', author_association: 'OWNER' },
+      repository: { owner: { login: 'acme' }, name: 'widgets', default_branch: 'master' },
+    })
+
+    const github = recordPosts(prior)
+    const result = await runCli({
+      argv: ['--event-path', eventPath, '--event-name', 'issue_comment'],
+      env: { ...env, AGENT_MAX_TOKENS: '50000' },
+      logger: silentLogger,
+      fetch: github.fetch,
+    })
+
+    expect(result.status).toBe('failed')
+    expect(github.posted).toHaveLength(1)
+    expect(github.edits).toEqual([])
   })
 
   test('a repository that wants no labels gets none', async () => {

--- a/tests/opencode-agent/cli.test.ts
+++ b/tests/opencode-agent/cli.test.ts
@@ -176,8 +176,18 @@ interface PostRecorder {
    * exists to make.
    */
   reactions: { url: string; body: string }[]
+  /**
+   * Label writes, kept apart for the same reason as the reactions, plus one of
+   * its own: labels are the channel most likely to be issued and least likely
+   * to be noticed, so a label POST landing in `posted` would quietly turn every
+   * "posted exactly one comment" assertion in this file into a lie.
+   */
+  labelCalls: { method: string; url: string; body: string }[]
   fetch: FetchLike
 }
+
+/** Labels the fake issue already carries, none of them this pipeline's. */
+const EXISTING_LABELS = [{ name: 'bug' }]
 
 /**
  * A GitHub transport that answers reads with `thread` and records writes.
@@ -186,19 +196,34 @@ interface PostRecorder {
 const recordPosts = (thread: unknown): PostRecorder => {
   const posted: string[] = []
   const reactions: { url: string; body: string }[] = []
+  const labelCalls: { method: string; url: string; body: string }[] = []
   const json = (payload: unknown, status: number): Response =>
     new Response(JSON.stringify(payload), { status, headers: { 'content-type': 'application/json' } })
 
-  const write = (url: string, body: string): Response => {
+  const isLabelCall = (url: string): boolean => /\/labels(\/|\?|$)/u.test(url)
+
+  const write = (method: string, url: string, body: string): Response => {
     if (url.includes('/reactions')) {
       reactions.push({ url, body })
       return json({ id: 5, content: 'eyes' }, 201)
     }
+    if (isLabelCall(url)) {
+      labelCalls.push({ method, url, body })
+      return json([], 200)
+    }
     posted.push(body)
     return json({ id: 9, html_url: 'https://example.test/c/9' }, 201)
   }
-  const read = (): Response => json(thread, 200)
-  const byMethod: Record<string, (url: string, body: string) => Response> = { POST: write, PATCH: write }
+  const read = (method: string, url: string, body: string): Response => {
+    if (!isLabelCall(url)) return json(thread, 200)
+    labelCalls.push({ method, url, body })
+    return json(EXISTING_LABELS, 200)
+  }
+  const byMethod: Record<string, (method: string, url: string, body: string) => Response> = {
+    POST: write,
+    PATCH: write,
+    DELETE: write,
+  }
   // Octokit always sends a string body; the wider `RequestInit` type does not
   // know that, and stringifying a non-string would silently record "[object Object]".
   const bodyOf = (body: BodyInit | null | undefined): string => (typeof body === 'string' ? body : '')
@@ -206,7 +231,11 @@ const recordPosts = (thread: unknown): PostRecorder => {
   return {
     posted,
     reactions,
-    fetch: (url, init) => Promise.resolve((byMethod[init?.method ?? 'GET'] ?? read)(url, bodyOf(init?.body))),
+    labelCalls,
+    fetch: (url, init) => {
+      const method = init?.method ?? 'GET'
+      return Promise.resolve((byMethod[method] ?? read)(method, url, bodyOf(init?.body)))
+    },
   }
 }
 
@@ -220,6 +249,17 @@ const refusingReactions = (inner: FetchLike): FetchLike => {
     Promise.resolve(new Response('{"message":"Resource not accessible by integration"}', { status: 403 }))
 
   return (url, init) => (url.includes('/reactions') ? refuse() : inner(url, init))
+}
+
+/**
+ * The same, for every label endpoint — including the read, because a token that
+ * cannot write labels is usually one that cannot see the issue at all.
+ */
+const refusingLabels = (inner: FetchLike): FetchLike => {
+  const refuse = (): Promise<Response> =>
+    Promise.resolve(new Response('{"message":"Resource not accessible by integration"}', { status: 403 }))
+
+  return (url, init) => (/\/labels(\/|\?|$)/u.test(url) ? refuse() : inner(url, init))
 }
 
 /**
@@ -370,6 +410,118 @@ describe('runCli', () => {
     expect(github.reactions).toHaveLength(1)
     expect(github.reactions[0]?.url).toContain('/repos/acme/widgets/issues/comments/8811/reactions')
     expect(github.reactions[0]?.body).toContain('"content":"eyes"')
+  })
+
+  test('a real run labels the issue it finished', async () => {
+    // Same lesson as the reaction above, and the label endpoints are four new
+    // chances to relearn it: a correct adapter that `contain` and
+    // `assembleDeps` never hand anything passes every phase test. `/cancel`
+    // reaches COMPLETE without a pull request, which is `agent:stopped`.
+    const prior = [
+      {
+        id: 1,
+        user: { login: 'agent-bot' },
+        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 2, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
+      },
+    ]
+    const eventPath = await writeEvent('labels', {
+      action: 'created',
+      sender: { login: 'maintainer', type: 'User' },
+      issue: { number: 42, title: 't', body: 'b', author_association: 'OWNER' },
+      comment: { id: 8811, body: '/cancel', author_association: 'OWNER' },
+      repository: { owner: { login: 'acme' }, name: 'widgets', default_branch: 'master' },
+    })
+
+    const github = recordPosts(prior)
+    const result = await runCli({
+      argv: ['--event-path', eventPath, '--event-name', 'issue_comment'],
+      env,
+      logger: silentLogger,
+      fetch: github.fetch,
+    })
+
+    expect(result.status).toBe('completed')
+    expect(github.labelCalls).toContainEqual({
+      method: 'GET',
+      url: 'https://api.github.com/repos/acme/widgets/issues/42/labels?per_page=100',
+      body: '',
+    })
+    expect(github.labelCalls).toContainEqual({
+      method: 'POST',
+      url: 'https://api.github.com/repos/acme/widgets/labels',
+      body: '{"name":"agent:stopped","color":"6a737d"}',
+    })
+    expect(github.labelCalls).toContainEqual({
+      method: 'POST',
+      url: 'https://api.github.com/repos/acme/widgets/issues/42/labels',
+      body: '{"labels":["agent:stopped"]}',
+    })
+    // `bug` is the repository's own and was on the issue before this run.
+    expect(github.labelCalls.filter((call) => call.url.endsWith('/labels/bug'))).toEqual([])
+    // And none of it became a comment: the label writes go to their own
+    // endpoints, not through `createComment`.
+    expect(github.posted).toHaveLength(1)
+  })
+
+  test('a repository that wants no labels gets none', async () => {
+    const prior = [
+      {
+        id: 1,
+        user: { login: 'agent-bot' },
+        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 2, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
+      },
+    ]
+    const eventPath = await writeEvent('labels-none', {
+      action: 'created',
+      sender: { login: 'maintainer', type: 'User' },
+      issue: { number: 42, title: 't', body: 'b', author_association: 'OWNER' },
+      comment: { id: 8811, body: '/cancel', author_association: 'OWNER' },
+      repository: { owner: { login: 'acme' }, name: 'widgets', default_branch: 'master' },
+    })
+
+    const github = recordPosts(prior)
+    const result = await runCli({
+      argv: ['--event-path', eventPath, '--event-name', 'issue_comment'],
+      env: { ...env, AGENT_LABEL_PREFIX: 'none' },
+      logger: silentLogger,
+      fetch: github.fetch,
+    })
+
+    expect(result.status).toBe('completed')
+    expect(github.labelCalls).toEqual([])
+    expect(github.posted).toHaveLength(1)
+  })
+
+  test('labels GitHub refuses do not fail the run', async () => {
+    // The rule-1 test at the transport: a token without `issues: write`, or a
+    // repository that restricts who may create a label, reaches the same
+    // result and posts the same comment as one where the channel worked.
+    const prior = [
+      {
+        id: 1,
+        user: { login: 'agent-bot' },
+        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 2, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
+      },
+    ]
+    const eventPath = await writeEvent('labels-403', {
+      action: 'created',
+      sender: { login: 'maintainer', type: 'User' },
+      issue: { number: 42, title: 't', body: 'b', author_association: 'OWNER' },
+      comment: { id: 8811, body: '/cancel', author_association: 'OWNER' },
+      repository: { owner: { login: 'acme' }, name: 'widgets', default_branch: 'master' },
+    })
+
+    const github = recordPosts(prior)
+    const result = await runCli({
+      argv: ['--event-path', eventPath, '--event-name', 'issue_comment'],
+      env,
+      logger: silentLogger,
+      fetch: refusingLabels(github.fetch),
+    })
+
+    expect(result.status).toBe('completed')
+    expect(result.reported).toBe(true)
+    expect(github.posted).toHaveLength(1)
   })
 
   test('a reaction GitHub refuses does not fail the run', async () => {

--- a/tests/opencode-agent/cli.test.ts
+++ b/tests/opencode-agent/cli.test.ts
@@ -167,6 +167,15 @@ describe('memoizeAgent', () => {
 
 interface PostRecorder {
   posted: string[]
+  /**
+   * Reaction writes, kept apart from `posted`.
+   *
+   * Not tidiness: a reaction is not a comment, and folding the two together
+   * would let a run that says nothing on the issue but reacts to it read as a
+   * run that reported — which is the exact distinction `RunResult.reported`
+   * exists to make.
+   */
+  reactions: { url: string; body: string }[]
   fetch: FetchLike
 }
 
@@ -176,23 +185,41 @@ interface PostRecorder {
  */
 const recordPosts = (thread: unknown): PostRecorder => {
   const posted: string[] = []
+  const reactions: { url: string; body: string }[] = []
   const json = (payload: unknown, status: number): Response =>
     new Response(JSON.stringify(payload), { status, headers: { 'content-type': 'application/json' } })
 
-  const write = (body: string): Response => {
+  const write = (url: string, body: string): Response => {
+    if (url.includes('/reactions')) {
+      reactions.push({ url, body })
+      return json({ id: 5, content: 'eyes' }, 201)
+    }
     posted.push(body)
     return json({ id: 9, html_url: 'https://example.test/c/9' }, 201)
   }
   const read = (): Response => json(thread, 200)
-  const byMethod: Record<string, (body: string) => Response> = { POST: write, PATCH: write }
+  const byMethod: Record<string, (url: string, body: string) => Response> = { POST: write, PATCH: write }
   // Octokit always sends a string body; the wider `RequestInit` type does not
   // know that, and stringifying a non-string would silently record "[object Object]".
   const bodyOf = (body: BodyInit | null | undefined): string => (typeof body === 'string' ? body : '')
 
   return {
     posted,
-    fetch: (_url, init) => Promise.resolve((byMethod[init?.method ?? 'GET'] ?? read)(bodyOf(init?.body))),
+    reactions,
+    fetch: (url, init) => Promise.resolve((byMethod[init?.method ?? 'GET'] ?? read)(url, bodyOf(init?.body))),
   }
+}
+
+/**
+ * A transport that turns down every reaction and passes everything else
+ * through — a token without `issues: write`, seen from the wire. Out here
+ * because a test body may carry no conditional.
+ */
+const refusingReactions = (inner: FetchLike): FetchLike => {
+  const refuse = (): Promise<Response> =>
+    Promise.resolve(new Response('{"message":"Resource not accessible by integration"}', { status: 403 }))
+
+  return (url, init) => (url.includes('/reactions') ? refuse() : inner(url, init))
 }
 
 /**
@@ -306,6 +333,74 @@ describe('runCli', () => {
     // the hidden block republishes on every comment.
     expect(github.posted[0]).toContain('[redacted]')
     expect(github.posted[0]).not.toContain(token)
+  })
+
+  test('a real run acknowledges the comment that triggered it', async () => {
+    // End to end through `contain`, `assembleDeps` and the real Octokit
+    // adapter. The recorded lesson of this workspace (ROADMAP S2-6, S3-3, S3-9)
+    // is that a correct adapter which is never wired in passes every phase
+    // test, so the wiring is what this exercises — not the module.
+    // `/cancel` reaches a finished run without booting a model.
+    const prior = [
+      {
+        id: 1,
+        user: { login: 'agent-bot' },
+        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 2, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
+      },
+    ]
+    const eventPath = await writeEvent('reaction', {
+      action: 'created',
+      sender: { login: 'maintainer', type: 'User' },
+      issue: { number: 42, title: 't', body: 'b', author_association: 'OWNER' },
+      comment: { id: 8811, body: '/cancel', author_association: 'OWNER' },
+      repository: { owner: { login: 'acme' }, name: 'widgets', default_branch: 'master' },
+    })
+
+    const github = recordPosts(prior)
+    const result = await runCli({
+      argv: ['--event-path', eventPath, '--event-name', 'issue_comment'],
+      env,
+      logger: silentLogger,
+      fetch: github.fetch,
+    })
+
+    expect(result.status).toBe('completed')
+    // On the comment the maintainer typed, which is the whole point — the id
+    // was parsed and thrown away until this stage carried it through.
+    expect(github.reactions).toHaveLength(1)
+    expect(github.reactions[0]?.url).toContain('/repos/acme/widgets/issues/comments/8811/reactions')
+    expect(github.reactions[0]?.body).toContain('"content":"eyes"')
+  })
+
+  test('a reaction GitHub refuses does not fail the run', async () => {
+    // A token without `issues: write`, a fork run, an org policy. The rule is
+    // that none of them may change what the run does or what it posts, and this
+    // is the only place the real adapter's rejection is on the path.
+    const prior = [
+      {
+        id: 1,
+        user: { login: 'agent-bot' },
+        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 2, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
+      },
+    ]
+    const eventPath = await writeEvent('reaction-403', {
+      action: 'created',
+      sender: { login: 'maintainer', type: 'User' },
+      issue: { number: 42, title: 't', body: 'b', author_association: 'OWNER' },
+      comment: { id: 8811, body: '/cancel', author_association: 'OWNER' },
+      repository: { owner: { login: 'acme' }, name: 'widgets', default_branch: 'master' },
+    })
+
+    const github = recordPosts(prior)
+    const result = await runCli({
+      argv: ['--event-path', eventPath, '--event-name', 'issue_comment'],
+      env,
+      logger: silentLogger,
+      fetch: refusingReactions(github.fetch),
+    })
+
+    expect(result.status).toBe('completed')
+    expect(github.posted).toHaveLength(1)
   })
 
   test('tells the workflow it has reported, when it posted the failure itself', async () => {

--- a/tests/opencode-agent/guardrails.test.ts
+++ b/tests/opencode-agent/guardrails.test.ts
@@ -32,6 +32,7 @@ const issueEvent = (overrides: Partial<IssueTriggerEvent> = {}): IssueTriggerEve
   issueBody: 'Please add retries.',
   isPullRequest: false,
   commentBody: null,
+  commentId: null,
   repositoryOwner: 'acme',
   defaultBranch: 'main',
   ...overrides,
@@ -66,6 +67,23 @@ describe('parseTriggerEvent — issue events', () => {
     const parsed = parseTriggerEvent('issue_comment', payload)
 
     expect(parsed).toMatchObject({ kind: 'issue', authorAssociation: 'NONE', commentBody: '/approve' })
+  })
+
+  test('carries the id of the comment that triggered the run', () => {
+    // The schema always parsed it; the parser threw it away, so the pipeline
+    // could not address the one place the person waiting is looking.
+    const payload = issuePayload({
+      action: 'created',
+      comment: { id: 8811, body: 'looks right', author_association: 'OWNER' },
+    })
+
+    expect(parseTriggerEvent('issue_comment', payload)).toMatchObject({ commentId: 8811 })
+  })
+
+  test('reports no comment id for an issues.opened event', () => {
+    // There is no comment to address, and a fabricated id would be pointed at
+    // somebody else's. Feedback falls back to the issue itself.
+    expect(parseTriggerEvent('issues', issuePayload())).toMatchObject({ commentId: null })
   })
 
   test('flags a comment on a pull request', () => {

--- a/tests/opencode-agent/identity.test.ts
+++ b/tests/opencode-agent/identity.test.ts
@@ -36,6 +36,7 @@ const api = (login: () => Promise<string>): GitHubApi => {
     findPullRequest: unused,
     createPullRequest: unused,
     updatePullRequest: unused,
+    addReaction: unused,
   }
 }
 

--- a/tests/opencode-agent/identity.test.ts
+++ b/tests/opencode-agent/identity.test.ts
@@ -37,6 +37,10 @@ const api = (login: () => Promise<string>): GitHubApi => {
     createPullRequest: unused,
     updatePullRequest: unused,
     addReaction: unused,
+    listLabels: unused,
+    addLabels: unused,
+    removeLabel: unused,
+    createLabel: unused,
   }
 }
 

--- a/tests/opencode-agent/identity.test.ts
+++ b/tests/opencode-agent/identity.test.ts
@@ -32,6 +32,7 @@ const api = (login: () => Promise<string>): GitHubApi => {
     getAuthenticatedLogin: login,
     listIssueComments: unused,
     createComment: unused,
+    updateComment: unused,
     getIssue: unused,
     findPullRequest: unused,
     createPullRequest: unused,

--- a/tests/opencode-agent/labels.test.ts
+++ b/tests/opencode-agent/labels.test.ts
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import type { LabelApi } from '../../opencode-agent/src/github-labels.js'
+import { reconcileLabels, settleLabels } from '../../opencode-agent/src/labels.js'
+import type { LabelDeps } from '../../opencode-agent/src/labels.js'
+import type { Logger } from '../../opencode-agent/src/logger.js'
+import { initialState } from '../../opencode-agent/src/state-manager.js'
+import type { AgentState, Phase, RunResult } from '../../opencode-agent/src/types.js'
+
+const ISSUE = 42
+
+const stateIn = (phase: Phase, patch: Partial<AgentState> = {}): AgentState => ({
+  ...initialState(ISSUE),
+  phase,
+  ...patch,
+})
+
+interface LabelIo {
+  /** What the issue carries, mutated by the writes the reconcile issues. */
+  labels: string[]
+  /**
+   * Every call, in order and including the read.
+   *
+   * The whole claim being tested is about the calls, not the end state: a
+   * clear-and-reapply reaches exactly the same set as a diff, and differs only
+   * in how many timeline entries it left behind on the way.
+   */
+  calls: string[]
+  warnings: string[]
+  error: Error | null
+}
+
+const makeDeps = (labels: readonly string[] = [], labelPrefix: string | null = 'agent:'): [LabelDeps, LabelIo] => {
+  const io: LabelIo = { labels: [...labels], calls: [], warnings: [], error: null }
+
+  const record = (call: string, apply: () => void): Promise<void> => {
+    io.calls.push(call)
+    if (io.error !== null) return Promise.reject(io.error)
+    apply()
+    return Promise.resolve()
+  }
+
+  const github: LabelApi = {
+    listLabels: (issueNumber): Promise<string[]> => {
+      io.calls.push(`list:${issueNumber}`)
+      return io.error === null ? Promise.resolve([...io.labels]) : Promise.reject(io.error)
+    },
+    addLabels: (_issueNumber, names): Promise<void> =>
+      record(`+${names.join(',')}`, () => {
+        io.labels.push(...names)
+      }),
+    removeLabel: (_issueNumber, name): Promise<void> =>
+      record(`-${name}`, () => {
+        io.labels = io.labels.filter((existing) => existing !== name)
+      }),
+    createLabel: (name, color): Promise<void> => record(`create:${name}:${color}`, () => undefined),
+  }
+
+  const log: Logger = {
+    debug: (): void => {},
+    info: (): void => {},
+    warn: (_fields, message): void => void io.warnings.push(message),
+    error: (): void => {},
+  }
+
+  return [{ github, log, config: { labelPrefix } }, io]
+}
+
+/** Just the writes: the read is not the thing a diff is judged on. */
+const writes = (io: LabelIo): string[] => io.calls.filter((call) => !call.startsWith('list:'))
+
+describe('reconcileLabels', () => {
+  test('a state whose labels are already right writes nothing at all', async () => {
+    // The point of computing a diff. A clear-and-reapply would issue a removal
+    // and an add here — two timeline entries and a visible flicker — for a run
+    // that changed nothing, which is most runs.
+    const [deps, io] = makeDeps(['agent:plan-review', 'agent:needs-you'])
+
+    await reconcileLabels(deps, stateIn('PLAN_REVIEW'), 'waiting')
+
+    expect(writes(io)).toEqual([])
+    expect(io.calls).toEqual([`list:${ISSUE}`])
+  })
+
+  test('a phase move is one add and one removal, nothing more', async () => {
+    const [deps, io] = makeDeps(['agent:plan-review', 'agent:needs-you'])
+
+    await reconcileLabels(deps, stateIn('REVIEW_AND_MUTATE'), 'working')
+
+    expect(writes(io)).toEqual([
+      'create:agent:implementing:1d76db',
+      'create:agent:working:1d76db',
+      '+agent:implementing,agent:working',
+      '-agent:plan-review',
+      '-agent:needs-you',
+    ])
+    expect(io.labels.sort()).toEqual(['agent:implementing', 'agent:working'])
+  })
+
+  test('an `agent:` label the state does not imply is removed', async () => {
+    // The repair half, and the one easiest to leave out. It covers both a
+    // hand-edited issue and the runner killed mid-flight that leaves
+    // `agent:working` stranded on an issue nothing is working.
+    const [deps, io] = makeDeps(['agent:done', 'agent:working', 'agent:plan-review', 'agent:needs-you'])
+
+    await reconcileLabels(deps, stateIn('PLAN_REVIEW'), 'waiting')
+
+    expect(writes(io)).toEqual(['-agent:done', '-agent:working'])
+    expect(io.labels.sort()).toEqual(['agent:needs-you', 'agent:plan-review'])
+  })
+
+  test('a label the repository owns is left strictly alone', async () => {
+    // The worst thing this module could do. `bug` and `agentic-workflows` are
+    // somebody else's labels: this pipeline did not put them there, and
+    // "remove what I do not recognise" would take them off every issue it runs
+    // on. Note `agentic-workflows` — it shares a prefix with the *word*, and
+    // only the configured `agent:` decides ownership.
+    const [deps, io] = makeDeps(['bug', 'agentic-workflows', 'agent:done'])
+
+    await reconcileLabels(deps, stateIn('PLAN_REVIEW'), 'waiting')
+
+    expect(writes(io)).toEqual([
+      'create:agent:plan-review:d4a72c',
+      'create:agent:needs-you:d4a72c',
+      '+agent:plan-review,agent:needs-you',
+      '-agent:done',
+    ])
+    expect(io.labels).toContain('bug')
+    expect(io.labels).toContain('agentic-workflows')
+  })
+
+  test('a custom prefix is what decides ownership, end to end', async () => {
+    // The knob is not optional polish: this pipeline runs in repositories with
+    // their own conventions. Under `bot/`, an `agent:` label is one of *theirs*
+    // and must survive untouched.
+    const [deps, io] = makeDeps(['bot/done', 'agent:done'], 'bot/')
+
+    await reconcileLabels(deps, stateIn('DESIGN_SPEC'), 'waiting')
+
+    expect(writes(io)).toEqual([
+      'create:bot/spec-review:d4a72c',
+      'create:bot/needs-you:d4a72c',
+      '+bot/spec-review,bot/needs-you',
+      '-bot/done',
+    ])
+    expect(io.labels).toContain('agent:done')
+  })
+
+  test('`none` issues no label call of any kind, not even the read', async () => {
+    const [deps, io] = makeDeps(['agent:done'], null)
+
+    await reconcileLabels(deps, stateIn('PLAN_REVIEW'), 'waiting')
+
+    expect(io.calls).toEqual([])
+    expect(io.labels).toEqual(['agent:done'])
+  })
+
+  test('a GitHub that refuses every label call resolves and warns', async () => {
+    // Rule 1, at the level it is enforced: one function is the only door to the
+    // label API, and it swallows everything. A token without `issues: write`, a
+    // fork run and an org policy on label creation are all real.
+    const [deps, io] = makeDeps(['agent:done'])
+    io.error = new Error('Resource not accessible by integration')
+
+    await reconcileLabels(deps, stateIn('PLAN_REVIEW'), 'waiting')
+
+    expect(io.warnings).toEqual(['Could not reconcile the issue labels'])
+  })
+
+  test('a refusal partway through still leaves the run to carry on', async () => {
+    // The read succeeds, the first write does not — the shape a token with
+    // read-only issue access presents.
+    const [deps, io] = makeDeps(['agent:done'])
+    const failing: LabelDeps = {
+      ...deps,
+      github: { ...deps.github, createLabel: (): Promise<void> => Promise.reject(new Error('403')) },
+    }
+
+    await reconcileLabels(failing, stateIn('PLAN_REVIEW'), 'waiting')
+
+    expect(io.warnings).toEqual(['Could not reconcile the issue labels'])
+  })
+
+  test('the issue it labels is the one the state names', async () => {
+    const [deps, io] = makeDeps()
+
+    await reconcileLabels(deps, { ...stateIn('FAILED'), issueId: 99 }, 'waiting')
+
+    expect(io.calls[0]).toBe('list:99')
+  })
+})
+
+describe('settleLabels', () => {
+  const result = (state: AgentState | null): RunResult => ({
+    status: 'skipped',
+    reason: 'nothing to do',
+    state,
+    reported: false,
+  })
+
+  test('hands the result back untouched', async () => {
+    // A label is not a report, and this is the function every exit goes through:
+    // if it could alter a `RunResult`, it could suppress the workflow's fallback
+    // comment.
+    const [deps] = makeDeps()
+    const original = result(stateIn('PLAN_REVIEW'))
+
+    expect(await settleLabels(deps, original, stateIn('DESIGN_SPEC'))).toBe(original)
+  })
+
+  test('reconciles from the run’s own state when it has one', async () => {
+    const [deps, io] = makeDeps(['agent:working'])
+
+    await settleLabels(deps, result(stateIn('PLAN_REVIEW')), stateIn('DESIGN_SPEC'))
+
+    expect(io.labels.sort()).toEqual(['agent:needs-you', 'agent:plan-review'])
+  })
+
+  test('falls back to the restored state for a run that carries none', async () => {
+    // A guardrail-shaped skip reports `state: null`. Reconciling the restored
+    // state is still the repair, which is what takes a stranded `agent:working`
+    // off an issue whose only event this hour was somebody typing "thanks".
+    const [deps, io] = makeDeps(['agent:working', 'agent:spec-review'])
+
+    await settleLabels(deps, result(null), stateIn('DESIGN_SPEC'))
+
+    expect(writes(io)).toEqual(['create:agent:needs-you:d4a72c', '+agent:needs-you', '-agent:working'])
+  })
+})

--- a/tests/opencode-agent/markdown.test.ts
+++ b/tests/opencode-agent/markdown.test.ts
@@ -95,7 +95,7 @@ describe('fence', () => {
 describe('renderFailure', () => {
   const failed = transition(initialState(1), 'FAILED', { lastError: 'x' })
 
-  const render = (message: string): string => renderFailure('INIT_OR_CLARIFY', message, failed, 3)
+  const render = (message: string): string => renderFailure('INIT_OR_CLARIFY', message, failed, 3, null)
 
   test('keeps the recovery instruction readable when the error carries a fence', () => {
     // This is the line the maintainer has to act on; a broken fence buries it

--- a/tests/opencode-agent/markdown.test.ts
+++ b/tests/opencode-agent/markdown.test.ts
@@ -4,13 +4,26 @@
 // See LICENSE in the project root for details.
 
 import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 
 import { formatFailures } from '../../opencode-agent/src/check-loop.js'
 import { acceptedCommands, SLASH_COMMANDS } from '../../opencode-agent/src/commands.js'
 import { modelResponseError } from '../../opencode-agent/src/errors.js'
 import { fence } from '../../opencode-agent/src/markdown.js'
-import { presentationFor } from '../../opencode-agent/src/presentation.js'
-import { renderFailure, renderSettled } from '../../opencode-agent/src/run-report.js'
+import { OUTCOME_GLYPHS, PRESENTATION, presentationFor } from '../../opencode-agent/src/presentation.js'
+import type { OutcomeKey } from '../../opencode-agent/src/presentation.js'
+import {
+  renderAnswerFailure,
+  renderAnswerOverBudget,
+  renderCiExhausted,
+  renderClosing,
+  renderExhausted,
+  renderFailure,
+  renderOverBudget,
+  renderRefusedCommand,
+  renderSettled,
+} from '../../opencode-agent/src/run-report.js'
 import { initialState, transition } from '../../opencode-agent/src/state-manager.js'
 import type { AgentState, Phase } from '../../opencode-agent/src/types.js'
 
@@ -106,7 +119,7 @@ describe('renderFailure', () => {
     const rendered = render(modelResponseError('no JSON object', FENCED_REPLY).message)
 
     expect(prose(rendered)).toContain('/retry')
-    expect(prose(rendered)).toContain('### Run failed in INIT_OR_CLARIFY')
+    expect(prose(rendered)).toContain('### ❌ Run failed in INIT_OR_CLARIFY')
   })
 
   test('keeps the whole error inside the block', () => {
@@ -166,8 +179,55 @@ describe('renderSettled', () => {
     // an invitation the state machine refuses.
     const delivered: AgentState = { ...parked('COMPLETE'), prUrl: 'https://example.test/pull/7' }
 
-    expect(renderSettled(delivered)).toContain('### Done')
-    expect(renderSettled(parked('COMPLETE'))).toContain('### Stopped')
+    expect(renderSettled(delivered)).toContain('### ✅ Done')
+    expect(renderSettled(parked('COMPLETE'))).toContain('### 🛑 Stopped')
+  })
+})
+
+describe('comment headings', () => {
+  const failed = transition(initialState(42), 'FAILED', { lastError: 'x' })
+
+  /** One entry per renderer that speaks about an outcome, with its key. */
+  const OUTCOME_COMMENTS: readonly (readonly [OutcomeKey, string])[] = [
+    ['RUN_FAILED', renderFailure('EXECUTION_PLAN', 'boom', failed, 3, null)],
+    ['ANSWER_FAILED', renderAnswerFailure('DESIGN_SPEC', 'boom')],
+    ['RETRIES_SPENT', renderExhausted('Retry budget exhausted')],
+    ['TOKENS_SPENT', renderOverBudget(1, 2, 'EXECUTION_PLAN')],
+    ['ANSWER_TOKENS_SPENT', renderAnswerOverBudget(1, 2, 'DESIGN_SPEC')],
+    ['CI_GAVE_UP', renderCiExhausted('spent', null)],
+    ['COMMAND_REFUSED', renderRefusedCommand('/approve', 'COMPLETE', [])],
+  ]
+
+  test.each(OUTCOME_COMMENTS)('%s leads with the glyph the outcome table gives it', (key, rendered) => {
+    // Read from the table rather than written out here: the point of the table
+    // is that no renderer picks its own glyph, and a test that hardcoded them
+    // would be a second place to change.
+    expect(rendered.startsWith(`### ${OUTCOME_GLYPHS[key]} `)).toBe(true)
+  })
+
+  test('the closing comment reads from the phase table, not the outcome one', () => {
+    // "Delivered" and "Stopped" are states, not outcomes — the same two the
+    // label reconciler names on this very comment, so they share one source.
+    const delivered: AgentState = { ...initialState(42), phase: 'COMPLETE', prUrl: 'https://example.test/pull/7' }
+    const cancelled: AgentState = { ...initialState(42), phase: 'COMPLETE' }
+
+    expect(renderClosing(delivered).startsWith(`### ${PRESENTATION['COMPLETE:delivered'].glyph} Done`)).toBe(true)
+    expect(renderClosing(cancelled).startsWith(`### ${PRESENTATION['COMPLETE:cancelled'].glyph} Stopped`)).toBe(true)
+  })
+
+  test('no renderer writes a heading of its own', () => {
+    // The class, not the instance. Nine renderers each picking a glyph by hand
+    // is the defect the tables exist to prevent, and it comes back the moment
+    // somebody adds a tenth with a literal `### ` — which every one of these
+    // renderers had until this stage. Comments are stripped first: several of
+    // them quote the old headings on purpose.
+    const source = readFileSync(
+      path.join(import.meta.dir, '..', '..', 'opencode-agent', 'src', 'run-report.ts'),
+      'utf8',
+    )
+    const stripped = source.replaceAll(/\/\*[\s\S]*?\*\//gu, '').replaceAll(/^\s*\/\/.*$/gmu, '')
+
+    expect(stripped).not.toMatch(/['"`]### /u)
   })
 })
 

--- a/tests/opencode-agent/markdown.test.ts
+++ b/tests/opencode-agent/markdown.test.ts
@@ -6,10 +6,13 @@
 import { describe, expect, test } from 'bun:test'
 
 import { formatFailures } from '../../opencode-agent/src/check-loop.js'
+import { acceptedCommands, SLASH_COMMANDS } from '../../opencode-agent/src/commands.js'
 import { modelResponseError } from '../../opencode-agent/src/errors.js'
 import { fence } from '../../opencode-agent/src/markdown.js'
-import { renderFailure } from '../../opencode-agent/src/run-report.js'
+import { presentationFor } from '../../opencode-agent/src/presentation.js'
+import { renderFailure, renderSettled } from '../../opencode-agent/src/run-report.js'
 import { initialState, transition } from '../../opencode-agent/src/state-manager.js'
+import type { AgentState, Phase } from '../../opencode-agent/src/types.js'
 
 /**
  * Everything this pipeline fences is written by something else — a model reply,
@@ -121,6 +124,50 @@ describe('renderFailure', () => {
 
   test('leaves no unclosed fence', () => {
     expect(spans(render(modelResponseError('no JSON', FENCED_REPLY).message)).unclosed).toBe(false)
+  })
+})
+
+describe('renderSettled', () => {
+  const parked = (phase: Phase): AgentState => ({ ...initialState(42), phase })
+
+  /** Every phase the cascade can actually stop at without a handler. */
+  const WAITING: readonly Phase[] = ['DESIGN_SPEC', 'PLAN_REVIEW', 'FAILED']
+
+  test.each([...WAITING])('%s names exactly the commands the transition table accepts', (phase) => {
+    // The gap this closes: the comment used to be `### Waiting` over "Parked in
+    // `PLAN_REVIEW`." and nothing else, while every other waiting comment in
+    // the file carries a "what now". Derived from `acceptedCommands`, not
+    // written out here, so the assertion cannot drift from the machine either.
+    const rendered = renderSettled(parked(phase))
+    const accepted = acceptedCommands(phase)
+
+    for (const command of accepted) expect(rendered).toContain(`\`${command}\``)
+    for (const command of SLASH_COMMANDS.filter((name) => !accepted.includes(name))) {
+      expect(rendered).not.toContain(`\`${command}\``)
+    }
+  })
+
+  test.each([...WAITING])('%s leads with the headline the presentation table gives it', (phase) => {
+    // `PLAN_REVIEW` means nothing to a maintainer who has not read the state
+    // machine, which is why the phase name is no longer the whole comment.
+    const { glyph, headline } = presentationFor(parked(phase), 'waiting')
+
+    expect(renderSettled(parked(phase)).startsWith(`### ${glyph} ${headline}`)).toBe(true)
+  })
+
+  test('still says which phase it is parked in', () => {
+    // The name is what a maintainer quotes into an issue when asking about it,
+    // and what the hidden state block says a line below.
+    expect(renderSettled(parked('PLAN_REVIEW'))).toContain('`PLAN_REVIEW`')
+  })
+
+  test('a finished issue keeps the closing comment, not the waiting one', () => {
+    // COMPLETE accepts no command at all, so offering a list of them would be
+    // an invitation the state machine refuses.
+    const delivered: AgentState = { ...parked('COMPLETE'), prUrl: 'https://example.test/pull/7' }
+
+    expect(renderSettled(delivered)).toContain('### Done')
+    expect(renderSettled(parked('COMPLETE'))).toContain('### Stopped')
   })
 })
 

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -2517,7 +2517,8 @@ describe('labels — feedback never fails a run', () => {
   })
 
   test('a label is not a report, so it never suppresses the fallback comment', async () => {
-    // `RunResult.reported` gates the workflow's "Agent job failed" comment. A
+    // `RunResult.reported` gates the workflow's "Agent job did not finish"
+    // comment. A
     // run that only ever labelled has said nothing on the issue.
     const harness = makeHarness()
     await toComplete(harness)

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -10,7 +10,13 @@ import type { IssueComment } from '../../opencode-agent/src/blocks.js'
 import { DEFAULT_CHECKS } from '../../opencode-agent/src/config.js'
 import type { PipelineConfig } from '../../opencode-agent/src/config.js'
 import type { Git } from '../../opencode-agent/src/git.js'
-import type { GitHubApi, PullRequestRef, PullRequestStatus } from '../../opencode-agent/src/github.js'
+import type {
+  GitHubApi,
+  PullRequestRef,
+  PullRequestStatus,
+  ReactionContent,
+  ReactionTarget,
+} from '../../opencode-agent/src/github.js'
 import type { CiTriggerEvent, IssueTriggerEvent } from '../../opencode-agent/src/guardrails.js'
 import type { Logger } from '../../opencode-agent/src/logger.js'
 import type { AgentPromptRequest, OpenCodeAgent } from '../../opencode-agent/src/opencode-adapter.js'
@@ -18,8 +24,14 @@ import { runPipeline } from '../../opencode-agent/src/orchestrator.js'
 import type { PhaseDeps } from '../../opencode-agent/src/phase-context.js'
 import type { ReviewRunResult } from '../../opencode-agent/src/review-runner.js'
 import type { CommandResult } from '../../opencode-agent/src/shell.js'
-import { extractState, initialState, serializeState, STATE_MARKER } from '../../opencode-agent/src/state-manager.js'
-import type { AgentState, Phase } from '../../opencode-agent/src/types.js'
+import {
+  extractState,
+  findLatestState,
+  initialState,
+  serializeState,
+  STATE_MARKER,
+} from '../../opencode-agent/src/state-manager.js'
+import type { AgentState, Phase, RunResult } from '../../opencode-agent/src/types.js'
 
 const AGENT_LOGIN = 'agent-bot'
 const ISSUE = 42
@@ -58,6 +70,7 @@ const config = (overrides: Partial<PipelineConfig> = {}): PipelineConfig => ({
   maxTokens: 5_000_000,
   diffLimits: { maxFiles: 100, maxLines: 20_000 },
   gitRemoteBase: 'https://github.com/',
+  runUrl: null,
   skillRoots: ['.superpowers/skills'],
   ...overrides,
 })
@@ -74,13 +87,17 @@ const issueEvent = (overrides: Partial<IssueTriggerEvent> = {}): IssueTriggerEve
   issueBody: 'Please add retries to the HTTP client.',
   isPullRequest: false,
   commentBody: null,
+  commentId: null,
   repositoryOwner: 'acme',
   defaultBranch: BASE_BRANCH,
   ...overrides,
 })
 
+/** The comment a maintainer typed, which feedback lands on rather than the issue. */
+const COMMENT_ID = 555
+
 const comment = (body: string): IssueTriggerEvent =>
-  issueEvent({ eventName: 'issue_comment', action: 'created', commentBody: body })
+  issueEvent({ eventName: 'issue_comment', action: 'created', commentBody: body, commentId: COMMENT_ID })
 
 const ciEvent = (overrides: Partial<CiTriggerEvent> = {}): CiTriggerEvent => ({
   kind: 'ci',
@@ -117,6 +134,16 @@ interface PipelineIo {
   prTitles: string[]
   /** The account GitHub records as the author of the agent's comments. */
   postedAs: string
+  /** Every reaction the run placed, in order, with what it landed on. */
+  reactions: { target: ReactionTarget; content: ReactionContent }[]
+  /**
+   * What `addReaction` rejects with, when set.
+   *
+   * A token without `issues: write`, a fork run and an org policy all produce
+   * exactly this, and the rule is that none of them may change a single thing
+   * about the run.
+   */
+  reactionError: Error | null
 }
 
 interface Harness {
@@ -147,6 +174,8 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
     prBodies: [],
     prTitles: [],
     postedAs: AGENT_LOGIN,
+    reactions: [],
+    reactionError: null,
   }
 
   let nextCommentId = 100
@@ -178,6 +207,12 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
       io.prBodies.push(patch.body)
       io.prTitles.push(patch.title)
       return Promise.resolve()
+    },
+    addReaction: (target, content) => {
+      // Recorded before the refusal, so a test can prove the pipeline *asked*
+      // even in the run where every ask is turned down.
+      io.reactions.push({ target, content })
+      return io.reactionError === null ? Promise.resolve() : Promise.reject(io.reactionError)
     },
   }
 
@@ -263,6 +298,9 @@ const toDesignSpec = async (harness: Harness): Promise<void> => {
   harness.io.replies = [SPEC_REPLY]
   await runPipeline({ event: issueEvent(), deps: harness.deps })
   harness.io.posted.length = 0
+  // Reactions too: these helpers exist to put an issue in a starting position,
+  // and what the setup runs acknowledged is not part of the test that follows.
+  harness.io.reactions.length = 0
 }
 
 /** Drives an issue as far as PLAN_REVIEW. */
@@ -271,6 +309,7 @@ const toPlanReview = async (harness: Harness): Promise<void> => {
   harness.io.replies = [PLAN_REPLY]
   await runPipeline({ event: comment('/approve'), deps: harness.deps })
   harness.io.posted.length = 0
+  harness.io.reactions.length = 0
 }
 
 describe('guardrails', () => {
@@ -1813,5 +1852,335 @@ describe('the token budget', () => {
     expect(result.status).toBe('failed')
     expect(harness.io.posted[0]).toContain('### Token budget spent')
     expect(latestPostedState(harness)?.phase).toBe('COMPLETE')
+  })
+})
+
+/** Just the contents, in order — the target is asserted where it is the point. */
+const reactionsOf = (harness: Harness): ReactionContent[] => harness.io.reactions.map((entry) => entry.content)
+
+/** A run that goes all the way from an approved plan to an open pull request. */
+const driveDelivery = async (harness: Harness): Promise<RunResult> => {
+  await toPlanReview(harness)
+  harness.io.replies = ['Implemented.']
+  return runPipeline({ event: comment('/approve'), deps: harness.deps })
+}
+
+/** An issue parked in COMPLETE, where no command and no comment is actionable. */
+const toComplete = async (harness: Harness): Promise<void> => {
+  await toDesignSpec(harness)
+  await runPipeline({ event: comment('/cancel'), deps: harness.deps })
+  harness.io.posted.length = 0
+  harness.io.reactions.length = 0
+}
+
+describe('reactions — acknowledging a trigger', () => {
+  test('👀 on the comment that asked for the work, before any of it happens', async () => {
+    // The gap this closes: a maintainer types `/approve` and the next thing on
+    // the issue is the finished artefact, up to `AGENT_TIMEOUT_MS` later. For
+    // that whole window the issue looks exactly like one where the workflow
+    // never fired — which is also a real outcome, since a guardrail can drop
+    // the event.
+    const harness = makeHarness()
+    await toDesignSpec(harness)
+    harness.io.replies = [PLAN_REPLY]
+
+    await runPipeline({ event: comment('/approve'), deps: harness.deps })
+
+    expect(harness.io.reactions[0]).toEqual({ target: { kind: 'comment', id: COMMENT_ID }, content: 'eyes' })
+  })
+
+  test('👀 lands on the issue when no comment raised the run', async () => {
+    const harness = makeHarness()
+    harness.io.replies = [SPEC_REPLY]
+
+    await runPipeline({ event: issueEvent(), deps: harness.deps })
+
+    expect(harness.io.reactions[0]).toEqual({ target: { kind: 'issue', number: ISSUE }, content: 'eyes' })
+  })
+
+  test('👀 arrives before the pipeline even reads the thread', async () => {
+    // Ordering is the whole value of this reaction. One placed after the phase
+    // handler would land at the same moment as the comment it is meant to
+    // precede, and buy nothing at all.
+    const harness = makeHarness()
+    const order: string[] = []
+    harness.deps.github.listIssueComments = (): Promise<IssueComment[]> => {
+      order.push('read-thread')
+      return Promise.resolve([...harness.io.thread])
+    }
+    harness.deps.github.addReaction = (): Promise<void> => {
+      order.push('react')
+      return Promise.resolve()
+    }
+    harness.io.replies = [SPEC_REPLY]
+
+    await runPipeline({ event: issueEvent(), deps: harness.deps })
+
+    expect(order[0]).toBe('react')
+  })
+
+  test('🚀 once a run has actually delivered a pull request', async () => {
+    const harness = makeHarness()
+
+    const result = await driveDelivery(harness)
+
+    expect(result.status).toBe('completed')
+    expect(reactionsOf(harness)).toEqual(['eyes', 'rocket'])
+  })
+
+  test('🚀 for a refreshed pull request too — the work is still delivered', async () => {
+    const harness = makeHarness()
+    harness.io.existingPr = { number: 3, url: 'https://example.test/pull/3', state: 'open' }
+
+    await driveDelivery(harness)
+
+    expect(reactionsOf(harness)).toEqual(['eyes', 'rocket'])
+  })
+
+  test('no 🚀 when delivery stands down instead of delivering', async () => {
+    // The settled branch reports the same `PR_OPENED` signal and reaches the
+    // same `COMPLETE`, having opened and refreshed nothing. A rocket there would
+    // announce a delivery that did not happen.
+    const harness = makeHarness()
+    harness.io.existingPr = { number: 3, url: 'https://example.test/pull/3', state: 'merged' }
+
+    const result = await driveDelivery(harness)
+
+    expect(result.status).toBe('completed')
+    expect(reactionsOf(harness)).toEqual(['eyes'])
+  })
+})
+
+describe('reactions — the silences that stay silent', () => {
+  const onPullRequest = issueEvent({
+    eventName: 'issue_comment',
+    action: 'created',
+    commentBody: '/approve',
+    commentId: COMMENT_ID,
+    isPullRequest: true,
+  })
+
+  test.each([
+    ['a bot sender', issueEvent({ senderType: 'Bot' })],
+    ['the agent talking to itself', issueEvent({ senderLogin: AGENT_LOGIN })],
+    ['a comment on a pull request', onPullRequest],
+    ['an event this pipeline does not handle', issueEvent({ eventName: 'push' })],
+    ['an action this pipeline does not handle', issueEvent({ action: 'edited' })],
+  ])('says nothing to %s', async (_label, event) => {
+    // Machine noise with nobody waiting on it. The existing log line is the
+    // right amount of record, and a reaction is a write to somebody else's
+    // timeline for no reader's benefit.
+    const harness = makeHarness()
+
+    const result = await runPipeline({ event, deps: harness.deps })
+
+    expect(result.status).toBe('skipped')
+    expect(harness.io.reactions).toEqual([])
+  })
+
+  test('a whole CI-fix run reacts to nothing', async () => {
+    // A `workflow_run` payload names no comment and nobody typed it, so there
+    // is no timeline a reaction would reach and no person it would reach.
+    const harness = makeHarness()
+    await driveDelivery(harness)
+    harness.io.reactions.length = 0
+
+    const result = await runPipeline({ event: ciEvent(), deps: harness.deps })
+
+    expect(result.status).toBe('completed')
+    expect(harness.io.reactions).toEqual([])
+  })
+})
+
+describe('reactions — breaking the remaining silences', () => {
+  test('😕 to a sender without maintainer rights', async () => {
+    // A write triggered by an account without write access, and the judgement
+    // call is deliberate: one reaction, no content, no notification storm —
+    // against an outsider's comment vanishing into a log they cannot read.
+    const harness = makeHarness()
+    const outsider = issueEvent({
+      eventName: 'issue_comment',
+      action: 'created',
+      commentBody: 'please fix this',
+      commentId: 901,
+      authorAssociation: 'CONTRIBUTOR',
+    })
+
+    const result = await runPipeline({ event: outsider, deps: harness.deps })
+
+    expect(result.status).toBe('skipped')
+    expect(harness.io.reactions).toEqual([{ target: { kind: 'comment', id: 901 }, content: 'confused' }])
+    // A reaction is not a report: the issue still carries nothing about this
+    // run, so the workflow's fallback comment must stay in scope for it.
+    expect(result.reported).toBe(false)
+    expect(harness.io.posted).toEqual([])
+  })
+
+  test('😕 to a command the current phase cannot take', async () => {
+    // Both `refuseCommand` call sites — an unknown command and one the phase
+    // refuses — react through the same function, so this covers the pair.
+    const harness = makeHarness()
+    await toComplete(harness)
+
+    const result = await runPipeline({ event: comment('/approve'), deps: harness.deps })
+
+    expect(result.status).toBe('skipped')
+    expect(reactionsOf(harness)).toEqual(['eyes', 'confused'])
+    // The comment is still the better answer; the reaction only beats it there.
+    expect(harness.io.posted[0]).toContain('does not apply right now')
+  })
+
+  test('👍 to a plain comment on a phase that is not waiting for one', async () => {
+    const harness = makeHarness()
+    await toComplete(harness)
+
+    const result = await runPipeline({ event: comment('ok, can we revisit this?'), deps: harness.deps })
+
+    expect(result.status).toBe('skipped')
+    expect(reactionsOf(harness)).toEqual(['eyes', '+1'])
+    // 👍 rather than a comment: "I have decided to do nothing", said out loud to
+    // every aside, is the noise this channel exists to avoid.
+    expect(harness.io.posted).toEqual([])
+  })
+
+  test('👍 to a comment the classifier read as chatter', async () => {
+    const harness = makeHarness()
+    await toDesignSpec(harness)
+    harness.io.replies = [JSON.stringify({ intent: 'none' })]
+
+    const result = await runPipeline({ event: comment('thanks!'), deps: harness.deps })
+
+    expect(result.status).toBe('skipped')
+    expect(reactionsOf(harness)).toEqual(['eyes', '+1'])
+    expect(harness.io.posted).toEqual([])
+  })
+
+  test('👍 to chatter while the agent is waiting on its own clarifying questions', async () => {
+    // The third instance of one silence, and the one most likely to be reached:
+    // `INIT_OR_CLARIFY` is where the agent parks waiting for a maintainer to
+    // answer, so it is where a maintainer is most likely to be typing. Reacting
+    // on two of the three call sites would be this workspace's recurring defect
+    // exactly — the fix that closes the instance and leaves the class open.
+    const harness = makeHarness()
+    harness.io.replies = [JSON.stringify({ status: 'clarify', questions: ['Which client?'] })]
+    await runPipeline({ event: issueEvent(), deps: harness.deps })
+
+    const parked = latestPostedState(harness)
+    expect(parked?.phase).toBe('INIT_OR_CLARIFY')
+    harness.io.posted.length = 0
+    harness.io.reactions.length = 0
+
+    harness.io.replies = [JSON.stringify({ intent: 'none' })]
+    const result = await runPipeline({ event: comment('thanks!'), deps: harness.deps })
+
+    expect(result.status).toBe('skipped')
+    expect(reactionsOf(harness)).toEqual(['eyes', '+1'])
+    expect(harness.io.posted).toEqual([])
+    // The persisted state, not just the status. Nothing was posted, so the block
+    // the next job restores from must still be the one the clarification left —
+    // read back the way that job would read it, off the thread.
+    expect(findLatestState(harness.io.thread, AGENT_LOGIN, ISSUE)).toEqual(parked)
+    expect(result.reported).toBe(false)
+  })
+
+  test('👍 to an empty comment', async () => {
+    const harness = makeHarness()
+    await toDesignSpec(harness)
+
+    const result = await runPipeline({ event: comment('   '), deps: harness.deps })
+
+    expect(result.status).toBe('skipped')
+    expect(reactionsOf(harness)).toEqual(['eyes', '+1'])
+  })
+})
+
+describe('reactions — feedback never fails a run', () => {
+  test('a GitHub that refuses every reaction changes nothing about the run', async () => {
+    // The most important property in this stage. A token without
+    // `issues: write`, a fork run and an org policy all present exactly this,
+    // and every one of them is real — so the run has to reach the same result,
+    // and leave the same block on the issue, as one where the channel worked.
+    const healthy = makeHarness()
+    const broken = makeHarness()
+    broken.io.reactionError = new Error('Resource not accessible by integration')
+
+    const expected = await driveDelivery(healthy)
+    const actual = await driveDelivery(broken)
+
+    expect(actual).toEqual(expected)
+    // The persisted state, not just the returned status: a state that is never
+    // posted never happened, and that is the half a status cannot show.
+    expect(latestPostedState(broken)).toEqual(latestPostedState(healthy))
+    expect(broken.io.posted).toEqual(healthy.io.posted)
+    // And it really did try, rather than passing by never asking.
+    expect(reactionsOf(broken)).toEqual(['eyes', 'rocket'])
+  })
+
+  test('a refused reaction leaves a guardrail denial exactly as it was', async () => {
+    const harness = makeHarness()
+    harness.io.reactionError = new Error('403 Resource not accessible by integration')
+
+    const result = await runPipeline({ event: issueEvent({ authorAssociation: 'CONTRIBUTOR' }), deps: harness.deps })
+
+    expect(result).toEqual({
+      status: 'skipped',
+      reason: 'Author association CONTRIBUTOR lacks maintainer rights',
+      state: null,
+      reported: false,
+    })
+  })
+
+  test('a refused reaction still lets a refused command answer on the issue', async () => {
+    const harness = makeHarness()
+    await toComplete(harness)
+    harness.io.reactionError = new Error('403')
+
+    const result = await runPipeline({ event: comment('/approve'), deps: harness.deps })
+
+    expect(result.status).toBe('skipped')
+    expect(result.reported).toBe(true)
+    expect(harness.io.posted[0]).toContain('does not apply right now')
+  })
+})
+
+describe('the run link', () => {
+  const RUN_URL = 'https://github.test/acme/widgets/actions/runs/1482/attempts/2'
+
+  test('the failure comment says which job failed', async () => {
+    // `/retry` used to be the only lead a maintainer had from this comment. The
+    // job that produced the error above carries the rest of the story.
+    const harness = makeHarness({ runUrl: RUN_URL })
+    harness.io.replies = ['not json at all']
+
+    const result = await runPipeline({ event: issueEvent(), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(harness.io.posted[0]).toContain(`The job that failed: ${RUN_URL}`)
+  })
+
+  test('a local run says nothing rather than linking nowhere', async () => {
+    // Driving this CLI from an `--event-path` file is an ordinary thing to do,
+    // and an empty label is worse than a missing line.
+    const harness = makeHarness()
+    harness.io.replies = ['not json at all']
+
+    await runPipeline({ event: issueEvent(), deps: harness.deps })
+
+    expect(harness.io.posted[0]).not.toContain('The job that failed')
+    expect(harness.io.posted[0]).toContain('### Run failed in')
+  })
+
+  test('the CI-fix comment tells the red run from the run repairing it', async () => {
+    // Both were "run" in this comment, and only the red one was ever printed.
+    const harness = makeHarness({ runUrl: RUN_URL })
+    await driveDelivery(harness)
+    harness.io.posted.length = 0
+    const red = 'https://github.test/acme/widgets/actions/runs/77'
+
+    await runPipeline({ event: ciEvent({ runUrl: red }), deps: harness.deps })
+
+    const report = String(harness.io.posted[0])
+    expect(report).toContain(`- Red run I am repairing: ${red}`)
+    expect(report).toContain(`- This repair ran in: ${RUN_URL}`)
   })
 })

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -6,6 +6,7 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
 
 import { findArtifact, PLAN_MARKER, renderArtifact, SPEC_MARKER } from '../../opencode-agent/src/artifacts.js'
+import { readBlock } from '../../opencode-agent/src/blocks.js'
 import type { IssueComment } from '../../opencode-agent/src/blocks.js'
 import { DEFAULT_CHECKS } from '../../opencode-agent/src/config.js'
 import type { PipelineConfig } from '../../opencode-agent/src/config.js'
@@ -31,6 +32,7 @@ import {
   serializeState,
   STATE_MARKER,
 } from '../../opencode-agent/src/state-manager.js'
+import { STATUS_MARKER } from '../../opencode-agent/src/status-comment.js'
 import { createStatusReporter } from '../../opencode-agent/src/status-reporter.js'
 import type { AgentState, Phase, RunResult } from '../../opencode-agent/src/types.js'
 
@@ -2663,6 +2665,10 @@ describe('the status comment — rule 4, the state channel is untouched', () => 
     expect(loud.io.thread.length).toBeGreaterThan(quiet.io.thread.length)
     expect(statusPosts(loud)).toHaveLength(1)
     expect(statusPosts(loud)[0]).not.toContain(STATE_MARKER)
+    // And the comment that really went out carries the marker the prompt layer
+    // filters on — a renderer that grew one is worth nothing if the pipeline
+    // posts something else.
+    expect(readBlock(String(statusPosts(loud)[0]), STATUS_MARKER)).toEqual({ run: JOB_URL })
   })
 
   test('the comment a later job restores from is a report, never the status', async () => {

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -31,6 +31,7 @@ import {
   serializeState,
   STATE_MARKER,
 } from '../../opencode-agent/src/state-manager.js'
+import { createStatusReporter } from '../../opencode-agent/src/status-reporter.js'
 import type { AgentState, Phase, RunResult } from '../../opencode-agent/src/types.js'
 
 const AGENT_LOGIN = 'agent-bot'
@@ -162,6 +163,27 @@ interface PipelineIo {
   labelReads: number
   /** What every label call rejects with, when set. */
   labelError: Error | null
+  /** Every comment edit, in order — the status comment's and the state rewrites'. */
+  edits: { id: number; body: string }[]
+  /**
+   * What the status channel rejects with, when set.
+   *
+   * Turns down every edit, and the one *create* that carries no `AGENT_STATE`
+   * block. That is not a trick: the status comment is the only comment this
+   * pipeline posts without one — rule 4 — so the discriminator is the invariant
+   * itself, and a status comment that ever grew a block would take this harness
+   * down with it rather than quietly passing.
+   */
+  statusError: Error | null
+  /**
+   * The mirror image: what a *report* create rejects with, when set.
+   *
+   * A 502 on the comment that carries the state block is how a run dies
+   * mid-phase with its status comment already on the issue.
+   */
+  postError: Error | null
+  /** The clock the status reporter reads, so its rate limit is provable. */
+  nowMs: number
 }
 
 interface Harness {
@@ -199,6 +221,10 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
     labelsCreated: [],
     labelReads: 0,
     labelError: null,
+    edits: [],
+    statusError: null,
+    postError: null,
+    nowMs: Date.UTC(2026, 7, 7, 14, 2),
   }
 
   let nextCommentId = 100
@@ -211,9 +237,14 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
     return Promise.resolve()
   }
 
+  /** True for the status comment and for nothing else — see `io.statusError`. */
+  const isStatus = (body: string): boolean => !body.includes(STATE_MARKER)
+
   const github: GitHubApi = {
     listIssueComments: () => Promise.resolve([...io.thread]),
     createComment: (_issueNumber, body) => {
+      if (io.statusError !== null && isStatus(body)) return Promise.reject(io.statusError)
+      if (io.postError !== null && !isStatus(body)) return Promise.reject(io.postError)
       nextCommentId += 1
       io.posted.push(body)
       io.thread.push({ id: nextCommentId, body, authorLogin: io.postedAs })
@@ -222,6 +253,20 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
         url: `https://example.test/c/${nextCommentId}`,
         authorLogin: io.postedAs,
       })
+    },
+    // Edits land on the thread the way GitHub's do, so a rewritten state block
+    // is read back by the next `findLatestState` rather than only recorded.
+    updateComment: (commentId, body) => {
+      io.edits.push({ id: commentId, body })
+      if (io.statusError !== null) return Promise.reject(io.statusError)
+
+      const index = io.thread.findIndex((existing) => existing.id === commentId)
+      const target = io.thread[index]
+      if (target !== undefined) io.thread[index] = { ...target, body }
+      // A status comment is not one of the run's *posts*; folding the two would
+      // let an edit read as a comment, which is the distinction the whole
+      // one-comment budget rests on.
+      return Promise.resolve()
     },
     getIssue: () => Promise.resolve({ number: ISSUE, title: 'Add retries', body: 'Please add retries.' }),
     getAuthenticatedLogin: () => Promise.resolve(AGENT_LOGIN),
@@ -292,8 +337,15 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
     close: () => Promise.resolve(),
   }
 
+  const pipelineConfig = config(overrides)
+  const log = silentLogger()
+
   const deps: PhaseDeps = {
     github,
+    // The real reporter, built the way `contain` builds it — which for the
+    // default config (`runUrl: null`) hands back the no-op, so every test that
+    // is not about this channel drives exactly what it drove before.
+    status: createStatusReporter({ github, log, config: pipelineConfig, now: () => io.nowMs }),
     git,
     runCheck: (check) => Promise.resolve(io.checkResults.get(check.name) ?? OK_CHECK),
     runReview: () => Promise.resolve(io.reviewResult),
@@ -302,8 +354,8 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
     skills: () => Promise.resolve([]),
     baseBranch: () => Promise.resolve(BASE_BRANCH),
     selfLogin: () => Promise.resolve(AGENT_LOGIN),
-    config: config(overrides),
-    log: silentLogger(),
+    config: pipelineConfig,
+    log,
   }
 
   return { deps, io }
@@ -343,14 +395,26 @@ const spentIn = (result: { state: AgentState | null }): number => result.state?.
 
 const headings = (harness: Harness): string[] => harness.io.posted.map((body) => body.split('\n')[0] ?? '')
 
+/**
+ * The comments that carry a state block — every post except the run's status
+ * comment, which by rule 4 carries none.
+ *
+ * `io.posted` stays the truthful count of comments created, because that is what
+ * the one-comment budget is asserted against; a test about what the pipeline
+ * *said* asks for the reports.
+ */
+const reportsOf = (harness: Harness): string[] => harness.io.posted.filter((body) => body.includes(STATE_MARKER))
+
 /** Drives an issue as far as DESIGN_SPEC, ready for the review conversation. */
 const toDesignSpec = async (harness: Harness): Promise<void> => {
   harness.io.replies = [SPEC_REPLY]
   await runPipeline({ event: issueEvent(), deps: harness.deps })
   harness.io.posted.length = 0
-  // Reactions too: these helpers exist to put an issue in a starting position,
-  // and what the setup runs acknowledged is not part of the test that follows.
+  // Reactions and status edits too: these helpers exist to put an issue in a
+  // starting position, and what the setup runs acknowledged is not part of the
+  // test that follows.
   harness.io.reactions.length = 0
+  harness.io.edits.length = 0
 }
 
 /** Drives an issue as far as PLAN_REVIEW. */
@@ -360,6 +424,7 @@ const toPlanReview = async (harness: Harness): Promise<void> => {
   await runPipeline({ event: comment('/approve'), deps: harness.deps })
   harness.io.posted.length = 0
   harness.io.reactions.length = 0
+  harness.io.edits.length = 0
 }
 
 describe('guardrails', () => {
@@ -1921,6 +1986,7 @@ const toComplete = async (harness: Harness): Promise<void> => {
   await runPipeline({ event: comment('/cancel'), deps: harness.deps })
   harness.io.posted.length = 0
   harness.io.reactions.length = 0
+  harness.io.edits.length = 0
 }
 
 describe('reactions — acknowledging a trigger', () => {
@@ -2205,7 +2271,7 @@ describe('the run link', () => {
     const result = await runPipeline({ event: issueEvent(), deps: harness.deps })
 
     expect(result.status).toBe('failed')
-    expect(harness.io.posted[0]).toContain(`The job that failed: ${RUN_URL}`)
+    expect(reportsOf(harness)[0]).toContain(`The job that failed: ${RUN_URL}`)
   })
 
   test('a local run says nothing rather than linking nowhere', async () => {
@@ -2229,7 +2295,7 @@ describe('the run link', () => {
 
     await runPipeline({ event: ciEvent({ runUrl: red }), deps: harness.deps })
 
-    const report = String(harness.io.posted[0])
+    const report = String(reportsOf(harness)[0])
     expect(report).toContain(`- Red run I am repairing: ${red}`)
     expect(report).toContain(`- This repair ran in: ${RUN_URL}`)
   })
@@ -2457,5 +2523,251 @@ describe('labels — feedback never fails a run', () => {
     const result = await runPipeline({ event: comment('any plans to revisit?'), deps: harness.deps })
 
     expect(result.reported).toBe(false)
+  })
+})
+
+/** A harness whose run has a job to link to, so the status channel is live. */
+const JOB_URL = 'https://github.test/acme/widgets/actions/runs/1482'
+
+const withStatus = (overrides: Partial<PipelineConfig> = {}): Harness => makeHarness({ runUrl: JOB_URL, ...overrides })
+
+/** Bodies the run created that carry no state block — the status comment, and nothing else. */
+const statusPosts = (harness: Harness): string[] => harness.io.posted.filter((body) => !body.includes(STATE_MARKER))
+
+describe('the live status comment', () => {
+  test('one comment per run, opened when the work starts and edited as it moves', async () => {
+    // The whole comment budget this plan allows itself. A run that added a
+    // comment per phase would be the noise the budget exists to prevent.
+    const harness = withStatus()
+
+    await driveDelivery(harness)
+
+    expect(statusPosts(harness)).toHaveLength(1)
+    expect(harness.io.edits.length).toBeGreaterThan(0)
+    expect(new Set(harness.io.edits.map((edit) => edit.id)).size).toBe(1)
+  })
+
+  test('it says which job is doing the work, and what phase it is on', async () => {
+    const harness = withStatus()
+    await toDesignSpec(harness)
+    harness.io.replies = [PLAN_REPLY]
+
+    await runPipeline({ event: comment('/approve'), deps: harness.deps })
+
+    const opened = String(statusPosts(harness)[0])
+    expect(opened).toContain(`[this run](${JOB_URL})`)
+    expect(opened.split('\n')[0]).toBe('### 🗺️ Breaking the spec into steps — run in progress')
+  })
+
+  test('it is finalised where the run stopped', async () => {
+    const harness = withStatus()
+    await toDesignSpec(harness)
+    harness.io.replies = [PLAN_REPLY]
+
+    await runPipeline({ event: comment('/approve'), deps: harness.deps })
+
+    const last = harness.io.edits.at(-1)
+    expect(last?.body.split('\n')[0]).toBe('### 🧭 Plan is waiting for you')
+    expect(last?.body).not.toContain('run in progress')
+  })
+
+  test('a run that does nothing opens no comment at all', async () => {
+    // Same gate as the working label, for the same reason: opening a status
+    // comment for a run that is about to skip spends the whole budget on
+    // nothing.
+    const harness = withStatus()
+    await toComplete(harness)
+    harness.io.edits.length = 0
+
+    await runPipeline({ event: comment('any plans to revisit?'), deps: harness.deps })
+
+    expect(harness.io.posted).toEqual([])
+    expect(harness.io.edits).toEqual([])
+  })
+
+  test('a guardrail denial opens no comment either', async () => {
+    const harness = withStatus()
+
+    await runPipeline({ event: issueEvent({ authorAssociation: 'CONTRIBUTOR' }), deps: harness.deps })
+
+    expect(harness.io.posted).toEqual([])
+  })
+})
+
+describe('the status comment — rule 7, it is not a report', () => {
+  test('a run that only ever wrote status has still said nothing about itself', async () => {
+    // `RunResult.reported` means the issue carries this run's account of what
+    // happened, and the workflow's fallback comment is gated on it. A status
+    // comment is not an account of anything, so a run whose only writes were on
+    // that channel leaves the flag exactly where a run without the channel
+    // would.
+    const harness = withStatus()
+    await toDesignSpec(harness)
+    harness.io.replies = [JSON.stringify({ intent: 'none' })]
+
+    const result = await runPipeline({ event: comment('thanks!'), deps: harness.deps })
+
+    expect(result.reported).toBe(false)
+  })
+
+  test('a run killed mid-phase leaves the status mid-flight and yields no result to mark', async () => {
+    // The case rule 7 is really about. The report comment never lands, so the
+    // run dies with "run in progress" on the issue and hands back no
+    // `RunResult` at all — which is exactly why the flag must never be set from
+    // the status comment's existence: there would be nothing left to explain
+    // the silence.
+    const harness = withStatus()
+    await toDesignSpec(harness)
+    harness.io.replies = [PLAN_REPLY]
+    harness.io.postError = new Error('502 from GitHub')
+
+    await expect(runPipeline({ event: comment('/approve'), deps: harness.deps })).rejects.toThrow('502')
+
+    expect(harness.io.thread.at(-1)?.body).toContain('run in progress')
+    // `step-output.ts` writes the marker only on a returning path, and nothing
+    // returned; the state block on the issue is still the one from before.
+    expect(harness.io.thread.filter((entry) => entry.body.includes(STATE_MARKER))).toHaveLength(1)
+  })
+
+  test('finalising it on a returning path does not set the flag either', async () => {
+    // Two writers of one flag is how it drifts. The paths that report already
+    // do; this one has nothing to add.
+    const harness = withStatus()
+    harness.io.replies = [JSON.stringify({ intent: 'none' })]
+    seedState(harness, { phase: 'DESIGN_SPEC' })
+
+    const result = await runPipeline({ event: comment('nice work'), deps: harness.deps })
+
+    expect(result.status).toBe('skipped')
+    expect(result.reported).toBe(false)
+    expect(statusPosts(harness)).toEqual([])
+  })
+})
+
+describe('the status comment — rule 4, the state channel is untouched', () => {
+  test('state restored from a thread with status comments equals the same thread without them', async () => {
+    // The invariant, stated as one. `findLatestState` restores from the newest
+    // agent comment carrying a valid block, so a status comment that ever grew
+    // one would become a second, competing source of truth — and it is written
+    // by the channel least likely to be looked at.
+    const quiet = makeHarness()
+    const loud = withStatus()
+
+    await driveDelivery(quiet)
+    await driveDelivery(loud)
+
+    expect(findLatestState(loud.io.thread, AGENT_LOGIN, ISSUE)).toEqual(
+      findLatestState(quiet.io.thread, AGENT_LOGIN, ISSUE),
+    )
+    // And it really did interleave them, rather than passing by never writing.
+    expect(loud.io.thread.length).toBeGreaterThan(quiet.io.thread.length)
+    expect(statusPosts(loud)).toHaveLength(1)
+    expect(statusPosts(loud)[0]).not.toContain(STATE_MARKER)
+  })
+
+  test('the comment a later job restores from is a report, never the status', async () => {
+    const harness = withStatus()
+    await driveDelivery(harness)
+
+    const restored = harness.io.thread.filter((entry) => extractState(entry.body) !== null)
+
+    expect(restored.length).toBeGreaterThan(0)
+    expect(restored.every((entry) => !entry.body.includes('run in progress'))).toBe(true)
+  })
+})
+
+describe('the status comment — rule 1, feedback never fails a run', () => {
+  test('a GitHub that refuses every status write changes nothing about the run', async () => {
+    // Measured against a run with no status channel at all, which is the exact
+    // degradation the rule allows: a failed create leaves the pipeline where it
+    // was before this stage, and a failed edit is a warning.
+    const silent = makeHarness()
+    const broken = withStatus()
+    broken.io.statusError = new Error('Resource not accessible by integration')
+
+    const expected = await driveDelivery(silent)
+    const actual = await driveDelivery(broken)
+
+    expect(actual).toEqual(expected)
+    // The persisted state, not just the returned status: a state that is never
+    // posted never happened, and that is the half a status cannot show.
+    expect(findLatestState(broken.io.thread, AGENT_LOGIN, ISSUE)).toEqual(
+      findLatestState(silent.io.thread, AGENT_LOGIN, ISSUE),
+    )
+    expect(broken.io.posted).toEqual(silent.io.posted)
+  })
+
+  test('a refused status write still lets a failure report itself', async () => {
+    const harness = withStatus()
+    harness.io.statusError = new Error('403')
+    harness.io.replies = ['not json at all']
+
+    const result = await runPipeline({ event: issueEvent(), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(result.reported).toBe(true)
+    expect(reportsOf(harness)[0]).toContain('### ❌ Run failed in')
+  })
+})
+
+describe('recording what a skipped classification cost', () => {
+  test('a comment the classifier reads as chatter records its spend without posting', async () => {
+    // The one model turn in this pipeline that posts nothing, and so the one
+    // whose spend used to vanish with the runner. An issue could buy one per
+    // comment for as long as anybody kept commenting.
+    const harness = makeHarness()
+    await toDesignSpec(harness)
+    harness.io.tokensUsed = 40_000
+    harness.io.replies = [JSON.stringify({ intent: 'none' })]
+
+    const result = await runPipeline({ event: comment('thanks!'), deps: harness.deps })
+
+    expect(result.status).toBe('skipped')
+    expect(harness.io.posted).toEqual([])
+    expect(spentIn(result)).toBe(40_000)
+    expect(findLatestState(harness.io.thread, AGENT_LOGIN, ISSUE)?.tokensSpent).toBe(40_000)
+  })
+
+  test('the rewrite lands on the comment the next job will restore from', async () => {
+    const harness = makeHarness()
+    await toDesignSpec(harness)
+    const restoredFrom = harness.io.thread.at(-1)?.id
+    harness.io.tokensUsed = 12_000
+    harness.io.replies = [JSON.stringify({ intent: 'none' })]
+
+    await runPipeline({ event: comment('thanks!'), deps: harness.deps })
+
+    expect(harness.io.edits).toHaveLength(1)
+    expect(harness.io.edits[0]?.id).toBe(restoredFrom)
+    // The phase is untouched: this records spend, it does not move anything.
+    expect(findLatestState(harness.io.thread, AGENT_LOGIN, ISSUE)?.phase).toBe('DESIGN_SPEC')
+  })
+
+  test('a skip that spent nothing writes nothing', async () => {
+    // Most skips never open a session. A rewrite that only ever restated the
+    // figure already on the issue would be a request per "thanks!".
+    const harness = makeHarness()
+    await toDesignSpec(harness)
+    harness.io.replies = [JSON.stringify({ intent: 'none' })]
+
+    await runPipeline({ event: comment('thanks!'), deps: harness.deps })
+
+    expect(harness.io.edits).toEqual([])
+  })
+
+  test('a refused rewrite reports the figure the issue actually carries', async () => {
+    // Best-effort, like every other write this stage adds: a `RunResult`
+    // claiming a total no reader will ever find would be worse than the leak.
+    const harness = makeHarness()
+    await toDesignSpec(harness)
+    harness.io.statusError = new Error('403')
+    harness.io.tokensUsed = 40_000
+    harness.io.replies = [JSON.stringify({ intent: 'none' })]
+
+    const result = await runPipeline({ event: comment('thanks!'), deps: harness.deps })
+
+    expect(result.status).toBe('skipped')
+    expect(spentIn(result)).toBe(0)
+    expect(findLatestState(harness.io.thread, AGENT_LOGIN, ISSUE)?.tokensSpent).toBe(0)
   })
 })

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -556,7 +556,7 @@ describe('chatter while the agent is clarifying', () => {
 
     expect(result.status).toBe('failed')
     expect(harness.io.prompts).toEqual([])
-    expect(harness.io.posted[0]).toContain('### Token budget spent')
+    expect(harness.io.posted[0]).toContain('### ⛔ Token budget spent')
 
     const state = latestPostedState(harness)
     expect(state?.phase).toBe('FAILED')
@@ -698,7 +698,7 @@ describe('answering outside the review gates', () => {
     const result = await runPipeline({ event: comment('/ask what did you change?'), deps: harness.deps })
 
     expect(result.status).toBe('failed')
-    expect(harness.io.posted[0]).toContain('### I could not answer that')
+    expect(harness.io.posted[0]).toContain('### ⚠️ I could not answer that')
     expect(harness.io.posted[0]).toContain('the model endpoint rejected it')
 
     const state = latestPostedState(harness)
@@ -1369,7 +1369,7 @@ describe('commands and budgets', () => {
 
     // Delivery posts its own closing comment; no bare "Stopped" on a shipped issue.
     expect(harness.io.posted.at(-1)).toContain('https://example.test/pull/7')
-    expect(harness.io.posted.join('\n')).not.toContain('### Stopped')
+    expect(harness.io.posted.join('\n')).not.toContain('### 🛑 Stopped')
   })
 
   test('rejects /approve arriving in a phase that cannot accept it', async () => {
@@ -1463,7 +1463,7 @@ describe('commands and budgets', () => {
 
     expect(result.status).toBe('failed')
     expect(result.reason).toContain('Retry budget exhausted')
-    expect(harness.io.posted[0]).toContain('### Giving up')
+    expect(harness.io.posted[0]).toContain('### ⛔ Giving up')
   })
 })
 
@@ -1504,7 +1504,7 @@ describe('the retry budget', () => {
     await runPipeline({ event: comment('/retry'), deps: harness.deps })
 
     expect(harness.io.posted).toHaveLength(1)
-    expect(harness.io.posted[0]).toContain('### Giving up')
+    expect(harness.io.posted[0]).toContain('### ⛔ Giving up')
     expect(harness.io.posted[0]).toContain('3 of 3 attempts')
     // The notice may only offer what the machine will actually take. Bare
     // "reply `/retry`" is not that: the budget is spent, so the next `/retry`
@@ -1529,7 +1529,7 @@ describe('the retry budget', () => {
     expect(result.status).toBe('failed')
     expect(result.reason).toContain('Retry budget exhausted')
     expect(result.reason).not.toContain('not valid in')
-    expect(harness.io.posted[0]).toContain('### Giving up')
+    expect(harness.io.posted[0]).toContain('### ⛔ Giving up')
     expect(latestPostedState(harness)?.resumeFrom).toBe('EXECUTION_PLAN')
   })
 
@@ -1676,7 +1676,7 @@ describe('the token budget', () => {
     const result = await runPipeline({ event: comment('/ask why that file?'), deps: harness.deps })
 
     expect(result.status).toBe('failed')
-    expect(harness.io.posted[0]).toContain('### I could not answer that')
+    expect(harness.io.posted[0]).toContain('### ⚠️ I could not answer that')
 
     const state = latestPostedState(harness)
     expect(state?.phase).toBe('DESIGN_SPEC')
@@ -1693,7 +1693,7 @@ describe('the token budget', () => {
 
     expect(result.status).toBe('failed')
     expect(result.reason).toContain('Token budget spent')
-    expect(harness.io.posted[0]).toContain('### Token budget spent')
+    expect(harness.io.posted[0]).toContain('### ⛔ Token budget spent')
   })
 
   test('says why a bare /retry will not help, and names what makes it help', async () => {
@@ -1755,7 +1755,7 @@ describe('the token budget', () => {
     const result = await runPipeline({ event: comment('/approve'), deps: harness.deps })
 
     expect(result.status).toBe('failed')
-    expect(harness.io.posted[0]).toContain('### Token budget spent')
+    expect(harness.io.posted[0]).toContain('### ⛔ Token budget spent')
 
     const state = latestPostedState(harness)
     expect(state?.phase).toBe('FAILED')
@@ -1780,7 +1780,7 @@ describe('the token budget', () => {
     const result = await runPipeline({ event: comment('/approve'), deps: harness.deps })
 
     expect(result.status).toBe('failed')
-    expect(headings(harness)).toEqual(['### Implementation report', '### Token budget spent'])
+    expect(headings(harness)).toEqual(['### Implementation report', '### ⛔ Token budget spent'])
 
     const state = latestPostedState(harness)
     expect(state?.phase).toBe('FAILED')
@@ -1882,7 +1882,7 @@ describe('the token budget', () => {
 
     expect(result.status).toBe('failed')
     expect(harness.io.prompts).toEqual([])
-    expect(harness.io.posted[0]).toContain('### Token budget spent')
+    expect(harness.io.posted[0]).toContain('### ⛔ Token budget spent')
 
     const state = latestPostedState(harness)
     expect(state?.phase).toBe('DESIGN_SPEC')
@@ -1900,7 +1900,7 @@ describe('the token budget', () => {
     const result = await runPipeline({ event: comment('/ask what did you change?'), deps: harness.deps })
 
     expect(result.status).toBe('failed')
-    expect(harness.io.posted[0]).toContain('### Token budget spent')
+    expect(harness.io.posted[0]).toContain('### ⛔ Token budget spent')
     expect(latestPostedState(harness)?.phase).toBe('COMPLETE')
   })
 })
@@ -2217,7 +2217,7 @@ describe('the run link', () => {
     await runPipeline({ event: issueEvent(), deps: harness.deps })
 
     expect(harness.io.posted[0]).not.toContain('The job that failed')
-    expect(harness.io.posted[0]).toContain('### Run failed in')
+    expect(harness.io.posted[0]).toContain('### ❌ Run failed in')
   })
 
   test('the CI-fix comment tells the red run from the run repairing it', async () => {
@@ -2294,6 +2294,38 @@ describe('labels — the state at a glance', () => {
     await runPipeline({ event: comment('thanks!'), deps: harness.deps })
 
     expect(harness.io.labelWrites).toEqual([])
+    expect(harness.io.labels.sort()).toEqual(['agent:needs-you', 'agent:spec-review'])
+  })
+
+  test('a state move with no handler behind it is not "working" either', async () => {
+    // `/cancel` moves the state and runs nothing. Marking it working would add
+    // the marker and take it off in the same second — the same two timeline
+    // entries a skipped run avoids, on a run that did move the issue.
+    const harness = makeHarness()
+    await toDesignSpec(harness)
+    harness.io.labelWrites.length = 0
+
+    await runPipeline({ event: comment('/cancel'), deps: harness.deps })
+
+    // Nothing mentions the marker in either direction: it was never put on, so
+    // there is nothing to take off.
+    expect(harness.io.labelWrites.filter((write) => write.includes('agent:working'))).toEqual([])
+    expect(harness.io.labels).toEqual(['agent:stopped'])
+  })
+
+  test('answering a question is work, even though it moves nothing', async () => {
+    // The other half of "will anything run": `/ask` leaves the phase exactly
+    // where it was, so the handler table says nothing about it — but it is a
+    // model turn, often the slowest thing the pipeline does, and an issue that
+    // shows no sign of it is the silence this whole plan is about.
+    const harness = makeHarness()
+    await toDesignSpec(harness)
+    harness.io.labelWrites.length = 0
+    harness.io.replies = ['Because the retry helper already exists there.']
+
+    await runPipeline({ event: comment('/ask why that file?'), deps: harness.deps })
+
+    expect(harness.io.labelWrites).toContain('+agent:working')
     expect(harness.io.labels.sort()).toEqual(['agent:needs-you', 'agent:spec-review'])
   })
 
@@ -2413,7 +2445,7 @@ describe('labels — feedback never fails a run', () => {
 
     expect(result.status).toBe('failed')
     expect(result.reported).toBe(true)
-    expect(harness.io.posted[0]).toContain('### Run failed in')
+    expect(harness.io.posted[0]).toContain('### ❌ Run failed in')
   })
 
   test('a label is not a report, so it never suppresses the fallback comment', async () => {

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -71,6 +71,7 @@ const config = (overrides: Partial<PipelineConfig> = {}): PipelineConfig => ({
   diffLimits: { maxFiles: 100, maxLines: 20_000 },
   gitRemoteBase: 'https://github.com/',
   runUrl: null,
+  labelPrefix: 'agent:',
   skillRoots: ['.superpowers/skills'],
   ...overrides,
 })
@@ -144,6 +145,23 @@ interface PipelineIo {
    * about the run.
    */
   reactionError: Error | null
+  /**
+   * Labels the issue carries, as GitHub holds them — including any this
+   * pipeline did not put there.
+   */
+  labels: string[]
+  /**
+   * Every label *write*, in order, and deliberately not folded into `labels`:
+   * the point of a diff is what it did not ask for, and a set that ends up
+   * right cannot tell a single add from a clear-and-reapply.
+   */
+  labelWrites: string[]
+  /** Repository labels created on demand, by name and colour. */
+  labelsCreated: { name: string; color: string }[]
+  /** Reads attempted, so a run that is refused everything can still be shown to have asked. */
+  labelReads: number
+  /** What every label call rejects with, when set. */
+  labelError: Error | null
 }
 
 interface Harness {
@@ -176,9 +194,22 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
     postedAs: AGENT_LOGIN,
     reactions: [],
     reactionError: null,
+    labels: [],
+    labelWrites: [],
+    labelsCreated: [],
+    labelReads: 0,
+    labelError: null,
   }
 
   let nextCommentId = 100
+
+  /** Records the ask, then answers the way `io.labelError` says to. */
+  const label = (write: string, apply: () => void): Promise<void> => {
+    io.labelWrites.push(write)
+    if (io.labelError !== null) return Promise.reject(io.labelError)
+    apply()
+    return Promise.resolve()
+  }
 
   const github: GitHubApi = {
     listIssueComments: () => Promise.resolve([...io.thread]),
@@ -214,6 +245,25 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
       io.reactions.push({ target, content })
       return io.reactionError === null ? Promise.resolve() : Promise.reject(io.reactionError)
     },
+    // Reading is not a write, so it is not recorded as one — but it does fail
+    // when the token cannot see the issue at all, which is a real 403 and the
+    // one that reaches the reconcile before it has decided anything.
+    listLabels: () => {
+      io.labelReads += 1
+      return io.labelError === null ? Promise.resolve([...io.labels]) : Promise.reject(io.labelError)
+    },
+    addLabels: (_issueNumber, names) =>
+      label(`+${names.join(',')}`, () => {
+        io.labels.push(...names.filter((name) => !io.labels.includes(name)))
+      }),
+    removeLabel: (_issueNumber, name) =>
+      label(`-${name}`, () => {
+        io.labels = io.labels.filter((existing) => existing !== name)
+      }),
+    createLabel: (name, color) =>
+      label(`create:${name}`, () => {
+        io.labelsCreated.push({ name, color })
+      }),
   }
 
   const git: Git = {
@@ -2182,5 +2232,198 @@ describe('the run link', () => {
     const report = String(harness.io.posted[0])
     expect(report).toContain(`- Red run I am repairing: ${red}`)
     expect(report).toContain(`- This repair ran in: ${RUN_URL}`)
+  })
+})
+
+describe('labels — the state at a glance', () => {
+  test('a run marks the issue as worked on, then hands it back', async () => {
+    // The two orthogonal markers, over one run: `agent:working` goes on when
+    // work starts and comes off when it ends, and `agent:needs-you` takes its
+    // place because the plan is now parked in front of a human.
+    const harness = makeHarness()
+    await toDesignSpec(harness)
+    harness.io.replies = [PLAN_REPLY]
+
+    await runPipeline({ event: comment('/approve'), deps: harness.deps })
+
+    expect(harness.io.labels.sort()).toEqual(['agent:needs-you', 'agent:plan-review'])
+    expect(harness.io.labelWrites).toContain('+agent:planning,agent:working')
+    expect(harness.io.labelWrites).toContain('-agent:working')
+  })
+
+  test('the two markers never sit on the issue together', async () => {
+    // A run in flight is not waiting on anybody, and an issue that is both
+    // "happening now" and "blocked on me" answers neither question.
+    const harness = makeHarness()
+    await toDesignSpec(harness)
+    harness.io.replies = [PLAN_REPLY]
+
+    await runPipeline({ event: comment('/approve'), deps: harness.deps })
+
+    expect(harness.io.labels).not.toContain('agent:working')
+  })
+
+  test('a delivered issue is labelled done, a cancelled one stopped', async () => {
+    const delivered = makeHarness()
+    await driveDelivery(delivered)
+
+    const cancelled = makeHarness()
+    await toComplete(cancelled)
+
+    expect(delivered.io.labels).toEqual(['agent:done'])
+    expect(cancelled.io.labels).toEqual(['agent:stopped'])
+  })
+
+  test('a failure asks for a human', async () => {
+    const harness = makeHarness()
+    harness.io.replies = ['not json at all']
+
+    await runPipeline({ event: issueEvent(), deps: harness.deps })
+
+    expect(harness.io.labels.sort()).toEqual(['agent:failed', 'agent:needs-you'])
+  })
+
+  test('a labelled issue whose state has not moved is written to not at all', async () => {
+    // The diff, from the pipeline's side. Most runs move nothing, and a
+    // clear-and-reapply would leave two timeline entries on every one of them.
+    const harness = makeHarness()
+    await toDesignSpec(harness)
+    harness.io.labelWrites.length = 0
+    harness.io.replies = [JSON.stringify({ intent: 'none' })]
+
+    await runPipeline({ event: comment('thanks!'), deps: harness.deps })
+
+    expect(harness.io.labelWrites).toEqual([])
+    expect(harness.io.labels.sort()).toEqual(['agent:needs-you', 'agent:spec-review'])
+  })
+
+  test('a skipped run does not flash the working marker on and off', async () => {
+    // Marking a run that is about to skip would add the marker and remove it
+    // within the second — two timeline entries for an issue where nothing
+    // happened, which is the noise this channel is sized to avoid.
+    const harness = makeHarness()
+    await toComplete(harness)
+    harness.io.labelWrites.length = 0
+
+    await runPipeline({ event: comment('any plans to revisit?'), deps: harness.deps })
+
+    expect(harness.io.labelWrites).toEqual([])
+  })
+
+  test('a marker stranded by a killed runner is repaired on the next event', async () => {
+    // The failure mode `agent:working` has: a runner killed mid-flight leaves
+    // it on. The reconcile computes the desired set from the restored state,
+    // so any `agent:*` label that state does not imply comes off — no
+    // bookkeeping, and it repairs a hand-edited issue by the same rule.
+    const harness = makeHarness()
+    await toDesignSpec(harness)
+    harness.io.labels.push('agent:working', 'agent:implementing')
+    harness.io.labelWrites.length = 0
+    harness.io.replies = [JSON.stringify({ intent: 'none' })]
+
+    await runPipeline({ event: comment('thanks!'), deps: harness.deps })
+
+    expect(harness.io.labelWrites.sort()).toEqual(['-agent:implementing', '-agent:working'])
+    expect(harness.io.labels.sort()).toEqual(['agent:needs-you', 'agent:spec-review'])
+  })
+
+  test('the repository’s own labels are never touched', async () => {
+    // The worst thing this channel could do, and the one that would be found
+    // by somebody else losing their triage.
+    const harness = makeHarness()
+    harness.io.labels.push('bug', 'good first issue')
+    harness.io.replies = [SPEC_REPLY]
+
+    await runPipeline({ event: issueEvent(), deps: harness.deps })
+
+    expect(harness.io.labels).toContain('bug')
+    expect(harness.io.labels).toContain('good first issue')
+    expect(harness.io.labelWrites).not.toContain('-bug')
+    expect(harness.io.labelWrites).not.toContain('-good first issue')
+  })
+
+  test('labels are created with the palette before they are applied', async () => {
+    const harness = makeHarness()
+    harness.io.replies = [SPEC_REPLY]
+
+    await runPipeline({ event: issueEvent(), deps: harness.deps })
+
+    expect(harness.io.labelsCreated).toContainEqual({ name: 'agent:spec-review', color: 'd4a72c' })
+    expect(harness.io.labelsCreated).toContainEqual({ name: 'agent:needs-you', color: 'd4a72c' })
+  })
+
+  test('a custom prefix reaches every label the run writes', async () => {
+    const harness = makeHarness({ labelPrefix: 'bot/' })
+    harness.io.replies = [SPEC_REPLY]
+
+    await runPipeline({ event: issueEvent(), deps: harness.deps })
+
+    expect(harness.io.labels.sort()).toEqual(['bot/needs-you', 'bot/spec-review'])
+  })
+
+  test('`none` runs the whole pipeline without one label call', async () => {
+    // A repository that wants none of this must get none of it — not a
+    // different set of names.
+    const harness = makeHarness({ labelPrefix: null })
+    harness.io.labels.push('agent:working')
+
+    const result = await driveDelivery(harness)
+
+    expect(result.status).toBe('completed')
+    expect(harness.io.labelWrites).toEqual([])
+    expect(harness.io.labels).toEqual(['agent:working'])
+  })
+})
+
+describe('labels — feedback never fails a run', () => {
+  test('a GitHub that refuses every label call changes nothing about the run', async () => {
+    // The rule-1 test for this stage. A token without `issues: write`, a
+    // repository that restricts label creation, and a fork run all present
+    // exactly this, and none of them may change what the run concludes or what
+    // it leaves on the issue.
+    const healthy = makeHarness()
+    const broken = makeHarness()
+    broken.io.labelError = new Error('Resource not accessible by integration')
+
+    const expected = await driveDelivery(healthy)
+    const actual = await driveDelivery(broken)
+
+    expect(actual).toEqual(expected)
+    // The persisted state, not just the returned status: a state that is never
+    // posted never happened, and that is the half a status cannot show.
+    expect(findLatestState(broken.io.thread, AGENT_LOGIN, ISSUE)).toEqual(
+      findLatestState(healthy.io.thread, AGENT_LOGIN, ISSUE),
+    )
+    expect(broken.io.posted).toEqual(healthy.io.posted)
+    // And it really did try, rather than passing by never asking. A 403 on this
+    // token refuses the read as well, which is why the ask is counted rather
+    // than looked for among the writes.
+    expect(broken.io.labelReads).toBeGreaterThan(0)
+    expect(broken.io.labelWrites).toEqual([])
+  })
+
+  test('a refused label still lets a failure report itself', async () => {
+    // The path where feedback failing on top of a failure would be worst: the
+    // comment explaining what broke is the only thing the maintainer gets.
+    const harness = makeHarness()
+    harness.io.labelError = new Error('403')
+    harness.io.replies = ['not json at all']
+
+    const result = await runPipeline({ event: issueEvent(), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(result.reported).toBe(true)
+    expect(harness.io.posted[0]).toContain('### Run failed in')
+  })
+
+  test('a label is not a report, so it never suppresses the fallback comment', async () => {
+    // `RunResult.reported` gates the workflow's "Agent job failed" comment. A
+    // run that only ever labelled has said nothing on the issue.
+    const harness = makeHarness()
+    await toComplete(harness)
+
+    const result = await runPipeline({ event: comment('any plans to revisit?'), deps: harness.deps })
+
+    expect(result.reported).toBe(false)
   })
 })

--- a/tests/opencode-agent/presentation.test.ts
+++ b/tests/opencode-agent/presentation.test.ts
@@ -8,6 +8,10 @@ import { describe, expect, test } from 'bun:test'
 import { desiredLabels } from '../../opencode-agent/src/labels.js'
 import {
   NEEDS_YOU_LABEL,
+  OUTCOME_GLYPHS,
+  OUTCOME_KEYS,
+  outcomeHeading,
+  phaseHeading,
   PRESENTATION,
   PRESENTATION_KEYS,
   presentationFor,
@@ -100,6 +104,50 @@ describe('the presentation table', () => {
     reached.add(presentationKey(DELIVERED, 'waiting'))
 
     expect([...reached].sort()).toEqual([...PRESENTATION_KEYS].sort())
+  })
+})
+
+describe('the outcome table', () => {
+  test.each([...OUTCOME_KEYS])('%s has a glyph', (key) => {
+    expect(OUTCOME_GLYPHS[key].length).toBeGreaterThan(0)
+  })
+
+  test('a bound reached is not a thing that broke', () => {
+    // The whole argument for the budget notices being separate renderers is
+    // that a ceiling is not a failure: nothing broke, the run stopped because
+    // it was told to. Giving them ❌ would undo that in the one place a
+    // maintainer actually looks.
+    const bounds = [OUTCOME_GLYPHS.RETRIES_SPENT, OUTCOME_GLYPHS.TOKENS_SPENT, OUTCOME_GLYPHS.ANSWER_TOKENS_SPENT]
+
+    expect(new Set(bounds).size).toBe(1)
+    expect(bounds).not.toContain(OUTCOME_GLYPHS.RUN_FAILED)
+  })
+
+  test('a failed answer is not a failed run', () => {
+    // `failAnswer` moves nothing — no phase, no `resumeFrom`, no attempt spent.
+    // ❌ on that comment tells a maintainer their delivered pull request broke.
+    expect(OUTCOME_GLYPHS.ANSWER_FAILED).not.toBe(OUTCOME_GLYPHS.RUN_FAILED)
+  })
+
+  test('giving up on CI keeps the glyph the CI-fix phase wore', () => {
+    // The maintainer has been watching this glyph on the issue for however many
+    // rounds it took to give up; the ending belongs to the same story.
+    expect(OUTCOME_GLYPHS.CI_GAVE_UP).toBe(PRESENTATION.CI_FIX.glyph)
+  })
+
+  test('a refused command answers with the reaction it also gets', () => {
+    // `refuseCommand` places 😕 on the comment and posts this reply; two
+    // different faces for one event is the vocabulary spreading again.
+    expect(OUTCOME_GLYPHS.COMMAND_REFUSED).toBe('😕')
+  })
+
+  test('a heading is the glyph and the words, in that order', () => {
+    expect(outcomeHeading('RUN_FAILED', 'Run failed in EXECUTION_PLAN')).toBe('### ❌ Run failed in EXECUTION_PLAN')
+  })
+
+  test('a phase heading reads from the phase table, splits and all', () => {
+    expect(phaseHeading(DELIVERED, 'waiting', 'Done')).toBe('### ✅ Done')
+    expect(phaseHeading(CANCELLED, 'waiting', 'Stopped')).toBe('### 🛑 Stopped')
   })
 })
 

--- a/tests/opencode-agent/presentation.test.ts
+++ b/tests/opencode-agent/presentation.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { desiredLabels } from '../../opencode-agent/src/labels.js'
+import {
+  NEEDS_YOU_LABEL,
+  PRESENTATION,
+  PRESENTATION_KEYS,
+  presentationFor,
+  presentationKey,
+  WORKING_LABEL,
+} from '../../opencode-agent/src/presentation.js'
+import type { RunStance } from '../../opencode-agent/src/presentation.js'
+import { initialState } from '../../opencode-agent/src/state-manager.js'
+import { PHASES } from '../../opencode-agent/src/types.js'
+import type { AgentState, Phase } from '../../opencode-agent/src/types.js'
+
+const ISSUE = 42
+
+const stateIn = (phase: Phase, patch: Partial<AgentState> = {}): AgentState => ({
+  ...initialState(ISSUE),
+  phase,
+  ...patch,
+})
+
+const DELIVERED = stateIn('COMPLETE', { prUrl: 'https://example.test/pull/7', prNumber: 7 })
+const CANCELLED = stateIn('COMPLETE')
+
+const STANCES: readonly RunStance[] = ['working', 'waiting']
+
+describe('the presentation table', () => {
+  test.each([...PHASES])('%s resolves in both stances', (phase) => {
+    // Totality is a compile-time property — `Record` over a closed union, and a
+    // `presentationKey` whose fall-through only type-checks while every phase
+    // has a row. This asserts it at run time too, because the fall-through is
+    // the kind of line a refactor can widen to `string` without noticing.
+    for (const stance of STANCES) {
+      const presentation = presentationFor(stateIn(phase), stance)
+      expect(presentation.label.suffix.length).toBeGreaterThan(0)
+      expect(presentation.headline.length).toBeGreaterThan(0)
+      expect(presentation.glyph.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('no two rows share a label', () => {
+    // A shared label collapses two states into one on the surface whose entire
+    // job is to tell them apart, and would make the reconcile's diff read a
+    // phase move as "nothing changed".
+    const suffixes = PRESENTATION_KEYS.map((key) => PRESENTATION[key].label.suffix)
+
+    expect(new Set(suffixes).size).toBe(suffixes.length)
+  })
+
+  test('every label carries a six-digit hex colour, which is what GitHub takes', () => {
+    const colors = [...PRESENTATION_KEYS.map((key) => PRESENTATION[key].label.color), WORKING_LABEL.color]
+
+    for (const color of [...colors, NEEDS_YOU_LABEL.color]) expect(color).toMatch(/^[0-9a-f]{6}$/u)
+  })
+
+  test('INIT_OR_CLARIFY is two states, not one', () => {
+    // The one phase that is both a working state and a waiting state: it is
+    // where the agent sits after asking clarifying questions. Keying on the
+    // phase alone would make "reading the issue" and "waiting on your answers"
+    // the same row, which is the whole reason the key is a pair.
+    const triaging = presentationFor(stateIn('INIT_OR_CLARIFY'), 'working')
+    const clarifying = presentationFor(stateIn('INIT_OR_CLARIFY'), 'waiting')
+
+    expect(triaging.label.suffix).toBe('triaging')
+    expect(triaging.whoseTurn).toBe('agent')
+    expect(clarifying.label.suffix).toBe('clarifying')
+    expect(clarifying.whoseTurn).toBe('you')
+  })
+
+  test('COMPLETE splits on the pull request, exactly as the closing comment does', () => {
+    // `renderClosing` already reads `prUrl` to decide between "Done" and
+    // "Stopped". A label that said `done` for a cancelled issue would contradict
+    // the comment sitting right above it.
+    expect(presentationFor(DELIVERED, 'waiting').label.suffix).toBe('done')
+    expect(presentationFor(CANCELLED, 'waiting').label.suffix).toBe('stopped')
+  })
+
+  test.each([...STANCES])('a finished issue is nobody’s turn, in either stance (%s)', (stance) => {
+    expect(presentationFor(DELIVERED, stance).whoseTurn).toBe('nobody')
+    expect(presentationFor(CANCELLED, stance).whoseTurn).toBe('nobody')
+  })
+
+  test('a failure is your turn — it waits for `/retry` or `/cancel`', () => {
+    expect(presentationFor(stateIn('FAILED'), 'waiting').whoseTurn).toBe('you')
+  })
+
+  test('every key the table declares is reachable from some state', () => {
+    // The other direction of totality: a row nothing resolves to is a row that
+    // was renamed on one side only.
+    const reached = new Set<string>()
+    for (const phase of PHASES) for (const stance of STANCES) reached.add(presentationKey(stateIn(phase), stance))
+    reached.add(presentationKey(DELIVERED, 'waiting'))
+
+    expect([...reached].sort()).toEqual([...PRESENTATION_KEYS].sort())
+  })
+})
+
+describe('desiredLabels', () => {
+  const names = (state: AgentState, stance: RunStance, prefix = 'agent:'): string[] =>
+    desiredLabels(state, stance, prefix).map((label) => label.name)
+
+  test('a working run carries the phase label and the working marker', () => {
+    expect(names(stateIn('REVIEW_AND_MUTATE'), 'working')).toEqual(['agent:implementing', 'agent:working'])
+  })
+
+  test('a run that has handed back carries the phase label and needs-you', () => {
+    expect(names(stateIn('PLAN_REVIEW'), 'waiting')).toEqual(['agent:plan-review', 'agent:needs-you'])
+  })
+
+  test('the two markers are mutually exclusive', () => {
+    // While the agent holds the issue it is not waiting on anybody, so a run in
+    // flight must not also appear in the "blocked on me" filter it is clearing.
+    expect(names(stateIn('DESIGN_SPEC'), 'working')).not.toContain('agent:needs-you')
+    expect(names(stateIn('DESIGN_SPEC'), 'waiting')).not.toContain('agent:working')
+  })
+
+  test('a finished issue carries neither marker', () => {
+    expect(names(DELIVERED, 'waiting')).toEqual(['agent:done'])
+    expect(names(CANCELLED, 'waiting')).toEqual(['agent:stopped'])
+  })
+
+  test('a failure asks for you', () => {
+    expect(names(stateIn('FAILED'), 'waiting')).toEqual(['agent:failed', 'agent:needs-you'])
+  })
+
+  test('the prefix reaches every name, markers included', () => {
+    // The prefix is the whole of the namespacing story: a name that escapes it
+    // is a label the reconcile will not recognise as its own, so it is added
+    // once and then never cleaned up.
+    for (const name of names(stateIn('FAILED'), 'waiting', 'bot/')) expect(name.startsWith('bot/')).toBe(true)
+  })
+})

--- a/tests/opencode-agent/progress.test.ts
+++ b/tests/opencode-agent/progress.test.ts
@@ -540,6 +540,39 @@ describe('withHeartbeat', () => {
     expect(timer.cancels).toBe(1)
   })
 
+  test('hands the same snapshot to a second reader, and still writes the log line', async () => {
+    // The heartbeat already knows everything the live status comment wants to
+    // say, and said it only into a log nobody has a link to. Routing it keeps
+    // one clock in the pipeline — and the log half is unchanged, which is the
+    // half a CI reader still depends on.
+    const { log, lines } = recorder()
+    const timer = manual()
+    const ticks: ProgressSnapshot[] = []
+
+    await withHeartbeat(Promise.resolve('done'), {
+      everyMs: 60_000,
+      log,
+      snapshot,
+      schedule: timer.schedule,
+      onTick: (progress) => void ticks.push(progress),
+    })
+    timer.fire()
+
+    expect(ticks).toEqual([snapshot()])
+    expect(lines).toHaveLength(1)
+    expect(lines[0]?.message).toContain('not stuck')
+  })
+
+  test('a heartbeat with no second reader still ticks', async () => {
+    const { log, lines } = recorder()
+    const timer = manual()
+
+    await withHeartbeat(Promise.resolve('done'), { everyMs: 60_000, log, snapshot, schedule: timer.schedule })
+    timer.fire()
+
+    expect(lines).toHaveLength(1)
+  })
+
   test('schedules nothing at all when disabled', async () => {
     const { log } = recorder()
     const timer = manual()

--- a/tests/opencode-agent/provider-proxy.test.ts
+++ b/tests/opencode-agent/provider-proxy.test.ts
@@ -365,6 +365,7 @@ describe('contain', () => {
     diffLimits: { maxFiles: 100, maxLines: 20_000 },
     gitRemoteBase: 'https://github.com/',
     runUrl: null,
+    labelPrefix: 'agent:',
     skillRoots: [],
   })
 

--- a/tests/opencode-agent/provider-proxy.test.ts
+++ b/tests/opencode-agent/provider-proxy.test.ts
@@ -364,6 +364,7 @@ describe('contain', () => {
     maxTokens: 5_000_000,
     diffLimits: { maxFiles: 100, maxLines: 20_000 },
     gitRemoteBase: 'https://github.com/',
+    runUrl: null,
     skillRoots: [],
   })
 
@@ -379,6 +380,7 @@ describe('contain', () => {
     issueBody: 'b',
     isPullRequest: false,
     commentBody: null,
+    commentId: null,
     repositoryOwner: 'acme',
     defaultBranch: 'master',
   }

--- a/tests/opencode-agent/status.test.ts
+++ b/tests/opencode-agent/status.test.ts
@@ -1,0 +1,492 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import type { IssueComment } from '../../opencode-agent/src/blocks.js'
+import { DEFAULT_CHECKS } from '../../opencode-agent/src/config.js'
+import type { PipelineConfig } from '../../opencode-agent/src/config.js'
+import type { PostedComment } from '../../opencode-agent/src/github.js'
+import type { Logger } from '../../opencode-agent/src/logger.js'
+import type { ProgressSnapshot } from '../../opencode-agent/src/progress.js'
+import {
+  findLatestState,
+  findLatestStateComment,
+  initialState,
+  serializeState,
+} from '../../opencode-agent/src/state-manager.js'
+import { persistState } from '../../opencode-agent/src/state-persist.js'
+import type { StatePersistDeps } from '../../opencode-agent/src/state-persist.js'
+import { renderStatus } from '../../opencode-agent/src/status-comment.js'
+import type { StatusView } from '../../opencode-agent/src/status-comment.js'
+import { createStatusReporter, MIN_EDIT_INTERVAL_MS } from '../../opencode-agent/src/status-reporter.js'
+import type { StatusDeps } from '../../opencode-agent/src/status-reporter.js'
+import type { AgentState, RunResult } from '../../opencode-agent/src/types.js'
+
+const AGENT_LOGIN = 'agent-bot'
+const ISSUE = 42
+const RUN_URL = 'https://github.test/acme/widgets/actions/runs/1482'
+const STARTED = Date.UTC(2026, 7, 7, 14, 2)
+
+const silentLogger = (): Logger => ({
+  debug: (): void => {},
+  info: (): void => {},
+  warn: (): void => {},
+  error: (): void => {},
+})
+
+const config = (overrides: Partial<PipelineConfig> = {}): PipelineConfig => ({
+  repoRoot: '/repo',
+  owner: 'acme',
+  repo: 'widgets',
+  githubToken: 'token',
+  selfLoginOverride: AGENT_LOGIN,
+  selfWorkflowName: 'OpenCode Issue Agent',
+  openai: { apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1', model: 'gpt-5' },
+  commitAuthorName: 'agent',
+  commitAuthorEmail: 'agent@example.com',
+  checkCommand: 'bun test',
+  reviewCommand: null,
+  checks: DEFAULT_CHECKS,
+  reviewMaxRounds: 2,
+  reviewPoolSize: 1,
+  agentTimeoutMs: 1000,
+  ciFixMaxRounds: 2,
+  maxCiAttempts: 3,
+  maxAttempts: 3,
+  maxTokens: 5_000_000,
+  diffLimits: { maxFiles: 100, maxLines: 20_000 },
+  gitRemoteBase: 'https://github.com/',
+  runUrl: RUN_URL,
+  labelPrefix: 'agent:',
+  skillRoots: [],
+  ...overrides,
+})
+
+const state = (patch: Partial<AgentState> = {}): AgentState => ({ ...initialState(ISSUE), ...patch })
+
+const view = (overrides: Partial<StatusView> = {}): StatusView => ({
+  state: state({ phase: 'REVIEW_AND_MUTATE' }),
+  progress: null,
+  live: true,
+  runUrl: RUN_URL,
+  startedMs: STARTED,
+  carriedTokens: 0,
+  config: config(),
+  ...overrides,
+})
+
+/** The row for one step of the progress table, whatever it currently says. */
+const rowFor = (body: string, title: string): string =>
+  body.split('\n').find((line) => line.includes(`${title} |`)) ?? '(no such row)'
+
+describe('renderStatus', () => {
+  test('heads the comment with the phase’s own glyph and headline', () => {
+    // Not "Implementing": that is the label suffix, and a third name per phase
+    // is exactly what one presentation table exists to prevent.
+    const body = renderStatus(view())
+
+    expect(body.split('\n')[0]).toBe('### 🛠️ Writing and reviewing the code — run in progress')
+  })
+
+  test('links the job that is doing the work, and says when it started', () => {
+    // The one question a maintainer has during the silence: is something
+    // actually running, and where do I look. Not an elapsed figure — a minute
+    // counter would change the body every minute and defeat the suppression
+    // that makes a quiet stretch free.
+    const body = renderStatus(view())
+
+    expect(body).toBe(renderStatus(view()))
+    expect(body).toContain(`**Job:** [this run](${RUN_URL}) · started 14:02 UTC`)
+    expect(body).not.toContain('elapsed')
+  })
+
+  test('names the branch and says plainly that there is no pull request yet', () => {
+    expect(renderStatus(view())).toContain('**Branch:** `agent/issue-42` · **Pull request:** _not opened yet_')
+  })
+
+  test('marks the phases behind, the phase in flight, and the ones still ahead', () => {
+    const body = renderStatus(view())
+
+    expect(rowFor(body, 'Triage')).toBe('| 🔍 Triage | ✅ |')
+    expect(rowFor(body, 'Implementation')).toBe('| 🛠️ Implementation | ⏳ **now** |')
+    expect(rowFor(body, 'Pull request')).toBe('| 📦 Pull request | ⬜ |')
+  })
+
+  test('reads each artefact’s revision rather than recounting it', () => {
+    // The two counters were split apart because one number could not honestly
+    // label two artefacts; this table is the second place that would go wrong.
+    const body = renderStatus(view({ state: state({ phase: 'REVIEW_AND_MUTATE', specRevision: 3, planRevision: 1 }) }))
+
+    expect(rowFor(body, 'Design spec')).toContain('· revision 3')
+    expect(rowFor(body, 'Execution plan')).toContain('· revision 1')
+  })
+
+  test('the plan waiting for approval is the execution-plan row, not a sixth one', () => {
+    const body = renderStatus(view({ state: state({ phase: 'PLAN_REVIEW' }) }))
+
+    expect(rowFor(body, 'Execution plan')).toContain('⏳ **now**')
+    expect(body.split('\n').filter((line) => line.startsWith('| ')).length).toBe(7)
+  })
+
+  test('says what the model is doing, in names and counts only', () => {
+    const progress: ProgressSnapshot = { lastAction: 'bash (running)', toolCalls: 34, tokens: 218_000, cost: 0 }
+
+    const body = renderStatus(view({ progress }))
+
+    expect(body).toContain('**Doing:** bash (running) · 34 tool calls')
+    // The live figure, from the heartbeat, while the persisted one is still
+    // whatever the last posted comment recorded.
+    expect(body).toContain('**Budget:** 218,000 of 5,000,000 tokens')
+  })
+
+  test('never claims a smaller total than the state block already carries', () => {
+    // The persisted figure comes from the provider's usage block; the
+    // heartbeat's is summed from events that have arrived so far. A phase that
+    // has already posted therefore knows more than the tick does, and the line
+    // must not walk the total backwards when it ticks again.
+    const progress: ProgressSnapshot = { lastAction: 'starting', toolCalls: 0, tokens: 10, cost: 0 }
+
+    const body = renderStatus(view({ state: state({ tokensSpent: 900_000 }), carriedTokens: 0, progress }))
+
+    expect(body).toContain('**Budget:** 900,000 of 5,000,000 tokens')
+  })
+
+  test('the attempt in flight is the one a failure here would report', () => {
+    expect(renderStatus(view({ state: state({ phase: 'EXECUTION_PLAN', attempts: 1 }) }))).toContain('attempt 2 of 3')
+  })
+
+  test('a CI round says it is counted per pull request', () => {
+    // `ciAttempts` is per pull request, so the same "2 of 3" on the next one
+    // would be two different attempts.
+    const body = renderStatus(view({ state: state({ phase: 'CI_FIX', ciAttempts: 2, prUrl: 'https://p/1' }) }))
+
+    expect(body).toContain('attempt 2 of 3 on this pull request')
+  })
+
+  test('a finished run drops the progress line and wears the state it ended in', () => {
+    const progress: ProgressSnapshot = { lastAction: 'bash (running)', toolCalls: 34, tokens: 5, cost: 0 }
+    const ended = state({ phase: 'COMPLETE', prUrl: 'https://example.test/pull/7' })
+
+    const body = renderStatus(view({ state: ended, live: false, progress }))
+
+    expect(body.split('\n')[0]).toBe('### ✅ Delivered')
+    expect(body).not.toContain('**Doing:**')
+    expect(rowFor(body, 'Pull request')).toBe('| 📦 Pull request | ✅ |')
+  })
+
+  test('a failed run marks the step it broke on with the failure’s own glyph', () => {
+    const broken = state({ phase: 'FAILED', resumeFrom: 'EXECUTION_PLAN' })
+
+    const body = renderStatus(view({ state: broken, live: false }))
+
+    expect(rowFor(body, 'Execution plan')).toBe('| 🗺️ Execution plan | ❌ |')
+    expect(rowFor(body, 'Implementation')).toBe('| 🛠️ Implementation | ⬜ |')
+  })
+
+  test('a cancelled issue stops where its artefacts say it got to', () => {
+    // `COMPLETE` alone says only that the conversation is over. Claiming every
+    // step finished on an issue cancelled during spec review would be a lie the
+    // table tells about work nobody did.
+    const cancelled = state({ phase: 'COMPLETE', specRevision: 1 })
+
+    const body = renderStatus(view({ state: cancelled, live: false }))
+
+    expect(rowFor(body, 'Design spec')).toContain('🛑')
+    expect(rowFor(body, 'Implementation')).toBe('| 🛠️ Implementation | ⬜ |')
+  })
+
+  test('carries no state block, whatever it is rendering', () => {
+    // Rule 4, at the renderer: `findLatestState` restores from the newest agent
+    // comment carrying one, so a second writer of that block is a second source
+    // of truth.
+    expect(renderStatus(view())).not.toContain('AGENT_STATE')
+  })
+})
+
+/** Records what the status channel sent, and can be told to refuse. */
+interface StatusIo {
+  created: string[]
+  edits: { id: number; body: string }[]
+  createError: Error | null
+  editError: Error | null
+  nowMs: number
+}
+
+const statusHarness = (overrides: Partial<PipelineConfig> = {}): { io: StatusIo; deps: StatusDeps } => {
+  const io: StatusIo = { created: [], edits: [], createError: null, editError: null, nowMs: STARTED }
+
+  const deps: StatusDeps = {
+    github: {
+      createComment: (_issueNumber, body): Promise<PostedComment> => {
+        if (io.createError !== null) return Promise.reject(io.createError)
+        io.created.push(body)
+        return Promise.resolve({ id: 900, url: 'https://example.test/c/900', authorLogin: AGENT_LOGIN })
+      },
+      updateComment: (id, body): Promise<void> => {
+        io.edits.push({ id, body })
+        return io.editError === null ? Promise.resolve() : Promise.reject(io.editError)
+      },
+    },
+    log: silentLogger(),
+    config: config(overrides),
+    now: () => io.nowMs,
+  }
+
+  return { io, deps }
+}
+
+const done: RunResult = {
+  status: 'completed',
+  reason: 'Pipeline finished',
+  state: { ...initialState(ISSUE), phase: 'COMPLETE', prUrl: 'https://example.test/pull/7' },
+  reported: true,
+}
+
+describe('createStatusReporter', () => {
+  test('opens exactly one comment for the run and edits it thereafter', () => {
+    const { io, deps } = statusHarness()
+    const reporter = createStatusReporter(deps)
+
+    return (async (): Promise<void> => {
+      await reporter.start(state({ phase: 'EXECUTION_PLAN' }))
+      io.nowMs += MIN_EDIT_INTERVAL_MS
+      await reporter.enter(state({ phase: 'REVIEW_AND_MUTATE' }))
+
+      expect(io.created).toHaveLength(1)
+      expect(io.edits).toHaveLength(1)
+      expect(io.edits[0]?.id).toBe(900)
+      expect(io.edits[0]?.body).toContain('Writing and reviewing the code')
+    })()
+  })
+
+  test('a second tick inside the window issues no request', async () => {
+    // The clock is injected precisely so this is provable without waiting a
+    // minute for it, and the bound is what keeps a 90-minute run inside the
+    // secondary rate limit on content-mutating requests.
+    const { io, deps } = statusHarness()
+    const reporter = createStatusReporter(deps)
+    await reporter.start(state({ phase: 'REVIEW_AND_MUTATE' }))
+
+    io.nowMs += MIN_EDIT_INTERVAL_MS
+    await reporter.tick({ lastAction: 'bash (running)', toolCalls: 1, tokens: 10, cost: 0 })
+    io.nowMs += 1_000
+    await reporter.tick({ lastAction: 'read (running)', toolCalls: 2, tokens: 20, cost: 0 })
+
+    expect(io.edits).toHaveLength(1)
+    expect(io.edits[0]?.body).toContain('bash (running)')
+  })
+
+  test('an unchanged body issues nothing, however long the run has been quiet', async () => {
+    // The other half of the cost bound, and the one that makes a twenty-minute
+    // model call with no tool use free rather than twenty edits saying the same
+    // thing. The window is long past, so only the body is holding this back.
+    const { io, deps } = statusHarness()
+    const reporter = createStatusReporter(deps)
+    await reporter.start(state({ phase: 'REVIEW_AND_MUTATE' }))
+    const quiet: ProgressSnapshot = { lastAction: 'thinking', toolCalls: 0, tokens: 0, cost: 0 }
+
+    io.nowMs += 10 * MIN_EDIT_INTERVAL_MS
+    await reporter.enter(state({ phase: 'REVIEW_AND_MUTATE' }))
+    await reporter.tick(quiet)
+    io.nowMs += 10 * MIN_EDIT_INTERVAL_MS
+    await reporter.tick(quiet)
+
+    // One edit, for the tick that actually said something new.
+    expect(io.edits).toHaveLength(1)
+    expect(io.edits[0]?.body).toContain('**Doing:** thinking · 0 tool calls')
+  })
+
+  test('the final edit is not held back by the window', async () => {
+    // A run that ends inside the minute would otherwise leave "run in progress"
+    // on the issue for ever.
+    const { io, deps } = statusHarness()
+    const reporter = createStatusReporter(deps)
+    await reporter.start(state({ phase: 'PR_DELIVERY' }))
+
+    io.nowMs += 2_000
+    await reporter.finish(done)
+
+    expect(io.edits).toHaveLength(1)
+    expect(io.edits[0]?.body.split('\n')[0]).toBe('### ✅ Delivered')
+    expect(io.edits[0]?.body).not.toContain('run in progress')
+  })
+
+  test('a refused edit is a warning, and the next one retries it', async () => {
+    const { io, deps } = statusHarness()
+    const reporter = createStatusReporter(deps)
+    await reporter.start(state({ phase: 'REVIEW_AND_MUTATE' }))
+    io.editError = new Error('Resource not accessible by integration')
+
+    io.nowMs += MIN_EDIT_INTERVAL_MS
+    await expect(reporter.enter(state({ phase: 'PR_DELIVERY' }))).resolves.toBeUndefined()
+    io.editError = null
+    io.nowMs += MIN_EDIT_INTERVAL_MS
+    await reporter.enter(state({ phase: 'PR_DELIVERY' }))
+
+    // The body it failed to write is not remembered as written, so the retry
+    // actually carries it.
+    expect(io.edits).toHaveLength(2)
+    expect(io.edits[1]?.body).toContain('Opening the pull request')
+  })
+
+  test('a refused create leaves every later call a no-op', async () => {
+    // The degradation this channel is allowed: back to exactly the behaviour of
+    // a pipeline that never had a status comment.
+    const { io, deps } = statusHarness()
+    io.createError = new Error('403')
+    const reporter = createStatusReporter(deps)
+
+    await expect(reporter.start(state())).resolves.toBeUndefined()
+    await reporter.enter(state({ phase: 'REVIEW_AND_MUTATE' }))
+    await reporter.tick({ lastAction: 'bash (running)', toolCalls: 1, tokens: 1, cost: 0 })
+    await reporter.finish(done)
+
+    expect(io.edits).toEqual([])
+  })
+
+  test('a run with no job to link to says nothing at all', async () => {
+    // A local `--event-path` run is an ordinary way to drive this CLI, and the
+    // comment's first line is a link to the job doing the work.
+    const { io, deps } = statusHarness({ runUrl: null })
+    const reporter = createStatusReporter(deps)
+
+    await reporter.start(state())
+    await reporter.finish(done)
+
+    expect(io.created).toEqual([])
+    expect(io.edits).toEqual([])
+  })
+
+  test('finish returns nothing, so a status comment cannot report', async () => {
+    // Rule 7 in the type system rather than in a convention: `RunResult` never
+    // comes back out of this channel, so the flag the workflow's fallback
+    // comment is gated on is unreachable from here.
+    const { deps } = statusHarness()
+    const reporter = createStatusReporter(deps)
+    await reporter.start(state({ phase: 'REVIEW_AND_MUTATE' }))
+
+    expect(await reporter.finish(done)).toBeUndefined()
+    expect(done.reported).toBe(true)
+  })
+})
+
+const agentComment = (id: number, body: string): IssueComment => ({ id, body, authorLogin: AGENT_LOGIN })
+
+const withState = (id: number, patch: Partial<AgentState>, prose = 'earlier'): IssueComment =>
+  agentComment(id, `${prose}\n\n${serializeState(state(patch))}`)
+
+const persistDeps = (edits: { id: number; body: string }[], error: Error | null = null): StatePersistDeps => ({
+  github: {
+    updateComment: (id, body): Promise<void> => {
+      edits.push({ id, body })
+      return error === null ? Promise.resolve() : Promise.reject(error)
+    },
+  },
+  log: silentLogger(),
+  selfLogin: (): Promise<string> => Promise.resolve(AGENT_LOGIN),
+})
+
+/** The thread as GitHub would hold it after an in-place rewrite. */
+const applyEdits = (thread: readonly IssueComment[], edits: { id: number; body: string }[]): IssueComment[] =>
+  thread.map((comment) => {
+    const edit = edits.find((candidate) => candidate.id === comment.id)
+    return edit === undefined ? comment : { ...comment, body: edit.body }
+  })
+
+describe('persistState', () => {
+  test('rewrites the comment the restore scan selected, not the last in the thread', async () => {
+    // The failure mode of an in-place update. The newest comment here is a
+    // status comment carrying no block, and the one before it is a bystander's
+    // — so "the last comment" and "the comment the reader will look at" are
+    // three apart.
+    const thread: IssueComment[] = [
+      withState(1, { phase: 'DESIGN_SPEC' }),
+      withState(2, { phase: 'PLAN_REVIEW', tokensSpent: 100 }),
+      { id: 3, body: 'looks good to me', authorLogin: 'maintainer' },
+      agentComment(4, '### 🛠️ Writing and reviewing the code — run in progress'),
+    ]
+    const edits: { id: number; body: string }[] = []
+
+    await persistState(persistDeps(edits), thread, state({ phase: 'PLAN_REVIEW', tokensSpent: 40_100 }))
+
+    expect(edits).toHaveLength(1)
+    expect(edits[0]?.id).toBe(2)
+    expect(findLatestStateComment(thread, AGENT_LOGIN, ISSUE)?.comment.id).toBe(2)
+  })
+
+  test('the state restored afterwards is the state that was written', async () => {
+    const thread = [withState(1, { phase: 'PLAN_REVIEW', tokensSpent: 100 })]
+    const edits: { id: number; body: string }[] = []
+    const recorded = state({ phase: 'PLAN_REVIEW', tokensSpent: 40_100, planRevision: 2 })
+
+    expect(await persistState(persistDeps(edits), thread, recorded)).toEqual(recorded)
+    expect(findLatestState(applyEdits(thread, edits), AGENT_LOGIN, ISSUE)).toEqual(recorded)
+  })
+
+  test('leaves the visible prose of the comment it rewrites alone', async () => {
+    const thread = [withState(1, { phase: 'PLAN_REVIEW' }, '### 🧭 Plan is waiting for you\n\nHere it is.')]
+    const edits: { id: number; body: string }[] = []
+
+    await persistState(persistDeps(edits), thread, state({ phase: 'PLAN_REVIEW', tokensSpent: 7 }))
+
+    expect(edits[0]?.body).toContain('### 🧭 Plan is waiting for you\n\nHere it is.')
+  })
+
+  test('a payload that could forge the block’s terminator survives the round trip', async () => {
+    // `renderBlock` escapes every `<` and `>` so a payload cannot end its own
+    // block, and `lastError` carries compiler output verbatim — `-->` is
+    // ordinary in it. An in-place rewrite that assembled the block itself would
+    // reintroduce that bug on a new surface.
+    const hostile = 'error[E0308] expected struct\n  --> src/a.rs:3:9\n   |'
+    const thread = [withState(1, { phase: 'FAILED', lastError: 'boom' })]
+    const edits: { id: number; body: string }[] = []
+    const recorded = state({ phase: 'FAILED', resumeFrom: 'EXECUTION_PLAN', lastError: hostile, tokensSpent: 12 })
+
+    await persistState(persistDeps(edits), thread, recorded)
+
+    expect(edits[0]?.body).not.toContain('-->\n   |')
+    expect(findLatestState(applyEdits(thread, edits), AGENT_LOGIN, ISSUE)).toEqual(recorded)
+  })
+
+  test('a refused rewrite reports that nothing was persisted', async () => {
+    // Best-effort, like every other write this stage adds: recording a few
+    // thousand tokens is not worth failing a phase over, and a caller that was
+    // told `null` reports the figure the issue actually carries.
+    const thread = [withState(1, { phase: 'PLAN_REVIEW' })]
+    const edits: { id: number; body: string }[] = []
+
+    const persisted = await persistState(persistDeps(edits, new Error('403')), thread, state({ tokensSpent: 5 }))
+
+    expect(persisted).toBeNull()
+    expect(edits).toHaveLength(1)
+  })
+
+  test('a thread with nothing to rewrite is left alone', async () => {
+    const edits: { id: number; body: string }[] = []
+
+    const persisted = await persistState(persistDeps(edits), [agentComment(1, 'no block here')], state())
+
+    expect(persisted).toBeNull()
+    expect(edits).toEqual([])
+  })
+
+  test('a block planted for another issue is never the one rewritten', async () => {
+    // The security half of the restore scan, which this call inherits by asking
+    // the same function: anyone who can edit the agent's comments can plant a
+    // block, and `issueId` is what the rest of the pipeline treats as authority.
+    const foreign: IssueComment = {
+      id: 9,
+      body: `planted\n\n${serializeState({ ...initialState(7), phase: 'PLAN_REVIEW' })}`,
+      authorLogin: AGENT_LOGIN,
+    }
+    const thread = [withState(1, { phase: 'DESIGN_SPEC' }), foreign]
+    const edits: { id: number; body: string }[] = []
+
+    await persistState(persistDeps(edits), thread, state({ phase: 'DESIGN_SPEC', tokensSpent: 3 }))
+
+    expect(edits[0]?.id).toBe(1)
+  })
+})

--- a/tests/opencode-agent/status.test.ts
+++ b/tests/opencode-agent/status.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, expect, test } from 'bun:test'
 
+import { readBlock } from '../../opencode-agent/src/blocks.js'
 import type { IssueComment } from '../../opencode-agent/src/blocks.js'
 import { DEFAULT_CHECKS } from '../../opencode-agent/src/config.js'
 import type { PipelineConfig } from '../../opencode-agent/src/config.js'
@@ -12,6 +13,7 @@ import type { PostedComment } from '../../opencode-agent/src/github.js'
 import type { Logger } from '../../opencode-agent/src/logger.js'
 import type { ProgressSnapshot } from '../../opencode-agent/src/progress.js'
 import {
+  extractState,
   findLatestState,
   findLatestStateComment,
   initialState,
@@ -19,7 +21,7 @@ import {
 } from '../../opencode-agent/src/state-manager.js'
 import { persistState } from '../../opencode-agent/src/state-persist.js'
 import type { StatePersistDeps } from '../../opencode-agent/src/state-persist.js'
-import { renderStatus } from '../../opencode-agent/src/status-comment.js'
+import { renderStatus, STATUS_MARKER } from '../../opencode-agent/src/status-comment.js'
 import type { StatusView } from '../../opencode-agent/src/status-comment.js'
 import { createStatusReporter, MIN_EDIT_INTERVAL_MS } from '../../opencode-agent/src/status-reporter.js'
 import type { StatusDeps } from '../../opencode-agent/src/status-reporter.js'
@@ -202,7 +204,34 @@ describe('renderStatus', () => {
     // Rule 4, at the renderer: `findLatestState` restores from the newest agent
     // comment carrying one, so a second writer of that block is a second source
     // of truth.
-    expect(renderStatus(view())).not.toContain('AGENT_STATE')
+    const body = renderStatus(view())
+
+    expect(body).not.toContain('AGENT_STATE')
+    expect(extractState(body)).toBeNull()
+  })
+
+  test('carries a marker of its own, so the prompt layer can leave it out', () => {
+    // The comment has to be findable without being believable. A marker is
+    // matched exactly, so `AGENT_STATUS` cannot be read as `AGENT_STATE` by the
+    // restore scan — and `renderThread` drops what carries it, because one
+    // progress table per run would otherwise eat the window the model reads the
+    // conversation through.
+    expect(readBlock(renderStatus(view()), STATUS_MARKER)).toEqual({ run: RUN_URL })
+  })
+
+  test('the two markers do not read as each other', () => {
+    expect(readBlock(renderStatus(view()), 'AGENT_STATE')).toBeUndefined()
+    expect(readBlock(`prose\n\n${serializeState(state())}`, STATUS_MARKER)).toBeUndefined()
+  })
+
+  test('a thread carrying status comments restores the same state as one without', () => {
+    // The rule-4 invariant at the scan itself, with the marked comment newest —
+    // which is where a marker that collided would do its damage.
+    const conversation = [withState(1, { phase: 'PLAN_REVIEW', planRevision: 2 })]
+    const interleaved = [...conversation, agentComment(2, renderStatus(view()))]
+
+    expect(findLatestState(interleaved, AGENT_LOGIN, ISSUE)).toEqual(findLatestState(conversation, AGENT_LOGIN, ISSUE))
+    expect(findLatestStateComment(interleaved, AGENT_LOGIN, ISSUE)?.comment.id).toBe(1)
   })
 })
 

--- a/tests/opencode-agent/workflow.test.ts
+++ b/tests/opencode-agent/workflow.test.ts
@@ -4,11 +4,15 @@
 // See LICENSE in the project root for details.
 
 import { describe, expect, test } from 'bun:test'
-import { readFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 import { z } from 'zod'
 
+import { DEFAULT_LABEL_PREFIX } from '../../opencode-agent/src/config.js'
+import { issueNumberFromBranch } from '../../opencode-agent/src/git.js'
+import { WORKING_LABEL } from '../../opencode-agent/src/presentation.js'
 import { REPORTED_OUTPUT } from '../../opencode-agent/src/step-output.js'
 
 /**
@@ -147,6 +151,76 @@ const step = (fragment: string): WorkflowStep =>
 
 const checkoutStep = steps.find((candidate) => candidate.uses.startsWith('actions/checkout')) ?? NO_STEP
 
+/** The two steps whose bodies are executed below, rather than only read. */
+const resolveStep = step('resolve the issue number')
+const cleanupStep = step('working label')
+
+interface StepRun {
+  /** What the runner would colour the step by — and, for a best-effort step, the assertion. */
+  exitCode: number
+  /** `$GITHUB_OUTPUT` as the runner reads it back, so a later step's `if:` can be reasoned about. */
+  outputs: Record<string, string>
+  /** Every `gh` invocation the body made, argv joined: the whole of what it wrote to GitHub. */
+  gh: readonly string[]
+}
+
+const parseOutputs = (raw: string): Record<string, string> =>
+  Object.fromEntries(
+    raw
+      .split('\n')
+      .filter((line) => line.includes('='))
+      .map((line) => [line.slice(0, line.indexOf('=')), line.slice(line.indexOf('=') + 1)]),
+  )
+
+/**
+ * Runs a step's `run:` body the way the runner would.
+ *
+ * Reading the YAML is enough for a condition — an `if:` is a value, and a test
+ * can compare it. It is not enough for a body: "resolves the same issue number
+ * the pipeline does", "no-ops under `AGENT_LABEL_PREFIX: none`" and "cannot fail
+ * the job" are all claims about what a shell script *does*, and a test that only
+ * greps the script for `none` passes against a script that reads the variable
+ * and ignores it. So the body is extracted from the workflow and executed:
+ * `bash -e` (the runner's default shell on Linux), `$GITHUB_OUTPUT` pointed
+ * somewhere readable, and `gh` replaced by a stub on `PATH` that records its
+ * argv and nothing else — no network, per this workspace's rule, and no way for
+ * a body under test to reach GitHub even if it tried.
+ */
+const runStepScript = async (script: string, env: Record<string, string>, ghExitCode = 0): Promise<StepRun> => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'agent-workflow-'))
+
+  try {
+    const ghLog = path.join(dir, 'gh.log')
+    const stub = path.join(dir, 'gh')
+    writeFileSync(stub, `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> '${ghLog}'\nexit ${ghExitCode}\n`)
+    chmodSync(stub, 0o755)
+
+    const outputPath = path.join(dir, 'github-output')
+    writeFileSync(outputPath, '')
+    const scriptPath = path.join(dir, 'step.sh')
+    writeFileSync(scriptPath, script)
+
+    const child = Bun.spawn(['bash', '-e', scriptPath], {
+      env: { PATH: `${dir}:${process.env['PATH'] ?? ''}`, GITHUB_OUTPUT: outputPath, ...env },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const exitCode = await child.exited
+
+    return {
+      exitCode,
+      outputs: parseOutputs(readFileSync(outputPath, 'utf8')),
+      gh: existsSync(ghLog)
+        ? readFileSync(ghLog, 'utf8')
+            .split('\n')
+            .filter((line) => line.length > 0)
+        : [],
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
 /**
  * Knobs the workflow deliberately does not forward, each with a reason a reader
  * can check. Anything else the README documents has to be passed through.
@@ -268,8 +342,29 @@ describe('steps', () => {
   })
 
   test('reports an infrastructure failure only when there is an issue to post to', () => {
+    // The issue number comes from the resolve step, never from the payload
+    // field directly: `github.event.issue.number` is empty on a `workflow_run`
+    // event, so gating on it here excluded every CI-fix run — a runner that died
+    // mid-repair posted nothing anywhere at all.
     expect(step('infrastructure failure').if).toContain('failure()')
-    expect(step('infrastructure failure').if).toContain('github.event.issue.number')
+    expect(step('infrastructure failure').if).toContain(`steps.${resolveStep.id}.outputs.number`)
+    expect(step('infrastructure failure').if).not.toContain('github.event.issue.number')
+    expect(step('infrastructure failure').env['ISSUE_NUMBER']).toBe(`\${{ steps.${resolveStep.id}.outputs.number }}`)
+  })
+
+  test('covers a cancelled job, which failure() does not select', () => {
+    // A run that looks hung is a run somebody cancels, and that is precisely
+    // when the issue must not fall silent. `failure()` is false for a cancelled
+    // job, so before this the maintainer who cancelled got nothing.
+    expect(step('infrastructure failure').if).toContain('cancelled()')
+  })
+
+  test('keeps the widened status test parenthesised, inside the reported gate', () => {
+    // `&&` binds tighter than `||` in GitHub expressions, so an unbracketed
+    // `failure() || cancelled() && …` reads as `failure() || (cancelled() && …)`
+    // — which restores the unconditional `if: failure()` this step spent a
+    // commit getting away from, double comment and all.
+    expect(step('infrastructure failure').if).toContain('(failure() || cancelled())')
   })
 
   test('falls back only when the pipeline did not report on the issue itself', () => {
@@ -284,6 +379,135 @@ describe('steps', () => {
     expect(step('infrastructure failure').if).toContain(
       `steps.${step('agent pipeline').id}.outputs.${REPORTED_OUTPUT} != 'true'`,
     )
+  })
+})
+
+/**
+ * Branch names the resolve step and `issueNumberFromBranch` must agree on.
+ *
+ * The realistic ones prove the CI-fix path resolves at all; the rest are the
+ * shapes a hand-written shell parse gets wrong — a nested path under the prefix,
+ * a suffix that is not digits, a branch that merely contains the prefix, issue
+ * zero, and a suffix large enough to wrap 64-bit arithmetic into a number that
+ * looks like somebody's issue.
+ */
+const BRANCH_CORPUS = [
+  'agent/issue-42',
+  'agent/issue-7',
+  'agent/issue-007',
+  'agent/issue-0',
+  'agent/issue-',
+  'agent/issue-x',
+  'agent/issue-12a',
+  'agent/issue-12/nested',
+  'feature/agent/issue-3',
+  'main',
+  'agent/issue-9007199254740991',
+  'agent/issue-9007199254740993',
+  'agent/issue-99999999999999999999',
+] as const
+
+/** What the resolve step printed to `$GITHUB_OUTPUT`, empty when it resolved nothing. */
+const resolvedNumber = async (env: Record<string, string>): Promise<string> => {
+  const run = await runStepScript(resolveStep.run, env)
+  return run.outputs['number'] ?? ''
+}
+
+/** The same answer from the pipeline's parser, in the shape a step output takes. */
+const parsedNumber = (branch: string): string => String(issueNumberFromBranch(branch) ?? '')
+
+describe('the issue number both feedback steps read', () => {
+  test('resolves before anything that can fail', () => {
+    // The whole point of the step: a job that dies in `bun install`, or is
+    // cancelled while the model is thinking, still has to know where to post. A
+    // resolve that depends on the checkout is a resolve that is absent in the
+    // cases it exists for.
+    expect(steps[0]?.name.toLowerCase()).toContain('resolve the issue number')
+    expect(steps[0]?.uses).toBe('')
+  })
+
+  test('agrees with issueNumberFromBranch on every branch shape', async () => {
+    // The workflow cannot import the pipeline's parser — GitHub expressions have
+    // no regular expressions and the checkout may not have happened yet — so the
+    // two parses exist twice and this is what keeps them one behaviour. Reading
+    // the script for the string `agent/issue-` would not: the interesting half
+    // is which suffixes it rejects.
+    const resolved = await Promise.all(
+      BRANCH_CORPUS.map(
+        async (branch) => `${branch} -> ${await resolvedNumber({ ISSUE_NUMBER: '', HEAD_BRANCH: branch })}`,
+      ),
+    )
+
+    expect(resolved).toEqual(BRANCH_CORPUS.map((branch) => `${branch} -> ${parsedNumber(branch)}`))
+  })
+
+  test('takes the issue event number when there is one, the branch when there is not', async () => {
+    const issueEvent = await resolvedNumber({ ISSUE_NUMBER: '42', HEAD_BRANCH: '' })
+    const ciEvent = await resolvedNumber({ ISSUE_NUMBER: '', HEAD_BRANCH: 'agent/issue-42' })
+    // No real payload carries both; pinning the precedence anyway, because the
+    // payload field is the direct answer and the branch is the inference.
+    const both = await resolvedNumber({ ISSUE_NUMBER: '17', HEAD_BRANCH: 'agent/issue-42' })
+
+    expect(issueEvent).toBe('42')
+    expect(ciEvent).toBe('42')
+    expect(both).toBe('17')
+  })
+})
+
+describe('the working-label cleanup', () => {
+  test('runs whatever the job did', () => {
+    // `agent:working` has exactly one failure mode: a runner killed mid-flight
+    // leaves it on. Every condition narrower than `always()` is a condition the
+    // kill can land outside of.
+    expect(cleanupStep.if).toBe('always()')
+    expect(cleanupStep.env['ISSUE_NUMBER']).toBe(`\${{ steps.${resolveStep.id}.outputs.number }}`)
+  })
+
+  test('removes the working label and touches nothing else', async () => {
+    const run = await runStepScript(cleanupStep.run, { ISSUE_NUMBER: '42', LABEL_PREFIX: '' })
+
+    // Not a clear-and-reapply: every other agent label names the state the issue
+    // is parked in, and this step has no idea which that is.
+    expect(run.gh).toEqual([`issue edit 42 --remove-label ${DEFAULT_LABEL_PREFIX}${WORKING_LABEL.suffix}`])
+    expect(run.exitCode).toBe(0)
+  })
+
+  test('applies the operator prefix rather than a hardcoded namespace', async () => {
+    const run = await runStepScript(cleanupStep.run, { ISSUE_NUMBER: '42', LABEL_PREFIX: 'bot/' })
+
+    expect(run.gh).toEqual([`issue edit 42 --remove-label bot/${WORKING_LABEL.suffix}`])
+  })
+
+  test('touches no label at all when labelling is switched off', async () => {
+    // A repository that opted out of the channel opted out of every writer on
+    // it. `labelPrefix()` trims and compares case-insensitively, so this does.
+    const runs = await Promise.all(
+      ['none', 'None', '  none  '].map((prefix) =>
+        runStepScript(cleanupStep.run, { ISSUE_NUMBER: '42', LABEL_PREFIX: prefix }),
+      ),
+    )
+
+    expect(runs.map((run) => run.gh)).toEqual([[], [], []])
+    expect(runs.map((run) => run.exitCode)).toEqual([0, 0, 0])
+  })
+
+  test('does nothing when no issue number could be resolved', async () => {
+    const run = await runStepScript(cleanupStep.run, { ISSUE_NUMBER: '', LABEL_PREFIX: '' })
+
+    expect(run.gh).toEqual([])
+    expect(run.exitCode).toBe(0)
+  })
+
+  test('never fails the job when the label write fails', async () => {
+    // The rule labels.ts states, on the one writer that is not in labels.ts. A
+    // rejected removal is the *ordinary* case on a healthy run — the in-run
+    // reconcile already took the label off, and removing a label an issue does
+    // not carry is a 404 — so a step that propagated it would paint most green
+    // runs red.
+    const run = await runStepScript(cleanupStep.run, { ISSUE_NUMBER: '42', LABEL_PREFIX: '' }, 1)
+
+    expect(run.gh).toHaveLength(1)
+    expect(run.exitCode).toBe(0)
   })
 })
 


### PR DESCRIPTION
Audits every surface a maintainer can currently see — issue comments
posted only at phase end, an Actions log nothing links to, and a hidden
state block — and records nine gaps, the largest being that a trigger is
never acknowledged, no comment links the run doing the work, and every
guardrail and skip path rejects in total silence.

Plans four feedback channels against the workspace's existing rules
(feedback must never fail a run; outbound redaction stays at the GitHub
adapter; progress carries names, statuses and counts only; the state
block stays the sole durability channel): reactions for instant
acknowledgement, a namespaced label set with `agent:working` and
`agent:needs-you` as the filterable markers, one edited-in-place live
status comment per run carrying the run link, phase checklist and token
budget, and run URLs wired through from the runner environment.

Staged so each step ships alone, with the silence audit, workflow
fallback fixes, test plan and risks recorded alongside.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DW46VeaumJkYAUim5jChCg