### PR TITLE
feat(opencode-agent): say which server died, and ask the runner why

### DIFF
--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -416,6 +416,67 @@ jobs:
             --event-name "$GITHUB_EVENT_NAME" \
             --repo-root "$GITHUB_WORKSPACE"
 
+      # The two facts a dead pipeline cannot report about itself, collected while
+      # the runner still exists.
+      #
+      # Issue #239 failed three times in one phase and the cause could not be
+      # settled from any surviving evidence. The runner is ephemeral, the workflow
+      # uploads no artefacts, and the model turn is unrecoverable by design — so
+      # "the OpenCode server went away" was established, and *why* was not. The two
+      # candidates were an out-of-memory kill and a second `opencode` the model had
+      # started from `bash`; both are visible here for the width of a few
+      # milliseconds after the job fails, and nowhere else, ever again.
+      #
+      # **Names and counts only, never command lines.** `ps` is asked for `comm`
+      # rather than `args` deliberately: the argument vector of a tool child is
+      # model-authored content, and this log is world-readable on a public
+      # repository — the same rule `opencode-agent/src/activity.ts` enforces on the
+      # event stream, which is what keeps the pipeline's own logs safe to publish.
+      # Two live `opencode` processes is the finding; what either was told to do is
+      # not this step's to print. Get that from a local `--event-path` run.
+      #
+      # Every probe is individually optional and none may fail the job: `dmesg`
+      # needs privileges the runner may not grant, and the cgroup file is v2-only.
+      # A step that reports nothing is a step that found nothing worth reporting.
+      - name: Post-mortem for a failed pipeline
+        if: failure() && steps.pipeline.conclusion == 'failure'
+        run: |
+          echo '--- processes still alive (names only, no command lines) ---'
+          # `awk` drops the zero-RSS rows, which are kernel threads: there are over
+          # a hundred of them on a hosted runner and they would fill this list
+          # entirely, burying the handful of processes the failure is about.
+          ps -eo pid,ppid,pgid,rss,etime,comm --sort=-rss | awk 'NR == 1 || $4 > 0' | head -30
+
+          echo '--- how many of them are opencode ---'
+          # More than one is the finding: the pipeline spawns exactly one server,
+          # so a second is something the model started.
+          # `|| true`, not `|| echo 0`: `pgrep -c` already prints `0` when nothing
+          # matched *and* exits 1, so the obvious fallback prints the count twice.
+          pgrep -c -x opencode || true
+
+          echo '--- kernel out-of-memory kills ---'
+          # Collected to a file and then tested for size, rather than branching on
+          # the pipeline's status: the exit code of `a | grep | tail` is `tail`'s,
+          # which is 0 whether or not `grep` matched, so the obvious `if` would
+          # announce an OOM kill on every healthy runner.
+          # `sudo -n` so a runner that will not grant it says so and moves on.
+          sudo -n dmesg -T 2>/dev/null | grep -iE 'killed process|out of memory' | tail -20 > /tmp/agent-oom.txt || true
+          if [ -s /tmp/agent-oom.txt ]; then
+            cat /tmp/agent-oom.txt
+          else
+            echo 'No OOM kill found, or dmesg is not readable on this runner.'
+          fi
+
+          echo '--- peak memory for this job cgroup ---'
+          cat /sys/fs/cgroup/memory.peak 2>/dev/null || echo 'memory.peak is unavailable (cgroup v1, or not exposed).'
+          free -m || true
+
+          echo '--- opencode server log (size only; contents are model-adjacent) ---'
+          # Deliberately `wc -c`, not `cat`. The size says whether the server got
+          # far enough to write anything and whether it died mid-write; the
+          # contents are read from a local reproduction, not from a public log.
+          find "$HOME/.local/share/opencode/log" -type f -exec wc -c {} + 2>/dev/null || echo 'No opencode log directory.'
+
       # For a job that stopped with nothing on the issue: an install failure, a
       # runner timeout, a cancelled job, a config error thrown before the first
       # comment could be posted, a crash.

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -86,6 +86,17 @@ findings: `ROADMAP.md`.
   testable without a filesystem or a remote, and neither has a literal fallback:
   a baked-in review path reported every run outside this repository as
   permanently red, and a `main` default killed every run inside it.
+- The OpenCode boundary is three files, split by what changes them.
+  `src/sdk-contract.ts` is what the SDK **says** — the shapes, recorded;
+  `src/opencode-connect.ts` is how it is **started and addressed** — a spawned
+  process, a port, a base URL; `src/opencode-adapter.ts` is the **session** the
+  pipeline holds — an id, a lifetime, a teardown. `src/turn-run.ts` is the fourth
+  and the newest: one **turn**, which is the thing with a clock, a heartbeat and
+  three ways to end. It owns the bound, the heartbeat and the failure
+  classification, and it never imports back from the adapter — `TurnBounds` and
+  `TurnConnection` are narrow slices that `OpenCodeAgentOptions` and
+  `OpenCodeConnection` extend, so each states what running a turn actually needs
+  rather than restating what an agent is.
 - Every external boundary is an injected interface (`GitHubApi`, `Git`,
   `CheckRunner`, `RunReview`, `OpenCodeAgent`, `ReadSkillFile`).
 
@@ -554,6 +565,20 @@ not permitted to create or approve pull requests` is a repository or
   phase `buildClassifyPrompt` briefs on what the phase means, because `none` is
   now load-bearing and a real answer is often a bare fragment that reads as
   chatter to a phase-blind classifier.
+- **A turn that broke says _which_ remote broke.** `runTurn` probes
+  `connection.alive()` on the failure path and raises `serverGoneError` when the
+  local `opencode serve` has stopped answering, instead of passing on the
+  transport's `The socket connection was closed unexpectedly` — a sentence that
+  names neither end of the socket and sends every reader to the model provider.
+  Three orderings there are load-bearing: a turn deadline leaves **before** the
+  probe (a ceiling relabelled as a crash throws away finished steps), a probe that
+  **rejects** reads as `false` rather than replacing the failure it was asked
+  about, and a failure over a server that still answers is passed through
+  untouched. It is a classification and must never become a **retry**: the one
+  layer that may retry is `provider-proxy.ts`, the only one that still has an HTTP
+  status. The workflow's post-mortem step is the other half — it reports the OOM
+  killer, the cgroup memory peak and a process census by `comm`, because _why_ the
+  server died is not visible from inside the process that lost it.
 - **Bounds go on the finished prompt, and on waiting.** `prompt-budget.ts` caps
   what reaches the model — per prompt, not per input, since a per-input cap
   bounds one log and nothing else. `deadline.ts` bounds waiting for a model turn;
@@ -618,9 +643,16 @@ not permitted to create or approve pull requests` is a repository or
 - One class per file: pipeline failures are constructed through the factories in
   `src/errors.ts` rather than new error subclasses.
 - Tests live in `tests/opencode-agent/`, follow `tests/CLAUDE.md`, and must not
