### PR TITLE
fix(opencode-agent): give one turn an hour, not half of one

### DIFF
--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -566,6 +566,16 @@ token ceiling is checked, whether there is time to start another one.
 the `git add`, the commit, the push, the comment, the state block and the label a
 stop still has to do, against an observed tail of about ten seconds.
 
+With the shrink in place the per-turn cap is free to be generous, and it now is:
+`AGENT_TIMEOUT_MS` defaults to an **hour** rather than the half-hour above. The
+30-minute default outlived the defect that made it dangerous and became the
+opposite problem — with the job ceiling at 90 it was the _only_ bound long runs
+ever reached, and three consecutive live runs ended at the same 33 minutes of
+wall clock, each one a single turn aborted at its cap, wrapped up and parked with
+an hour of paid-for runner unspent. Raising it cannot recreate D3, because the
+`min` above is what stands between a turn and the runner: a turn opened late gets
+what is left of the job minus the two slices, whatever this is set to.
+
 **A wall-clock stop is a ceiling reached, not work that broke**, and the pipeline
 says so in the vocabulary it already had: ⛔ rather than ❌, and a park in
 `INCOMPLETE` rather than in `FAILED`. That is a phase of its own, not a flag,
@@ -1267,7 +1277,7 @@ cannot drift.
 | `AGENT_MAX_ATTEMPTS`                       | no       | `3`                                             | Failures before `/retry` stops resuming               |
 | `AGENT_MAX_CHANGED_FILES`                  | no       | `100`                                           | Files one commit may carry                            |
 | `AGENT_MAX_CHANGED_LINES`                  | no       | `20000`                                         | Lines one commit may change                           |
-| `AGENT_TIMEOUT_MS`                         | no       | `1800000`                                       | Timeout for one model turn, and for each subprocess   |
+| `AGENT_TIMEOUT_MS`                         | no       | `3600000`                                       | Timeout for one model turn, and for each subprocess   |
 | `AGENT_JOB_STARTED_MS`                     | no       | unset — no job deadline                         | Epoch ms this job began; the workflow's first step    |
 | `AGENT_JOB_TIMEOUT_MINUTES`                | no       | unset — no job deadline                         | The job's own ceiling, shared with `timeout-minutes:` |
 | `AGENT_TEARDOWN_RESERVE_MS`                | no       | `180000`                                        | Held back from the job so a time stop can report      |

