### PR TITLE
fix(opencode-agent): stop defaulting AGENT_SELF_LOGIN to the repository owner

### DIFF
--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -146,7 +146,15 @@ jobs:
           LLM_MODEL: ${{ vars.LLM_MODEL }}
 
           # Pipeline configuration — see opencode-agent/README.md.
-          AGENT_SELF_LOGIN: ${{ vars.AGENT_SELF_LOGIN || github.repository_owner }}
+          # Passed through unset when the variable is unset, with no
+          # `|| github.repository_owner` default. That default looked harmless
+          # and was the bug: `AGENT_SELF_LOGIN` is an override that wins
+          # outright, so an owner-shaped value stopped src/identity.ts from ever
+          # asking the token who it is. The agent posts as `github-actions[bot]`,
+          # failed to recognise its own state comments, and restarted every
+          # issue at phase one on every event — `/approve` and `/changes` were
+          # rejected as invalid in INIT_OR_CLARIFY.
+          AGENT_SELF_LOGIN: ${{ vars.AGENT_SELF_LOGIN }}
           AGENT_WORKFLOW_NAME: OpenCode Issue Agent
           # AGENT_BASE_BRANCH is deliberately unset: the pipeline reads the
           # branch off the payload's repository.default_branch. Passing it here

--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -129,7 +129,12 @@ jobs:
           bun add --global opencode-ai@1.18.7
           echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 
+      # `id:` is load-bearing, not decoration: the pipeline writes
+      # `reported=true` to $GITHUB_OUTPUT for every path that has already put a
+      # comment on the issue, and the fallback step below is gated on
+      # `steps.pipeline.outputs.reported`.
       - name: Run the agent pipeline
+        id: pipeline
         env:
           # Repository access. Swap for a GitHub App installation token when you
           # want the agent's pull requests to trigger other workflows — pushes
@@ -180,12 +185,27 @@ jobs:
             --event-name "$GITHUB_EVENT_NAME" \
             --repo-root "$GITHUB_WORKSPACE"
 
-      # The pipeline posts its own failure comment and parks the state in FAILED
-      # before exiting non-zero. This step only covers the case where the job
-      # itself died first (install failure, runner timeout, cancelled job), where
-      # nothing would otherwise appear on the issue.
+      # For a job that died with nothing on the issue: an install failure, a
+      # runner timeout, a cancelled job, a config error thrown before the first
+      # comment could be posted, a crash.
+      #
+      # `if: failure()` alone did not select that, though the comment here used
+      # to claim it did. It selects every red job, and six pipeline paths exit 1
+      # only *after* posting their own report — `failRun` and `failAnswer`, both
+      # over-budget stops, `refuseExhausted` and the CI-budget notice. So every
+      # genuine failure drew a second comment contradicting the first: "The issue
+      # state is unchanged" beside a state block that had just moved to FAILED,
+      # and "reply `/retry`" beside a notice explaining why `/retry` would be
+      # refused. Only CI-triggered runs escaped, by accident —
+      # `github.event.issue.number` is empty on a workflow_run event.
+      #
+      # The pipeline knows which of its exits posted, so it says so: `runCli`
+      # appends `reported=true` to $GITHUB_OUTPUT before returning, and the
+      # runner processes a step's file commands in a `finally` around the
+      # handler, so the marker survives that same step exiting 1. The job stays
+      # red either way — the exit code is real signal.
       - name: Report an infrastructure failure on the issue
-        if: failure() && github.event.issue.number
+        if: failure() && github.event.issue.number && steps.pipeline.outputs.reported != 'true'
         env:
           GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -53,9 +53,22 @@ findings: `ROADMAP.md`.
   it is the one layer that sees a real HTTP status and the only one the review
   loop's subprocesses also pass through; do not add a second retry in the
   adapter, where the status is already gone.
+- **The retry budget is refused, never applied-then-regretted.** A `/retry` past
+  `maxAttempts` is turned down in `src/triggers.ts` before the signal reaches
+  `transition`, so the issue keeps `FAILED` and its `resumeFrom` and raising
+  `AGENT_MAX_ATTEMPTS` still resumes it. It used to be checked in `driveMachine`,
+  after `applyTrigger` had applied `RETRY` — which clears `resumeFrom` — so
+  spending the budget parked the issue in a handler phase that `/retry` (needs
+  `FAILED`) and a plain comment (needs a waiting phase) both refuse, reachable
+  only by `/cancel`, under a notice inviting the `/retry` that had just become
+  impossible. There is deliberately **one** such check and no backstop in the
+  cascade: forward moves reset `attempts`, so `RETRY` is the only way a spent
+  count reaches a handler. The invariant to preserve: no path may leave the
+  persisted state in a phase that has a handler but that no trigger can
+  re-enter.
 - **The token budget is per issue and persisted.** `tokensSpent` lives in the
-  state block; the orchestrator checks it before each phase, beside the retry
-  budget it resembles. Budget on **tokens**, never on `cost`: token counts come
+  state block; the orchestrator checks it before each phase. Budget on
+  **tokens**, never on `cost`: token counts come
   from the provider's usage block, while cost is derived from OpenCode's model
   catalogue and is `0` for any model it does not price. Read the total from
   `session.get`, not by summing events — the check happens immediately after a

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -14,7 +14,8 @@ findings: `ROADMAP.md`.
   not on disk: `AGENT_STATE` for the machine, `AGENT_SPEC` / `AGENT_PLAN` /
   `AGENT_REPORT` for the artefacts.
 - `src/triggers.ts` decides _whether and where_ an event moves the state;
-  `src/orchestrator.ts` drives the phase cascade once that decision is made.
+  `src/orchestrator.ts` drives the phase cascade once that decision is made;
+  `src/token-budget.ts` decides whether the cascade may afford another step.
   Phase handlers in `src/phases/` return a `TransitionSignal`, a comment body and
   optional artefact blocks, and never write state or decide the next phase
   themselves.
@@ -66,6 +67,22 @@ findings: `ROADMAP.md`.
   count reaches a handler. The invariant to preserve: no path may leave the
   persisted state in a phase that has a handler but that no trigger can
   re-enter.
+- **An over-budget stop parks in `FAILED`; it does not stay put.** The token
+  check sits inside the cascade, before each handler, and cannot move to the
+  trigger layer the way the retry gate did: half its firings are mid-cascade
+  (`REVIEW_AND_MUTATE` → `PR_DELIVERY` → `COMPLETE` in one job), where the phase
+  has rightly advanced and there is no signal to refuse. So the **stop** carries
+  the invariant instead — `transition(FAILED)` with `resumeFrom` naming the
+  phase it refused to start, which is the recovery path that already exists and
+  is what makes "raise `AGENT_MAX_TOKENS`, reply `/retry`" true. Leaving the
+  phase alone stranded the issue in a handler phase, reachable only by
+  `/cancel`, on a first `/approve` with no failure involved. `attempts` is
+  **carried, not incremented**: running out of tokens is not a failed attempt,
+  and spending one would let the retry gate refuse the very `/retry` the token
+  notice asks for, citing a ceiling it never mentioned. The **answer** path is
+  the deliberate exception and moves nothing, for the reasons `failAnswer` moves
+  nothing — plus `COMPLETE` accepts no `FAILED`, so parking a question there
+  would throw out of the pipeline.
 - **The token budget is per issue and persisted.** `tokensSpent` lives in the
   state block; the orchestrator checks it before each phase. Budget on
   **tokens**, never on `cost`: token counts come

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -90,6 +90,27 @@ findings: `ROADMAP.md`.
   catalogue and is `0` for any model it does not price. Read the total from
   `session.get`, not by summing events — the check happens immediately after a
   prompt returns, and an event-derived total is whatever has arrived by then.
+- **Every state block a job writes records the running total**, through
+  `recordSpend` in `token-budget.ts` — a phase that succeeded, one that threw,
+  and one the budget refused to start, all three. Written separately they drifted
+  apart at once: `runHandler` patched `tokensSpent` while `failRun` and
+  `failAnswer` did not, so a job that spent 250,000 tokens and then threw
+  persisted `0`. That is the worst possible place to be blind, because retries
+  **are** the failure path — the runaway this bounds is an issue bouncing through
+  `/retry` and CI-fix rounds, so an issue could burn the ceiling and hand the
+  next runner a clean slate, round after round. The figure is always
+  `carriedTokens` (the restored block, captured once) plus the job's session
+  total, never a per-phase sum: one job's session is already cumulative across
+  the phases it cascades through.
+- **Do not pay to classify a comment the budget cannot act on.** `applyIntent`
+  asks `withinBudget` before `classifyComment` and routes an over-budget comment
+  to the answer path, where the cascade's one stop reports it. The classifier is
+  the single model turn whose spend cannot be recorded — its `none` branch posts
+  nothing, and this pipeline persists state only by posting — so the ceiling has
+  to stop the turn rather than count it. A run **under** budget that classifies
+  `none` still leaks that turn; the known cost of not replying to every "thanks!",
+  and not to be papered over with an `updateComment`-style write without deciding
+  that larger question first.
 - **Bounds go on the finished prompt, and on waiting.** `prompt-budget.ts` caps
   what reaches the model — per prompt, not per input, since a per-input cap
   bounds one log and nothing else. `deadline.ts` bounds waiting for a model turn;

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -29,6 +29,17 @@ findings: `ROADMAP.md`.
 - **Never scrape prose to recover an artefact.** Spec, plan and report travel in
   hidden blocks via `blocks.ts` / `artifacts.ts`. Heading-and-trailer scraping
   silently truncated specs at their first `---` rule; do not reintroduce it.
+- **Each artefact counts its own revisions.** `specRevision` and `planRevision`
+  are separate fields and each handler renders and stores one of them, from a
+  single local so the visible heading and the hidden block cannot disagree. They
+  were one shared `revision` bumped by both `SPEC_POSTED` and `PLAN_POSTED`, so
+  the counts interleaved and the first execution plan on every issue announced
+  itself as revision 2 — revision 3 if the spec had been revised once first —
+  which is not a reading "the Nth version of this artefact" allows. The report
+  block stamps `planRevision`: it records which plan was implemented, and no
+  signal bumps a report counter. Splitting them needed no `STATE_VERSION` bump
+  because both fields default; the old key is dropped rather than mapped onto
+  either, since it was a sum and never a count of either artefact.
 - **Answering is phase-neutral in both directions.** `ANSWERED` is deliberately
   absent from `TRANSITIONS`; `transition` handles it as a non-moving signal
   accepted in every phase, because `/ask` is accepted in every phase. Do not put

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -83,6 +83,22 @@ findings: `ROADMAP.md`.
   the deliberate exception and moves nothing, for the reasons `failAnswer` moves
   nothing — plus `COMPLETE` accepts no `FAILED`, so parking a question there
   would throw out of the pipeline.
+- **A run says whether it reported, and the workflow reads that.** `RunResult`
+  carries `reported`, and `step-output.ts` turns it into a `reported=true` line
+  in `$GITHUB_OUTPUT`; the workflow's fallback "Agent job failed" comment is
+  gated on `steps.pipeline.outputs.reported != 'true'`. It used to be gated on
+  `if: failure()` alone, which selects **every** red job — and six paths exit 1
+  only after posting their own report (`failRun`, `failAnswer`, both over-budget
+  stops, `refuseExhausted`, the CI-budget notice), so every genuine failure drew
+  a second comment claiming "the issue state is unchanged" beside a block that
+  had just moved to `FAILED`. Only CI runs escaped, by accident:
+  `github.event.issue.number` is empty on a `workflow_run` event. Set `reported`
+  on any new terminal path from what that path **posted**, never from its status
+  — `failed` covers both a reported failure and a crash, and `skipped` covers
+  both a silent guardrail drop and a refused command that answered on the issue.
+  A throw is deliberately unmarked: that is the crash the fallback comment is
+  for. Writing the marker is best-effort and must never throw — `GITHUB_OUTPUT`
+  is absent on every `--event-path` run.
 - **The token budget is per issue and persisted.** `tokensSpent` lives in the
   state block; the orchestrator checks it before each phase. Budget on
   **tokens**, never on `cost`: token counts come

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -172,6 +172,23 @@ findings: `ROADMAP.md`.
   `none` still leaks that turn; the known cost of not replying to every "thanks!",
   and not to be papered over with an `updateComment`-style write without deciding
   that larger question first.
+- **`INIT_OR_CLARIFY` classifies with the default inverted.** `applyClarifyIntent`
+  skips a comment only when the classifier positively reports `none`; every other
+  reading re-runs triage, which is what the phase used to do for every comment —
+  a "thanks", a 👍 or a bystander's aside each bought a full triage turn. It
+  cannot reuse `applyIntent`: that bias exists to protect an approved artefact and
+  there is none here, so a misread answer is not one cheap extra reply but a
+  stalled conversation, the agent answering its own clarifying questions back at
+  the maintainer while the issue stays parked. `question` is deliberately **not**
+  admitted as a skip-to-answer for the same reason — in this phase it is the
+  bucket every failure and ambiguity lands in, not a verdict, so honouring it
+  would stall exactly the comments least able to survive it. A blank body (the
+  `issues.opened` event that starts every issue) and an over-budget issue both
+  skip the classifier and fall through to triage, where the cascade's own stop
+  reports the ceiling — the rule above, one model turn cheaper. This is the one
+  phase `buildClassifyPrompt` briefs on what the phase means, because `none` is
+  now load-bearing and a real answer is often a bare fragment that reads as
+  chatter to a phase-blind classifier.
 - **Bounds go on the finished prompt, and on waiting.** `prompt-budget.ts` caps
   what reaches the model — per prompt, not per input, since a per-input cap
   bounds one log and nothing else. `deadline.ts` bounds waiting for a model turn;

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -26,6 +26,16 @@ findings: `ROADMAP.md`.
 - **Never scrape prose to recover an artefact.** Spec, plan and report travel in
   hidden blocks via `blocks.ts` / `artifacts.ts`. Heading-and-trailer scraping
   silently truncated specs at their first `---` rule; do not reintroduce it.
+- **Answering is phase-neutral in both directions.** `ANSWERED` is deliberately
+  absent from `TRANSITIONS`; `transition` handles it as a non-moving signal
+  accepted in every phase, because `/ask` is accepted in every phase. Do not put
+  it back as a row per phase — the table and `/ask`'s reach drifting apart is
+  what made a question asked in `COMPLETE`, `FAILED` or mid-pipeline throw
+  `InvalidTransitionError` out of the pipeline, after the model turn was paid
+  for and with nothing posted on the issue. A **failed** answer does not move the
+  phase either: `failAnswer` posts and leaves `phase`, `resumeFrom` and
+  `attempts` alone, which is also why `resumeFrom` can never name a waiting phase
+  with no handler for `/retry` to resume into.
 - **The review loop is `review-loop/`, not a local reimplementation.** Phase 3
   drives that workspace through `review-runner.ts`. `check-loop.ts` exists only
   for CI fixing, which the workspace does not cover. In that loop the first round

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -13,8 +13,10 @@ findings: `ROADMAP.md`.
 - One CI job = one call to `runCli`. State lives in hidden blocks on the issue,
   not on disk: `AGENT_STATE` for the machine, `AGENT_SPEC` / `AGENT_PLAN` /
   `AGENT_REPORT` for the artefacts.
-- `src/triggers.ts` decides _whether and where_ an event moves the state;
-  `src/orchestrator.ts` drives the phase cascade once that decision is made;
+- `src/triggers.ts` decides _whether and where_ an event moves the state, with
+  the red-CI half in `src/ci-trigger.ts` and the shared outcome shape in
+  `src/trigger-outcome.ts`; `src/orchestrator.ts` drives the phase cascade once
+  that decision is made;
   `src/token-budget.ts` decides whether the cascade may afford another step.
   Phase handlers in `src/phases/` return a `TransitionSignal`, a comment body and
   optional artefact blocks, and never write state or decide the next phase
@@ -83,6 +85,38 @@ findings: `ROADMAP.md`.
   the deliberate exception and moves nothing, for the reasons `failAnswer` moves
   nothing — plus `COMPLETE` accepts no `FAILED`, so parking a question there
   would throw out of the pipeline.
+- **A red run is acted on where the branch is live and no job is on it.**
+  `CI_FAILED` names two rows in `TRANSITIONS`, `COMPLETE` and `PR_DELIVERY`, and
+  the absences are the design. `PR_DELIVERY` is the genuine race: phase 3 pushes
+  the branch and posts a block naming that phase before phase 4 opens the pull
+  request, so a job that died in between left a live branch whose red checks were
+  refused as an invalid transition and dropped — nothing posted, no `ciAttempts`
+  spent, no trace but a `reason` string nobody reads. The four phases before the
+  branch exists stay out because `handleCiFix` would run the checks against a
+  branch cut from the base; `REVIEW_AND_MUTATE` and `CI_FIX` stay out because the
+  machine never persists them (a block is written only when a handler posts, and
+  both post the phase they moved _to_), and honouring a hand-edited one would put
+  a second job on a branch another is mid-commit on — the workflow's concurrency
+  group queues those two, but only while `workflow_run.head_branch` and
+  `agent/issue-<n>` agree, which is a coincidence and not a proof. **`FAILED`
+  stays out deliberately**, the close call: the branch is pushed there, but
+  `CI_FAILED` is a forward move, so it would reset `attempts` and leave the one
+  phase `/retry` accepts, and a fix that went green would park the issue in
+  `COMPLETE` announcing success for a delivery that never finished. Those red
+  checks are deferred behind the `/retry` the failure comment already asked for,
+  not abandoned. A refused red run **logs at `warn` with the phase** and posts
+  nothing, for the reason `settledPullRequest` sets out: CI fires on every push,
+  so a comment per red run is spam.
+- **The CI-fix budget belongs to a pull request, not to an issue.**
+  `handleDeliver` clears `ciAttempts` and `ciBudgetReported` on its
+  `existing === null` branch — a genuinely new pull request — and leaves both
+  alone when it refreshes the open one. Neither used to reset at all, and `applyCiTrigger` short-circuits
+  on `ciBudgetReported` before it even looks the pull request up, so an issue
+  that burned its rounds on one pull request and then delivered a second got no
+  fix round on the new one and no comment explaining the silence. Do not extend
+  the reset to the refresh path: same branch, same commits, same checks that
+  spent the rounds, and a clean slate there is one broken branch bouncing off the
+  agent for as long as anyone keeps replying `/retry`.
 - **A run says whether it reported, and the workflow reads that.** `RunResult`
   carries `reported`, and `step-output.ts` turns it into a `reported=true` line
   in `$GITHUB_OUTPUT`; the workflow's fallback "Agent job failed" comment is

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -106,6 +106,21 @@ any classification failure, resolves to "question"** — answering a comment tha
 was really a change request costs one reply, whereas re-planning a comment that
 was really a question discards an approved artefact.
 
+**`INIT_OR_CLARIFY` classifies too, with that default inverted.** A comment
+arriving while the agent waits for answers to its own clarifying questions is
+skipped only when the classifier positively reports "no action" — a thanks, an
+emoji, a bystander's aside. Every other reading, including the "question" the
+classifier falls back to whenever it fails or cannot tell, re-runs triage, which
+is what this phase used to do for every comment unconditionally. The bias cannot
+be borrowed from the waiting phases, because it protects an approved artefact
+and there is none here: a maintainer's answer misread as a question would be
+answered rather than acted on, leaving the issue parked on the same questions
+and the maintainer repeating themselves. That is worse than the triage turn a
+"thanks" used to buy, so only the one verdict a classifier has to actively
+choose acts on anything. The classification prompt tells the model what this
+phase means, since a real answer is often a bare fragment that reads like
+chatter to anyone who has not matched it against the question it replies to.
+
 A command only counts on a line that _starts_ with it, and fenced code blocks
 are ignored, so the agent quoting its own instructions does not fire them.
 
@@ -314,9 +329,11 @@ that classifies a plain maintainer comment as needing no action. That last one i
 a deliberate residual. Classification happens before any phase runs, and when it
 answers "no action" the run posts nothing — replying to every "thanks!" would be
 spam — so there is no comment for a state block to ride on. What the agent does
-instead is refuse to pay for it: once an issue is over budget the comment goes
-straight to the answer path, which reports the ceiling without a model turn, so a
-maxed-out issue stops buying a classification per comment.
+instead is refuse to pay for it: once an issue is over budget the comment skips
+the classifier entirely and goes to the path that reports the ceiling without a
+model turn — the answer path on a waiting phase, triage's own stop in
+`INIT_OR_CLARIFY` — so a maxed-out issue stops buying a classification per
+comment.
 
 ## Watching a run
 

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -396,10 +396,22 @@ It is now resolved, in order:
 1. `AGENT_SELF_LOGIN`, if set. An operator who knows the answer is not
    second-guessed, and this is the escape hatch for everything below.
 2. Otherwise the token's own identity. Exact for a personal access token.
-3. Otherwise the repository owner, **with a warning naming `AGENT_SELF_LOGIN`**.
+3. Otherwise `github-actions[bot]`, **with a warning naming `AGENT_SELF_LOGIN`**.
    A GitHub App installation token cannot read `/user`, so this is the expected
-   path for the token this README recommends — set the variable to
+   path for an Actions-issued token — and it is the account the runtime's own
+   `GITHUB_TOKEN` posts as. For any other app, set the variable to
    `<app-slug>[bot]`.
+
+Step 3 used to fall back to the repository owner, which was never a possible
+answer: the branch is only reached for an installation token, whose author is
+always a `[bot]` account.
+
+Because step 1 wins outright, **the workflow must pass `AGENT_SELF_LOGIN`
+through unset when the variable is unset** — no `|| github.repository_owner`
+default. Defaulting it upstream turned "nobody pinned a login" into "an operator
+pinned the owner", which skipped steps 2 and 3 and their warning with them. The
+agent then failed to recognise its own comments, restored a fresh state on every
+event, and refused `/approve` and `/changes` as invalid in `INIT_OR_CLARIFY`.
 
 Whatever it resolves to is checked against reality for free: a created comment
 comes back carrying its author, and a mismatch is logged at `error`. The in-job
@@ -524,8 +536,11 @@ both are 26–28 KB and neither applies to a single-session CI run.
 1. Repository secret `LLM_API_KEY`.
 2. Repository variables `LLM_MODEL` and `LLM_BASE_URL`.
 3. Repository variable `AGENT_SELF_LOGIN` — the login the agent comments under.
-   Optional for a PAT, but required for a GitHub App token, which cannot report
-   its own identity.
+   Leave it unset for a PAT (derived) or for the job's own `GITHUB_TOKEN`
+   (`github-actions[bot]`, the fallback). Set it to `<app-slug>[bot]` for any
+   other GitHub App token, which cannot report its own identity. Getting it
+   wrong is not silent: the first comment the agent posts logs the mismatch at
+   `error`, naming the account it actually posted as.
 4. Optionally `AGENT_GITHUB_TOKEN`, a GitHub App installation token. Without it
    the agent's pushes do not trigger CI, so the CI-fix path never runs.
 5. Actions needs write access to contents, issues and pull requests.

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -219,6 +219,17 @@ request, and repeating it three times only delays saying so. OpenCode retries a
 rate limit itself as well, with its own backoff, so this is a second and closer
 layer rather than the only one.
 
+The retry budget bounds the other loop: `AGENT_MAX_ATTEMPTS` consecutive
+failures, after which `/retry` is **refused where it stands** rather than
+applied and then regretted. That distinction is the whole behaviour. Applying it
+first clears `resumeFrom` and moves the issue into the phase it was resuming,
+and once the budget check then stops the run, the issue is parked in a phase
+nothing can re-enter — `/retry` needs `FAILED`, a plain comment needs a waiting
+phase — with only `/cancel` left. Refused, the issue stays in `FAILED` with its
+resume point intact, so raising `AGENT_MAX_ATTEMPTS` and replying `/retry`
+resumes exactly where it broke. The give-up notice says so, because a notice
+that invites a command the machine will refuse is worse than no notice.
+
 The token budget is the one bound that spans jobs. It is counted **per issue**
 and kept in the state block, because the runaway it stops is not a single run —
 it is an issue bouncing through retries and CI-fix rounds, each on a fresh runner

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -265,8 +265,23 @@ counts and zero cost. For a pipeline built around one arbitrary configured
 endpoint that is the ordinary case, and a ceiling that silently never fires is
 worse than none.
 
-Two things it cannot see: the review loop's `opencode run` subprocesses, which
-have their own sessions, and any spend before the first prompt of a job.
+Every state block a job writes carries the running total, whether the phase
+succeeded, threw, or was the one the budget refused to start. A failure counts
+for the same reason the budget is persisted at all: the model turn is paid for
+long before the parse that rejects its reply, and `/retry` out of `FAILED` is
+exactly how an issue comes back for another expensive round. A failure that
+recorded nothing let an issue burn the ceiling and then hand the next runner a
+clean slate, round after round.
+
+Three things it cannot see: the review loop's `opencode run` subprocesses, which
+have their own sessions; any spend before the first prompt of a job; and the turn
+that classifies a plain maintainer comment as needing no action. That last one is
+a deliberate residual. Classification happens before any phase runs, and when it
+answers "no action" the run posts nothing — replying to every "thanks!" would be
+spam — so there is no comment for a state block to ride on. What the agent does
+instead is refuse to pay for it: once an issue is over budget the comment goes
+straight to the answer path, which reports the ceiling without a model turn, so a
+maxed-out issue stops buying a classification per comment.
 
 ## Watching a run
 

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -606,6 +606,26 @@ Nothing to configure for `GITHUB_TOKEN` or `GITHUB_REPOSITORY` — see
 
 The workflow lives at `.github/workflows/agent-pipeline.yml`.
 
+### The fallback failure comment
+
+The workflow's last step posts an "Agent job failed" comment saying the issue
+state is unchanged and inviting a `/retry`. That is only ever true for a job
+that died with nothing on the issue: an install failure, a runner timeout, a
+cancelled job, a config error thrown before the first comment, a crash.
+
+It cannot be gated on `if: failure()` alone, which is what it used to be:
+`failure()` selects every red job, and the pipeline exits 1 from six paths that
+have already posted their own report — a failed phase, a failed answer, either
+over-budget stop, a refused `/retry` and the CI-fix give-up notice. Each of
+those drew a second comment contradicting the first, next to a state block that
+had just moved to `FAILED`.
+
+So the run step carries `id: pipeline` and the pipeline appends `reported=true`
+to `$GITHUB_OUTPUT` for every exit that posted; the fallback step is gated on
+`steps.pipeline.outputs.reported != 'true'`. The marker survives the run step's
+own exit 1 — the runner processes a step's file commands in a `finally` around
+the handler — and the job still goes red, because the exit code is real signal.
+
 ## Local runs
 
 ```bash
@@ -652,6 +672,9 @@ For the CI-fix path, pass a `workflow_run` payload with
 Exit code is `0` for skipped/waiting/completed, `1` only when a phase failed.
 Logs are NDJSON on stdout.
 
+`$GITHUB_OUTPUT` is absent on a local run, so the `reported` marker described
+under **Setup** is simply not written. Nothing else changes.
+
 ## Module map
 
 | File                                          | Responsibility                                                         |
@@ -660,6 +683,7 @@ Logs are NDJSON on stdout.
 | `src/orchestrator.ts`                         | The state machine: guardrails and the phase cascade                    |
 | `src/triggers.ts`                             | Turning a command, comment or red CI run into the state move to make   |
 | `src/run-report.ts`                           | Everything the orchestrator writes back to the issue                   |
+| `src/step-output.ts`                          | The one thing a run tells the rest of its own workflow job             |
 | `src/token-budget.ts`                         | The per-issue token ceiling, and how a run over it parks in `FAILED`   |
 | `src/state-manager.ts`                        | Transition table and the `AGENT_STATE` block                           |
 | `src/blocks.ts` / `src/artifacts.ts`          | The hidden-block channel and the spec/plan/report artefacts            |

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -61,7 +61,7 @@ value to point elsewhere.
 | `PR_DELIVERY`       | automatic                                 | Opens or refreshes the PR with `Closes #<n>`                          | PR opened                                 |
 | `CI_FIX`            | a red check run on `agent/issue-<n>`      | Reproduces CI locally, repairs, pushes                                | Fix pushed                                |
 | `COMPLETE`          | —                                         | Terminal, but re-enterable from `CI_FIX`                              | —                                         |