-  touch the network. The one exception is `live-sdk.integration.ts`, which is
-  deliberately not a `*.test.ts` so default discovery skips it; it needs the
-  `opencode` CLI and is run via `bun run opencode-agent:test:live`.
+  touch the network. Two files are deliberately not `*.test.ts`, so default
+  discovery skips them; both need the `opencode` CLI and neither runs in CI.
+  `live-sdk.integration.ts` (`bun run opencode-agent:test:live`) is the recorder —
+  the SDK response fixtures in `adapters.test.ts` come from it, so re-run it rather
+  than adjusting a decoder by inspection when the pin moves.
+  `server-survival.integration.ts` (`bun run opencode-agent:test:survival`) is the
+  diagnostic: it drives candidate shell commands through `POST /session/:id/shell`
+  and asks after each whether this job's own server survived them. Both are driven
+  **without a model** — the shell endpoint spawns the same `bash -l -c` child the
+  bash tool does — which is what makes them cheap enough to run on a laptop.
 - When a command test asserts an outcome, assert the **persisted state**, not
   just the returned status — a state that is never posted never happened.
 - **The SDK response shapes are recorded, not guessed.** `sdk-contract.ts`'s

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -1005,6 +1005,36 @@ holds.
 Token and cost totals ride along, per step and in every heartbeat, and the token
 half is now a ceiling as well as a reading — see **What bounds a run** above.
 
+### The post-mortem, for a job whose server died
+
+The rule above has a cost, and it was paid on issue #239: when a run failed three
+times with `The socket connection was closed unexpectedly`, nothing in the log
+could say why. That message is Bun's wording for a `fetch` whose peer went away
+and names neither end of it, so it reads as a model-provider problem — while the
+peer that had actually gone was the `opencode serve` this job spawned on
+loopback. The pipeline now says so itself: a turn that fails asks the server
+whether it is still there, and reports **the local OpenCode server stopped
+answering** rather than quoting the transport.
+
+_Why_ it died is not visible from inside the process that lost it, so a
+`if: failure()` step asks the runner before it disappears:
+
+```
+--- processes still alive (names only, no command lines) ---
+--- how many of them are opencode ---
+--- kernel out-of-memory kills ---
+--- peak memory for this job cgroup ---
+```
+
+Two live `opencode` processes means something started a second one; a line from
+the OOM killer means the runner ran out of memory. **Names and counts only**, by
+the same rule as the rest of this section — `ps` is asked for `comm` and never
+`args`, because a tool child's argument vector is model-authored content and this
+log is public. When you need the commands themselves, reproduce locally: see
+**Local runs** below, and `bun run opencode-agent:test:survival`, which drives
+candidate commands at a throwaway server and reports which of them it does not
+survive.
+
 ## Guardrails
 
 Policy lives in `src/guardrails.ts`. What an event _is_ lives in

--- a/opencode-agent/ROADMAP.md
+++ b/opencode-agent/ROADMAP.md
@@ -2086,6 +2086,64 @@ in the proxy's `authorization` header. Removed, with the invariant written down
 instead. What survives is `formatFailures`' `>` versus `>=`, where slicing the
 tail of a string that is exactly the budget returns the same string.
 
+### S5-12 — a dead server reported as a socket, and a cause no log could settle
+
+Issue #239 failed three times in `REVIEW_AND_MUTATE` and never committed a step.
+Two distinct failures, not one, and telling them apart took the whole thread:
+
+- **Run 1** hit `AGENT_TIMEOUT_MS` with the server healthy — 355 tool calls,
+  heartbeats frozen on `bash (running)` for three-minute stretches, and teardown
+  reporting a **second** `opencode` process, a `bun`, three `bash` and a `curl`
+  left alive. A foreground child that never exited.
+- **Runs 2 and 3** died mid-turn with `The socket connection was closed
+unexpectedly`, Bun's wording for a `fetch` whose peer went away.
+
+That message names neither end of the socket, so it reads as a provider problem.
+It was not: the `session.get` that `tokensUsed()` makes next failed too — the
+`"did not report session usage"` warning is present in runs 2 and 3 and **absent**
+in run 1 — and that call is loopback. The `opencode serve` this job spawned had
+died. Issue #240, in the same phase with the same model and profile, ran sixteen
+minutes and 152 tool calls and reached `idle` cleanly, so this is not general
+flakiness.
+
+The **cause** of the server's death is still open, and the honest reason is that
+nothing survived to settle it. The runner is ephemeral, the workflow uploads no
+artefacts, and `activity.ts` keeps tool input out of the log by design — so
+whether the model typed `pkill opencode`, whether the runner ran out of memory, or
+whether the server crashed cannot be recovered from run 31280928888 or any other.
+
+What was in reach, and is now done:
+
+1. **The failure names itself.** `serverGoneError` in `errors.ts`, raised by
+   `runTurn` in the new `turn-run.ts`, which probes `connection.alive()` on the
+   failure path only and reports the death rather than quoting the transport. The
+   probe is the same `session.get` the inference above was drawn from — turned
+   from something reconstructed a week later into something the run says at the
+   time. Ordering is load-bearing and tested three ways: a turn deadline leaves
+   first, a probe that rejects reads as `false`, and a live server leaves an
+   ordinary failure alone.
+2. **The runner is asked what it saw, before it disappears.** A post-mortem step
+   in `agent-pipeline.yml`, `if: failure()`, reporting the OOM killer, the cgroup
+   memory peak and a process census. **Names and counts only** — `ps` is asked for
+   `comm`, never `args`, because a tool child's argument vector is model-authored
+   content and that log is world-readable, which is `activity.ts`'s rule applied to
+   the one place it had not been. Two live `opencode` processes is the finding;
+   what either was told to do is not that step's to print.
+3. **The kill is reproducible without a model.**
+   `tests/opencode-agent/server-survival.integration.ts`
+   (`bun run opencode-agent:test:survival`) drives candidate commands through
+   `POST /session/:id/shell` — the same `bash -l -c` child the bash tool spawns, no
+   credentials needed — and probes the server after each. The `pkill` hypothesis is
+   deliberately **not** a row: automating it means killing every `opencode` on the
+   host. If every row comes back `alive`, that is what is left.
+
+The finding underneath all three is not a pipeline bug. Plan step 2 told the model
+to "run the live-run experiments against the real `opencode` binary" inside the
+container whose control plane _is_ an `opencode serve` on loopback, with the
+`build` profile's unrestricted `bash`. A research plan that drives this pipeline's
+own tooling belongs in a separate job; the three items above make the next such
+run legible rather than preventing it.
+
 Measured coverage of the spike's own suite:
 
 | File                  | Lines  | Functions | Gap                                                                                                |