--- a/opencode-agent/src/config-values.ts
+++ b/opencode-agent/src/config-values.ts
@@ -76,6 +76,28 @@ export const ROUND_RANGE: IntRange = { min: 1, max: 20 }
 export const TIMEOUT_RANGE: IntRange = { min: 1_000, max: 7_200_000 }
 
 /**
+ * An hour for one model turn, and for each subprocess.
+ *
+ * A constant beside its range rather than a literal at the call site, because the
+ * two only mean anything together — this has to be a value the range would accept
+ * as an override, and the pair drifting apart is the class of bug the "default
+ * would itself be accepted" test exists to catch.
+ *
+ * Half an hour before, which outlived the defect that chose it. The turn cap and
+ * the job ceiling used to be two hand-kept numbers, and 30-against-90 was the
+ * safe side of that; once `turnTimeoutMs` started deriving the turn's bound from
+ * the job's own clock, the danger was gone and only the smallness was left. What
+ * that cost was measurable: with the ceiling at 90 this was the *only* bound long
+ * runs ever reached, and three consecutive live runs ended at the same 33 minutes
+ * of wall clock — each one a single turn aborted at its cap, wrapped up and
+ * parked, with an hour of paid-for runner unspent. Raising it cannot bring the
+ * old defect back, because a turn is handed the **smaller** of this and what is
+ * left of the job: one opened late still shrinks to fit the runner it will die
+ * with, whatever this says.
+ */
+export const DEFAULT_TURN_TIMEOUT_MS = 3_600_000
+
+/**
  * When the job began, as epoch milliseconds, from the runner rather than from an
  * operator.
  *

--- a/opencode-agent/src/config.ts
+++ b/opencode-agent/src/config.ts
@@ -10,6 +10,7 @@ import { resolveReviewCommand } from './config-discovery.js'
 import {
   boundedInt,
   boundedIntOrNull,
+  DEFAULT_TURN_TIMEOUT_MS,
   EPOCH_MS_RANGE,
   FILES_RANGE,
   JOB_MINUTES_RANGE,
@@ -263,7 +264,7 @@ export const loadConfig = (env: Env, repoRoot: string): PipelineConfig => {
     checks: parseChecks(env['AGENT_CHECKS']),
     reviewMaxRounds: boundedInt(env, 'AGENT_REVIEW_MAX_ROUNDS', 4, ROUND_RANGE),
     reviewPoolSize: boundedInt(env, 'AGENT_REVIEW_POOL_SIZE', 2, POOL_RANGE),
-    agentTimeoutMs: boundedInt(env, 'AGENT_TIMEOUT_MS', 1_800_000, TIMEOUT_RANGE),
+    agentTimeoutMs: boundedInt(env, 'AGENT_TIMEOUT_MS', DEFAULT_TURN_TIMEOUT_MS, TIMEOUT_RANGE),
     jobDeadlineMs: buildJobDeadline(env),
     teardownReserveMs: boundedInt(env, 'AGENT_TEARDOWN_RESERVE_MS', 180_000, RESERVE_RANGE),
     wrapUpMs: boundedInt(env, 'AGENT_WRAP_UP_MS', 120_000, WRAP_UP_RANGE),

--- a/tests/opencode-agent/adapters.test.ts
+++ b/tests/opencode-agent/adapters.test.ts
@@ -1416,6 +1416,21 @@ describe('config', () => {
     expect(loadConfig({ ...baseEnv, AGENT_MAX_ATTEMPTS: raw }, '/repo').maxAttempts).toBe(3)
   })
 
+  test('gives one turn an hour by default, not half of one', () => {
+    // The default used to be 30 minutes, and that number — not the job's 90-minute
+    // ceiling — is what every long run actually stopped on: three consecutive runs
+    // ended at the same 33 minutes of wall clock, each one a single turn aborted at
+    // its cap, wrapped up and parked, with an hour of paid-for runner left unused.
+    // A turn is the granularity a plan step runs at, and a step worth doing is
+    // routinely worth more than half an hour.
+    //
+    // Safe against the ceiling it sits under precisely because `turnTimeoutMs`
+    // takes the *smaller* of the two: a turn opened late in the job still gets what
+    // is left of it minus the reserve and the wrap-up, so raising this can lengthen
+    // a turn that has room and can never let one outlive the runner.
+    expect(loadConfig(baseEnv, '/repo').agentTimeoutMs).toBe(3_600_000)
+  })
+
   /** Two facts a runner knows and nothing else does, as the workflow forwards them. */
   const JOB_STARTED = Date.UTC(2026, 7, 8, 12, 0)
   const jobEnv: Env = {


### PR DESCRIPTION
The job ceiling was never what long runs stopped on. `AGENT_TIMEOUT_MS`
defaulted to 30 minutes against a 90-minute `timeout-minutes:`, so with
the shrink in `turnTimeoutMs` doing its job the per-turn cap was the only
bound a long run ever reached — three consecutive live runs ended at the
same 33 minutes of wall clock, each one a single turn aborted at its cap,
wrapped up and parked, with an hour of paid-for runner unspent.

30-against-90 was the safe side of a defect that no longer exists. When
the two were hand-kept numbers a generous turn cap could outlive the
runner and post nothing; now a turn is handed the smaller of this and
what is left of the job, so one opened late still shrinks to fit the
runner it will die with, whatever this says. Raising it cannot bring
that back.

The default moves to `config-values.ts` as `DEFAULT_TURN_TIMEOUT_MS`,
beside the range it has to satisfy: the two only mean anything together,
and the pair drifting apart is what the "default would itself be accepted
as an override" test exists to catch.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TkfuBg5nWaKjV4PKX1QSib