-| `FAILED`            | any handler throwing                      | Failure comment posted, `resumeFrom` recorded                         | `/retry` or `/cancel`                     |
+| `FAILED`            | any _phase_ handler throwing              | Failure comment posted, `resumeFrom` recorded                         | `/retry` or `/cancel`                     |
 
 There are two review gates, not one. The spec and the plan are each parked in
 front of a human before anything downstream is spent.
@@ -75,6 +75,16 @@ front of a human before anything downstream is spent.
 | `/ask <question>`           | anywhere                     | Answer, grounded in the repo, without moving the state machine |
 | `/retry`                    | `FAILED`                     | Resume the exact phase that failed                             |
 | `/cancel`                   | anything but `COMPLETE`      | Stop for good — a cancelled issue cannot be restarted          |
+
+**`/ask` really does mean anywhere,** and in both directions. `ANSWERED` is not
+in the transition table at all: it is a non-moving signal the machine accepts in
+every phase, so a question in `COMPLETE`, in `FAILED`, or halfway through the
+pipeline is answered exactly where the issue stands. A question that _fails_
+moves nothing either — the failure is posted, but the phase, `resumeFrom` and
+the retry budget are left alone, and the notice does not offer `/retry`. The
+phase records where the **work** is, and a side conversation about that work is
+not the work; parking a delivered pull request in `FAILED` because a model turn
+about it broke would be a lie about what happened.
 
 **Plain replies work too.** A comment with no command on a waiting phase is
 classified as a question, a change request, or an approval, and handled

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -31,6 +31,19 @@ markdown. That is not a style preference: a spec is model-written markdown full
 of headings and `---` rules, and any heading-and-trailer scraping truncates it at
 the first horizontal rule.
 
+The spec and the plan are numbered **separately**, each by its own revisions: the
+first spec is "Design spec (revision 1)" and the first plan is "Execution plan
+(revision 1)", whether or not the spec was revised on the way there. `AGENT_STATE`
+carries a counter each (`specRevision`, `planRevision`), and the number in a
+heading is the number in that artefact's own block — one value renders both. A
+single shared counter used to bump on either artefact, so the numbers interleaved
+and the first plan on a straight-through issue called itself revision 2. Both
+counters default, so blocks written before the split still parse; an issue
+mid-conversation across that change restarts its counts at 1, because the number
+it was carrying was the sum of two artefacts and never the count of either.
+`AGENT_REPORT` carries the revision of the plan it implemented — provenance, not
+a count of reports.
+
 Blocks are read back byte-exact, and a payload cannot forge its own delimiter:
 `<` and `>` are escaped as JSON unicode escapes before serialization, so text
 containing `-->` — a mermaid arrow, a compiler diagnostic in `lastError` — cannot

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -148,6 +148,20 @@ the checks it skipped have not been looked at since before a repair edited the
 tree, and a fix for one check can break another, so a **full pass is what
 declares green**. That pass costs commands but no model call, and so no round.
 
+A red run is acted on in `COMPLETE` and in `PR_DELIVERY`, and nowhere else.
+`PR_DELIVERY` is the race that matters: phase 3 pushes the branch and posts a
+state block naming that phase before phase 4 opens the pull request, so a job
+that died in between leaves a live branch whose checks go red against a state
+that is not `COMPLETE` yet. Before the branch exists there is nothing pushed to
+repair, and a fix round would run the configured checks against a branch cut
+fresh from the base. `FAILED` is deliberately left out even though its branch
+_is_ pushed: entering `CI_FIX` from there would leave the one phase `/retry`
+accepts and, once green, land the issue in `COMPLETE` claiming success for a
+delivery that never finished — and the issue is not silent in the meantime, it
+is sitting under a failure comment asking for that `/retry`. A refused red run
+is logged at `warn` with the phase; it draws no comment, for the same reason a
+red run on a merged pull request draws none.
+
 Two budgets bound it. `AGENT_CI_FIX_MAX_ROUNDS` caps repair rounds within one
 job; `AGENT_MAX_CI_ATTEMPTS` caps rounds across the pull request's whole life, so
 a genuinely broken branch cannot bounce between the agent and CI forever. The
@@ -156,6 +170,14 @@ agent's own workflow is excluded, so its failures never feed itself.
 When that lifetime budget runs out the agent says so on the issue, once, naming
 the pull request — it does not simply stop. Later red runs are then ignored
 silently, because CI fires on every push and repeating the notice would be spam.
+
+That budget is **per pull request**, not per issue: opening a _new_ pull request
+resets both the spent rounds and the "I have stopped trying" flag, so the second
+delivery gets its own rounds and can say its own piece. Refreshing the pull
+request that is already open does not reset anything — it is the same branch and
+the same commits whose checks spent the rounds, and handing it a clean slate is
+how one broken branch bounces off the agent for as long as anyone keeps replying
+`/retry`.
 
 > **This path only fires if CI runs on the agent's branch.** Pushes made with the
 > default `GITHUB_TOKEN` deliberately do not trigger other workflows. Set
@@ -681,7 +703,8 @@ under **Setup** is simply not written. Nothing else changes.
 | --------------------------------------------- | ---------------------------------------------------------------------- |
 | `src/index.ts`                                | CLI entry: flags, config, dependency wiring, agent teardown, exit code |
 | `src/orchestrator.ts`                         | The state machine: guardrails and the phase cascade                    |
-| `src/triggers.ts`                             | Turning a command, comment or red CI run into the state move to make   |
+| `src/triggers.ts`                             | Turning a command or comment into the state move to make               |
+| `src/ci-trigger.ts`                           | Whether a red check run buys a fix round, a notice, or nothing         |
 | `src/run-report.ts`                           | Everything the orchestrator writes back to the issue                   |
 | `src/step-output.ts`                          | The one thing a run tells the rest of its own workflow job             |
 | `src/token-budget.ts`                         | The per-issue token ceiling, and how a run over it parks in `FAILED`   |

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -233,9 +233,29 @@ that invites a command the machine will refuse is worse than no notice.
 The token budget is the one bound that spans jobs. It is counted **per issue**
 and kept in the state block, because the runaway it stops is not a single run —
 it is an issue bouncing through retries and CI-fix rounds, each on a fresh runner
-with no memory of what the last one spent. When it runs out the agent says so on
-the issue and stops; `/retry` will not help, since the total is persisted, so the
-notice names `AGENT_MAX_TOKENS` instead.
+with no memory of what the last one spent.
+
+When it runs out the agent parks the issue in `FAILED`, with `resumeFrom` naming
+the phase it refused to start, and says so on the issue. Parking rather than
+stopping where it stands is the whole behaviour, and it is deliberately _not_
+the refusal the retry budget uses. The token check runs before each phase,
+inside the cascade, and half its firings have no trigger to refuse: it also
+fires between `REVIEW_AND_MUTATE`, `PR_DELIVERY` and `COMPLETE` inside a single
+job, where the earlier phase legitimately did its work and posted. Stopping in
+place left the issue in a phase with a handler that nothing re-enters — `/retry`
+needs `FAILED`, a plain comment needs a waiting phase — so `/cancel` was the
+only event left, and the notice's own "raise `AGENT_MAX_TOKENS` to continue" led
+nowhere at any ceiling. Reachable on a first `/approve` with no failure in the
+story at all. Parked, the remedy the notice names really works: raise
+`AGENT_MAX_TOKENS`, reply `/retry`, and the named phase runs.
+
+The stop carries `attempts` across rather than spending one, because running out
+of tokens is not a failed attempt at anything — and because spending one would
+collide the two budgets, letting the retry gate turn down the very `/retry` the
+token notice asks for over a ceiling it never mentioned. A question is the one
+exception: an over-budget `/ask` reports and moves nothing, since answering is a
+side conversation about work that lives elsewhere, `resumeFrom` may never name a
+waiting phase, and `COMPLETE` accepts no `FAILED` at all.
 
 Tokens rather than currency, deliberately. Token counts come from the provider's
 own usage block and are always right; the cost figure OpenCode reports is derived
@@ -625,6 +645,7 @@ Logs are NDJSON on stdout.
 | `src/orchestrator.ts`                         | The state machine: guardrails and the phase cascade                    |
 | `src/triggers.ts`                             | Turning a command, comment or red CI run into the state move to make   |
 | `src/run-report.ts`                           | Everything the orchestrator writes back to the issue                   |
+| `src/token-budget.ts`                         | The per-issue token ceiling, and how a run over it parks in `FAILED`   |
 | `src/state-manager.ts`                        | Transition table and the `AGENT_STATE` block                           |
 | `src/blocks.ts` / `src/artifacts.ts`          | The hidden-block channel and the spec/plan/report artefacts            |
 | `src/guardrails.ts`                           | Payload normalization (issue vs CI) and every abort rule               |

--- a/opencode-agent/src/ci-trigger.ts
+++ b/opencode-agent/src/ci-trigger.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { branchNameFor } from './git.js'
+import type { PhaseInput } from './phase-context.js'
+import { postAndAppend, renderCiExhausted } from './run-report.js'
+import { canTransition, markCiBudgetReported, transition } from './state-manager.js'
+import { skip } from './trigger-outcome.js'
+import type { TriggerOutcome } from './trigger-outcome.js'
+
+/**
+ * What a red check run buys, before any phase handler runs.
+ *
+ * Split out of `triggers.ts` — which was at the file-length limit — rather than
+ * compressed into it, because this half answers a different question from the
+ * commands and comments next door. Those ask what a human meant; this one asks
+ * whether there is a live, pushed branch worth spending a repair round on, and
+ * every one of its exits is deliberately quiet.
+ */
+
+/**
+ * A red CI run either buys a fix attempt or, once the budget is spent, buys the
+ * maintainer a notice — exactly once. Neither, if the phase has no pushed branch
+ * to repair, or if the pull request it would be fixing is no longer live.
+ *
+ * Silence on a spent budget is the failure mode: CI events arrive on their own
+ * schedule with nobody reading the Actions log, so an agent that quietly stops
+ * fixing looks identical to one still working. Repeating the notice on every
+ * later red run would be the opposite mistake, which is what `ciBudgetReported`
+ * prevents — and `handleDeliver` clears that flag when it opens a *new* pull
+ * request, so "exactly once" is once per pull request rather than once per issue.
+ */
+export const applyCiTrigger = async (input: PhaseInput): Promise<TriggerOutcome> => {
+  const { state, deps, thread } = input
+
+  const refused = refuseUnfixablePhase(input)
+  if (refused !== null) return refused
+
+  const spent = state.ciAttempts >= deps.config.maxCiAttempts
+  const reason = `Spent the CI-fix budget (${state.ciAttempts} of ${deps.config.maxCiAttempts} attempts).`
+
+  // Decided already, so do not pay for a pull-request lookup to re-decide it.
+  // Safe to short-circuit on because the flag is per pull request: a delivery
+  // that opens a fresh one hands the budget back, so this cannot outlive the
+  // checks that spent it the way it used to.
+  if (spent && state.ciBudgetReported) {
+    return { state, halt: skip(state, `${reason} Already reported.`), answer: false }
+  }
+
+  const settled = await settledPullRequest(input)
+  if (settled !== null) return settled
+
+  if (!spent) return enterCiFix(input)
+
+  const marked = markCiBudgetReported(state)
+  deps.log.warn({ issue: state.issueId, ciAttempts: state.ciAttempts }, 'CI-fix budget spent')
+  await postAndAppend(thread, input, renderCiExhausted(reason, state.prUrl), marked)
+
+  // `reported: true` is about this run's comment, not about `ciBudgetReported`
+  // — the two happen to coincide here, and stay separate everywhere else.
+  return { state: marked, halt: { status: 'failed', reason, state: marked, reported: true }, answer: false }
+}
+
+/**
+ * Drops a red run in a phase the transition table does not admit `CI_FAILED`
+ * from — before the pull-request lookup, because no answer it could give would
+ * change this.
+ *
+ * Asked of `canTransition` rather than of a second list of phases here, so the
+ * set cannot drift from the table that enforces it; the table itself carries the
+ * reasoning for which phases are in and which are out.
+ *
+ * Logged at `warn`, matching `refuseCommand` and `refuseExhausted` next door,
+ * because this used to be the quietest path in the pipeline: the refusal fell
+ * out of `moveOrSkip` as an ordinary skip whose only trace was a `reason` string
+ * nobody reads, so a red run in `PR_DELIVERY` or `FAILED` left no record
+ * anywhere at all. It stays a `log` and not a comment for the reason
+ * {@link settledPullRequest} sets out at length — CI fires on every push and
+ * re-run, and a comment per red run is spam — and here that argument is
+ * stronger, not weaker: the phases that refuse are the ones where either
+ * nothing is pushed yet or the issue is already parked under a failure comment
+ * telling the maintainer what to do.
+ */
+const refuseUnfixablePhase = (input: PhaseInput): TriggerOutcome | null => {
+  const { state, deps } = input
+  if (canTransition(state.phase, 'CI_FAILED')) return null
+
+  deps.log.warn({ issue: state.issueId, phase: state.phase }, 'Refused a red CI run')
+
+  return { state, halt: skip(state, `A red CI run is not actionable in ${state.phase}`), answer: false }
+}
+
+/**
+ * Applies the move the phase gate has already proved legal.
+ *
+ * No `try`/`catch` around the `transition`, unlike `moveOrSkip` in
+ * `triggers.ts`: {@link refuseUnfixablePhase} asked the same table this call
+ * consults, so a throw here would mean the two disagree, and swallowing that
+ * into a silent skip is what hid the missing `PR_DELIVERY` row in the first
+ * place.
+ */
+const enterCiFix = (input: PhaseInput): TriggerOutcome => {
+  const { state, deps } = input
+  const next = transition(state, 'CI_FAILED')
+  deps.log.info({ source: 'a red CI run', from: state.phase, to: next.phase }, 'Applied trigger')
+
+  return { state: next, halt: null, answer: false }
+}
+
+/**
+ * Drops a red run whose pull request is no longer live.
+ *
+ * A merged branch's checks keep firing — a later push, a re-run, a flake — and
+ * a fix round buys nothing: its commits land on a branch nobody will merge
+ * again. A closed-unmerged one is the same with a maintainer's decision on top,
+ * and no pull request at all leaves a fix with nowhere to go. None of the three
+ * should spend a CI-fix attempt, and the delivery phase already refuses to open
+ * a replacement for any of them.
+ *
+ * Deliberately silent, unlike the spent-budget notice above. That one breaks
+ * silence because a maintainer is waiting on work that has stopped; here the
+ * work has landed or been rejected, the issue is already `COMPLETE`, and CI
+ * fires on every push — so a comment per red run would be pure spam.
+ */
+const settledPullRequest = async (input: PhaseInput): Promise<TriggerOutcome | null> => {
+  const { state, deps } = input
+
+  const pr = await deps.github.findPullRequest(branchNameFor(state.issueId))
+  if (pr !== null && pr.state === 'open') return null
+
+  const reason =
+    pr === null
+      ? 'The branch has no pull request, so a CI fix has nowhere to go'
+      : `Pull request #${pr.number} is ${pr.state}, so there is nothing left to fix`
+  deps.log.info({ issue: state.issueId, pr: pr?.number, prState: pr?.state }, 'Red run on a settled pull request')
+
+  return { state, halt: skip(state, reason), answer: false }
+}