--- a/opencode-agent/package.json
+++ b/opencode-agent/package.json
@@ -10,6 +10,7 @@
     "format": "cd .. && oxfmt --write opencode-agent/src tests/opencode-agent --ignore-path=.oxfmtignore",
     "format:check": "cd .. && oxfmt --check opencode-agent/src tests/opencode-agent --ignore-path=.oxfmtignore",
     "test:live": "cd .. && bun run tests/opencode-agent/live-sdk.integration.ts",
+    "test:survival": "cd .. && bun run tests/opencode-agent/server-survival.integration.ts",
     "verify-skills": "cd .. && bun run opencode-agent/scripts/verify-skills.ts"
   },
   "dependencies": {

--- a/opencode-agent/src/errors.ts
+++ b/opencode-agent/src/errors.ts
@@ -176,6 +176,47 @@ export const turnDeadlineError = (elapsedMs: number, progress: ProgressSnapshot)
 export const isTurnDeadline = (error: unknown): error is PipelineError =>
   error instanceof PipelineError && error.code === TURN_DEADLINE
 
+/** The other failure a reader cannot diagnose from its message alone. */
+const SERVER_GONE = 'OPENCODE_SERVER_GONE'
+
+/**
+ * A turn whose OpenCode server stopped answering, named rather than quoted.
+ *
+ * Issue #239 failed twice with `The socket connection was closed unexpectedly`,
+ * which is Bun's wording for a `fetch` whose peer went away and names neither
+ * end of it. Every reader starts at the model provider, because that is the only
+ * remote a model turn obviously has. It was the `opencode serve` **this job
+ * spawned** — established only afterwards, and only by inference: the
+ * `session.get` that `tokensUsed()` makes next failed too, and that call is a
+ * loopback request no provider is on the path of. So the evidence was in hand at
+ * the moment of failure and thrown away, and the run reported the one sentence
+ * that sends you the wrong way.
+ *
+ * This asks the question instead of leaving it to be reconstructed from two log
+ * lines a week later. The transport's own message is kept, because it is the only
+ * account of *how* the socket went; what is added is which socket it was, and
+ * where to look for the cause — the post-mortem step, which reports an
+ * out-of-memory kill and a second `opencode` process precisely because neither is
+ * visible from here.
+ *
+ * Distinguishable by code for the reason {@link turnDeadlineError} is, and it is
+ * checked **after** that one: a deadline is a ceiling the phase salvages work for,
+ * and a turn cut off by its own bound must keep meaning that even when the probe
+ * that runs afterwards finds the server gone too.
+ */
+export const serverGoneError = (transport: string): PipelineError =>
+  new PipelineError(
+    SERVER_GONE,
+    'The local OpenCode server stopped answering mid-turn, so this turn ended with nothing to show for it. ' +
+      `The transport reported: ${transport}. That is the \`opencode serve\` this job spawned on loopback — ` +
+      'not the model provider — so look at the run’s post-mortem step for an out-of-memory kill or for a ' +
+      'second `opencode` process the model started from `bash`.',
+  )
+
+/** Whether a rejection is that death. */
+export const isServerGone = (error: unknown): error is PipelineError =>
+  error instanceof PipelineError && error.code === SERVER_GONE
+
 export const modelResponseError = (message: string, raw: string): PipelineError =>
   new PipelineError('MODEL_RESPONSE', `${message}\n\nRaw reply:\n${raw.slice(0, 2000)}`)
 

--- a/opencode-agent/src/opencode-adapter.ts
+++ b/opencode-agent/src/opencode-adapter.ts
@@ -4,15 +4,17 @@
 // See LICENSE in the project root for details.
 
 import { withDeadline } from './deadline.js'
-import { openCodeError, turnDeadlineError } from './errors.js'
+import { openCodeError } from './errors.js'
 import type { Logger } from './logger.js'
 import { modelRef } from './openai-config.js'
 import type { OpenAiSettings } from './openai-config.js'
 import { connectSdk } from './opencode-connect.js'
-import { createProgressTracker, followEvents, withHeartbeat } from './progress.js'
-import type { EventFollower, ProgressSnapshot, ProgressTracker } from './progress.js'
+import { createProgressTracker, followEvents } from './progress.js'
+import type { EventFollower, ProgressTracker } from './progress.js'
 import { buildBody, decodeAbort, decodeReply, parseModelRef } from './sdk-contract.js'
-import type { SdkPromptBody, SessionUsage } from './sdk-contract.js'
+import type { SessionUsage } from './sdk-contract.js'
+import { runTurn } from './turn-run.js'
+import type { TurnBounds, TurnConnection } from './turn-run.js'
 
 export type { ModelRef, SdkPromptBody } from './sdk-contract.js'
 export { parseModelRef } from './sdk-contract.js'
@@ -61,10 +63,15 @@ export interface OpenCodeAgent {
   close(): Promise<void>
 }
 
-/** Minimal slice of the SDK surface the adapter drives. */
-export interface OpenCodeConnection {
+/**
+ * Minimal slice of the SDK surface the adapter drives.
+ *
+ * The two calls a *turn* makes — `sendPrompt` and `alive` — are inherited rather
+ * than restated: they are the contract `turn-run.ts` needs, and a second
+ * declaration here is a second thing to keep in step.
+ */
+export interface OpenCodeConnection extends TurnConnection {
   createSession(title: string): Promise<string>
-  sendPrompt(sessionId: string, body: SdkPromptBody): Promise<unknown>
   /**
    * The server's event stream, used only to report progress.
    *
@@ -88,57 +95,14 @@ export interface OpenCodeConnection {
   close(): Promise<void>
 }
 
-export interface OpenCodeAgentOptions {
+export interface OpenCodeAgentOptions extends TurnBounds {
   directory: string
   /** The single OpenAI-compatible endpoint this pipeline talks to. */
   openai: OpenAiSettings
   sessionTitle: string
-  /**
-   * Upper bound on one model turn, from `AGENT_TIMEOUT_MS` shrunk to fit the job.
-   * Omitted means unbounded, which only a caller with nothing to bound should want —
-   * config range-checks that variable to at least a second.
-   *
-   * Every subprocess this pipeline drives already had one — the check runner and
-   * the review loop both pass it to `runCommand` — and the in-process session,
-   * the one turn that can run for twenty minutes, was the only path without.
-   *
-   * A **function** is the form that matters, and a number is kept only for callers
-   * with a fixed bound. The session is memoized for the whole job and the bound is
-   * derived from the job's remaining clock, so a number is read once — when the
-   * server first boots — and every later turn in that job carries a bound sized for a
-   * clock that has since moved. That was survivable while a job ran one turn per
-   * phase; with one turn per plan step it is the silence this bound exists to
-   * prevent, because a step starting six minutes before the runner's own
-   * `timeout-minutes` would be handed the thirty-minute cap and killed with the job.
-   * Resolved per turn in {@link bounded}, so the bound tracks the resource it protects.
-   */
-  timeoutMs?: number | (() => number)
-  /** Where progress goes. The adapter is the only thing that can see it. */
-  log: Logger
-  /** Heartbeat period while a turn is outstanding. `0` disables it. */
-  heartbeatMs?: number
-  /**
-   * Where each heartbeat goes besides the log.
-   *
-   * The adapter is the only layer that can see a turn in flight, and the live
-   * status comment on the issue is the only surface a maintainer has a link to
-   * — so the snapshot has to be handed out from here or the two never meet.
-   * Optional because most runs have nowhere to send it: a local `--event-path`
-   * run has no status comment at all.
-   */
-  onTick?: (snapshot: ProgressSnapshot) => void
   /** Injection seam for tests. Defaults to the real SDK server + client. */
   connect?: () => Promise<OpenCodeConnection>
 }
-
-/**
- * How often a turn says it is still alive.
- *
- * A minute is short enough that a stalled job is obvious within one screen of
- * log, and long enough that a twenty-minute implement phase adds twenty lines
- * rather than swamping the tool calls that carry the real information.
- */
-const DEFAULT_HEARTBEAT_MS = 60_000
 
 /**
  * Boots a headless OpenCode server in-process and opens one session against the
@@ -163,7 +127,7 @@ export const createOpenCodeAgent = async (options: OpenCodeAgentOptions): Promis
   return {
     sessionId,
     prompt: async (request) => {
-      const reply = await bounded(connection.sendPrompt(sessionId, buildBody(model, request)), options, tracker)
+      const reply = await runTurn(connection, sessionId, buildBody(model, request), options, tracker)
       return { text: decodeReply(reply), sessionId }
     },
     tokensUsed: async (): Promise<number> => {
@@ -259,34 +223,3 @@ const startReporting = (
     },
   }
 }
-
-/** This turn's bound: asked afresh when the caller supplied a way to ask. */
-const turnBound = (options: OpenCodeAgentOptions): number => {
-  const bound = options.timeoutMs ?? 0
-  return typeof bound === 'function' ? bound() : bound
-}
-
-/**
- * Wraps one turn in both of its bounds.
- *
- * Heartbeat outside the deadline, never inside it: a deadline that fires leaves
- * the underlying call pending, so an inner heartbeat's cleanup would never run
- * and its interval would hold the process open past the end of the job.
- */
-const bounded = (work: Promise<unknown>, options: OpenCodeAgentOptions, tracker: ProgressTracker): Promise<unknown> =>
-  withHeartbeat(
-    // The snapshot is read *at the rejection*, not when the bound was armed: what
-    // the phase needs to report is what the turn had managed by the time it was
-    // stopped, and this is the last frame that can still see the tracker.
-    //
-    // The bound itself is read here, per turn, for the reason `timeoutMs` may be a
-    // function: a job now runs a turn per plan step, and a bound derived from the
-    // job's remaining clock has to be asked again each time or it stops tracking it.
-    withDeadline(work, turnBound(options), (elapsed) => turnDeadlineError(elapsed, tracker.snapshot())),
-    {
-      everyMs: options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS,
-      log: options.log,
-      snapshot: tracker.snapshot,
-      onTick: options.onTick,
-    },
-  )

--- a/opencode-agent/src/opencode-connect.ts
+++ b/opencode-agent/src/opencode-connect.ts
@@ -7,6 +7,7 @@ import { createServer } from 'node:net'
 
 import { createOpencodeClient, createOpencodeServer } from '@opencode-ai/sdk'
 
+import { withDeadline } from './deadline.js'
 import { buildOpencodeConfig } from './openai-config.js'
 import type { OpenAiSettings } from './openai-config.js'
 import type { OpenCodeConnection } from './opencode-adapter.js'
@@ -53,6 +54,44 @@ const reservePort = (): Promise<number> => {
 /** The SDK's own default is 5s, which a cold runner with a large repo can miss. */
 const SERVER_BOOT_TIMEOUT_MS = 60_000
 
+/**
+ * How long the liveness probe waits before calling the server gone.
+ *
+ * Short on purpose. This runs after a turn has already failed, on a loopback
+ * request to a process on the same host, and its whole value is being answered
+ * while the run is still able to report — a generous bound here buys nothing and
+ * delays the failure comment.
+ */
+const PROBE_TIMEOUT_MS = 5_000
+
+/**
+ * Whether the server answers at all, for {@link OpenCodeConnection.alive}.
+ *
+ * Deliberately the same call as `usage`, asked for its *transport* rather than
+ * its payload: whatever `session.get` answers, an answer at all means the server
+ * is up. Reusing a recorded endpoint rather than reaching for a health route
+ * keeps this workspace's rule intact — the SDK shapes here are recorded from a
+ * live server, and an endpoint nothing has driven is a guess.
+ *
+ * Bounded, because "gone" and "wedged" both have to end as `false`: a server
+ * whose event loop is stuck would otherwise hold this open for as long as the
+ * socket stays half-open, on a path that only ever runs while a failure is
+ * already being reported.
+ */
+const probeAlive = (
+  client: ReturnType<typeof createOpencodeClient>,
+  directory: string,
+  sessionId: string,
+): Promise<boolean> =>
+  withDeadline(
+    client.session.get({ path: { id: sessionId }, query: { directory } }),
+    PROBE_TIMEOUT_MS,
+    () => new Error('probe timed out'),
+  ).then(
+    () => true,
+    () => false,
+  )
+
 export const connectSdk = async (directory: string, openai: OpenAiSettings): Promise<OpenCodeConnection> => {
   // The provider, endpoint and model are pinned in the server's own config, so
   // the session cannot fall back to whatever credentials happen to be in env.
@@ -84,6 +123,7 @@ export const connectSdk = async (directory: string, openai: OpenAiSettings): Pro
     events: async () => (await client.event.subscribe({ sseMaxRetryAttempts: 0 })).stream,
     usage: async (sessionId) =>
       decodeSessionUsage(await client.session.get({ path: { id: sessionId }, query: { directory } })),
+    alive: (sessionId) => probeAlive(client, directory, sessionId),
     // The stop. Measured against a live server: this kills the tool child the
     // model is running and leaves the server itself up — which is the opposite of
     // what `close()` does, and the reason the two are not interchangeable.

--- a/opencode-agent/src/turn-run.ts
+++ b/opencode-agent/src/turn-run.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { withDeadline } from './deadline.js'
+import { isTurnDeadline, serverGoneError, turnDeadlineError } from './errors.js'
+import type { Logger } from './logger.js'
+import { withHeartbeat } from './progress.js'
+import type { ProgressSnapshot, ProgressTracker } from './progress.js'
+import type { SdkPromptBody } from './sdk-contract.js'
+import { errorMessage } from './types.js'
+
+/**
+ * Running **one** model turn: bounding it, reporting on it while it is
+ * outstanding, and saying how it ended.
+ *
+ * Split from `opencode-adapter.ts` when the failure classification would not fit
+ * beside the session wiring, along a seam that file already had. The adapter owns
+ * a *session* — a server, a session id, a lifetime, a teardown — and this owns a
+ * *turn*, which is the thing that has a clock, a heartbeat and three ways to end.
+ * They change for different reasons: the adapter on a lifecycle question, this one
+ * when the pipeline learns something new about how a turn dies.
+ *
+ * The two interfaces below are narrow on purpose. `OpenCodeAgentOptions` and
+ * `OpenCodeConnection` extend them, so this module never imports back from the one
+ * it was split out of, and each states exactly what running a turn requires —
+ * which is a much smaller claim than "an agent".
+ */
+
+/**
+ * How often a turn says it is still alive.
+ *
+ * A minute is short enough that a stalled job is obvious within one screen of
+ * log, and long enough that a twenty-minute implement phase adds twenty lines
+ * rather than swamping the tool calls that carry the real information.
+ */
+const DEFAULT_HEARTBEAT_MS = 60_000
+
+/** What a turn needs to know about its own clock and where it reports. */
+export interface TurnBounds {
+  /**
+   * Upper bound on one model turn, from `AGENT_TIMEOUT_MS` shrunk to fit the job.
+   * Omitted means unbounded, which only a caller with nothing to bound should want —
+   * config range-checks that variable to at least a second.
+   *
+   * Every subprocess this pipeline drives already had one — the check runner and
+   * the review loop both pass it to `runCommand` — and the in-process session,
+   * the one turn that can run for twenty minutes, was the only path without.
+   *
+   * A **function** is the form that matters, and a number is kept only for callers
+   * with a fixed bound. The session is memoized for the whole job and the bound is
+   * derived from the job's remaining clock, so a number is read once — when the
+   * server first boots — and every later turn in that job carries a bound sized for a
+   * clock that has since moved. That was survivable while a job ran one turn per
+   * phase; with one turn per plan step it is the silence this bound exists to
+   * prevent, because a step starting six minutes before the runner's own
+   * `timeout-minutes` would be handed the thirty-minute cap and killed with the job.
+   * Resolved per turn in {@link bounded}, so the bound tracks the resource it protects.
+   */
+  timeoutMs?: number | (() => number)
+  /** Where progress goes. The adapter is the only thing that can see it. */
+  log: Logger
+  /** Heartbeat period while a turn is outstanding. `0` disables it. */
+  heartbeatMs?: number
+  /**
+   * Where each heartbeat goes besides the log.
+   *
+   * The adapter is the only layer that can see a turn in flight, and the live
+   * status comment on the issue is the only surface a maintainer has a link to
+   * — so the snapshot has to be handed out from here or the two never meet.
+   * Optional because most runs have nowhere to send it: a local `--event-path`
+   * run has no status comment at all.
+   */
+  onTick?: (snapshot: ProgressSnapshot) => void
+}
+
+/**
+ * The two calls one turn makes: the turn itself, and the question its failure
+ * raises.
+ */
+export interface TurnConnection {
+  sendPrompt(sessionId: string, body: SdkPromptBody): Promise<unknown>
+  /**
+   * Whether the server is still there at all, asked of the transport.
+   *
+   * The same endpoint `usage` calls, deliberately, and a different question —
+   * which is why it is a second method rather than a reading of the first. `usage`
+   * asks *what the server says* and answers `null` for a payload it does not
+   * recognise; this asks *whether anything answered*, and only a rejection is a
+   * `false`. Collapsing them loses exactly the distinction issue #239 needed: a
+   * `null` usage was the evidence the server had died, and it is indistinguishable
+   * from a shape the decoder has not been taught.
+   *
+   * Required rather than optional, for the reason `events` and `abort` are on the
+   * connection this one is a slice of.
+   */
+  alive(sessionId: string): Promise<boolean>
+}
+
+/** This turn's bound: asked afresh when the caller supplied a way to ask. */
+const turnBound = (bounds: TurnBounds): number => {
+  const timeout = bounds.timeoutMs ?? 0
+  return typeof timeout === 'function' ? timeout() : timeout
+}
+
+/**
+ * The bound and the heartbeat, in the one order that works.
+ *
+ * Heartbeat outside the deadline, never inside it: a deadline that fires leaves
+ * the underlying call pending, so an inner heartbeat's cleanup would never run
+ * and its interval would hold the process open past the end of the job.
+ */
+const bounded = (work: Promise<unknown>, bounds: TurnBounds, tracker: ProgressTracker): Promise<unknown> =>
+  withHeartbeat(
+    // The snapshot is read *at the rejection*, not when the bound was armed: what
+    // the phase needs to report is what the turn had managed by the time it was
+    // stopped, and this is the last frame that can still see the tracker.
+    //
+    // The bound itself is read here, per turn, for the reason `timeoutMs` may be a
+    // function: a job now runs a turn per plan step, and a bound derived from the
+    // job's remaining clock has to be asked again each time or it stops tracking it.
+    withDeadline(work, turnBound(bounds), (elapsed) => turnDeadlineError(elapsed, tracker.snapshot())),
+    {
+      everyMs: bounds.heartbeatMs ?? DEFAULT_HEARTBEAT_MS,
+      log: bounds.log,
+      snapshot: tracker.snapshot,
+      onTick: bounds.onTick,
+    },
+  )
+
+/**
+ * Runs one turn and, when it breaks, says whether the server it was talking to is
+ * still there.
+ *
+ * The probe runs **only on the failure path**, so a healthy run pays nothing for
+ * it, and it asks a question that stops being answerable seconds later: this
+ * pipeline closes the server in `runCli`'s `finally`, so by the time a failure has
+ * been rendered into a comment there is nothing left to ask.
+ *
+ * Three orderings here are each load-bearing. A turn deadline leaves before the
+ * probe, because it is the one rejection a phase branches on and a ceiling
+ * relabelled as a crash throws away finished steps. A probe that **rejects** is
+ * read as `false` rather than propagated — a refused connection is the strongest
+ * evidence there is that the server is gone, and letting it escape would replace
+ * the failure it was asked about with a footnote. And an ordinary failure over a
+ * server that still answers is returned untouched, because a rate limit reported
+ * as a dead server is a worse lie than the bare socket message this replaces.
+ *
+ * Not a retry, and it must not become one: the one layer that may retry is
+ * `provider-proxy.ts`, which is the only one that still has an HTTP status.
+ */
+export const runTurn = async (
+  connection: TurnConnection,
+  sessionId: string,
+  body: SdkPromptBody,
+  bounds: TurnBounds,
+  tracker: ProgressTracker,
+): Promise<unknown> => {
+  try {
+    return await bounded(connection.sendPrompt(sessionId, body), bounds, tracker)
+  } catch (error) {
+    if (isTurnDeadline(error)) throw error
+
+    const alive = await connection.alive(sessionId).catch(() => false)
+    if (alive) throw error
+
+    bounds.log.error({ sessionId }, 'The OpenCode server stopped answering; the turn died with it')
+    throw serverGoneError(errorMessage(error))
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mutation-improve:start": "bun run --filter mutation-improve start",
     "opencode-agent:test": "bun run --filter opencode-agent test",
     "opencode-agent:test:live": "bun run --filter opencode-agent test:live",
+    "opencode-agent:test:survival": "bun run --filter opencode-agent test:survival",
     "opencode-agent:verify-skills": "bun run --filter opencode-agent verify-skills",
     "opencode-agent:typecheck": "bun run --filter opencode-agent typecheck",
     "opencode-agent:lint": "bun run --filter opencode-agent lint",

--- a/tests/opencode-agent/adapters.test.ts
+++ b/tests/opencode-agent/adapters.test.ts
@@ -14,7 +14,13 @@ import { resolveBaseBranch, resolveReviewCommand } from '../../opencode-agent/sr
 import { loadConfig, parseChecks } from '../../opencode-agent/src/config.js'
 import type { Env } from '../../opencode-agent/src/config.js'
 import { withDeadline } from '../../opencode-agent/src/deadline.js'
-import { isTurnDeadline, openCodeError, PipelineError, turnDeadlineError } from '../../opencode-agent/src/errors.js'
+import {
+  isServerGone,
+  isTurnDeadline,
+  openCodeError,
+  PipelineError,
+  turnDeadlineError,
+} from '../../opencode-agent/src/errors.js'
 import { createGit } from '../../opencode-agent/src/git.js'
 import type { GitOptions } from '../../opencode-agent/src/git.js'
 import type { PullRequestState } from '../../opencode-agent/src/github-pulls.js'
@@ -44,7 +50,7 @@ import type { SessionUsage } from '../../opencode-agent/src/sdk-contract.js'
 import { redactSecrets, scrubSecrets } from '../../opencode-agent/src/secrets.js'
 import type { CommandRunner } from '../../opencode-agent/src/shell.js'
 import { STATUS_MARKER } from '../../opencode-agent/src/status-comment.js'
-import { PHASES } from '../../opencode-agent/src/types.js'
+import { errorMessage, PHASES } from '../../opencode-agent/src/types.js'
 
 describe('collectText', () => {
   test('joins text parts and drops everything else', () => {
@@ -317,6 +323,9 @@ const noUsage = (): Promise<SessionUsage | null> => Promise.resolve({ tokens: 0,
 /** An abort nobody in this test is asking about, answering the recorded shape. */
 const noAbort = (): Promise<unknown> => Promise.resolve({ data: true })
 
+/** A server that is still there, for the tests the liveness probe is not about. */
+const stillThere = (): Promise<boolean> => Promise.resolve(true)
+
 describe('createOpenCodeAgent', () => {
   const fakeConnection = (sink: { bodies: SdkPromptBody[]; closed: number }, reply: unknown): OpenCodeConnection => ({
     createSession: (): Promise<string> => Promise.resolve('session-9'),
@@ -327,6 +336,7 @@ describe('createOpenCodeAgent', () => {
     events: noEvents,
     usage: noUsage,
     abort: noAbort,
+    alive: stillThere,
     close: (): Promise<void> => {
       sink.closed += 1
       return Promise.resolve()
@@ -407,6 +417,7 @@ describe('createOpenCodeAgent', () => {
           events: noEvents,
           usage: noUsage,
           abort: noAbort,
+          alive: stillThere,
           close: () => {
             closed += 1
             return Promise.resolve()
@@ -433,6 +444,9 @@ describe('createOpenCodeAgent', () => {
           events: noEvents,
           usage: noUsage,
           abort: noAbort,
+          // Deliberately the *unhelpful* answer: a deadline must win on its own,
+          // not because the probe happened to agree the server was fine.
+          alive: () => Promise.resolve(false),
           close: () => Promise.resolve(),
         }),
     })
@@ -457,6 +471,7 @@ describe('createOpenCodeAgent', () => {
           sendPrompt: () => Promise.resolve({ data: { parts: [] } }),
           usage: noUsage,
           abort: noAbort,
+          alive: stillThere,
           events: () =>
             Promise.resolve(
               streamOf(
@@ -486,6 +501,7 @@ describe('createOpenCodeAgent', () => {
           events: noEvents,
           usage: () => Promise.resolve({ tokens: 3602, cost: 0.014 }),
           abort: noAbort,
+          alive: stillThere,
           close: () => Promise.resolve(),
         }),
     })
@@ -512,6 +528,7 @@ describe('createOpenCodeAgent', () => {
           events: noEvents,
           usage,
           abort: noAbort,
+          alive: stillThere,
           close: () => Promise.resolve(),
         }),
     })
@@ -534,6 +551,7 @@ describe('createOpenCodeAgent', () => {
           sendPrompt: () => Promise.resolve({ data: { parts: [{ type: 'text', text: 'fine' }] } }),
           usage: noUsage,
           abort: noAbort,
+          alive: stillThere,
           events: () => Promise.reject(new Error('/event is not available')),
           close: () => Promise.resolve(),
         }),
@@ -563,6 +581,86 @@ describe('createOpenCodeAgent', () => {
     expect(isTurnDeadline(rejection)).toBe(true)
   })
 
+  /**
+   * A turn that breaks, over a server that answers a liveness probe as the test says.
+   *
+   * The default failure is verbatim what issue #239 reported twice: Bun's message
+   * for a socket that went away, which names neither end of it.
+   */
+  const brokenTurnAgent = (
+    alive: () => Promise<boolean>,
+    failure: Error = new Error('The socket connection was closed unexpectedly'),
+  ): Promise<OpenCodeAgent> =>
+    createOpenCodeAgent({
+      directory: '/repo',
+      openai: { apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1', model: 'm' },
+      sessionTitle: 't',
+      log: silentLog,
+      connect: () =>
+        Promise.resolve({
+          createSession: () => Promise.resolve('session-1'),
+          sendPrompt: () => Promise.reject(failure),
+          events: noEvents,
+          usage: noUsage,
+          abort: noAbort,
+          alive,
+          close: () => Promise.resolve(),
+        }),
+    })
+
+  test('names the server that went away, rather than repeating the socket error', async () => {
+    // Issue #239 failed twice with "The socket connection was closed unexpectedly",
+    // which sends a reader to the model provider. It was the `opencode serve` this
+    // job spawned — proven only because the *next* call, a loopback `session.get`
+    // that never touches a provider, failed too. That inference is what this makes
+    // into a statement the failure comment can carry on its own.
+    const agent = await brokenTurnAgent(() => Promise.resolve(false))
+
+    const rejection = await agent.prompt({ prompt: 'go' }).catch((error: unknown) => error)
+
+    expect(isServerGone(rejection)).toBe(true)
+    expect(errorMessage(rejection)).toContain('OpenCode server')
+    // The transport's own words are kept: they are the only evidence of *how* it went.
+    expect(errorMessage(rejection)).toContain('The socket connection was closed unexpectedly')
+  })
+
+  test('leaves a failure alone while the server is still answering', async () => {
+    // The probe has to be able to say "not this" or it is just a relabelling of
+    // every rejection, and a rate limit reported as a dead server is a worse lie
+    // than the bare socket message this replaces.
+    const agent = await brokenTurnAgent(stillThere, new Error('rate limited'))
+
+    const rejection = await agent.prompt({ prompt: 'go' }).catch((error: unknown) => error)
+
+    expect(isServerGone(rejection)).toBe(false)
+    expect(errorMessage(rejection)).toBe('rate limited')
+  })
+
+  test('reads a probe that cannot answer as a server that is not there', async () => {
+    // A probe that throws is evidence, not an accident to propagate: it must never
+    // replace the failure it was asked about, which is what an unguarded `await`
+    // here would do.
+    const agent = await brokenTurnAgent(() => Promise.reject(new Error('connection refused')))
+
+    const rejection = await agent.prompt({ prompt: 'go' }).catch((error: unknown) => error)
+
+    expect(isServerGone(rejection)).toBe(true)
+    expect(errorMessage(rejection)).toContain('The socket connection was closed unexpectedly')
+  })
+
+  test('a turn stopped by its own bound stays a deadline, whatever the probe says', async () => {
+    // Order matters. `settleWalk` parks the issue in `INCOMPLETE` and keeps the
+    // branch for a deadline, and fails the run for everything else — so a timed-out
+    // turn relabelled by a probe that happens to answer `false` would throw away
+    // finished steps.
+    const agent = await hangingAgent(5)
+
+    const rejection = await agent.prompt({ prompt: 'go' }).catch((error: unknown) => error)
+
+    expect(isTurnDeadline(rejection)).toBe(true)
+    expect(isServerGone(rejection)).toBe(false)
+  })
+
   /** A connection whose `abort` answers however the test wants it to. */
   const abortingAgent = (answer: () => Promise<unknown>, log = silentLog): Promise<OpenCodeAgent> =>
     createOpenCodeAgent({
@@ -577,6 +675,7 @@ describe('createOpenCodeAgent', () => {
           events: noEvents,
           usage: noUsage,
           abort: answer,
+          alive: stillThere,
           close: () => Promise.resolve(),
         }),
     })
@@ -637,6 +736,7 @@ describe('createOpenCodeAgent', () => {
           events: noEvents,
           usage: noUsage,
           abort: noAbort,
+          alive: stillThere,
           close: () => Promise.resolve(),
         }),
     })

--- a/tests/opencode-agent/server-survival.integration.ts
+++ b/tests/opencode-agent/server-survival.integration.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+/**
+ * Which commands run inside a job take that job's own OpenCode server down.
+ *
+ * Issue #239 approved a plan whose step 2 told the model to "run the live-run
+ * experiments against the real `opencode` binary", inside the container whose
+ * control plane *is* an `opencode serve` on loopback, with the `build` profile's
+ * unrestricted `bash`. It failed three times: once on the turn deadline with two
+ * live `opencode` processes and a `curl` left at teardown, and twice with the
+ * server gone mid-turn. Which of those a given command causes was not knowable
+ * from the CI logs — the runner is ephemeral and `activity.ts` keeps tool input
+ * out of the log by design — so it stayed an inference.
+ *
+ * This turns it into a measurement. `POST /session/:id/shell` spawns the same
+ * `bash -l -c` child the bash *tool* does, and blocks until it exits, so a
+ * candidate command can be driven with **no model and no credentials** — which is
+ * what makes this cheap enough to run on a laptop instead of burning an attempt on
+ * a real issue. After each candidate the server is asked whether it is still
+ * there, through the same probe `opencode-adapter.ts` uses on its failure path.
+ *
+ * Not a `*.test.ts`, for the reason `live-sdk.integration.ts` is not: it needs the
+ * `opencode` CLI on PATH and spends real seconds. Run it with:
+ *
+ *   bun run opencode-agent:test:survival
+ *
+ * **What this deliberately does not test.** The remaining hypothesis for the two
+ * socket deaths is that the model typed `pkill opencode` — the obvious cleanup
+ * after an experiment hangs. Automating that means killing every `opencode` on the
+ * host, including the one belonging to whoever is running this, so it stays a
+ * hand-run check rather than a candidate here. If the rows below all come back
+ * `alive`, that is the hypothesis left standing.
+ */
+
+import { createOpencodeClient, createOpencodeServer } from '@opencode-ai/sdk'
+
+import { withDeadline } from '../../opencode-agent/src/deadline.js'
+import { buildOpencodeConfig } from '../../opencode-agent/src/openai-config.js'
+import type { OpenAiSettings } from '../../opencode-agent/src/openai-config.js'
+import { decodeSessionId } from '../../opencode-agent/src/sdk-contract.js'
+
+/**
+ * No provider is ever contacted: every candidate is driven through the shell
+ * endpoint, which runs a command rather than prompting. The placeholder is here
+ * because `buildOpencodeConfig` needs one, and its unreachable host is the proof —
+ * anything that tried to reach a model would fail loudly rather than quietly work.
+ */
+const SETTINGS: OpenAiSettings = {
+  apiKey: 'unused-no-model-turn-in-this-probe',
+  baseUrl: 'http://127.0.0.1:1/v1',
+  model: 'unused',
+}
+
+/** Long enough to prove a command hangs, short enough to run the whole table. */
+const COMMAND_TIMEOUT_MS = 20_000
+
+/** The probe's own bound, matching the one the adapter's liveness check uses. */
+const PROBE_TIMEOUT_MS = 5_000
+
+interface Candidate {
+  /** What the row is called in the report. */
+  name: string
+  /** Exactly what a `bash` tool call would carry. */
+  command: string
+  /** What this row is evidence about, printed beside the result. */
+  asks: string
+}
+
+/**
+ * The commands, in the order the failures happened.
+ *
+ * Each is something plan step 2 asks for in so many words, reduced to the
+ * smallest command that can carry the same risk. Nothing here touches a process
+ * it did not start.
+ */
+const CANDIDATES: readonly Candidate[] = [
+  {
+    name: 'baseline: a command that simply takes a while',
+    command: 'sleep 5',
+    asks: 'that a slow tool call is not by itself fatal — the control for every row below',
+  },
+  {
+    name: 'a nested `opencode serve`, backgrounded',
+    command: 'nohup opencode serve --hostname=127.0.0.1 --port=0 >/dev/null 2>&1 & sleep 3; echo started',
+    asks: 'whether a second server can coexist with the pipeline’s own, or takes it down',
+  },
+  {
+    name: 'a nested `opencode serve`, left in the foreground',
+    command: 'opencode serve --hostname=127.0.0.1 --port=0',
+    asks: 'run 1’s shape: a foreground child that never exits, holding the turn to its deadline',
+  },
+  {
+    name: 'a foreground stdio process that never reads or exits',
+    command: 'cat',
+    asks: 'the same hang from the MCP-server direction — step 2’s fixture speaks stdio',
+  },
+]
+
+interface Outcome {
+  candidate: Candidate
+  /** How the command itself ended, from this side of the socket. */
+  command: 'returned' | 'timed out' | 'failed'
+  /** Whether the server answered afterwards. This is the finding. */
+  server: 'alive' | 'gone'
+}
+
+const main = async (): Promise<void> => {
+  const server = await createOpencodeServer({
+    hostname: '127.0.0.1',
+    port: 0,
+    config: buildOpencodeConfig(SETTINGS),
+    timeout: 60_000,
+  })
+  const directory = process.cwd()
+  const client = createOpencodeClient({ baseUrl: server.url, directory })
+  const sessionId = decodeSessionId(await client.session.create({ body: { title: 'survival' }, query: { directory } }))
+
+  console.log(`server up on ${server.url}, session ${sessionId}\n`)
+
+  /**
+   * The same question `OpenCodeConnection.alive` asks, for the same reason: any
+   * answer at all means the server is up, and only a rejection is a `false`.
+   */
+  const alive = (): Promise<boolean> =>
+    withDeadline(
+      client.session.get({ path: { id: sessionId }, query: { directory } }),
+      PROBE_TIMEOUT_MS,
+      () => new Error('probe timed out'),
+    ).then(
+      () => true,
+      () => false,
+    )
+
+  const run = async (candidate: Candidate): Promise<Outcome> => {
+    console.log(`→ ${candidate.name}`)
+    const command = await withDeadline(
+      client.session.shell({
+        path: { id: sessionId },
+        body: { agent: 'build', command: candidate.command },
+        query: { directory },
+      }),
+      COMMAND_TIMEOUT_MS,
+      () => new Error('command timed out'),
+    ).then(
+      (): Outcome['command'] => 'returned',
+      (error: unknown): Outcome['command'] =>
+        error instanceof Error && error.message === 'command timed out' ? 'timed out' : 'failed',
+    )
+
+    return { candidate, command, server: (await alive()) ? 'alive' : 'gone' }
+  }
+
+  // `mapSeries` is the repo's answer to `await` in a loop, and the order matters
+  // here for a second reason: a row that kills the server makes every row after it
+  // meaningless, so they cannot overlap.
+  const outcomes: Outcome[] = []
+  await CANDIDATES.reduce(
+    (chain, candidate) => chain.then(async () => void outcomes.push(await run(candidate))),
+    Promise.resolve(),
+  )
+
+  console.log('\n--- results ---')
+  for (const outcome of outcomes) {
+    console.log(`${outcome.server === 'gone' ? '✗' : '✓'} server ${outcome.server}  |  command ${outcome.command}`)
+    console.log(`   ${outcome.candidate.name}`)
+    console.log(`   asks: ${outcome.candidate.asks}`)
+  }
+
+  const killers = outcomes.filter((outcome) => outcome.server === 'gone')
+  console.log(
+    killers.length === 0
+      ? '\nNo candidate took the server down. The `pkill` hypothesis in this file’s header is what is left.'
+      : `\n${killers.length} candidate(s) took the server down; the first is the one to fix.`,
+  )
+
+  server.close()
+}
+
+await main()


### PR DESCRIPTION
Issue #239 failed three times in REVIEW_AND_MUTATE and never committed a
step. Two of those runs reported `The socket connection was closed
unexpectedly` — Bun's wording for a fetch whose peer went away, which names
neither end of the socket and so reads as a model-provider fault. It was
not. The peer that had gone was the `opencode serve` this job spawns on
loopback, established only afterwards and only by inference: the
`session.get` that `tokensUsed()` makes next failed too, and that call
reaches no provider.

That inference was available at the moment of failure and thrown away, so
`runTurn` now asks. On the failure path only, it probes the connection and
raises `serverGoneError` when nothing answers. Three orderings are
load-bearing and each has a test that fails without it: a turn deadline
leaves before the probe, since a ceiling relabelled as a crash would throw
away finished steps; a probe that rejects reads as `false` rather than
replacing the failure it was asked about; and a failure over a live server
is passed through untouched, because a rate limit reported as a dead server
is a worse lie than the message this replaces.

Why the server died is not visible from inside the process that lost it,
and nothing survived to settle it — the runner is ephemeral, the workflow
uploads no artefacts, and activity.ts keeps tool input out of the log by
design. So a post-mortem step asks the runner before it disappears: the OOM
killer, the cgroup memory peak, and a process census. Names and counts
only — `ps` is asked for `comm`, never `args`, because a tool child's
argument vector is model-authored content and that log is world-readable.
Two live `opencode` processes is the finding; what either was told to do is
not that step's to print.

For the part a log cannot answer, server-survival.integration.ts drives
candidate commands through `POST /session/:id/shell` — the same `bash -l -c`
child the bash tool spawns, no model and no credentials — and probes the
server after each. `pkill` is deliberately not a row: automating it means
killing every opencode on the host.

turn-run.ts is a split, not a new layer: the adapter owns a session and this
owns a turn, and the file was over max-lines once the classification landed.
TurnBounds and TurnConnection are narrow slices the adapter's own interfaces
extend, so nothing imports back.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pt6JMpq8muaJb4gomUX4CA