--- a/opencode-agent/src/deps.ts
+++ b/opencode-agent/src/deps.ts
@@ -115,9 +115,7 @@ export const assembleDeps = ({ config, secrets, event, env, run, log, agent, fet
     baseBranch: memoize(() =>
       resolveBaseBranch(env, { fromEvent: event.defaultBranch, fromGit: () => git.defaultBranch() }),
     ),
-    selfLogin: memoize(() =>
-      resolveSelfLogin({ override: config.selfLoginOverride, api: github, owner: config.owner, log }),
-    ),
+    selfLogin: memoize(() => resolveSelfLogin({ override: config.selfLoginOverride, api: github, log })),
     config,
     log,
   }

--- a/opencode-agent/src/identity.ts
+++ b/opencode-agent/src/identity.ts
@@ -12,10 +12,19 @@ export interface SelfLoginSources {
   override: string | null
   /** Who the API says this token is. */
   api: GitHubApi
-  /** Last resort, and the pipeline's original behaviour. */
-  owner: string
   log: Logger
 }
+
+/**
+ * The account the Actions runtime's own `GITHUB_TOKEN` posts as.
+ *
+ * The last-resort guess, and deliberately not the repository owner. This branch
+ * is only ever reached when the token cannot read `/user`, which means it is an
+ * installation token — whose author is always some `<app-slug>[bot]` and never
+ * a human. The owner therefore had no chance of being right, while this is
+ * exactly right for the token the workflow uses by default.
+ */
+export const DEFAULT_BOT_LOGIN = 'github-actions[bot]'
 
 /**
  * Works out which login the pipeline should treat as its own.
@@ -28,23 +37,27 @@ export interface SelfLoginSources {
  * behaviour whenever the agent posts as anything else — which, for the GitHub
  * App token the README recommends, is always.
  *
- * The order is override, then the token's own identity, then the owner:
+ * The order is override, then the token's own identity, then a bot login:
  *
  * 1. An explicit `AGENT_SELF_LOGIN` always wins. An operator who knows the
  *    answer should not be second-guessed, and it is the escape hatch for every
- *    case below.
+ *    case below. Because it wins outright, the caller must pass it through
+ *    *unset* when nobody pinned one — an override defaulted upstream to
+ *    something plausible is the exact failure this ladder exists to prevent,
+ *    and it silences steps 2 and 3 along with their warning.
  * 2. Otherwise ask the API. For a personal access token this is exact.
- * 3. If that fails, fall back to the owner **and say so at `warn`**. A GitHub
- *    App installation token cannot read `/user` — the identity behind one is
- *    `<app-slug>[bot]`, which needs a JWT and a different endpoint — so this
- *    branch is the expected path for the token the workflow recommends, not an
- *    exotic error. The warning names `AGENT_SELF_LOGIN` because that is the fix.
+ * 3. If that fails, fall back to {@link DEFAULT_BOT_LOGIN} **and say so at
+ *    `warn`**. A GitHub App installation token cannot read `/user` — the
+ *    identity behind one is `<app-slug>[bot]`, which needs a JWT and a
+ *    different endpoint — so this branch is the expected path for an
+ *    Actions-issued token, not an exotic error. The warning names
+ *    `AGENT_SELF_LOGIN` because that is the fix for every other app slug.
  *
  * Deliberately shaped so correctness does not depend on knowing which token
  * types can answer: it asks, and falls back on any failure.
  */
 export const resolveSelfLogin = async (sources: SelfLoginSources): Promise<string> => {
-  const { override, owner, log } = sources
+  const { override, log } = sources
   if (override !== null && override.trim().length > 0) return override.trim()
 
   try {
@@ -55,10 +68,10 @@ export const resolveSelfLogin = async (sources: SelfLoginSources): Promise<strin
     return login
   } catch (error) {
     log.warn(
-      { owner, error: errorMessage(error) },
-      'Could not read the token identity; falling back to the repository owner. Set AGENT_SELF_LOGIN if the agent posts as anything else, or its own comments will be unreadable to it.',
+      { fallback: DEFAULT_BOT_LOGIN, error: errorMessage(error) },
+      `Could not read the token identity; assuming ${DEFAULT_BOT_LOGIN}. Set AGENT_SELF_LOGIN if the agent posts as anything else, or its own comments will be unreadable to it.`,
     )
-    return owner
+    return DEFAULT_BOT_LOGIN
   }
 }
 

--- a/opencode-agent/src/index.ts
+++ b/opencode-agent/src/index.ts
@@ -25,6 +25,7 @@ import type { ProviderProxy } from './provider-proxy.js'
 import { pipelineSecrets, scrubSecrets } from './secrets.js'
 import { runCommand } from './shell.js'
 import type { CommandRunner } from './shell.js'
+import { recordReport } from './step-output.js'
 import { errorMessage } from './types.js'
 import type { RunResult } from './types.js'
 
@@ -214,7 +215,9 @@ export const runCli = async (options: MainOptions): Promise<RunResult> => {
   const event = parseTriggerEvent(args.eventName, payload)
   if (event === null) {
     log.warn({ eventName: args.eventName }, 'Payload carries nothing this pipeline acts on')
-    return { status: 'skipped', reason: 'Payload carries nothing to act on', state: null }
+    // No marker: nothing was posted, and nothing needs one — this exits 0, so
+    // the fallback step is out of scope either way.
+    return { status: 'skipped', reason: 'Payload carries nothing to act on', state: null, reported: false }
   }
 
   const { proxy, agent, deps } = contain({ config, event, log, run: options.run ?? runCommand, options })
@@ -228,6 +231,10 @@ export const runCli = async (options: MainOptions): Promise<RunResult> => {
     const result = await runPipeline({ event, deps })
     const phase = result.state === null ? null : result.state.phase
     log.info({ status: result.status, reason: result.reason, phase }, 'Pipeline finished')
+    // Only on the returning path. A `runPipeline` that throws is precisely the
+    // crash the fallback comment is for, and marking it here would silence the
+    // one comment the issue would otherwise get.
+    await recordReport(result, options.env, log)
     return result
   } finally {
     // Both hold listening sockets; without this the process stays alive after

--- a/opencode-agent/src/orchestrator.ts
+++ b/opencode-agent/src/orchestrator.ts
@@ -15,7 +15,7 @@ import { handlePlan } from './phases/plan.js'
 import { handleTriage } from './phases/triage.js'
 import { postAndAppend, renderAnswerFailure, renderFailure, renderSettled } from './run-report.js'
 import { findLatestState, initialState, transition } from './state-manager.js'
-import { stopIfOverBudget, totalTokens } from './token-budget.js'
+import { recordSpend, stopIfOverBudget } from './token-budget.js'
 import { applyTrigger } from './triggers.js'
 import { errorMessage } from './types.js'
 import type { AgentState, Phase, RunResult, TransitionSignal } from './types.js'
@@ -182,8 +182,7 @@ type HandlerAttempt = { ok: true; outcome: PhaseOutcome; next: AgentState } | { 
 const runHandler = async (handler: PhaseHandler, input: MachineInput): Promise<HandlerAttempt> => {
   try {
     const outcome = await handler(input)
-    const patch = { ...outcome.patch, tokensSpent: await totalTokens(input) }
-    return { ok: true, outcome, next: transition(input.state, outcome.signal, patch) }
+    return { ok: true, outcome, next: transition(input.state, outcome.signal, await recordSpend(input, outcome.patch)) }
   } catch (error) {
     return { ok: false, error }
   }
@@ -193,13 +192,20 @@ const runHandler = async (handler: PhaseHandler, input: MachineInput): Promise<H
  * Records the failure on the issue and parks the state in FAILED with
  * `resumeFrom` set, so `/retry` re-enters the exact phase that broke instead of
  * replaying the whole pipeline.
+ *
+ * Through `recordSpend`, exactly as the success path is. A failing phase spends
+ * what it spent — the model turn is paid for long before the parse that rejects
+ * its reply — and this used to write `lastError` and nothing else, so the tokens
+ * went unrecorded and the next runner read `0`. That is the one path the ceiling
+ * most needs to see: the state it parks in is `FAILED`, and `/retry` out of
+ * `FAILED` is how an issue comes back for another expensive round.
  */
 const failRun = async (input: MachineInput, error: unknown): Promise<RunResult> => {
   const { state, deps, thread } = input
   const message = errorMessage(error)
   deps.log.error({ issue: state.issueId, phase: state.phase, error: message }, 'Phase handler failed')
 
-  const failed = transition(state, 'FAILED', { lastError: message })
+  const failed = transition(state, 'FAILED', await recordSpend(input, { lastError: message }))
   await postAndAppend(thread, input, renderFailure(state.phase, message, failed, deps.config.maxAttempts), failed)
 
   return { status: 'failed', reason: message, state: failed }
@@ -223,13 +229,21 @@ const failRun = async (input: MachineInput, error: unknown): Promise<RunResult> 
  * the `/retry` the failure comment invited then resumed into a phase with no
  * handler and re-parked with "Parked in `DESIGN_SPEC`" — one attempt poorer for
  * a round trip that did nothing.
+ *
+ * Moving nothing is not the same as recording nothing, which is the distinction
+ * this path missed: it posted the restored state verbatim, so a question that
+ * reached the model and then failed on a deadline or a rejected request handed
+ * the next job a total with that turn missing from it. The spend is the one
+ * thing a failed answer really does change, and it is written the way every
+ * other state block writes it — see {@link recordSpend}.
  */
 const failAnswer = async (input: MachineInput, error: unknown): Promise<RunResult> => {
   const { state, deps, thread } = input
   const message = errorMessage(error)
   deps.log.error({ issue: state.issueId, phase: state.phase, error: message }, 'Answering a question failed')
 
-  await postAndAppend(thread, input, renderAnswerFailure(state.phase, message), state)
+  const carried = { ...state, ...(await recordSpend(input)) }
+  await postAndAppend(thread, input, renderAnswerFailure(state.phase, message), carried)
 
-  return { status: 'failed', reason: message, state }
+  return { status: 'failed', reason: message, state: carried }
 }

--- a/opencode-agent/src/orchestrator.ts
+++ b/opencode-agent/src/orchestrator.ts
@@ -58,7 +58,9 @@ export const runPipeline = async (options: RunOptions): Promise<RunResult> => {
   })
   if (!guard.allowed) {
     deps.log.warn({ code: guard.code, event: event.eventName }, 'Trigger rejected by guardrails')
-    return { status: 'skipped', reason: guard.reason, state: null }
+    // `reported: false` and it has to stay that way: a rejection here is
+    // deliberately silent, so the issue carries nothing about this run.
+    return { status: 'skipped', reason: guard.reason, state: null, reported: false }
   }
 
   const thread = await deps.github.listIssueComments(event.issueNumber)
@@ -141,7 +143,7 @@ const driveMachine = async (input: MachineInput): Promise<RunResult> => {
   const grown = await postAndAppend(thread, input, outcome.comment, next, outcome.blocks)
 
   if (PAUSE_SIGNALS.has(outcome.signal)) {
-    return { status: 'waiting', reason: `Waiting for a maintainer in ${next.phase}`, state: next }
+    return { status: 'waiting', reason: `Waiting for a maintainer in ${next.phase}`, state: next, reported: true }
   }
 
   return driveMachine({ ...input, answer: false, state: next, thread: grown, posted: true })
@@ -154,6 +156,10 @@ const driveMachine = async (input: MachineInput): Promise<RunResult> => {
  * ran to write it down — `/cancel` is the case that matters. A state that is
  * never posted never happened: the next event would restore the old phase and
  * the cancel would silently undo itself. So the terminal path posts too.
+ *
+ * Which is exactly why `reported` is unconditionally true here rather than
+ * `posted`: the branch that has not posted is the branch that posts, so both
+ * ways out of this function leave a comment on the issue.
  */
 const settle = async (input: MachineInput): Promise<RunResult> => {
   const { state, thread, posted } = input
@@ -161,8 +167,8 @@ const settle = async (input: MachineInput): Promise<RunResult> => {
   if (!posted) await postAndAppend(thread, input, renderSettled(state), state)
 
   return state.phase === 'COMPLETE'
-    ? { status: 'completed', reason: 'Pipeline finished', state }
-    : { status: 'waiting', reason: `Waiting for a maintainer in ${state.phase}`, state }
+    ? { status: 'completed', reason: 'Pipeline finished', state, reported: true }
+    : { status: 'waiting', reason: `Waiting for a maintainer in ${state.phase}`, state, reported: true }
 }
 
 type HandlerAttempt = { ok: true; outcome: PhaseOutcome; next: AgentState } | { ok: false; error: unknown }
@@ -208,7 +214,10 @@ const failRun = async (input: MachineInput, error: unknown): Promise<RunResult> 
   const failed = transition(state, 'FAILED', await recordSpend(input, { lastError: message }))
   await postAndAppend(thread, input, renderFailure(state.phase, message, failed, deps.config.maxAttempts), failed)
 
-  return { status: 'failed', reason: message, state: failed }
+  // The comment above is what the workflow's fallback step would otherwise
+  // duplicate, contradicting it: this run has moved the issue to `FAILED`, so
+  // "the issue state is unchanged" is false the moment `postAndAppend` returns.
+  return { status: 'failed', reason: message, state: failed, reported: true }
 }
 
 /**
@@ -245,5 +254,5 @@ const failAnswer = async (input: MachineInput, error: unknown): Promise<RunResul
   const carried = { ...state, ...(await recordSpend(input)) }
   await postAndAppend(thread, input, renderAnswerFailure(state.phase, message), carried)
 
-  return { status: 'failed', reason: message, state: carried }
+  return { status: 'failed', reason: message, state: carried, reported: true }
 }

--- a/opencode-agent/src/orchestrator.ts
+++ b/opencode-agent/src/orchestrator.ts
@@ -13,11 +13,18 @@ import { handleDeliver } from './phases/deliver.js'
 import { handleImplement } from './phases/implement.js'
 import { handlePlan } from './phases/plan.js'
 import { handleTriage } from './phases/triage.js'
-import { postAndAppend, renderExhausted, renderFailure, renderOverBudget, renderSettled } from './run-report.js'
+import {
+  postAndAppend,
+  renderAnswerFailure,
+  renderExhausted,
+  renderFailure,
+  renderOverBudget,
+  renderSettled,
+} from './run-report.js'
 import { findLatestState, initialState, transition } from './state-manager.js'
 import { applyTrigger } from './triggers.js'
 import { errorMessage } from './types.js'
-import type { Phase, RunResult, TransitionSignal } from './types.js'
+import type { AgentState, Phase, RunResult, TransitionSignal } from './types.js'
 
 /**
  * Phases the pipeline can act on unattended. A phase with no handler is a
@@ -123,13 +130,12 @@ const driveMachine = async (input: MachineInput): Promise<RunResult> => {
   if (spent >= deps.config.maxTokens) return overBudget(input, spent)
 
   const attempt = await runHandler(handler, input)
-  if (!attempt.ok) return failRun(input, attempt.error)
+  if (!attempt.ok) return input.answer ? failAnswer(input, attempt.error) : failRun(input, attempt.error)
 
-  const { signal, comment, blocks, patch } = attempt.outcome
-  const next = transition(state, signal, { ...patch, tokensSpent: await totalTokens(input) })
-  const grown = await postAndAppend(thread, input, comment, next, blocks)
+  const { outcome, next } = attempt
+  const grown = await postAndAppend(thread, input, outcome.comment, next, outcome.blocks)
 
-  if (PAUSE_SIGNALS.has(signal)) {
+  if (PAUSE_SIGNALS.has(outcome.signal)) {
     return { status: 'waiting', reason: `Waiting for a maintainer in ${next.phase}`, state: next }
   }
 
@@ -181,11 +187,25 @@ const overBudget = async (input: MachineInput, spent: number): Promise<RunResult
   return { status: 'failed', reason, state: { ...state, tokensSpent: spent } }
 }
 
-type HandlerAttempt = { ok: true; outcome: PhaseOutcome } | { ok: false; error: unknown }
+type HandlerAttempt = { ok: true; outcome: PhaseOutcome; next: AgentState } | { ok: false; error: unknown }
 
-const runHandler = async (handler: PhaseHandler, input: PhaseInput): Promise<HandlerAttempt> => {
+/**
+ * Runs one handler and applies its signal, both inside the same guard.
+ *
+ * The `transition` used to sit outside it, on the caller's happy path. A
+ * handler reporting a signal its phase does not accept therefore threw straight
+ * out of `driveMachine`, past `runPipeline` and `runCli`, and `main` printed a
+ * stack trace and exited 1 — with the model turn already paid for and not a
+ * word posted on the issue. That is how `/ask` failed outside the three phases
+ * whose transition rows happened to name `ANSWERED`. Inside the guard, any
+ * future handler/phase mismatch is reported on the issue like any other phase
+ * failure, which is the only place a maintainer will ever see it.
+ */
+const runHandler = async (handler: PhaseHandler, input: MachineInput): Promise<HandlerAttempt> => {
   try {
-    return { ok: true, outcome: await handler(input) }
+    const outcome = await handler(input)
+    const patch = { ...outcome.patch, tokensSpent: await totalTokens(input) }
+    return { ok: true, outcome, next: transition(input.state, outcome.signal, patch) }
   } catch (error) {
     return { ok: false, error }
   }
@@ -205,4 +225,33 @@ const failRun = async (input: MachineInput, error: unknown): Promise<RunResult> 
   await postAndAppend(thread, input, renderFailure(state.phase, message, failed, deps.config.maxAttempts), failed)
 
   return { status: 'failed', reason: message, state: failed }
+}
+
+/**
+ * Reports a failed answer without moving the machine, and without spending an
+ * attempt.
+ *
+ * A question is a side conversation about work that lives elsewhere: the phase
+ * records where the *work* is, so parking a delivered pull request or an
+ * in-flight implementation in FAILED because a model turn about it broke is a
+ * lie about what happened. In COMPLETE it was not even reachable — the FAILED
+ * guard in `canTransition` refuses that move — so {@link failRun}'s own
+ * `transition` threw and took the whole runner with it.
+ *
+ * The retry budget is left alone for the same reason: `attempts` counts
+ * consecutive failures to make progress on the issue, and a question makes
+ * none either way. Leaving `resumeFrom` alone is what makes the notice honest.
+ * Answering in a waiting phase used to record `resumeFrom: 'DESIGN_SPEC'`, and
+ * the `/retry` the failure comment invited then resumed into a phase with no
+ * handler and re-parked with "Parked in `DESIGN_SPEC`" — one attempt poorer for
+ * a round trip that did nothing.
+ */
+const failAnswer = async (input: MachineInput, error: unknown): Promise<RunResult> => {
+  const { state, deps, thread } = input
+  const message = errorMessage(error)
+  deps.log.error({ issue: state.issueId, phase: state.phase, error: message }, 'Answering a question failed')
+
+  await postAndAppend(thread, input, renderAnswerFailure(state.phase, message), state)
+
+  return { status: 'failed', reason: message, state }
 }

--- a/opencode-agent/src/orchestrator.ts
+++ b/opencode-agent/src/orchestrator.ts
@@ -6,15 +6,16 @@
 import { parseSlashCommand } from './commands.js'
 import { evaluateGuardrails } from './guardrails.js'
 import type { TriggerEvent } from './guardrails.js'
-import type { IssueContext, PhaseDeps, PhaseHandler, PhaseInput, PhaseOutcome } from './phase-context.js'
+import type { IssueContext, MachineInput, PhaseDeps, PhaseHandler, PhaseInput, PhaseOutcome } from './phase-context.js'
 import { handleAnswer } from './phases/answer.js'
 import { handleCiFix } from './phases/ci-fix.js'
 import { handleDeliver } from './phases/deliver.js'
 import { handleImplement } from './phases/implement.js'
 import { handlePlan } from './phases/plan.js'
 import { handleTriage } from './phases/triage.js'
-import { postAndAppend, renderAnswerFailure, renderFailure, renderOverBudget, renderSettled } from './run-report.js'
+import { postAndAppend, renderAnswerFailure, renderFailure, renderSettled } from './run-report.js'
 import { findLatestState, initialState, transition } from './state-manager.js'
+import { stopIfOverBudget, totalTokens } from './token-budget.js'
 import { applyTrigger } from './triggers.js'
 import { errorMessage } from './types.js'
 import type { AgentState, Phase, RunResult, TransitionSignal } from './types.js'
@@ -89,29 +90,22 @@ const resolveIssue = (event: TriggerEvent, deps: PhaseDeps): Promise<IssueContex
   return deps.github.getIssue(event.issueNumber)
 }
 
-interface MachineInput extends PhaseInput {
-  answer: boolean
-  /** Whether this run has already written a state block to the thread. */
-  posted: boolean
-  /** Tokens this issue had spent before this job started. */
-  carriedTokens: number
-}
-
-/** Everything this issue has spent, prior jobs included. */
-const totalTokens = async (input: MachineInput): Promise<number> =>
-  input.carriedTokens + (await input.deps.tokensUsed())
-
 /**
  * Runs handlers back-to-back. Recursion rather than a loop: each step's result
  * feeds the next call's state and thread, and the repo forbids awaiting inside
  * a loop body. The cascade ends at a phase with no handler.
  *
  * The **retry** budget is deliberately not checked here, unlike the token
- * budget below. It used to be, and being inside the cascade was the whole
- * problem: by this point `applyTrigger` has applied `RETRY`, which clears
- * `resumeFrom`, so the give-up notice posted the state that had already left
- * `FAILED` and stranded the issue in a handler phase nothing re-enters.
+ * budget in `token-budget.ts`. It used to be, and being inside the cascade was
+ * the whole problem: by this point `applyTrigger` has applied `RETRY`, which
+ * clears `resumeFrom`, so the give-up notice posted the state that had already
+ * left `FAILED` and stranded the issue in a handler phase nothing re-enters.
  * `refuseExhausted` in `triggers.ts` turns the signal down instead.
+ *
+ * The token budget answers the same invariant from the other end, because it
+ * cannot move to the trigger layer: half its firings are between two phases of
+ * one job, with no signal to refuse. It stays inside the cascade and parks the
+ * issue in `FAILED` with a resume point instead — see `stopIfOverBudget`.
  *
  * Not moved here, and not kept as a second check either, because there is
  * nothing left for one to catch. `attempts` only ever grows on a `FAILED`
@@ -128,18 +122,17 @@ const totalTokens = async (input: MachineInput): Promise<number> =>
  * holds — so one gate, in the layer that owns the decision, is the whole rule.
  */
 const driveMachine = async (input: MachineInput): Promise<RunResult> => {
-  const { deps, state, thread } = input
+  const { state, thread } = input
 
   const handler = input.answer ? handleAnswer : HANDLERS[state.phase]
   if (handler === undefined) return settle(input)
 
-  // Before the handler, not after: the point of a ceiling is to stop the next
-  // expensive thing, and checking afterwards would let every phase overspend
-  // once. Checked per phase rather than per prompt because a phase is the
-  // granularity at which spend is knowable — the review loop's subprocesses run
-  // in their own sessions, which this total cannot see.
-  const spent = await totalTokens(input)
-  if (spent >= deps.config.maxTokens) return overBudget(input, spent)
+  // Before the handler, and it is `token-budget.ts` that decides what "stop"
+  // means: over budget the run parks in FAILED naming this phase, so raising
+  // `AGENT_MAX_TOKENS` and replying `/retry` resumes exactly here. Stopping in
+  // place used to leave the issue in a phase no trigger re-enters.
+  const stopped = await stopIfOverBudget(input)
+  if (stopped !== null) return stopped
 
   const attempt = await runHandler(handler, input)
   if (!attempt.ok) return input.answer ? failAnswer(input, attempt.error) : failRun(input, attempt.error)
@@ -170,23 +163,6 @@ const settle = async (input: MachineInput): Promise<RunResult> => {
   return state.phase === 'COMPLETE'
     ? { status: 'completed', reason: 'Pipeline finished', state }
     : { status: 'waiting', reason: `Waiting for a maintainer in ${state.phase}`, state }
-}
-
-/**
- * Stops an issue that has spent its token budget.
- *
- * Shaped like `refuseExhausted` in `triggers.ts` — post on the issue, leave the
- * phase alone, and report a failed run — because a guardrail that stops in
- * silence reads as an agent that lost interest.
- */
-const overBudget = async (input: MachineInput, spent: number): Promise<RunResult> => {
-  const { state, deps, thread } = input
-  const reason = `Token budget spent (${spent} of ${deps.config.maxTokens} tokens for this issue)`
-  deps.log.warn({ issue: state.issueId, spent, limit: deps.config.maxTokens }, 'Stopping: token budget spent')
-
-  await postAndAppend(thread, input, renderOverBudget(spent, deps.config.maxTokens), { ...state, tokensSpent: spent })
-
-  return { status: 'failed', reason, state: { ...state, tokensSpent: spent } }
 }
 
 type HandlerAttempt = { ok: true; outcome: PhaseOutcome; next: AgentState } | { ok: false; error: unknown }

--- a/opencode-agent/src/orchestrator.ts
+++ b/opencode-agent/src/orchestrator.ts
@@ -13,14 +13,7 @@ import { handleDeliver } from './phases/deliver.js'
 import { handleImplement } from './phases/implement.js'
 import { handlePlan } from './phases/plan.js'
 import { handleTriage } from './phases/triage.js'
-import {
-  postAndAppend,
-  renderAnswerFailure,
-  renderExhausted,
-  renderFailure,
-  renderOverBudget,
-  renderSettled,
-} from './run-report.js'
+import { postAndAppend, renderAnswerFailure, renderFailure, renderOverBudget, renderSettled } from './run-report.js'
 import { findLatestState, initialState, transition } from './state-manager.js'
 import { applyTrigger } from './triggers.js'
 import { errorMessage } from './types.js'
@@ -112,14 +105,33 @@ const totalTokens = async (input: MachineInput): Promise<number> =>
  * Runs handlers back-to-back. Recursion rather than a loop: each step's result
  * feeds the next call's state and thread, and the repo forbids awaiting inside
  * a loop body. The cascade ends at a phase with no handler.
+ *
+ * The **retry** budget is deliberately not checked here, unlike the token
+ * budget below. It used to be, and being inside the cascade was the whole
+ * problem: by this point `applyTrigger` has applied `RETRY`, which clears
+ * `resumeFrom`, so the give-up notice posted the state that had already left
+ * `FAILED` and stranded the issue in a handler phase nothing re-enters.
+ * `refuseExhausted` in `triggers.ts` turns the signal down instead.
+ *
+ * Not moved here, and not kept as a second check either, because there is
+ * nothing left for one to catch. `attempts` only ever grows on a `FAILED`
+ * transition, every forward move resets it to 0, and `RETRY` — the single
+ * signal that carries a non-zero count into a phase with a handler — is now
+ * gated on the budget before it is applied, so no state this pipeline writes
+ * can reach a handler over the ceiling. A backstop would only fire on a
+ * hand-edited state block, and the one that stood here made that case worse
+ * rather than better: it posted the state unchanged, re-creating in
+ * `INIT_OR_CLARIFY` the same unreachable park it was meant to report, and it
+ * sat in front of the answer handler too, so `/ask` in `FAILED` past the budget
+ * replied "Giving up" instead of an answer. A hand-edited count cannot run away
+ * on its own — every failure still lands in `FAILED`, where the trigger gate
+ * holds — so one gate, in the layer that owns the decision, is the whole rule.
  */
 const driveMachine = async (input: MachineInput): Promise<RunResult> => {
   const { deps, state, thread } = input
 
   const handler = input.answer ? handleAnswer : HANDLERS[state.phase]
   if (handler === undefined) return settle(input)
-
-  if (state.attempts >= deps.config.maxAttempts) return exhausted(input)
 
   // Before the handler, not after: the point of a ceiling is to stop the next
   // expensive thing, and checking afterwards would let every phase overspend
@@ -160,22 +172,12 @@ const settle = async (input: MachineInput): Promise<RunResult> => {
     : { status: 'waiting', reason: `Waiting for a maintainer in ${state.phase}`, state }
 }
 
-/** Reports the retry budget on the issue instead of failing in silence. */
-const exhausted = async (input: MachineInput): Promise<RunResult> => {
-  const { state, deps, thread } = input
-  const reason = `Retry budget exhausted (${state.attempts} of ${deps.config.maxAttempts} attempts)`
-
-  await postAndAppend(thread, input, renderExhausted(reason), state)
-
-  return { status: 'failed', reason, state }
-}
-
 /**
  * Stops an issue that has spent its token budget.
  *
- * Shaped like {@link exhausted} — post on the issue, leave the phase alone, and
- * report a failed run — because a guardrail that stops in silence reads as an
- * agent that lost interest.
+ * Shaped like `refuseExhausted` in `triggers.ts` — post on the issue, leave the
+ * phase alone, and report a failed run — because a guardrail that stops in
+ * silence reads as an agent that lost interest.
  */
 const overBudget = async (input: MachineInput, spent: number): Promise<RunResult> => {
   const { state, deps, thread } = input

--- a/opencode-agent/src/phase-context.ts
+++ b/opencode-agent/src/phase-context.ts
@@ -75,6 +75,22 @@ export interface PhaseInput {
 }
 
 /**
+ * What the phase cascade carries on top of a handler's input.
+ *
+ * Here rather than in `orchestrator.ts`, where it began, because the cascade is
+ * no longer the only module that reasons over it: `token-budget.ts` decides
+ * whether the next phase can be afforded, and a shape shared by two modules in
+ * the file one of them owns is how an import cycle starts.
+ */
+export interface MachineInput extends PhaseInput {
+  answer: boolean
+  /** Whether this run has already written a state block to the thread. */
+  posted: boolean
+  /** Tokens this issue had spent before this job started. */
+  carriedTokens: number
+}
+
+/**
  * What a handler reports. The handler never writes state or decides the next
  * phase; the runner applies `signal` to the state machine and posts `comment`
  * with the resulting state block appended.

--- a/opencode-agent/src/phases/deliver.ts
+++ b/opencode-agent/src/phases/deliver.ts
@@ -7,6 +7,7 @@ import { findArtifact, REPORT_MARKER } from '../artifacts.js'
 import { branchNameFor } from '../git.js'
 import type { PullRequestPresentation, PullRequestRef, PullRequestStatus } from '../github.js'
 import type { PhaseHandler, PhaseInput, PhaseOutcome } from '../phase-context.js'
+import type { AgentState } from '../types.js'
 
 /**
  * Phase 4. Opens the pull request, refreshes the open one when a retry
@@ -42,9 +43,33 @@ export const handleDeliver: PhaseHandler = async (input): Promise<PhaseOutcome> 
   return {
     signal: 'PR_OPENED',
     comment: renderDelivery(pr, existing !== null),
-    patch: { prUrl: pr.url, prNumber: pr.number },
+    patch: { prUrl: pr.url, prNumber: pr.number, ...(existing === null ? FRESH_CI_BUDGET : {}) },
   }
 }
+
+/**
+ * The CI-fix budget, handed back to a pull request whose checks have not spent
+ * any of it.
+ *
+ * `ciAttempts` and `ciBudgetReported` count rounds against *a pull request*, not
+ * against the issue, and nothing used to reset either — `ciAttempts` was even
+ * documented as "Never reset". So an issue that burned its rounds on one pull
+ * request, said "I have stopped trying to fix CI", and then delivered a second
+ * one got no CI fixing at all on the new one, and said nothing about it either:
+ * `applyCiTrigger` short-circuits on `ciBudgetReported` before it even looks the
+ * pull request up, so the give-up notice could not repeat and no fix round could
+ * start. The remedy the notice suggests — push a fix yourself — is precisely
+ * what leads here, through a maintainer reopening the work and the pipeline
+ * delivering again.
+ *
+ * Applied on `existing === null` only, which is this phase's own distinction
+ * between opening a pull request and refreshing one. A refreshed pull request is
+ * the same pull request whose checks spent the budget, on the same branch and
+ * the same commits; handing it a clean slate would let one red branch bounce off
+ * the agent for as long as anyone keeps replying `/retry`, which is the runaway
+ * `AGENT_MAX_CI_ATTEMPTS` exists to bound.
+ */
+const FRESH_CI_BUDGET: Partial<AgentState> = { ciAttempts: 0, ciBudgetReported: false }
 
 /**
  * Ends delivery when the branch's pull request is no longer live.

--- a/opencode-agent/src/phases/implement.ts
+++ b/opencode-agent/src/phases/implement.ts
@@ -11,6 +11,7 @@ import { composeSystemPrompt } from '../obra-skills.js'
 import type { PhaseHandler, PhaseOutcome } from '../phase-context.js'
 import { buildImplementPrompt } from '../prompts.js'
 import type { ReviewOutcome, ReviewRunResult } from '../review-runner.js'
+import type { AgentState } from '../types.js'
 import { mintEnvelope } from './envelope.js'
 
 const IMPLEMENT_INSTRUCTIONS = [
@@ -65,12 +66,24 @@ export const handleImplement: PhaseHandler = async (input): Promise<PhaseOutcome
   deps.log.info({ issue: state.issueId, branch, review: review.outcome }, 'Implementation pushed')
 
   const report = renderReport(review)
-  return {
-    signal: 'CHANGES_COMMITTED',
-    comment: report,
-    blocks: [renderArtifact(REPORT_MARKER, report, state.revision)],
-  }
+  return { signal: 'CHANGES_COMMITTED', comment: report, blocks: [reportBlock(report, state)] }
 }
+
+/**
+ * The implementation report, stamped with the plan revision it implemented.
+ *
+ * Provenance rather than a revision of the report itself: nothing bumps a report
+ * counter — `CHANGES_COMMITTED` is not one of the artefact signals — so a second
+ * run over the same plan writes the same number, and what the figure answers is
+ * "was this report built from the plan currently on the issue?".
+ *
+ * It reads `planRevision` and not `specRevision` because that is what the one
+ * shared counter held here too: the plan is the last artefact posted before this
+ * phase, so the shared value had just been bumped to the plan's own heading
+ * number. The same figure, now by construction rather than by coincidence.
+ */
+const reportBlock = (report: string, state: AgentState): string =>
+  renderArtifact(REPORT_MARKER, report, state.planRevision)
 
 const implementMessage = (issueNumber: number): string =>
   `feat(agent): implement issue #${issueNumber}\n\nRefs #${issueNumber}`

--- a/opencode-agent/src/phases/plan.ts
+++ b/opencode-agent/src/phases/plan.ts
@@ -74,10 +74,14 @@ export const handlePlan: PhaseHandler = async (input): Promise<PhaseOutcome> => 
   await deps.git.ensureBranch(branch, await deps.baseBranch())
 
   const markdown = renderPlanMarkdown(plan)
+  // Counted over plans alone, and one local feeds both the heading and the
+  // block so the two cannot disagree. `PLAN_POSTED` bumps `planRevision` to
+  // exactly this value; revising the spec never moves it.
+  const revision = state.planRevision + 1
   return {
     signal: 'PLAN_POSTED',
-    comment: renderPlanComment(markdown, branch, state.revision + 1),
-    blocks: [renderArtifact(PLAN_MARKER, markdown, state.revision + 1)],
+    comment: renderPlanComment(markdown, branch, revision),
+    blocks: [renderArtifact(PLAN_MARKER, markdown, revision)],
   }
 }
 

--- a/opencode-agent/src/phases/triage.ts
+++ b/opencode-agent/src/phases/triage.ts
@@ -57,10 +57,16 @@ export const handleTriage: PhaseHandler = async (input): Promise<PhaseOutcome> =
     return { signal: 'NEEDS_CLARIFICATION', comment: renderQuestions(decision.questions) }
   }
 
+  // One local feeds both the visible heading and the hidden block, so the number
+  // a maintainer reads and the number the next job reads back cannot drift
+  // apart. `SPEC_POSTED` bumps `specRevision` to exactly this value, and counts
+  // only specs — the shared counter it replaced had the first plan on a fresh
+  // issue call itself revision 2.
+  const revision = state.specRevision + 1
   return {
     signal: 'SPEC_POSTED',
-    comment: renderSpec(decision.spec, state.revision + 1),
-    blocks: [renderArtifact(SPEC_MARKER, decision.spec, state.revision + 1)],
+    comment: renderSpec(decision.spec, revision),
+    blocks: [renderArtifact(SPEC_MARKER, decision.spec, revision)],
   }
 }
 

--- a/opencode-agent/src/prompts.ts
+++ b/opencode-agent/src/prompts.ts
@@ -7,6 +7,7 @@ import type { IssueComment } from './blocks.js'
 import { clipTail } from './check-loop.js'
 import type { CheckFailure } from './check-loop.js'
 import { CHECK_OUTPUT_BUDGET, renderThread, shareBudget } from './prompt-budget.js'
+import type { Phase } from './types.js'
 
 /**
  * Per-run envelope for text the pipeline did not write.
@@ -203,9 +204,40 @@ export const CLASSIFY_INSTRUCTIONS = [
   'When the comment is ambiguous, answer "question": answering costs one reply, whereas re-planning discards approved work.',
 ].join('\n')
 
-export const buildClassifyPrompt = (envelope: UntrustedEnvelope, comment: string, phase: string): string =>
-  [
+/**
+ * What being parked in a phase means for reading a comment that arrives in it.
+ *
+ * The phase name on its own is a label whose meaning the model has to guess, and
+ * `INIT_OR_CLARIFY` is where the guess costs the most: the agent has asked
+ * clarifying questions, so the next comment is usually an *answer* to them —
+ * often a bare fragment ("the HTTP client") that reads like chatter to anyone
+ * who has not matched it against the question it replies to. `applyClarifyIntent`
+ * acts on `none` and on nothing else, so a `none` reached by mistake is the one
+ * misread that can drop a maintainer's answer on the floor; every other verdict
+ * re-runs triage regardless. This brief exists to make that single verdict
+ * harder to reach by accident, not to steer the other three.
+ *
+ * The waiting phases get no brief. Their default is the opposite one — anything
+ * unclear is answered — so nothing there turns on the model knowing what the
+ * phase means, and a brief would only be prompt weight per classification.
+ */
+const CLASSIFY_PHASE_BRIEFS: Partial<Record<Phase, string>> = {
+  INIT_OR_CLARIFY: [
+    'The agent has asked this maintainer clarifying questions and is waiting for the answers,',
+    'so a comment here is most likely one of those answers — however short it is, and even when',
+    'it quotes no question and reads as a fragment rather than a sentence.',
+    'Answer "none" only for a comment that tells the agent nothing it could act on at all:',
+    'thanks, an acknowledgement, an emoji, or an aside between maintainers about something else.',
+  ].join('\n'),
+}
+
+export const buildClassifyPrompt = (envelope: UntrustedEnvelope, comment: string, phase: Phase): string => {
+  const brief = CLASSIFY_PHASE_BRIEFS[phase]
+
+  return [
     `The task is currently parked in phase ${phase}, waiting on a maintainer.`,
+    ...(brief === undefined ? [] : [brief]),
     'Classify this comment:',
     envelope.wrap('maintainer-comment', comment),
   ].join('\n\n')
+}

--- a/opencode-agent/src/run-report.ts
+++ b/opencode-agent/src/run-report.ts
@@ -124,6 +124,27 @@ export const renderFailure = (phase: Phase, message: string, next: AgentState, m
   ].join('\n')
 
 /**
+ * The reply to a question the agent could not answer.
+ *
+ * Separate from {@link renderFailure} because nothing failed *about the issue*:
+ * the phase has not moved, `resumeFrom` is untouched and no attempt was spent,
+ * so the wording has to say that rather than borrow the failure comment's. That
+ * comment invites `/retry`, which would be wrong here twice over — there is
+ * nothing parked in FAILED for it to resume, and back when a failed answer did
+ * park the state, the `/retry` it invited resumed into a waiting phase with no
+ * handler and re-parked with "Parked in `DESIGN_SPEC`", one attempt poorer.
+ */
+export const renderAnswerFailure = (phase: Phase, message: string): string =>
+  [
+    '### I could not answer that',
+    '',
+    // The message carries raw model output, which usually contains fences.
+    fence(message),
+    '',
+    `Nothing has changed: this issue is still in \`${phase}\`. Ask again, or carry on where you were.`,
+  ].join('\n')
+
+/**
  * The token-budget notice.
  *
  * Separate from {@link renderExhausted} because the remedy is different, and

--- a/opencode-agent/src/run-report.ts
+++ b/opencode-agent/src/run-report.ts
@@ -69,6 +69,29 @@ export const renderClosing = (state: AgentState): string =>
 export const renderSettled = (state: AgentState): string =>
   state.phase === 'COMPLETE' ? renderClosing(state) : `### Waiting\n\nParked in \`${state.phase}\`.`
 
+/**
+ * The reply to a slash command the current phase cannot accept.
+ *
+ * A maintainer typed something and is waiting for it to happen; skipping in
+ * silence leaves them watching an issue that will never move, with the reason
+ * buried in an Actions log nobody opens. That is how a mis-set
+ * `AGENT_SELF_LOGIN` stayed invisible: every `/changes` was refused against a
+ * freshly-restarted state and nothing was ever posted.
+ *
+ * The accepted list is derived from the transition table rather than written
+ * out here, so it cannot drift away from what the machine will actually take.
+ */
+export const renderRefusedCommand = (command: string, phase: Phase, accepted: readonly string[]): string =>
+  [
+    `### \`${command}\` does not apply right now`,
+    '',
+    `I am parked in \`${phase}\`, which does not accept it, so nothing has changed.`,
+    '',
+    accepted.length === 0
+      ? 'No command moves this issue on from here.'
+      : `What works here: ${accepted.map((name) => `\`${name}\``).join(', ')}.`,
+  ].join('\n')
+
 export const renderExhausted = (reason: string): string =>
   ['### Giving up', '', reason, '', 'Fix the underlying problem, then reply `/retry`.'].join('\n')
 

--- a/opencode-agent/src/run-report.ts
+++ b/opencode-agent/src/run-report.ts
@@ -92,8 +92,27 @@ export const renderRefusedCommand = (command: string, phase: Phase, accepted: re
       : `What works here: ${accepted.map((name) => `\`${name}\``).join(', ')}.`,
   ].join('\n')
 
+/**
+ * The retry-budget notice.
+ *
+ * It used to end "Fix the underlying problem, then reply `/retry`", advice the
+ * pipeline itself made impossible to follow: the budget is spent, so that
+ * `/retry` is refused and lands straight back on this comment. What is true is
+ * that the failure stays parked with its resume point intact, so raising the
+ * ceiling makes the very same `/retry` work — and that is what the notice
+ * offers, the way {@link renderOverBudget} names `AGENT_MAX_TOKENS` instead of
+ * inviting a retry that cannot help either.
+ */
 export const renderExhausted = (reason: string): string =>
-  ['### Giving up', '', reason, '', 'Fix the underlying problem, then reply `/retry`.'].join('\n')
+  [
+    '### Giving up',
+    '',
+    reason,
+    '',
+    'The failure is still parked with its resume point, so raising `AGENT_MAX_ATTEMPTS` in the workflow and ' +
+      'replying `/retry` picks it up from exactly where it broke.',
+    'Otherwise take it from here yourself, or reply `/cancel` to stop.',
+  ].join('\n')
 
 /**
  * The CI-fix equivalent, and the one that matters more.

--- a/opencode-agent/src/run-report.ts
+++ b/opencode-agent/src/run-report.ts
@@ -163,20 +163,60 @@ export const renderAnswerFailure = (phase: Phase, message: string): string =>
     `Nothing has changed: this issue is still in \`${phase}\`. Ask again, or carry on where you were.`,
   ].join('\n')
 
+/** Both token-budget notices open on the same fact, so they state it identically. */
+const tokenLine = (spent: number, limit: number): string =>
+  `This issue has used ${spent.toLocaleString('en-US')} model tokens of the ${limit.toLocaleString('en-US')} it is allowed.`
+
 /**
- * The token-budget notice.
+ * The token-budget notice, naming the phase the stop parked in.
  *
- * Separate from {@link renderExhausted} because the remedy is different, and
- * telling someone to reply `/retry` here would be a lie: the spend is persisted,
- * so a retry re-reads the same total and stops again immediately. The only ways
- * forward are a bigger budget or a fresh issue, and the notice says so.
+ * Every claim here has to survive the state block posted beside it, and this
+ * one did not. It read "raise `AGENT_MAX_TOKENS` in the workflow to continue"
+ * while the stop left the issue in the handler phase a trigger had just moved
+ * it into — a phase no event re-enters at any ceiling, so the advice led
+ * nowhere and `/cancel` was the only thing that still worked. Its other line,
+ * "so `/retry` will stop here again", was misleading in a second way: `/retry`
+ * was not being refused over tokens at all, it was refused because the phase
+ * was not `FAILED`.
+ *
+ * Now the stop parks in `FAILED` with a resume point, so the two commands the
+ * notice names really do compose: raise the ceiling, reply `/retry`, and
+ * `resumeFrom` runs. Naming the phase is not decoration — it tells a maintainer
+ * deciding whether to bother that the branch is already pushed and only
+ * delivery is left, or that nothing has been written yet.
+ *
+ * Still distinct from {@link renderExhausted}, which offers the same `/retry`
+ * against the other ceiling: getting the variable name wrong sends someone to
+ * raise a bound that was never the one that stopped them.
  */
-export const renderOverBudget = (spent: number, limit: number): string =>
+export const renderOverBudget = (spent: number, limit: number, resumeFrom: Phase): string =>
   [
     '### Token budget spent',
     '',
-    `This issue has used ${spent.toLocaleString('en-US')} model tokens of the ${limit.toLocaleString('en-US')} it is allowed.`,
+    tokenLine(spent, limit),
     '',
-    'The count carries across every job this issue has run, so `/retry` will stop here again.',
-    'Raise `AGENT_MAX_TOKENS` in the workflow to continue, or open a fresh issue for the remaining work.',
+    `I have parked this in \`FAILED\`, resuming from \`${resumeFrom}\`, so nothing already done is lost.`,
+    'The count carries across every job this issue has run, so a `/retry` on the same ceiling stops right back ' +
+      `here. Raise \`AGENT_MAX_TOKENS\` in the workflow **first**, then reply \`/retry\` and I pick \`${resumeFrom}\` ` +
+      'back up.',
+    'Otherwise open a fresh issue for the remaining work, or reply `/cancel` to stop.',
+  ].join('\n')
+
+/**
+ * The same budget, reported for a question rather than for the work.
+ *
+ * Separate from {@link renderOverBudget} for the reason {@link renderAnswerFailure}
+ * is separate from {@link renderFailure}: nothing was parked and nothing moved,
+ * so promising a `/retry` that resumes a phase would describe a state block
+ * that does not exist. What is true is narrower — the question was not put to
+ * the model, and asking it again under a bigger ceiling is the whole remedy.
+ */
+export const renderAnswerOverBudget = (spent: number, limit: number, phase: Phase): string =>
+  [
+    '### Token budget spent',
+    '',
+    `${tokenLine(spent, limit)} I did not put that question to the model.`,
+    '',
+    `Nothing has changed: this issue is still in \`${phase}\`. Raise \`AGENT_MAX_TOKENS\` in the workflow and ask ` +
+      'again.',
   ].join('\n')

--- a/opencode-agent/src/state-manager.ts
+++ b/opencode-agent/src/state-manager.ts
@@ -21,6 +21,47 @@ export const STATE_MARKER = 'AGENT_STATE'
  * `ANSWERED` is deliberately not in this table at all — see {@link transition}.
  * Every entry here names a phase the machine *moves to*; a signal that leaves
  * the phase alone has no business being expressed as a row per phase.
+ *
+ * `CI_FAILED` appears in exactly two rows, and the four absences are the
+ * decision rather than an oversight. A red run is worth acting on only where
+ * the branch is already pushed *and* no job of this pipeline is working it:
+ * `COMPLETE` is the ordinary case, and `PR_DELIVERY` is the genuine race.
+ * Phase 3 pushes the branch and posts a state block naming `PR_DELIVERY`
+ * before phase 4 opens the pull request, and a delivery that dies after the
+ * pull request exists leaves exactly that block behind — so the branch is live,
+ * the checks are red, and the row that used to be missing had `applyCiTrigger`
+ * refuse the run, post nothing and spend nothing. Silence is the failure mode
+ * the whole CI path is built around, so it was the wrong row to leave out.
+ *
+ * The four phases before the branch exists — `INIT_OR_CLARIFY`, `DESIGN_SPEC`,
+ * `EXECUTION_PLAN`, `PLAN_REVIEW` — have nothing pushed to repair, and
+ * `handleCiFix` would happily run the configured checks against a branch cut
+ * fresh from the base and commit the base's own failures onto the issue.
+ *
+ * `REVIEW_AND_MUTATE` and `CI_FIX` are out because the machine never persists
+ * them: a state block is written only when a handler posts, and both of those
+ * handlers post the phase they moved *to* (`PR_DELIVERY`, `COMPLETE`). A red
+ * run appearing to find one is reading a hand-edited block, and honouring it
+ * would put a second agent job on a branch another job is mid-commit on. The
+ * workflow's concurrency group (`opencode-agent-<branch>`,
+ * `cancel-in-progress: false`) does queue those two runs rather than overlap
+ * them — but it keys a CI run off `workflow_run.head_branch` and an issue run
+ * off `agent/issue-<n>`, so it holds only while those two strings agree, which
+ * is a narrow coincidence to hang a push race on rather than a proof.
+ *
+ * `FAILED` is deliberately absent and is the close call, because there the
+ * branch *is* pushed, a pull request may well be open, and its checks do go red
+ * with nobody acting. It stays out because `FAILED`'s entire content is a
+ * recorded pipeline failure plus the `resumeFrom` that undoes it, and
+ * `CI_FAILED` is a forward move: it would reset `attempts`, and it would leave
+ * `FAILED` for a phase where `/retry` is refused — `resumeFrom` survives the
+ * move but nothing can ever act on it again — so a fix that went green would
+ * land the issue in `COMPLETE`, announcing success for a pipeline that never
+ * finished delivering. Nor is this the silence the `PR_DELIVERY` row is about:
+ * a failed run has already posted "this failed, reply `/retry`", and that
+ * `/retry` resumes the phase that broke, delivers, and reaches `COMPLETE`,
+ * where the next red run is picked up as usual. The red checks are deferred
+ * behind a maintainer, not abandoned.
  */
 const TRANSITIONS: Record<Phase, Partial<Record<TransitionSignal, Phase>>> = {
   INIT_OR_CLARIFY: { NEEDS_CLARIFICATION: 'INIT_OR_CLARIFY', SPEC_POSTED: 'DESIGN_SPEC' },
@@ -28,7 +69,7 @@ const TRANSITIONS: Record<Phase, Partial<Record<TransitionSignal, Phase>>> = {
   EXECUTION_PLAN: { PLAN_POSTED: 'PLAN_REVIEW' },
   PLAN_REVIEW: { CHANGES_REQUESTED: 'EXECUTION_PLAN', APPROVED: 'REVIEW_AND_MUTATE' },
   REVIEW_AND_MUTATE: { CHANGES_COMMITTED: 'PR_DELIVERY' },
-  PR_DELIVERY: { PR_OPENED: 'COMPLETE' },
+  PR_DELIVERY: { PR_OPENED: 'COMPLETE', CI_FAILED: 'CI_FIX' },
   CI_FIX: { CI_FIXED: 'COMPLETE' },
   COMPLETE: { CI_FAILED: 'CI_FIX' },
   FAILED: {},

--- a/opencode-agent/src/state-manager.ts
+++ b/opencode-agent/src/state-manager.ts
@@ -75,9 +75,6 @@ const TRANSITIONS: Record<Phase, Partial<Record<TransitionSignal, Phase>>> = {
   FAILED: {},
 }
 
-/** Signals that produce a revised spec or plan, bumping the artefact revision. */
-const REVISION_SIGNALS: ReadonlySet<TransitionSignal> = new Set<TransitionSignal>(['SPEC_POSTED', 'PLAN_POSTED'])
-
 /** Fresh state for an issue the agent has not seen before. */
 export const initialState = (issueId: number): AgentState =>
   agentStateSchema.parse({ v: STATE_VERSION, phase: 'INIT_OR_CLARIFY', issueId })
@@ -145,6 +142,25 @@ const failTransition = (state: AgentState, patch: Partial<AgentState>): Partial<
   ...patch,
 })
 
+/**
+ * The artefact counter this move bumps, if it rewrites an artefact at all.
+ *
+ * Spec and plan are counted apart because the heading each handler renders reads
+ * as "the Nth version of *this* artefact" and cannot be read as anything else.
+ * One counter serving both had them interleave, so the first execution plan on
+ * every issue announced itself as revision 2 — and revision 3 if the spec had
+ * been revised once first.
+ *
+ * A branch per signal rather than a lookup table with a computed key: the two
+ * artefacts are the whole list, and naming the fields keeps a mistyped one a
+ * compile error rather than a counter that silently never moves.
+ */
+const revisionBump = (state: AgentState, signal: TransitionSignal): Partial<AgentState> => {
+  if (signal === 'SPEC_POSTED') return { specRevision: state.specRevision + 1 }
+  if (signal === 'PLAN_POSTED') return { planRevision: state.planRevision + 1 }
+  return {}
+}
+
 const forwardTransition = (
   state: AgentState,
   signal: TransitionSignal,
@@ -161,7 +177,7 @@ const forwardTransition = (
   // loop stays bounded, and `ANSWERED` clears it from its own branch below for
   // exactly the same reason.
   attempts: 0,
-  revision: REVISION_SIGNALS.has(signal) ? state.revision + 1 : state.revision,
+  ...revisionBump(state, signal),
   ciAttempts: signal === 'CI_FAILED' ? state.ciAttempts + 1 : state.ciAttempts,
   lastError: null,
   ...patch,
@@ -193,8 +209,9 @@ export const transition = (
   // Handled here rather than by adding a row to every phase because two sources
   // of truth for "stay put" is what let the table and `/ask`'s reach drift apart
   // in the first place. The patch reproduces what the old rows did: `attempts`
-  // cleared, because answering is a handler success; `revision` and `ciAttempts`
-  // untouched, because no artefact was rewritten and no CI round was spent.
+  // cleared, because answering is a handler success; the artefact revisions and
+  // `ciAttempts` untouched, because neither the spec nor the plan was rewritten
+  // and no CI round was spent.
   if (signal === 'ANSWERED') return applyPatch(state, { attempts: 0, lastError: null, ...patch })
 
   if (signal === 'FAILED') return applyPatch(state, failTransition(state, patch))

--- a/opencode-agent/src/state-manager.ts
+++ b/opencode-agent/src/state-manager.ts
@@ -17,12 +17,16 @@ export const STATE_MARKER = 'AGENT_STATE'
  * Where each signal leads. Signals absent from a phase's row are rejected, so a
  * command arriving in the wrong phase is a loud no-op rather than a silent
  * corruption of the persisted state.
+ *
+ * `ANSWERED` is deliberately not in this table at all — see {@link transition}.
+ * Every entry here names a phase the machine *moves to*; a signal that leaves
+ * the phase alone has no business being expressed as a row per phase.
  */
 const TRANSITIONS: Record<Phase, Partial<Record<TransitionSignal, Phase>>> = {
-  INIT_OR_CLARIFY: { NEEDS_CLARIFICATION: 'INIT_OR_CLARIFY', ANSWERED: 'INIT_OR_CLARIFY', SPEC_POSTED: 'DESIGN_SPEC' },
-  DESIGN_SPEC: { ANSWERED: 'DESIGN_SPEC', CHANGES_REQUESTED: 'INIT_OR_CLARIFY', APPROVED: 'EXECUTION_PLAN' },
+  INIT_OR_CLARIFY: { NEEDS_CLARIFICATION: 'INIT_OR_CLARIFY', SPEC_POSTED: 'DESIGN_SPEC' },
+  DESIGN_SPEC: { CHANGES_REQUESTED: 'INIT_OR_CLARIFY', APPROVED: 'EXECUTION_PLAN' },
   EXECUTION_PLAN: { PLAN_POSTED: 'PLAN_REVIEW' },
-  PLAN_REVIEW: { ANSWERED: 'PLAN_REVIEW', CHANGES_REQUESTED: 'EXECUTION_PLAN', APPROVED: 'REVIEW_AND_MUTATE' },
+  PLAN_REVIEW: { CHANGES_REQUESTED: 'EXECUTION_PLAN', APPROVED: 'REVIEW_AND_MUTATE' },
   REVIEW_AND_MUTATE: { CHANGES_COMMITTED: 'PR_DELIVERY' },
   PR_DELIVERY: { PR_OPENED: 'COMPLETE' },
   CI_FIX: { CI_FIXED: 'COMPLETE' },
@@ -87,6 +91,7 @@ const ownedBy =
 
 /** Whether `signal` is accepted in `phase`. */
 export const canTransition = (phase: Phase, signal: TransitionSignal): boolean => {
+  if (signal === 'ANSWERED') return true
   if (signal === 'FAILED' || signal === 'CANCELLED') return phase !== 'COMPLETE'
   if (signal === 'RETRY') return phase === 'FAILED'
   return TRANSITIONS[phase][signal] !== undefined
@@ -112,7 +117,8 @@ const forwardTransition = (
   // question are handler successes, so a conversation with the odd hiccup
   // accumulated toward the cap across runs that all succeeded. `RETRY` is the
   // deliberate exception and preserves the count in its own branch, so a retry
-  // loop stays bounded.
+  // loop stays bounded, and `ANSWERED` clears it from its own branch below for
+  // exactly the same reason.
   attempts: 0,
   revision: REVISION_SIGNALS.has(signal) ? state.revision + 1 : state.revision,
   ciAttempts: signal === 'CI_FAILED' ? state.ciAttempts + 1 : state.ciAttempts,
@@ -131,6 +137,24 @@ export const transition = (
   patch: Partial<AgentState> = {},
 ): AgentState => {
   if (!canTransition(state.phase, signal)) throw new InvalidTransitionError(state.phase, signal)
+
+  // Answering is phase-neutral: it is accepted everywhere and moves nothing.
+  //
+  // It used to be three self-referencing rows in TRANSITIONS — INIT_OR_CLARIFY,
+  // DESIGN_SPEC, PLAN_REVIEW — while `/ask` was accepted in every phase, so the
+  // two disagreed and the disagreement was fatal: a question asked in COMPLETE,
+  // FAILED, REVIEW_AND_MUTATE, PR_DELIVERY or CI_FIX paid for the model turn and
+  // then threw `InvalidTransitionError` out of the pipeline, which the runner
+  // printed as a stack trace while the issue heard nothing at all. FAILED was
+  // the worst of them, being exactly the state a maintainer asks "why did this
+  // fail?" in.
+  //
+  // Handled here rather than by adding a row to every phase because two sources
+  // of truth for "stay put" is what let the table and `/ask`'s reach drift apart
+  // in the first place. The patch reproduces what the old rows did: `attempts`
+  // cleared, because answering is a handler success; `revision` and `ciAttempts`
+  // untouched, because no artefact was rewritten and no CI round was spent.
+  if (signal === 'ANSWERED') return applyPatch(state, { attempts: 0, lastError: null, ...patch })
 
   if (signal === 'FAILED') return applyPatch(state, failTransition(state, patch))
   if (signal === 'CANCELLED') return applyPatch(state, { phase: 'COMPLETE', resumeFrom: null, ...patch })

--- a/opencode-agent/src/step-output.ts
+++ b/opencode-agent/src/step-output.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { appendFile } from 'node:fs/promises'
+
+import type { Logger } from './logger.js'
+import { errorMessage } from './types.js'
+import type { RunResult } from './types.js'
+
+/**
+ * The one thing this pipeline tells the rest of its own workflow.
+ *
+ * Its own file for the reason `run-report.ts` is: that module is what the run
+ * says to a maintainer, this is what it says to the next step of the job, and
+ * the two change for different reasons. `index.ts` wires and exits; it does not
+ * need to carry the Actions runner's file-command channel as well.
+ */
+
+/**
+ * The step output name the workflow's fallback failure comment is gated on.
+ *
+ * Exported so `tests/opencode-agent/workflow.test.ts` can assert the `if:`
+ * expression names the same key this writes, rather than the two agreeing by
+ * having been typed the same way twice.
+ */
+export const REPORTED_OUTPUT = 'reported'
+
+/**
+ * Tells the workflow that the issue already carries this run's report.
+ *
+ * The last step of `.github/workflows/agent-pipeline.yml` posts an "Agent job
+ * failed" comment under `if: failure()`, which selects every red job — and six
+ * pipeline paths exit 1 *after* posting their own report, so every genuine
+ * failure drew a second comment claiming the issue state was unchanged when it
+ * had just been moved to `FAILED`. Gating that step on this marker leaves it
+ * covering the case its wording describes and no other: a job that died before
+ * or during the run — install failure, runner timeout, cancelled job, a config
+ * error thrown before anything could be posted, a crash — with nothing on the
+ * issue at all.
+ *
+ * The marker survives the process exiting 1 because the runner does not read
+ * `$GITHUB_OUTPUT` from the step's exit code: `ActionRunner.RunAsync` calls
+ * `fileCommandManager.ProcessFiles` in a `finally` around the handler, so a
+ * failing step's file commands are processed exactly like a passing one's.
+ * Nothing is written when the run posted nothing, so an absent output reads as
+ * the empty string in the `if:` and the fallback fires.
+ *
+ * Writing is best-effort in both directions. `GITHUB_OUTPUT` is absent on a
+ * local `--event-path` run, which is a normal way to use this CLI and not a
+ * failure; and a write that does fail must not turn a run that already reported
+ * on the issue into a crash that reports nothing — the failure mode this whole
+ * marker exists to remove.
+ */
+export const recordReport = async (result: RunResult, env: NodeJS.ProcessEnv, log: Logger): Promise<void> => {
+  const outputPath = env['GITHUB_OUTPUT']
+  if (!result.reported || outputPath === undefined || outputPath.length === 0) return
+
+  await appendFile(outputPath, `${REPORTED_OUTPUT}=true\n`, 'utf8').catch((error: unknown) => {
+    log.warn({ error: errorMessage(error) }, 'Could not record that the pipeline reported on the issue')
+  })
+}

--- a/opencode-agent/src/token-budget.ts
+++ b/opencode-agent/src/token-budget.ts
@@ -3,10 +3,11 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import type { MachineInput } from './phase-context.js'
+import type { PipelineConfig } from './config.js'
+import type { MachineInput, PhaseDeps } from './phase-context.js'
 import { postAndAppend, renderAnswerOverBudget, renderOverBudget } from './run-report.js'
 import { transition } from './state-manager.js'
-import type { RunResult } from './types.js'
+import type { AgentState, RunResult } from './types.js'
 
 /**
  * The per-issue token ceiling: what an issue has spent, and how a run stops
@@ -19,9 +20,53 @@ import type { RunResult } from './types.js'
  * has to reason about a figure the running job did not produce.
  */
 
-/** Everything this issue has spent, prior jobs included. */
-export const totalTokens = async (input: MachineInput): Promise<number> =>
-  input.carriedTokens + (await input.deps.tokensUsed())
+/**
+ * Everything this issue has spent, prior jobs included.
+ *
+ * Takes the carried figure rather than reading it off the state, because the
+ * state moves under the run: `carriedTokens` is captured once from the *restored*
+ * block, since a job's session total is already cumulative across the phases it
+ * cascades through and adding it to each phase's own figure would count the
+ * earlier phases again. The trigger layer, which has no `MachineInput` and has
+ * opened no session yet, passes the restored figure directly.
+ */
+export const totalTokens = async (deps: PhaseDeps, carried: number): Promise<number> =>
+  carried + (await deps.tokensUsed())
+
+/**
+ * Whether an issue that has spent `spent` may still pay for a model turn.
+ *
+ * One comparison, in one place, because the boundary is exact: "spent 5,000,000
+ * of 5,000,000" is spent, and a `>` here would let every ceiling buy one more
+ * phase. Also asked from `triggers.ts`, which declines to pay for classifying a
+ * comment it could not afford to act on.
+ */
+export const withinBudget = (spent: number, config: PipelineConfig): boolean => spent < config.maxTokens
+
+/** The single field a state block records spend in, however the run ended. */
+const spendPatch = (spent: number, patch: Partial<AgentState>): Partial<AgentState> => ({
+  ...patch,
+  tokensSpent: spent,
+})
+
+/**
+ * That same patch for a caller that has not already measured — the three places
+ * `orchestrator.ts` writes a state block after a job has prompted the model.
+ *
+ * Shared because the paths silently disagreed for as long as they were written
+ * out separately: the success path patched `tokensSpent`, `failRun` transitioned
+ * to `FAILED` with only `lastError`, and `failAnswer` posted the restored state
+ * untouched. So a job whose session reported 250,000 tokens and whose handler
+ * then threw persisted `0`, and the ceiling was blind precisely where it was
+ * built to bite — the runaway it bounds is an issue bouncing through retries and
+ * CI-fix rounds, and retries *are* the failure path. An issue could spend the
+ * whole budget, fail, and hand the next runner a clean slate, round after round.
+ * The over-budget stops below never had the bug, having been written after it;
+ * they take the figure the check has already measured, so the notice and the
+ * block beside it cannot quote different totals.
+ */
+export const recordSpend = async (input: MachineInput, patch: Partial<AgentState> = {}): Promise<Partial<AgentState>> =>
+  spendPatch(await totalTokens(input.deps, input.carriedTokens), patch)
 
 /**
  * Stops a run that has spent its token budget, or `null` when it may carry on.
@@ -38,8 +83,8 @@ export const totalTokens = async (input: MachineInput): Promise<number> =>
 export const stopIfOverBudget = async (input: MachineInput): Promise<RunResult | null> => {
   const { state, deps } = input
 
-  const spent = await totalTokens(input)
-  if (spent < deps.config.maxTokens) return null
+  const spent = await totalTokens(deps, input.carriedTokens)
+  if (withinBudget(spent, deps.config)) return null
 
   const reason = `Token budget spent (${spent} of ${deps.config.maxTokens} tokens for this issue)`
   deps.log.warn(
@@ -85,7 +130,7 @@ export const stopIfOverBudget = async (input: MachineInput): Promise<RunResult |
 const parkOverBudget = async (input: MachineInput, spent: number, reason: string): Promise<RunResult> => {
   const { state, deps, thread } = input
 
-  const parked = transition(state, 'FAILED', { attempts: state.attempts, tokensSpent: spent, lastError: reason })
+  const parked = transition(state, 'FAILED', spendPatch(spent, { attempts: state.attempts, lastError: reason }))
   await postAndAppend(thread, input, renderOverBudget(spent, deps.config.maxTokens, state.phase), parked)
 
   return { status: 'failed', reason, state: parked }
@@ -111,7 +156,7 @@ const parkOverBudget = async (input: MachineInput, spent: number, reason: string
  */
 const answerOverBudget = async (input: MachineInput, spent: number, reason: string): Promise<RunResult> => {
   const { state, deps, thread } = input
-  const carried = { ...state, tokensSpent: spent }
+  const carried = { ...state, ...spendPatch(spent, {}) }
 
   await postAndAppend(thread, input, renderAnswerOverBudget(spent, deps.config.maxTokens, state.phase), carried)
 

--- a/opencode-agent/src/token-budget.ts
+++ b/opencode-agent/src/token-budget.ts
@@ -78,7 +78,12 @@ export const recordSpend = async (input: MachineInput, patch: Partial<AgentState
  * their own sessions, which this total cannot see.
  *
  * Both stops below post on the issue, because a guardrail that stops in silence
- * reads as an agent that lost interest.
+ * reads as an agent that lost interest — which is also why both report
+ * `reported: true`. They are `failed` runs, so the job goes red and the
+ * workflow's fallback step is in scope; without the marker it appended "The
+ * issue state is unchanged; reply `/retry` once the cause is addressed" under a
+ * notice that had just parked the issue in `FAILED` and asked for
+ * `AGENT_MAX_TOKENS` to be raised **first**.
  */
 export const stopIfOverBudget = async (input: MachineInput): Promise<RunResult | null> => {
   const { state, deps } = input
@@ -133,7 +138,7 @@ const parkOverBudget = async (input: MachineInput, spent: number, reason: string
   const parked = transition(state, 'FAILED', spendPatch(spent, { attempts: state.attempts, lastError: reason }))
   await postAndAppend(thread, input, renderOverBudget(spent, deps.config.maxTokens, state.phase), parked)
 
-  return { status: 'failed', reason, state: parked }
+  return { status: 'failed', reason, state: parked, reported: true }
 }
 
 /**
@@ -160,5 +165,5 @@ const answerOverBudget = async (input: MachineInput, spent: number, reason: stri
 
   await postAndAppend(thread, input, renderAnswerOverBudget(spent, deps.config.maxTokens, state.phase), carried)
 
-  return { status: 'failed', reason, state: carried }
+  return { status: 'failed', reason, state: carried, reported: true }
 }

--- a/opencode-agent/src/token-budget.ts
+++ b/opencode-agent/src/token-budget.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { MachineInput } from './phase-context.js'
+import { postAndAppend, renderAnswerOverBudget, renderOverBudget } from './run-report.js'
+import { transition } from './state-manager.js'
+import type { RunResult } from './types.js'
+
+/**
+ * The per-issue token ceiling: what an issue has spent, and how a run stops
+ * when it cannot afford the phase in front of it.
+ *
+ * Split out of `orchestrator.ts` the way `run-report.ts` and `triggers.ts` were,
+ * and for the same reason: that file drives the phase cascade, this one decides
+ * whether the cascade may take another step, and the two change for different
+ * reasons. It is also the only bound that spans jobs, so it is the only one that
+ * has to reason about a figure the running job did not produce.
+ */
+
+/** Everything this issue has spent, prior jobs included. */
+export const totalTokens = async (input: MachineInput): Promise<number> =>
+  input.carriedTokens + (await input.deps.tokensUsed())
+
+/**
+ * Stops a run that has spent its token budget, or `null` when it may carry on.
+ *
+ * Called before the handler, not after: the point of a ceiling is to stop the
+ * next expensive thing, and checking afterwards would let every phase overspend
+ * once. Checked per phase rather than per prompt because a phase is the
+ * granularity at which spend is knowable — the review loop's subprocesses run in
+ * their own sessions, which this total cannot see.
+ *
+ * Both stops below post on the issue, because a guardrail that stops in silence
+ * reads as an agent that lost interest.
+ */
+export const stopIfOverBudget = async (input: MachineInput): Promise<RunResult | null> => {
+  const { state, deps } = input
+
+  const spent = await totalTokens(input)
+  if (spent < deps.config.maxTokens) return null
+
+  const reason = `Token budget spent (${spent} of ${deps.config.maxTokens} tokens for this issue)`
+  deps.log.warn(
+    { issue: state.issueId, phase: state.phase, spent, limit: deps.config.maxTokens },
+    'Stopping: token budget spent',
+  )
+
+  return input.answer ? answerOverBudget(input, spent, reason) : parkOverBudget(input, spent, reason)
+}
+
+/**
+ * Parks the issue in `FAILED`, with the phase it refused to start as
+ * `resumeFrom`.
+ *
+ * It used to leave the phase alone, which is the shape `refuseExhausted` in
+ * `triggers.ts` takes for the retry budget — and here that shape strands the
+ * issue, because unlike a `/retry` this check is not standing in front of a
+ * trigger. Leaving the phase alone left it *in a handler phase*: `/approve`
+ * from `DESIGN_SPEC` had already moved the state to `EXECUTION_PLAN` by the time
+ * this stopped the run, and nothing can re-enter `EXECUTION_PLAN` — `/retry`
+ * needs `FAILED`, a plain comment needs a waiting phase — so `/cancel` was the
+ * only event left, under a notice pointing at `AGENT_MAX_TOKENS` as though
+ * raising it would help. It never could: no event re-enters that phase at any
+ * ceiling. Reachable on a first approval, with no failure anywhere in the story.
+ *
+ * A trigger-layer refusal, the answer the retry budget took, only covers half of
+ * it. This check has a second firing point with no trigger involved at all:
+ * mid-cascade, `REVIEW_AND_MUTATE` → `PR_DELIVERY` → `COMPLETE` inside one job,
+ * where the earlier phase rightly did its work and posted and the cascade stops
+ * before the next. The phase has legitimately advanced and there is no signal to
+ * turn down; only parking reaches that case. So the check stays where it is, and
+ * the *stop* is what carries the invariant.
+ *
+ * `FAILED` with a `resumeFrom` is not a new mechanism — it is exactly the one
+ * `failRun` already writes and `/retry` already resumes, which is what turns the
+ * notice's advice into something that works: raise `AGENT_MAX_TOKENS`, reply
+ * `/retry`, and the parked phase runs. `attempts` is carried over rather than
+ * incremented because running out of tokens is not a failed attempt at
+ * anything; letting it spend one would collide the two budgets, since the very
+ * `/retry` this notice asks for would then be turned down by the retry gate in
+ * `triggers.ts`, citing a ceiling the notice never mentioned.
+ */
+const parkOverBudget = async (input: MachineInput, spent: number, reason: string): Promise<RunResult> => {
+  const { state, deps, thread } = input
+
+  const parked = transition(state, 'FAILED', { attempts: state.attempts, tokensSpent: spent, lastError: reason })
+  await postAndAppend(thread, input, renderOverBudget(spent, deps.config.maxTokens, state.phase), parked)
+
+  return { status: 'failed', reason, state: parked }
+}
+
+/**
+ * The same stop for a question, which parks nothing.
+ *
+ * Separate for the reasons `failAnswer` is separate, and one more. A question is
+ * a side conversation about work that lives elsewhere: the phase records where
+ * the *work* is, so `FAILED` would be a lie about a delivered pull request whose
+ * maintainer only asked what changed. Worse, `resumeFrom` would then name the
+ * phase the question was asked in, and those are the waiting phases — a `/retry`
+ * into `DESIGN_SPEC` finds no handler and re-parks with "Parked in
+ * `DESIGN_SPEC`", the exact round trip that rule exists to prevent. In
+ * `COMPLETE` it would not even be reachable: that phase accepts no `FAILED`, so
+ * `transition` would throw out of the pipeline and take the runner with it,
+ * posting nothing at all.
+ *
+ * Nothing is stranded by leaving the phase alone here either, which is what lets
+ * the two paths differ: `/ask` moves no state, so the phase is still the one the
+ * trigger layer just accepted an event in.
+ */
+const answerOverBudget = async (input: MachineInput, spent: number, reason: string): Promise<RunResult> => {
+  const { state, deps, thread } = input
+  const carried = { ...state, tokensSpent: spent }
+
+  await postAndAppend(thread, input, renderAnswerOverBudget(spent, deps.config.maxTokens, state.phase), carried)
+
+  return { status: 'failed', reason, state: carried }
+}

--- a/opencode-agent/src/trigger-outcome.ts
+++ b/opencode-agent/src/trigger-outcome.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { AgentState, RunResult } from './types.js'
+
+/**
+ * What the trigger layer concluded, shared by `triggers.ts` and `ci-trigger.ts`.
+ *
+ * In its own module for the reason `MachineInput` is: two modules now decide
+ * trigger outcomes, and a shape owned by the file one of them lives in is how an
+ * import cycle starts.
+ */
+export interface TriggerOutcome {
+  state: AgentState
+  halt: RunResult | null
+  /** Set when the trigger should be handled as a question rather than a phase. */
+  answer: boolean
+}
+
+/**
+ * A trigger that moved nothing.
+ *
+ * `reported` defaults to false because nearly every skip in the trigger layer is
+ * deliberately silent — a red run on a settled pull request, a red run in a
+ * phase with no branch to fix, an empty comment, a classification of `none`, an
+ * already-reported CI budget. `refuseCommand` in `triggers.ts` is the one that
+ * answers on the issue first, and passes `true`.
+ *
+ * That distinction is worth carrying even though a skipped run exits 0 and so
+ * never reaches the workflow's fallback step. The flag means "this run posted",
+ * full stop; a path where a comment exists and the flag says otherwise is
+ * exactly the shape of the bug it was added to fix, and the next reader of the
+ * flag will not know to check whether the status happened to make it moot.
+ */
+export const skip = (state: AgentState, reason: string, reported = false): RunResult => ({
+  status: 'skipped',
+  reason,
+  state,
+  reported,
+})

--- a/opencode-agent/src/triggers.ts
+++ b/opencode-agent/src/triggers.ts
@@ -37,16 +37,20 @@ const COMMAND_SIGNALS: Record<string, TransitionSignal> = {
  * Turns the trigger into a state move.
  *
  * A red CI run enters `CI_FIX`. An explicit slash command wins outright. A
- * plain maintainer comment on a waiting phase is classified, because "review
- * and refine" is a conversation, not a command language — and the classifier
- * defaults to *question*, the only reading that cannot destroy approved work.
+ * plain maintainer comment is classified, because "review and refine" is a
+ * conversation, not a command language — but the two phases that classify want
+ * opposite defaults, so they read the same verdict through different branches.
+ * On a waiting phase, {@link applyIntent} defaults to *question*, the only
+ * reading that cannot destroy approved work. In `INIT_OR_CLARIFY` there is no
+ * approved work yet and the comment is probably an answer the agent asked for,
+ * so {@link applyClarifyIntent} defaults the other way — see there.
  */
 export const applyTrigger = (input: PhaseInput): Promise<TriggerOutcome> => {
   const { state, trigger, command } = input
 
   if (trigger.kind === 'ci') return applyCiTrigger(input)
   if (command !== null) return applyCommand(input, command)
-  if (state.phase === 'INIT_OR_CLARIFY') return Promise.resolve({ state, halt: null, answer: false })
+  if (state.phase === 'INIT_OR_CLARIFY') return applyClarifyIntent(input)
   if (!WAITING_PHASES.has(state.phase)) {
     return Promise.resolve({ state, halt: skip(state, `No actionable command while in ${state.phase}`), answer: false })
   }
@@ -87,8 +91,8 @@ const applyCommand = (input: PhaseInput, command: ParsedCommand): Promise<Trigge
  *
  * Only explicit commands come here. A classified plain comment cannot reach it
  * — `applyIntent` runs solely in the waiting phases, both of which accept both
- * of the signals it can produce — and the CI paths above have their own,
- * deliberately quieter, reporting.
+ * of the signals it can produce, and `applyClarifyIntent` produces no signal at
+ * all — and the CI paths above have their own, deliberately quieter, reporting.
  */
 const refuseCommand = async (input: PhaseInput, command: string, reason: string): Promise<TriggerOutcome> => {
   const { state, thread, deps } = input
@@ -190,6 +194,74 @@ const applyIntent = async (input: PhaseInput): Promise<TriggerOutcome> => {
 
   const signal: TransitionSignal = intent === 'approve' ? 'APPROVED' : 'CHANGES_REQUESTED'
   return moveOrSkip(state, signal, deps, `an implied ${intent}`)
+}
+
+/**
+ * Reads a plain comment that arrived while the agent is waiting for answers to
+ * its own clarifying questions, and lets through everything the classifier does
+ * not positively call chatter.
+ *
+ * This phase used to skip classification altogether and hand every comment
+ * straight to triage. That is a whole triage turn — the model re-reads the
+ * issue, the whole thread and the repository, then writes a fresh design spec or
+ * another round of questions — bought by a "thanks", a 👍, or one maintainer's
+ * aside to another while the agent waits. Cheap to say, expensive to answer.
+ *
+ * The fix cannot be to route this phase through {@link applyIntent}, because
+ * that function's default points the wrong way here. `classifyComment` resolves
+ * every failure and every ambiguity to `question`, chosen for the waiting phases
+ * where answering costs one reply while re-planning discards an approved
+ * artefact. There is no approved artefact in `INIT_OR_CLARIFY`, and the cost is
+ * reversed: a maintainer's answer misread as a question gets *answered* instead
+ * of acted on, so the agent replies about its own questions, stays parked, and
+ * the maintainer has to say the same thing a second time. So the default is
+ * inverted rather than borrowed — `none` is the only verdict that skips, and
+ * every other reading, including the one the classifier falls back to when it
+ * breaks, re-runs triage exactly as before.
+ *
+ * `question` is deliberately **not** admitted as a skip-to-answer, even though a
+ * maintainer really can ask "why do you need that?" mid-clarification. In this
+ * phase it is not a verdict: it is also the bucket a failed model call, an
+ * unparsable reply and a genuinely ambiguous comment all land in, so honouring
+ * it would route every one of those into an answer turn — precisely the stall
+ * above, on exactly the comments least able to survive it. `none` is the one
+ * reading the classifier has to actively choose, so `none` is the one that acts.
+ * The price of leaving `question` out is a wasted triage turn on a real
+ * mid-clarification question; the price of letting it in is a dropped answer,
+ * and only the first of those is recoverable without the maintainer noticing.
+ *
+ * Two comments never reach the classifier at all, and both fall through to
+ * triage rather than skipping. An **absent or blank** body is the
+ * `issues.opened` event that starts every issue — there is no comment to read,
+ * and skipping it would mean the agent never runs at all. **Over budget** is the
+ * rule {@link applyIntent} sets out at length: the classifier is the one turn
+ * whose spend can never be written down, so the ceiling has to stop it rather
+ * than count it. Falling through costs nothing, because the cascade's own stop
+ * fires before `handleTriage` and reports the ceiling on the issue — the same
+ * notice a maintainer would have got anyway, one model turn cheaper.
+ */
+const applyClarifyIntent = async (input: PhaseInput): Promise<TriggerOutcome> => {
+  const { state, trigger, deps } = input
+  const retriage: TriggerOutcome = { state, halt: null, answer: false }
+
+  const body = trigger.kind === 'issue' ? trigger.commentBody : null
+  if (body === null || body.trim().length === 0) return retriage
+
+  const spent = await totalTokens(deps, state.tokensSpent)
+  if (!withinBudget(spent, deps.config)) {
+    deps.log.warn(
+      { issue: state.issueId, phase: state.phase, spent, limit: deps.config.maxTokens },
+      'Over budget: not paying to classify a comment while clarifying',
+    )
+    return retriage
+  }
+
+  const intent = await classifyComment({ body, phase: state.phase, deps, state })
+  deps.log.info({ intent, phase: state.phase }, 'Classified a maintainer comment while clarifying')
+
+  if (intent !== 'none') return retriage
+
+  return { state, halt: skip(state, 'Comment needs no action'), answer: false }
 }
 
 const moveOrSkip = (state: AgentState, signal: TransitionSignal, deps: PhaseDeps, source: string): TriggerOutcome => {

--- a/opencode-agent/src/triggers.ts
+++ b/opencode-agent/src/triggers.ts
@@ -7,10 +7,10 @@ import type { ParsedCommand } from './commands.js'
 import { branchNameFor } from './git.js'
 import { classifyComment } from './intent.js'
 import type { PhaseDeps, PhaseInput } from './phase-context.js'
-import { postAndAppend, renderCiExhausted } from './run-report.js'
-import { markCiBudgetReported, transition } from './state-manager.js'
+import { postAndAppend, renderCiExhausted, renderRefusedCommand } from './run-report.js'
+import { canTransition, markCiBudgetReported, transition } from './state-manager.js'
 import { errorMessage, WAITING_PHASES } from './types.js'
-import type { AgentState, RunResult, TransitionSignal } from './types.js'
+import type { AgentState, Phase, RunResult, TransitionSignal } from './types.js'
 
 /**
  * Turning a trigger — a slash command, a plain comment, a red CI run — into the
@@ -45,10 +45,10 @@ const COMMAND_SIGNALS: Record<string, TransitionSignal> = {
  * defaults to *question*, the only reading that cannot destroy approved work.
  */
 export const applyTrigger = (input: PhaseInput): Promise<TriggerOutcome> => {
-  const { state, trigger, command, deps } = input
+  const { state, trigger, command } = input
 
   if (trigger.kind === 'ci') return applyCiTrigger(input)
-  if (command !== null) return Promise.resolve(applyCommand(state, command, deps))
+  if (command !== null) return applyCommand(input, command)
   if (state.phase === 'INIT_OR_CLARIFY') return Promise.resolve({ state, halt: null, answer: false })
   if (!WAITING_PHASES.has(state.phase)) {
     return Promise.resolve({ state, halt: skip(state, `No actionable command while in ${state.phase}`), answer: false })
@@ -120,13 +120,45 @@ const settledPullRequest = async (input: PhaseInput): Promise<TriggerOutcome | n
   return { state, halt: skip(state, reason), answer: false }
 }
 
-const applyCommand = (state: AgentState, command: ParsedCommand, deps: PhaseDeps): TriggerOutcome => {
-  if (command.command === '/ask') return { state, halt: null, answer: true }
+const applyCommand = (input: PhaseInput, command: ParsedCommand): Promise<TriggerOutcome> => {
+  const { state, deps } = input
+  // Always available: answering asks nothing of the state machine, so there is
+  // no phase in which it can be the wrong thing to do.
+  if (command.command === '/ask') return Promise.resolve({ state, halt: null, answer: true })
 
   const signal = COMMAND_SIGNALS[command.command]
-  if (signal === undefined) return { state, halt: skip(state, `Unknown command ${command.command}`), answer: false }
-  return moveOrSkip(state, signal, deps, command.command)
+  if (signal === undefined) return refuseCommand(input, command.command, `Unknown command ${command.command}`)
+
+  const outcome = moveOrSkip(state, signal, deps, command.command)
+  if (outcome.halt === null) return Promise.resolve(outcome)
+
+  return refuseCommand(input, command.command, outcome.halt.reason)
 }
+
+/**
+ * Answers a refused command on the issue, then skips.
+ *
+ * Only explicit commands come here. A classified plain comment cannot reach it
+ * — `applyIntent` runs solely in the waiting phases, both of which accept both
+ * of the signals it can produce — and the CI paths above have their own,
+ * deliberately quieter, reporting.
+ */
+const refuseCommand = async (input: PhaseInput, command: string, reason: string): Promise<TriggerOutcome> => {
+  const { state, thread, deps } = input
+  deps.log.warn({ issue: state.issueId, phase: state.phase, command }, 'Refused a slash command')
+
+  await postAndAppend(thread, input, renderRefusedCommand(command, state.phase, acceptedCommands(state.phase)), state)
+
+  return { state, halt: skip(state, reason), answer: false }
+}
+
+/** The commands `phase` would actually accept, straight from the transition table. */
+const acceptedCommands = (phase: Phase): readonly string[] => [
+  ...Object.entries(COMMAND_SIGNALS)
+    .filter(([, signal]) => canTransition(phase, signal))
+    .map(([command]) => command),
+  '/ask',
+]
 
 const applyIntent = async (input: PhaseInput): Promise<TriggerOutcome> => {
   const { state, trigger, deps } = input

--- a/opencode-agent/src/triggers.ts
+++ b/opencode-agent/src/triggers.ts
@@ -84,11 +84,13 @@ const applyCiTrigger = async (input: PhaseInput): Promise<TriggerOutcome> => {
 
   if (!spent) return moveOrSkip(state, 'CI_FAILED', deps, 'a red CI run')
 
-  const reported = markCiBudgetReported(state)
+  const marked = markCiBudgetReported(state)
   deps.log.warn({ issue: state.issueId, ciAttempts: state.ciAttempts }, 'CI-fix budget spent')
-  await postAndAppend(thread, input, renderCiExhausted(reason, state.prUrl), reported)
+  await postAndAppend(thread, input, renderCiExhausted(reason, state.prUrl), marked)
 
-  return { state: reported, halt: { status: 'failed', reason, state: reported }, answer: false }
+  // `reported: true` is about this run's comment, not about `ciBudgetReported`
+  // — the two happen to coincide here, and stay separate everywhere else.
+  return { state: marked, halt: { status: 'failed', reason, state: marked, reported: true }, answer: false }
 }
 
 /**
@@ -163,7 +165,7 @@ const refuseCommand = async (input: PhaseInput, command: string, reason: string)
 
   await postAndAppend(thread, input, renderRefusedCommand(command, state.phase, acceptedCommands(state.phase)), state)
 
-  return { state, halt: skip(state, reason), answer: false }
+  return { state, halt: skip(state, reason, true), answer: false }
 }
 
 /**
@@ -197,7 +199,7 @@ const refuseExhausted = async (input: PhaseInput): Promise<TriggerOutcome> => {
 
   await postAndAppend(thread, input, renderExhausted(reason), state)
 
-  return { state, halt: { status: 'failed', reason, state }, answer: false }
+  return { state, halt: { status: 'failed', reason, state, reported: true }, answer: false }
 }
 
 /** The commands `phase` would actually accept, straight from the transition table. */
@@ -273,4 +275,23 @@ const moveOrSkip = (state: AgentState, signal: TransitionSignal, deps: PhaseDeps
   }
 }
 
-const skip = (state: AgentState, reason: string): RunResult => ({ status: 'skipped', reason, state })
+/**
+ * A trigger that moved nothing.
+ *
+ * `reported` defaults to false because nearly every skip in this file is
+ * deliberately silent — a red run on a settled pull request, an empty comment, a
+ * classification of `none`, an already-reported CI budget. {@link refuseCommand}
+ * is the one that answers on the issue first, and passes `true`.
+ *
+ * That distinction is worth carrying even though a skipped run exits 0 and so
+ * never reaches the workflow's fallback step. The flag means "this run posted",
+ * full stop; a path where a comment exists and the flag says otherwise is
+ * exactly the shape of the bug it was added to fix, and the next reader of the
+ * flag will not know to check whether the status happened to make it moot.
+ */
+const skip = (state: AgentState, reason: string, reported = false): RunResult => ({
+  status: 'skipped',
+  reason,
+  state,
+  reported,
+})

--- a/opencode-agent/src/triggers.ts
+++ b/opencode-agent/src/triggers.ts
@@ -123,7 +123,12 @@ const settledPullRequest = async (input: PhaseInput): Promise<TriggerOutcome | n
 const applyCommand = (input: PhaseInput, command: ParsedCommand): Promise<TriggerOutcome> => {
   const { state, deps } = input
   // Always available: answering asks nothing of the state machine, so there is
-  // no phase in which it can be the wrong thing to do.
+  // no phase in which it can be the wrong thing to do. The machine now agrees —
+  // `ANSWERED` is a non-moving signal accepted in every phase. It did not use
+  // to: it lived in three rows of the transition table while this line let
+  // `/ask` through everywhere, so a question in COMPLETE, FAILED or any
+  // mid-pipeline phase paid for the model turn and then crashed the runner on
+  // an `InvalidTransitionError` nobody on the issue ever saw.
   if (command.command === '/ask') return Promise.resolve({ state, halt: null, answer: true })
 
   const signal = COMMAND_SIGNALS[command.command]

--- a/opencode-agent/src/triggers.ts
+++ b/opencode-agent/src/triggers.ts
@@ -7,7 +7,7 @@ import type { ParsedCommand } from './commands.js'
 import { branchNameFor } from './git.js'
 import { classifyComment } from './intent.js'
 import type { PhaseDeps, PhaseInput } from './phase-context.js'
-import { postAndAppend, renderCiExhausted, renderRefusedCommand } from './run-report.js'
+import { postAndAppend, renderCiExhausted, renderExhausted, renderRefusedCommand } from './run-report.js'
 import { canTransition, markCiBudgetReported, transition } from './state-manager.js'
 import { errorMessage, WAITING_PHASES } from './types.js'
 import type { AgentState, Phase, RunResult, TransitionSignal } from './types.js'
@@ -134,6 +134,14 @@ const applyCommand = (input: PhaseInput, command: ParsedCommand): Promise<Trigge
   const signal = COMMAND_SIGNALS[command.command]
   if (signal === undefined) return refuseCommand(input, command.command, `Unknown command ${command.command}`)
 
+  // Before the move, not after it — see `refuseExhausted` below. Asked of the
+  // transition table rather than of `state.phase` directly, so this cannot start
+  // answering for a `/retry` the phase was going to turn down anyway: a retry
+  // that does not apply here is a wrong-command refusal, not a spent budget.
+  if (signal === 'RETRY' && canTransition(state.phase, signal) && state.attempts >= deps.config.maxAttempts) {
+    return refuseExhausted(input)
+  }
+
   const outcome = moveOrSkip(state, signal, deps, command.command)
   if (outcome.halt === null) return Promise.resolve(outcome)
 
@@ -155,6 +163,40 @@ const refuseCommand = async (input: PhaseInput, command: string, reason: string)
   await postAndAppend(thread, input, renderRefusedCommand(command, state.phase, acceptedCommands(state.phase)), state)
 
   return { state, halt: skip(state, reason), answer: false }
+}
+
+/**
+ * Turns down a `/retry` the retry budget can no longer pay for, before the
+ * signal is applied.
+ *
+ * Before, because this is the last moment the state is still the one the
+ * maintainer is looking at. The ceiling used to be checked in `driveMachine`,
+ * one step too late: `applyTrigger` had already applied `RETRY`, which clears
+ * `resumeFrom` while carrying `attempts` across, so the give-up notice posted a
+ * state that had left `FAILED` for the handler phase it was resuming into.
+ * Nothing could re-enter that phase — `/retry` needs `FAILED` and a plain
+ * comment needs a waiting phase — so spending the budget parked the issue
+ * somewhere only `/cancel` reached, and the notice's own advice was guaranteed
+ * to be refused. Refusing here leaves `FAILED` and its `resumeFrom` untouched,
+ * which is what makes raising `AGENT_MAX_ATTEMPTS` and retrying a real remedy
+ * rather than a suggestion.
+ *
+ * Beside {@link refuseCommand} rather than inside it because the two say
+ * different things. That one lists the commands the phase does accept, which
+ * here would name `/retry` itself — the command being refused — and its "does
+ * not apply right now" is wrong twice over: the command applies perfectly, a
+ * bound was reached. So this one carries the give-up wording, logs a spent
+ * budget, and reports a `failed` run rather than a skipped one, exactly as the
+ * check it replaces did.
+ */
+const refuseExhausted = async (input: PhaseInput): Promise<TriggerOutcome> => {
+  const { state, thread, deps } = input
+  const reason = `Retry budget exhausted (${state.attempts} of ${deps.config.maxAttempts} attempts)`
+  deps.log.warn({ issue: state.issueId, attempts: state.attempts, resumeFrom: state.resumeFrom }, 'Retry budget spent')
+
+  await postAndAppend(thread, input, renderExhausted(reason), state)
+
+  return { state, halt: { status: 'failed', reason, state }, answer: false }
 }
 
 /** The commands `phase` would actually accept, straight from the transition table. */

--- a/opencode-agent/src/triggers.ts
+++ b/opencode-agent/src/triggers.ts
@@ -3,15 +3,17 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import { applyCiTrigger } from './ci-trigger.js'
 import type { ParsedCommand } from './commands.js'
-import { branchNameFor } from './git.js'
 import { classifyComment } from './intent.js'
 import type { PhaseDeps, PhaseInput } from './phase-context.js'
-import { postAndAppend, renderCiExhausted, renderExhausted, renderRefusedCommand } from './run-report.js'
-import { canTransition, markCiBudgetReported, transition } from './state-manager.js'
+import { postAndAppend, renderExhausted, renderRefusedCommand } from './run-report.js'
+import { canTransition, transition } from './state-manager.js'
 import { totalTokens, withinBudget } from './token-budget.js'
+import { skip } from './trigger-outcome.js'
+import type { TriggerOutcome } from './trigger-outcome.js'
 import { errorMessage, WAITING_PHASES } from './types.js'
-import type { AgentState, Phase, RunResult, TransitionSignal } from './types.js'
+import type { AgentState, Phase, TransitionSignal } from './types.js'
 
 /**
  * Turning a trigger — a slash command, a plain comment, a red CI run — into the
@@ -19,15 +21,9 @@ import type { AgentState, Phase, RunResult, TransitionSignal } from './types.js'
  *
  * Split out of `orchestrator.ts`, which now owns only the phase cascade. The two
  * answer different questions: this one decides *whether and where* to go, that
- * one drives the handlers once the decision is made.
+ * one drives the handlers once the decision is made. The CI half went the same
+ * way, into `ci-trigger.ts`, when this file reached the length limit.
  */
-
-export interface TriggerOutcome {
-  state: AgentState
-  halt: RunResult | null
-  /** Set when the trigger should be handled as a question rather than a phase. */
-  answer: boolean
-}
 
 /** Slash commands, mapped to the signal they inject before handlers run. */
 const COMMAND_SIGNALS: Record<string, TransitionSignal> = {
@@ -56,71 +52,6 @@ export const applyTrigger = (input: PhaseInput): Promise<TriggerOutcome> => {
   }
 
   return applyIntent(input)
-}
-
-/**
- * A red CI run either buys a fix attempt or, once the budget is spent, buys the
- * maintainer a notice — exactly once. Neither, if the pull request it would be
- * fixing is no longer live.
- *
- * Silence on a spent budget is the failure mode: CI events arrive on their own
- * schedule with nobody reading the Actions log, so an agent that quietly stops
- * fixing looks identical to one still working. Repeating the notice on every
- * later red run would be the opposite mistake, which is what `ciBudgetReported`
- * prevents.
- */
-const applyCiTrigger = async (input: PhaseInput): Promise<TriggerOutcome> => {
-  const { state, deps, thread } = input
-  const spent = state.ciAttempts >= deps.config.maxCiAttempts
-  const reason = `Spent the CI-fix budget (${state.ciAttempts} of ${deps.config.maxCiAttempts} attempts).`
-
-  // Decided already, so do not pay for a pull-request lookup to re-decide it.
-  if (spent && state.ciBudgetReported) {
-    return { state, halt: skip(state, `${reason} Already reported.`), answer: false }
-  }
-
-  const settled = await settledPullRequest(input)
-  if (settled !== null) return settled
-
-  if (!spent) return moveOrSkip(state, 'CI_FAILED', deps, 'a red CI run')
-
-  const marked = markCiBudgetReported(state)
-  deps.log.warn({ issue: state.issueId, ciAttempts: state.ciAttempts }, 'CI-fix budget spent')
-  await postAndAppend(thread, input, renderCiExhausted(reason, state.prUrl), marked)
-
-  // `reported: true` is about this run's comment, not about `ciBudgetReported`
-  // — the two happen to coincide here, and stay separate everywhere else.
-  return { state: marked, halt: { status: 'failed', reason, state: marked, reported: true }, answer: false }
-}
-
-/**
- * Drops a red run whose pull request is no longer live.
- *
- * A merged branch's checks keep firing — a later push, a re-run, a flake — and
- * a fix round buys nothing: its commits land on a branch nobody will merge
- * again. A closed-unmerged one is the same with a maintainer's decision on top,
- * and no pull request at all leaves a fix with nowhere to go. None of the three
- * should spend a CI-fix attempt, and the delivery phase already refuses to open
- * a replacement for any of them.
- *
- * Deliberately silent, unlike the spent-budget notice above. That one breaks
- * silence because a maintainer is waiting on work that has stopped; here the
- * work has landed or been rejected, the issue is already `COMPLETE`, and CI
- * fires on every push — so a comment per red run would be pure spam.
- */
-const settledPullRequest = async (input: PhaseInput): Promise<TriggerOutcome | null> => {
-  const { state, deps } = input
-
-  const pr = await deps.github.findPullRequest(branchNameFor(state.issueId))
-  if (pr !== null && pr.state === 'open') return null
-
-  const reason =
-    pr === null
-      ? 'The branch has no pull request, so a CI fix has nowhere to go'
-      : `Pull request #${pr.number} is ${pr.state}, so there is nothing left to fix`
-  deps.log.info({ issue: state.issueId, pr: pr?.number, prState: pr?.state }, 'Red run on a settled pull request')
-
-  return { state, halt: skip(state, reason), answer: false }
 }
 
 const applyCommand = (input: PhaseInput, command: ParsedCommand): Promise<TriggerOutcome> => {
@@ -274,24 +205,3 @@ const moveOrSkip = (state: AgentState, signal: TransitionSignal, deps: PhaseDeps
     }
   }
 }
-
-/**
- * A trigger that moved nothing.
- *
- * `reported` defaults to false because nearly every skip in this file is
- * deliberately silent — a red run on a settled pull request, an empty comment, a
- * classification of `none`, an already-reported CI budget. {@link refuseCommand}
- * is the one that answers on the issue first, and passes `true`.
- *
- * That distinction is worth carrying even though a skipped run exits 0 and so
- * never reaches the workflow's fallback step. The flag means "this run posted",
- * full stop; a path where a comment exists and the flag says otherwise is
- * exactly the shape of the bug it was added to fix, and the next reader of the
- * flag will not know to check whether the status happened to make it moot.
- */
-const skip = (state: AgentState, reason: string, reported = false): RunResult => ({
-  status: 'skipped',
-  reason,
-  state,
-  reported,
-})

--- a/opencode-agent/src/triggers.ts
+++ b/opencode-agent/src/triggers.ts
@@ -9,6 +9,7 @@ import { classifyComment } from './intent.js'
 import type { PhaseDeps, PhaseInput } from './phase-context.js'
 import { postAndAppend, renderCiExhausted, renderExhausted, renderRefusedCommand } from './run-report.js'
 import { canTransition, markCiBudgetReported, transition } from './state-manager.js'
+import { totalTokens, withinBudget } from './token-budget.js'
 import { errorMessage, WAITING_PHASES } from './types.js'
 import type { AgentState, Phase, RunResult, TransitionSignal } from './types.js'
 
@@ -207,11 +208,45 @@ const acceptedCommands = (phase: Phase): readonly string[] => [
   '/ask',
 ]
 
+/**
+ * Reads a plain comment as an intent, and decides first whether that reading is
+ * affordable.
+ *
+ * Classifying costs a model turn, and it is the one turn in the pipeline whose
+ * spend can never be written down. State is persisted only by posting a comment,
+ * and the `none` branch below deliberately posts nothing — replying to every
+ * "thanks!" would be spam — so a session that reported 40,000 tokens for the
+ * classification vanishes with the runner. The ceiling is therefore asked
+ * *before* the turn rather than after it: over budget there is nothing any
+ * classification could buy, since every branch here leads either to a handler or
+ * to the answer path and `stopIfOverBudget` refuses both. Handing the comment
+ * straight to the answer path lets that one check report it, in the wording it
+ * already has, without a second stop in this layer and without paying to learn
+ * what to say — otherwise a maxed-out issue keeps buying a classification per
+ * comment for as long as anyone keeps commenting on it.
+ *
+ * That leaves one leak, knowingly: a run **under** budget whose classifier
+ * answers `none` still spends a turn nothing records. Closing it needs a way to
+ * persist state without posting — an `updateComment` on the last state block —
+ * which is a larger design change than a stray few thousand tokens per no-op
+ * comment justifies. The bound it erodes is per issue and human-paced, and every
+ * other branch folds the classification in, because `deps.tokensUsed()` reports
+ * the whole job's session and whatever the run goes on to post writes that total.
+ */
 const applyIntent = async (input: PhaseInput): Promise<TriggerOutcome> => {
   const { state, trigger, deps } = input
   const body = trigger.kind === 'issue' ? trigger.commentBody : null
   if (body === null || body.trim().length === 0) {
     return { state, halt: skip(state, 'Empty comment'), answer: false }
+  }
+
+  const spent = await totalTokens(deps, state.tokensSpent)
+  if (!withinBudget(spent, deps.config)) {
+    deps.log.warn(
+      { issue: state.issueId, phase: state.phase, spent, limit: deps.config.maxTokens },
+      'Over budget: not paying to classify the comment',
+    )
+    return { state, halt: null, answer: true }
   }
 
   const intent = await classifyComment({ body, phase: state.phase, deps, state })

--- a/opencode-agent/src/types.ts
+++ b/opencode-agent/src/types.ts
@@ -79,11 +79,21 @@ export const agentStateSchema = z.object({
   resumeFrom: z.enum(PHASES).nullable().default(null),
   /** Consecutive failures. Cleared by any forward move; preserved across `/retry`. */
   attempts: z.number().int().min(0).default(0),
-  /** CI-fix rounds spent on the delivered pull request. Never reset. */
+  /**
+   * CI-fix rounds spent on the delivered pull request.
+   *
+   * Per pull request, not per issue: `handleDeliver` clears it — with
+   * `ciBudgetReported` — when it opens a **new** one, and leaves both alone when
+   * it refreshes the one already open. Nothing else resets it, so within a
+   * single pull request the count only climbs, which is what bounds an agent and
+   * CI bouncing off each other.
+   */
   ciAttempts: z.number().int().min(0).default(0),
   /**
-   * Whether the "I have stopped fixing CI" notice has been posted. CI events
-   * arrive on every push and re-run, so without this the notice repeats forever.
+   * Whether the "I have stopped fixing CI" notice has been posted for the
+   * current pull request. CI events arrive on every push and re-run, so without
+   * this the notice repeats forever; cleared alongside `ciAttempts` when a new
+   * pull request is opened, or the notice could never be said again for it.
    */
   ciBudgetReported: z.boolean().default(false),
   /** Bumped each time the spec or plan is revised, for the artefact blocks. */

--- a/opencode-agent/src/types.ts
+++ b/opencode-agent/src/types.ts
@@ -96,8 +96,29 @@ export const agentStateSchema = z.object({
    * pull request is opened, or the notice could never be said again for it.
    */
   ciBudgetReported: z.boolean().default(false),
-  /** Bumped each time the spec or plan is revised, for the artefact blocks. */
-  revision: z.number().int().min(0).default(0),
+  /**
+   * Revisions of the design spec and of the execution plan, counted apart.
+   *
+   * One shared counter used to serve both, bumped on `SPEC_POSTED` and on
+   * `PLAN_POSTED` alike while each handler rendered it into its own heading, so
+   * the two numbers interleaved. On an issue that ran straight through, the
+   * first spec a maintainer ever saw was "revision 1" and the first plan
+   * "revision 2"; revise the spec once beforehand and that same first plan was
+   * "revision 3". A revision number on a heading is read as "the Nth version of
+   * this artefact" — there is nothing else it could mean — so neither figure
+   * meant what it said.
+   *
+   * Both carry defaults, so a block written before the split still parses and
+   * needs no `STATE_VERSION` bump, which would strand every in-flight issue (see
+   * the README's migration note). The old `revision` key is dropped as an
+   * unknown one, exactly as `approved` and `updatedAt` were. The price is that
+   * an issue mid-conversation across the change restarts both counts at 1, and
+   * that is the deliberate choice: the number it was carrying is a sum of two
+   * artefacts' revisions and was never the count of either, so carrying it into
+   * one of the new fields would preserve nothing but the wrong answer.
+   */
+  specRevision: z.number().int().min(0).default(0),
+  planRevision: z.number().int().min(0).default(0),
   /**
    * Model tokens this issue has consumed, across every job it has run.
    *

--- a/opencode-agent/src/types.ts
+++ b/opencode-agent/src/types.ts
@@ -143,4 +143,32 @@ export interface RunResult {
   status: RunStatus
   reason: string
   state: AgentState | null
+  /**
+   * Whether this run has already said what happened on the issue itself.
+   *
+   * Not diagnostic — the workflow reads it. Its last step posts an "Agent job
+   * failed" comment under `if: failure()`, and `failure()` selects *every* red
+   * job, including the six paths that exit 1 only after posting their own
+   * report: `failRun`, `failAnswer`, both over-budget stops in
+   * `token-budget.ts`, `refuseExhausted` and the CI-budget notice in
+   * `triggers.ts`. So every genuine failure drew a second, contradicting
+   * comment — "The issue state is unchanged" beside a block that had just been
+   * moved to `FAILED` or parked with a resume point, and "reply `/retry`"
+   * beside a notice that had just explained why `/retry` is refused. Only the
+   * CI path escaped, by accident: `github.event.issue.number` is empty on a
+   * `workflow_run` event. `runCli` turns this flag into a `$GITHUB_OUTPUT`
+   * marker the fallback step is gated on, so it covers what its own wording
+   * claims and nothing else: a job that died with nothing on the issue at all.
+   *
+   * A field rather than something derived from `status` and `state`, because
+   * neither says it. `failed` covers both a reported failure and a crash;
+   * `skipped` covers both a silent guardrail rejection and a refused command
+   * that answered on the issue; and the state block rides on the same call that
+   * posts, so "the state moved" and "a comment exists" are one event seen from
+   * the side that cannot distinguish the paths that post from the ones that do
+   * not. Required rather than optional so a new terminal path has to decide,
+   * the way `SystemPromptInput.nonce` makes forgetting the envelope a type
+   * error.
+   */
+  reported: boolean
 }

--- a/tests/opencode-agent/cli.test.ts
+++ b/tests/opencode-agent/cli.test.ts
@@ -4,7 +4,7 @@
 // See LICENSE in the project root for details.
 
 import { afterAll, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
@@ -13,6 +13,7 @@ import { memoizeAgent, parseArgs, runCli, UsageError } from '../../opencode-agen
 import { createLogger } from '../../opencode-agent/src/logger.js'
 import type { OpenCodeAgent } from '../../opencode-agent/src/opencode-adapter.js'
 import type { CommandRunner } from '../../opencode-agent/src/shell.js'
+import { REPORTED_OUTPUT } from '../../opencode-agent/src/step-output.js'
 
 const workDir = await mkdtemp(path.join(tmpdir(), 'opencode-agent-cli-'))
 
@@ -194,6 +195,19 @@ const recordPosts = (thread: unknown): PostRecorder => {
   }
 }
 
+/**
+ * A fresh, empty `$GITHUB_OUTPUT`, and a reader for whatever the run appended.
+ *
+ * Empty rather than absent so the two marker tests differ only in the run, not
+ * in whether the file existed — an absent file would let a write that silently
+ * did nothing pass for a write that was correctly withheld.
+ */
+const outputFile = async (name: string): Promise<{ path: string; read: () => Promise<string> }> => {
+  const filePath = path.join(workDir, `${name}.output`)
+  await writeFile(filePath, '', 'utf8')
+  return { path: filePath, read: (): Promise<string> => readFile(filePath, 'utf8') }
+}
+
 describe('runCli', () => {
   const env = {
     GITHUB_REPOSITORY: 'acme/widgets',
@@ -292,6 +306,115 @@ describe('runCli', () => {
     // the hidden block republishes on every comment.
     expect(github.posted[0]).toContain('[redacted]')
     expect(github.posted[0]).not.toContain(token)
+  })
+
+  test('tells the workflow it has reported, when it posted the failure itself', async () => {
+    // The workflow's last step posts "The issue state is unchanged; reply
+    // `/retry` once the cause is addressed" under `if: failure()`, which selects
+    // every red job — including this one, which has just posted a give-up notice
+    // explaining that `/retry` is precisely what it will not accept. The marker
+    // is what keeps that step to the case its own wording describes.
+    //
+    // A spent retry budget is the failure path that needs no model: the run
+    // posts, halts `failed`, and `main` maps that to exit 1.
+    const output = await outputFile('reported')
+    const prior = [
+      {
+        id: 1,
+        user: { login: 'agent-bot' },
+        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({
+          v: 2,
+          phase: 'FAILED',
+          issueId: 42,
+          resumeFrom: 'EXECUTION_PLAN',
+          attempts: 3,
+        })} -->`,
+      },
+    ]
+    const eventPath = await writeEvent('reported', {
+      action: 'created',
+      sender: { login: 'maintainer', type: 'User' },
+      issue: { number: 42, title: 't', body: 'b', author_association: 'OWNER' },
+      comment: { id: 2, body: '/retry', author_association: 'OWNER' },
+      repository: { owner: { login: 'acme' }, name: 'widgets', default_branch: 'master' },
+    })
+
+    const github = recordPosts(prior)
+    const result = await runCli({
+      argv: ['--event-path', eventPath, '--event-name', 'issue_comment'],
+      env: { ...env, GITHUB_OUTPUT: output.path },
+      logger: silentLogger,
+      fetch: github.fetch,
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.reported).toBe(true)
+    // Asserting the flag alone is not enough: the workflow reads the file, and
+    // a flag that never reaches it gates nothing.
+    expect(github.posted).toHaveLength(1)
+    expect(await output.read()).toContain(`${REPORTED_OUTPUT}=true`)
+  })
+
+  test('leaves the marker unwritten when it posted nothing', async () => {
+    // The other half of the contract, and the one that decides whether the
+    // fallback comment still happens at all: a run that says nothing on the
+    // issue must not claim it did, or a job that dies with the issue silent goes
+    // unreported. A guardrail drop is the cheapest silent exit there is.
+    const output = await outputFile('unreported')
+    const eventPath = await writeEvent('unreported', {
+      action: 'created',
+      sender: { login: 'agent-bot', type: 'Bot' },
+      issue: { number: 42, title: 't', body: 'b', author_association: 'OWNER' },
+      comment: { id: 1, body: '/approve', author_association: 'OWNER' },
+      repository: { owner: { login: 'acme' }, name: 'widgets', default_branch: 'main' },
+    })
+
+    const result = await runCli({
+      argv: ['--event-path', eventPath, '--event-name', 'issue_comment'],
+      env: { ...env, GITHUB_OUTPUT: output.path },
+      logger: silentLogger,
+    })
+
+    expect(result.status).toBe('skipped')
+    expect(result.reported).toBe(false)
+    expect(await output.read()).toBe('')
+  })
+
+  test('a run with no $GITHUB_OUTPUT is a local run, not a failure', async () => {
+    // Every `--event-path` run is one: the variable only exists inside a step.
+    // Writing to it has to be optional, and must never be the thing that turns a
+    // reported failure into a crash that reports nothing.
+    const prior = [
+      {
+        id: 1,
+        user: { login: 'agent-bot' },
+        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({
+          v: 2,
+          phase: 'FAILED',
+          issueId: 42,
+          resumeFrom: 'EXECUTION_PLAN',
+          attempts: 3,
+        })} -->`,
+      },
+    ]
+    const eventPath = await writeEvent('nooutput', {
+      action: 'created',
+      sender: { login: 'maintainer', type: 'User' },
+      issue: { number: 42, title: 't', body: 'b', author_association: 'OWNER' },
+      comment: { id: 2, body: '/retry', author_association: 'OWNER' },
+      repository: { owner: { login: 'acme' }, name: 'widgets', default_branch: 'master' },
+    })
+
+    const github = recordPosts(prior)
+    const result = await runCli({
+      argv: ['--event-path', eventPath, '--event-name', 'issue_comment'],
+      env: { ...env },
+      logger: silentLogger,
+      fetch: github.fetch,
+    })
+
+    expect(result.reported).toBe(true)
+    expect(github.posted).toHaveLength(1)
   })
 
   test('a guarded run never shells out to work out a base branch', async () => {

--- a/tests/opencode-agent/identity.test.ts
+++ b/tests/opencode-agent/identity.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, test } from 'bun:test'
 
 import type { GitHubApi } from '../../opencode-agent/src/github.js'
-import { reportIdentityDrift, resolveSelfLogin } from '../../opencode-agent/src/identity.js'
+import { DEFAULT_BOT_LOGIN, reportIdentityDrift, resolveSelfLogin } from '../../opencode-agent/src/identity.js'
 import type { Logger, LogLevel } from '../../opencode-agent/src/logger.js'
 
 interface Recorded {
@@ -46,38 +46,36 @@ describe('resolveSelfLogin', () => {
   test('an explicit override wins outright', async () => {
     const { log } = recorder()
 
-    expect(await resolveSelfLogin({ override: 'agent-bot', api: refuses('never called'), owner: 'acme', log })).toBe(
-      'agent-bot',
-    )
+    expect(await resolveSelfLogin({ override: 'agent-bot', api: refuses('never called'), log })).toBe('agent-bot')
   })
 
   test.each(['', '   '])('a blank override %p is not an override', async (override) => {
     const { log } = recorder()
 
-    expect(await resolveSelfLogin({ override, api: answers('from-token'), owner: 'acme', log })).toBe('from-token')
+    expect(await resolveSelfLogin({ override, api: answers('from-token'), log })).toBe('from-token')
   })
 
   test('derives the identity from the token when nothing is pinned', async () => {
     const { log } = recorder()
 
-    expect(await resolveSelfLogin({ override: null, api: answers('agent-bot'), owner: 'acme', log })).toBe('agent-bot')
+    expect(await resolveSelfLogin({ override: null, api: answers('agent-bot'), log })).toBe('agent-bot')
   })
 
-  test('falls back to the owner when the token cannot say, and warns', async () => {
-    // A GitHub App installation token cannot read `/user`, and that is the token
-    // the workflow recommends — so this branch is the expected path, not an
+  test('falls back to the Actions bot when the token cannot say, and warns', async () => {
+    // A GitHub App installation token cannot read `/user`, and that is what the
+    // workflow's default token is — so this branch is the expected path, not an
     // exotic error. It has to be loud, because the failure it prevents is
-    // silent.
+    // silent. The repository owner, which this used to return, is the one
+    // answer that cannot be right here: no installation token posts as a human.
     const { lines, log } = recorder()
 
     const login = await resolveSelfLogin({
       override: null,
       api: refuses('Resource not accessible by integration'),
-      owner: 'acme',
       log,
     })
 
-    expect(login).toBe('acme')
+    expect(login).toBe(DEFAULT_BOT_LOGIN)
     expect(lines.filter((line) => line.level === 'warn')).toHaveLength(1)
     expect(lines[0]?.message).toContain('AGENT_SELF_LOGIN')
   })
@@ -85,7 +83,7 @@ describe('resolveSelfLogin', () => {
   test('treats an empty answer as no answer', async () => {
     const { lines, log } = recorder()
 
-    expect(await resolveSelfLogin({ override: null, api: answers('   '), owner: 'acme', log })).toBe('acme')
+    expect(await resolveSelfLogin({ override: null, api: answers('   '), log })).toBe(DEFAULT_BOT_LOGIN)
     expect(lines.some((line) => line.level === 'warn')).toBe(true)
   })
 })

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -1096,6 +1096,110 @@ describe('commands and budgets', () => {
   })
 })
 
+describe('the retry budget', () => {
+  /** A failure an earlier job parked, with the last attempt already spent on it. */
+  const seedSpentBudget = (harness: Harness): void =>
+    seedState(harness, {
+      phase: 'FAILED',
+      resumeFrom: 'EXECUTION_PLAN',
+      attempts: 3,
+      lastError: 'the planning turn returned no JSON',
+    })
+
+  test('a /retry past the budget leaves the failure parked where it was', async () => {
+    // Spending the budget used to *move* the state: the signal was applied
+    // first and the ceiling checked a step later, so the give-up notice posted
+    // `EXECUTION_PLAN` with `resumeFrom` cleared — a handler phase that
+    // `/retry` (which needs FAILED) and a plain comment (which needs a waiting
+    // phase) both refuse. Only `/cancel` could reach the issue after that.
+    const harness = makeHarness({ maxAttempts: 3 })
+    seedSpentBudget(harness)
+
+    const result = await runPipeline({ event: comment('/retry'), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(result.reason).toContain('Retry budget exhausted')
+
+    const state = latestPostedState(harness)
+    expect(state?.phase).toBe('FAILED')
+    expect(state?.resumeFrom).toBe('EXECUTION_PLAN')
+    expect(state?.attempts).toBe(3)
+  })
+
+  test('reports the spent budget on the issue without paying for a model turn', async () => {
+    const harness = makeHarness({ maxAttempts: 3 })
+    seedSpentBudget(harness)
+
+    await runPipeline({ event: comment('/retry'), deps: harness.deps })
+
+    expect(harness.io.posted).toHaveLength(1)
+    expect(harness.io.posted[0]).toContain('### Giving up')
+    expect(harness.io.posted[0]).toContain('3 of 3 attempts')
+    // The notice may only offer what the machine will actually take. Bare
+    // "reply `/retry`" is not that: the budget is spent, so the next `/retry`
+    // lands straight back here. Raising the ceiling is the remedy that works.
+    expect(harness.io.posted[0]).toContain('AGENT_MAX_ATTEMPTS')
+    // Refused before the cascade, so no handler and no session was ever opened.
+    expect(harness.io.prompts).toEqual([])
+    expect(harness.io.gitCalls).toEqual([])
+  })
+
+  test('a second /retry is still answered by the budget, not by the transition table', async () => {
+    // The tell that the first one moved nothing. Against the moved state this
+    // came back as `/retry is not valid in EXECUTION_PLAN`, which is a true
+    // sentence about a phase the maintainer never asked to be in.
+    const harness = makeHarness({ maxAttempts: 3 })
+    seedSpentBudget(harness)
+    await runPipeline({ event: comment('/retry'), deps: harness.deps })
+    harness.io.posted.length = 0
+
+    const result = await runPipeline({ event: comment('/retry'), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(result.reason).toContain('Retry budget exhausted')
+    expect(result.reason).not.toContain('not valid in')
+    expect(harness.io.posted[0]).toContain('### Giving up')
+    expect(latestPostedState(harness)?.resumeFrom).toBe('EXECUTION_PLAN')
+  })
+
+  test('raising the ceiling resumes the parked phase, which is what makes the notice honest', async () => {
+    // The notice names `AGENT_MAX_ATTEMPTS` as the way out, so the way out has
+    // to still exist: the resume point survives the refusal, and the same
+    // `/retry` picks the failed phase back up once the ceiling allows it.
+    const harness = makeHarness({ maxAttempts: 3 })
+    seedState(harness, { phase: 'FAILED', resumeFrom: 'INIT_OR_CLARIFY', attempts: 3 })
+    await runPipeline({ event: comment('/retry'), deps: harness.deps })
+    harness.io.posted.length = 0
+
+    harness.deps.config = config({ maxAttempts: 4 })
+    harness.io.replies = [SPEC_REPLY]
+    const result = await runPipeline({ event: comment('/retry'), deps: harness.deps })
+
+    expect(result.status).toBe('waiting')
+    expect(harness.io.posted.at(-1)).toContain('### Design spec')
+    expect(latestPostedState(harness)?.phase).toBe('DESIGN_SPEC')
+  })
+
+  test('/ask still answers a failure whose budget is spent', async () => {
+    // Answering is not retrying: it spends no attempt and moves nothing, so the
+    // retry ceiling has no business stopping it. The check inside the cascade
+    // sat in front of the answer handler too, so this replied "Giving up" — in
+    // the one phase a maintainer most wants to ask "why did this fail?" in.
+    const harness = makeHarness({ maxAttempts: 3 })
+    seedSpentBudget(harness)
+    harness.io.replies = ['The planning prompt exceeded the model’s context.']
+
+    const result = await runPipeline({ event: comment('/ask why did this fail?'), deps: harness.deps })
+
+    expect(result.status).toBe('waiting')
+    expect(harness.io.posted[0]).toContain('The planning prompt exceeded the model’s context.')
+
+    const state = latestPostedState(harness)
+    expect(state?.phase).toBe('FAILED')
+    expect(state?.resumeFrom).toBe('EXECUTION_PLAN')
+  })
+})
+
 describe('the token budget', () => {
   /** A prior job's state block, carrying what that job spent. */
   const seedSpend = (harness: Harness, tokensSpent: number): void => {

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -5,7 +5,7 @@
 
 import { beforeEach, describe, expect, test } from 'bun:test'
 
-import { findArtifact, PLAN_MARKER, SPEC_MARKER } from '../../opencode-agent/src/artifacts.js'
+import { findArtifact, PLAN_MARKER, renderArtifact, SPEC_MARKER } from '../../opencode-agent/src/artifacts.js'
 import type { IssueComment } from '../../opencode-agent/src/blocks.js'
 import { DEFAULT_CHECKS } from '../../opencode-agent/src/config.js'
 import type { PipelineConfig } from '../../opencode-agent/src/config.js'
@@ -18,7 +18,7 @@ import { runPipeline } from '../../opencode-agent/src/orchestrator.js'
 import type { PhaseDeps } from '../../opencode-agent/src/phase-context.js'
 import type { ReviewRunResult } from '../../opencode-agent/src/review-runner.js'
 import type { CommandResult } from '../../opencode-agent/src/shell.js'
-import { extractState, initialState, serializeState } from '../../opencode-agent/src/state-manager.js'
+import { extractState, initialState, serializeState, STATE_MARKER } from '../../opencode-agent/src/state-manager.js'
 import type { AgentState, Phase } from '../../opencode-agent/src/types.js'
 
 const AGENT_LOGIN = 'agent-bot'
@@ -460,7 +460,7 @@ describe('review conversation', () => {
 
     expect(result.status).toBe('waiting')
     expect(harness.io.posted[0]).toContain('### Answer')
-    expect(latestPostedState(harness)?.revision).toBe(1)
+    expect(latestPostedState(harness)?.specRevision).toBe(1)
   })
 })
 
@@ -561,7 +561,7 @@ describe('plan review gate', () => {
     const result = await runPipeline({ event: comment('/approve'), deps: harness.deps })
 
     expect(result.status).toBe('waiting')
-    expect(headings(harness)).toEqual(['### Execution plan (revision 2)'])
+    expect(headings(harness)).toEqual(['### Execution plan (revision 1)'])
     expect(latestPostedState(harness)?.phase).toBe('PLAN_REVIEW')
     expect(harness.io.gitCalls).toEqual([`ensureBranch:agent/issue-${ISSUE}:${BASE_BRANCH}`])
   })
@@ -572,8 +572,8 @@ describe('plan review gate', () => {
 
     await runPipeline({ event: comment('/changes split step 1'), deps: harness.deps })
 
-    expect(harness.io.posted[0]).toContain('### Execution plan (revision 3)')
-    expect(latestPostedState(harness)?.phase).toBe('PLAN_REVIEW')
+    expect(harness.io.posted[0]).toContain('### Execution plan (revision 2)')
+    expect(latestPostedState(harness)).toMatchObject({ phase: 'PLAN_REVIEW', specRevision: 1, planRevision: 2 })
   })
 
   test('/approve on the plan cascades through implementation and delivery', async () => {
@@ -585,6 +585,83 @@ describe('plan review gate', () => {
     expect(result.status).toBe('completed')
     expect(headings(harness)).toEqual(['### Implementation report', '### Pull request ready'])
     expect(latestPostedState(harness)?.phase).toBe('COMPLETE')
+  })
+})
+
+/**
+ * The spec and the plan used to share one `revision`, bumped by both
+ * `SPEC_POSTED` and `PLAN_POSTED` and rendered into both headings, so the first
+ * execution plan a maintainer ever saw was labelled revision 2 — revision 3 if
+ * the spec had been revised once first. Nothing was corrupted; the numbers
+ * simply counted something no reader could name.
+ */
+describe('artefact revision numbering', () => {
+  let harness: Harness
+
+  beforeEach(() => {
+    harness = makeHarness()
+  })
+
+  test('the first execution plan is revision 1', async () => {
+    await toDesignSpec(harness)
+    harness.io.replies = [PLAN_REPLY]
+
+    await runPipeline({ event: comment('/approve'), deps: harness.deps })
+
+    expect(harness.io.posted[0]).toContain('### Execution plan (revision 1)')
+    expect(latestPostedState(harness)).toMatchObject({ specRevision: 1, planRevision: 1 })
+  })
+
+  test('revising the spec twice still leaves the first plan at revision 1', async () => {
+    await toDesignSpec(harness)
+    harness.io.replies = [JSON.stringify({ status: 'spec', spec: 'Second attempt.' })]
+    await runPipeline({ event: comment('/changes use the existing helper'), deps: harness.deps })
+    harness.io.replies = [JSON.stringify({ status: 'spec', spec: 'Third attempt.' })]
+    await runPipeline({ event: comment('/changes name the helper'), deps: harness.deps })
+
+    expect(harness.io.posted.at(-1)).toContain('### Design spec (revision 3)')
+
+    harness.io.posted.length = 0
+    harness.io.replies = [PLAN_REPLY]
+    await runPipeline({ event: comment('/approve'), deps: harness.deps })
+
+    expect(harness.io.posted[0]).toContain('### Execution plan (revision 1)')
+    expect(latestPostedState(harness)).toMatchObject({ specRevision: 3, planRevision: 1 })
+  })
+
+  test('revising the plan reaches revision 2 while the spec stays where it was', async () => {
+    await toPlanReview(harness)
+    harness.io.replies = [PLAN_REPLY]
+
+    await runPipeline({ event: comment('/changes split step 1'), deps: harness.deps })
+
+    expect(harness.io.posted[0]).toContain('### Execution plan (revision 2)')
+    // Read back the way the next job does: the hidden block's `revision` is
+    // written from the same local as the heading, so they cannot disagree.
+    expect(findArtifact(harness.io.thread, AGENT_LOGIN, PLAN_MARKER)?.revision).toBe(2)
+    expect(findArtifact(harness.io.thread, AGENT_LOGIN, SPEC_MARKER)?.revision).toBe(1)
+    expect(latestPostedState(harness)).toMatchObject({ specRevision: 1, planRevision: 2 })
+  })
+
+  test('a state block written before the counters split still drives the pipeline', async () => {
+    // Both fields default, so the split needed no `STATE_VERSION` bump and this
+    // issue is not stranded mid-conversation. What it loses is the old shared
+    // count, which was a sum of two artefacts and never the count of either —
+    // so its plan starts at 1, which is the number this change exists to make
+    // true.
+    const legacy = `<!-- ${STATE_MARKER}: {"v":2,"phase":"DESIGN_SPEC","issueId":${ISSUE},"revision":3} -->`
+    harness.io.thread.push({
+      id: 800,
+      body: [`earlier`, legacy, renderArtifact(SPEC_MARKER, 'Add a retry wrapper around fetch.', 3)].join('\n\n'),
+      authorLogin: AGENT_LOGIN,
+    })
+    harness.io.replies = [PLAN_REPLY]
+
+    const result = await runPipeline({ event: comment('/approve'), deps: harness.deps })
+
+    expect(result.status).toBe('waiting')
+    expect(harness.io.posted[0]).toContain('### Execution plan (revision 1)')
+    expect(latestPostedState(harness)).toMatchObject({ phase: 'PLAN_REVIEW', specRevision: 0, planRevision: 1 })
   })
 })
 

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -1265,16 +1265,19 @@ describe('the token budget', () => {
     expect(harness.io.posted[0]).toContain('### Token budget spent')
   })
 
-  test('says why /retry will not help, and names what would', async () => {
-    // The spend is persisted, so a retry re-reads the same total and stops
-    // again. Naming AGENT_MAX_TOKENS is the only advice that leads anywhere.
+  test('says why a bare /retry will not help, and names what makes it help', async () => {
+    // The spend is persisted, so a retry against the same ceiling re-reads the
+    // same total and stops again — but it is no longer a dead end, because the
+    // stop parks a resume point. So the notice has to name both halves in
+    // order: raise AGENT_MAX_TOKENS, *then* `/retry`.
     const harness = makeHarness({ maxTokens: 50_000 })
     seedSpend(harness, 60_000)
 
     await runPipeline({ event: comment('/changes again'), deps: harness.deps })
 
     expect(harness.io.posted[0]).toContain('AGENT_MAX_TOKENS')
-    expect(harness.io.posted[0]).toContain('will stop here again')
+    expect(harness.io.posted[0]).toContain('stops right back here')
+    expect(harness.io.posted[0]).toContain('/retry')
   })
 
   test('checks before the phase runs, not after it has spent more', async () => {
@@ -1306,5 +1309,145 @@ describe('the token budget', () => {
     const result = await runPipeline({ event: issueEvent(), deps: harness.deps })
 
     expect(result.status).toBe('waiting')
+  })
+
+  test('parks the stop in FAILED, resuming from the phase it refused to start', async () => {
+    // Trigger point one: the budget runs out on the *first* phase of a run,
+    // right after a trigger moved the state. The stop used to leave the state
+    // exactly where the trigger had put it — `EXECUTION_PLAN`, a phase with a
+    // handler — so the issue was parked somewhere `/retry` (needs FAILED) and a
+    // plain comment (needs a waiting phase) both refuse, and only `/cancel`
+    // reached it. Reachable on a first approval with no failure involved.
+    const harness = makeHarness({ maxTokens: 100 })
+    seedState(harness, { phase: 'DESIGN_SPEC', tokensSpent: 500 })
+
+    const result = await runPipeline({ event: comment('/approve'), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(harness.io.posted[0]).toContain('### Token budget spent')
+
+    const state = latestPostedState(harness)
+    expect(state?.phase).toBe('FAILED')
+    expect(state?.resumeFrom).toBe('EXECUTION_PLAN')
+    expect(state?.tokensSpent).toBe(500)
+  })
+
+  test('parks a mid-cascade stop too, where no trigger moved the state', async () => {
+    // Trigger point two, which no trigger-layer refusal can reach: the earlier
+    // phase legitimately did its work and posted, and the cascade stops before
+    // the next one. Stopping in `PR_DELIVERY` is the same dead end as stopping
+    // in `EXECUTION_PLAN` above — worse, in fact, since the branch is already
+    // pushed and only delivery is left.
+    const harness = makeHarness({ maxTokens: 50_000 })
+    await toPlanReview(harness)
+    harness.io.replies = ['Implemented.']
+    harness.deps.runReview = (): Promise<ReviewRunResult> => {
+      harness.io.tokensUsed = 60_000
+      return Promise.resolve(harness.io.reviewResult)
+    }
+
+    const result = await runPipeline({ event: comment('/approve'), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(headings(harness)).toEqual(['### Implementation report', '### Token budget spent'])
+
+    const state = latestPostedState(harness)
+    expect(state?.phase).toBe('FAILED')
+    expect(state?.resumeFrom).toBe('PR_DELIVERY')
+    expect(state?.tokensSpent).toBe(60_000)
+  })
+
+  test('names the phase it parked in, so the notice and the state block agree', async () => {
+    const harness = makeHarness({ maxTokens: 100 })
+    seedState(harness, { phase: 'DESIGN_SPEC', tokensSpent: 500 })
+
+    await runPipeline({ event: comment('/approve'), deps: harness.deps })
+
+    expect(harness.io.posted[0]).toContain('AGENT_MAX_TOKENS')
+    expect(harness.io.posted[0]).toContain('/retry')
+    expect(harness.io.posted[0]).toContain(`\`${String(latestPostedState(harness)?.resumeFrom)}\``)
+  })
+
+  test('raising the ceiling and replying /retry resumes the phase it stopped before', async () => {
+    // What makes the notice honest. It names `AGENT_MAX_TOKENS` and `/retry`,
+    // so both together have to actually finish the work — before, raising the
+    // ceiling left the issue in `PR_DELIVERY` with no event able to re-enter it.
+    const harness = makeHarness({ maxTokens: 50_000 })
+    await toPlanReview(harness)
+    harness.io.replies = ['Implemented.']
+    harness.deps.runReview = (): Promise<ReviewRunResult> => {
+      harness.io.tokensUsed = 60_000
+      return Promise.resolve(harness.io.reviewResult)
+    }
+    await runPipeline({ event: comment('/approve'), deps: harness.deps })
+    harness.io.posted.length = 0
+
+    // A fresh runner: a new session that has spent nothing, under a raised ceiling.
+    harness.io.tokensUsed = 0
+    harness.deps.config = config({ maxTokens: 500_000 })
+    const result = await runPipeline({ event: comment('/retry'), deps: harness.deps })
+
+    expect(result.status).toBe('completed')
+    expect(harness.io.posted.at(-1)).toContain('### Pull request ready')
+    expect(latestPostedState(harness)?.phase).toBe('COMPLETE')
+  })
+
+  test('an over-budget stop does not eat the retry budget', async () => {
+    // A stop for want of tokens is not a failed attempt, so it must not spend
+    // one — otherwise the two budgets collide: the token notice says to raise
+    // `AGENT_MAX_TOKENS` and reply `/retry`, and that `/retry` is then turned
+    // down by the *retry* gate in `triggers.ts` for a ceiling nobody mentioned.
+    const harness = makeHarness({ maxAttempts: 3 })
+    await toDesignSpec(harness)
+    seedState(harness, { phase: 'FAILED', resumeFrom: 'EXECUTION_PLAN', attempts: 2, tokensSpent: 500 })
+
+    harness.deps.config = config({ maxAttempts: 3, maxTokens: 100 })
+    await runPipeline({ event: comment('/retry'), deps: harness.deps })
+    expect(latestPostedState(harness)?.attempts).toBe(2)
+    harness.io.posted.length = 0
+
+    harness.deps.config = config({ maxAttempts: 3, maxTokens: 500_000 })
+    harness.io.replies = [PLAN_REPLY]
+    const result = await runPipeline({ event: comment('/retry'), deps: harness.deps })
+
+    expect(result.reason).not.toContain('Retry budget exhausted')
+    expect(harness.io.posted.at(-1)).toContain('### Execution plan')
+    expect(latestPostedState(harness)?.phase).toBe('PLAN_REVIEW')
+  })
+
+  test('an over-budget /ask leaves the phase alone rather than parking a question', async () => {
+    // Answering is a side conversation about work that lives elsewhere, so the
+    // park above must not apply to it. `resumeFrom` may never name a waiting
+    // phase — a `/retry` into `DESIGN_SPEC` finds no handler and re-parks with
+    // "Parked in `DESIGN_SPEC`", one round trip for nothing — and the phase the
+    // question was asked in is one a trigger can already re-enter.
+    const harness = makeHarness({ maxTokens: 100 })
+    seedState(harness, { phase: 'DESIGN_SPEC', tokensSpent: 500 })
+
+    const result = await runPipeline({ event: comment('/ask why that file?'), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(harness.io.prompts).toEqual([])
+    expect(harness.io.posted[0]).toContain('AGENT_MAX_TOKENS')
+
+    const state = latestPostedState(harness)
+    expect(state?.phase).toBe('DESIGN_SPEC')
+    expect(state?.resumeFrom).toBeNull()
+    expect(state?.tokensSpent).toBe(500)
+  })
+
+  test('an over-budget /ask in COMPLETE reports instead of crashing the runner', async () => {
+    // `COMPLETE` accepts neither FAILED nor CANCELLED, so parking a question
+    // there would throw `InvalidTransitionError` straight out of the pipeline —
+    // the runner exits 1 and the issue hears nothing, which is the failure the
+    // answer path has already been burned by twice.
+    const harness = makeHarness({ maxTokens: 100 })
+    seedState(harness, { phase: 'COMPLETE', tokensSpent: 500, prUrl: 'https://example.test/pull/7' })
+
+    const result = await runPipeline({ event: comment('/ask what did you change?'), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(harness.io.posted[0]).toContain('### Token budget spent')
+    expect(latestPostedState(harness)?.phase).toBe('COMPLETE')
   })
 })

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -1252,6 +1252,66 @@ describe('the token budget', () => {
     expect(result.state?.tokensSpent).toBe(spentIn(planned) + 900)
   })
 
+  test('a phase that fails records what it spent, so the next job does not start from zero', async () => {
+    // The counter used to be blind exactly where the ceiling was meant to bite.
+    // `runHandler` patched `tokensSpent` on the way out and `failRun` did not,
+    // so a job that spent a quarter of a million tokens and then threw persisted
+    // `0` — and retries *are* the failure path, so an issue could burn the
+    // ceiling round after round and restore a clean slate every time.
+    const harness = makeHarness()
+    harness.io.replies = ['not json', 'still not json']
+    harness.io.tokensUsed = 250_000
+
+    const result = await runPipeline({ event: issueEvent(), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+
+    const state = latestPostedState(harness)
+    expect(state?.phase).toBe('FAILED')
+    expect(state?.tokensSpent).toBe(250_000)
+  })
+
+  test('a failure adds this job’s spend to the earlier jobs’, counting neither twice', async () => {
+    // The figure a failure writes has to be the one the success path writes: the
+    // running total. 10,000 alone would drop everything the issue spent before
+    // this job; 90,000 would be the carried figure counted once by the restored
+    // state and again by the patch.
+    const harness = makeHarness()
+    seedSpend(harness, 40_000)
+    harness.io.replies = ['not json', 'still not json']
+    harness.io.tokensUsed = 10_000
+
+    const result = await runPipeline({ event: comment('/approve'), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(latestPostedState(harness)?.tokensSpent).toBe(50_000)
+  })
+
+  test('a failed answer records what the question cost', async () => {
+    // A model turn that fails still spent what it spent — a deadline or a
+    // rejected request lands here with the provider's meter already run. The
+    // answer path posts the state unchanged, so it dropped the whole figure.
+    const harness = makeHarness()
+    seedSpend(harness, 40_000)
+    harness.io.tokensUsed = 10_000
+    harness.deps.agent = (): Promise<OpenCodeAgent> =>
+      Promise.resolve({
+        sessionId: 'session-1',
+        prompt: () => Promise.reject(new Error('the model timed out')),
+        tokensUsed: () => Promise.resolve(harness.io.tokensUsed),
+        close: () => Promise.resolve(),
+      })
+
+    const result = await runPipeline({ event: comment('/ask why that file?'), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(harness.io.posted[0]).toContain('### I could not answer that')
+
+    const state = latestPostedState(harness)
+    expect(state?.phase).toBe('DESIGN_SPEC')
+    expect(state?.tokensSpent).toBe(50_000)
+  })
+
   test('stops the issue once an earlier job has spent the budget', async () => {
     // The whole point of persisting it: this job's own session has spent
     // nothing, and it still must not start.
@@ -1433,6 +1493,28 @@ describe('the token budget', () => {
     const state = latestPostedState(harness)
     expect(state?.phase).toBe('DESIGN_SPEC')
     expect(state?.resumeFrom).toBeNull()
+    expect(state?.tokensSpent).toBe(500)
+  })
+
+  test('stops paying the classifier once the issue is over budget', async () => {
+    // Classifying a plain comment is the one model turn whose spend can never be
+    // written down: when the classifier answers `none` the run skips without
+    // posting, and this pipeline persists state only by posting a comment. Over
+    // budget nothing any classification could ask for is affordable — every
+    // branch below it leads to a handler the cascade will refuse — so the
+    // ceiling is asked *before* the classifier rather than after paying it,
+    // which is what stops a maxed-out issue paying a turn per comment for ever.
+    const harness = makeHarness({ maxTokens: 100 })
+    seedState(harness, { phase: 'DESIGN_SPEC', tokensSpent: 500 })
+
+    const result = await runPipeline({ event: comment('looks good to me'), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(harness.io.prompts).toEqual([])
+    expect(harness.io.posted[0]).toContain('### Token budget spent')
+
+    const state = latestPostedState(harness)
+    expect(state?.phase).toBe('DESIGN_SPEC')
     expect(state?.tokensSpent).toBe(500)
   })
 

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -948,6 +948,120 @@ describe('CI fixing', () => {
   })
 })
 
+describe('a red run away from COMPLETE', () => {
+  let harness: Harness
+
+  beforeEach(() => {
+    harness = makeHarness()
+    // Every case here starts from a live pull request on the agent's branch, so
+    // the settled-pull-request guard is never what decides the outcome.
+    harness.io.existingPr = { number: 7, url: 'https://example.test/pull/7', state: 'open' }
+  })
+
+  test('a red run in PR_DELIVERY buys a fix round rather than vanishing', async () => {
+    // Phase 3 pushes the branch and posts a state block naming PR_DELIVERY
+    // before phase 4 opens the pull request, so a job that died in that window
+    // leaves this exact block behind a live branch. The transition table used to
+    // name CI_FAILED in COMPLETE alone, so the run was refused as invalid and
+    // ended `skipped` — nothing posted, nothing spent, nobody told.
+    seedState(harness, { phase: 'PR_DELIVERY', prUrl: 'https://example.test/pull/7', prNumber: 7 })
+
+    const result = await runPipeline({ event: ciEvent(), deps: harness.deps })
+
+    expect(result.status).toBe('completed')
+    expect(harness.io.posted[0]).toContain('### CI fix attempt 1 of 2')
+
+    const state = latestPostedState(harness)
+    expect(state?.phase).toBe('COMPLETE')
+    expect(state?.ciAttempts).toBe(1)
+  })
+
+  test.each<Phase>(['INIT_OR_CLARIFY', 'DESIGN_SPEC', 'EXECUTION_PLAN', 'PLAN_REVIEW', 'FAILED'])(
+    'a red run in %s posts nothing and spends no CI-fix attempt',
+    async (phase) => {
+      // Nothing is pushed before PR_DELIVERY, so a fix round would run the
+      // checks against a branch cut fresh from the base; and FAILED is already
+      // parked under a failure comment asking for `/retry`, which is the path a
+      // forward move to CI_FIX would take away.
+      seedState(harness, { phase })
+
+      const result = await runPipeline({ event: ciEvent(), deps: harness.deps })
+
+      expect(result.status).toBe('skipped')
+      expect(harness.io.posted).toEqual([])
+      expect(harness.io.gitCalls).toEqual([])
+      // State is persisted only by posting, so an untouched thread is itself the
+      // assertion that no attempt was spent; the returned state agrees.
+      expect(result.state?.ciAttempts).toBe(0)
+    },
+  )
+
+  test('a red run leaves a FAILED issue the /retry path its failure comment promised', async () => {
+    seedState(harness, { phase: 'FAILED', resumeFrom: 'PR_DELIVERY', attempts: 1 })
+
+    await runPipeline({ event: ciEvent(), deps: harness.deps })
+    const resumed = await runPipeline({ event: comment('/retry'), deps: harness.deps })
+
+    expect(resumed.status).toBe('completed')
+    expect(latestPostedState(harness)?.phase).toBe('COMPLETE')
+  })
+})
+
+describe('the CI-fix budget across pull requests', () => {
+  let harness: Harness
+
+  /** An issue whose first pull request burned every CI-fix round it had. */
+  const spentOnAnEarlierPullRequest = (): void => {
+    seedState(harness, { phase: 'FAILED', resumeFrom: 'PR_DELIVERY', ciAttempts: 2, ciBudgetReported: true })
+  }
+
+  beforeEach(() => {
+    harness = makeHarness()
+  })
+
+  test('a new pull request hands the CI-fix budget back', async () => {
+    spentOnAnEarlierPullRequest()
+    harness.io.existingPr = null
+
+    await runPipeline({ event: comment('/retry'), deps: harness.deps })
+
+    const state = latestPostedState(harness)
+    expect(state?.prNumber).toBe(7)
+    expect(state?.ciAttempts).toBe(0)
+    expect(state?.ciBudgetReported).toBe(false)
+  })
+
+  test('a refreshed pull request keeps the budget its own checks spent', async () => {
+    // The same pull request, on the same commits, whose red checks spent the
+    // rounds. Handing it a clean slate is how one broken branch bounces off the
+    // agent for as long as anyone keeps replying `/retry`.
+    spentOnAnEarlierPullRequest()
+    harness.io.existingPr = { number: 3, url: 'https://example.test/pull/3', state: 'open' }
+
+    await runPipeline({ event: comment('/retry'), deps: harness.deps })
+
+    const state = latestPostedState(harness)
+    expect(harness.io.createdPr).toBeNull()
+    expect(state?.ciAttempts).toBe(2)
+    expect(state?.ciBudgetReported).toBe(true)
+  })
+
+  test('the returned budget is real — a red run on the new pull request buys a fix round', async () => {
+    // `applyCiTrigger` short-circuits on `ciBudgetReported` before it even looks
+    // the pull request up, so a flag that outlived the pull request that set it
+    // meant no fix round *and* no notice explaining the silence.
+    spentOnAnEarlierPullRequest()
+    harness.io.existingPr = null
+    await runPipeline({ event: comment('/retry'), deps: harness.deps })
+    harness.io.posted.length = 0
+
+    const result = await runPipeline({ event: ciEvent(), deps: harness.deps })
+
+    expect(result.status).toBe('completed')
+    expect(harness.io.posted[0]).toContain('### CI fix attempt 1 of 2')
+  })
+})
+
 describe('commands and budgets', () => {
   test('/cancel is durable — a later /approve does not resurrect the issue', async () => {
     const harness = makeHarness()

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -19,7 +19,7 @@ import type { PhaseDeps } from '../../opencode-agent/src/phase-context.js'
 import type { ReviewRunResult } from '../../opencode-agent/src/review-runner.js'
 import type { CommandResult } from '../../opencode-agent/src/shell.js'
 import { extractState, initialState, serializeState } from '../../opencode-agent/src/state-manager.js'
-import type { AgentState } from '../../opencode-agent/src/types.js'
+import type { AgentState, Phase } from '../../opencode-agent/src/types.js'
 
 const AGENT_LOGIN = 'agent-bot'
 const ISSUE = 42
@@ -247,6 +247,12 @@ const latestPostedState = (harness: Harness): AgentState | null => {
   return last === undefined ? null : extractState(last)
 }
 
+/** A state block an earlier job left on the thread, as a later job reads it back. */
+const seedState = (harness: Harness, patch: Partial<AgentState>): void => {
+  const prior: AgentState = { ...initialState(ISSUE), ...patch }
+  harness.io.thread.push({ id: 800, body: `earlier\n\n${serializeState(prior)}`, authorLogin: AGENT_LOGIN })
+}
+
 /** Keeps the "did a run return a state?" narrowing out of the test bodies. */
 const spentIn = (result: { state: AgentState | null }): number => result.state?.tokensSpent ?? -1
 
@@ -455,6 +461,89 @@ describe('review conversation', () => {
     expect(result.status).toBe('waiting')
     expect(harness.io.posted[0]).toContain('### Answer')
     expect(latestPostedState(harness)?.revision).toBe(1)
+  })
+})
+
+describe('answering outside the review gates', () => {
+  let harness: Harness
+
+  beforeEach(() => {
+    harness = makeHarness()
+  })
+
+  test.each<Phase>(['COMPLETE', 'REVIEW_AND_MUTATE', 'PR_DELIVERY', 'CI_FIX'])(
+    '/ask in %s is answered and leaves the phase exactly there',
+    async (phase) => {
+      // `/ask` has always been accepted in every phase, but ANSWERED lived in
+      // three rows of the transition table, so each of these crashed the runner
+      // with an InvalidTransitionError after the model turn was paid for —
+      // nothing posted, exit code 1, the maintainer left staring at an issue.
+      seedState(harness, { phase })
+      harness.io.replies = ['Because the retry helper already exists there.']
+
+      const result = await runPipeline({ event: comment('/ask why that file?'), deps: harness.deps })
+
+      expect(result.status).toBe('waiting')
+      expect(harness.io.posted[0]).toContain('### Answer')
+      expect(harness.io.posted[0]).toContain('Because the retry helper already exists there.')
+      expect(latestPostedState(harness)?.phase).toBe(phase)
+    },
+  )
+
+  test('/ask in FAILED answers without disturbing the parked failure', async () => {
+    // The phase a maintainer most wants to ask a question in, and the one the
+    // crash hurt most: the run had already failed, so this was the only thing
+    // left to try.
+    seedState(harness, { phase: 'FAILED', resumeFrom: 'REVIEW_AND_MUTATE', attempts: 1, lastError: 'tests exploded' })
+    harness.io.replies = ['The check runner could not find bun on the PATH.']
+
+    const result = await runPipeline({ event: comment('/ask why did this fail?'), deps: harness.deps })
+
+    expect(result.status).toBe('waiting')
+    expect(harness.io.posted[0]).toContain('The check runner could not find bun on the PATH.')
+
+    const state = latestPostedState(harness)
+    expect(state?.phase).toBe('FAILED')
+    // Still resumable: a question must not cost the maintainer the `/retry`.
+    expect(state?.resumeFrom).toBe('REVIEW_AND_MUTATE')
+  })
+
+  test('a failed /ask in COMPLETE reports without dragging a delivered issue backwards', async () => {
+    // Two crashes on one path: the answer's own ANSWERED was refused, and when
+    // the model call failed instead, the failure path's `transition(FAILED)`
+    // was refused too, because COMPLETE deliberately accepts neither.
+    seedState(harness, { phase: 'COMPLETE', prUrl: 'https://example.test/pull/7' })
+    harness.deps.agent = (): Promise<OpenCodeAgent> => Promise.reject(new Error('the model endpoint rejected it'))
+
+    const result = await runPipeline({ event: comment('/ask what did you change?'), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(harness.io.posted[0]).toContain('### I could not answer that')
+    expect(harness.io.posted[0]).toContain('the model endpoint rejected it')
+
+    const state = latestPostedState(harness)
+    expect(state?.phase).toBe('COMPLETE')
+    expect(state?.resumeFrom).toBeNull()
+    expect(state?.attempts).toBe(0)
+  })
+
+  test('a failed /ask spends no attempt and promises no retry', async () => {
+    // The related defect: a failed answer used to park the state with
+    // `resumeFrom: 'DESIGN_SPEC'` and invite `/retry`, which then resumed into a
+    // waiting phase with no handler and re-parked with "Parked in DESIGN_SPEC",
+    // one attempt poorer for a round trip that did nothing.
+    await toDesignSpec(harness)
+    harness.deps.agent = (): Promise<OpenCodeAgent> => Promise.reject(new Error('the model timed out'))
+
+    const result = await runPipeline({ event: comment('/ask why that file?'), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(harness.io.posted[0]).not.toContain('/retry')
+
+    const state = latestPostedState(harness)
+    expect(state?.phase).toBe('DESIGN_SPEC')
+    expect(state?.resumeFrom).toBeNull()
+    expect(state?.attempts).toBe(0)
   })
 })
 

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -919,7 +919,41 @@ describe('commands and budgets', () => {
 
     expect(result.status).toBe('skipped')
     expect(result.reason).toContain('not valid in INIT_OR_CLARIFY')
-    expect(harness.io.posted).toEqual([])
+  })
+
+  test('says so on the issue rather than only in the job log', async () => {
+    // This used to skip in silence. A maintainer who types a command and sees
+    // nothing has no way to tell a refusal from an agent that never woke up —
+    // which is how a mis-set AGENT_SELF_LOGIN went unnoticed while every
+    // `/changes` was refused against a state that had been restarted.
+    const harness = makeHarness()
+
+    await runPipeline({ event: comment('/changes do it differently'), deps: harness.deps })
+
+    const refusal = String(harness.io.posted.at(-1))
+    expect(refusal).toContain('/changes')
+    expect(refusal).toContain('INIT_OR_CLARIFY')
+    // Derived from the transition table, so it cannot promise a command the
+    // machine would refuse in turn.
+    expect(refusal).toContain('/cancel')
+    expect(refusal).toContain('/ask')
+    expect(refusal).not.toContain('`/approve`')
+  })
+
+  test('/changes is accepted once the agent can read back its own spec', async () => {
+    // The regression this file exists for: with the wrong self-login the spec
+    // comment is invisible, the state restores to INIT_OR_CLARIFY, and the
+    // maintainer's `/changes` is refused. Reading it back is what makes the
+    // command land in DESIGN_SPEC and send the issue round for a new spec.
+    const harness = makeHarness()
+    harness.io.replies = [SPEC_REPLY, SPEC_REPLY]
+    await runPipeline({ event: issueEvent(), deps: harness.deps })
+
+    const result = await runPipeline({ event: comment('/changes narrow the scope'), deps: harness.deps })
+
+    expect(result.status).toBe('waiting')
+    expect(result.state?.phase).toBe('DESIGN_SPEC')
+    expect(harness.io.posted.at(-1)).toContain('### Design spec')
   })
 
   test('a single malformed reply is repaired rather than failing the run', async () => {

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -361,7 +361,13 @@ describe('phase 1 — triage', () => {
   })
 
   test('a plain reply while clarifying re-runs triage', async () => {
-    harness.io.replies = [JSON.stringify({ status: 'clarify', questions: ['Which client?'] }), SPEC_REPLY]
+    // Three replies for three turns: the clarification, the classification of
+    // the answer that comes back, and the triage that answer earns.
+    harness.io.replies = [
+      JSON.stringify({ status: 'clarify', questions: ['Which client?'] }),
+      JSON.stringify({ intent: 'question' }),
+      SPEC_REPLY,
+    ]
     await runPipeline({ event: issueEvent(), deps: harness.deps })
     harness.io.posted.length = 0
 
@@ -382,6 +388,91 @@ describe('phase 1 — triage', () => {
     const state = latestPostedState(harness)
     expect(state?.phase).toBe('FAILED')
     expect(state?.resumeFrom).toBe('INIT_OR_CLARIFY')
+  })
+})
+
+/**
+ * `INIT_OR_CLARIFY` used to skip classification altogether, so every comment
+ * that landed while the agent waited for its clarifying questions to be answered
+ * bought a full triage turn — a "thanks", a 👍 and a bystander's aside included.
+ * Classifying it is the fix, but the classifier's documented bias points the
+ * wrong way for this phase, so the branch inverts the default instead of
+ * borrowing `applyIntent`'s: `none` skips, and everything else — including the
+ * `question` a broken or unsure classifier falls back to — re-runs triage.
+ */
+describe('chatter while the agent is clarifying', () => {
+  let harness: Harness
+
+  beforeEach(() => {
+    harness = makeHarness()
+  })
+
+  test('a comment that needs no action runs no triage and posts nothing', async () => {
+    seedState(harness, { phase: 'INIT_OR_CLARIFY' })
+    harness.io.replies = [JSON.stringify({ intent: 'none' })]
+
+    const result = await runPipeline({ event: comment('thanks! 👍'), deps: harness.deps })
+
+    expect(result.status).toBe('skipped')
+    expect(result.reason).toContain('needs no action')
+    expect(harness.io.posted).toEqual([])
+    // The classification is the only turn paid for; triage never ran.
+    expect(harness.io.prompts).toHaveLength(1)
+    expect(String(harness.io.prompts[0]?.prompt)).toContain('Classify this comment')
+    // State is persisted only by posting, so an untouched thread is itself the
+    // assertion that the issue is still parked on its clarifying questions.
+    expect(latestPostedState(harness)).toBeNull()
+    expect(result.state?.phase).toBe('INIT_OR_CLARIFY')
+  })
+
+  test('an answer read as a question still re-runs triage rather than being answered', async () => {
+    // `question` is the classifier's fallback bucket, not a verdict about this
+    // phase, so acting on it would answer the maintainer's answer and leave the
+    // issue parked on the same questions — the stall this branch exists to avoid.
+    seedState(harness, { phase: 'INIT_OR_CLARIFY' })
+    harness.io.replies = [JSON.stringify({ intent: 'question' }), SPEC_REPLY]
+
+    const result = await runPipeline({ event: comment('The HTTP client.'), deps: harness.deps })
+
+    expect(result.status).toBe('waiting')
+    expect(String(harness.io.prompts[0]?.prompt)).toContain('Classify this comment')
+    expect(harness.io.posted[0]).toContain('### Design spec')
+    expect(latestPostedState(harness)?.phase).toBe('DESIGN_SPEC')
+  })
+
+  test('a classifier that fails re-runs triage rather than dropping a possible answer', async () => {
+    // Two unusable replies exhaust `promptForJson`'s one re-ask, so
+    // `classifyComment` swallows the throw and reports `question`. Only `none`
+    // skips, so a classifier this run could not use costs the issue nothing.
+    seedState(harness, { phase: 'INIT_OR_CLARIFY' })
+    harness.io.replies = ['not json at all', 'still not json', SPEC_REPLY]
+
+    const result = await runPipeline({ event: comment('The HTTP client.'), deps: harness.deps })
+
+    expect(result.status).toBe('waiting')
+    expect(harness.io.posted[0]).toContain('### Design spec')
+    expect(latestPostedState(harness)?.phase).toBe('DESIGN_SPEC')
+  })
+
+  test('an over-budget comment is reported without paying to classify it', async () => {
+    // The ceiling is asked before the classifier, not after: classification is
+    // the one turn whose spend can never be written down. The queued verdict is
+    // the tell — reaching for it would consume the reply, skip in silence, and
+    // leave the maintainer with no notice at all.
+    harness = makeHarness({ maxTokens: 100 })
+    seedState(harness, { phase: 'INIT_OR_CLARIFY', tokensSpent: 500 })
+    harness.io.replies = [JSON.stringify({ intent: 'none' })]
+
+    const result = await runPipeline({ event: comment('The HTTP client.'), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(harness.io.prompts).toEqual([])
+    expect(harness.io.posted[0]).toContain('### Token budget spent')
+
+    const state = latestPostedState(harness)
+    expect(state?.phase).toBe('FAILED')
+    expect(state?.resumeFrom).toBe('INIT_OR_CLARIFY')
+    expect(state?.tokensSpent).toBe(500)
   })
 })
 

--- a/tests/opencode-agent/state-manager.test.ts
+++ b/tests/opencode-agent/state-manager.test.ts
@@ -102,13 +102,25 @@ describe('serializeState / extractState', () => {
       attempts: 0,
       ciAttempts: 0,
       ciBudgetReported: false,
-      revision: 0,
+      specRevision: 0,
+      planRevision: 0,
       // Defaulted, which is why adding it needed no STATE_VERSION bump.
       tokensSpent: 0,
       lastError: null,
       prUrl: null,
       prNumber: null,
     })
+  })
+
+  test('a block written before the revision counters split still restores', () => {
+    // The two counters replaced one shared `revision`, and both default, so no
+    // STATE_VERSION bump was needed and an issue mid-conversation is not
+    // stranded. The old key is dropped rather than mapped onto either field: it
+    // was the sum of both artefacts' revisions and never the count of either.
+    const older = `<!-- ${STATE_MARKER}: {"v":2,"phase":"DESIGN_SPEC","issueId":5,"revision":3} -->`
+
+    expect(extractState(older)).toMatchObject({ phase: 'DESIGN_SPEC', specRevision: 0, planRevision: 0 })
+    expect(extractState(older)).not.toHaveProperty('revision')
   })
 
   test('a block written before a field existed still restores', () => {
@@ -287,14 +299,29 @@ describe('transition', () => {
     expect(state.phase).toBe('COMPLETE')
   })
 
-  test('bumps the artefact revision only when an artefact is rewritten', () => {
+  test('bumps an artefact revision only when that artefact is rewritten', () => {
     const spec = transition(initialState(1), 'SPEC_POSTED')
-    expect(spec.revision).toBe(1)
+    expect(spec).toMatchObject({ specRevision: 1, planRevision: 0 })
 
     const approved = transition(spec, 'APPROVED')
-    expect(approved.revision).toBe(1)
+    expect(approved).toMatchObject({ specRevision: 1, planRevision: 0 })
 
-    expect(transition(approved, 'PLAN_POSTED').revision).toBe(2)
+    // The plan's first revision is 1, not 2. One counter served both, so the
+    // first execution plan on every issue was labelled with the spec's count
+    // plus its own.
+    expect(transition(approved, 'PLAN_POSTED')).toMatchObject({ specRevision: 1, planRevision: 1 })
+  })
+
+  test('revising one artefact never moves the other one’s number', () => {
+    const twiceSpecced = transition(
+      transition(transition(initialState(1), 'SPEC_POSTED'), 'CHANGES_REQUESTED'),
+      'SPEC_POSTED',
+    )
+    const planned = transition(transition(twiceSpecced, 'APPROVED'), 'PLAN_POSTED')
+    expect(planned).toMatchObject({ specRevision: 2, planRevision: 1 })
+
+    const replanned = transition(transition(planned, 'CHANGES_REQUESTED'), 'PLAN_POSTED')
+    expect(replanned).toMatchObject({ specRevision: 2, planRevision: 2 })
   })
 
   test('a question is a self-loop that changes nothing else', () => {
@@ -302,7 +329,8 @@ describe('transition', () => {
     const answered = transition(spec, 'ANSWERED')
 
     expect(answered.phase).toBe('DESIGN_SPEC')
-    expect(answered.revision).toBe(spec.revision)
+    expect(answered.specRevision).toBe(spec.specRevision)
+    expect(answered.planRevision).toBe(spec.planRevision)
   })
 
   test.each<Phase>([...PHASES])('a question asked in %s is answered where it stands', (phase) => {
@@ -312,14 +340,15 @@ describe('transition', () => {
     // COMPLETE, FAILED or anywhere mid-pipeline threw InvalidTransitionError out
     // of the pipeline with the model turn already paid for. FAILED mattered
     // most: it is the phase a maintainer asks "why did this fail?" in.
-    const before: AgentState = { ...at(phase), attempts: 2, revision: 3, ciAttempts: 1 }
+    const before: AgentState = { ...at(phase), attempts: 2, specRevision: 3, planRevision: 2, ciAttempts: 1 }
     const answered = transition(before, 'ANSWERED')
 
     expect(canTransition(phase, 'ANSWERED')).toBe(true)
     expect(answered.phase).toBe(phase)
     // No artefact was rewritten and no CI round was spent, but a handler did
     // succeed — the same patch the three table rows used to produce.
-    expect(answered.revision).toBe(3)
+    expect(answered.specRevision).toBe(3)
+    expect(answered.planRevision).toBe(2)
     expect(answered.ciAttempts).toBe(1)
     expect(answered.attempts).toBe(0)
   })

--- a/tests/opencode-agent/state-manager.test.ts
+++ b/tests/opencode-agent/state-manager.test.ts
@@ -18,7 +18,7 @@ import {
   STATE_MARKER,
   transition,
 } from '../../opencode-agent/src/state-manager.js'
-import { InvalidTransitionError, STATE_VERSION } from '../../opencode-agent/src/types.js'
+import { InvalidTransitionError, PHASES, STATE_VERSION } from '../../opencode-agent/src/types.js'
 import type { AgentState, Phase, TransitionSignal } from '../../opencode-agent/src/types.js'
 
 const comment = (authorLogin: string, body: string, id = 1): IssueComment => ({ id, body, authorLogin })
@@ -303,6 +303,34 @@ describe('transition', () => {
 
     expect(answered.phase).toBe('DESIGN_SPEC')
     expect(answered.revision).toBe(spec.revision)
+  })
+
+  test.each<Phase>([...PHASES])('a question asked in %s is answered where it stands', (phase) => {
+    // `/ask` is accepted in every phase, so the machine has to accept ANSWERED
+    // in every phase too. It used to live in three rows of the transition table
+    // — INIT_OR_CLARIFY, DESIGN_SPEC, PLAN_REVIEW — so a question asked in
+    // COMPLETE, FAILED or anywhere mid-pipeline threw InvalidTransitionError out
+    // of the pipeline with the model turn already paid for. FAILED mattered
+    // most: it is the phase a maintainer asks "why did this fail?" in.
+    const before: AgentState = { ...at(phase), attempts: 2, revision: 3, ciAttempts: 1 }
+    const answered = transition(before, 'ANSWERED')
+
+    expect(canTransition(phase, 'ANSWERED')).toBe(true)
+    expect(answered.phase).toBe(phase)
+    // No artefact was rewritten and no CI round was spent, but a handler did
+    // succeed — the same patch the three table rows used to produce.
+    expect(answered.revision).toBe(3)
+    expect(answered.ciAttempts).toBe(1)
+    expect(answered.attempts).toBe(0)
+  })
+
+  test('a question in FAILED leaves the phase its retry needs to resume from', () => {
+    const failed = transition(at('REVIEW_AND_MUTATE'), 'FAILED', { lastError: 'tests exploded' })
+    const answered = transition(failed, 'ANSWERED')
+
+    expect(answered.phase).toBe('FAILED')
+    expect(answered.resumeFrom).toBe('REVIEW_AND_MUTATE')
+    expect(transition(answered, 'RETRY').phase).toBe('REVIEW_AND_MUTATE')
   })
 
   test.each<[Phase, Phase]>([

--- a/tests/opencode-agent/state-manager.test.ts
+++ b/tests/opencode-agent/state-manager.test.ts
@@ -432,7 +432,30 @@ describe('transition', () => {
     expect(transition(fixing, 'CI_FIXED').phase).toBe('COMPLETE')
   })
 
-  test('CI attempts accumulate across rounds and never reset', () => {
+  test('a delivery interrupted by a red run enters CI_FIX', () => {
+    // Phase 3 pushes the branch and posts a state block naming PR_DELIVERY
+    // before phase 4 opens the pull request, so the branch is live while this is
+    // the persisted phase. CI_FAILED named COMPLETE alone, and the run was
+    // refused as an invalid transition.
+    const fixing = transition(at('PR_DELIVERY'), 'CI_FAILED')
+
+    expect(fixing.phase).toBe('CI_FIX')
+    expect(fixing.ciAttempts).toBe(1)
+  })
+
+  test.each<Phase>(['INIT_OR_CLARIFY', 'DESIGN_SPEC', 'EXECUTION_PLAN', 'PLAN_REVIEW', 'REVIEW_AND_MUTATE', 'FAILED'])(
+    'a red run is refused in %s',
+    (phase) => {
+      // Four of these have no pushed branch, so a fix round would run the checks
+      // against a branch cut fresh from the base. REVIEW_AND_MUTATE is another
+      // job mid-commit on the branch. FAILED is the close call: a forward move
+      // would reset `attempts`, leave the one phase `/retry` accepts, and end in
+      // COMPLETE claiming success for a delivery that never finished.
+      expect(canTransition(phase, 'CI_FAILED')).toBe(false)
+    },
+  )
+
+  test('CI attempts accumulate across rounds within one pull request', () => {
     let state = at('COMPLETE')
     state = transition(transition(state, 'CI_FAILED'), 'CI_FIXED')
     state = transition(transition(state, 'CI_FAILED'), 'CI_FIXED')

--- a/tests/opencode-agent/workflow.test.ts
+++ b/tests/opencode-agent/workflow.test.ts
@@ -238,6 +238,20 @@ describe('steps', () => {
     expect(Object.keys(step('agent pipeline').env)).not.toContain('AGENT_BASE_BRANCH')
   })
 
+  test('leaves an unset AGENT_SELF_LOGIN unset instead of guessing the owner', () => {
+    // `AGENT_SELF_LOGIN` is an override that wins outright in identity.ts, so a
+    // `|| github.repository_owner` default here is not a default at all — it is
+    // an operator pinning the wrong login, and it silences the resolution
+    // ladder and its warning. The agent posts as `github-actions[bot]`, stops
+    // recognising its own state comments, and restarts every issue at phase one
+    // on every event, so `/approve` and `/changes` are refused as invalid in
+    // INIT_OR_CLARIFY.
+    const pinned = step('agent pipeline').env['AGENT_SELF_LOGIN']
+
+    expect(pinned).toBe('${{ vars.AGENT_SELF_LOGIN }}')
+    expect(pinned).not.toContain('repository_owner')
+  })
+
   test('passes every knob the README documents, or names it as deliberately absent', () => {
     // The finding named two missing vars; there were five, two of which this
     // workspace added itself while fixing something else. A list that has to be

--- a/tests/opencode-agent/workflow.test.ts
+++ b/tests/opencode-agent/workflow.test.ts
@@ -9,6 +9,8 @@ import path from 'node:path'
 
 import { z } from 'zod'
 
+import { REPORTED_OUTPUT } from '../../opencode-agent/src/step-output.js'
+
 /**
  * The workflow is the one part of this pipeline no other test reaches: its
  * trigger surface and job condition are GitHub expression language, evaluated
@@ -23,6 +25,7 @@ const WORKFLOW_PATH = path.join(import.meta.dir, '..', '..', '.github', 'workflo
 
 const stepSchema = z.object({
   name: z.string().default(''),
+  id: z.string().default(''),
   if: z.string().default(''),
   uses: z.string().default(''),
   with: z.record(z.string(), z.unknown()).default({}),
@@ -267,6 +270,20 @@ describe('steps', () => {
   test('reports an infrastructure failure only when there is an issue to post to', () => {
     expect(step('infrastructure failure').if).toContain('failure()')
     expect(step('infrastructure failure').if).toContain('github.event.issue.number')
+  })
+
+  test('falls back only when the pipeline did not report on the issue itself', () => {
+    // `failure()` selects every red job, and six pipeline paths exit 1 only
+    // after posting their own report — so this step used to append "The issue
+    // state is unchanged; reply `/retry`" to every genuine failure, beside a
+    // state block that had just moved to FAILED and a notice explaining why
+    // that `/retry` would be refused. The run step marks what it posted through
+    // $GITHUB_OUTPUT; this gate is the half that reads it, and a marker written
+    // by a step nothing can name is no marker at all.
+    expect(step('agent pipeline').id).toBe('pipeline')
+    expect(step('infrastructure failure').if).toContain(
+      `steps.${step('agent pipeline').id}.outputs.${REPORTED_OUTPUT} != 'true'`,
+    )
   })
 })
 


### PR DESCRIPTION
`/changes` on an issue parked in DESIGN_SPEC was refused as invalid in
INIT_OR_CLARIFY: the agent could not read back its own state comment, so
every event restored a fresh state.

The workflow passed `AGENT_SELF_LOGIN: ${{ vars.AGENT_SELF_LOGIN ||
github.repository_owner }}`. That override wins outright in
`resolveSelfLogin`, so with the variable unset the pipeline was pinned to
the owner and never asked the token who it is. It posts as
`github-actions[bot]`, so `findLatestState`'s author filter matched
nothing. `reportIdentityDrift` logged the mismatch at `error` on the run
that made it — in the Actions log, which nobody was reading.

- Pass the variable through unset, so the resolution ladder runs.
- Fall back to `github-actions[bot]`, not the repository owner. That
  branch is only reached when the token cannot read `/user`, which means
  an installation token, whose author is never a human — so the owner had
  no chance of being right, and `owner` leaves `SelfLoginSources`.
- Answer a refused slash command on the issue instead of skipping in
  silence, listing what the current phase does accept, derived from the
  transition table. Silence is what let this stay invisible: a maintainer
  who types a command and sees nothing cannot tell a refusal from an
  agent that never woke up.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XjRTNymWZbVzQwwPYQTghu