### PR TITLE
feat(opencode-agent): make the agent OpenSpec-compliant (folder is truth, archive door, no legacy)

### DIFF
--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -25,6 +25,14 @@ on:
   workflow_run:
     workflows: ['CI']
     types: [completed]
+  # Design D7 — the archive door: a merged pull request on `agent/issue-<n>`
+  # runs the `ARCHIVE` phase, which archives the change folder as a follow-up
+  # commit on the base branch. `closed` fires for every close; the in-process
+  # guardrail checks `merged` and the agent branch, so an unmerged close or a
+  # foreign fork never boots a runner with the keys mounted (the `if:` below
+  # mirrors that filter).
+  pull_request:
+    types: [closed]
 
 permissions:
   contents: write
@@ -111,13 +119,23 @@ jobs:
        github.event.issue.pull_request == null &&
        github.event.sender.type != 'Bot' &&
        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.issue.author_association))
-      ||
-      (github.event_name == 'issue_comment' &&
-       github.event.action == 'created' &&
-       github.event.issue.pull_request != null &&
-       contains(github.event.comment.body, '/review') &&
-       github.event.sender.type != 'Bot' &&
-       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+       ||
+       (github.event_name == 'issue_comment' &&
+        github.event.action == 'created' &&
+        github.event.issue.pull_request != null &&
+        contains(github.event.comment.body, '/review') &&
+        github.event.sender.type != 'Bot' &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+       ||
+       # Design D7 — the archive door. A merged pull request on an agent branch
+       # whose head is this repository. The in-process parse checks the same four
+       # things; this arm keeps a fork's `agent/issue-42` or an unmerged close
+       # from ever booting a runner with the API keys mounted.
+       (github.event_name == 'pull_request' &&
+        github.event.action == 'closed' &&
+        github.event.pull_request.merged == true &&
+        startsWith(github.event.pull_request.head.ref, 'agent/issue-') &&
+        github.event.pull_request.head_repository.full_name == github.repository)
 
     steps:
       # The one fact a pull-request comment's payload does not carry. Every block
@@ -182,7 +200,12 @@ jobs:
         id: issue
         env:
           ISSUE_NUMBER: ${{ github.event.issue.pull_request == null && github.event.issue.number || '' }}
-          HEAD_BRANCH: ${{ steps.head.outputs.branch || github.event.workflow_run.head_branch }}
+          # Three event kinds name their issue three ways. An issue event carries
+          # the number directly; a `workflow_run` carries the branch that went
+          # red; a `pull_request` webhook (the archive door, D7) carries its own
+          # `head.ref`. The script below parses `agent/issue-<n>` from whichever
+          # branch this resolves to.
+          HEAD_BRANCH: ${{ steps.head.outputs.branch || github.event.workflow_run.head_branch || github.event.pull_request.head.ref }}
         run: |
           number="$ISSUE_NUMBER"
           if [ -z "$number" ]; then
@@ -339,6 +362,14 @@ jobs:
         run: |
           bun add --global opencode-ai@1.18.7
           echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+
+      # Design D3/D7 — the openspec CLI drives the planning protocol (`new
+      # change`, `status --json`, `instructions --json`, `validate --strict`) and
+      # the archive door. Pinned like every other third-party surface this
+      # pipeline trusts: a moving ref would change the planning contract under
+      # review.
+      - name: Install the OpenSpec CLI
+        run: bun add --global @fission-ai/openspec@1.8.0
 
       # `id:` is load-bearing, not decoration: the pipeline writes
       # `reported=true` to $GITHUB_OUTPUT for every path that has already put a

--- a/docs/architecture/openspec-superpowers-hybrid.md
+++ b/docs/architecture/openspec-superpowers-hybrid.md
@@ -159,6 +159,19 @@ remain the decision research. Porting individual legacy items into OpenSpec
 (one at a time: archive/adopt/seed/retire) is operationalized by
 [`docs/operations/legacy-migration-runbook.md`](../operations/legacy-migration-runbook.md).
 
+### opencode-agent — the last entry point
+
+`opencode-agent/` was the one entry point the migration above left untouched:
+its `PHASE_SKILLS` still routed triage to `brainstorming` and planning to
+`writing-plans`, producing freeform `AGENT_SPEC`/`AGENT_PLAN` blocks no
+`openspec validate` ever saw. The `opencode-agent-openspec-compliance` change
+brings it onto the same OpenSpec substrate as every other entry point — see
+`openspec/changes/opencode-agent-openspec-compliance/` for the full design
+(D1–D13): the folder is truth (comments are renders), `PHASE_SKILLS` rewired
+to `openspec-explore`/`openspec-propose`, `tasks.md` as the step source,
+steering-drift (D6), the merged-PR archive door (D7), and the deliberate
+`STATE_VERSION` bump that strands legacy issues onto a fresh restart (D12).
+
 ## 5. Open questions
 
 - Enable expanded profile for `/opsx:verify` + `/opsx:onboard`, or stay on core

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -11,17 +11,24 @@ findings: `ROADMAP.md`.
 ## Shape
 
 - One CI job = one call to `runCli`. State lives in hidden blocks on the issue,
-  not on disk: `AGENT_STATE` for the machine, `AGENT_SPEC` / `AGENT_PLAN` /
-  `AGENT_REPORT` / `AGENT_HANDOFF` for the artefacts. `AGENT_STATUS` is the odd one out — it marks
+  not on disk: `AGENT_STATE` for the machine, `AGENT_REPORT` / `AGENT_HANDOFF`
+  for the report and the wall-clock handoff. The design spec and the plan used
+  to travel here too (`AGENT_SPEC` / `AGENT_PLAN`); under the OpenSpec rework
+  (design D1 — the folder is truth, comments are renders) they live in
+  `openspec/changes/<name>/` on `agent/issue-<n>`, and the human parks review
+  rendered digests of that folder. `AGENT_STATUS` is the odd one out — it marks
   the run's live status comment so `renderThread` can leave it out of a prompt,
   and it is read by nothing else.
 - An event is parsed before it is judged: `src/trigger-events.ts` says what a raw
   payload **is** and `src/guardrails.ts` whether the pipeline may act on it. That
   split is not tidiness — it is what lets `src/pr-trigger.ts` finish a parse
   without importing the policy layer that will judge the finished event, which
-  would be a cycle. There are **three** doors, not two: an issue event, a red CI
-  run, and a comment typed on a pull request, which is the one `parseTriggerEvent`
-  cannot finish alone (`src/github-pulls.ts` reads the head that names its issue).
+  would be a cycle. There are **four** doors, not three: an issue event, a red CI
+  run, a comment typed on a pull request (the one `parseTriggerEvent` cannot
+  finish alone — `src/github-pulls.ts` reads the head that names its issue), and
+  a merged pull request (`pull_request.closed(merged)`, the archive door D7 —
+  `src/phases/archive.ts` runs `openspec archive` as a follow-up commit on the
+  base branch).
   `src/agent-handle.ts` holds the memoized OpenCode session `index.ts` used to
   own, which also ends `deps.ts` importing back from the module it was split from.
 - `src/triggers.ts` decides _whether and where_ an event moves the state — it
@@ -107,25 +114,20 @@ findings: `ROADMAP.md`.
 - **Never scrape prose to recover an artefact.** Spec, plan, report and the
   wall-clock handoff travel in hidden blocks via `blocks.ts` / `artifacts.ts`.
   Heading-and-trailer scraping silently truncated specs at their first `---` rule;
-  do not reintroduce it. The plan is the case that had to grow a second half: its
-  block carries the ordered **steps** beside the text, and the text is _rendered from
-  them_ by `renderPlanMarkdown`, so the comment a maintainer approved and the list the
-  implementation walks cannot disagree. Reading the steps back out of the markdown
-  would be that same bug on a new surface, which is why `findPlan` exists and why a
-  `steps` field the schema cannot vouch for degrades to **no steps at all** rather than
-  to the steps it could parse — half a plan read as a whole plan is the failure being
-  avoided, and no steps is a shape this pipeline already runs correctly.
-- **Each artefact counts its own revisions.** `specRevision` and `planRevision`
-  are separate fields and each handler renders and stores one of them, from a
-  single local so the visible heading and the hidden block cannot disagree. They
-  were one shared `revision` bumped by both `SPEC_POSTED` and `PLAN_POSTED`, so
-  the counts interleaved and the first plan on every issue announced
-  itself as revision 2 — revision 3 if the spec had been revised once first —
-  which is not a reading "the Nth version of this artefact" allows. The report
-  block stamps `planRevision`: it records which plan was implemented, and no
-  signal bumps a report counter. Splitting them needed no `STATE_VERSION` bump
-  because both fields default; the old key is dropped rather than mapped onto
-  either, since it was a sum and never a count of either artefact.
+  do not reintroduce it. The design spec and the plan **used to** travel in
+  `AGENT_SPEC` / `AGENT_PLAN` blocks; under the OpenSpec rework (design D1) they
+  live in `openspec/changes/<name>/` on the branch, the human parks review
+  rendered digests (`renderDigest` in `artifacts.ts`), and `REVIEW_AND_MUTATE`
+  walks `tasks.md` checkboxes as the step source (D5). The retired block names
+  and their revision counters (`specRevision`) are gone; no legacy restore path
+  exists, and in-flight issues restart under the `STATE_VERSION` bump (D12).
+- **The plan counts one identity token, not two artefact revisions.** Under D1
+  only `planRevision` remains — a machine identity for "a new plan happened",
+  bumped by `PLAN_POSTED` alone, not an artefact revision. The former
+  `specRevision` is gone: the proposal lives in the folder and `DESIGN_SPEC`
+  reviews a digest of it, so nothing counts spec revisions. The report block
+  stamps `planRevision`: it records which plan was implemented, and no signal
+  bumps a report counter.
 - **A phase rename is a persisted-shape change, and is migrated rather than
   bumped.** `PLANNING` was `EXECUTION_PLAN`; the name is written into every
   `AGENT_STATE` block as `phase` and `resumeFrom`, so an unmigrated rename has

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -25,38 +25,40 @@ hidden HTML blocks:
 - `<!-- AGENT_STATE: … -->` — phase and counters. Written afresh with every
   comment the pipeline posts, and rewritten **in place** by a run that spent
   model tokens and had nothing to post.
-- `<!-- AGENT_SPEC: … -->` — the current design spec.
-- `<!-- AGENT_PLAN: … -->` — the current implementation plan, as **both** the
-  markdown a maintainer approved and the ordered steps it was rendered from. The
-  implementation walks those steps; it never parses the markdown back, which is the
-  rule the whole block channel exists for. A plan block without them — every plan
-  approved before they were carried — is implemented in one turn, permanently.
 - `<!-- AGENT_REPORT: … -->` — the newest report. The implementation one, until
   a `/review` writes its own under the same marker: the scan takes the newest
   block of a marker, and that is what a later pull-request refresh presents, so
   the body and the thread cannot end up telling different stories.
+- `<!-- AGENT_HANDOFF: … -->` — the wall-clock handoff a `/continue` reads.
 - `<!-- AGENT_STATUS: … -->` — the odd one out: it marks a run's live status
   comment so the prompt layer can leave that comment out, and nothing else reads
   it. It is deliberately not `AGENT_STATE`, or the restore scan would have two
   sources of truth.
 
-Artefacts get their own blocks rather than being scraped back out of the visible
-markdown. That is not a style preference: a spec is model-written markdown full
-of headings and `---` rules, and any heading-and-trailer scraping truncates it at
-the first horizontal rule.
+The design spec and the plan **used to** travel in `AGENT_SPEC` / `AGENT_PLAN`
+blocks. Under the OpenSpec rework (design D1 — the folder is truth, comments are
+renders) they live in `openspec/changes/<name>/` on `agent/issue-<n>`:
 
-The spec and the plan are numbered **separately**, each by its own revisions: the
-first spec is "Design spec (revision 1)" and the first plan is "Plan
-(revision 1)", whether or not the spec was revised on the way there. `AGENT_STATE`
-carries a counter each (`specRevision`, `planRevision`), and the number in a
-heading is the number in that artefact's own block — one value renders both. A
-single shared counter used to bump on either artefact, so the numbers interleaved
-and the first plan on a straight-through issue called itself revision 2. Both
-counters default, so blocks written before the split still parse; an issue
-mid-conversation across that change restarts its counts at 1, because the number
-it was carrying was the sum of two artefacts and never the count of either.
-`AGENT_REPORT` carries the revision of the plan it implemented — provenance, not
-a count of reports.
+- `proposal.md` — the captured goal, drafted by triage and reviewed at the
+  `DESIGN_SPEC` park via a rendered digest.
+- `design.md`, `tasks.md` — drafted by the `PLANNING` loop (`status --json` →
+  compose → `validate --strict` → retry ≤2), reviewed at `PLAN_REVIEW`.
+- `tasks.md` is the implementation's step source (D5): `REVIEW_AND_MUTATE`
+  walks its checkboxes, ticking each box in the same commit as the step's work.
+
+Artefacts get their own blocks (or their own folder) rather than being scraped
+back out of the visible markdown. That is not a style preference: a spec is
+model-written markdown full of headings and `---` rules, and any
+heading-and-trailer scraping truncates it at the first horizontal rule.
+
+`AGENT_STATE` carries one artefact-identity token — `planRevision` — bumped by
+`PLAN_POSTED` alone. The former `specRevision` is gone: the proposal lives in
+the folder and `DESIGN_SPEC` reviews a digest of it, so nothing counts spec
+revisions. The report block stamps `planRevision`: it records which plan was
+implemented, and no signal bumps a report counter. A deliberate `STATE_VERSION`
+bump (D12) retires the legacy `AGENT_SPEC`/`AGENT_PLAN` blocks outright —
+in-flight issues restart under the compliant pipeline rather than carrying a
+dual format.
 
 Blocks are read back byte-exact, and a payload cannot forge its own delimiter:
 `<` and `>` are escaped as JSON unicode escapes before serialization, so text

--- a/opencode-agent/ROADMAP.md
+++ b/opencode-agent/ROADMAP.md
@@ -7,6 +7,18 @@ See LICENSE in the project root for details.
 
 # opencode-agent — follow-up roadmap
 
+> **OpenSpec rework.** The `opencode-agent-openspec-compliance` change rewired
+> this workspace onto the repo's OpenSpec substrate: `PHASE_SKILLS` routes to
+> `openspec-explore`/`openspec-propose` (not `brainstorming`/`writing-plans`),
+> the `AGENT_SPEC`/`AGENT_PLAN` artefact blocks are retired in favour of a real
+> `openspec/changes/<name>/` folder on `agent/issue-<n>` (D1), `tasks.md` is the
+> implementation step source (D5), a merged PR is the archive door (D7), and a
+> deliberate `STATE_VERSION` bump (D12) strands legacy issues onto a fresh
+> restart. Findings below that reference the retired blocks or the old skill
+> names are historical — they describe what the audit found and how it was
+> fixed, and the fix has since been superseded by the folder model. The full
+> design is `openspec/changes/opencode-agent-openspec-compliance/design.md`.
+
 > **Status.** This began as a report-only audit; much of it has since been fixed.
 > Resolved items are marked **[FIXED]** inline, each with what was verified and —
 > where it applies — what the first attempt at the fix got wrong. All of **S1**,

--- a/opencode-agent/src/artifacts.ts
+++ b/opencode-agent/src/artifacts.ts
@@ -36,6 +36,23 @@ export const REPORT_MARKER = 'AGENT_REPORT'
  */
 export const HANDOFF_MARKER = 'AGENT_HANDOFF'
 
+/**
+ * Input to {@link renderDigest}: where the artifact lives on the branch, and
+ * the machine identity a park tracks (if any).
+ */
+export interface DigestMeta {
+  /** The OpenSpec change folder the artifact was read from. */
+  readonly changeName: string
+  /** The branch carrying the folder — the artifact's real history (its commits). */
+  readonly branch: string
+  /**
+   * The plan-identity token, when the digest is rendered at `PLAN_REVIEW`.
+   * `null` at `DESIGN_SPEC`: the proposal has no revision counter (the retired
+   * `specRevision` is gone), so its history is the branch's commits alone.
+   */
+  readonly revision: number | null
+}
+
 const artifactSchema = z.object({
   text: z.string().min(1),
   revision: z.number().int().min(0).default(0),
@@ -46,6 +63,40 @@ export type Artifact = z.infer<typeof artifactSchema>
 /** Renders the hidden block that carries an artefact to the next job. */
 export const renderArtifact = (marker: string, text: string, revision: number): string =>
   renderBlock(marker, { text, revision })
+
+/**
+ * Renders a folder artifact as a park digest (design D1: the folder is truth;
+ * comments are renders).
+ *
+ * The two human parks (`DESIGN_SPEC`, `PLAN_REVIEW`) each show a snapshot of
+ * what landed in `openspec/changes/<name>/` — the proposal at `DESIGN_SPEC`,
+ * `tasks.md` at `PLAN_REVIEW` — read straight back from the folder rather than
+ * remembered from the model reply. The digest carries the branch as the history
+ * of record (the folder's commits are the artifact's real history) and, for the
+ * plan, the revision token the machine uses to tell two plans apart.
+ *
+ * It does not carry the artifact itself as truth: a rendered snapshot that
+ * pretended to be the artifact would be two truths, exactly the drift the
+ * `AGENT_SPEC`/`AGENT_PLAN` blocks retired. The content rides inside a
+ * `<details>` block so a long tasks.md does not dominate the issue thread, and
+ * it is the content read from the folder verbatim — the park reviews what the
+ * branch carries, not a paraphrase of it.
+ */
+export const renderDigest = (content: string, meta: DigestMeta): string => {
+  const history =
+    meta.revision === null
+      ? `openspec/changes/${meta.changeName}/ on \`${meta.branch}\``
+      : `openspec/changes/${meta.changeName}/ on \`${meta.branch}\` · plan revision ${meta.revision}`
+  return [
+    '<details><summary>Folder digest</summary>',
+    '',
+    `Source of truth: \`${history}\`.`,
+    '',
+    content.trim(),
+    '',
+    '</details>',
+  ].join('\n')
+}
 
 /** Reads the newest agent-authored artefact of this kind; `null` when absent. */
 export const findArtifact = (thread: readonly IssueComment[], agentLogin: string, marker: string): Artifact | null => {

--- a/opencode-agent/src/artifacts.ts
+++ b/opencode-agent/src/artifacts.ts
@@ -7,32 +7,32 @@ import { z } from 'zod'
 
 import { findLatestBlock, renderBlock } from './blocks.js'
 import type { IssueComment } from './blocks.js'
-import { planStepSchema } from './plan-steps.js'
-import type { PlanStep } from './plan-steps.js'
 
 /**
- * Artefacts the pipeline writes once and reads back in a later job: the design
- * spec, the plan, and the implementation report.
+ * Artefacts the pipeline writes once and reads back in a later job: the
+ * implementation report and the wall-clock handoff.
  *
  * Each is persisted in its own hidden block rather than recovered by matching a
  * markdown heading in the visible comment. That distinction matters: these
  * payloads are model-written markdown full of headings and `---` rules, and any
  * scraping scheme truncates them the moment the model writes one.
+ *
+ * The design spec and the plan used to travel here too (`AGENT_SPEC`/
+ * `AGENT_PLAN`); under the OpenSpec rework (design D1) they live in the change
+ * folder on the branch, so only the report and the handoff remain as blocks.
  */
-export const SPEC_MARKER = 'AGENT_SPEC'
-export const PLAN_MARKER = 'AGENT_PLAN'
 export const REPORT_MARKER = 'AGENT_REPORT'
 /**
  * The handoff a wall-clock stop leaves for the `/continue` that follows it: what
  * the interrupted turn finished, what remains, and what it tried that did not work.
  *
- * A block like the others rather than a heading in the notice, for the reason this
- * module exists at all — it is model-written markdown full of headings and lists,
- * and every scraping scheme truncates that the moment the model writes one. It is
- * also the artefact with the most to lose from a bad recovery: the "tried and did
- * not work" section is the one thing a fresh session cannot re-derive from the
- * diff and the plan, so a truncated read is not a cosmetic loss, it is a
- * continuation re-treading ground somebody already paid for.
+ * A block like the report rather than a heading in the notice, for the reason
+ * this module exists at all — it is model-written markdown full of headings and
+ * lists, and every scraping scheme truncates that the moment the model writes
+ * one. It is also the artefact with the most to lose from a bad recovery: the
+ * "tried and did not work" section is the one thing a fresh session cannot
+ * re-derive from the diff and the plan, so a truncated read is not a cosmetic
+ * loss, it is a continuation re-treading ground somebody already paid for.
  */
 export const HANDOFF_MARKER = 'AGENT_HANDOFF'
 
@@ -51,53 +51,6 @@ export const renderArtifact = (marker: string, text: string, revision: number): 
 export const findArtifact = (thread: readonly IssueComment[], agentLogin: string, marker: string): Artifact | null => {
   const result = artifactSchema.safeParse(findLatestBlock(thread, agentLogin, marker))
   return result.success ? result.data : null
-}
-
-/**
- * The plan block, which carries the steps beside the text.
- *
- * `steps` is `.catch([])` rather than optional-with-a-default, and the fallback is
- * the point: **absent, malformed and half-malformed all read as "no steps"**, which
- * is exactly the one-turn implementation this pipeline did before stage 3. Three
- * cases arrive here and all three want that answer — a plan approved on a live issue
- * before steps existed, a hand-edited block (this is attacker-editable text like
- * every other one), and a payload from a future shape this code does not know.
- *
- * Note what it deliberately does *not* do: recover the steps it can parse and drop
- * the rest. Half a plan read as a whole plan is the failure this module exists to
- * prevent — the truncated spec, one level along — so a list the schema cannot vouch
- * for is no list at all, and the phase falls back to the document a human approved.
- *
- * The fallback is **permanent, not a migration**. There is nothing to migrate *to*:
- * the steps are the planner's own structured output, and no amount of parsing can
- * invent them for a plan that was approved without them. Re-deriving them would mean
- * a second planning turn against a spec the maintainer has already signed off on, in
- * a phase whose job is to implement — so an old plan runs as one turn, exactly as it
- * did on the day it was approved.
- */
-const planArtifactSchema = artifactSchema.extend({ steps: z.array(planStepSchema).catch([]) })
-
-export type PlanArtifact = z.infer<typeof planArtifactSchema>
-
-/** Renders the plan block: the text a maintainer reads and the steps it was rendered from. */
-export const renderPlanArtifact = (text: string, revision: number, steps: readonly PlanStep[]): string =>
-  renderBlock(PLAN_MARKER, { text, revision, steps })
-
-/** Reads the newest plan the agent posted, steps included; `null` when there is none. */
-export const findPlan = (thread: readonly IssueComment[], agentLogin: string): PlanArtifact | null => {
-  const result = planArtifactSchema.safeParse(findLatestBlock(thread, agentLogin, PLAN_MARKER))
-  return result.success ? result.data : null
-}
-
-/** The plan, or the caller's own failure when the issue carries none. */
-export const requirePlan = (
-  thread: readonly IssueComment[],
-  agentLogin: string,
-  onMissing: () => Error,
-): PlanArtifact => {
-  const plan = findPlan(thread, agentLogin)
-  if (plan === null) throw onMissing()
-  return plan
 }
 
 /**
@@ -131,16 +84,4 @@ export const findHandoff = (
   if (handoff === null) return null
 
   return handoff.revision === planRevision ? handoff.text : null
-}
-
-/** Reads an artefact's text, or throws via `onMissing` when it is not there. */
-export const requireArtifact = (
-  thread: readonly IssueComment[],
-  agentLogin: string,
-  marker: string,
-  onMissing: () => Error,
-): string => {
-  const artifact = findArtifact(thread, agentLogin, marker)
-  if (artifact === null) throw onMissing()
-  return artifact.text
 }

--- a/opencode-agent/src/cascade.ts
+++ b/opencode-agent/src/cascade.ts
@@ -6,6 +6,7 @@
 import type { MachineInput, PhaseHandler, PhaseOutcome } from './phase-context.js'
 import { failAnswer, failRun } from './phase-failure.js'
 import { handleAnswer } from './phases/answer.js'
+import { handleArchive } from './phases/archive.js'
 import { handleCiFix } from './phases/ci-fix.js'
 import { handleDeliver } from './phases/deliver.js'
 import { handleImplement } from './phases/implement.js'
@@ -48,6 +49,7 @@ const HANDLERS: Partial<Record<Phase, PhaseHandler>> = {
   PR_DELIVERY: handleDeliver,
   CODE_REVIEW: handleReview,
   CI_FIX: handleCiFix,
+  ARCHIVE: handleArchive,
 }
 
 /**

--- a/opencode-agent/src/comment-intent.ts
+++ b/opencode-agent/src/comment-intent.ts
@@ -207,3 +207,44 @@ export const applyClarifyIntent = async (input: PhaseInput): Promise<TriggerOutc
   // waits for answers to its own questions.
   return readAndSkip(input, 'Comment needs no action')
 }
+
+/**
+ * Reads a plain comment that arrives while the agent is implementing
+ * (`REVIEW_AND_MUTATE`), as steering-drift (design D6).
+ *
+ * Implementation is not interrupted for anything less than a scope-affecting
+ * change: a comment classified `changes` routes back to `PLANNING` for an
+ * artifact-update turn (edit → validate → commit) before implementation
+ * continues, so the folder cannot rot relative to the conversation. Everything
+ * else — chatter, a question, an approve — skips with a 👍, because the cost of
+ * interrupting an implementation run for an ambiguity is higher than the cost of
+ * a maintainer typing `/ask` to ask the question for real. That is the opposite
+ * default from {@link applyIntent}, where answering is cheap and re-planning is
+ * expensive; here re-planning is the *point*, and the bar to reach it is a
+ * positive `changes` verdict the classifier has to actively choose.
+ *
+ * The budget gate sits *before* the classifier, for the same reason as
+ * {@link applyIntent}: the classifier is the one turn whose spend a skip never
+ * writes down, so the ceiling stops it rather than paying to learn what to say.
+ */
+export const applySteeringIntent = async (input: PhaseInput): Promise<TriggerOutcome> => {
+  const { state, trigger, deps } = input
+  const body = trigger.kind === 'issue' ? trigger.commentBody : null
+  if (body === null || body.trim().length === 0) return readAndSkip(input, 'Empty comment')
+
+  const spent = await totalTokens(deps, state.tokensSpent)
+  if (!withinBudget(spent, deps.config)) {
+    deps.log.warn(
+      { issue: state.issueId, phase: state.phase, spent, limit: deps.config.maxTokens },
+      'Over budget: not paying to classify a steering comment',
+    )
+    return readAndSkip(input, 'Over budget; not classifying a steering comment')
+  }
+
+  const intent = await classifyComment({ body, phase: state.phase, deps, state })
+  deps.log.info({ intent, phase: state.phase }, 'Classified a maintainer comment while implementing')
+
+  if (intent !== 'changes') return readAndSkip(input, `Comment classified as ${intent}; not scope-affecting`)
+
+  return moveOrSkip(state, 'CHANGES_REQUESTED', deps, 'steering-drift')
+}

--- a/opencode-agent/src/config-discovery.ts
+++ b/opencode-agent/src/config-discovery.ts
@@ -33,6 +33,36 @@ import type { Env } from './config-values.js'
 /** This repository's own review-loop workspace, when the checkout has one. */
 const REVIEW_LOOP_ENTRY = 'review-loop/src/cli.ts'
 
+/** The directory whose presence makes this checkout OpenSpec-compliant (D10). */
+const OPENSPEC_ROOT = 'openspec'
+
+/**
+ * The two answers the `openspec/` root probe can return — design D10.
+ *
+ * `compliant` is the ordinary mode in a repo that has adopted OpenSpec; the
+ * reworked pipeline runs. `stand-down` is the fail-closed posture for a foreign
+ * repo without an `openspec/` tree: the agent posts one clear comment naming the
+ * remedy (e.g. `openspec init`) and does no work, because every artefact path in
+ * the compliant pipeline assumes that tree exists. The agent never scaffolds
+ * OpenSpec into a repo that has not adopted it.
+ */
+export type OpenSpecMode = { readonly mode: 'compliant' } | { readonly mode: 'stand-down'; readonly reason: string }
+
+/** The comment the stand-down door posts, kept beside the verdict it explains. */
+export const STAND_DOWN_REASON =
+  'This repository has no `openspec/` tree, so the agent cannot run its OpenSpec-compliant pipeline. Run `openspec init` (or adopt OpenSpec) to enable it; until then the agent is standing down.'
+
+/**
+ * Resolves whether this checkout is OpenSpec-compliant.
+ *
+ * Same testable ladder shape as {@link resolveReviewCommand}: an injected
+ * `exists` callback keeps the probe testable without a filesystem, and the path
+ * is checked at the repo root only — a nested `openspec/` (say, under `src/`)
+ * is a different directory and must not satisfy the probe.
+ */
+export const resolveOpenSpecMode = (repoRoot: string, exists: (filePath: string) => boolean): OpenSpecMode =>
+  exists(path.join(repoRoot, OPENSPEC_ROOT)) ? { mode: 'compliant' } : { mode: 'stand-down', reason: STAND_DOWN_REASON }
+
 /**
  * Resolves the review command.
  *

--- a/opencode-agent/src/config.ts
+++ b/opencode-agent/src/config.ts
@@ -202,8 +202,8 @@ export const loadOpenAiSettings = (env: Env): OpenAiSettings => ({
   model: required(env, 'LLM_MODEL'),
 })
 
-/** Skill roots searched in order; the vendored superpowers checkout wins. */
-const DEFAULT_SKILL_ROOTS = ['.superpowers/skills', '.claude/skills'] as const
+/** Loader roots, first-hit-wins (D11): in-repo OpenSpec trees first, then the pinned superpowers checkout. */
+const DEFAULT_SKILL_ROOTS = ['.opencode/skills', '.agents/skills', '.superpowers/skills', '.claude/skills'] as const
 
 /**
  * Builds the URL of the run this process is executing in.

--- a/opencode-agent/src/deps.ts
+++ b/opencode-agent/src/deps.ts
@@ -15,6 +15,7 @@ import type { Logger } from './logger.js'
 import { loadPhaseSkills } from './obra-skills.js'
 import type { SkillDocument } from './obra-skills.js'
 import { opencodeConfigEnv } from './openai-config.js'
+import { createOpenSpecDriver } from './openspec-driver.js'
 import type { PhaseDeps, RunReview } from './phase-context.js'
 import { runReviewLoop } from './review-runner.js'
 import type { CommandRunner } from './shell.js'
@@ -134,6 +135,7 @@ export const assembleDeps = ({
     git,
     runCheck: makeCheckRunner(run, config),
     runReview: makeReviewRunner(run, config, log),
+    openspec: createOpenSpecDriver({ runner: run, cwd: config.repoRoot }),
     agent: agent.get,
     tokensUsed: agent.tokensUsed,
     skills: makeSkillLoader(config, log),

--- a/opencode-agent/src/deps.ts
+++ b/opencode-agent/src/deps.ts
@@ -3,6 +3,8 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import { writeFile as writeFileNode } from 'node:fs/promises'
+
 import type { AgentHandle } from './agent-handle.js'
 import type { CheckRunner } from './check-loop.js'
 import { createCiGroups } from './ci-groups.js'
@@ -139,6 +141,7 @@ export const assembleDeps = ({
     agent: agent.get,
     tokensUsed: agent.tokensUsed,
     skills: makeSkillLoader(config, log),
+    writeFile: (filePath, content) => writeFileNode(filePath, content, 'utf8'),
     baseBranch: memoize(() =>
       resolveBaseBranch(env, { fromEvent: event.defaultBranch, fromGit: () => git.defaultBranch() }),
     ),

--- a/opencode-agent/src/deps.ts
+++ b/opencode-agent/src/deps.ts
@@ -3,7 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { writeFile as writeFileNode } from 'node:fs/promises'
+import { writeFile as writeFileNode, readFile as readFileNode } from 'node:fs/promises'
 
 import type { AgentHandle } from './agent-handle.js'
 import type { CheckRunner } from './check-loop.js'
@@ -142,6 +142,7 @@ export const assembleDeps = ({
     tokensUsed: agent.tokensUsed,
     skills: makeSkillLoader(config, log),
     writeFile: (filePath, content) => writeFileNode(filePath, content, 'utf8'),
+    readFile: (filePath) => readFileNode(filePath, 'utf8'),
     baseBranch: memoize(() =>
       resolveBaseBranch(env, { fromEvent: event.defaultBranch, fromGit: () => git.defaultBranch() }),
     ),

--- a/opencode-agent/src/diff-guard.ts
+++ b/opencode-agent/src/diff-guard.ts
@@ -175,3 +175,19 @@ export const inspectSalvage = (
 }
 
 const paths = (files: readonly StagedFile[]): string[] => files.map((file) => file.path)
+
+/**
+ * Design D8 — which staged paths fall **outside** the change folder a turn was
+ * granted write access to.
+ *
+ * Planner/spec turns are scoped to `openspec/changes/<change-name>/`: the
+ * confined commit path refuses anything this returns, the same shape
+ * sdd-runner's guard takes. A path is under the prefix only when the prefix
+ * ends on a segment boundary, so a sibling change (`add-x` vs `add-xtras`) is
+ * correctly outside. The prefix is normalised with a trailing slash so callers
+ * may spell it either way.
+ */
+export const outsidePrefix = (staged: readonly string[], prefix: string): string[] => {
+  const root = prefix.endsWith('/') ? prefix : `${prefix}/`
+  return staged.filter((path) => !path.startsWith(root))
+}

--- a/opencode-agent/src/errors.ts
+++ b/opencode-agent/src/errors.ts
@@ -39,15 +39,6 @@ export class PipelineError extends Error {
   }
 }
 
-export const missingSpecError = (issueNumber: number): PipelineError =>
-  new PipelineError(
-    'MISSING_SPEC',
-    `No approved design spec found on issue #${issueNumber}. Was the spec comment deleted?`,
-  )
-
-export const missingPlanError = (issueNumber: number): PipelineError =>
-  new PipelineError('MISSING_PLAN', `No plan found on issue #${issueNumber}. Was the plan comment deleted?`)
-
 export const noChangesError = (issueNumber: number): PipelineError =>
   new PipelineError(
     'NO_CHANGES',

--- a/opencode-agent/src/feedback.ts
+++ b/opencode-agent/src/feedback.ts
@@ -84,6 +84,9 @@ export const reactionTarget = (trigger: TriggerEvent): ReactionTarget | null => 
         : { kind: 'comment', id: trigger.commentId }
     case 'pull-request':
       return { kind: 'comment', id: trigger.commentId }
+    case 'pr-merged':
+      // A system event — nobody typed a comment to acknowledge.
+      return null
     default:
       return unreachable(trigger)
   }

--- a/opencode-agent/src/git.ts
+++ b/opencode-agent/src/git.ts
@@ -82,6 +82,21 @@ export class GitError extends Error {
 export interface Git {
   ensureBranch(branch: string, base: string): Promise<void>
   /**
+   * Force-resets `branch` to `base`, discarding any prior commits on it (D12).
+   *
+   * Used by the capture scaffold: a restarted issue whose `agent/issue-<n>`
+   * branch already carries partial legacy work must start from zero, not adopt
+   * the old diff. Force-pushes so the remote reflects the reset — then the
+   * scaffold's own commit and push are an ordinary fast-forward from base.
+   */
+  resetBranchToBase(branch: string, base: string): Promise<void>
+  /**
+   * Deletes the remote branch (D9 cancel cleanup). A mis-capture's branch +
+   * change folder are the work being undone; `git push origin --delete` removes
+   * them from the remote. The local checkout dies with the job.
+   */
+  deleteRemoteBranch(branch: string): Promise<void>
+  /**
    * Commits every change; resolves `null` when the tree was already clean.
    *
    * That return is the only "did anything change?" answer the pipeline needs —
@@ -217,6 +232,23 @@ export const createGit = (options: GitOptions): Git => {
 
   return {
     ensureBranch: (branch, base) => ensureBranch(git, gitOrThrow, branch, base),
+    resetBranchToBase: async (branch, base) => {
+      await gitOrThrow('fetch', 'origin', base)
+      // `-B` force-resets the local branch to `origin/<base>`, discarding any
+      // prior commits on it — restart means from zero (D12).
+      await gitOrThrow('checkout', '-B', branch, `origin/${base}`)
+      // Force-push so the remote reflects the reset; the scaffold's own push is
+      // then an ordinary fast-forward.
+      await gitOrThrow('push', '--force', '-u', 'origin', branch)
+    },
+    deleteRemoteBranch: (branch) =>
+      // `--delete` is idempotent against a branch that was never pushed: a
+      // pre-capture `/cancel` has no branch to remove, and a missing ref is not
+      // an error this pipeline needs to surface.
+      gitOrThrow('push', 'origin', '--delete', branch).then(
+        () => undefined,
+        () => undefined,
+      ),
     commitAll: (message) => commitAll(gitOrThrow, options, message),
     salvageAll: (message) => salvageAll(gitOrThrow, options, message),
     push: async (branch, pushOptions) => {

--- a/opencode-agent/src/guardrails.ts
+++ b/opencode-agent/src/guardrails.ts
@@ -6,7 +6,7 @@
 import { unreachable } from './errors.js'
 import { branchNameFor } from './git.js'
 import type { PullRequestRefusal, PullRequestTriggerEvent } from './pr-trigger.js'
-import type { CiTriggerEvent, IssueTriggerEvent, TriggerEvent } from './trigger-events.js'
+import type { CiTriggerEvent, IssueTriggerEvent, PrMergedTriggerEvent, TriggerEvent } from './trigger-events.js'
 
 /**
  * Whether the pipeline may act on an event it has already understood.
@@ -164,10 +164,24 @@ const evaluatePullRequestGuardrails = (event: PullRequestTriggerEvent, options: 
   checkSender(event, options)
 
 /**
+ * A merged pull request is a system event — nobody typed a command — so the
+ * sender rules do not apply. The one structural guard the archive door (D7)
+ * needs is the foreign-repo check, for the same reason the CI path needs it:
+ * `head.ref` is attacker-controlled, and a fork whose branch is named
+ * `agent/issue-42` must not archive into this repository.
+ */
+const evaluatePrMergedGuardrails = (event: PrMergedTriggerEvent): GuardrailDecision => {
+  if (!event.fromThisRepository) {
+    return deny('PR_FOREIGN_REPOSITORY', 'Merged pull request came from another repository, not this one')
+  }
+  return { allowed: true }
+}
+
+/**
  * Applies every abort rule for the event's kind, in the order a reviewer
  * expects.
  *
- * A `switch` rather than the ternary this was: with three kinds, a fallthrough
+ * A `switch` rather than the ternary this was: with four kinds, a fallthrough
  * arm silently buckets whichever one is added next into the rules written for
  * another, and an exhaustive switch makes that a compile error instead.
  */
@@ -179,6 +193,8 @@ export const evaluateGuardrails = (event: TriggerEvent, options: GuardrailOption
       return evaluateCiGuardrails(event, options)
     case 'pull-request':
       return evaluatePullRequestGuardrails(event, options)
+    case 'pr-merged':
+      return evaluatePrMergedGuardrails(event)
     default:
       return unreachable(event)
   }

--- a/opencode-agent/src/index.ts
+++ b/opencode-agent/src/index.ts
@@ -3,6 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
@@ -10,6 +11,7 @@ import { pathToFileURL } from 'node:url'
 import type { AgentHandle } from './agent-handle.js'
 import type { CliArgs, MainOptions } from './cli-args.js'
 import { parseArgs } from './cli-args.js'
+import { resolveOpenSpecMode } from './config-discovery.js'
 import { loadConfig } from './config.js'
 import type { PipelineConfig } from './config.js'
 import { contain } from './contain.js'
@@ -122,6 +124,55 @@ const runPipelineLifecycle = async (input: LifecycleInput): Promise<RunResult> =
 }
 
 /**
+ * The fail-closed door for a checkout with no `openspec/` tree (design D10).
+ *
+ * Posts one clear comment naming the remedy and stands down: the agent never
+ * scaffolds OpenSpec into a foreign repo, and with `AGENT_SPEC`/`AGENT_PLAN`
+ * retired (D12) there is no legacy block mode to fall back to. Called before
+ * `contain`, so no OpenCode server spawns for a run that will do no work.
+ */
+const postStandDown = async (
+  reason: string,
+  issueNumber: number,
+  github: GitHubApi,
+  log: Logger,
+): Promise<RunResult> => {
+  log.warn({ mode: 'stand-down', issue: issueNumber }, 'No openspec/ tree; posting stand-down and exiting')
+  await github.createComment(issueNumber, reason)
+  return { status: 'skipped', reason: 'stand-down: no openspec/ tree', state: null, reported: true }
+}
+
+/**
+ * Resolves the event this run acts on, and the two early-exit doors that can
+ * close before any work starts: a payload this pipeline ignores, and the
+ * OpenSpec stand-down (design D10) for a checkout with no `openspec/` tree.
+ *
+ * Returning a discriminated union keeps `runCli` under `max-lines-per-function`
+ * without spreading the door logic across the entry point. The probe lives here
+ * rather than in `loadConfig` because this is its sole consumer, and folding it
+ * into config would grow that file past `max-lines` for a single call site.
+ */
+type DoorResolution =
+  | { readonly kind: 'door'; readonly result: RunResult }
+  | { readonly kind: 'event'; readonly event: TriggerEvent }
+
+const resolveEventOrDoor = async (args: CliArgs, github: GitHubApi, log: Logger): Promise<DoorResolution> => {
+  const event = await readEvent(args, github, log)
+  if (event === null) {
+    return {
+      kind: 'door',
+      result: { status: 'skipped', reason: 'Payload carries nothing to act on', state: null, reported: false },
+    }
+  }
+
+  const mode = resolveOpenSpecMode(args.repoRoot, existsSync)
+  if (mode.mode === 'stand-down')
+    return { kind: 'door', result: await postStandDown(mode.reason, event.issueNumber, github, log) }
+
+  return { kind: 'event', event }
+}
+
+/**
  * Entry point shared by the Action and by local `--event-path` runs.
  *
  * Returns a {@link RunResult} rather than exiting so the same call is drivable
@@ -145,12 +196,9 @@ export const runCli = async (options: MainOptions): Promise<RunResult> => {
   // Before the event is even known, because resolving a pull-request comment to
   // its issue is an API call — see {@link ContainInput.github}.
   const github = githubFor(config, secrets, options)
-  const event = await readEvent(args, github, log)
-  if (event === null) {
-    // No marker: nothing was posted, and nothing needs one — this exits 0, so
-    // the fallback step is out of scope either way.
-    return { status: 'skipped', reason: 'Payload carries nothing to act on', state: null, reported: false }
-  }
+  const resolved = await resolveEventOrDoor(args, github, log)
+  if (resolved.kind === 'door') return resolved.result
+  const { event } = resolved
 
   // After the event is known: a payload this pipeline ignores must not spend
   // the one keyless warning — or create the empty artefact — on a run that was

--- a/opencode-agent/src/obra-skills.ts
+++ b/opencode-agent/src/obra-skills.ts
@@ -20,23 +20,33 @@ export interface SkillDocument {
 }
 
 /**
- * Skills each phase asks for, by their directory name in obra/superpowers.
+ * Skills each phase asks for, by their directory name on the loader roots.
  *
  * `required` skills fail the phase when they are missing rather than degrading
- * silently — a planning phase without `writing-plans` is not the pipeline
- * anyone configured. `optional` ones are nice-to-have context.
+ * silently — a planning phase without its skill is not the pipeline anyone
+ * configured. `optional` ones are nice-to-have context.
  *
- * `subagent-driven-development` and `writing-skills` are deliberately absent:
- * both are large (26–28 KB) and neither applies to a single-session CI run.
+ * Reworked (design D4) onto the repo's own OpenSpec skills: `INIT_OR_CLARIFY`
+ * takes `openspec-explore` (the triage/clarify stance) and `PLANNING` takes
+ * `openspec-propose` (the proposal/drafter loop), replacing `brainstorming` and
+ * `writing-plans`. The retired `brainstorming`, `writing-plans` and
+ * `executing-plans` names are gone entirely: `executing-plans` was subsumed by
+ * the `tasks.md` step source, and the other two by the OpenSpec workflow.
+ *
+ * Execution skills are unchanged on the apply layer — `REVIEW_AND_MUTATE` keeps
+ * `test-driven-development` + `verification-before-completion`, and `CI_FIX`
+ * keeps `systematic-debugging`. `subagent-driven-development` and
+ * `writing-skills` are deliberately absent: both are large and neither applies
+ * to a single-session CI run.
  */
 export const PHASE_SKILLS: Record<Phase, { required: readonly string[]; optional: readonly string[] }> = {
-  INIT_OR_CLARIFY: { required: ['brainstorming'], optional: ['writing-plans'] },
+  INIT_OR_CLARIFY: { required: ['openspec-explore'], optional: [] },
   DESIGN_SPEC: { required: [], optional: [] },
-  PLANNING: { required: ['writing-plans'], optional: ['executing-plans'] },
+  PLANNING: { required: ['openspec-propose'], optional: [] },
   PLAN_REVIEW: { required: [], optional: [] },
   REVIEW_AND_MUTATE: {
     required: ['test-driven-development'],
-    optional: ['executing-plans', 'verification-before-completion'],
+    optional: ['verification-before-completion'],
   },
   PR_DELIVERY: { required: [], optional: [] },
   // Empty on purpose: `CODE_REVIEW` shells out to the `review-loop/` workspace

--- a/opencode-agent/src/obra-skills.ts
+++ b/opencode-agent/src/obra-skills.ts
@@ -54,6 +54,10 @@ export const PHASE_SKILLS: Record<Phase, { required: readonly string[]; optional
   // into nothing.
   CODE_REVIEW: { required: [], optional: [] },
   CI_FIX: { required: ['systematic-debugging'], optional: ['test-driven-development'] },
+  // Empty like `CODE_REVIEW`: archiving is a CLI file move the handler drives,
+  // not content the model composes, so no OpenCode session boots and no skill
+  // is inlined.
+  ARCHIVE: { required: [], optional: [] },
   COMPLETE: { required: [], optional: [] },
   FAILED: { required: [], optional: [] },
   // Empty like every other phase with no handler: nothing runs in `INCOMPLETE`, so

--- a/opencode-agent/src/openai-config.ts
+++ b/opencode-agent/src/openai-config.ts
@@ -63,6 +63,16 @@ const WRITE_TOOLS = [
   'external_directory',
 ] as const
 
+/**
+ * Design D8 — the one tool an artifact-writing (planner/spec) turn needs beyond
+ * reading. The drafter composes proposal/spec/design/tasks content and writes it
+ * into `openspec/changes/<name>/`; the diff guard's `outsidePrefix` confines
+ * what survives staging to that folder, so a write anywhere else is refused even
+ * though the tool itself is granted. No `bash`: composing artefacts is not
+ * running commands, and the two execution profiles (`build`) keep that.
+ */
+const PROPOSE_TOOLS = ['edit'] as const
+
 const grant = (tools: readonly string[]): Record<string, 'allow' | 'deny'> => ({
   '*': 'deny',
   ...Object.fromEntries(tools.map((tool) => [tool, 'allow'])),
@@ -73,6 +83,9 @@ export const READ_ONLY_PERMISSION = grant(READ_TOOLS)
 
 /** Everything above plus editing and running commands. */
 export const WRITE_PERMISSION = grant([...READ_TOOLS, ...WRITE_TOOLS])
+
+/** Reading plus editing, scoped by the diff guard to the change folder (D8). */
+export const PROPOSE_PERMISSION = grant([...READ_TOOLS, ...PROPOSE_TOOLS])
 
 export const buildOpencodeConfig = (settings: OpenAiSettings): Config => ({
   $schema: 'https://opencode.ai/config.json',
@@ -95,6 +108,9 @@ export const buildOpencodeConfig = (settings: OpenAiSettings): Config => ({
     // successful injection during the two *review* gates, before a maintainer
     // has approved anything, cannot reach the working tree at all.
     plan: { permission: READ_ONLY_PERMISSION },
+    // The artefact-drafting turns (design D8): read plus edit, confined by the
+    // diff guard to `openspec/changes/<change-name>/`. No `bash`.
+    propose: { permission: PROPOSE_PERMISSION },
     // Implementation and CI repair, and the review-loop subprocesses: `opencode
     // run` without `--agent` resolves to the primary agent, which
     // `opencode agent list` reports as `build`.

--- a/opencode-agent/src/openspec-driver.ts
+++ b/opencode-agent/src/openspec-driver.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+import type { CommandRunner, CommandResult } from './shell.js'
+
+/**
+ * The thin TypeScript seam over the `openspec` CLI — design D3.
+ *
+ * The same division of labour the archived `sdd-runner` established: TypeScript
+ * owns the CLI protocol (argv vectors, JSON decoding, exit-code handling), the
+ * model composes artifact content only. Re-implemented here rather than imported
+ * because `sdd-runner` is a peer workspace this agent never depended on, and the
+ * compliance idiom is a pattern to adopt, not a module to couple to.
+ *
+ * Every command runs through the injected {@link CommandRunner}, which spawns
+ * argv vectors with `shell: false` — the same boundary that keeps untrusted
+ * issue text out of `/bin/sh` everywhere else in this workspace.
+ */
+
+/** Spawned-command seam shared with every other external boundary here. */
+export interface OpenSpecDriverDeps {
+  readonly runner: CommandRunner
+  readonly cwd: string
+  /** Defaults to `openspec`; overridable for a pinned install path. */
+  readonly binary?: string
+}
+
+export interface NewChangeResult {
+  readonly changeName: string
+}
+
+export interface StatusResult {
+  readonly schemaName: string
+  readonly artifacts: Record<string, string>
+  readonly isPlanningComplete: boolean
+}
+
+export interface InstructionDependency {
+  readonly id: string
+  readonly done?: boolean
+  readonly path?: string
+  readonly description?: string
+}
+
+export interface InstructionsResult {
+  readonly instruction: string
+  readonly template: string | undefined
+  readonly rules: readonly string[]
+  readonly resolvedOutputPath: string
+  readonly existingOutputPaths: readonly string[]
+  readonly dependencies: readonly InstructionDependency[]
+}
+
+export interface ValidateResult {
+  readonly ok: boolean
+  /** Combined stdout+stderr; the drafter's retry attaches this as the complaint. */
+  readonly output: string
+}
+
+export interface OpenSpecDriver {
+  readonly newChange: (changeName: string, schema: string) => Promise<NewChangeResult>
+  readonly status: (changeName: string) => Promise<StatusResult>
+  readonly instructions: (artifactId: string, changeName: string) => Promise<InstructionsResult>
+  readonly validateStrict: (changeName: string) => Promise<ValidateResult>
+  readonly archive: (changeName: string) => Promise<void>
+}
+
+const StatusArtifactSchema = z.object({ id: z.string().min(1), status: z.string().min(1) })
+
+const StatusPayloadSchema = z.object({
+  schemaName: z.string().min(1),
+  artifacts: z.array(StatusArtifactSchema),
+  isPlanningComplete: z.boolean().optional(),
+})
+
+const InstructionDependencySchema = z.object({
+  id: z.string(),
+  done: z.boolean().optional(),
+  path: z.string().optional(),
+  description: z.string().optional(),
+})
+
+const InstructionsPayloadSchema = z.object({
+  instruction: z.string(),
+  template: z.string().optional(),
+  rules: z.array(z.string()).optional(),
+  resolvedOutputPath: z.string().min(1),
+  existingOutputPaths: z.array(z.string()).optional(),
+  dependencies: z.array(InstructionDependencySchema).optional(),
+})
+
+const argvFor = (deps: OpenSpecDriverDeps, args: readonly string[]): readonly string[] => [
+  deps.binary ?? 'openspec',
+  ...args,
+]
+
+/**
+ * Runs a command that is expected to succeed and throws naming the subcommand
+ * when it does not. Used by everything except `validateStrict`, whose non-zero
+ * exit is an ordinary result the drafter decides what to do with.
+ */
+const runExpectOk = async (deps: OpenSpecDriverDeps, args: readonly string[], label: string): Promise<string> => {
+  const result = await deps.runner(argvFor(deps, args), { cwd: deps.cwd })
+  if (result.exitCode !== 0) {
+    throw new Error(`openspec ${label} failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`)
+  }
+  return result.stdout
+}
+
+const parseJson = (stdout: string, label: string): unknown => {
+  try {
+    return JSON.parse(stdout)
+  } catch (error) {
+    throw new Error(`openspec ${label}: unparseable JSON output`, { cause: error })
+  }
+}
+
+export function createOpenSpecDriver(deps: OpenSpecDriverDeps): OpenSpecDriver {
+  return {
+    newChange: async (changeName, schema) => {
+      await runExpectOk(deps, ['new', 'change', changeName, '--schema', schema], 'new change')
+      return { changeName }
+    },
+
+    status: async (changeName) => {
+      const stdout = await runExpectOk(deps, ['status', '--change', changeName, '--json'], 'status')
+      const payload = StatusPayloadSchema.parse(parseJson(stdout, 'status'))
+      const artifacts: Record<string, string> = {}
+      for (const artifact of payload.artifacts) artifacts[artifact.id] = artifact.status
+      return { schemaName: payload.schemaName, artifacts, isPlanningComplete: payload.isPlanningComplete ?? false }
+    },
+
+    instructions: async (artifactId, changeName) => {
+      const stdout = await runExpectOk(
+        deps,
+        ['instructions', artifactId, '--change', changeName, '--json'],
+        'instructions',
+      )
+      const payload = InstructionsPayloadSchema.parse(parseJson(stdout, 'instructions'))
+      return {
+        instruction: payload.instruction,
+        template: payload.template,
+        rules: payload.rules ?? [],
+        resolvedOutputPath: payload.resolvedOutputPath,
+        existingOutputPaths: payload.existingOutputPaths ?? [],
+        dependencies: payload.dependencies ?? [],
+      }
+    },
+
+    validateStrict: async (changeName) => {
+      const result: CommandResult = await deps.runner(argvFor(deps, ['validate', changeName, '--strict']), {
+        cwd: deps.cwd,
+      })
+      return { ok: result.exitCode === 0, output: `${result.stdout}${result.stderr}` }
+    },
+
+    archive: async (changeName) => {
+      await runExpectOk(deps, ['archive', changeName], 'archive')
+    },
+  }
+}

--- a/opencode-agent/src/orchestrator.ts
+++ b/opencode-agent/src/orchestrator.ts
@@ -156,6 +156,8 @@ const triggerCommand = (event: TriggerEvent): ParsedCommand | null => {
       return parseSlashCommand(event.commentBody)
     case 'pull-request':
       return parseSlashCommand(event.commentBody)
+    case 'pr-merged':
+      return null
     default:
       return unreachable(event)
   }

--- a/opencode-agent/src/phase-context.ts
+++ b/opencode-agent/src/phase-context.ts
@@ -13,6 +13,7 @@ import type { GitHubApi } from './github.js'
 import type { Logger } from './logger.js'
 import type { SkillDocument } from './obra-skills.js'
 import type { OpenCodeAgent } from './opencode-adapter.js'
+import type { OpenSpecDriver } from './openspec-driver.js'
 import type { ReviewRunResult } from './review-runner.js'
 import type { StatusReporter } from './status-reporter.js'
 import type { TriggerEvent } from './trigger-events.js'
@@ -50,6 +51,13 @@ export interface PhaseDeps {
    */
   tokensUsed: () => Promise<number>
   skills: (phase: Phase) => Promise<SkillDocument[]>
+  /**
+   * The OpenSpec CLI driver (design D3): the thin TS seam over `openspec new
+   * change` / `status --json` / `instructions --json` / `validate --strict` /
+   * `archive`. Injected like every other external boundary so the whole state
+   * machine runs against a fake in tests.
+   */
+  openspec: OpenSpecDriver
   /**
    * Branch new work forks from and pull requests target. Memoized and lazy:
    * resolving it can cost a round trip to the remote, and a run stopped by a

--- a/opencode-agent/src/phase-context.ts
+++ b/opencode-agent/src/phase-context.ts
@@ -52,6 +52,12 @@ export interface PhaseDeps {
   tokensUsed: () => Promise<number>
   skills: (phase: Phase) => Promise<SkillDocument[]>
   /**
+   * Writes composed artifact content to a resolved path under the change folder
+   * (design D3). The drafter asks the model for content and hands it here; the
+   * diff guard's `outsidePrefix` confines what the subsequent commit keeps.
+   */
+  writeFile: (filePath: string, content: string) => Promise<void>
+  /**
    * The OpenSpec CLI driver (design D3): the thin TS seam over `openspec new
    * change` / `status --json` / `instructions --json` / `validate --strict` /
    * `archive`. Injected like every other external boundary so the whole state

--- a/opencode-agent/src/phase-context.ts
+++ b/opencode-agent/src/phase-context.ts
@@ -58,6 +58,11 @@ export interface PhaseDeps {
    */
   writeFile: (filePath: string, content: string) => Promise<void>
   /**
+   * Reads a file under the change folder. `REVIEW_AND_MUTATE` reads `tasks.md`
+   * to walk its checkboxes and to check each box in the step's commit (D5).
+   */
+  readFile: (filePath: string) => Promise<string>
+  /**
    * The OpenSpec CLI driver (design D3): the thin TS seam over `openspec new
    * change` / `status --json` / `instructions --json` / `validate --strict` /
    * `archive`. Injected like every other external boundary so the whole state

--- a/opencode-agent/src/phase-names.ts
+++ b/opencode-agent/src/phase-names.ts
@@ -62,6 +62,7 @@ export const PHASES = [
   'PR_DELIVERY',
   'CODE_REVIEW',
   'CI_FIX',
+  'ARCHIVE',
   'COMPLETE',
   'FAILED',
   'INCOMPLETE',

--- a/opencode-agent/src/phases/answer.ts
+++ b/opencode-agent/src/phases/answer.ts
@@ -3,7 +3,6 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { findArtifact, PLAN_MARKER, SPEC_MARKER } from '../artifacts.js'
 import { composeSystemPrompt } from '../obra-skills.js'
 import type { PhaseHandler, PhaseInput, PhaseOutcome } from '../phase-context.js'
 import { ANSWER_INSTRUCTIONS, buildAnswerPrompt } from '../prompts.js'
@@ -51,11 +50,23 @@ const questionText = (input: PhaseInput): string => {
   return '(the maintainer left no question text)'
 }
 
-/** The spec or plan the maintainer is most likely asking about. */
+/**
+ * The artefact the maintainer is most likely asking about, read straight from
+ * the change folder (design D1 — the folder is truth).
+ *
+ * At `PLAN_REVIEW` the artefact under review is the plan (`tasks.md`); at
+ * `DESIGN_SPEC` it is the proposal. `changeName` is set on every state that
+ * reaches either park (capture puts it there), so a `null` here is a hand-edit
+ * rather than an ordinary shape, and the answer proceeds without the grounding
+ * rather than throwing — the question still reaches the model, which has the
+ * issue body and the thread to reason from.
+ */
 const artifactUnderReview = async (input: PhaseInput): Promise<string | null> => {
-  const marker = input.state.phase === 'PLAN_REVIEW' ? PLAN_MARKER : SPEC_MARKER
-  const artifact = findArtifact(input.thread, await input.deps.selfLogin(), marker)
-  return artifact === null ? null : artifact.text
+  const { deps, state } = input
+  if (state.changeName === null) return null
+  const artifactId = state.phase === 'PLAN_REVIEW' ? 'tasks' : 'proposal'
+  const path = (await deps.openspec.instructions(artifactId, state.changeName)).resolvedOutputPath
+  return deps.readFile(path)
 }
 
 const NEXT_STEPS: Record<string, string> = {

--- a/opencode-agent/src/phases/archive.ts
+++ b/opencode-agent/src/phases/archive.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { PhaseHandler, PhaseOutcome } from '../phase-context.js'
+import type { TriggerEvent } from '../trigger-events.js'
+
+/**
+ * The archive door (design D7): a merged pull request on `agent/issue-<n>`
+ * runs `openspec archive` as a follow-up commit on the base branch, closing the
+ * propose → apply → archive loop.
+ *
+ * The handler is one shot: it checks out the base branch the merged PR targeted
+ * (`pull_request.base.ref`), archives the change folder the issue carried, and
+ * pushes. No model turn — archiving is a file move the CLI owns, not content the
+ * model composes, so no OpenCode session boots. Reached only from `COMPLETE` on
+ * `PR_MERGED`, and never persisted as a waiting state: a second merge event on
+ * the same issue finds it back in `COMPLETE`, the folder is already archived,
+ * and the archive command is a no-op the diff guard reports as nothing to commit.
+ */
+export const handleArchive: PhaseHandler = async (input): Promise<PhaseOutcome> => {
+  const { deps, state, trigger } = input
+  if (state.changeName === null) throw new Error('ARCHIVE reached without a changeName on the state')
+  const changeName = state.changeName
+  const baseBranch = archiveBaseBranch(trigger, await deps.baseBranch())
+
+  deps.log.info({ issue: state.issueId, change: changeName, base: baseBranch }, 'Archiving merged change')
+
+  // Onto the base branch the merged PR targeted, not `agent/issue-<n>`: the
+  // archive is a follow-up commit on master, and the agent branch dies with the
+  // merge. `ensureBranch(base, base)` checks out the base branch from itself.
+  await deps.git.ensureBranch(baseBranch, baseBranch)
+  await deps.openspec.archive(changeName)
+  await deps.git.commitAll(`chore(openspec): archive ${changeName}\n\nCloses #${state.issueId}`)
+  await deps.git.push(baseBranch)
+
+  return {
+    signal: 'ARCHIVED',
+    comment: renderArchiveComment(changeName),
+  }
+}
+
+/**
+ * The branch the archive commits to: the merged PR's base when the trigger
+ * carries it (the honest answer — that is the branch the maintainer merged
+ * into), falling back to the resolved base for any other path here.
+ */
+const archiveBaseBranch = (trigger: TriggerEvent, resolved: string): string =>
+  trigger.kind === 'pr-merged' ? trigger.baseBranch : resolved
+
+const renderArchiveComment = (changeName: string): string =>
+  [
+    '### Archived',
+    '',
+    `Merged pull request closed the loop: \`${changeName}\` is archived under \`openspec/archive/\`.`,
+    '',
+    'The change folder left `openspec/changes/` as a follow-up commit on the base branch.',
+  ].join('\n')

--- a/opencode-agent/src/phases/implement-steps.ts
+++ b/opencode-agent/src/phases/implement-steps.ts
@@ -7,7 +7,8 @@ import { isTurnDeadline } from '../errors.js'
 import type { PipelineError } from '../errors.js'
 import { buildImplementPrompt } from '../implement-prompts.js'
 import type { PhaseInput } from '../phase-context.js'
-import type { PlanStep, StepMarker } from '../plan-steps.js'
+import { checkBoxText } from '../plan-steps.js'
+import type { StepMarker, TaskStep } from '../plan-steps.js'
 import type { UntrustedEnvelope } from '../prompts.js'
 import { msToDeadline, timeForAnotherStep } from '../time-budget.js'
 import { commitStep } from './implement-commit.js'
@@ -74,12 +75,14 @@ export interface StepWalkInput {
   input: PhaseInput
   /** Branch the steps commit onto — already checked out by the handler. */
   branch: string
-  /** The approved plan as markdown, which every step's prompt carries as context. */
+  /** The approved plan as markdown (the folder's `tasks.md`), carried as context in every step's prompt. */
   plan: string
-  /** The steps to walk; empty means one turn for the whole plan. */
-  steps: readonly PlanStep[]
-  /** Steps of this plan a previous job already finished. */
+  /** The unchecked `tasks.md` boxes to walk this run (design D5). */
+  steps: readonly TaskStep[]
+  /** Steps of this plan a previous job already finished (cursor into the unchecked list). */
   from: number
+  /** Resolved path to `tasks.md`, so each step's commit can check its box (D5). */
+  tasksPath: string
   /**
    * The handler's one envelope and the system prompt built from it.
    *
@@ -126,27 +129,28 @@ export interface StepWalk {
   stopped: PipelineError | null
 }
 
-/** One unit of work: a declared step, or `null` for the whole plan at once. */
-type Unit = PlanStep | null
+/** One unit of work: an unchecked `tasks.md` box. */
+type Unit = TaskStep
 
 export const walkPlanSteps = (walk: StepWalkInput): Promise<StepWalk> => {
   const from = cursor(walk)
-  const units: readonly Unit[] = walk.steps.length === 0 ? [null] : walk.steps.slice(from)
+  const units: readonly Unit[] = walk.steps.slice(from)
   return step({ ...walk, from }, units, 0, { lines: 0, commits: 0, repairs: 0 })
 }
 
 /**
  * Where to start, with a cursor that names no step in this plan sent back to the top.
  *
- * A state block is attacker-editable text, and a cursor past the end of the plan would
- * leave the walk with nothing to do — reported as "finished the plan without touching
- * a single file", parked in `FAILED`, and unrecoverable, because every `/retry` would
- * reach the same conclusion. Starting over is the same answer `resumeTransition` gives
- * a hand-edited block that names no resume point, and it is safe: the steps already on
- * the branch are done, so their turns commit nothing and the walk carries on.
+ * A state block is attacker-editable text, and a cursor past the end of the
+ * unchecked list would leave the walk with nothing to do — reported as "finished
+ * the plan without touching a single file", parked in `FAILED`, and unrecoverable,
+ * because every `/retry` would reach the same conclusion. Starting over is the
+ * same answer `resumeTransition` gives a hand-edited block that names no resume
+ * point, and it is safe: the boxes already checked on the branch are skipped by
+ * the parser, so their turns commit nothing and the walk carries on.
  */
 const cursor = (walk: StepWalkInput): number => {
-  if (walk.steps.length === 0 || walk.from < walk.steps.length) return walk.from
+  if (walk.from < walk.steps.length) return walk.from
 
   walk.input.deps.log.warn(
     { issue: walk.input.state.issueId, stepsDone: walk.from, steps: walk.steps.length },
@@ -172,7 +176,7 @@ const step = async (walk: StepWalkInput, units: readonly Unit[], index: number, 
   if (unit === undefined) return { kind: 'finished', ...tally, done: walk.from + index, step: null, stopped: null }
 
   const { deps } = walk.input
-  const marker = markerFor(walk, unit, index)
+  const marker = markerFor(unit)
   // `spent` defaults to the tally this step began with, and is passed explicitly by
   // the one exit that happens after a commit attempt has been paid for.
   const at = (kind: StepWalk['kind'], stopped: PipelineError | null, spent: Tally = tally): StepWalk => ({
@@ -183,14 +187,10 @@ const step = async (walk: StepWalkInput, units: readonly Unit[], index: number, 
     stopped,
   })
 
-  // The gate, and it is asked only of a declared step. A plan with no steps is one
-  // indivisible turn: refusing to start it would cost the run everything that turn
-  // would have written, where starting it and being interrupted keeps what it wrote.
-  // With steps there is a boundary to stop on, so the same clock costs nothing.
   const toDeadline = msToDeadline(deps.config, deps.now())
-  if (unit !== null && toDeadline !== null && !timeForAnotherStep(toDeadline, deps.config)) {
+  if (toDeadline !== null && !timeForAnotherStep(toDeadline, deps.config)) {
     deps.log.warn(
-      { issue: walk.input.state.issueId, step: marker?.number, of: marker?.total, toDeadline },
+      { issue: walk.input.state.issueId, step: marker.number, of: marker.total, toDeadline },
       'Out of time for another plan step; stopping between steps with the branch pushed',
     )
     return at('out-of-time', null)
@@ -198,6 +198,12 @@ const step = async (walk: StepWalkInput, units: readonly Unit[], index: number, 
 
   const stopped = await promptForStep(walk, marker, unit, index === 0)
   if (stopped !== null) return at('interrupted', stopped)
+
+  // Design D5: check this step's box in `tasks.md` so the box-check lands in the
+  // same commit as the step's work. The model implements; the pipeline ticks the
+  // box — the folder is the plan's only shape, and a box nobody checks is a step
+  // nobody can see is done.
+  await checkBoxInFile(walk, unit)
 
   const committed = await commitStep(walk, marker)
   const spent: Tally = { ...tally, repairs: tally.repairs + committed.repairs }
@@ -215,9 +221,21 @@ const step = async (walk: StepWalkInput, units: readonly Unit[], index: number, 
   })
 }
 
-/** Where this unit sits in the plan, one-based, and `null` when the plan has no steps. */
-const markerFor = (walk: StepWalkInput, unit: Unit, index: number): StepMarker | null =>
-  unit === null ? null : { number: walk.from + index + 1, total: walk.steps.length, title: unit.title }
+/** The marker a maintainer reads for this box, from the TaskStep's own count. */
+const markerFor = (unit: TaskStep): StepMarker => ({ number: unit.number, total: unit.total, title: unit.text })
+
+/**
+ * Reads `tasks.md`, ticks this step's box, writes it back. One line edited, by
+ * the line number the parser recorded, so an indented sub-item keeps its
+ * indentation and the rest of the file is untouched.
+ */
+const checkBoxInFile = async (walk: StepWalkInput, unit: TaskStep): Promise<void> => {
+  const content = await walk.input.deps.readFile(walk.tasksPath)
+  const lines = content.split('\n')
+  const target = lines[unit.line - 1]
+  if (target !== undefined) lines[unit.line - 1] = checkBoxText(target)
+  await walk.input.deps.writeFile(walk.tasksPath, lines.join('\n'))
+}
 
 /**
  * One step's turn, and `null` unless the clock stopped it part-way through.
@@ -235,8 +253,8 @@ const markerFor = (walk: StepWalkInput, unit: Unit, index: number): StepMarker |
  */
 const promptForStep = async (
   walk: StepWalkInput,
-  marker: StepMarker | null,
-  unit: Unit,
+  marker: StepMarker,
+  unit: TaskStep,
   first: boolean,
 ): Promise<PipelineError | null> => {
   const agent = await walk.input.deps.agent()
@@ -248,7 +266,14 @@ const promptForStep = async (
         envelope: walk.envelope,
         issueNumber: walk.input.state.issueId,
         plan: walk.plan,
-        step: marker === null || unit === null ? null : { ...marker, step: unit },
+        // A `tasks.md` box carries its text but not named files or a verification
+        // command; the model derives both from the approved plan it is shown.
+        step: {
+          number: marker.number,
+          total: marker.total,
+          title: unit.text,
+          step: { title: unit.text, files: [], verification: '' },
+        },
         handoff: first ? walk.handoff : null,
       }),
       agent: 'build',

--- a/opencode-agent/src/phases/implement-steps.ts
+++ b/opencode-agent/src/phases/implement-steps.ts
@@ -8,7 +8,7 @@ import type { PipelineError } from '../errors.js'
 import { buildImplementPrompt } from '../implement-prompts.js'
 import type { PhaseInput } from '../phase-context.js'
 import { checkBoxText } from '../plan-steps.js'
-import type { StepMarker, TaskStep } from '../plan-steps.js'
+import type { PlanBox, StepMarker } from '../plan-steps.js'
 import type { UntrustedEnvelope } from '../prompts.js'
 import { msToDeadline, timeForAnotherStep } from '../time-budget.js'
 import { commitStep } from './implement-commit.js'
@@ -77,9 +77,15 @@ export interface StepWalkInput {
   branch: string
   /** The approved plan as markdown (the folder's `tasks.md`), carried as context in every step's prompt. */
   plan: string
-  /** The unchecked `tasks.md` boxes to walk this run (design D5). */
-  steps: readonly TaskStep[]
-  /** Steps of this plan a previous job already finished (cursor into the unchecked list). */
+  /** Every `tasks.md` checkbox, in file order, with absolute numbering (design D5). */
+  steps: readonly PlanBox[]
+  /**
+   * Absolute index of the box a previous job finished (a count of steps done),
+   * so a resume starts at the next box. The cursor is reconciled with the
+   * boxes' own `checked` state — a ticked box is skipped without a turn — which
+   * is why a `/continue` that arrives after a between-steps park lands on the
+   * right box even though the boxes ahead of it have been ticked.
+   */
   from: number
   /** Resolved path to `tasks.md`, so each step's commit can check its box (D5). */
   tasksPath: string
@@ -129,25 +135,21 @@ export interface StepWalk {
   stopped: PipelineError | null
 }
 
-/** One unit of work: an unchecked `tasks.md` box. */
-type Unit = TaskStep
-
 export const walkPlanSteps = (walk: StepWalkInput): Promise<StepWalk> => {
-  const from = cursor(walk)
-  const units: readonly Unit[] = walk.steps.slice(from)
-  return step({ ...walk, from }, units, 0, { lines: 0, commits: 0, repairs: 0 })
+  const start = cursor(walk)
+  return step(walk, start, false, { lines: 0, commits: 0, repairs: 0 })
 }
 
 /**
  * Where to start, with a cursor that names no step in this plan sent back to the top.
  *
- * A state block is attacker-editable text, and a cursor past the end of the
- * unchecked list would leave the walk with nothing to do — reported as "finished
- * the plan without touching a single file", parked in `FAILED`, and unrecoverable,
+ * A state block is attacker-editable text, and a cursor past the end of the plan
+ * would leave the walk with nothing to do — reported as "finished the plan
+ * without touching a single file", parked in `FAILED`, and unrecoverable,
  * because every `/retry` would reach the same conclusion. Starting over is the
  * same answer `resumeTransition` gives a hand-edited block that names no resume
  * point, and it is safe: the boxes already checked on the branch are skipped by
- * the parser, so their turns commit nothing and the walk carries on.
+ * the walk, so their turns commit nothing and the run carries on.
  */
 const cursor = (walk: StepWalkInput): number => {
   if (walk.from < walk.steps.length) return walk.from
@@ -166,23 +168,27 @@ interface Tally {
 }
 
 /**
- * One unit, then the rest — or a stop.
+ * One box, then the rest — or a stop. Visits boxes by absolute index; a checked
+ * box is done and is skipped without a turn.
  *
- * Tail recursion rather than a loop because the repo forbids awaiting in a loop body,
- * and the same shape the phase cascade itself uses for the same reason.
+ * Tail recursion rather than a loop because the repo forbids awaiting in a loop
+ * body, and the same shape the phase cascade itself uses for the same reason.
+ * `ranStep` carries whether any step has prompted yet this run, so the handoff
+ * reaches the first step actually worked and not a box skipped past at the top.
  */
-const step = async (walk: StepWalkInput, units: readonly Unit[], index: number, tally: Tally): Promise<StepWalk> => {
-  const unit = units[index]
-  if (unit === undefined) return { kind: 'finished', ...tally, done: walk.from + index, step: null, stopped: null }
+const step = async (walk: StepWalkInput, i: number, ranStep: boolean, tally: Tally): Promise<StepWalk> => {
+  const box = walk.steps[i]
+  if (box === undefined) return { kind: 'finished', ...tally, done: i, step: null, stopped: null }
+  if (box.checked) return step(walk, i + 1, ranStep, tally)
 
   const { deps } = walk.input
-  const marker = markerFor(unit)
+  const marker = markerFor(box)
   // `spent` defaults to the tally this step began with, and is passed explicitly by
   // the one exit that happens after a commit attempt has been paid for.
   const at = (kind: StepWalk['kind'], stopped: PipelineError | null, spent: Tally = tally): StepWalk => ({
     kind,
     ...spent,
-    done: walk.from + index,
+    done: i,
     step: marker,
     stopped,
   })
@@ -196,14 +202,14 @@ const step = async (walk: StepWalkInput, units: readonly Unit[], index: number, 
     return at('out-of-time', null)
   }
 
-  const stopped = await promptForStep(walk, marker, unit, index === 0)
+  const stopped = await promptForStep(walk, marker, box, !ranStep)
   if (stopped !== null) return at('interrupted', stopped)
 
   // Design D5: check this step's box in `tasks.md` so the box-check lands in the
   // same commit as the step's work. The model implements; the pipeline ticks the
   // box — the folder is the plan's only shape, and a box nobody checks is a step
   // nobody can see is done.
-  await checkBoxInFile(walk, unit)
+  await checkBoxInFile(walk, box)
 
   const committed = await commitStep(walk, marker)
   const spent: Tally = { ...tally, repairs: tally.repairs + committed.repairs }
@@ -214,26 +220,26 @@ const step = async (walk: StepWalkInput, units: readonly Unit[], index: number, 
   // stops leave by the one door `settleWalk` already knows about.
   if (committed.stopped !== null) return at('interrupted', committed.stopped, spent)
 
-  return step(walk, units, index + 1, {
+  return step(walk, i + 1, true, {
     ...spent,
     lines: spent.lines + (committed.totals?.lines ?? 0),
     commits: spent.commits + (committed.totals === null ? 0 : 1),
   })
 }
 
-/** The marker a maintainer reads for this box, from the TaskStep's own count. */
-const markerFor = (unit: TaskStep): StepMarker => ({ number: unit.number, total: unit.total, title: unit.text })
+/** The marker a maintainer reads for this box, from the PlanBox's own count. */
+const markerFor = (box: PlanBox): StepMarker => ({ number: box.number, total: box.total, title: box.text })
 
 /**
  * Reads `tasks.md`, ticks this step's box, writes it back. One line edited, by
  * the line number the parser recorded, so an indented sub-item keeps its
  * indentation and the rest of the file is untouched.
  */
-const checkBoxInFile = async (walk: StepWalkInput, unit: TaskStep): Promise<void> => {
+const checkBoxInFile = async (walk: StepWalkInput, box: PlanBox): Promise<void> => {
   const content = await walk.input.deps.readFile(walk.tasksPath)
   const lines = content.split('\n')
-  const target = lines[unit.line - 1]
-  if (target !== undefined) lines[unit.line - 1] = checkBoxText(target)
+  const target = lines[box.line - 1]
+  if (target !== undefined) lines[box.line - 1] = checkBoxText(target)
   await walk.input.deps.writeFile(walk.tasksPath, lines.join('\n'))
 }
 
@@ -254,7 +260,7 @@ const checkBoxInFile = async (walk: StepWalkInput, unit: TaskStep): Promise<void
 const promptForStep = async (
   walk: StepWalkInput,
   marker: StepMarker,
-  unit: TaskStep,
+  box: PlanBox,
   first: boolean,
 ): Promise<PipelineError | null> => {
   const agent = await walk.input.deps.agent()
@@ -271,8 +277,8 @@ const promptForStep = async (
         step: {
           number: marker.number,
           total: marker.total,
-          title: unit.text,
-          step: { title: unit.text, files: [], verification: '' },
+          title: box.text,
+          step: { title: box.text, files: [], verification: '' },
         },
         handoff: first ? walk.handoff : null,
       }),

--- a/opencode-agent/src/phases/implement.ts
+++ b/opencode-agent/src/phases/implement.ts
@@ -9,7 +9,7 @@ import { branchNameFor } from '../git.js'
 import { IMPLEMENT_INSTRUCTIONS } from '../implement-prompts.js'
 import { composeSystemPrompt } from '../obra-skills.js'
 import type { PhaseHandler, PhaseInput, PhaseOutcome } from '../phase-context.js'
-import { parseTaskCheckboxes, taskStepsFromCheckboxes } from '../plan-steps.js'
+import { planBoxes } from '../plan-steps.js'
 import { msToDeadline } from '../time-budget.js'
 import { renderStoppedBetweenSteps } from '../time-notices.js'
 import { stopPartWayThrough } from '../turn-stop.js'
@@ -41,7 +41,7 @@ export const handleImplement: PhaseHandler = async (input): Promise<PhaseOutcome
   if (state.changeName === null) throw new Error('REVIEW_AND_MUTATE reached without a changeName on the state')
   const tasksPath = (await deps.openspec.instructions('tasks', state.changeName)).resolvedOutputPath
   const tasksMd = await deps.readFile(tasksPath)
-  const steps = taskStepsFromCheckboxes(parseTaskCheckboxes(tasksMd))
+  const steps = planBoxes(tasksMd)
 
   const branch = branchNameFor(state.issueId)
   await deps.git.ensureBranch(branch, await deps.baseBranch())

--- a/opencode-agent/src/phases/implement.ts
+++ b/opencode-agent/src/phases/implement.ts
@@ -3,12 +3,13 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { findHandoff, renderArtifact, REPORT_MARKER, requirePlan } from '../artifacts.js'
-import { missingPlanError, noChangesError } from '../errors.js'
+import { findHandoff, renderArtifact, REPORT_MARKER } from '../artifacts.js'
+import { noChangesError } from '../errors.js'
 import { branchNameFor } from '../git.js'
 import { IMPLEMENT_INSTRUCTIONS } from '../implement-prompts.js'
 import { composeSystemPrompt } from '../obra-skills.js'
 import type { PhaseHandler, PhaseInput, PhaseOutcome } from '../phase-context.js'
+import { parseTaskCheckboxes, taskStepsFromCheckboxes } from '../plan-steps.js'
 import { msToDeadline } from '../time-budget.js'
 import { renderStoppedBetweenSteps } from '../time-notices.js'
 import { stopPartWayThrough } from '../turn-stop.js'
@@ -37,7 +38,10 @@ import type { StepWalk } from './implement-steps.js'
  */
 export const handleImplement: PhaseHandler = async (input): Promise<PhaseOutcome> => {
   const { deps, state } = input
-  const plan = requirePlan(input.thread, await deps.selfLogin(), () => missingPlanError(state.issueId))
+  if (state.changeName === null) throw new Error('REVIEW_AND_MUTATE reached without a changeName on the state')
+  const tasksPath = (await deps.openspec.instructions('tasks', state.changeName)).resolvedOutputPath
+  const tasksMd = await deps.readFile(tasksPath)
+  const steps = taskStepsFromCheckboxes(parseTaskCheckboxes(tasksMd))
 
   const branch = branchNameFor(state.issueId)
   await deps.git.ensureBranch(branch, await deps.baseBranch())
@@ -58,11 +62,11 @@ export const handleImplement: PhaseHandler = async (input): Promise<PhaseOutcome
   const walk = await walkPlanSteps({
     input,
     branch,
-    plan: plan.text,
-    steps: plan.steps,
-    // Where a previous job's stop left the plan. `0` for a fresh implementation and
-    // for every plan that has no steps.
+    plan: tasksMd,
+    steps,
+    // Where a previous job's stop left the plan. `0` for a fresh implementation.
     from: state.stepsDone,
+    tasksPath,
     envelope,
     system,
     // A note the *previous* out-of-time run wrote about this same plan. Read through
@@ -71,7 +75,7 @@ export const handleImplement: PhaseHandler = async (input): Promise<PhaseOutcome
     handoff: findHandoff(input.thread, await deps.selfLogin(), state.planRevision),
   })
 
-  return settleWalk({ input, branch, system, total: plan.steps.length, walk })
+  return settleWalk({ input, branch, system, total: steps.length, walk })
 }
 
 interface Settlement {

--- a/opencode-agent/src/phases/plan.ts
+++ b/opencode-agent/src/phases/plan.ts
@@ -3,83 +3,145 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { renderPlanArtifact, requireArtifact, SPEC_MARKER } from '../artifacts.js'
+import { z } from 'zod'
+
 import { promptForJson } from '../ask-json.js'
-import { missingSpecError } from '../errors.js'
 import { branchNameFor } from '../git.js'
 import { composeSystemPrompt } from '../obra-skills.js'
+import type { InstructionsResult } from '../openspec-driver.js'
 import type { PhaseHandler, PhaseInput, PhaseOutcome } from '../phase-context.js'
-import { executionPlanSchema, renderPlanMarkdown } from '../plan-steps.js'
-import type { ExecutionPlan } from '../plan-steps.js'
-import { buildPlanPrompt } from '../prompts.js'
+import type { UntrustedEnvelope } from '../prompts.js'
 import { mintEnvelope } from './envelope.js'
 
-const PLAN_INSTRUCTIONS = [
-  'Break the approved spec into a granular, ordered implementation plan.',
-  'Every step names the files it touches and how it will be verified.',
-  'No step may create or edit a file under .github/workflows/ — this pipeline cannot push one. Where the work ' +
-    'needs a workflow change, make the last step write down what a maintainer should apply by hand.',
-  'Do not modify any files in this phase — planning only.',
+/**
+ * Phase 2 — the PLANNING drafter loop (design D3).
+ *
+ * Reads the change's status from the folder, drafts each pending artifact
+ * (typed instruction → model composes per template → write → `validate --strict`
+ * → retry once with the complaint attached), commits the lot confined to the
+ * folder, and signals `PLAN_POSTED`. The plan is `tasks.md` on the branch now,
+ * not an `AGENT_PLAN` block on the issue; the folder is truth (D1).
+ *
+ * `propose` agent profile: the drafter composes content as a JSON reply and TS
+ * writes it, so the model's edit capability is not exercised — but the profile
+ * is the one a future model-writes-files drafter would take, and the diff
+ * guard's `outsidePrefix` confines whatever lands in the index to the folder.
+ */
+
+const draftReplySchema = z.object({ content: z.string().min(1) })
+
+const PROPOSE_INSTRUCTIONS = [
+  'You are drafting one artifact of an OpenSpec change folder.',
+  'Use the instruction, template and rules below; the artifact must satisfy `openspec validate --strict`.',
+  'Reply with a single JSON object and nothing else: {"content":"<markdown>"}',
+  'Write only the artifact asked for. Do not invent capabilities or deltas the change does not claim.',
 ].join('\n')
 
-/**
- * Phase 2. Runs after a maintainer approves the spec: drives the superpowers
- * planning skills to produce a step breakdown and cuts the working branch.
- *
- * Re-entered when a maintainer requests changes to a plan, with their feedback
- * threaded into the prompt.
- */
 export const handlePlan: PhaseHandler = async (input): Promise<PhaseOutcome> => {
   const { deps, state } = input
-  const spec = requireArtifact(input.thread, await deps.selfLogin(), SPEC_MARKER, () => missingSpecError(state.issueId))
-
+  if (state.changeName === null) throw new Error('PLANNING reached without a changeName on the state')
+  const changeName = state.changeName
   const branch = branchNameFor(state.issueId)
-  const feedback = changeRequest(input)
-  deps.log.info({ issue: state.issueId, branch, revising: feedback !== null }, 'Building the plan')
+  deps.log.info({ issue: state.issueId, change: changeName, branch }, 'Drafting change artifacts')
 
-  const plan = await askForPlan(input, { spec, branch, feedback })
-
+  await draftUntilComplete(input)
   await deps.git.ensureBranch(branch, await deps.baseBranch())
+  await deps.git.commitAll(`docs(openspec): draft artifacts for ${changeName}`)
+  await deps.git.push(branch)
 
-  const markdown = renderPlanMarkdown(plan)
-  // Counted over plans alone, and one local feeds both the heading and the
-  // block so the two cannot disagree. `PLAN_POSTED` bumps `planRevision` to
-  // exactly this value; revising the spec never moves it.
-  const revision = state.planRevision + 1
   return {
     signal: 'PLAN_POSTED',
-    comment: renderPlanComment(markdown, branch, revision),
-    // The steps ride in the block beside the text they were rendered into, so the
-    // implementation walks the very list this comment shows rather than a reading of
-    // it. Never recovered by parsing the markdown back: that is the workspace's
-    // oldest rule, and it exists because heading-scraping truncated specs.
-    blocks: [renderPlanArtifact(markdown, revision, plan.steps)],
-    // A new plan is a new list of steps, so the cursor into the old one means
-    // nothing. Reset here rather than in `transitions.ts` because it is a fact about
-    // what this handler *wrote*, not about the move `PLAN_POSTED` makes — and a
-    // cursor carried across a `/changes` would skip work nobody has done, the same
-    // argument that retires the handoff note on a plan revision.
-    patch: { stepsDone: 0 },
+    comment: renderPlanComment(changeName, branch, state.planRevision + 1),
+    // The plan's identity token bumps; its content lives on the branch.
+    patch: { planRevision: state.planRevision + 1, stepsDone: 0 },
   }
 }
 
 /**
- * The one model turn of this phase, asked for as **JSON**.
+ * Loops drafting the next ready artifact until `openspec status` reports
+ * planning complete. Re-reads status after each artifact so a dependent one
+ * (tasks blocked on design) becomes draftable the moment its dependency lands.
  *
- * Through `promptForJson`, which re-asks once with the validation complaint attached —
- * which is also what enforces `MAX_PLAN_STEPS`: an over-long plan comes back coarser
- * from the same turn rather than failing the phase. Never `agent.prompt` plus a parse.
+ * Tail recursion rather than a loop body: the repo forbids `await` inside a
+ * loop, and the drafter is inherently sequential — each artifact's status
+ * depends on the previous one landing in the folder.
  */
-const askForPlan = async (
-  input: PhaseInput,
-  about: { spec: string; branch: string; feedback: string | null },
-): Promise<ExecutionPlan> => {
-  const { deps, state } = input
-  const envelope = mintEnvelope()
+const draftUntilComplete = async (input: PhaseInput): Promise<void> => {
+  const changeName = input.state.changeName
+  if (changeName === null) throw new Error('PLANNING reached without a changeName on the state')
+  const status = await input.deps.openspec.status(changeName)
+  return draftNext(input, changeName, status, 0)
+}
 
-  return promptForJson({
+const draftNext = async (
+  input: PhaseInput,
+  changeName: string,
+  status: import('../openspec-driver.js').StatusResult,
+  depth: number,
+): Promise<void> => {
+  if (status.isPlanningComplete) return
+  if (depth > MAX_DRAFT_ITERATIONS) throw new Error('drafter loop did not converge')
+  const next = readyArtifact(status.artifacts)
+  if (next === null) return
+
+  const instruction = await input.deps.openspec.instructions(next, changeName)
+  await composeAndValidate(input, instruction, null)
+  const refreshed = await input.deps.openspec.status(changeName)
+  return draftNext(input, changeName, refreshed, depth + 1)
+}
+
+/** The first artifact whose status is `ready` (draftable now), or null. */
+const readyArtifact = (artifacts: Record<string, string>): string | null => {
+  for (const [id, artifactStatus] of Object.entries(artifacts)) {
+    if (artifactStatus === 'ready') return id
+  }
+  return null
+}
+
+/** A guard against a driver whose status never converges (a fake loop bug). */
+const MAX_DRAFT_ITERATIONS = 16
+
+/**
+ * Composes one artifact, writes it, and validates the change. On a validation
+ * failure re-asks **once** with the complaint attached, exactly the
+ * `promptForJson` pattern generalised to the validate-strict verdict.
+ */
+const composeAndValidate = async (
+  input: PhaseInput,
+  instruction: InstructionsResult,
+  complaint: string | null,
+): Promise<void> => {
+  const { deps } = input
+  const content = await composeArtifact(input, instruction, complaint)
+  await deps.writeFile(instruction.resolvedOutputPath, content)
+
+  const changeName = input.state.changeName
+  if (changeName === null) return
+  const verdict = await deps.openspec.validateStrict(changeName)
+  if (verdict.ok) return
+
+  if (complaint !== null) {
+    // Second attempt still invalid: the strict complaint is the failure reason.
+    throw new Error(`openspec validate --strict failed after retry: ${verdict.output}`)
+  }
+  await composeAndValidate(input, instruction, verdict.output)
+}
+
+/**
+ * Asks the model for the artifact content. `complaint` is null on the first
+ * attempt and the validate-strict output on the repair, so the model sees what
+ * it got wrong.
+ */
+const composeArtifact = async (
+  input: PhaseInput,
+  instruction: InstructionsResult,
+  complaint: string | null,
+): Promise<string> => {
+  const { deps } = input
+  const envelope = mintEnvelope()
+  const reply = await promptForJson({
     agent: await deps.agent(),
-    schema: executionPlanSchema,
+    schema: draftReplySchema,
     envelope,
     log: deps.log,
     request: {
@@ -88,28 +150,42 @@ const askForPlan = async (
         skills: await deps.skills('PLANNING'),
         repoRoot: deps.config.repoRoot,
         nonce: envelope.nonce,
-        instructions: PLAN_INSTRUCTIONS,
+        instructions: PROPOSE_INSTRUCTIONS,
       }),
-      prompt: buildPlanPrompt({ envelope, issueNumber: state.issueId, ...about }),
-      agent: 'plan',
+      prompt: draftPrompt(envelope, instruction, complaint),
+      agent: 'propose',
     },
   })
+  return reply.content
 }
 
-const changeRequest = (input: PhaseInput): string | null => {
-  const { command } = input
-  if (command === null || command.command !== '/changes') return null
-  return command.argument.length > 0 ? command.argument : null
+const draftPrompt = (
+  envelope: UntrustedEnvelope,
+  instruction: InstructionsResult,
+  complaint: string | null,
+): string => {
+  const sections = [
+    `Instruction: ${instruction.instruction}`,
+    instruction.template === undefined ? '' : envelope.wrap('template', instruction.template),
+    instruction.rules.length === 0 ? '' : `Rules:\n${instruction.rules.map((rule) => `- ${rule}`).join('\n')}`,
+    `Write to: ${instruction.resolvedOutputPath}`,
+  ].filter((section) => section.length > 0)
+
+  if (complaint !== null) {
+    sections.push(
+      'Your previous draft failed `openspec validate --strict` with the complaint below. Revise the artifact so it validates.',
+      envelope.wrap('validate-complaint', complaint),
+    )
+  }
+  return sections.join('\n\n')
 }
 
-const renderPlanComment = (markdown: string, branch: string, revision: number): string =>
+const renderPlanComment = (changeName: string, branch: string, revision: number): string =>
   [
     `### Plan (revision ${revision})`,
     '',
-    markdown,
+    `Change \`${changeName}\` is fully drafted in \`openspec/changes/${changeName}/\` on \`${branch}\`.`,
     '',
-    `Working branch: \`${branch}\`.`,
-    '',
-    '**What now?** `/approve` to implement this plan, `/changes <what to change>` to revise it,',
+    '**What now?** `/approve` to implement the plan, `/changes <what to change>` to revise it,',
     '`/ask <question>` to ask about it, or `/cancel` to stop.',
   ].join('\n')

--- a/opencode-agent/src/phases/plan.ts
+++ b/opencode-agent/src/phases/plan.ts
@@ -5,6 +5,7 @@
 
 import { z } from 'zod'
 
+import { renderDigest } from '../artifacts.js'
 import { promptForJson } from '../ask-json.js'
 import { branchNameFor } from '../git.js'
 import { composeSystemPrompt } from '../obra-skills.js'
@@ -49,12 +50,26 @@ export const handlePlan: PhaseHandler = async (input): Promise<PhaseOutcome> => 
   await deps.git.commitAll(`docs(openspec): draft artifacts for ${changeName}`)
   await deps.git.push(branch)
 
+  // The plan digest is a render of the folder's tasks.md, read straight back
+  // from where the drafter wrote it (design D1) — not a memory of the model
+  // reply. The revision token is the machine's plan identity; the branch's
+  // commits are the artifact's real history, and the digest says so.
+  const tasks = await readTasksArtifact(input, changeName)
   return {
     signal: 'PLAN_POSTED',
-    comment: renderPlanComment(changeName, branch, state.planRevision + 1),
+    comment: renderPlanComment(changeName, branch, state.planRevision + 1, tasks),
     // The plan's identity token bumps; its content lives on the branch.
     patch: { planRevision: state.planRevision + 1, stepsDone: 0 },
   }
+}
+
+/**
+ * Resolves the change's `tasks.md` path from the folder and reads it back, the
+ * same read the implementation and review phases make of the approved plan.
+ */
+const readTasksArtifact = async (input: PhaseInput, changeName: string): Promise<string> => {
+  const tasksPath = (await input.deps.openspec.instructions('tasks', changeName)).resolvedOutputPath
+  return input.deps.readFile(tasksPath)
 }
 
 /**
@@ -180,11 +195,13 @@ const draftPrompt = (
   return sections.join('\n\n')
 }
 
-const renderPlanComment = (changeName: string, branch: string, revision: number): string =>
+const renderPlanComment = (changeName: string, branch: string, revision: number, tasks: string): string =>
   [
     `### Plan (revision ${revision})`,
     '',
     `Change \`${changeName}\` is fully drafted in \`openspec/changes/${changeName}/\` on \`${branch}\`.`,
+    '',
+    renderDigest(tasks, { changeName, branch, revision }),
     '',
     '**What now?** `/approve` to implement the plan, `/changes <what to change>` to revise it,',
     '`/ask <question>` to ask about it, or `/cancel` to stop.',

--- a/opencode-agent/src/phases/plan.ts
+++ b/opencode-agent/src/phases/plan.ts
@@ -43,9 +43,13 @@ export const handlePlan: PhaseHandler = async (input): Promise<PhaseOutcome> => 
   if (state.changeName === null) throw new Error('PLANNING reached without a changeName on the state')
   const changeName = state.changeName
   const branch = branchNameFor(state.issueId)
-  deps.log.info({ issue: state.issueId, change: changeName, branch }, 'Drafting change artifacts')
+  const feedback = revisionFeedback(input)
+  deps.log.info(
+    { issue: state.issueId, change: changeName, branch, revising: feedback !== null },
+    'Drafting change artifacts',
+  )
 
-  await draftUntilComplete(input)
+  await draftUntilComplete(input, feedback)
   await deps.git.ensureBranch(branch, await deps.baseBranch())
   await deps.git.commitAll(`docs(openspec): draft artifacts for ${changeName}`)
   await deps.git.push(branch)
@@ -64,6 +68,27 @@ export const handlePlan: PhaseHandler = async (input): Promise<PhaseOutcome> => 
 }
 
 /**
+ * The maintainer feedback a re-draft is grounded in, or `null` for a fresh plan.
+ *
+ * Two channels reach PLANNING with feedback: `/changes <argument>` from a
+ * waiting phase, and a plain steering comment (design D6) that arrived
+ * mid-implementation and routed back here. Both tell the drafter what to revise;
+ * a first plan (`/approve` out of `DESIGN_SPEC`) carries neither, and the
+ * drafter composes from the instruction alone.
+ */
+const revisionFeedback = (input: PhaseInput): string | null => {
+  const { command, trigger } = input
+  if (command !== null && command.command === '/changes' && command.argument.length > 0) {
+    return command.argument
+  }
+  if (command === null && trigger.kind === 'issue') {
+    const body = trigger.commentBody
+    if (body !== null && body.trim().length > 0) return body.trim()
+  }
+  return null
+}
+
+/**
  * Resolves the change's `tasks.md` path from the folder and reads it back, the
  * same read the implementation and review phases make of the approved plan.
  */
@@ -77,21 +102,26 @@ const readTasksArtifact = async (input: PhaseInput, changeName: string): Promise
  * planning complete. Re-reads status after each artifact so a dependent one
  * (tasks blocked on design) becomes draftable the moment its dependency lands.
  *
+ * `feedback` is the maintainer's revision request when PLANNING was re-entered
+ * via `/changes` or a steering comment (D6); it threads into every artifact's
+ * draft prompt so a re-draft revises against it rather than composing blind.
+ *
  * Tail recursion rather than a loop body: the repo forbids `await` inside a
  * loop, and the drafter is inherently sequential — each artifact's status
  * depends on the previous one landing in the folder.
  */
-const draftUntilComplete = async (input: PhaseInput): Promise<void> => {
+const draftUntilComplete = async (input: PhaseInput, feedback: string | null): Promise<void> => {
   const changeName = input.state.changeName
   if (changeName === null) throw new Error('PLANNING reached without a changeName on the state')
   const status = await input.deps.openspec.status(changeName)
-  return draftNext(input, changeName, status, 0)
+  return draftNext(input, changeName, status, feedback, 0)
 }
 
 const draftNext = async (
   input: PhaseInput,
   changeName: string,
   status: import('../openspec-driver.js').StatusResult,
+  feedback: string | null,
   depth: number,
 ): Promise<void> => {
   if (status.isPlanningComplete) return
@@ -100,9 +130,9 @@ const draftNext = async (
   if (next === null) return
 
   const instruction = await input.deps.openspec.instructions(next, changeName)
-  await composeAndValidate(input, instruction, null)
+  await composeAndValidate(input, instruction, null, feedback)
   const refreshed = await input.deps.openspec.status(changeName)
-  return draftNext(input, changeName, refreshed, depth + 1)
+  return draftNext(input, changeName, refreshed, feedback, depth + 1)
 }
 
 /** The first artifact whose status is `ready` (draftable now), or null. */
@@ -125,9 +155,10 @@ const composeAndValidate = async (
   input: PhaseInput,
   instruction: InstructionsResult,
   complaint: string | null,
+  feedback: string | null,
 ): Promise<void> => {
   const { deps } = input
-  const content = await composeArtifact(input, instruction, complaint)
+  const content = await composeArtifact(input, instruction, complaint, feedback)
   await deps.writeFile(instruction.resolvedOutputPath, content)
 
   const changeName = input.state.changeName
@@ -139,18 +170,20 @@ const composeAndValidate = async (
     // Second attempt still invalid: the strict complaint is the failure reason.
     throw new Error(`openspec validate --strict failed after retry: ${verdict.output}`)
   }
-  await composeAndValidate(input, instruction, verdict.output)
+  await composeAndValidate(input, instruction, verdict.output, feedback)
 }
 
 /**
  * Asks the model for the artifact content. `complaint` is null on the first
  * attempt and the validate-strict output on the repair, so the model sees what
- * it got wrong.
+ * it got wrong. `feedback` is the maintainer's revision request when the draft
+ * is a re-plan (D6), null on a fresh plan.
  */
 const composeArtifact = async (
   input: PhaseInput,
   instruction: InstructionsResult,
   complaint: string | null,
+  feedback: string | null,
 ): Promise<string> => {
   const { deps } = input
   const envelope = mintEnvelope()
@@ -167,7 +200,7 @@ const composeArtifact = async (
         nonce: envelope.nonce,
         instructions: PROPOSE_INSTRUCTIONS,
       }),
-      prompt: draftPrompt(envelope, instruction, complaint),
+      prompt: draftPrompt(envelope, instruction, complaint, feedback),
       agent: 'propose',
     },
   })
@@ -178,6 +211,7 @@ const draftPrompt = (
   envelope: UntrustedEnvelope,
   instruction: InstructionsResult,
   complaint: string | null,
+  feedback: string | null,
 ): string => {
   const sections = [
     `Instruction: ${instruction.instruction}`,
@@ -185,6 +219,13 @@ const draftPrompt = (
     instruction.rules.length === 0 ? '' : `Rules:\n${instruction.rules.map((rule) => `- ${rule}`).join('\n')}`,
     `Write to: ${instruction.resolvedOutputPath}`,
   ].filter((section) => section.length > 0)
+
+  if (feedback !== null) {
+    sections.push(
+      'A maintainer requested the following changes — revise the artifact to address them (design D6: the folder cannot rot relative to the conversation).',
+      envelope.wrap('revision-feedback', feedback),
+    )
+  }
 
   if (complaint !== null) {
     sections.push(

--- a/opencode-agent/src/phases/review.ts
+++ b/opencode-agent/src/phases/review.ts
@@ -3,8 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { PLAN_MARKER, renderArtifact, REPORT_MARKER, requireArtifact } from '../artifacts.js'
-import { missingPlanError } from '../errors.js'
+import { renderArtifact, REPORT_MARKER } from '../artifacts.js'
 import { branchNameFor } from '../git.js'
 import { fence } from '../markdown.js'
 import type { PhaseHandler, PhaseInput, PhaseOutcome } from '../phase-context.js'
@@ -32,8 +31,9 @@ import type { AgentState } from '../types.js'
 export const handleReview: PhaseHandler = async (input): Promise<PhaseOutcome> => {
   const { deps, state } = input
   // The plan, exactly as the implementation phase reads it: the loop reviews
-  // the work against what was approved, not against the issue's prose.
-  const plan = requireArtifact(input.thread, await deps.selfLogin(), PLAN_MARKER, () => missingPlanError(state.issueId))
+  // the work against what was approved, read from the folder's `tasks.md`
+  // (design D1) rather than a block on the issue.
+  const plan = await planFromFolder(input)
 
   // Not optional, and this is the difference from the review that used to run
   // inside phase 3: that one always had the tree it had just written, while this
@@ -64,20 +64,27 @@ export const handleReview: PhaseHandler = async (input): Promise<PhaseOutcome> =
   const verdict = reviewLine(review)
   const report = renderReport(review, applied, verdict)
   await refreshPullRequest(input, report)
-  // Both writes are the handler's, and neither breaks its contract: a handler
-  // returns a signal, a comment and blocks and never writes state or decides the
-  // next phase, and these do neither — they are decoration around a result that
-  // is already fixed by the time they run. The orchestrator is the wrong home
-  // for the second one in particular: it posts the run's *account* on the issue
-  // and knows nothing of review outcomes, so putting this there would mean
-  // widening `PhaseOutcome` to carry a verdict the cascade cannot read, for one
-  // phase out of six. What that costs is ordering: the note names a report the
-  // orchestrator has not posted yet, which is exactly why it points at the
-  // **issue** and not at a comment — an issue is there to be read the moment the
-  // pointer is written, and a comment id would not be.
+  // The note lives in the handler rather than the orchestrator because it carries
+  // a verdict the cascade cannot read, and it points at the **issue** rather than
+  // a comment id: the report the note names is posted by the orchestrator after
+  // this handler returns, so an issue (always readable) is the only stable link.
   await noteReview(deps, input.trigger, { issueNumber: state.issueId, verdict, applied })
 
   return { signal: 'REVIEW_DONE', comment: report, blocks: [reportBlock(report, state)] }
+}
+
+/**
+ * The approved plan, read from the folder's `tasks.md` (design D1).
+ *
+ * Same read the implementation phase makes: the loop reviews the work against
+ * what was approved, not against the issue's prose, and the approved plan lives
+ * on the branch now rather than in an `AGENT_PLAN` block on the issue.
+ */
+const planFromFolder = async (input: PhaseInput): Promise<string> => {
+  const { deps, state } = input
+  if (state.changeName === null) throw new Error('CODE_REVIEW reached without a changeName on the state')
+  const tasksPath = (await deps.openspec.instructions('tasks', state.changeName)).resolvedOutputPath
+  return deps.readFile(tasksPath)
 }
 
 /**

--- a/opencode-agent/src/phases/triage.ts
+++ b/opencode-agent/src/phases/triage.ts
@@ -5,7 +5,7 @@
 
 import { z } from 'zod'
 
-import { renderArtifact, SPEC_MARKER } from '../artifacts.js'
+import { findArtifact, renderArtifact, SPEC_MARKER } from '../artifacts.js'
 import { promptForJson } from '../ask-json.js'
 import { composeSystemPrompt } from '../obra-skills.js'
 import type { PhaseHandler, PhaseInput, PhaseOutcome } from '../phase-context.js'
@@ -24,6 +24,15 @@ const triageSchema = z.discriminatedUnion('status', [
  * Re-entered whenever a maintainer requests changes to a spec, in which case
  * their feedback is threaded into the prompt and the spec is rewritten rather
  * than regenerated from scratch.
+ *
+ * > Bridge note. The full OpenSpec capture model (design D9: a
+ * > `clarify | capture | answer` triage outcome, association-gated
+ * > auto-capture, and scaffolding a real `openspec/changes/<name>/` folder on
+ * > `agent/issue-<n>`) lands in the focused S3 pass. Until then this handler
+ * > keeps the existing spec-posting behaviour, but emits `CAPTURED` (the signal
+ * > the reworked spine renamed from `SPEC_POSTED`) and derives the revision
+ * > from the thread rather than the retired `specRevision` counter — so the
+ * > tree compiles against the new spine without keeping a dead state field.
  */
 export const handleTriage: PhaseHandler = async (input): Promise<PhaseOutcome> => {
   const { deps, issue, state } = input
@@ -59,15 +68,22 @@ export const handleTriage: PhaseHandler = async (input): Promise<PhaseOutcome> =
 
   // One local feeds both the visible heading and the hidden block, so the number
   // a maintainer reads and the number the next job reads back cannot drift
-  // apart. `SPEC_POSTED` bumps `specRevision` to exactly this value, and counts
-  // only specs — the shared counter it replaced had the first plan on a fresh
-  // issue call itself revision 2.
-  const revision = state.specRevision + 1
+  // apart. Under the OpenSpec rework the revision counter left the state block
+  // (the proposal's history is the folder's commits), so it is derived here from
+  // the thread's own latest spec block — the one place that number was always
+  // read from before.
+  const revision = await nextRevision(input)
   return {
-    signal: 'SPEC_POSTED',
+    signal: 'CAPTURED',
     comment: renderSpec(decision.spec, revision),
     blocks: [renderArtifact(SPEC_MARKER, decision.spec, revision)],
   }
+}
+
+/** The previous spec block's revision plus one, or 1 for the first spec on the thread. */
+const nextRevision = async (input: PhaseInput): Promise<number> => {
+  const latest = findArtifact(input.thread, await input.deps.selfLogin(), SPEC_MARKER)
+  return (latest?.revision ?? 0) + 1
 }
 
 /** The maintainer's `/changes` argument, when this run was triggered by one. */

--- a/opencode-agent/src/phases/triage.ts
+++ b/opencode-agent/src/phases/triage.ts
@@ -7,32 +7,52 @@ import { z } from 'zod'
 
 import { findArtifact, renderArtifact, SPEC_MARKER } from '../artifacts.js'
 import { promptForJson } from '../ask-json.js'
+import { MAINTAINER_ASSOCIATIONS } from '../guardrails.js'
 import { composeSystemPrompt } from '../obra-skills.js'
+import type { AgentPromptRequest } from '../opencode-adapter.js'
 import type { PhaseHandler, PhaseInput, PhaseOutcome } from '../phase-context.js'
 import { buildTriagePrompt, TRIAGE_INSTRUCTIONS } from '../prompts.js'
+import type { UntrustedEnvelope } from '../prompts.js'
+import type { TriggerEvent } from '../trigger-events.js'
 import { mintEnvelope } from './envelope.js'
+
+/**
+ * A kebab-case OpenSpec change name: lowercase alphanumeric segments joined by
+ * single hyphens. The CLI has its own view, but validating here means the
+ * `promptForJson` re-ask fires on a name the model misspelled ("Add Retry
+ * Helper") rather than a scaffold that fails inside the driver.
+ */
+const changeNameSchema = z
+  .string()
+  .min(1)
+  .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/u, 'changeName must be kebab-case (lowercase letters, digits, hyphens)')
 
 const triageSchema = z.discriminatedUnion('status', [
   z.object({ status: z.literal('clarify'), questions: z.array(z.string().min(1)).min(1) }),
-  z.object({ status: z.literal('spec'), spec: z.string().min(1) }),
+  // Bridge (slice A): `capture` still carries `spec` text so PLANNING — not yet
+  // reworked onto the folder — can read the design spec from the SPEC block.
+  // Slice B drops `spec`, drafts the proposal into the folder, and retires the
+  // SPEC block entirely.
+  z.object({ status: z.literal('capture'), changeName: changeNameSchema, spec: z.string().min(1) }),
+  z.object({ status: z.literal('answer'), reply: z.string().min(1) }),
 ])
 
 /**
- * Phase 1. Reads the issue plus every maintainer reply so far and either asks
- * for clarification (staying in this phase) or posts a design spec for review.
+ * Phase 1. Reads the issue plus every maintainer reply so far and decides one
+ * of three things — ask for clarification, capture the issue as an OpenSpec
+ * change, or answer it as a question (design D9).
  *
- * Re-entered whenever a maintainer requests changes to a spec, in which case
- * their feedback is threaded into the prompt and the spec is rewritten rather
- * than regenerated from scratch.
+ * `capture` scaffolds a real `openspec/changes/<name>/` folder via the driver,
+ * sets `state.changeName`, and parks at `DESIGN_SPEC` — but only when the
+ * trigger's author association is a maintainer (OWNER/MEMBER/COLLABORATOR). An
+ * untrusted author gets a consent comment naming the change and parks here; the
+ * capture completes when a maintainer replies affirmatively, which
+ * `applyClarifyIntent` routes back into triage (the re-run sees the
+ * maintainer's trusted association and captures).
  *
- * > Bridge note. The full OpenSpec capture model (design D9: a
- * > `clarify | capture | answer` triage outcome, association-gated
- * > auto-capture, and scaffolding a real `openspec/changes/<name>/` folder on
- * > `agent/issue-<n>`) lands in the focused S3 pass. Until then this handler
- * > keeps the existing spec-posting behaviour, but emits `CAPTURED` (the signal
- * > the reworked spine renamed from `SPEC_POSTED`) and derives the revision
- * > from the thread rather than the retired `specRevision` counter — so the
- * > tree compiles against the new spine without keeping a dead state field.
+ * `answer` is the inline form of the answer path: the model has already read
+ * the issue, so it replies directly and the machine stays put (`ANSWERED` is
+ * phase-neutral). It is how triage says "this is a question, not work".
  */
 export const handleTriage: PhaseHandler = async (input): Promise<PhaseOutcome> => {
   const { deps, issue, state } = input
@@ -40,44 +60,98 @@ export const handleTriage: PhaseHandler = async (input): Promise<PhaseOutcome> =
   deps.log.info({ issue: state.issueId, revising: feedback !== null }, 'Triaging issue')
 
   const envelope = mintEnvelope()
-  const agent = await deps.agent()
   const decision = await promptForJson({
-    agent,
+    agent: await deps.agent(),
     schema: triageSchema,
     envelope,
     log: deps.log,
-    request: {
-      system: composeSystemPrompt({
-        phase: 'INIT_OR_CLARIFY',
-        skills: await deps.skills('INIT_OR_CLARIFY'),
-        repoRoot: deps.config.repoRoot,
-        nonce: envelope.nonce,
-        instructions: TRIAGE_INSTRUCTIONS,
-      }),
-      prompt: buildTriagePrompt(
-        { envelope, issueNumber: issue.number, title: issue.title, body: issue.body, thread: input.thread },
-        feedback,
-      ),
-      agent: 'plan',
-    },
+    request: await triageRequest(input, envelope, feedback, issue),
   })
 
   if (decision.status === 'clarify') {
     return { signal: 'NEEDS_CLARIFICATION', comment: renderQuestions(decision.questions) }
   }
+  if (decision.status === 'answer') {
+    return { signal: 'ANSWERED', comment: renderAnswer(decision.reply) }
+  }
+  return captureOutcome(input, decision)
+}
 
+/**
+ * Builds the prompt request for the triage turn. Extracted so the handler reads
+ * as decide-then-act: one prompt, three outcomes, each its own return.
+ */
+const triageRequest = async (
+  input: PhaseInput,
+  envelope: UntrustedEnvelope,
+  feedback: string | null,
+  issue: { number: number; title: string; body: string },
+): Promise<AgentPromptRequest> => {
+  const { deps, thread } = input
+  return {
+    system: composeSystemPrompt({
+      phase: 'INIT_OR_CLARIFY',
+      skills: await deps.skills('INIT_OR_CLARIFY'),
+      repoRoot: deps.config.repoRoot,
+      nonce: envelope.nonce,
+      instructions: TRIAGE_INSTRUCTIONS,
+    }),
+    prompt: buildTriagePrompt(
+      { envelope, issueNumber: issue.number, title: issue.title, body: issue.body, thread },
+      feedback,
+    ),
+    agent: 'plan',
+  }
+}
+
+/**
+ * The `capture` branch and its D9 gate: auto-capture only for authors the
+ * guardrails already trust with maintainer rights, and a consent comment for
+ * everybody else. The association is the *current trigger's* — so an untrusted
+ * issue author parks behind consent, and the maintainer whose affirmative reply
+ * re-runs triage passes the gate on the re-run and captures.
+ */
+const captureOutcome = async (
+  input: PhaseInput,
+  decision: { changeName: string; spec: string },
+): Promise<PhaseOutcome> => {
+  const { deps, state, trigger } = input
+  const association = authorAssociation(trigger)
+  if (!MAINTAINER_ASSOCIATIONS.has(association)) {
+    deps.log.info({ issue: state.issueId, association, changeName: decision.changeName }, 'Capture awaiting consent')
+    return { signal: 'NEEDS_CLARIFICATION', comment: renderConsent(decision.changeName) }
+  }
+
+  await deps.openspec.newChange(decision.changeName, OPENSPEC_SCHEMA)
   // One local feeds both the visible heading and the hidden block, so the number
   // a maintainer reads and the number the next job reads back cannot drift
   // apart. Under the OpenSpec rework the revision counter left the state block
   // (the proposal's history is the folder's commits), so it is derived here from
-  // the thread's own latest spec block — the one place that number was always
-  // read from before.
+  // the thread's own latest spec block — the bridge shape, retired in slice B.
   const revision = await nextRevision(input)
   return {
     signal: 'CAPTURED',
-    comment: renderSpec(decision.spec, revision),
+    comment: renderCapture(decision.changeName, decision.spec, revision),
     blocks: [renderArtifact(SPEC_MARKER, decision.spec, revision)],
+    patch: { changeName: decision.changeName },
   }
+}
+
+/** The OpenSpec schema every agent change is scaffolded under. */
+const OPENSPEC_SCHEMA = 'spec-driven'
+
+/**
+ * The author association the D9 gate reads, regardless of which trigger kind
+ * reached triage.
+ *
+ * Both human kinds carry it (an issue event and a resolved pull-request comment
+ * event). A CI event does not, but a CI event never reaches `INIT_OR_CLARIFY` —
+ * `CI_FAILED` moves straight to `CI_FIX` — so the `NONE` fallback names a
+ * shape that cannot capture and never misleads.
+ */
+const authorAssociation = (trigger: TriggerEvent): string => {
+  if (trigger.kind === 'issue' || trigger.kind === 'pull-request') return trigger.authorAssociation
+  return 'NONE'
 }
 
 /** The previous spec block's revision plus one, or 1 for the first spec on the thread. */
@@ -97,16 +171,36 @@ const renderQuestions = (questions: readonly string[]): string =>
   [
     '### Clarification needed',
     '',
-    'I need a bit more before I can write a design spec:',
+    'I need a bit more before I can capture this as a change:',
     '',
     ...questions.map((question, index) => `${index + 1}. ${question}`),
     '',
     'Reply in this thread with the answers and I will pick it up from there.',
   ].join('\n')
 
-const renderSpec = (spec: string, revision: number): string =>
+const renderAnswer = (reply: string): string =>
+  [
+    '### Answer',
+    '',
+    reply.trim(),
+    '',
+    '_This looks like a question rather than work — reply with the details if you want me to capture it as a change._',
+  ].join('\n')
+
+const renderConsent = (changeName: string): string =>
+  [
+    '### Ready to capture',
+    '',
+    `I would scaffold this as \`openspec/changes/${changeName}/\` and plan the work — but I want a maintainer to confirm first.`,
+    '',
+    'Reply to confirm (or describe what should change), and I will pick it up from there.',
+  ].join('\n')
+
+const renderCapture = (changeName: string, spec: string, revision: number): string =>
   [
     `### Design spec (revision ${revision})`,
+    '',
+    `Captured into \`openspec/changes/${changeName}/\`.`,
     '',
     spec.trim(),
     '',

--- a/opencode-agent/src/phases/triage.ts
+++ b/opencode-agent/src/phases/triage.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 
 import { findArtifact, renderArtifact, SPEC_MARKER } from '../artifacts.js'
 import { promptForJson } from '../ask-json.js'
+import { branchNameFor } from '../git.js'
 import { MAINTAINER_ASSOCIATIONS } from '../guardrails.js'
 import { composeSystemPrompt } from '../obra-skills.js'
 import type { AgentPromptRequest } from '../opencode-adapter.js'
@@ -123,6 +124,7 @@ const captureOutcome = async (
   }
 
   await deps.openspec.newChange(decision.changeName, OPENSPEC_SCHEMA)
+  await scaffoldOnBranch(input, decision.changeName)
   // One local feeds both the visible heading and the hidden block, so the number
   // a maintainer reads and the number the next job reads back cannot drift
   // apart. Under the OpenSpec rework the revision counter left the state block
@@ -135,6 +137,23 @@ const captureOutcome = async (
     blocks: [renderArtifact(SPEC_MARKER, decision.spec, revision)],
     patch: { changeName: decision.changeName },
   }
+}
+
+/**
+ * Design D2 — the scaffold is durable the moment capture converges.
+ *
+ * Creates `agent/issue-<n>` off the configured base, commits the scaffolded
+ * folder as commit #1, and pushes, so planning artefacts survive the Actions
+ * runner without travelling in hidden blocks. `openspec new change` has already
+ * written the folder into the working tree; the untracked files carry across
+ * the branch switch and land in this commit.
+ */
+const scaffoldOnBranch = async (input: PhaseInput, changeName: string): Promise<void> => {
+  const { deps, state } = input
+  const branch = branchNameFor(state.issueId)
+  await deps.git.ensureBranch(branch, await deps.baseBranch())
+  await deps.git.commitAll(`chore(openspec): scaffold ${changeName}`)
+  await deps.git.push(branch)
 }
 
 /** The OpenSpec schema every agent change is scaffolded under. */

--- a/opencode-agent/src/phases/triage.ts
+++ b/opencode-agent/src/phases/triage.ts
@@ -143,18 +143,21 @@ const captureOutcome = async (
 }
 
 /**
- * Design D2 — the scaffold is durable the moment capture converges.
+ * Design D2 — the scaffold is durable the moment capture converges, and D12 —
+ * a restart starts from zero.
  *
- * Creates `agent/issue-<n>` off the configured base, commits the scaffolded
- * folder as commit #1, and pushes, so planning artefacts survive the Actions
- * runner without travelling in hidden blocks. `openspec new change` has already
- * written the folder into the working tree; the untracked files carry across
- * the branch switch and land in this commit.
+ * Creates `agent/issue-<n>` off the configured base, force-resetting any prior
+ * branch to base first (a restarted issue's branch may carry partial legacy
+ * work that must not be adopted), commits the scaffolded folder as commit #1,
+ * and pushes, so planning artefacts survive the Actions runner without
+ * travelling in hidden blocks. `openspec new change` has already written the
+ * folder into the working tree; the untracked files carry across the branch
+ * switch and land in this commit.
  */
 const scaffoldOnBranch = async (input: PhaseInput, changeName: string): Promise<void> => {
   const { deps, state } = input
   const branch = branchNameFor(state.issueId)
-  await deps.git.ensureBranch(branch, await deps.baseBranch())
+  await deps.git.resetBranchToBase(branch, await deps.baseBranch())
   await deps.git.commitAll(`chore(openspec): scaffold ${changeName}`)
   await deps.git.push(branch)
 }

--- a/opencode-agent/src/phases/triage.ts
+++ b/opencode-agent/src/phases/triage.ts
@@ -5,6 +5,7 @@
 
 import { z } from 'zod'
 
+import { renderDigest } from '../artifacts.js'
 import { promptForJson } from '../ask-json.js'
 import { branchNameFor } from '../git.js'
 import { MAINTAINER_ASSOCIATIONS } from '../guardrails.js'
@@ -130,9 +131,13 @@ const captureOutcome = async (
   const proposalPath = (await deps.openspec.instructions('proposal', decision.changeName)).resolvedOutputPath
   await deps.writeFile(proposalPath, `${decision.spec.trim()}\n`)
   await scaffoldOnBranch(input, decision.changeName)
+  // The park digest is a render of the folder, not a memory of the model reply:
+  // the proposal is read straight back from where it landed (design D1). The
+  // branch carries the real history; the comment is a snapshot of it.
+  const proposal = await deps.readFile(proposalPath)
   return {
     signal: 'CAPTURED',
-    comment: renderCapture(decision.changeName, decision.spec),
+    comment: renderCapture(decision.changeName, proposal, branchNameFor(state.issueId)),
     patch: { changeName: decision.changeName },
   }
 }
@@ -207,13 +212,13 @@ const renderConsent = (changeName: string): string =>
     'Reply to confirm (or describe what should change), and I will pick it up from there.',
   ].join('\n')
 
-const renderCapture = (changeName: string, spec: string): string =>
+const renderCapture = (changeName: string, proposal: string, branch: string): string =>
   [
     `### Captured: ${changeName}`,
     '',
     `Captured into \`openspec/changes/${changeName}/\`. The proposal drafted from the issue:`,
     '',
-    spec.trim(),
+    renderDigest(proposal, { changeName, branch, revision: null }),
     '',
     '**What now?** `/approve` to plan the work, `/changes <what to change>` to revise the proposal,',
     '`/ask <question>` to ask about it, or `/cancel` to stop. A plain reply works too — I will',

--- a/opencode-agent/src/phases/triage.ts
+++ b/opencode-agent/src/phases/triage.ts
@@ -5,7 +5,6 @@
 
 import { z } from 'zod'
 
-import { findArtifact, renderArtifact, SPEC_MARKER } from '../artifacts.js'
 import { promptForJson } from '../ask-json.js'
 import { branchNameFor } from '../git.js'
 import { MAINTAINER_ASSOCIATIONS } from '../guardrails.js'
@@ -111,6 +110,10 @@ const triageRequest = async (
  * everybody else. The association is the *current trigger's* — so an untrusted
  * issue author parks behind consent, and the maintainer whose affirmative reply
  * re-runs triage passes the gate on the re-run and captures.
+ *
+ * On auto-capture the design spec the model produced is written to the folder's
+ * `proposal.md` — the folder is truth (D1), so no `AGENT_SPEC` block rides on
+ * the issue. The scaffold commit (D2) carries it.
  */
 const captureOutcome = async (
   input: PhaseInput,
@@ -124,17 +127,12 @@ const captureOutcome = async (
   }
 
   await deps.openspec.newChange(decision.changeName, OPENSPEC_SCHEMA)
+  const proposalPath = (await deps.openspec.instructions('proposal', decision.changeName)).resolvedOutputPath
+  await deps.writeFile(proposalPath, `${decision.spec.trim()}\n`)
   await scaffoldOnBranch(input, decision.changeName)
-  // One local feeds both the visible heading and the hidden block, so the number
-  // a maintainer reads and the number the next job reads back cannot drift
-  // apart. Under the OpenSpec rework the revision counter left the state block
-  // (the proposal's history is the folder's commits), so it is derived here from
-  // the thread's own latest spec block — the bridge shape, retired in slice B.
-  const revision = await nextRevision(input)
   return {
     signal: 'CAPTURED',
-    comment: renderCapture(decision.changeName, decision.spec, revision),
-    blocks: [renderArtifact(SPEC_MARKER, decision.spec, revision)],
+    comment: renderCapture(decision.changeName, decision.spec),
     patch: { changeName: decision.changeName },
   }
 }
@@ -173,12 +171,6 @@ const authorAssociation = (trigger: TriggerEvent): string => {
   return 'NONE'
 }
 
-/** The previous spec block's revision plus one, or 1 for the first spec on the thread. */
-const nextRevision = async (input: PhaseInput): Promise<number> => {
-  const latest = findArtifact(input.thread, await input.deps.selfLogin(), SPEC_MARKER)
-  return (latest?.revision ?? 0) + 1
-}
-
 /** The maintainer's `/changes` argument, when this run was triggered by one. */
 const changeRequest = (input: PhaseInput): string | null => {
   const { command } = input
@@ -215,15 +207,15 @@ const renderConsent = (changeName: string): string =>
     'Reply to confirm (or describe what should change), and I will pick it up from there.',
   ].join('\n')
 
-const renderCapture = (changeName: string, spec: string, revision: number): string =>
+const renderCapture = (changeName: string, spec: string): string =>
   [
-    `### Design spec (revision ${revision})`,
+    `### Captured: ${changeName}`,
     '',
-    `Captured into \`openspec/changes/${changeName}/\`.`,
+    `Captured into \`openspec/changes/${changeName}/\`. The proposal drafted from the issue:`,
     '',
     spec.trim(),
     '',
-    '**What now?** `/approve` to plan the work, `/changes <what to change>` to revise this spec,',
+    '**What now?** `/approve` to plan the work, `/changes <what to change>` to revise the proposal,',
     '`/ask <question>` to ask about it, or `/cancel` to stop. A plain reply works too — I will',
     'read it as a question unless it clearly asks for changes.',
   ].join('\n')

--- a/opencode-agent/src/plan-steps.ts
+++ b/opencode-agent/src/plan-steps.ts
@@ -125,6 +125,49 @@ export const describeStep = (step: PlanStep): string =>
 const SUBJECT_LIMIT = 72
 
 /**
+ * One `tasks.md` checkbox, as `REVIEW_AND_MUTATE` walks it (design D5).
+ *
+ * `line` is the 1-based line number in the file, so the box-check edit (`- [ ]`
+ * → `- [x]`) targets the exact line. `checked` is the state the parser read —
+ * the walk checks each box in the same commit as the step's work.
+ */
+export interface TaskCheckbox {
+  line: number
+  text: string
+  checked: boolean
+}
+
+const CHECKBOX = /^(\s*)- \[([ x])\] (.*)$/u
+
+/**
+ * Parses a `tasks.md` body into its ordered checkbox list.
+ *
+ * The walk reads the unchecked boxes from `state.stepsDone`; everything else
+ * (prose, headings, `---` rules) is ignored. Indented sub-item checkboxes are
+ * included — they are real steps a maintainer can break work into — and keep
+ * their indentation in the edit because {@link checkBoxText} rewrites only the
+ * `[ ]` marker.
+ */
+export const parseTaskCheckboxes = (markdown: string): TaskCheckbox[] => {
+  const boxes: TaskCheckbox[] = []
+  const lines = markdown.split('\n')
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = CHECKBOX.exec(lines[index] ?? '')
+    if (match === null) continue
+    const checked = match[2] === 'x'
+    boxes.push({ line: index + 1, text: match[3]?.trim() ?? '', checked })
+  }
+  return boxes
+}
+
+/**
+ * The box-check edit for a line: `[ ]` → `[x] on its way into the step's commit.
+ * Rewrites only the marker, so an indented sub-item keeps its indentation and
+ * the text after the marker is untouched.
+ */
+export const checkBoxText = (line: string): string => line.replace(/^(\s*- \[) \]/u, '$1x]')
+
+/**
  * A step's title, safe to put in a commit subject.
  *
  * One line and clamped. Not a safety boundary — commits are spawned as an argv

--- a/opencode-agent/src/plan-steps.ts
+++ b/opencode-agent/src/plan-steps.ts
@@ -6,24 +6,17 @@
 import { z } from 'zod'
 
 /**
- * What a plan is, as **data** rather than as prose.
+ * What a plan is, under design D5: `tasks.md` checkboxes.
  *
- * The planning phase has always asked the model for JSON — `promptForJson`, one
- * re-ask on a validation complaint — and then thrown the structure away, keeping
- * only the markdown it rendered from it. That was fine while the implementation was
- * one turn for the whole plan; it is not fine now that the unit of work is a step,
- * because the alternative to carrying the steps is recovering them from the
- * markdown. Scraping prose to recover an artefact is the oldest rule in this
- * workspace and it exists because heading-and-trailer scraping silently truncated
- * specs at their first `---` rule.
+ * The plan no longer travels as a JSON steps object rendered into a comment and
+ * a hidden block — the folder is truth (D1), and `tasks.md` is the plan's only
+ * shape. `REVIEW_AND_MUTATE` walks its checkboxes one turn at a time and ticks
+ * each box in the same commit as the step's work; this module owns the parser
+ * that turns the file into the ordered box list the walk reads, plus the
+ * `PlanStep`/`describeStep` the implement prompt still borrows to phrase a turn.
  *
- * So the steps travel in the plan block beside the text (`artifacts.ts`), and the
- * text a maintainer reads is **rendered from them** ({@link renderPlanMarkdown}).
- * One value feeds the comment and the block, so the plan somebody approved and the
- * steps the implementation walks cannot disagree.
- *
- * A leaf on purpose: this module imports nothing but zod, so `artifacts.ts` can own
- * the block round trip without either file importing the other.
+ * A leaf on purpose: this module imports nothing but zod, so nothing here can
+ * pull the pipeline's graph in by accident.
  */
 
 export const planStepSchema = z.object({
@@ -40,12 +33,6 @@ export type PlanStep = z.infer<typeof planStepSchema>
  * A cap because every step is a model turn plus a commit plus a push: a plan of two
  * hundred "steps" is not a finer plan, it is a plan whose steps are single edits,
  * and walking it would spend a whole job's clock on the overhead between them.
- * Enforced on the **ask** rather than on the read, which is what makes it cheap:
- * `promptForJson` re-asks once with zod's own complaint attached ("expected array to
- * have <=25 items"), so the ordinary outcome is a coarser breakdown from the same
- * planning turn. A planner that will not coarsen twice fails the phase, where a
- * maintainer's `/changes` is the remedy — deliberately louder than truncating the
- * list, which would post a plan whose second half nobody would ever implement.
  *
  * Twenty-five because it is comfortably more than any plan this pipeline has
  * produced and comfortably fewer than a job can walk: at the observed few minutes a
@@ -53,23 +40,6 @@ export type PlanStep = z.infer<typeof planStepSchema>
  * a plan that wanted splitting into issues.
  */
 export const MAX_PLAN_STEPS = 25
-
-/**
- * The plan the planner is asked for.
- *
- * `min(1)` is a decision and not a formality: a planning turn that reports no steps
- * has not planned, and the phase must say so rather than fall through to a one-shot
- * implementation of a document with nothing in it. That is the opposite reading from
- * a plan *block* with no steps, which is a legacy record and runs as one turn — the
- * difference being that one is a model failing now and the other is a maintainer
- * having approved something before steps existed.
- */
-export const executionPlanSchema = z.object({
-  steps: z.array(planStepSchema).min(1).max(MAX_PLAN_STEPS),
-  summary: z.string().default(''),
-})
-
-export type ExecutionPlan = z.infer<typeof executionPlanSchema>
 
 /**
  * Where in a plan a run was, for the two readers that have to be told.
@@ -87,25 +57,6 @@ export interface StepMarker {
   number: number
   total: number
   title: string
-}
-
-const filesLine = (step: PlanStep): string =>
-  step.files.length === 0 ? '_(no files declared)_' : step.files.map((file) => `\`${file}\``).join(', ')
-
-const verificationLine = (step: PlanStep): string =>
-  step.verification.trim() === '' ? '_(not stated)_' : step.verification.trim()
-
-/** The plan as markdown: the comment a maintainer approves, rendered from the steps. */
-export const renderPlanMarkdown = (plan: ExecutionPlan): string => {
-  const steps = plan.steps.map(
-    (step, index) =>
-      `${index + 1}. **${step.title}**\n   - Files: ${filesLine(step)}\n   - Verified by: ${verificationLine(step)}`,
-  )
-
-  const sections: string[] = []
-  if (plan.summary.trim() !== '') sections.push(plan.summary.trim())
-  sections.push(steps.join('\n'))
-  return sections.join('\n\n')
 }
 
 /**

--- a/opencode-agent/src/plan-steps.ts
+++ b/opencode-agent/src/plan-steps.ts
@@ -161,6 +161,35 @@ export const parseTaskCheckboxes = (markdown: string): TaskCheckbox[] => {
 }
 
 /**
+ * One unchecked `tasks.md` box, as `REVIEW_AND_MUTATE` walks it.
+ *
+ * `number`/`total` are the marker a maintainer reads ("step 3 of 5") — counted
+ * among the **unchecked** boxes only, since checked ones are finished work.
+ * `line` is the 1-based file line the box-check edit targets.
+ */
+export interface TaskStep {
+  number: number
+  total: number
+  text: string
+  line: number
+}
+
+/**
+ * The unchecked boxes the run will walk, numbered absolutely (1-based among the
+ * unchecked). The walk's own cursor (`state.stepsDone`) slices into this list,
+ * so a resume starts at the first box a previous stop did not reach.
+ */
+export const taskStepsFromCheckboxes = (boxes: readonly TaskCheckbox[]): TaskStep[] => {
+  const pending = boxes.filter((box) => !box.checked)
+  return pending.map((box, index) => ({
+    number: index + 1,
+    total: pending.length,
+    text: box.text,
+    line: box.line,
+  }))
+}
+
+/**
  * The box-check edit for a line: `[ ]` → `[x] on its way into the step's commit.
  * Rewrites only the marker, so an indented sub-item keeps its indentation and
  * the text after the marker is untouched.

--- a/opencode-agent/src/plan-steps.ts
+++ b/opencode-agent/src/plan-steps.ts
@@ -161,31 +161,42 @@ export const parseTaskCheckboxes = (markdown: string): TaskCheckbox[] => {
 }
 
 /**
- * One unchecked `tasks.md` box, as `REVIEW_AND_MUTATE` walks it.
+ * One `tasks.md` checkbox with its **absolute** position in the plan, as
+ * `REVIEW_AND_MUTATE` walks it (design D5).
  *
- * `number`/`total` are the marker a maintainer reads ("step 3 of 5") — counted
- * among the **unchecked** boxes only, since checked ones are finished work.
- * `line` is the 1-based file line the box-check edit targets.
+ * `number`/`total` are the marker a maintainer reads ("step 3 of 5"), counted
+ * among **every** box in the file — checked or not — so the number a step
+ * carries is stable across a run that checks the boxes ahead of it. `line` is
+ * the 1-based file line the box-check edit targets; `checked` is the state the
+ * parser read, which the walk treats as "done" and skips without a turn.
  */
-export interface TaskStep {
+export interface PlanBox {
   number: number
   total: number
   text: string
   line: number
+  checked: boolean
 }
 
 /**
- * The unchecked boxes the run will walk, numbered absolutely (1-based among the
- * unchecked). The walk's own cursor (`state.stepsDone`) slices into this list,
- * so a resume starts at the first box a previous stop did not reach.
+ * Every checkbox in a `tasks.md`, in file order, with absolute numbering.
+ *
+ * The walk reads the file once and visits each box by absolute index: a checked
+ * box is done and is skipped (the box-check is the persistence), an unchecked
+ * one gets a turn. Numbering among all boxes — not just the unchecked ones — is
+ * what keeps "step 3 of 5" honest on a `/continue` that arrives after steps 1
+ * and 2 have had their boxes ticked; numbering among the unchecked alone would
+ * re-label the third as the first and hide which step the cursor is on.
  */
-export const taskStepsFromCheckboxes = (boxes: readonly TaskCheckbox[]): TaskStep[] => {
-  const pending = boxes.filter((box) => !box.checked)
-  return pending.map((box, index) => ({
+export const planBoxes = (markdown: string): PlanBox[] => {
+  const checkboxes = parseTaskCheckboxes(markdown)
+  const total = checkboxes.length
+  return checkboxes.map((box, index) => ({
     number: index + 1,
-    total: pending.length,
+    total,
     text: box.text,
     line: box.line,
+    checked: box.checked,
   }))
 }
 

--- a/opencode-agent/src/presentation.ts
+++ b/opencode-agent/src/presentation.ts
@@ -99,6 +99,7 @@ export const PRESENTATION_KEYS = [
   'PR_DELIVERY',
   'CODE_REVIEW',
   'CI_FIX',
+  'ARCHIVE',
   'COMPLETE:delivered',
   'COMPLETE:cancelled',
   'FAILED',
@@ -170,6 +171,12 @@ export const PRESENTATION: Record<PresentationKey, PhasePresentation> = {
     label: { suffix: 'ci-fixing', color: BLUE },
     whoseTurn: 'agent',
     headline: 'Repairing red checks',
+  },
+  ARCHIVE: {
+    glyph: '📦',
+    label: { suffix: 'archiving', color: BLUE },
+    whoseTurn: 'agent',
+    headline: 'Archiving the merged change',
   },
   'COMPLETE:delivered': {
     glyph: '✅',

--- a/opencode-agent/src/prompts.ts
+++ b/opencode-agent/src/prompts.ts
@@ -6,7 +6,6 @@
 import type { IssueComment } from './blocks.js'
 import { clipTail } from './check-loop.js'
 import type { CheckFailure } from './check-loop.js'
-import { MAX_PLAN_STEPS } from './plan-steps.js'
 import { CHECK_OUTPUT_BUDGET, renderThread, shareBudget } from './prompt-budget.js'
 import type { Phase } from './types.js'
 
@@ -105,41 +104,6 @@ export const buildTriagePrompt = (context: PromptContext, feedback: string | nul
     sections.push(
       'A maintainer reviewed your previous design spec and asked for these changes. Rewrite the spec to address them:',
       context.envelope.wrap('requested-changes', feedback),
-    )
-  }
-
-  return sections.join('\n\n')
-}
-
-export interface PlanPromptInput {
-  envelope: UntrustedEnvelope
-  issueNumber: number
-  spec: string
-  branch: string
-  feedback: string | null
-}
-
-export const buildPlanPrompt = (input: PlanPromptInput): string => {
-  const sections = [
-    `The design spec below was approved by a maintainer for issue #${input.issueNumber}.`,
-    input.envelope.wrap('approved-spec', input.spec),
-    `Work happens on branch \`${input.branch}\`.`,
-    'Produce a granular implementation plan as a single JSON object and nothing else:',
-    '{"steps":[{"title":"…","files":["…"],"verification":"…"}],"summary":"…"}',
-    'Each step must be independently verifiable and touch a named set of files.',
-    'Order steps so tests land before or alongside the implementation they cover.',
-    // Said up front rather than left to the schema's re-ask, which would cost a
-    // second planning turn to learn it. The *why* is the part that shapes the answer:
-    // a step is a model turn plus a commit plus a push, so a step per edit spends the
-    // job's clock on the boundaries between them rather than on the work.
-    `Use at most ${MAX_PLAN_STEPS} steps: each one is implemented by its own model turn and committed on its own, ` +
-      'so make every step a coherent unit of work rather than a single edit.',
-  ]
-
-  if (input.feedback !== null) {
-    sections.push(
-      'A maintainer reviewed your previous plan and asked for these changes. Rewrite the plan to address them:',
-      input.envelope.wrap('requested-changes', input.feedback),
     )
   }
 

--- a/opencode-agent/src/prompts.ts
+++ b/opencode-agent/src/prompts.ts
@@ -82,12 +82,14 @@ export interface PromptContext {
 }
 
 export const TRIAGE_INSTRUCTIONS = [
-  'Decide whether the request below is specified well enough to implement without further input.',
+  'Decide whether the request below is a question, needs more detail, or is ready to capture as a change.',
   'Explore the repository before deciding — do not assume a file layout.',
-  'Reply with a single JSON object and nothing else:',
-  '{"status":"clarify","questions":["…"]} when you need maintainer input, or',
-  '{"status":"spec","spec":"<markdown design spec>"} when the request is actionable.',
-  'A spec must state: the goal, the files to touch, the intended behaviour change, and how it will be verified.',
+  'Reply with a single JSON object and nothing else. There are three outcomes:',
+  '{"status":"clarify","questions":["…"]} when you need maintainer input before you can act.',
+  '{"status":"capture","changeName":"kebab-case-name","spec":"<markdown design spec>"} when the request is actionable.',
+  '{"status":"answer","reply":"<markdown answer>"} when the request is a question, not work — answer it directly.',
+  '`changeName` must be kebab-case (lowercase letters, digits, hyphens) and name the change, not the issue.',
+  'A `spec` must state: the goal, the files to touch, the intended behaviour change, and how it will be verified.',
   'Ask questions only when a wrong guess would produce the wrong feature; prefer stating an assumption in the spec.',
 ].join('\n')
 

--- a/opencode-agent/src/pull-request-note.ts
+++ b/opencode-agent/src/pull-request-note.ts
@@ -97,6 +97,10 @@ export const noteTarget = (trigger: TriggerEvent): number | null => {
       // is also non-null by construction on this kind, so there is no
       // unreachable branch here to keep honest.
       return trigger.prNumber
+    case 'pr-merged':
+      // The archive door reports on the issue, not the pull request that
+      // triggered it — the PR is closed, and the issue is where state lives.
+      return null
     default:
       return unreachable(trigger)
   }

--- a/opencode-agent/src/status-comment.ts
+++ b/opencode-agent/src/status-comment.ts
@@ -148,7 +148,7 @@ const stepIndex = (state: AgentState): number => {
   if (state.prUrl !== null) return RUN_STEPS.length
 
   if (state.planRevision > 0) return PLAN_STEP
-  return state.specRevision > 0 ? SPEC_STEP : 0
+  return state.changeName === null ? 0 : SPEC_STEP
 }
 
 /**
@@ -170,13 +170,13 @@ const stepMark = (index: number, current: number, view: StatusView): string => {
 /**
  * The revision this row's artefact is on.
  *
- * Read from `specRevision` and `planRevision`, never recounted: the two counters
- * were split apart precisely because one number could not honestly label two
- * artefacts, and a table that re-derived them would be the second place that
- * went wrong.
+ * Only the plan row carries a revision now: under the OpenSpec rework the
+ * proposal lives in the `openspec/changes/<name>/` folder whose history *is*
+ * its revision (a rendered digest says so), so the "Design spec" row reports no
+ * counter. `planRevision` remains the machine's plan-identity token, read here
+ * for the row it has always labelled.
  */
 const revisionNote = (index: number, state: AgentState): string => {
-  if (index === SPEC_STEP && state.specRevision > 0) return ` · revision ${state.specRevision}`
   if (index === PLAN_STEP && state.planRevision > 0) return ` · revision ${state.planRevision}`
   return ''
 }

--- a/opencode-agent/src/status-comment.ts
+++ b/opencode-agent/src/status-comment.ts
@@ -106,6 +106,9 @@ const STEP_OF: Record<Phase, number | null> = {
   // the branch is pushed and the pull request open before either can start.
   CODE_REVIEW: 4,
   CI_FIX: 4,
+  // The archive door (D7) runs after delivery, on the base branch — past the
+  // pipeline's milestones, like COMPLETE.
+  ARCHIVE: null,
   COMPLETE: null,
   FAILED: null,
   INCOMPLETE: null,

--- a/opencode-agent/src/transitions.ts
+++ b/opencode-agent/src/transitions.ts
@@ -99,7 +99,10 @@ const TRANSITIONS: Record<Phase, Partial<Record<TransitionSignal, Phase>>> = {
   DESIGN_SPEC: { CHANGES_REQUESTED: 'INIT_OR_CLARIFY', APPROVED: 'PLANNING' },
   PLANNING: { PLAN_POSTED: 'PLAN_REVIEW' },
   PLAN_REVIEW: { CHANGES_REQUESTED: 'PLANNING', APPROVED: 'REVIEW_AND_MUTATE' },
-  REVIEW_AND_MUTATE: { CHANGES_COMMITTED: 'PR_DELIVERY' },
+  // Design D6 — steering-drift: a scope-affecting comment during implementation
+  // routes back to PLANNING for an artifact-update turn before implementation
+  // continues, so the folder cannot rot relative to the conversation.
+  REVIEW_AND_MUTATE: { CHANGES_REQUESTED: 'PLANNING', CHANGES_COMMITTED: 'PR_DELIVERY' },
   PR_DELIVERY: { PR_OPENED: 'COMPLETE', CI_FAILED: 'CI_FIX' },
   CODE_REVIEW: { REVIEW_DONE: 'COMPLETE' },
   CI_FIX: { CI_FIXED: 'COMPLETE' },

--- a/opencode-agent/src/transitions.ts
+++ b/opencode-agent/src/transitions.ts
@@ -95,7 +95,7 @@ import type { AgentState, Phase, TransitionSignal } from './types.js'
  * is worse than waiting for the `/continue` that finishes it.
  */
 const TRANSITIONS: Record<Phase, Partial<Record<TransitionSignal, Phase>>> = {
-  INIT_OR_CLARIFY: { NEEDS_CLARIFICATION: 'INIT_OR_CLARIFY', SPEC_POSTED: 'DESIGN_SPEC' },
+  INIT_OR_CLARIFY: { NEEDS_CLARIFICATION: 'INIT_OR_CLARIFY', CAPTURED: 'DESIGN_SPEC' },
   DESIGN_SPEC: { CHANGES_REQUESTED: 'INIT_OR_CLARIFY', APPROVED: 'PLANNING' },
   PLANNING: { PLAN_POSTED: 'PLAN_REVIEW' },
   PLAN_REVIEW: { CHANGES_REQUESTED: 'PLANNING', APPROVED: 'REVIEW_AND_MUTATE' },
@@ -163,20 +163,16 @@ const failTransition = (state: AgentState, patch: Partial<AgentState>): Partial<
 })
 
 /**
- * The artefact counter this move bumps, if it rewrites an artefact at all.
+ * The plan-identity token this move bumps, if it rewrites the plan at all.
  *
- * Spec and plan are counted apart because the heading each handler renders reads
- * as "the Nth version of *this* artefact" and cannot be read as anything else.
- * One counter serving both had them interleave, so the first plan on
- * every issue announced itself as revision 2 — and revision 3 if the spec had
- * been revised once first.
- *
- * A branch per signal rather than a lookup table with a computed key: the two
- * artefacts are the whole list, and naming the fields keeps a mistyped one a
+ * Under the OpenSpec rework (design D1) only `PLAN_POSTED` bumps a counter, and
+ * that counter is the plan-identity token `state.planRevision` documents — not
+ * an artifact revision. The former `SPEC_POSTED` branch is gone: the proposal
+ * lives in the folder and nothing counts spec revisions. A branch per signal
+ * rather than a lookup table with a computed key keeps a mistyped field a
  * compile error rather than a counter that silently never moves.
  */
 const revisionBump = (state: AgentState, signal: TransitionSignal): Partial<AgentState> => {
-  if (signal === 'SPEC_POSTED') return { specRevision: state.specRevision + 1 }
   if (signal === 'PLAN_POSTED') return { planRevision: state.planRevision + 1 }
   return {}
 }

--- a/opencode-agent/src/transitions.ts
+++ b/opencode-agent/src/transitions.ts
@@ -99,14 +99,14 @@ const TRANSITIONS: Record<Phase, Partial<Record<TransitionSignal, Phase>>> = {
   DESIGN_SPEC: { CHANGES_REQUESTED: 'INIT_OR_CLARIFY', APPROVED: 'PLANNING' },
   PLANNING: { PLAN_POSTED: 'PLAN_REVIEW' },
   PLAN_REVIEW: { CHANGES_REQUESTED: 'PLANNING', APPROVED: 'REVIEW_AND_MUTATE' },
-  // Design D6 — steering-drift: a scope-affecting comment during implementation
-  // routes back to PLANNING for an artifact-update turn before implementation
-  // continues, so the folder cannot rot relative to the conversation.
+  // D6 — steering-drift: a scope-affecting comment mid-implementation routes to PLANNING.
   REVIEW_AND_MUTATE: { CHANGES_REQUESTED: 'PLANNING', CHANGES_COMMITTED: 'PR_DELIVERY' },
   PR_DELIVERY: { PR_OPENED: 'COMPLETE', CI_FAILED: 'CI_FIX' },
   CODE_REVIEW: { REVIEW_DONE: 'COMPLETE' },
   CI_FIX: { CI_FIXED: 'COMPLETE' },
-  COMPLETE: { CI_FAILED: 'CI_FIX', REVIEW_REQUESTED: 'CODE_REVIEW' },
+  // D7 — archive door: merged PR → ARCHIVE → COMPLETE. Never persisted as waiting.
+  ARCHIVE: { ARCHIVED: 'COMPLETE' },
+  COMPLETE: { CI_FAILED: 'CI_FIX', REVIEW_REQUESTED: 'CODE_REVIEW', PR_MERGED: 'ARCHIVE' },
   FAILED: {},
   INCOMPLETE: {},
 }
@@ -130,6 +130,7 @@ const TIME_STOPPABLE: ReadonlySet<Phase> = new Set<Phase>([
   'PR_DELIVERY',
   'CODE_REVIEW',
   'CI_FIX',
+  'ARCHIVE',
 ])
 
 /**

--- a/opencode-agent/src/trigger-events.ts
+++ b/opencode-agent/src/trigger-events.ts
@@ -76,7 +76,22 @@ export interface CiTriggerEvent {
   defaultBranch: string | null
 }
 
-export type TriggerEvent = IssueTriggerEvent | CiTriggerEvent | PullRequestTriggerEvent
+/**
+ * A merged PR on an agent branch — the archive door (D7). A system event (no
+ * sender): `pull_request.closed(merged)` runs `ARCHIVE`. Fully parsed from the
+ * payload, since `head.ref` rides on a `pull_request` webhook.
+ */
+export interface PrMergedTriggerEvent {
+  kind: 'pr-merged'
+  eventName: string
+  prNumber: number
+  issueNumber: number
+  baseBranch: string
+  fromThisRepository: boolean
+  defaultBranch: string | null
+}
+
+export type TriggerEvent = IssueTriggerEvent | CiTriggerEvent | PullRequestTriggerEvent | PrMergedTriggerEvent
 
 /** What {@link parseTriggerEvent} yields: an event, or one still short an issue. */
 export type ParsedTrigger = TriggerEvent | PendingPullRequestEvent
@@ -235,19 +250,50 @@ const parsePullRequestEvent = (eventName: string, payload: unknown): PendingPull
 }
 
 /**
- * Normalizes a raw webhook payload. Returns `null` when the payload carries
- * nothing the pipeline acts on — an unrelated branch, a run with no branch, a
- * dispatch with no issue — which the caller treats as "nothing to do".
- *
- * A pull-request comment is tried first and yields a
- * {@link PendingPullRequestEvent}, the one shape this function cannot finish:
- * the issue it belongs to is only knowable from the API.
+ * Normalizes a raw webhook payload, or `null` when it carries nothing the
+ * pipeline acts on. A `pull_request` webhook (D7) finishes here; an
+ * `issue_comment` yields a `PendingPullRequestEvent` (its issue needs the API).
  */
 export const parseTriggerEvent = (eventName: string, payload: unknown): ParsedTrigger | null => {
   if (eventName === 'workflow_run' || eventName === 'check_suite') return parseCiEvent(eventName, payload)
+  if (eventName === 'pull_request') return parsePrMergedEvent(eventName, payload)
   return parseIssueOrPullRequest(eventName, payload)
 }
 
 const parseIssueOrPullRequest = (eventName: string, payload: unknown): ParsedTrigger | null =>
   (eventName === 'issue_comment' ? parsePullRequestEvent(eventName, payload) : null) ??
   parseIssueEvent(eventName, payload)
+
+const prMergedSchema = z.object({
+  action: z.literal('closed'),
+  pull_request: z.object({
+    merged: z.literal(true),
+    number: z.number().int().positive(),
+    head: z.object({
+      ref: z.string().min(1),
+      repo: z.object({ full_name: z.string().default('') }).optional(),
+    }),
+    base: z.object({ ref: z.string().min(1) }),
+  }),
+  repository: z.object({ full_name: z.string().default(''), default_branch: z.string().min(1).optional() }).optional(),
+})
+
+/** `pull_request.closed(merged)` on an agent branch — the archive door (D7). */
+const parsePrMergedEvent = (eventName: string, payload: unknown): PrMergedTriggerEvent | null => {
+  const parsed = prMergedSchema.safeParse(payload)
+  if (!parsed.success) return null
+  const { pull_request: pr, repository } = parsed.data
+  const issueNumber = issueNumberFromBranch(pr.head.ref)
+  if (issueNumber === null) return null
+  const headFullName = pr.head.repo?.full_name ?? ''
+  const repoFullName = repository?.full_name ?? ''
+  return {
+    kind: 'pr-merged',
+    eventName,
+    prNumber: pr.number,
+    issueNumber,
+    baseBranch: pr.base.ref,
+    fromThisRepository: headFullName.length > 0 && headFullName === repoFullName,
+    defaultBranch: repository?.default_branch ?? null,
+  }
+}

--- a/opencode-agent/src/triggers.ts
+++ b/opencode-agent/src/triggers.ts
@@ -52,6 +52,12 @@ export const applyTrigger = (input: PhaseInput): Promise<TriggerOutcome> => {
   const { state, trigger, command } = input
 
   if (trigger.kind === 'ci') return applyCiTrigger(input)
+  // Design D7 — the archive door: a merged PR on `agent/issue-<n>` moves
+  // COMPLETE → ARCHIVE. Routed before the issue-conversation branches because
+  // it is a fourth event kind, not a command — `moveOrSkip` turns the refusal
+  // (anything other than COMPLETE) into the same quiet skip the CI path uses for
+  // a red run that arrives in a phase with no branch to fix.
+  if (trigger.kind === 'pr-merged') return Promise.resolve(applyArchiveTrigger(input))
   // Before the command branch below, not folded into it: a pull request is a
   // narrower door onto the same commands, and the narrowing is what §6.2 of the
   // plan settles. Everything after this line is the issue conversation.
@@ -68,6 +74,21 @@ export const applyTrigger = (input: PhaseInput): Promise<TriggerOutcome> => {
   if (!WAITING_PHASES.has(state.phase)) return readAndSkip(input, `No actionable command while in ${state.phase}`)
 
   return applyIntent(input)
+}
+
+/**
+ * The archive door (D7): a merged PR moves `COMPLETE` → `ARCHIVE`.
+ *
+ * `moveOrSkip` turns anything other than COMPLETE into a quiet skip with a
+ * reason: a merged-PR event that arrives mid-pipeline, before delivery, has no
+ * archive to run (the folder is still being drafted against), and a second
+ * merge on an already-archived issue finds no `ARCHIVE` row from `COMPLETE` and
+ * is skipped the same way. No comment is posted on a skip, mirroring the CI
+ * path: the event is machine noise the issue does not need to hear about.
+ */
+export const applyArchiveTrigger = (input: PhaseInput): TriggerOutcome => {
+  const { state, deps } = input
+  return moveOrSkip(state, 'PR_MERGED', deps, 'a merged pull request')
 }
 
 /** The one command a pull request accepts. See {@link applyPullRequestCommand}. */

--- a/opencode-agent/src/triggers.ts
+++ b/opencode-agent/src/triggers.ts
@@ -7,7 +7,7 @@ import { renderExhausted, renderReviewsExhausted } from './budget-notices.js'
 import { applyCiTrigger } from './ci-trigger.js'
 import { acceptedCommands, commandApplies, COMMAND_SIGNALS } from './commands.js'
 import type { ParsedCommand, SlashCommand } from './commands.js'
-import { applyClarifyIntent, applyIntent, readAndSkip } from './comment-intent.js'
+import { applyClarifyIntent, applyIntent, applySteeringIntent, readAndSkip } from './comment-intent.js'
 import { react } from './feedback.js'
 import type { PhaseInput } from './phase-context.js'
 import { postAndAppend, renderRefusedCommand } from './run-report.js'
@@ -58,6 +58,13 @@ export const applyTrigger = (input: PhaseInput): Promise<TriggerOutcome> => {
   if (trigger.kind === 'pull-request') return applyPullRequestCommand(input, command)
   if (command !== null) return applyCommand(input, command)
   if (state.phase === 'INIT_OR_CLARIFY') return applyClarifyIntent(input)
+  // Design D6 — a plain comment mid-implementation is read as steering: a
+  // scope-affecting change routes back to PLANNING for an artifact-update turn
+  // before implementation continues. Before the generic skip below, not folded
+  // into it, because implementation is the one phase where prose can change
+  // scope — everywhere else a non-waiting, non-clarify phase has nothing for a
+  // plain comment to act on.
+  if (state.phase === 'REVIEW_AND_MUTATE') return applySteeringIntent(input)
   if (!WAITING_PHASES.has(state.phase)) return readAndSkip(input, `No actionable command while in ${state.phase}`)
 
   return applyIntent(input)

--- a/opencode-agent/src/triggers.ts
+++ b/opencode-agent/src/triggers.ts
@@ -9,12 +9,13 @@ import { acceptedCommands, commandApplies, COMMAND_SIGNALS } from './commands.js
 import type { ParsedCommand, SlashCommand } from './commands.js'
 import { applyClarifyIntent, applyIntent, applySteeringIntent, readAndSkip } from './comment-intent.js'
 import { react } from './feedback.js'
+import { branchNameFor } from './git.js'
 import type { PhaseInput } from './phase-context.js'
 import { postAndAppend, renderRefusedCommand } from './run-report.js'
 import { canTransition } from './transitions.js'
 import { moveOrSkip, skip } from './trigger-outcome.js'
 import type { TriggerOutcome } from './trigger-outcome.js'
-import { WAITING_PHASES } from './types.js'
+import { errorMessage, WAITING_PHASES } from './types.js'
 
 /**
  * Turning a trigger — a slash command, a plain comment, a red CI run — into the
@@ -126,7 +127,7 @@ const applyPullRequestCommand = (input: PhaseInput, command: ParsedCommand | nul
   return applyCommand(input, command)
 }
 
-const applyCommand = (input: PhaseInput, command: ParsedCommand): Promise<TriggerOutcome> => {
+const applyCommand = async (input: PhaseInput, command: ParsedCommand): Promise<TriggerOutcome> => {
   const { state, deps } = input
   // Always available: answering asks nothing of the state machine, so there is
   // no phase in which it can be the wrong thing to do. The machine now agrees —
@@ -169,9 +170,26 @@ const applyCommand = (input: PhaseInput, command: ParsedCommand): Promise<Trigge
   }
 
   const outcome = moveOrSkip(state, signal, deps, command.command)
-  if (outcome.halt === null) return Promise.resolve(outcome)
+  if (outcome.halt !== null) return refuseCommand(input, command.command, outcome.halt.reason)
+  // D9 — `/cancel` gains branch + change-folder cleanup (the mis-capture's work).
+  await afterCommandCleanup(input, command)
+  return outcome
+}
 
-  return refuseCommand(input, command.command, outcome.halt.reason)
+/**
+ * Side effects a successful command carries beyond the state move. Today only
+ * `/cancel` (D9): delete the `agent/issue-<n>` branch a mis-capture pushed, so
+ * the work is gone rather than orphaned. Only when capture happened.
+ */
+const afterCommandCleanup = async (input: PhaseInput, command: ParsedCommand): Promise<void> => {
+  if (command.command !== '/cancel' || input.state.changeName === null) return
+  const { deps, state } = input
+  try {
+    await deps.git.deleteRemoteBranch(branchNameFor(state.issueId))
+    deps.log.info({ issue: state.issueId }, 'Deleted the agent branch for /cancel')
+  } catch (error) {
+    deps.log.warn({ issue: state.issueId, error: errorMessage(error) }, 'Could not delete the agent branch for /cancel')
+  }
 }
 
 /**

--- a/opencode-agent/src/types.ts
+++ b/opencode-agent/src/types.ts
@@ -46,6 +46,11 @@ export const TRANSITION_SIGNALS = [
   'CI_FIXED',
   'REVIEW_REQUESTED',
   'REVIEW_DONE',
+  // Design D7 — the archive door. A merged pull request on `agent/issue-<n>`
+  // moves COMPLETE → ARCHIVE; the handler runs `openspec archive` as a
+  // follow-up commit on master and signals ARCHIVED back to COMPLETE.
+  'PR_MERGED',
+  'ARCHIVED',
   'CANCELLED',
   'FAILED',
   'RETRY',

--- a/opencode-agent/src/types.ts
+++ b/opencode-agent/src/types.ts
@@ -30,7 +30,12 @@ export { LEGACY_PHASE_NAMES, PHASES, WAITING_PHASES } from './phase-names.js'
  */
 export const TRANSITION_SIGNALS = [
   'NEEDS_CLARIFICATION',
-  'SPEC_POSTED',
+  // Was `SPEC_POSTED` when the design spec travelled in an `AGENT_SPEC` block.
+  // Renamed under the OpenSpec rework (design D1): triage no longer posts a
+  // spec block, it *captures* the issue as an `openspec/changes/<name>/` folder
+  // (scaffolded, branched and pushed as commit #1 — D2), then parks at
+  // `DESIGN_SPEC` for a human to review a rendered digest of that folder.
+  'CAPTURED',
   'CHANGES_REQUESTED',
   'ANSWERED',
   'APPROVED',
@@ -50,8 +55,20 @@ export const TRANSITION_SIGNALS = [
 
 export type TransitionSignal = (typeof TRANSITION_SIGNALS)[number]
 
-/** Bumped when the persisted shape changes in a way old blocks cannot satisfy. */
-export const STATE_VERSION = 2
+/**
+ * Bumped when the persisted shape changes in a way old blocks cannot satisfy.
+ *
+ * v3 is a **deliberate stranding** (design D12): the opencode-agent rework
+ * retires `AGENT_SPEC`/`AGENT_PLAN` artefact blocks outright and moves planning
+ * onto a real `openspec/changes/<name>/` folder, so an in-flight issue's legacy
+ * state describes a pipeline that no longer exists. Rather than carry a dual
+ * format, v2 blocks are rejected by the schema, the restore scan finds nothing
+ * valid, and the issue restarts at `INIT_OR_CLARIFY` under the compliant
+ * pipeline (with its `agent/issue-<n>` branch reset — D12). The migration
+ * precedent avoided bumps because stranding was the cost; here stranding is the
+ * chosen behaviour, and restart-with-reset is the recovery path.
+ */
+export const STATE_VERSION = 3
 
 /**
  * The durable state carried between ephemeral CI jobs. Serialized verbatim into
@@ -63,8 +80,14 @@ export const STATE_VERSION = 2
  * a multi-kilobyte spec each time would bloat the thread.
  */
 export const agentStateSchema = z.object({
-  /** Absent on v1 blocks written before versioning; those are treated as v1. */
-  v: z.number().int().min(1).default(1),
+  /**
+   * Must equal {@link STATE_VERSION} exactly. There is no default and no
+   * tolerance for an older `v`: a mismatched block is rejected so the restore
+   * scan walks past it (D12), which is the mechanism that strands legacy issues
+   * onto a fresh restart under the compliant pipeline rather than reading a
+   * state that describes a pipeline this code no longer runs.
+   */
+  v: z.literal(STATE_VERSION),
   phase: phaseName,
   issueId: z.number().int().positive(),
   // No `branch`: it is exactly `agent/issue-<issueId>`, every phase recomputes
@@ -163,27 +186,38 @@ export const agentStateSchema = z.object({
    */
   stepsDone: z.number().int().min(0).default(0),
   /**
-   * Revisions of the design spec and of the plan, counted apart.
+   * The OpenSpec change folder this issue was captured into — the kebab name
+   * triage reported and `openspec new change` scaffolded.
    *
-   * One shared counter used to serve both, bumped on `SPEC_POSTED` and on
-   * `PLAN_POSTED` alike while each handler rendered it into its own heading, so
-   * the two numbers interleaved. On an issue that ran straight through, the
-   * first spec a maintainer ever saw was "revision 1" and the first plan
-   * "revision 2"; revise the spec once beforehand and that same first plan was
-   * "revision 3". A revision number on a heading is read as "the Nth version of
-   * this artefact" — there is nothing else it could mean — so neither figure
-   * meant what it said.
+   * `null` until `INIT_OR_CLARIFY` converges on a capture (design D9), then the
+   * folder name for the rest of the issue's life. The branch is still derived
+   * from `issueId` (`agent/issue-<n>`), never persisted; this names the folder
+   * *inside* `openspec/changes/` on that branch, which is the one thing the
+   * issue number does not determine. Set on `CAPTURED` and read by every phase
+   * that writes or renders the folder's artifacts.
    *
-   * Both carry defaults, so a block written before the split still parses and
-   * needs no `STATE_VERSION` bump, which would strand every in-flight issue (see
-   * the README's migration note). The old `revision` key is dropped as an
-   * unknown one, exactly as `approved` and `updatedAt` were. The price is that
-   * an issue mid-conversation across the change restarts both counts at 1, and
-   * that is the deliberate choice: the number it was carrying is a sum of two
-   * artefacts' revisions and was never the count of either, so carrying it into
-   * one of the new fields would preserve nothing but the wrong answer.
+   * Needs no `STATE_VERSION` bump of its own — v3 is brand new under D12, and
+   * the field defaults so any v3 block written before it existed still parses.
    */
-  specRevision: z.number().int().min(0).default(0),
+  changeName: z.string().nullable().default(null),
+  /**
+   * The plan-identity token: which version of the folder's `tasks.md` the
+   * machine is on.
+   *
+   * Under the OpenSpec rework (design D1) the *content* of the plan no longer
+   * lives in an `AGENT_PLAN` block — it lives in `tasks.md` on the branch, which
+   * `REVIEW_AND_MUTATE` walks checkbox by checkbox (D5). What state still needs
+   * is a machine identity for "a new plan happened", so the wall-clock handoff
+   * (`findHandoff`) retires across a re-plan and the implementation report stamps
+   * which plan it executed. This counter is that token, bumped by `PLAN_POSTED`
+   * alone. It is a machine identity, not an artifact revision: the artifact's
+   * real history is the branch's commits, and rendered digests say so.
+   *
+   * The former companion `specRevision` is gone: the proposal lives in the
+   * folder and `DESIGN_SPEC` reviews a digest of it, so nothing counts spec
+   * revisions any more. Dropping it needed no `STATE_VERSION` bump — v3 is new,
+   * and the field defaulted anyway.
+   */
   planRevision: z.number().int().min(0).default(0),
   /**
    * Model tokens this issue has consumed, across every job it has run.

--- a/openspec/changes/opencode-agent-openspec-compliance/.openspec.yaml
+++ b/openspec/changes/opencode-agent-openspec-compliance/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-12
+skip_specs: true

--- a/openspec/changes/opencode-agent-openspec-compliance/design.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/design.md
@@ -1,0 +1,219 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Design: Make opencode-agent OpenSpec-compliant
+
+Motivation and scope: `proposal.md`. Precedent: archived changes
+`2026-08-10-migrate-brainstorming-to-openspec` (routing table D4, dogfood D2,
+shared root tree D7) and `2026-08-10-superpowers-residue-cleanup`.
+Compliance baseline: `sdd-runner/` + `docs/architecture/sdd-pipeline.md`.
+
+## Context
+
+- `opencode-agent` phases persist **artifacts** in hidden blocks on the issue
+  (`AGENT_SPEC`/`AGENT_PLAN`) because Actions runners are scratch and the
+  branch historically appears only at implementation time. `AGENT_STATE`
+  (the machine) also lives there.
+- `PHASE_SKILLS` and skill loader roots: `.superpowers/skills/` (pinned
+  `obra/superpowers` checkout), `.claude/skills/`,
+  `docs/superpowers/extensions/`. The openspec skills live in-repo at
+  `.opencode/skills/` and `.agents/skills/`.
+- `sdd-runner` established the compliance idiom this repo now standardizes
+  on: TypeScript drives the OpenSpec CLI protocol (`new change`,
+  `status --json`, `instructions --json`, `validate --strict` after every
+  write with retry ≤2), the model composes artifact content only, and the
+  diff guard confines model writes to `openspec/changes/`.
+- The openspec-propose skill's own *planning boundary* ("after artifacts,
+  stop; wait for a new user request") already matches the agent's park
+  semantics — the gate is built into the workflow, not bolted on.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Every issue that becomes work carries a real, `validate --strict`-passing
+  change folder on `agent/issue-<n>`; comments are renders of it.
+- The agent's skill routing satisfies the repo's D4 routing table.
+- Interactivity (clarify, `/ask`, mid-run steering, two human parks) is
+  preserved; the parks now gate folder content.
+
+**Non-Goals:**
+
+- Shared foundation with sdd-runner (patterns reused, code not shared).
+- Review-loop-on-artifacts automation; humans remain the quality gate.
+- Runtime/capability/scope-model impact: none (dev tooling).
+- DB changes: none. New external dependency: the `openspec` CLI in the CI
+  environment (installed in the workflow beside the `opencode` CLI; it is
+  dev tooling, not a papai dependency — same standing as the review-loop
+  subprocess dependency).
+
+## Decisions
+
+### D1 — The folder is truth; comments are renders
+
+proposal/specs/design/tasks live in `openspec/changes/<name>/` on
+`agent/issue-<n>`. `AGENT_SPEC`/`AGENT_PLAN` blocks are retired; revision
+counters become display metadata on rendered digests ("digest r3 ·
+folder@a1b2c3"). `AGENT_STATE` stays on the issue (the machine needs the
+thread; artifacts need the branch).
+Alternative: keep blocks as the artifact transport mirroring the folder —
+rejected: two truths, exactly the drift the archived migration eliminated.
+
+### D2 — Branch from first-spec
+
+The branch is created when `INIT_OR_CLARIFY` converges on a change, and the
+scaffolded folder is commit #1. Every artifact revision is a pushed commit —
+durability without blocks.
+Alternative: lazy branch at implementation (status quo) — rejected: planning
+artifacts would die with each Actions job, forcing blocks back in.
+
+### D3 — TS drives the CLI protocol; the model composes content
+
+A thin driver wraps `openspec status --json` / `instructions --json` /
+`validate --strict` (same division of labor as `sdd-runner`'s
+`openspec-driver.ts`, re-implemented, not imported). Phase handler loop:
+typed instruction → model composes per template → validate → retry ≤2 with
+the validation complaint attached (the existing `promptForJson` pattern
+generalized to artifacts).
+
+### D4 — Skill rewiring per the archived D4 routing table
+
+- `INIT_OR_CLARIFY`: required `openspec-explore` (stance only — clarify
+  material ambiguity, capture when crystallized); `brainstorming` dropped.
+- `PLANNING`: required `openspec-propose`; `writing-plans` and
+  `executing-plans` dropped.
+- `REVIEW_AND_MUTATE`: `test-driven-development` +
+  `verification-before-completion` unchanged (apply layer).
+- `CI_FIX`: `systematic-debugging` unchanged.
+- Loader roots gain `.opencode/skills/` (and `.agents/skills/` first-hit
+  precedence per the repo's own skill layout); the pinned
+  `obra/superpowers` checkout shrinks to execution skills.
+
+### D5 — tasks.md is the plan's only shape
+
+`implement-steps.ts` walks the change's `tasks.md` checkboxes; each step's
+commit checks its box in the same commit (`operations.apply`: checkbox state
+is filesystem state of record). Planner prompts inherit repo rules
+(`openspec/config.yaml` rules.tasks) via the CLI instructions protocol
+rather than prompt-hardening.
+
+### D6 — Steering that changes scope edits artifacts first
+
+Mid-run steering classified as scope-affecting triggers an artifact-update
+turn (edit → validate → commit) *before* implementation continues, so the
+folder cannot rot relative to the conversation — the interactive form of
+sdd-runner's drift check.
+
+### D7 — Merged PR is the archive door
+
+New workflow trigger `pull_request.closed(merged)` → `ARCHIVE` phase runs
+`openspec archive` as a small follow-up commit on master
+(`operations.archive`). Trigger plumbing follows the existing
+`ci-trigger.ts` door pattern (parse → guardrails → resolve issue via head
+branch).
+
+### D8 — Diff guard grants a named prefix for artifact writes
+
+Planner/spec model turns gain write capability scoped to
+`openspec/changes/<agent-change-name>/` only — same shape as sdd-runner's
+guard, deny-everything-else and the existing protected-paths staging
+(`.github/workflows/` etc.) unchanged.
+
+### D9 — Capture policy: auto-capture gated by author association (A+D)
+
+The triage turn ends with structured output via the existing `promptForJson`
+pattern: `clarify | capture | answer`, plus the kebab change name on
+`capture`. Auto-capture (scaffold + branch + proposal draft, no human touch)
+fires only for `OWNER` / `MEMBER` / `COLLABORATOR` issue authors — the
+association field the event payload already carries, in the spirit of the
+existing `PR_FOREIGN_REPOSITORY` guardrail. External/first-time authors get
+a "ready to capture `<name>` — confirm?" comment instead, and any
+affirmative reply (routed through the existing clarify-intent classifier,
+which re-runs triage on anything but `none`) completes the capture.
+Mis-captures are ejected at the `DESIGN_SPEC` park (revise in place) or by
+`/cancel`, which gains branch + change-folder cleanup. Rationale: the park
+is the honest place to absorb capture errors; consent-for-everyone taxes
+every crystal-clear issue with the maintainer touch the agent exists to
+eliminate; a mis-capture is `git push -d` plus a folder away from gone.
+Alternatives considered: explicit consent for all (friction on the fast
+path), zero-turn tiering (the tier boundary is itself model judgment).
+
+### D10 — Cross-repo posture: probe, fail closed
+
+The agent runs in repos other than papai. At job start, config-discovery's
+existing probe pattern gains an `openspec/` root probe (same testable ladder
+shape as the `review-loop/` probe). Present → this change's behavior.
+Absent → the agent posts one clear comment (the repo needs `openspec`
+scaffolding, e.g. `openspec init`) and stands down, `warn`-logged. It never
+scaffolds OpenSpec into a foreign repo, and — since `AGENT_SPEC`/
+`AGENT_PLAN` retire outright (D12) — there is no legacy block mode to fall
+back to; a block pipeline kept alive only for foreign repos is dead format
+for the same reasons as per-issue backcompat. Mirrors the migration
+precedent's scoping: overrides are repo-local; other projects adopt
+OpenSpec on their own terms.
+
+### D11 — Skill copy precedence
+
+Loader roots order: `.opencode/skills/`, then `.agents/skills/`, then the
+existing superpowers roots, first-hit wins (`loadSkills` already implements
+it). openspec-explore / openspec-propose resolve from `.opencode/skills/`;
+execution skills keep resolving from the pinned `.superpowers/` checkout.
+Duplicate copies across trees stay edited in lockstep per the migration's
+D9 rule.
+
+### D12 — In-flight issues restart; no dual format
+
+Deliberate `STATE_VERSION` bump: legacy state blocks are rejected by the
+schema, the restore scan finds no valid state, and the issue starts over at
+`INIT_OR_CLARIFY` under the compliant pipeline. When a restart finds a
+pre-existing `agent/issue-<n>` branch (partial legacy work), it is reset to
+the base branch before the scaffold commit — restart means *from zero*,
+not "adopt the old diff". The migration precedent deliberately avoided
+bumps *because* stranding was the cost; here stranding is the chosen
+behavior, and restart-with-reset is the defined recovery path.
+Alternative considered: per-issue format fork (`artifactMode` in state) —
+rejected: doubles every artifact read/write path for the lifetime of a
+handful of issues.
+
+### D13 — Dogfood
+
+This rework itself enters via `/opsx:propose` (this change). Post-merge
+there is no dedicated shakedown protocol: real issues (starting with the
+restarted in-flight ones) exercise the reworked pipeline immediately, and
+any tuning lands as follow-up changes in the ordinary way.
+
+## Risks / Trade-offs
+
+- **Mis-capture litters branches** — a false "ready to scaffold" now creates
+  a branch + folder, not just a comment → Mitigation: D9 (association-gated
+  auto-capture, park ejection, `/cancel` cleanup).
+- **Repo carries duplicate skill trees** (`.opencode/` vs `.agents/`) →
+  Mitigation: loader precedence fixed in D4; both copies stay in lockstep
+  per the migration's D9 rule.
+- **Non-papai target repos without an `openspec/` root** → the agent runs
+  in other repos; fail-closed per D10. Rolling OpenSpec out to those repos
+  is a separate, per-repo decision, not this change's job.
+- **openspec CLI availability in CI** → Mitigation: workflow installs it
+  beside the `opencode` CLI; version pinned like the superpowers checkout.
+- **In-flight legacy issues** → Mitigation: deliberate `STATE_VERSION` bump
+  (D12) — stranding is *intended* here; legacy blocks are rejected, the
+  restore scan finds nothing, and the issue restarts fresh under the
+  compliant pipeline.
+
+## Hook/TDD interactions
+
+New files under `opencode-agent/src/` are gated by the repo Write/Edit TDD
+hook pipeline; tests live in `tests/opencode-agent/` (no network). Work
+order is test-first: driver + skill-loader root tests, then phase-handler
+rewires, then the merged-PR trigger door. Live/integration suites
+(`live-sdk`, `server-survival`) are untouched.
+
+## Open Questions
+
+None — the three candidate questions are resolved as D9, D10, D11. If
+dogfooding (D13) shows mis-capture rates or consent friction higher than
+expected, D9's thresholds are the first knob to revisit.

--- a/openspec/changes/opencode-agent-openspec-compliance/proposal.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/proposal.md
@@ -1,0 +1,81 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Proposal: Make opencode-agent OpenSpec-compliant
+
+## Why
+
+The archived `migrate-brainstorming-to-openspec` change (D4 routing table)
+made OpenSpec the planning substrate for every entry point in this repo —
+**except** `opencode-agent`, whose `PHASE_SKILLS` still routes triage to
+`brainstorming` and planning to `writing-plans`, producing freeform
+`AGENT_SPEC`/`AGENT_PLAN` blocks that no `openspec validate` ever sees. Its
+branches ship code **without** a change folder, violating the
+`operations.apply` rule that artifacts ride with code. The agent is the last
+unmigrated entry point; `.worktrees` exploration and the now-built
+`sdd-runner` (real folder + CLI-driven + `validate --strict` after every
+write) prove the compliance idiom that the agent should adopt.
+
+## What Changes
+
+- `INIT_OR_CLARIFY` keeps its conversational clarify (the agent's
+  interactive identity) but inlines the **openspec-explore** stance instead
+  of `brainstorming`; when triage converges it scaffolds a real
+  `openspec/changes/<name>/` change on `agent/issue-<n>` and pushes it.
+- `PLANNING` inlines the **openspec-propose** skill instead of
+  `writing-plans`; the CLI protocol parts (`new change`, `status --json`,
+  `instructions --json`, `validate --strict` retry loop) are driven from
+  TypeScript, the model composes artifact content. `executing-plans` is
+  dropped everywhere (subsumed by `tasks.md`).
+- `DESIGN_SPEC` / `PLAN_REVIEW` stay human parks, but now review **rendered
+  digests of the real folder**; the folder on the branch is truth, comments
+  are renders.
+- `REVIEW_AND_MUTATE` walks `tasks.md` checkboxes as filesystem state of
+  record; each step's commit checks its box in the same commit. TDD and
+  `verification-before-completion` stay inlined (apply layer per D4).
+- **New** archive door: `pull_request.closed(merged)` trigger runs
+  `openspec archive` as a follow-up commit on master, closing the
+  propose → apply → archive loop.
+- Branch becomes the artifact durability mechanism: `AGENT_STATE` stays on
+  the issue; `AGENT_SPEC`/`AGENT_PLAN` blocks are retired.
+
+## Capabilities
+
+### New Capabilities
+
+None — dev-workflow/tooling change to `opencode-agent/` only; no papai
+runtime behavior changes. `skip_specs: true` is set in `.openspec.yaml`,
+matching the precedent of `migrate-brainstorming-to-openspec`.
+
+### Modified Capabilities
+
+None. `openspec/specs/` is empty (strangler); nothing to modify.
+
+## Non-goals
+
+- No changes to `sdd-runner/`; its compliance patterns are reused as
+  patterns, not imported as code, and no shared foundation is extracted.
+- No changes to papai runtime (`src/`, `client/`, `plugins/`); no
+  platform-instance/task-instance surface impact; no config-context scope
+  impact (no new persisted state keyed by any context id).
+- No removal of the agent's interactivity: clarifying conversation, `/ask`,
+  mid-run steering, and the two human parks are preserved.
+- No review-loop-on-artifacts (sdd-runner's convergence machinery); the
+  human parks remain the quality gate.
+- No legacy compatibility for in-flight issues: they are restarted under
+  the reworked pipeline (the stale branch is reset); no dual-format state.
+
+## Impact
+
+- **Docs/instructions:** `opencode-agent/CLAUDE.md`, `opencode-agent/README.md`,
+  `docs/architecture/openspec-superpowers-hybrid.md` (routing table note).
+- **Code:** `opencode-agent/` phases (`INIT_OR_CLARIFY`, `PLANNING`,
+  `DESIGN_SPEC`, `PLAN_REVIEW`, `REVIEW_AND_MUTATE` step source),
+  `PHASE_SKILLS`, artifact/blocks layer, diff-guard write grant for
+  `openspec/changes/`, new merged-PR trigger + `ARCHIVE` phase.
+- **OpenSpec tree:** this change lives in the root tree per the migration's
+  D7 (sub-workspaces share the root `openspec/` tree).

--- a/openspec/changes/opencode-agent-openspec-compliance/tasks.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/tasks.md
@@ -69,7 +69,7 @@ Write/Edit TDD hook pipeline.
   instruction → model composes per template → `validate --strict` → retry
   ≤2; digest rendering from the folder (D1) with revision display metadata
   — `bun test tests/opencode-agent/phases.test.ts`
-- [ ] 5.2 Implement the drafter loop; `DESIGN_SPEC`/`PLAN_REVIEW` parks
+- [x] 5.2 Implement the drafter loop; `DESIGN_SPEC`/`PLAN_REVIEW` parks
   render digests of real proposal/specs/design/tasks; retire
   `AGENT_SPEC`/`AGENT_PLAN` blocks outright (no legacy restore path —
   in-flight issues restart via the `STATE_VERSION` bump, D12)

--- a/openspec/changes/opencode-agent-openspec-compliance/tasks.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/tasks.md
@@ -90,11 +90,11 @@ Write/Edit TDD hook pipeline.
   — `bun test tests/opencode-agent/plan-steps.test.ts tests/opencode-agent/implement-steps.test.ts`
 - [x] 6.2 Implement the checkbox step source (D5)
   — `bun test tests/opencode-agent/implement-steps.test.ts`
-- [ ] 6.3 Add failing tests for steering-drift: scope-affecting steering in
+- [x] 6.3 Add failing tests for steering-drift: scope-affecting steering in
   `REVIEW_AND_MUTATE` triggers an artifact-update turn (edit → validate →
   commit) before implementation continues (D6)
   — `bun test tests/opencode-agent/comment-intent.test.ts tests/opencode-agent/phases.test.ts`
-- [ ] 6.4 Implement steering-drift (D6)
+- [x] 6.4 Implement steering-drift (D6)
   — `bun test tests/opencode-agent/phases.test.ts`
 
 ## 7. Archive door

--- a/openspec/changes/opencode-agent-openspec-compliance/tasks.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/tasks.md
@@ -84,11 +84,11 @@ Write/Edit TDD hook pipeline.
 
 ## 6. REVIEW_AND_MUTATE on tasks.md
 
-- [ ] 6.1 Add failing tests for walking `tasks.md` checkboxes as the step
+- [x] 6.1 Add failing tests for walking `tasks.md` checkboxes as the step
   source (D5), box checked in the same commit as the step's work, drift from
   a cursor past the end
   — `bun test tests/opencode-agent/plan-steps.test.ts tests/opencode-agent/implement-steps.test.ts`
-- [ ] 6.2 Implement the checkbox step source (D5)
+- [x] 6.2 Implement the checkbox step source (D5)
   — `bun test tests/opencode-agent/implement-steps.test.ts`
 - [ ] 6.3 Add failing tests for steering-drift: scope-affecting steering in
   `REVIEW_AND_MUTATE` triggers an artifact-update turn (edit → validate →

--- a/openspec/changes/opencode-agent-openspec-compliance/tasks.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/tasks.md
@@ -65,7 +65,7 @@ Write/Edit TDD hook pipeline.
 
 ## 5. PLANNING + parks on real artifacts
 
-- [ ] 5.1 Add failing tests for the PLANNING drafter loop (D3): typed
+- [x] 5.1 Add failing tests for the PLANNING drafter loop (D3): typed
   instruction → model composes per template → `validate --strict` → retry
   ≤2; digest rendering from the folder (D1) with revision display metadata
   — `bun test tests/opencode-agent/phases.test.ts`

--- a/openspec/changes/opencode-agent-openspec-compliance/tasks.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/tasks.md
@@ -119,7 +119,7 @@ Write/Edit TDD hook pipeline.
 
 ## 9. Docs + full verification
 
-- [ ] 9.1 Update `opencode-agent/CLAUDE.md` (phase descriptions, artifact
+- [x] 9.1 Update `opencode-agent/CLAUDE.md` (phase descriptions, artifact
   model, new door, no-legacy policy), `opencode-agent/README.md` and
   `opencode-agent/ROADMAP.md` (open findings referencing blocks or the
   superpowers skill set), and

--- a/openspec/changes/opencode-agent-openspec-compliance/tasks.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/tasks.md
@@ -42,13 +42,13 @@ Write/Edit TDD hook pipeline.
 
 ## 3. INIT_OR_CLARIFY: explore stance + capture policy
 
-- [ ] 3.1 Add failing tests for the structured triage outcome
+- [x] 3.1 Add failing tests for the structured triage outcome
   (`clarify | capture | answer` + kebab change name) parsed via
   `promptForJson`, and for the D9 association gate (auto-capture for
   OWNER/MEMBER/COLLABORATOR; consent comment otherwise; affirmative reply
   routed via `applyClarifyIntent` completes capture)
   — `bun test tests/opencode-agent/triggers.test.ts tests/opencode-agent/phases.test.ts`
-- [ ] 3.2 Implement the triage outcome + D9 gate + consent path; scaffold
+- [x] 3.2 Implement the triage outcome + D9 gate + consent path; scaffold
   the change (`new change` via driver) on capture
   — `bun test tests/opencode-agent/phases.test.ts`
 

--- a/openspec/changes/opencode-agent-openspec-compliance/tasks.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/tasks.md
@@ -1,0 +1,130 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Tasks: Make opencode-agent OpenSpec-compliant
+
+Design: `design.md` (D1–D13). Test-first throughout: each task's failing
+test lands before its implementation, per `tests/CLAUDE.md` and the repo
+Write/Edit TDD hook pipeline.
+
+## 1. OpenSpec driver + probes
+
+- [ ] 1.1 Add failing tests for an openspec CLI driver (`status --json`,
+  `instructions --json`, `new change`, `validate --strict`, retry ≤2 with
+  the validation complaint attached) in `tests/opencode-agent/openspec-driver.test.ts`
+  — `bun test tests/opencode-agent/openspec-driver.test.ts`
+- [ ] 1.2 Implement `opencode-agent/src/openspec-driver.ts` (DI'd shell
+  seam, argv vectors with `shell: false`, zod-decoded JSON output)
+  — `bun test tests/opencode-agent/openspec-driver.test.ts`
+- [ ] 1.3 Add failing tests for the `openspec/` root probe in
+  `config-discovery` (present → compliant mode; absent → stand-down
+  comment + `warn`, fail-closed per D10)
+  — `bun test tests/opencode-agent/config-discovery.test.ts`
+- [ ] 1.4 Implement the probe (D10), the stand-down path, and the
+  deliberate `STATE_VERSION` bump (D12): legacy state blocks rejected →
+  restore finds nothing → issue restarts fresh
+  — `bun test tests/opencode-agent/state-manager.test.ts tests/opencode-agent/config-discovery.test.ts`
+
+## 2. Skill rewiring
+
+- [ ] 2.1 Add failing tests for the reworked `PHASE_SKILLS` table (D4:
+  `INIT_OR_CLARIFY`→`openspec-explore`, `PLANNING`→`openspec-propose`,
+  execution skills unchanged, `brainstorming`/`writing-plans`/
+  `executing-plans` gone) and for loader root precedence (D11):
+  in-repo openspec trees first-hit-win — `bun test tests/opencode-agent/obra-skills.test.ts`
+- [ ] 2.2 Implement `PHASE_SKILLS` + loader roots (`.opencode/skills/`,
+  then `.agents/skills/`, then superpowers roots)
+  — `bun test tests/opencode-agent/obra-skills.test.ts`
+
+## 3. INIT_OR_CLARIFY: explore stance + capture policy
+
+- [ ] 3.1 Add failing tests for the structured triage outcome
+  (`clarify | capture | answer` + kebab change name) parsed via
+  `promptForJson`, and for the D9 association gate (auto-capture for
+  OWNER/MEMBER/COLLABORATOR; consent comment otherwise; affirmative reply
+  routed via `applyClarifyIntent` completes capture)
+  — `bun test tests/opencode-agent/triggers.test.ts tests/opencode-agent/phases.test.ts`
+- [ ] 3.2 Implement the triage outcome + D9 gate + consent path; scaffold
+  the change (`new change` via driver) on capture
+  — `bun test tests/opencode-agent/phases.test.ts`
+
+## 4. Branch-from-first-spec + artifact writes
+
+- [ ] 4.1 Add failing tests for capture-time branch creation
+  (`agent/issue-<n>` + folder scaffold as commit #1) and for the diff-guard
+  named-prefix grant limiting planner/spec turns to
+  `openspec/changes/<change-name>/` (D8), protected-paths staging unchanged
+  — `bun test tests/opencode-agent/git-commit.test.ts tests/opencode-agent/diff-guard.test.ts`
+- [ ] 4.2 Implement branch-from-first-spec (D2) and the prefix grant;
+  capability profile for artifact-writing turns (deny-by-default + named
+  grant) — `bun test tests/opencode-agent/diff-guard.test.ts tests/opencode-agent/openai-config.test.ts`
+
+## 5. PLANNING + parks on real artifacts
+
+- [ ] 5.1 Add failing tests for the PLANNING drafter loop (D3): typed
+  instruction → model composes per template → `validate --strict` → retry
+  ≤2; digest rendering from the folder (D1) with revision display metadata
+  — `bun test tests/opencode-agent/phases.test.ts`
+- [ ] 5.2 Implement the drafter loop; `DESIGN_SPEC`/`PLAN_REVIEW` parks
+  render digests of real proposal/specs/design/tasks; retire
+  `AGENT_SPEC`/`AGENT_PLAN` blocks outright (no legacy restore path —
+  in-flight issues restart via the `STATE_VERSION` bump, D12)
+  — `bun test tests/opencode-agent/phases.test.ts tests/opencode-agent/artifacts.test.ts`
+- [ ] 5.3 Sweep every remaining reader of the retired `AGENT_SPEC`/
+  `AGENT_PLAN` blocks and their revision counters (`specRevision`,
+  `planRevision`): prompts that envelope spec/plan text, PR body rendering,
+  status/progress tables, report block stamping, `findPlan`/`findHandoff`
+  — each becomes a folder read or is deleted; a repo-wide grep for the
+  retired block names returns only the migration-era test fixtures
+  — `bun test tests/opencode-agent/ && rg -l "AGENT_SPEC|AGENT_PLAN|specRevision|planRevision" opencode-agent/src`
+
+## 6. REVIEW_AND_MUTATE on tasks.md
+
+- [ ] 6.1 Add failing tests for walking `tasks.md` checkboxes as the step
+  source (D5), box checked in the same commit as the step's work, drift from
+  a cursor past the end
+  — `bun test tests/opencode-agent/plan-steps.test.ts tests/opencode-agent/implement-steps.test.ts`
+- [ ] 6.2 Implement the checkbox step source (D5)
+  — `bun test tests/opencode-agent/implement-steps.test.ts`
+- [ ] 6.3 Add failing tests for steering-drift: scope-affecting steering in
+  `REVIEW_AND_MUTATE` triggers an artifact-update turn (edit → validate →
+  commit) before implementation continues (D6)
+  — `bun test tests/opencode-agent/comment-intent.test.ts tests/opencode-agent/phases.test.ts`
+- [ ] 6.4 Implement steering-drift (D6)
+  — `bun test tests/opencode-agent/phases.test.ts`
+
+## 7. Archive door
+
+- [ ] 7.1 Add failing tests for the `pull_request.closed(merged)` trigger:
+  parse → guardrails → resolve issue via head branch (existing door
+  pattern), foreign-repo refusal, `ARCHIVE` phase running
+  `openspec archive` as a follow-up commit on master (D7)
+  — `bun test tests/opencode-agent/pr-trigger.test.ts tests/opencode-agent/triggers.test.ts`
+- [ ] 7.2 Implement the trigger + `ARCHIVE` phase + workflow YAML job;
+  install + pin the `openspec` CLI in `agent-pipeline.yml` beside the
+  `opencode` CLI — `bun test tests/opencode-agent/pr-trigger.test.ts`
+
+## 8. Restart + cancel cleanup
+
+- [ ] 8.1 Add failing tests for restart semantics (D12): a restarted issue
+  whose `agent/issue-<n>` branch already exists resets the branch to base
+  before the scaffold commit; and for `/cancel` gaining branch +
+  change-folder cleanup (D9) — `bun test tests/opencode-agent/triggers.test.ts`
+- [ ] 8.2 Implement restart-with-reset + cancel cleanup
+  — `bun test tests/opencode-agent/triggers.test.ts`
+
+## 9. Docs + full verification
+
+- [ ] 9.1 Update `opencode-agent/CLAUDE.md` (phase descriptions, artifact
+  model, new door, no-legacy policy), `opencode-agent/README.md` and
+  `opencode-agent/ROADMAP.md` (open findings referencing blocks or the
+  superpowers skill set), and
+  `docs/architecture/openspec-superpowers-hybrid.md` routing table
+  (opencode-agent entry now points at this change)
+  — `bun run format:check`
+- [ ] 9.2 Run full `bun test`, `bun run typecheck`, `bun run lint`
+  — `bun run test && bun run typecheck && bun run lint`

--- a/openspec/changes/opencode-agent-openspec-compliance/tasks.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/tasks.md
@@ -110,11 +110,11 @@ Write/Edit TDD hook pipeline.
 
 ## 8. Restart + cancel cleanup
 
-- [ ] 8.1 Add failing tests for restart semantics (D12): a restarted issue
+- [x] 8.1 Add failing tests for restart semantics (D12): a restarted issue
   whose `agent/issue-<n>` branch already exists resets the branch to base
   before the scaffold commit; and for `/cancel` gaining branch +
   change-folder cleanup (D9) — `bun test tests/opencode-agent/triggers.test.ts`
-- [ ] 8.2 Implement restart-with-reset + cancel cleanup
+- [x] 8.2 Implement restart-with-reset + cancel cleanup
   — `bun test tests/opencode-agent/triggers.test.ts`
 
 ## 9. Docs + full verification

--- a/openspec/changes/opencode-agent-openspec-compliance/tasks.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/tasks.md
@@ -74,7 +74,7 @@ Write/Edit TDD hook pipeline.
   `AGENT_SPEC`/`AGENT_PLAN` blocks outright (no legacy restore path —
   in-flight issues restart via the `STATE_VERSION` bump, D12)
   — `bun test tests/opencode-agent/phases.test.ts tests/opencode-agent/artifacts.test.ts`
-- [ ] 5.3 Sweep every remaining reader of the retired `AGENT_SPEC`/
+- [x] 5.3 Sweep every remaining reader of the retired `AGENT_SPEC`/
   `AGENT_PLAN` blocks and their revision counters (`specRevision`,
   `planRevision`): prompts that envelope spec/plan text, PR body rendering,
   status/progress tables, report block stamping, `findPlan`/`findHandoff`

--- a/openspec/changes/opencode-agent-openspec-compliance/tasks.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/tasks.md
@@ -54,12 +54,12 @@ Write/Edit TDD hook pipeline.
 
 ## 4. Branch-from-first-spec + artifact writes
 
-- [ ] 4.1 Add failing tests for capture-time branch creation
+- [x] 4.1 Add failing tests for capture-time branch creation
   (`agent/issue-<n>` + folder scaffold as commit #1) and for the diff-guard
   named-prefix grant limiting planner/spec turns to
   `openspec/changes/<change-name>/` (D8), protected-paths staging unchanged
   — `bun test tests/opencode-agent/git-commit.test.ts tests/opencode-agent/diff-guard.test.ts`
-- [ ] 4.2 Implement branch-from-first-spec (D2) and the prefix grant;
+- [x] 4.2 Implement branch-from-first-spec (D2) and the prefix grant;
   capability profile for artifact-writing turns (deny-by-default + named
   grant) — `bun test tests/opencode-agent/diff-guard.test.ts tests/opencode-agent/openai-config.test.ts`
 

--- a/openspec/changes/opencode-agent-openspec-compliance/tasks.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/tasks.md
@@ -126,5 +126,5 @@ Write/Edit TDD hook pipeline.
   `docs/architecture/openspec-superpowers-hybrid.md` routing table
   (opencode-agent entry now points at this change)
   — `bun run format:check`
-- [ ] 9.2 Run full `bun test`, `bun run typecheck`, `bun run lint`
+- [x] 9.2 Run full `bun test`, `bun run typecheck`, `bun run lint`
   — `bun run test && bun run typecheck && bun run lint`

--- a/openspec/changes/opencode-agent-openspec-compliance/tasks.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/tasks.md
@@ -99,12 +99,12 @@ Write/Edit TDD hook pipeline.
 
 ## 7. Archive door
 
-- [ ] 7.1 Add failing tests for the `pull_request.closed(merged)` trigger:
+- [x] 7.1 Add failing tests for the `pull_request.closed(merged)` trigger:
   parse → guardrails → resolve issue via head branch (existing door
   pattern), foreign-repo refusal, `ARCHIVE` phase running
   `openspec archive` as a follow-up commit on master (D7)
   — `bun test tests/opencode-agent/pr-trigger.test.ts tests/opencode-agent/triggers.test.ts`
-- [ ] 7.2 Implement the trigger + `ARCHIVE` phase + workflow YAML job;
+- [x] 7.2 Implement the trigger + `ARCHIVE` phase + workflow YAML job;
   install + pin the `openspec` CLI in `agent-pipeline.yml` beside the
   `opencode` CLI — `bun test tests/opencode-agent/pr-trigger.test.ts`
 

--- a/openspec/changes/opencode-agent-openspec-compliance/tasks.md
+++ b/openspec/changes/opencode-agent-openspec-compliance/tasks.md
@@ -13,30 +13,30 @@ Write/Edit TDD hook pipeline.
 
 ## 1. OpenSpec driver + probes
 
-- [ ] 1.1 Add failing tests for an openspec CLI driver (`status --json`,
+- [x] 1.1 Add failing tests for an openspec CLI driver (`status --json`,
   `instructions --json`, `new change`, `validate --strict`, retry ≤2 with
   the validation complaint attached) in `tests/opencode-agent/openspec-driver.test.ts`
   — `bun test tests/opencode-agent/openspec-driver.test.ts`
-- [ ] 1.2 Implement `opencode-agent/src/openspec-driver.ts` (DI'd shell
+- [x] 1.2 Implement `opencode-agent/src/openspec-driver.ts` (DI'd shell
   seam, argv vectors with `shell: false`, zod-decoded JSON output)
   — `bun test tests/opencode-agent/openspec-driver.test.ts`
-- [ ] 1.3 Add failing tests for the `openspec/` root probe in
+- [x] 1.3 Add failing tests for the `openspec/` root probe in
   `config-discovery` (present → compliant mode; absent → stand-down
   comment + `warn`, fail-closed per D10)
   — `bun test tests/opencode-agent/config-discovery.test.ts`
-- [ ] 1.4 Implement the probe (D10), the stand-down path, and the
+- [x] 1.4 Implement the probe (D10), the stand-down path, and the
   deliberate `STATE_VERSION` bump (D12): legacy state blocks rejected →
   restore finds nothing → issue restarts fresh
   — `bun test tests/opencode-agent/state-manager.test.ts tests/opencode-agent/config-discovery.test.ts`
 
 ## 2. Skill rewiring
 
-- [ ] 2.1 Add failing tests for the reworked `PHASE_SKILLS` table (D4:
+- [x] 2.1 Add failing tests for the reworked `PHASE_SKILLS` table (D4:
   `INIT_OR_CLARIFY`→`openspec-explore`, `PLANNING`→`openspec-propose`,
   execution skills unchanged, `brainstorming`/`writing-plans`/
   `executing-plans` gone) and for loader root precedence (D11):
   in-repo openspec trees first-hit-win — `bun test tests/opencode-agent/obra-skills.test.ts`
-- [ ] 2.2 Implement `PHASE_SKILLS` + loader roots (`.opencode/skills/`,
+- [x] 2.2 Implement `PHASE_SKILLS` + loader roots (`.opencode/skills/`,
   then `.agents/skills/`, then superpowers roots)
   — `bun test tests/opencode-agent/obra-skills.test.ts`
 

--- a/tests/opencode-agent/adapters.test.ts
+++ b/tests/opencode-agent/adapters.test.ts
@@ -935,16 +935,21 @@ describe('obra-skills', () => {
     }
   })
 
-  test('every named skill is one that exists upstream', () => {
-    // A hand-copied snapshot of obra/superpowers @ 44c9b2d, so this catches a
-    // typo in PHASE_SKILLS — not upstream drift, which it cannot see. The real
-    // guard against a bad checkout is `bun run opencode-agent:verify-skills`,
-    // which the workflow runs against the actual fetched files.
-    const upstreamAt44c9b2d = new Set([
+  test('every named skill is one that exists upstream or in-repo', () => {
+    // A hand-copied snapshot of obra/superpowers @ 44c9b2d plus this repo's own
+    // OpenSpec skills, so this catches a typo in PHASE_SKILLS — not upstream
+    // drift, which it cannot see. The real guard against a bad checkout is
+    // `bun run opencode-agent:verify-skills`, which the workflow runs against
+    // the actual fetched files. D4 routes two phases onto the in-repo OpenSpec
+    // skills (`openspec-explore`, `openspec-propose`), which live under
+    // `.opencode/skills/` rather than the obra/superpowers checkout.
+    const knownSkills = new Set([
       'brainstorming',
       'dispatching-parallel-agents',
       'executing-plans',
       'finishing-a-development-branch',
+      'openspec-explore',
+      'openspec-propose',
       'receiving-code-review',
       'requesting-code-review',
       'subagent-driven-development',
@@ -959,7 +964,7 @@ describe('obra-skills', () => {
 
     for (const phase of PHASES) {
       for (const name of [...PHASE_SKILLS[phase].required, ...PHASE_SKILLS[phase].optional]) {
-        expect(upstreamAt44c9b2d.has(name), `${phase} asks for unknown skill ${name}`).toBe(true)
+        expect(knownSkills.has(name), `${phase} asks for unknown skill ${name}`).toBe(true)
       }
     }
   })
@@ -971,7 +976,7 @@ describe('obra-skills', () => {
       read: () => Promise.reject(new Error('ENOENT')),
     })
 
-    await expect(attempt).rejects.toThrow('writing-plans')
+    await expect(attempt).rejects.toThrow('openspec-propose')
   })
 
   test('drops the YAML frontmatter before inlining a skill', async () => {

--- a/tests/opencode-agent/artifacts.test.ts
+++ b/tests/opencode-agent/artifacts.test.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import { renderDigest } from '../../opencode-agent/src/artifacts.js'
+
+/**
+ * Design D1 — the folder is truth; comments are renders.
+ *
+ * `renderDigest` is the one renderer for the two human parks (`DESIGN_SPEC`,
+ * `PLAN_REVIEW`): it frames the artifact content read from the folder with the
+ * branch as the history of record, and (for the plan) the revision token the
+ * machine uses to tell two plans apart. It does not carry the artifact itself —
+ * the folder's commits are the real history, and a rendered snapshot that
+ * pretended to be the artifact would be two truths, exactly the drift design
+ * D1 retired.
+ */
+
+describe('renderDigest · folder-is-truth framing (D1)', () => {
+  it('renders the artifact content and names the branch as the history of record', () => {
+    const digest = renderDigest('# Goal\n\nAdd a retry helper.', {
+      changeName: 'add-retry-helper',
+      branch: 'agent/issue-42',
+      revision: null,
+    })
+
+    // The content reaches the reader.
+    expect(digest).toContain('# Goal')
+    expect(digest).toContain('Add a retry helper.')
+    // The folder is named as the source of truth, with the branch its history.
+    expect(digest).toContain('openspec/changes/add-retry-helper/')
+    expect(digest).toContain('agent/issue-42')
+  })
+
+  it('stamps the plan revision token when the park tracks one (PLAN_REVIEW)', () => {
+    const digest = renderDigest('- [ ] Step one\n', {
+      changeName: 'add-retry-helper',
+      branch: 'agent/issue-42',
+      revision: 3,
+    })
+
+    // Revision display metadata (D1: "revision counters become display metadata
+    // on rendered digests"). The counter is a machine identity, not the
+    // artifact's history — the branch's commits are — and the digest says so.
+    expect(digest).toContain('3')
+  })
+
+  it('omits the revision stamp at DESIGN_SPEC (the proposal has no counter)', () => {
+    const digest = renderDigest('# Goal\n\nAdd retries.', {
+      changeName: 'add-retry-helper',
+      branch: 'agent/issue-42',
+      revision: null,
+    })
+
+    // No plan-revision label: the proposal's history is the branch's commits
+    // alone, and stamping a counter that does not exist would be a second
+    // truth the folder does not carry.
+    expect(digest).not.toContain('plan revision')
+    expect(digest).not.toContain('revision 0')
+  })
+
+  it('trims surrounding blank lines from the folder content but preserves inner structure', () => {
+    const digest = renderDigest('\n\n# Goal\n\n- a\n- b\n\n\n', {
+      changeName: 'add-x',
+      branch: 'agent/issue-1',
+      revision: null,
+    })
+
+    expect(digest).toContain('# Goal\n\n- a\n- b')
+  })
+})

--- a/tests/opencode-agent/cli.test.ts
+++ b/tests/opencode-agent/cli.test.ts
@@ -388,7 +388,7 @@ describe('runCli', () => {
         id: 1,
         user: { login: 'agent-bot' },
         body: `stopped\n\n<!-- AGENT_STATE: ${JSON.stringify({
-          v: 1,
+          v: 3,
           phase: 'FAILED',
           issueId: 42,
           resumeFrom: 'PLANNING',
@@ -420,6 +420,36 @@ describe('runCli', () => {
     expect(github.posted[0]).not.toContain(token)
   })
 
+  test('stands down with one comment when the checkout has no openspec/ tree (design D10)', async () => {
+    // The agent runs in repos other than papai. A checkout without an
+    // `openspec/` root cannot run the compliant pipeline, and the agent never
+    // scaffolds OpenSpec into a foreign repo: it posts one clear comment naming
+    // the remedy and exits without spawning the OpenCode server. The temp
+    // `workDir` has no `openspec/`, so pointing `--repo-root` at it triggers the
+    // probe's stand-down verdict.
+    const eventPath = await writeEvent('stand-down', {
+      action: 'created',
+      sender: { login: 'maintainer', type: 'User' },
+      issue: { number: 42, title: 'Add retries', body: 'Please add retries.', author_association: 'OWNER' },
+      comment: { id: 2, body: 'go ahead', author_association: 'OWNER' },
+      repository: { owner: { login: 'acme' }, name: 'widgets', default_branch: 'master' },
+    })
+
+    const github = recordPosts([])
+    const result = await runCli({
+      argv: ['--event-path', eventPath, '--event-name', 'issue_comment', '--repo-root', workDir],
+      env,
+      logger: silentLogger,
+      octokit: { fetch: github.fetch },
+    })
+
+    expect(result.status).toBe('skipped')
+    expect(result.reported).toBe(true)
+    expect(github.posted).toHaveLength(1)
+    expect(github.posted[0]).toContain('openspec')
+    expect(github.posted[0]).toContain('standing down')
+  })
+
   test('a real run acknowledges the comment that triggered it', async () => {
     // End to end through `contain`, `assembleDeps` and the real Octokit
     // adapter. The recorded lesson of this workspace (ROADMAP S2-6, S3-3, S3-9)
@@ -430,7 +460,7 @@ describe('runCli', () => {
       {
         id: 1,
         user: { login: 'agent-bot' },
-        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 2, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
+        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 3, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
       },
     ]
     const eventPath = await writeEvent('reaction', {
@@ -473,7 +503,7 @@ describe('runCli', () => {
       {
         id: 1,
         user: { login: 'agent-bot' },
-        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 2, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
+        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 3, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
       },
     ]
     const eventPath = await writeEvent('labels', {
@@ -525,7 +555,7 @@ describe('runCli', () => {
         id: 1,
         user: { login: 'agent-bot' },
         body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({
-          v: 2,
+          v: 3,
           phase: 'DESIGN_SPEC',
           issueId: 42,
           tokensSpent: 60_000,
@@ -569,7 +599,7 @@ describe('runCli', () => {
         id: 1,
         user: { login: 'agent-bot' },
         body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({
-          v: 2,
+          v: 3,
           phase: 'DESIGN_SPEC',
           issueId: 42,
           tokensSpent: 60_000,
@@ -602,7 +632,7 @@ describe('runCli', () => {
       {
         id: 1,
         user: { login: 'agent-bot' },
-        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 2, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
+        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 3, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
       },
     ]
     const eventPath = await writeEvent('labels-none', {
@@ -634,7 +664,7 @@ describe('runCli', () => {
       {
         id: 1,
         user: { login: 'agent-bot' },
-        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 2, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
+        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 3, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
       },
     ]
     const eventPath = await writeEvent('labels-403', {
@@ -668,7 +698,7 @@ describe('runCli', () => {
       {
         id: 1,
         user: { login: 'agent-bot' },
-        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 2, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
+        body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 3, phase: 'DESIGN_SPEC', issueId: 42 })} -->`,
       },
     ]
     const eventPath = await writeEvent('reaction-403', {
@@ -708,7 +738,7 @@ describe('runCli', () => {
         id: 1,
         user: { login: 'agent-bot' },
         body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({
-          v: 2,
+          v: 3,
           phase: 'FAILED',
           issueId: 42,
           resumeFrom: 'PLANNING',
@@ -774,7 +804,7 @@ describe('runCli', () => {
         id: 1,
         user: { login: 'agent-bot' },
         body: `parked\n\n<!-- AGENT_STATE: ${JSON.stringify({
-          v: 2,
+          v: 3,
           phase: 'FAILED',
           issueId: 42,
           resumeFrom: 'PLANNING',
@@ -852,7 +882,7 @@ describe('runCli', () => {
     {
       id: 1,
       user: { login: 'agent-bot' },
-      body: `stopped\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 2, phase: 'COMPLETE', issueId: 42 })} -->`,
+      body: `stopped\n\n<!-- AGENT_STATE: ${JSON.stringify({ v: 3, phase: 'COMPLETE', issueId: 42 })} -->`,
     },
   ]
 

--- a/tests/opencode-agent/comment-intent.test.ts
+++ b/tests/opencode-agent/comment-intent.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import { applySteeringIntent } from '../../opencode-agent/src/comment-intent.js'
+import type { PhaseInput } from '../../opencode-agent/src/phase-context.js'
+import type { TriggerEvent } from '../../opencode-agent/src/trigger-events.js'
+import type { AgentState } from '../../opencode-agent/src/types.js'
+import { stubPhaseDeps } from './test-helpers.js'
+
+/**
+ * Design D6 — steering-drift.
+ *
+ * A plain maintainer comment that arrives while the agent is implementing
+ * (`REVIEW_AND_MUTATE`) is classified: scope-affecting steering (`changes`)
+ * routes back to `PLANNING` for an artifact-update turn (edit → validate →
+ * commit) before implementation continues, so the folder cannot rot relative to
+ * the conversation. Anything else skips — implementation is not interrupted for
+ * ambiguity, and a maintainer who wants to ask uses `/ask`.
+ */
+
+const AGENT_LOGIN = 'agent-bot'
+
+const implState = (over: Partial<AgentState> = {}): AgentState => ({
+  v: 3,
+  phase: 'REVIEW_AND_MUTATE',
+  issueId: 42,
+  resumeFrom: null,
+  attempts: 0,
+  ciAttempts: 0,
+  ciBudgetReported: false,
+  reviewAttempts: 0,
+  changedLines: 0,
+  stepsDone: 0,
+  changeName: 'add-retries',
+  planRevision: 1,
+  tokensSpent: 0,
+  lastError: null,
+  prUrl: null,
+  prNumber: null,
+  ...over,
+})
+
+const commentTrigger = (body: string): TriggerEvent => ({
+  kind: 'issue',
+  eventName: 'issue_comment',
+  action: 'created',
+  senderLogin: 'maintainer',
+  senderType: 'User',
+  authorAssociation: 'OWNER',
+  issueNumber: 42,
+  issueTitle: 'Add retries',
+  issueBody: 'Please add a retry helper.',
+  isPullRequest: false,
+  commentBody: body,
+  commentId: 99,
+  repositoryOwner: 'acme',
+  defaultBranch: 'main',
+})
+
+const steer = (replies: readonly string[], state: Partial<AgentState> = {}): { input: PhaseInput } => {
+  const recording = stubPhaseDeps({ replies: [...replies], selfLogin: AGENT_LOGIN })
+  return {
+    input: {
+      state: implState(state),
+      issue: { number: 42, title: 'Add retries', body: 'Please add a retry helper.' },
+      trigger: commentTrigger('Actually, also add structured logging to each retry.'),
+      command: null,
+      thread: recording.io.thread,
+      deps: recording.deps,
+    },
+  }
+}
+
+describe('applySteeringIntent · steering-drift in REVIEW_AND_MUTATE (D6)', () => {
+  it('routes a scope-affecting comment to PLANNING for an artifact-update turn', async () => {
+    const { input } = steer([JSON.stringify({ intent: 'changes' })])
+
+    const outcome = await applySteeringIntent(input)
+
+    expect(outcome.state.phase).toBe('PLANNING')
+    expect(outcome.halt).toBeNull()
+    expect(outcome.answer).toBe(false)
+  })
+
+  it('skips chatter so a mid-implementation 👍 does not re-plan', async () => {
+    const { input } = steer([JSON.stringify({ intent: 'none' })])
+
+    const outcome = await applySteeringIntent(input)
+
+    expect(outcome.halt?.status).toBe('skipped')
+    expect(outcome.state.phase).toBe('REVIEW_AND_MUTATE')
+  })
+
+  it('skips a question rather than interrupting implementation (use /ask to ask)', async () => {
+    const { input } = steer([JSON.stringify({ intent: 'question' })])
+
+    const outcome = await applySteeringIntent(input)
+
+    expect(outcome.halt?.status).toBe('skipped')
+    expect(outcome.state.phase).toBe('REVIEW_AND_MUTATE')
+  })
+
+  it('skips a blank body (the agent posted, not a person)', async () => {
+    const recording = stubPhaseDeps({ replies: [], selfLogin: AGENT_LOGIN })
+    const input: PhaseInput = {
+      state: implState(),
+      issue: { number: 42, title: 't', body: 'b' },
+      trigger: commentTrigger(''),
+      command: null,
+      thread: recording.io.thread,
+      deps: recording.deps,
+    }
+
+    const outcome = await applySteeringIntent(input)
+
+    expect(outcome.halt?.status).toBe('skipped')
+    // No model turn bought to classify an empty comment.
+    expect(recording.io.prompts).toHaveLength(0)
+  })
+
+  it('does not pay to classify a comment the budget cannot act on', async () => {
+    const { input } = steer([JSON.stringify({ intent: 'changes' })], { tokensSpent: 10_000_000 })
+
+    const outcome = await applySteeringIntent(input)
+
+    expect(outcome.halt?.status).toBe('skipped')
+    expect(outcome.state.phase).toBe('REVIEW_AND_MUTATE')
+  })
+})

--- a/tests/opencode-agent/config-discovery.test.ts
+++ b/tests/opencode-agent/config-discovery.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+import path from 'node:path'
+
+import { resolveOpenSpecMode, STAND_DOWN_REASON } from '../../opencode-agent/src/config-discovery.js'
+
+/**
+ * The `openspec/` root probe — design D10.
+ *
+ * The agent runs in repos other than papai. At job start it asks whether the
+ * checkout carries an `openspec/` tree, the same testable ladder shape the
+ * `review-loop/` probe already uses: an injected `exists` callback keeps the
+ * ladder testable without a filesystem. Present → the compliant pipeline runs;
+ * absent → the agent posts one clear comment and stands down (fail-closed). It
+ * never scaffolds OpenSpec into a foreign repo.
+ */
+describe('resolveOpenSpecMode', () => {
+  it('reports compliant when the checkout has an openspec/ tree', () => {
+    const exists = (target: string): boolean => target === path.join('/repo', 'openspec')
+    expect(resolveOpenSpecMode('/repo', exists)).toEqual({ mode: 'compliant' })
+  })
+
+  it('reports stand-down when no openspec/ tree is present', () => {
+    expect(resolveOpenSpecMode('/repo', () => false).mode).toBe('stand-down')
+  })
+
+  it('the stand-down reason is the non-empty comment the door posts', () => {
+    expect(STAND_DOWN_REASON.length).toBeGreaterThan(0)
+    expect(resolveOpenSpecMode('/repo', () => false).mode).toBe('stand-down')
+  })
+
+  it('checks the openspec directory at the repo root, not a nested path', () => {
+    const seen: string[] = []
+    const exists = (target: string): boolean => {
+      seen.push(target)
+      return false
+    }
+    resolveOpenSpecMode('/repo', exists)
+    expect(seen).toEqual([path.join('/repo', 'openspec')])
+  })
+
+  it('does not treat a nested openspec/ (e.g. under src/) as present', () => {
+    // A foreign repo that happens to ship an `openspec` module under `src/`
+    // must not trick the probe into compliant mode.
+    const exists = (target: string): boolean => target === path.join('/repo', 'src', 'openspec')
+    expect(resolveOpenSpecMode('/repo', exists).mode).toBe('stand-down')
+  })
+})

--- a/tests/opencode-agent/diff-guard.test.ts
+++ b/tests/opencode-agent/diff-guard.test.ts
@@ -5,7 +5,13 @@
 
 import { describe, expect, test } from 'bun:test'
 
-import { inspectSalvage, inspectStaged, measure, parseNumstat } from '../../opencode-agent/src/diff-guard.js'
+import {
+  inspectSalvage,
+  inspectStaged,
+  measure,
+  outsidePrefix,
+  parseNumstat,
+} from '../../opencode-agent/src/diff-guard.js'
 import type { DiffLimits, DiffVerdict, SalvageVerdict, StagedFile } from '../../opencode-agent/src/diff-guard.js'
 import { createGit, credentialEnv } from '../../opencode-agent/src/git.js'
 import type { GitOptions, Salvage } from '../../opencode-agent/src/git.js'
@@ -658,5 +664,41 @@ describe('salvageAll drops what a push cannot carry', () => {
 
     expect(await createGit(guardedGit(run, LIMITS)).salvageAll('msg')).toEqual({ kind: 'clean' })
     expect(calls.some((call) => call.includes('commit'))).toBe(false)
+  })
+})
+
+/**
+ * Design D8 — the diff-guard named-prefix grant.
+ *
+ * Planner/spec turns are confined to `openspec/changes/<change-name>/`: a file a
+ * drafter turn writes outside that prefix is denied, exactly the shape
+ * sdd-runner's guard takes. This is the pure predicate the confined commit path
+ * reads; the protected-paths staging beside it is unchanged.
+ */
+describe('outsidePrefix (D8)', () => {
+  test('returns nothing when every path is under the change folder', () => {
+    expect(
+      outsidePrefix(
+        ['openspec/changes/add-x/proposal.md', 'openspec/changes/add-x/tasks.md'],
+        'openspec/changes/add-x/',
+      ),
+    ).toEqual([])
+  })
+
+  test('returns paths outside the change folder', () => {
+    expect(
+      outsidePrefix(['openspec/changes/add-x/proposal.md', 'src/a.ts', 'README.md'], 'openspec/changes/add-x/'),
+    ).toEqual(['src/a.ts', 'README.md'])
+  })
+
+  test('normalises a prefix without a trailing slash', () => {
+    expect(outsidePrefix(['openspec/changes/add-x/proposal.md'], 'openspec/changes/add-x')).toEqual([])
+  })
+
+  test('respects segment boundaries — a sibling change name is outside', () => {
+    // `add-xtras` shares the `add-x` prefix string but is a different folder.
+    expect(outsidePrefix(['openspec/changes/add-xtras/proposal.md'], 'openspec/changes/add-x/')).toEqual([
+      'openspec/changes/add-xtras/proposal.md',
+    ])
   })
 })

--- a/tests/opencode-agent/git-commit.test.ts
+++ b/tests/opencode-agent/git-commit.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import type { PhaseInput } from '../../opencode-agent/src/phase-context.js'
+import { handleTriage } from '../../opencode-agent/src/phases/triage.js'
+import type { TriggerEvent } from '../../opencode-agent/src/trigger-events.js'
+import type { AgentState } from '../../opencode-agent/src/types.js'
+import { stubPhaseDeps } from './test-helpers.js'
+
+/**
+ * Design D2 — branch from first spec.
+ *
+ * The branch `agent/issue-<n>` is created the moment triage converges on a
+ * capture, and the scaffolded `openspec/changes/<name>/` folder is commit #1 —
+ * pushed immediately, so planning artefacts are durable across Actions jobs
+ * without travelling in hidden blocks. These tests drive the triage handler
+ * through `PhaseDeps` and assert the git calls happen in the right order with
+ * the right branch, on a trusted auto-capture.
+ */
+
+const AGENT_LOGIN = 'agent-bot'
+
+const baseState = (over: Partial<AgentState> = {}): AgentState => ({
+  v: 3,
+  phase: 'INIT_OR_CLARIFY',
+  issueId: 42,
+  resumeFrom: null,
+  attempts: 0,
+  ciAttempts: 0,
+  ciBudgetReported: false,
+  reviewAttempts: 0,
+  changedLines: 0,
+  stepsDone: 0,
+  changeName: null,
+  planRevision: 0,
+  tokensSpent: 0,
+  lastError: null,
+  prUrl: null,
+  prNumber: null,
+  ...over,
+})
+
+const issueTrigger = (association: string): TriggerEvent => ({
+  kind: 'issue',
+  eventName: 'issues',
+  action: 'opened',
+  senderLogin: 'someone',
+  senderType: 'User',
+  authorAssociation: association,
+  issueNumber: 42,
+  issueTitle: 'Add a retry helper',
+  issueBody: 'Please add a retry helper.',
+  isPullRequest: false,
+  commentBody: null,
+  commentId: null,
+  repositoryOwner: 'acme',
+  defaultBranch: 'main',
+})
+
+const captureReply = JSON.stringify({
+  status: 'capture',
+  changeName: 'add-retry-helper',
+  spec: '# Goal\n\nAdd retries.',
+})
+
+describe('handleTriage · capture · branch-from-first-spec (D2)', () => {
+  it('creates agent/issue-<n>, commits the scaffold as #1, and pushes — in that order', async () => {
+    const recording = stubPhaseDeps({ replies: [captureReply], selfLogin: AGENT_LOGIN })
+    const input: PhaseInput = {
+      state: baseState(),
+      issue: { number: 42, title: 'Add a retry helper', body: 'Please add a retry helper.' },
+      trigger: issueTrigger('OWNER'),
+      command: null,
+      thread: recording.io.thread,
+      deps: recording.deps,
+    }
+
+    const outcome = await handleTriage(input)
+
+    expect(outcome.signal).toBe('CAPTURED')
+    // The scaffold is durable: branch → commit → push, in that order, on the
+    // agent's own branch off the configured base.
+    expect(recording.io.gitCalls).toEqual([
+      'ensureBranch:agent/issue-42:main',
+      'commit:chore(openspec): scaffold add-retry-helper',
+      'push:agent/issue-42',
+    ])
+  })
+
+  it('does not branch, commit or push when capture awaits consent (untrusted author)', async () => {
+    const recording = stubPhaseDeps({ replies: [captureReply], selfLogin: AGENT_LOGIN })
+    const input: PhaseInput = {
+      state: baseState(),
+      issue: { number: 42, title: 't', body: 'b' },
+      trigger: issueTrigger('NONE'),
+      command: null,
+      thread: recording.io.thread,
+      deps: recording.deps,
+    }
+
+    const outcome = await handleTriage(input)
+
+    expect(outcome.signal).toBe('NEEDS_CLARIFICATION')
+    expect(recording.io.gitCalls).toEqual([])
+  })
+})

--- a/tests/opencode-agent/git-commit.test.ts
+++ b/tests/opencode-agent/git-commit.test.ts
@@ -82,10 +82,12 @@ describe('handleTriage · capture · branch-from-first-spec (D2)', () => {
     const outcome = await handleTriage(input)
 
     expect(outcome.signal).toBe('CAPTURED')
-    // The scaffold is durable: branch → commit → push, in that order, on the
-    // agent's own branch off the configured base.
+    // The scaffold is durable: reset-to-base → commit → push, in that order, on
+    // the agent's own branch off the configured base. `resetBranchToBase` (D12)
+    // rather than `ensureBranch`: a restarted issue's branch may carry partial
+    // legacy work, and the new capture starts from zero.
     expect(recording.io.gitCalls).toEqual([
-      'ensureBranch:agent/issue-42:main',
+      'resetBranchToBase:agent/issue-42:main',
       'commit:chore(openspec): scaffold add-retry-helper',
       'push:agent/issue-42',
     ])

--- a/tests/opencode-agent/implement-steps.test.ts
+++ b/tests/opencode-agent/implement-steps.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from 'bun:test'
 import type { PhaseInput } from '../../opencode-agent/src/phase-context.js'
 import { mintEnvelope } from '../../opencode-agent/src/phases/envelope.js'
 import { walkPlanSteps } from '../../opencode-agent/src/phases/implement-steps.js'
-import { parseTaskCheckboxes, taskStepsFromCheckboxes, checkBoxText } from '../../opencode-agent/src/plan-steps.js'
+import { checkBoxText, planBoxes } from '../../opencode-agent/src/plan-steps.js'
 import type { TriggerEvent } from '../../opencode-agent/src/trigger-events.js'
 import type { AgentState } from '../../opencode-agent/src/types.js'
 import { stubPhaseDeps } from './test-helpers.js'
@@ -69,7 +69,7 @@ const makeWalk = (
 ): { run: () => ReturnType<typeof walkPlanSteps>; io: ReturnType<typeof stubPhaseDeps>['io'] } => {
   const built = stubPhaseDeps({ replies, selfLogin: AGENT_LOGIN })
   built.io.readContents[TASKS_PATH] = TASKS_MD
-  const steps = taskStepsFromCheckboxes(parseTaskCheckboxes(TASKS_MD))
+  const steps = planBoxes(TASKS_MD)
   const input: PhaseInput = {
     state: reviewState({ stepsDone: from }),
     issue: { number: 42, title: 'Add retries', body: 'b' },
@@ -129,8 +129,11 @@ describe('walkPlanSteps · tasks.md checkboxes (D5)', () => {
     const walk = await run()
 
     expect(walk.kind).toBe('finished')
+    // Only one box was worked this run: the second real step. The pre-checked
+    // 'scaffold' box is skipped without a turn, and the cursor (from = 1) started
+    // the walk at the second box rather than re-walking the first.
     expect(io.prompts).toHaveLength(1)
-    expect(walk.done).toBe(2)
+    expect(walk.commits).toBe(1)
   })
 
   it('the box-check uses checkBoxText (indented sub-items keep their indentation)', () => {

--- a/tests/opencode-agent/implement-steps.test.ts
+++ b/tests/opencode-agent/implement-steps.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import type { PhaseInput } from '../../opencode-agent/src/phase-context.js'
+import { mintEnvelope } from '../../opencode-agent/src/phases/envelope.js'
+import { walkPlanSteps } from '../../opencode-agent/src/phases/implement-steps.js'
+import { parseTaskCheckboxes, taskStepsFromCheckboxes, checkBoxText } from '../../opencode-agent/src/plan-steps.js'
+import type { TriggerEvent } from '../../opencode-agent/src/trigger-events.js'
+import type { AgentState } from '../../opencode-agent/src/types.js'
+import { stubPhaseDeps } from './test-helpers.js'
+
+/**
+ * Design D5 — `REVIEW_AND_MUTATE` walks `tasks.md` checkboxes.
+ *
+ * Each step is one model turn; the step's commit checks its box (`- [ ]` →
+ * `- [x]`) in the **same** commit as the work. The cursor (`state.stepsDone`)
+ * counts into the unchecked list, and a cursor past the end walks from the top.
+ */
+
+const TASKS_PATH = '/repo/openspec/changes/add-retries/tasks.md'
+const AGENT_LOGIN = 'agent-bot'
+
+const reviewState = (over: Partial<AgentState> = {}): AgentState => ({
+  v: 3,
+  phase: 'REVIEW_AND_MUTATE',
+  issueId: 42,
+  resumeFrom: null,
+  attempts: 0,
+  ciAttempts: 0,
+  ciBudgetReported: false,
+  reviewAttempts: 0,
+  changedLines: 0,
+  stepsDone: 0,
+  changeName: 'add-retries',
+  planRevision: 1,
+  tokensSpent: 0,
+  lastError: null,
+  prUrl: null,
+  prNumber: null,
+  ...over,
+})
+
+const issueTrigger = (): TriggerEvent => ({
+  kind: 'issue',
+  eventName: 'issues',
+  action: 'opened',
+  senderLogin: 'someone',
+  senderType: 'User',
+  authorAssociation: 'OWNER',
+  issueNumber: 42,
+  issueTitle: 'Add retries',
+  issueBody: 'b',
+  isPullRequest: false,
+  commentBody: null,
+  commentId: null,
+  repositoryOwner: 'acme',
+  defaultBranch: 'main',
+})
+
+const TASKS_MD = ['- [ ] 1.1 Write tests', '- [ ] 1.2 Implement', '- [x] 1.0 scaffold (done)'].join('\n') + '\n'
+
+const makeWalk = (
+  replies: string[],
+  from: number,
+): { run: () => ReturnType<typeof walkPlanSteps>; io: ReturnType<typeof stubPhaseDeps>['io'] } => {
+  const built = stubPhaseDeps({ replies, selfLogin: AGENT_LOGIN })
+  built.io.readContents[TASKS_PATH] = TASKS_MD
+  const steps = taskStepsFromCheckboxes(parseTaskCheckboxes(TASKS_MD))
+  const input: PhaseInput = {
+    state: reviewState({ stepsDone: from }),
+    issue: { number: 42, title: 'Add retries', body: 'b' },
+    trigger: issueTrigger(),
+    command: null,
+    thread: built.io.thread,
+    deps: built.deps,
+  }
+  const envelope = mintEnvelope()
+  return {
+    io: built.io,
+    run: () =>
+      walkPlanSteps({
+        input,
+        branch: 'agent/issue-42',
+        plan: TASKS_MD,
+        steps,
+        from,
+        envelope,
+        system: 'system prompt',
+        handoff: null,
+        tasksPath: TASKS_PATH,
+      }),
+  }
+}
+
+describe('walkPlanSteps · tasks.md checkboxes (D5)', () => {
+  it('walks each unchecked box: one turn, checks the box, commits, pushes — per step', async () => {
+    const { run, io } = makeWalk(['did tests', 'did impl'], 0)
+
+    const walk = await run()
+
+    expect(walk.kind).toBe('finished')
+    // Two model turns, two commits, two pushes (the checked box is skipped).
+    expect(io.prompts).toHaveLength(2)
+    expect(io.gitCalls.filter((c) => c.startsWith('commit:'))).toHaveLength(2)
+    expect(io.gitCalls.filter((c) => c.startsWith('push:'))).toHaveLength(2)
+    // The box-check: the last tasks.md write has both walked boxes ticked.
+    const lastTasksWrite = [...io.writes].reverse().find((w) => w.path === TASKS_PATH)
+    expect(lastTasksWrite?.content).toContain('- [x] 1.1 Write tests')
+    expect(lastTasksWrite?.content).toContain('- [x] 1.2 Implement')
+  })
+
+  it('checks exactly one box per step — the first write ticks only the first box', async () => {
+    const { run, io } = makeWalk(['did tests', 'did impl'], 0)
+
+    await run()
+
+    const firstWrite = io.writes.find((w) => w.path === TASKS_PATH)
+    expect(firstWrite?.content).toContain('- [x] 1.1 Write tests')
+    expect(firstWrite?.content).toContain('- [ ] 1.2 Implement')
+  })
+
+  it('resumes from the cursor — a run starting at step 2 walks only the remaining box', async () => {
+    const { run, io } = makeWalk(['did impl'], 1)
+
+    const walk = await run()
+
+    expect(walk.kind).toBe('finished')
+    expect(io.prompts).toHaveLength(1)
+    expect(walk.done).toBe(2)
+  })
+
+  it('the box-check uses checkBoxText (indented sub-items keep their indentation)', () => {
+    expect(checkBoxText('  - [ ] sub-task')).toBe('  - [x] sub-task')
+    expect(checkBoxText('- [ ] top')).toBe('- [x] top')
+  })
+})

--- a/tests/opencode-agent/index.test.ts
+++ b/tests/opencode-agent/index.test.ts
@@ -5,7 +5,7 @@
 
 import { afterAll, describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
@@ -60,6 +60,17 @@ const writeEvent = async (name: string, payload: unknown): Promise<string> => {
 
 const transcriptPath = (repoRoot: string): string => path.join(repoRoot, TRANSCRIPT_DIR, TRANSCRIPT_FILE)
 
+/**
+ * Gives a temp repoRoot an `openspec/` tree so the D10 probe reports compliant
+ * and the run proceeds past the stand-down door. These tests exercise the
+ * transcript lifecycle, not the probe, so they opt into the compliant path
+ * rather than plant the directory the probe would find on a real checkout.
+ */
+const compliantRoot = async (repoRoot: string): Promise<string> => {
+  await mkdir(path.join(repoRoot, 'openspec'), { recursive: true })
+  return repoRoot
+}
+
 /** A logger that records its lines, on a fixed clock so two runs compare equal. */
 const recording = (level: 'info' | 'warn', config: ReturnType<typeof loadConfig>): { log: Logger; lines: string[] } => {
   const lines: string[] = []
@@ -68,7 +79,7 @@ const recording = (level: 'info' | 'warn', config: ReturnType<typeof loadConfig>
 
 describe('runCli transcript lifecycle', () => {
   test('a keyless run warns exactly once and writes no file', async () => {
-    const repoRoot = path.join(workDir, 'keyless')
+    const repoRoot = await compliantRoot(path.join(workDir, 'keyless'))
     const eventPath = await writeEvent('keyless', BOT_EVENT)
     const config = loadConfig({ ...ENV }, repoRoot)
     const { log, lines } = recording('info', config)
@@ -85,7 +96,7 @@ describe('runCli transcript lifecycle', () => {
   })
 
   test('a keyed run leaves the transcript file and scrubs the key from the environment', async () => {
-    const repoRoot = path.join(workDir, 'keyed')
+    const repoRoot = await compliantRoot(path.join(workDir, 'keyed'))
     const eventPath = await writeEvent('keyed', BOT_EVENT)
     const live = { ...ENV, AGENT_LOG_KEY: KEY_B64 }
 
@@ -109,7 +120,7 @@ describe('runCli transcript lifecycle', () => {
     const eventPath = await writeEvent('identical', BOT_EVENT)
 
     const runWith = async (extra: Record<string, string>, name: string): Promise<string[]> => {
-      const repoRoot = path.join(workDir, name)
+      const repoRoot = await compliantRoot(path.join(workDir, name))
       const config = loadConfig({ ...ENV, ...extra }, repoRoot)
       const { log, lines } = recording('info', config)
       await runCli({

--- a/tests/opencode-agent/obra-skills.test.ts
+++ b/tests/opencode-agent/obra-skills.test.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+import path from 'node:path'
+
+import type { Logger } from '../../opencode-agent/src/logger.js'
+import { loadSkills, PHASE_SKILLS, stripFrontmatter } from '../../opencode-agent/src/obra-skills.js'
+import type { LoadSkillsOptions, ReadSkillFile } from '../../opencode-agent/src/obra-skills.js'
+import { PHASES } from '../../opencode-agent/src/types.js'
+
+/**
+ * The skill rewiring (design D4) and loader root precedence (D11).
+ *
+ * D4 routes the agent onto the repo's OpenSpec skills — `INIT_OR_CLARIFY` to
+ * `openspec-explore`, `PLANNING` to `openspec-propose` — and drops the retired
+ * `brainstorming` / `writing-plans` / `executing-plans` names. Execution skills
+ * (`test-driven-development`, `verification-before-completion`,
+ * `systematic-debugging`) stay on the apply layer.
+ *
+ * D11 orders the loader roots so in-repo OpenSpec trees win first: `.opencode/skills/`,
+ * then `.agents/skills/`, then the pinned superpowers roots. First-hit wins, so the
+ * openspec skills resolve from `.opencode/skills/` and the execution skills keep
+ * resolving from the pinned `.superpowers/` checkout.
+ */
+
+const RETIRED_SKILLS = ['brainstorming', 'writing-plans', 'executing-plans'] as const
+
+describe('PHASE_SKILLS (design D4)', () => {
+  it('routes INIT_OR_CLARIFY to openspec-explore and drops brainstorming', () => {
+    expect(PHASE_SKILLS.INIT_OR_CLARIFY.required).toContain('openspec-explore')
+    expect(PHASE_SKILLS.INIT_OR_CLARIFY.required).not.toContain('brainstorming')
+    expect([...PHASE_SKILLS.INIT_OR_CLARIFY.required, ...PHASE_SKILLS.INIT_OR_CLARIFY.optional]).not.toContain(
+      'writing-plans',
+    )
+  })
+
+  it('routes PLANNING to openspec-propose and drops writing-plans / executing-plans', () => {
+    expect(PHASE_SKILLS.PLANNING.required).toEqual(['openspec-propose'])
+    const all = [...PHASE_SKILLS.PLANNING.required, ...PHASE_SKILLS.PLANNING.optional]
+    expect(all).not.toContain('writing-plans')
+    expect(all).not.toContain('executing-plans')
+  })
+
+  it('keeps REVIEW_AND_MUTATE on the apply layer (TDD + verification)', () => {
+    expect(PHASE_SKILLS.REVIEW_AND_MUTATE.required).toContain('test-driven-development')
+    expect(PHASE_SKILLS.REVIEW_AND_MUTATE.optional).toContain('verification-before-completion')
+    const all = [...PHASE_SKILLS.REVIEW_AND_MUTATE.required, ...PHASE_SKILLS.REVIEW_AND_MUTATE.optional]
+    expect(all).not.toContain('executing-plans')
+  })
+
+  it('keeps CI_FIX on systematic-debugging', () => {
+    expect(PHASE_SKILLS.CI_FIX.required).toContain('systematic-debugging')
+  })
+
+  it('references none of the retired skill names anywhere in the table', () => {
+    for (const phase of PHASES) {
+      const entry = PHASE_SKILLS[phase]
+      const all = [...entry.required, ...entry.optional]
+      for (const retired of RETIRED_SKILLS) {
+        expect(all).not.toContain(retired)
+      }
+    }
+  })
+
+  it('references openspec-explore and openspec-propose (the repo OpenSpec skills)', () => {
+    const all = PHASES.flatMap((phase) => {
+      const entry = PHASE_SKILLS[phase]
+      return [...entry.required, ...entry.optional]
+    })
+    expect(all).toContain('openspec-explore')
+    expect(all).toContain('openspec-propose')
+  })
+})
+
+describe('loader root precedence (design D11)', () => {
+  /**
+   * A fake reader that "finds" a SKILL.md only at the paths given, returning
+   * frontmatter-bearing content. Mirrors what `loadOneSkill` does on disk
+   * without depending on which skill trees a given checkout has. Non-async with
+   * explicit Promises (the lint-clean shape this workspace's other fake takes).
+   */
+  const reader =
+    (files: Record<string, string>): ReadSkillFile =>
+    (filePath) => {
+      const content = files[filePath]
+      if (content === undefined) return Promise.reject(new Error('ENOENT'))
+      return Promise.resolve(content)
+    }
+
+  const options = (
+    repoRoot: string,
+    roots: readonly string[],
+    files: Record<string, string>,
+    log?: Logger,
+  ): LoadSkillsOptions => ({ repoRoot, roots, read: reader(files), ...(log === undefined ? {} : { log }) })
+
+  const skillPath = (root: string, name: string): string => path.join('/repo', root, name, 'SKILL.md')
+
+  it('resolves a skill from the first root that has it (first-hit wins)', async () => {
+    const roots = ['.opencode/skills', '.agents/skills', '.superpowers/skills']
+    // openspec-explore exists in both .opencode/skills and .agents/skills; the
+    // .opencode copy must win.
+    const files = {
+      [skillPath('.opencode/skills', 'openspec-explore')]: '---\nname: x\n---\nbody',
+      [skillPath('.agents/skills', 'openspec-explore')]: '---\nname: x\n---\nother',
+    }
+    const [doc] = await loadSkills(['openspec-explore'], options('/repo', roots, files))
+    expect(doc?.path).toBe(skillPath('.opencode/skills', 'openspec-explore'))
+  })
+
+  it('falls through to a later root when an earlier root does not have the skill', async () => {
+    const roots = ['.opencode/skills', '.agents/skills', '.superpowers/skills']
+    // An execution skill absent from the in-repo OpenSpec trees but present in
+    // the pinned superpowers checkout resolves from .superpowers/skills.
+    const files = { [skillPath('.superpowers/skills', 'test-driven-development')]: 'body' }
+    const [doc] = await loadSkills(['test-driven-development'], options('/repo', roots, files))
+    expect(doc?.path).toBe(skillPath('.superpowers/skills', 'test-driven-development'))
+  })
+
+  it('returns null (and logs) for a skill no root carries', async () => {
+    const roots = ['.opencode/skills', '.agents/skills']
+    const lines: string[] = []
+    const log: Logger = {
+      debug: () => {},
+      info: () => {},
+      warn: (_fields, message) => void lines.push(message),
+      error: () => {},
+    }
+    const docs = await loadSkills(['missing-skill'], options('/repo', roots, {}, log))
+    expect(docs).toEqual([])
+    expect(lines.some((line) => line.includes('not found'))).toBe(true)
+  })
+
+  it('treats an empty file as a miss and keeps walking', async () => {
+    const roots = ['.opencode/skills', '.agents/skills']
+    const files = {
+      [skillPath('.opencode/skills', 'x')]: '',
+      [skillPath('.agents/skills', 'x')]: 'real body',
+    }
+    const [doc] = await loadSkills(['x'], options('/repo', roots, files))
+    expect(doc?.path).toBe(skillPath('.agents/skills', 'x'))
+  })
+})
+
+describe('stripFrontmatter', () => {
+  it('drops a YAML frontmatter block and trims', () => {
+    expect(stripFrontmatter('---\nname: hi\ndescription: x\n---\nbody')).toBe('body')
+  })
+
+  it('leaves content without frontmatter untouched (trimmed)', () => {
+    expect(stripFrontmatter('just body')).toBe('just body')
+  })
+})

--- a/tests/opencode-agent/openai-config.test.ts
+++ b/tests/opencode-agent/openai-config.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import {
+  buildOpencodeConfig,
+  modelRef,
+  OPENAI_PROVIDER_ID,
+  PROPOSE_PERMISSION,
+  READ_ONLY_PERMISSION,
+  WRITE_PERMISSION,
+} from '../../opencode-agent/src/openai-config.js'
+import type { OpenAiSettings } from '../../opencode-agent/src/openai-config.js'
+
+/**
+ * Design D8 — the capability profile for artefact-writing turns.
+ *
+ * The drafter (PLANNING under the OpenSpec rework) gains `edit` on top of the
+ * read-only set, deny-by-default, with the diff guard's `outsidePrefix`
+ * confining what survives staging to `openspec/changes/<name>/`. No `bash`:
+ * composing artefacts is not running commands. These tests pin the profile's
+ * shape and its registration in the built config.
+ */
+
+const settings: OpenAiSettings = { apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1', model: 'gpt-5' }
+
+describe('PROPOSE_PERMISSION (D8)', () => {
+  it('is deny-by-default', () => {
+    expect(PROPOSE_PERMISSION['*']).toBe('deny')
+  })
+
+  it('grants edit on top of the read-only set', () => {
+    expect(PROPOSE_PERMISSION['edit']).toBe('allow')
+    expect(PROPOSE_PERMISSION['read']).toBe('allow')
+    expect(PROPOSE_PERMISSION['grep']).toBe('allow')
+  })
+
+  it('does not grant bash — composing artefacts is not running commands', () => {
+    expect(PROPOSE_PERMISSION['bash']).toBeUndefined()
+  })
+
+  it('is narrower than WRITE_PERMISSION (no bash, no external_directory)', () => {
+    expect(WRITE_PERMISSION['bash']).toBe('allow')
+    expect(WRITE_PERMISSION['external_directory']).toBe('allow')
+    expect(PROPOSE_PERMISSION['bash']).toBeUndefined()
+    expect(PROPOSE_PERMISSION['external_directory']).toBeUndefined()
+  })
+})
+
+describe('buildOpencodeConfig · propose agent registration', () => {
+  it('registers a propose agent with PROPOSE_PERMISSION', () => {
+    const config = buildOpencodeConfig(settings)
+    expect(config.agent?.['propose']?.permission).toEqual(PROPOSE_PERMISSION)
+  })
+
+  it('keeps plan read-only and build write-capable alongside it', () => {
+    const config = buildOpencodeConfig(settings)
+    expect(config.agent?.['plan']?.permission).toEqual(READ_ONLY_PERMISSION)
+    expect(config.agent?.['build']?.permission).toEqual(WRITE_PERMISSION)
+  })
+
+  it('pins the model reference the SDK and `opencode run` expect', () => {
+    const config = buildOpencodeConfig(settings)
+    expect(config.model).toBe(modelRef(settings))
+    expect(config.provider?.[OPENAI_PROVIDER_ID]?.models?.[settings.model]?.name).toBe(settings.model)
+  })
+})

--- a/tests/opencode-agent/openspec-driver.test.ts
+++ b/tests/opencode-agent/openspec-driver.test.ts
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import { createOpenSpecDriver } from '../../opencode-agent/src/openspec-driver.js'
+import type { OpenSpecDriverDeps } from '../../opencode-agent/src/openspec-driver.js'
+import type { CommandRunner, CommandResult } from '../../opencode-agent/src/shell.js'
+
+/**
+ * The OpenSpec CLI driver is the thin TypeScript seam over the `openspec`
+ * binary — the same division of labour the archived `sdd-runner` established
+ * (design D3): TypeScript owns the CLI protocol, the model composes artifact
+ * content. These tests pin the argv shape and the zod-decoded JSON contract.
+ */
+function fakeRunner(routes: Record<string, { stdout?: string; stderr?: string; exitCode?: number }>): {
+  runner: CommandRunner
+  calls: string[][]
+} {
+  const calls: string[][] = []
+  const runner: CommandRunner = (argv) => {
+    calls.push([...argv])
+    const key = argv.join(' ')
+    for (const [prefix, result] of Object.entries(routes)) {
+      if (key.includes(prefix)) {
+        const out: CommandResult = {
+          command: argv.join(' '),
+          stdout: result.stdout ?? '',
+          stderr: result.stderr ?? '',
+          exitCode: result.exitCode ?? 0,
+        }
+        return Promise.resolve(out)
+      }
+    }
+    return Promise.resolve({ command: argv.join(' '), stdout: '', stderr: `no route for: ${key}`, exitCode: 127 })
+  }
+  return { runner, calls }
+}
+
+const deps = (runner: CommandRunner, binary = 'openspec'): OpenSpecDriverDeps => ({ runner, cwd: '/repo', binary })
+
+const STATUS_JSON = JSON.stringify({
+  changeName: 'add-thing',
+  schemaName: 'spec-driven',
+  artifacts: [
+    { id: 'proposal', outputPath: 'proposal.md', status: 'done', requires: [] },
+    { id: 'specs', outputPath: 'specs/**/*.md', status: 'ready', requires: ['proposal'] },
+    { id: 'design', outputPath: 'design.md', status: 'blocked', requires: ['proposal'] },
+  ],
+  isPlanningComplete: false,
+})
+
+describe('openspec driver · newChange', () => {
+  it('runs `openspec new change <name> --schema <schema>` and returns the name', async () => {
+    const { runner, calls } = fakeRunner({ 'new change': { stdout: "Created change 'add-thing'\n" } })
+    const driver = createOpenSpecDriver(deps(runner))
+    const result = await driver.newChange('add-thing', 'spec-driven')
+    expect(result.changeName).toBe('add-thing')
+    expect(calls[0]).toEqual(['openspec', 'new', 'change', 'add-thing', '--schema', 'spec-driven'])
+  })
+
+  it('surfaces stderr when the CLI exits non-zero', async () => {
+    const { runner } = fakeRunner({ 'new change': { stderr: 'change already exists', exitCode: 1 } })
+    const driver = createOpenSpecDriver(deps(runner))
+    await expect(driver.newChange('add-thing', 'spec-driven')).rejects.toThrow(/already exists/u)
+  })
+})
+
+describe('openspec driver · status', () => {
+  it('parses artifact states into a typed map and surfaces planning completeness', async () => {
+    const { runner, calls } = fakeRunner({ 'status --change': { stdout: STATUS_JSON } })
+    const driver = createOpenSpecDriver(deps(runner))
+    const result = await driver.status('add-thing')
+    expect(result.artifacts).toEqual({ proposal: 'done', specs: 'ready', design: 'blocked' })
+    expect(result.schemaName).toBe('spec-driven')
+    expect(result.isPlanningComplete).toBe(false)
+    expect(calls[0]).toEqual(['openspec', 'status', '--change', 'add-thing', '--json'])
+  })
+
+  it('throws naming the command when the JSON is unparseable', async () => {
+    const { runner } = fakeRunner({ 'status --change': { stdout: 'not json' } })
+    const driver = createOpenSpecDriver(deps(runner))
+    await expect(driver.status('add-thing')).rejects.toThrow(/openspec status/u)
+  })
+
+  it('treats a missing isPlanningComplete as false rather than undefined', async () => {
+    const payload = JSON.stringify({
+      changeName: 'add-thing',
+      schemaName: 'spec-driven',
+      artifacts: [{ id: 'proposal', outputPath: 'proposal.md', status: 'done', requires: [] }],
+    })
+    const { runner } = fakeRunner({ 'status --change': { stdout: payload } })
+    const driver = createOpenSpecDriver(deps(runner))
+    const result = await driver.status('add-thing')
+    expect(result.isPlanningComplete).toBe(false)
+  })
+})
+
+describe('openspec driver · instructions', () => {
+  it('returns instruction, template, rules, output paths and dependencies for an artifact', async () => {
+    const payload = JSON.stringify({
+      instruction: 'Create the proposal.',
+      template: '## Why\n',
+      rules: ['Name the affected instances'],
+      resolvedOutputPath: '/repo/openspec/changes/add-thing/proposal.md',
+      existingOutputPaths: [],
+      dependencies: [],
+    })
+    const { runner, calls } = fakeRunner({ 'instructions proposal': { stdout: payload } })
+    const driver = createOpenSpecDriver(deps(runner))
+    const result = await driver.instructions('proposal', 'add-thing')
+    expect(result.instruction).toBe('Create the proposal.')
+    expect(result.template).toBe('## Why\n')
+    expect(result.rules).toEqual(['Name the affected instances'])
+    expect(result.resolvedOutputPath).toBe('/repo/openspec/changes/add-thing/proposal.md')
+    expect(calls[0]).toEqual(['openspec', 'instructions', 'proposal', '--change', 'add-thing', '--json'])
+  })
+
+  it('parses structured dependencies (the real CLI shape)', async () => {
+    const payload = JSON.stringify({
+      instruction: 'Create the specs.',
+      resolvedOutputPath: '/repo/openspec/changes/add-thing/specs/x/spec.md',
+      dependencies: [{ id: 'proposal', done: true, path: 'proposal.md', description: 'Initial proposal document' }],
+    })
+    const { runner } = fakeRunner({ 'instructions specs': { stdout: payload } })
+    const driver = createOpenSpecDriver(deps(runner))
+    const result = await driver.instructions('specs', 'add-thing')
+    expect(result.dependencies).toEqual([
+      { id: 'proposal', done: true, path: 'proposal.md', description: 'Initial proposal document' },
+    ])
+  })
+
+  it('defaults template/rules/paths to empty when the CLI omits them', async () => {
+    const payload = JSON.stringify({ instruction: 'Do the thing.', resolvedOutputPath: '/repo/x.md' })
+    const { runner } = fakeRunner({ 'instructions design': { stdout: payload } })
+    const driver = createOpenSpecDriver(deps(runner))
+    const result = await driver.instructions('design', 'add-thing')
+    expect(result.template).toBeUndefined()
+    expect(result.rules).toEqual([])
+    expect(result.existingOutputPaths).toEqual([])
+    expect(result.dependencies).toEqual([])
+  })
+})
+
+describe('openspec driver · validateStrict', () => {
+  it('reports ok and passes --strict', async () => {
+    const { runner, calls } = fakeRunner({ 'validate add-thing': { stdout: "Change 'add-thing' is valid\n" } })
+    const driver = createOpenSpecDriver(deps(runner))
+    const result = await driver.validateStrict('add-thing')
+    expect(result.ok).toBe(true)
+    expect(result.output).toContain('is valid')
+    expect(calls[0]).toEqual(['openspec', 'validate', 'add-thing', '--strict'])
+  })
+
+  it('reports not-ok with the complaint in `output` so the drafter retry can attach it', async () => {
+    const complaint = "Change 'add-thing' has issues\n\u2713 [ERROR] design.md: no deltas\n"
+    const { runner } = fakeRunner({ 'validate add-thing': { stdout: complaint, exitCode: 1 } })
+    const driver = createOpenSpecDriver(deps(runner))
+    const result = await driver.validateStrict('add-thing')
+    expect(result.ok).toBe(false)
+    expect(result.output).toContain('no deltas')
+  })
+
+  it('does not throw on a failing validation — the drafter owns the retry decision', async () => {
+    const { runner } = fakeRunner({ 'validate add-thing': { stderr: 'boom', exitCode: 2 } })
+    const driver = createOpenSpecDriver(deps(runner))
+    const result = await driver.validateStrict('add-thing')
+    expect(result.ok).toBe(false)
+    expect(result.output).toContain('boom')
+  })
+})
+
+describe('openspec driver · archive', () => {
+  it('runs `openspec archive <name>` for the merged-PR door (design D7)', async () => {
+    const { runner, calls } = fakeRunner({ 'archive add-thing': { stdout: "Archived 'add-thing'\n" } })
+    const driver = createOpenSpecDriver(deps(runner))
+    await driver.archive('add-thing')
+    expect(calls[0]).toEqual(['openspec', 'archive', 'add-thing'])
+  })
+
+  it('throws naming the command when archive fails', async () => {
+    const { runner } = fakeRunner({ 'archive add-thing': { stderr: 'not complete', exitCode: 1 } })
+    const driver = createOpenSpecDriver(deps(runner))
+    await expect(driver.archive('add-thing')).rejects.toThrow(/openspec archive/u)
+  })
+})
+
+describe('openspec driver · binary override', () => {
+  it('honours a non-default binary path', async () => {
+    const { runner, calls } = fakeRunner({ 'new change': { stdout: '' } })
+    const driver = createOpenSpecDriver(deps(runner, '/opt/openspec/bin/openspec'))
+    await driver.newChange('x', 'spec-driven')
+    const [invoked] = calls
+    expect(invoked?.[0]).toBe('/opt/openspec/bin/openspec')
+  })
+})

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -5,15 +5,7 @@
 
 import { beforeEach, describe, expect, test } from 'bun:test'
 
-import {
-  findArtifact,
-  findHandoff,
-  findPlan,
-  HANDOFF_MARKER,
-  PLAN_MARKER,
-  renderArtifact,
-  SPEC_MARKER,
-} from '../../opencode-agent/src/artifacts.js'
+import { findHandoff, HANDOFF_MARKER, renderArtifact } from '../../opencode-agent/src/artifacts.js'
 import { readBlock } from '../../opencode-agent/src/blocks.js'
 import type { IssueComment } from '../../opencode-agent/src/blocks.js'
 import { DEFAULT_CHECKS } from '../../opencode-agent/src/config.js'
@@ -55,6 +47,29 @@ const ISSUE = 42
 const RUN_NOW_MS = Date.UTC(2026, 7, 7, 14, 2)
 const BASE_BRANCH = 'trunk'
 const OPENING_TAG = /<untrusted_input source="[^"]*" id="([^"]+)">/u
+
+/**
+ * The change name every capture in this suite scaffolds, matching `SPEC_REPLY`.
+ * The folder is truth (design D1): the plan lives in `tasks.md` on the branch,
+ * not in an `AGENT_PLAN` block, so the harness seeds the folder rather than the
+ * thread wherever a previous job would already have drafted it.
+ */
+const CHANGE_NAME = 'add-retries'
+
+/** Resolved path of one artifact under the change folder, as the driver reports it. */
+const folderArtifactPath = (changeName: string, artifactId: string): string =>
+  `/repo/openspec/changes/${changeName}/${artifactId}.md`
+
+/** The folder's `tasks.md` — what `REVIEW_AND_MUTATE` walks and `/review` reads. */
+const TASKS_PATH = folderArtifactPath(CHANGE_NAME, 'tasks')
+
+/**
+ * A `tasks.md` of `count` unchecked boxes, the shape `REVIEW_AND_MUTATE` walks.
+ * Titles mirror the old `planReply` so a step-wise assertion can still tell
+ * which step a prompt is about.
+ */
+const tasksMarkdown = (count: number): string =>
+  Array.from({ length: count }, (_value, index) => `- [ ] Step ${index + 1} work`).join('\n')
 
 /** A newer state block for a different issue, as a comment edit could plant. */
 const PLANTED_STATE: AgentState = { ...initialState(7), phase: 'PLAN_REVIEW' }
@@ -220,6 +235,13 @@ interface PipelineIo {
   openspecStatus: import('../../opencode-agent/src/openspec-driver.js').StatusResult
   openspecInstructions: import('../../opencode-agent/src/openspec-driver.js').InstructionsResult
   openspecValidate: import('../../opencode-agent/src/openspec-driver.js').ValidateResult
+  /**
+   * The change folder's read surface (design D1). `writeFile` lands here and a
+   * later `readFile` of the same path answers it, so the folder is shared across
+   * the phases of one capture the way a branch's tree is shared across one job.
+   * Seeded directly by `seedTasks` for tests that fast-forward past planning.
+   */
+  readContents: Record<string, string>
   /** What `git` would report as the remote's default branch. */
   detectedBranch: string | null
   /**
@@ -391,6 +413,7 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
       dependencies: [],
     },
     openspecValidate: { ok: true, output: '' },
+    readContents: {},
   }
 
   let nextCommentId = 100
@@ -571,12 +594,20 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
     // the server reads what a closed server answers.
     tokensUsed: () => agent.tokensUsed(),
     skills: () => Promise.resolve([]),
-    writeFile: (_path: string, _content: string) => Promise.resolve(),
-    readFile: (_path: string) => Promise.resolve(''),
+    writeFile: (path: string, content: string): Promise<void> => {
+      // Recorded into the read surface so a later `readFile` of the same path
+      // answers what this run wrote — the folder is truth, and a handler that
+      // writes the proposal (triage) and one that reads it (/ask) share it.
+      io.readContents[path] = content
+      return Promise.resolve()
+    },
+    readFile: (path: string): Promise<string> => Promise.resolve(io.readContents[path] ?? ''),
     // The OpenSpec CLI driver fake (design D3). Records every call into `io` so
     // the capture/drafter/archive tests can assert the protocol; returns safe
     // defaults so a run that reaches it before its test sets up a canned
-    // response degrades rather than crashes.
+    // response degrades rather than crashes. `instructions` resolves a real
+    // per-artifact path under the change folder so the folder-read phases find
+    // the file `writeFile`/`seedTasks` placed there.
     openspec: {
       newChange: (changeName) => {
         io.openspecCalls.push(`newChange:${changeName}`)
@@ -588,7 +619,10 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
       },
       instructions: (artifactId, changeName) => {
         io.openspecCalls.push(`instructions:${artifactId}:${changeName}`)
-        return Promise.resolve(io.openspecInstructions)
+        return Promise.resolve({
+          ...io.openspecInstructions,
+          resolvedOutputPath: folderArtifactPath(changeName, artifactId),
+        })
       },
       validateStrict: (changeName) => {
         io.openspecCalls.push(`validate:${changeName}`)
@@ -680,21 +714,30 @@ const latestPostedState = (harness: Harness): AgentState | null => {
   return last === undefined ? null : extractState(last)
 }
 
-/** A state block an earlier job left on the thread, as a later job reads it back. */
+/**
+ * A state block an earlier job left on the thread, as a later job reads it back.
+ *
+ * `changeName` defaults to {@link CHANGE_NAME} because every state past
+ * `INIT_OR_CLARIFY` has been captured into that folder — a test seeding the
+ * opening phase passes `changeName: null` explicitly.
+ */
 const seedState = (harness: Harness, patch: Partial<AgentState>): void => {
-  const prior: AgentState = { ...initialState(ISSUE), ...patch }
+  const prior: AgentState = { ...initialState(ISSUE), changeName: CHANGE_NAME, ...patch }
   harness.io.thread.push({ id: 800, body: `earlier\n\n${serializeState(prior)}`, authorLogin: AGENT_LOGIN })
 }
 
 /**
- * An approved plan an earlier job left on the thread.
+ * The approved plan an earlier job drafted into the folder, as a later job reads
+ * it back from `tasks.md` (design D1 — the folder is truth).
  *
- * `CODE_REVIEW` reads it back the same way `REVIEW_AND_MUTATE` does — the review
- * loop is handed the plan, not the issue — so a seeded state alone is not enough
- * to reach that handler.
+ * `REVIEW_AND_MUTATE` walks these checkboxes and `CODE_REVIEW` reads the file
+ * verbatim, so a seeded state alone is not enough to reach either handler: the
+ * branch carries the plan, and the harness's read surface stands in for the
+ * branch. Defaults to a single step so a delivery test gets a one-turn
+ * implementation; step-wise tests pass their own.
  */
-const seedPlan = (harness: Harness, text = 'Write retry tests'): void => {
-  harness.io.thread.push({ id: 801, body: renderArtifact(PLAN_MARKER, text, 1), authorLogin: AGENT_LOGIN })
+const seedTasks = (harness: Harness, tasks = '- [ ] Write retry tests'): void => {
+  harness.io.readContents[TASKS_PATH] = `${tasks}\n`
 }
 
 /** Keeps the "did a run return a state?" narrowing out of the test bodies. */
@@ -729,30 +772,32 @@ const toDesignSpec = async (harness: Harness): Promise<void> => {
 }
 
 /**
- * A plan of `count` steps, as the planning turn reports it.
- *
- * The titles are numbered so a test can tell which step a prompt is about, which is
- * the whole assertion of a step-wise implementation.
+ * `tasks.md` content of `count` unchecked boxes, the shape `REVIEW_AND_MUTATE`
+ * walks (design D5). Titles mirror the old `planReply` so a step-wise assertion
+ * can still tell which step a prompt is about.
  */
-const planReply = (count: number): string =>
-  JSON.stringify({
-    steps: Array.from({ length: count }, (_value, index) => ({
-      title: `Step ${index + 1} work`,
-      files: [`src/step-${index + 1}.ts`],
-      verification: 'bun test',
-    })),
-    summary: `${count} steps.`,
-  })
+const tasksForSteps = (count: number): string => tasksMarkdown(count)
 
-/** Drives an issue as far as PLAN_REVIEW, optionally with a plan of several steps. */
-const toPlanReview = async (harness: Harness, plan: string = PLAN_REPLY): Promise<void> => {
+/**
+ * Drives an issue as far as PLAN_REVIEW and seeds the folder's `tasks.md`.
+ *
+ * The PLANNING drafter loop runs against the (empty) canned `openspec status`,
+ * finds nothing ready to draft, commits the scaffold and signals `PLAN_POSTED`;
+ * the plan content lives in `tasks.md`, which the harness seeds for whichever
+ * phase follows. `steps` controls how many checkboxes `REVIEW_AND_MUTATE` will
+ * walk (default one → a one-turn implementation, matching the pre-folder shape).
+ */
+const toPlanReview = async (harness: Harness, steps = 1): Promise<void> => {
   await toDesignSpec(harness)
-  harness.io.replies = [plan]
   await runPipeline({ event: comment('/approve'), deps: harness.deps })
+  seedTasks(harness, tasksForSteps(steps))
   harness.io.posted.length = 0
   harness.io.reactions.length = 0
   harness.io.reactionRemovals.length = 0
   harness.io.reactionLog.length = 0
+  // The scaffold commit (capture) and the drafter commit (PLANNING) are setup,
+  // not the phase under test — a delivery test counts implement's commits alone.
+  harness.io.gitCalls.length = 0
   harness.io.edits.length = 0
 }
 
@@ -800,20 +845,22 @@ describe('phase 1 — triage', () => {
     harness = makeHarness()
   })
 
-  test('posts a design spec and parks in DESIGN_SPEC', async () => {
+  test('captures the issue and parks in DESIGN_SPEC', async () => {
     harness.io.replies = [SPEC_REPLY]
 
     const result = await runPipeline({ event: issueEvent(), deps: harness.deps })
 
     expect(result.status).toBe('waiting')
-    expect(harness.io.posted[0]).toContain('### Design spec')
+    expect(harness.io.posted[0]).toContain('### Captured')
     expect(latestPostedState(harness)?.phase).toBe('DESIGN_SPEC')
+    expect(latestPostedState(harness)?.changeName).toBe(CHANGE_NAME)
   })
 
-  test('persists a spec whose markdown could forge the block delimiters', async () => {
+  test('persists a proposal whose markdown could forge the block delimiters', async () => {
     // Horizontal rules broke the original heading-scraping recovery; `-->`
-    // broke the block channel that replaced it. A real design spec contains
-    // both — a mermaid diagram is `A --> B`.
+    // broke the block channel that replaced it. A real proposal contains
+    // both — a mermaid diagram is `A --> B`. The folder write carries it
+    // verbatim, the way a later `/ask` or PLANNING turn reads it back.
     const spec = [
       '## Goal',
       '',
@@ -834,8 +881,9 @@ describe('phase 1 — triage', () => {
 
     await runPipeline({ event: issueEvent(), deps: harness.deps })
 
-    // Read it back the way a later job does, not by string surgery.
-    expect(findArtifact(harness.io.thread, AGENT_LOGIN, SPEC_MARKER)?.text).toBe(spec)
+    // The proposal lives in the folder now (design D1), written verbatim —
+    // read back the way a later `/ask` does, not by scraping the comment.
+    expect(harness.io.readContents[folderArtifactPath(CHANGE_NAME, 'proposal')]).toBe(`${spec}\n`)
     expect(latestPostedState(harness)?.phase).toBe('DESIGN_SPEC')
   })
 
@@ -936,7 +984,7 @@ describe('chatter while the agent is clarifying', () => {
 
     expect(result.status).toBe('waiting')
     expect(String(harness.io.prompts[0]?.prompt)).toContain('Classify this comment')
-    expect(harness.io.posted[0]).toContain('### Design spec')
+    expect(harness.io.posted[0]).toContain('### Captured')
     expect(latestPostedState(harness)?.phase).toBe('DESIGN_SPEC')
   })
 
@@ -950,7 +998,7 @@ describe('chatter while the agent is clarifying', () => {
     const result = await runPipeline({ event: comment('The HTTP client.'), deps: harness.deps })
 
     expect(result.status).toBe('waiting')
-    expect(harness.io.posted[0]).toContain('### Design spec')
+    expect(harness.io.posted[0]).toContain('### Captured')
     expect(latestPostedState(harness)?.phase).toBe('DESIGN_SPEC')
   })
 
@@ -1002,7 +1050,7 @@ describe('review conversation', () => {
     expect(String(harness.io.prompts.at(-1)?.prompt)).toContain('why that file?')
   })
 
-  test('/changes revises the spec and reports a new revision', async () => {
+  test('/changes revises the proposal in the folder and re-captures', async () => {
     harness.io.replies = [
       JSON.stringify({ status: 'capture', changeName: 'add-retries', spec: 'Use the existing helper.' }),
     ]
@@ -1010,7 +1058,10 @@ describe('review conversation', () => {
     const result = await runPipeline({ event: comment('/changes use the existing helper'), deps: harness.deps })
 
     expect(result.status).toBe('waiting')
-    expect(harness.io.posted[0]).toContain('Design spec (revision 2)')
+    expect(harness.io.posted[0]).toContain('### Captured')
+    // The revised proposal landed in the folder (design D1) — the comment names
+    // it, and a later `/ask` or PLANNING turn reads it back from there.
+    expect(harness.io.readContents[folderArtifactPath(CHANGE_NAME, 'proposal')]).toContain('Use the existing helper.')
     expect(latestPostedState(harness)?.phase).toBe('DESIGN_SPEC')
   })
 
@@ -1038,7 +1089,8 @@ describe('review conversation', () => {
 
     await runPipeline({ event: comment('please use the existing helper instead'), deps: harness.deps })
 
-    expect(harness.io.posted[0]).toContain('Design spec (revision 2)')
+    expect(harness.io.posted[0]).toContain('### Captured')
+    expect(harness.io.readContents[folderArtifactPath(CHANGE_NAME, 'proposal')]).toContain('revised')
   })
 
   test('a plain comment classified as approval proceeds to planning', async () => {
@@ -1154,14 +1206,19 @@ describe('plan review gate', () => {
 
   test('/approve on the spec stops at the plan rather than implementing', async () => {
     await toDesignSpec(harness)
-    harness.io.replies = [PLAN_REPLY]
 
     const result = await runPipeline({ event: comment('/approve'), deps: harness.deps })
 
     expect(result.status).toBe('waiting')
     expect(headings(harness)).toEqual(['### Plan (revision 1)'])
     expect(latestPostedState(harness)?.phase).toBe('PLAN_REVIEW')
-    expect(harness.io.gitCalls).toEqual([`ensureBranch:agent/issue-${ISSUE}:${BASE_BRANCH}`])
+    // PLANNING drafts onto the branch and pushes (design D2): the artefacts
+    // survive the job because they are committed, not carried in a block.
+    expect(harness.io.gitCalls).toEqual([
+      `ensureBranch:agent/issue-${ISSUE}:${BASE_BRANCH}`,
+      `commit:docs(openspec): draft artifacts for ${CHANGE_NAME}`,
+      `push:agent/issue-${ISSUE}`,
+    ])
   })
 
   test('/changes on the plan re-plans without touching the spec', async () => {
@@ -1202,7 +1259,6 @@ describe('artefact revision numbering', () => {
 
   test('the first plan is revision 1', async () => {
     await toDesignSpec(harness)
-    harness.io.replies = [PLAN_REPLY]
 
     await runPipeline({ event: comment('/approve'), deps: harness.deps })
 
@@ -1211,36 +1267,30 @@ describe('artefact revision numbering', () => {
   })
 
   test('revising the spec twice still leaves the first plan at revision 1', async () => {
+    // The proposal lives in the folder now (design D1), so a spec revision is a
+    // re-capture that re-writes `proposal.md` — it never bumps the plan-identity
+    // token. What survives the rework is the invariant these tests existed for:
+    // spec edits and the plan counter are independent.
     await toDesignSpec(harness)
     harness.io.replies = [JSON.stringify({ status: 'capture', changeName: 'add-retries', spec: 'Second attempt.' })]
     await runPipeline({ event: comment('/changes use the existing helper'), deps: harness.deps })
     harness.io.replies = [JSON.stringify({ status: 'capture', changeName: 'add-retries', spec: 'Third attempt.' })]
     await runPipeline({ event: comment('/changes name the helper'), deps: harness.deps })
-
-    expect(harness.io.posted.at(-1)).toContain('### Design spec (revision 3)')
+    expect(latestPostedState(harness)?.planRevision).toBe(0)
 
     harness.io.posted.length = 0
-    harness.io.replies = [PLAN_REPLY]
     await runPipeline({ event: comment('/approve'), deps: harness.deps })
 
     expect(harness.io.posted[0]).toContain('### Plan (revision 1)')
     expect(latestPostedState(harness)).toMatchObject({ planRevision: 1 })
-    // The spec block keeps its own revision in the thread (the folder's history
-    // under the full D1 rework); the state block no longer carries a spec counter.
-    expect(findArtifact(harness.io.thread, AGENT_LOGIN, SPEC_MARKER)?.revision).toBe(3)
   })
 
   test('revising the plan reaches revision 2 while the spec stays where it was', async () => {
     await toPlanReview(harness)
-    harness.io.replies = [PLAN_REPLY]
 
     await runPipeline({ event: comment('/changes split step 1'), deps: harness.deps })
 
     expect(harness.io.posted[0]).toContain('### Plan (revision 2)')
-    // Read back the way the next job does: the hidden block's `revision` is
-    // written from the same local as the heading, so they cannot disagree.
-    expect(findArtifact(harness.io.thread, AGENT_LOGIN, PLAN_MARKER)?.revision).toBe(2)
-    expect(findArtifact(harness.io.thread, AGENT_LOGIN, SPEC_MARKER)?.revision).toBe(1)
     expect(latestPostedState(harness)).toMatchObject({ planRevision: 2 })
   })
 })
@@ -1495,7 +1545,9 @@ describe('implementation and delivery', () => {
   test('persists the plan so a later job reads it back verbatim', async () => {
     await runPipeline({ event: comment('/approve'), deps: harness.deps })
 
-    expect(harness.io.thread.some((entry) => entry.body.includes(PLAN_MARKER))).toBe(true)
+    // The plan lives in `tasks.md` on the branch (design D1): a later job reads
+    // it back from the folder, not from a block on the issue.
+    expect(harness.io.readContents[TASKS_PATH]).toContain('Step 1 work')
   })
 })
 
@@ -1542,7 +1594,9 @@ describe('/review — the review loop as a command', () => {
   test('hands the loop the approved plan, not the issue body', async () => {
     await runPipeline({ event: comment('/review'), deps: harness.deps })
 
-    expect(harness.io.reviewCalls[0]).toContain('Write retry tests')
+    // The loop reads the plan from the folder's `tasks.md` verbatim (design D1)
+    // — the step the implementation walked, not the issue body the plan came from.
+    expect(harness.io.reviewCalls[0]).toContain('Step 1 work')
   })
 
   test('refreshes the pull request with what the review found', async () => {
@@ -1697,7 +1751,7 @@ describe('/review — where it does not apply', () => {
   test('raising the ceiling makes the refused review run, which is what makes the notice honest', async () => {
     harness = makeHarness({ maxReviewAttempts: 2 })
     seedState(harness, { phase: 'COMPLETE', prUrl: 'https://example.test/pull/7', prNumber: 7, reviewAttempts: 2 })
-    seedPlan(harness)
+    seedTasks(harness)
     await runPipeline({ event: comment('/review'), deps: harness.deps })
 
     harness.deps.config.maxReviewAttempts = 3
@@ -2355,7 +2409,7 @@ describe('commands and budgets', () => {
 
     expect(result.status).toBe('waiting')
     expect(result.state?.phase).toBe('DESIGN_SPEC')
-    expect(harness.io.posted.at(-1)).toContain('### Design spec')
+    expect(harness.io.posted.at(-1)).toContain('### Captured')
   })
 
   test('a single malformed reply is repaired rather than failing the run', async () => {
@@ -2367,7 +2421,7 @@ describe('commands and budgets', () => {
     const result = await runPipeline({ event: issueEvent(), deps: harness.deps })
 
     expect(result.status).toBe('waiting')
-    expect(harness.io.posted.at(-1)).toContain('### Design spec')
+    expect(harness.io.posted.at(-1)).toContain('### Captured')
     expect(harness.io.prompts).toHaveLength(2)
     expect(String(harness.io.prompts[1]?.prompt)).toContain('could not be used')
   })
@@ -2392,7 +2446,7 @@ describe('commands and budgets', () => {
     const result = await runPipeline({ event: comment('/retry'), deps: harness.deps })
 
     expect(result.status).toBe('waiting')
-    expect(harness.io.posted[0]).toContain('### Design spec')
+    expect(harness.io.posted[0]).toContain('### Captured')
   })
 
   test('an exhausted retry budget is reported on the issue, not swallowed', async () => {
@@ -2489,7 +2543,7 @@ describe('the retry budget', () => {
     const result = await runPipeline({ event: comment('/retry'), deps: harness.deps })
 
     expect(result.status).toBe('waiting')
-    expect(harness.io.posted.at(-1)).toContain('### Design spec')
+    expect(harness.io.posted.at(-1)).toContain('### Captured')
     expect(latestPostedState(harness)?.phase).toBe('DESIGN_SPEC')
   })
 
@@ -2554,8 +2608,10 @@ describe('the token budget', () => {
     harness.io.tokensUsed = 900
     harness.io.replies = [SPEC_REPLY]
     await runPipeline({ event: issueEvent(), deps: harness.deps })
-    harness.io.replies = [PLAN_REPLY]
     const planned = await runPipeline({ event: comment('/approve'), deps: harness.deps })
+    // The drafter wrote `tasks.md` onto the branch; seed it for the implement
+    // run that follows, the way the working tree carries it across jobs.
+    seedTasks(harness)
     harness.io.posted.length = 0
 
     const result = await runPipeline({ event: comment('/approve'), deps: harness.deps })
@@ -3545,7 +3601,7 @@ describe('implementing the plan a step at a time', () => {
     // An Actions working tree dies with the job, so a commit nobody pushed until the
     // end of the phase is a commit the job's death takes with it.
     const harness = makeHarness()
-    await toPlanReview(harness, planReply(3))
+    await toPlanReview(harness, 3)
     harness.io.prompts.length = 0
     harness.io.replies = ['one', 'two', 'three']
 
@@ -3564,7 +3620,7 @@ describe('implementing the plan a step at a time', () => {
 
   test('asks for one step at a time, naming which', async () => {
     const harness = makeHarness()
-    await toPlanReview(harness, planReply(3))
+    await toPlanReview(harness, 3)
     harness.io.prompts.length = 0
     harness.io.replies = ['one', 'two', 'three']
 
@@ -3583,7 +3639,7 @@ describe('implementing the plan a step at a time', () => {
     // one commit per phase and is a three-fold under-report now. It means "lines this
     // run's implementation committed, across its steps".
     const harness = makeHarness()
-    await toPlanReview(harness, planReply(3))
+    await toPlanReview(harness, 3)
     harness.io.replies = ['one', 'two', 'three']
 
     await runPipeline({ event: comment('/approve'), deps: harness.deps })
@@ -3595,7 +3651,7 @@ describe('implementing the plan a step at a time', () => {
     // Each step is guarded and committed on its own, so a step whose turn touched no
     // file is an ordinary outcome — the plan is not finished, and the run carries on.
     const harness = makeHarness()
-    await toPlanReview(harness, planReply(2))
+    await toPlanReview(harness, 2)
     harness.io.replies = ['nothing to do', 'two']
     cleanFirstCommit(harness)
 
@@ -3607,19 +3663,20 @@ describe('implementing the plan a step at a time', () => {
     expect(latestPostedState(harness)?.changedLines).toBe(7)
   })
 
-  test('a plan with no steps runs in one turn, exactly as before steps existed', async () => {
-    // Live issues carry plans approved before this stage, and the fallback is
-    // permanent: nothing can invent steps for a document a maintainer signed off on.
+  test('a tasks.md with no unchecked boxes fails fast rather than running a phantom turn', async () => {
+    // Under D5 the plan is `tasks.md`; a folder whose tasks are all done (or one
+    // that has none) is a malformed change, not a plan to run in one turn. The
+    // walk finds nothing to do and the phase reports noChanges — the same
+    // verdict a plan whose every step committed nothing reaches — rather than
+    // paying for a model turn over an empty document.
     const harness = makeHarness()
     seedState(harness, { phase: 'PLAN_REVIEW', planRevision: 1 })
-    seedPlan(harness)
-    harness.io.replies = ['Implemented.']
+    seedTasks(harness, '- [x] already done\n')
 
-    await runPipeline({ event: comment('/approve'), deps: harness.deps })
+    const result = await runPipeline({ event: comment('/approve'), deps: harness.deps })
 
-    expect(harness.io.prompts).toHaveLength(1)
-    expect(harness.io.prompts[0]?.prompt).not.toContain('step 1 of')
-    expect(writes(harness)).toEqual([`commit:feat(agent): implement issue #${ISSUE}`, `push:agent/issue-${ISSUE}`])
+    expect(result.status).toBe('failed')
+    expect(harness.io.prompts).toHaveLength(0)
   })
 
   test('stops cleanly between steps rather than starting one it cannot finish', async () => {
@@ -3627,7 +3684,7 @@ describe('implementing the plan a step at a time', () => {
     // cascade's own check would have let this through — and not enough for another
     // step, which is exactly the window where a step would be cut off mid-file.
     const harness = withClock(40 * MINUTE)
-    await toPlanReview(harness, planReply(3))
+    await toPlanReview(harness, 3)
     harness.io.prompts.length = 0
     harness.io.replies = ['one', 'two', 'three']
     burnClockOnPush(harness, 36 * MINUTE)
@@ -3656,7 +3713,7 @@ describe('implementing the plan a step at a time', () => {
     // The cursor is why the park costs nothing: without it a continuation would redo
     // the steps already on the branch, paying for them twice.
     const harness = withClock(40 * MINUTE)
-    await toPlanReview(harness, planReply(3))
+    await toPlanReview(harness, 3)
     harness.io.replies = ['one', 'two', 'three']
     burnClockOnPush(harness, 36 * MINUTE)
     await runPipeline({ event: comment('/approve'), deps: harness.deps })
@@ -3683,7 +3740,7 @@ describe('implementing the plan a step at a time', () => {
     // Stage 2's path, now with a step to name. The handoff is an account of one step
     // rather than of a whole plan, so the prompt that asks for it has to say which.
     const harness = makeHarness({ wrapUpMs: 30_000 })
-    await toPlanReview(harness, planReply(3))
+    await toPlanReview(harness, 3)
     harness.io.prompts.length = 0
     harness.io.promptFailures = [null, turnDeadlineError(1_800_000, PROGRESS)]
     harness.io.replies = ['one', HANDOFF]
@@ -3709,9 +3766,8 @@ describe('implementing the plan a step at a time', () => {
     // so a cursor carried across would skip work nobody has done — the same argument
     // that retires the handoff on a plan revision.
     const harness = makeHarness()
-    await toPlanReview(harness, planReply(3))
+    await toPlanReview(harness, 3)
     seedState(harness, { phase: 'PLAN_REVIEW', planRevision: 1, stepsDone: 4 })
-    harness.io.replies = [planReply(2)]
 
     await runPipeline({ event: comment('/changes make it smaller'), deps: harness.deps })
 
@@ -3725,7 +3781,7 @@ describe('implementing the plan a step at a time', () => {
     // it is about. Carried further it would arrive as a report about finished work,
     // framed as context for work that has not started.
     const harness = makeHarness({ wrapUpMs: 30_000 })
-    await toPlanReview(harness, planReply(3))
+    await toPlanReview(harness, 3)
     harness.io.promptFailures = [outOfTime()]
     harness.io.replies = [HANDOFF]
     await runPipeline({ event: comment('/approve'), deps: harness.deps })
@@ -3746,7 +3802,7 @@ describe('implementing the plan a step at a time', () => {
     // the same conclusion. Walking from the top is recoverable: the finished steps
     // commit nothing and the run carries on.
     const harness = makeHarness()
-    await toPlanReview(harness, planReply(2))
+    await toPlanReview(harness, 2)
     seedState(harness, { phase: 'PLAN_REVIEW', planRevision: 1, stepsDone: 99 })
     harness.io.prompts.length = 0
     harness.io.replies = ['one', 'two']
@@ -3758,15 +3814,14 @@ describe('implementing the plan a step at a time', () => {
   })
 
   test('the plan comment a maintainer approves lists the steps the run will walk', async () => {
-    // One value renders the comment and fills the block, so the plan somebody
-    // approved and the steps the implementation walks cannot disagree.
+    // The plan the maintainer approves and the steps the implementation walks are
+    // one value now: `tasks.md` in the folder (design D5). The comment points at
+    // the folder; the steps live there, so the two cannot disagree.
     const harness = makeHarness()
-    await toPlanReview(harness, planReply(2))
+    await toPlanReview(harness, 2)
 
-    const posted = harness.io.thread.map((entry) => entry.body).join('\n')
-    expect(posted).toContain('1. **Step 1 work**')
-    expect(posted).toContain('2. **Step 2 work**')
-    expect(findPlan(harness.io.thread, AGENT_LOGIN)?.steps).toHaveLength(2)
+    expect(harness.io.readContents[TASKS_PATH]).toContain('Step 1 work')
+    expect(harness.io.readContents[TASKS_PATH]).toContain('Step 2 work')
   })
 
   test('tells the model a clock may stop it, without depending on the answer', async () => {
@@ -3774,7 +3829,7 @@ describe('implementing the plan a step at a time', () => {
     // only biases a turn toward leaving the tree committable. Every bound that
     // matters is enforced outside the model.
     const harness = makeHarness()
-    await toPlanReview(harness, planReply(2))
+    await toPlanReview(harness, 2)
     harness.io.prompts.length = 0
     harness.io.replies = ['one', 'two']
 
@@ -3893,7 +3948,7 @@ describe('a commit the repository refuses', () => {
 
   test('repairs each refused step of a plan on its own', async () => {
     const harness = makeHarness()
-    await toPlanReview(harness, planReply(2))
+    await toPlanReview(harness, 2)
     harness.io.prompts.length = 0
     harness.io.replies = ['one', 'fixed one', 'two', 'fixed two']
     // Every commit is refused once: step 1, its repair, step 2, its repair.
@@ -4104,10 +4159,12 @@ describe('reactions — the acknowledgement does not outlive the run', () => {
 
   test('😕 replaces it when the run breaks', async () => {
     const harness = makeHarness()
-    await toDesignSpec(harness)
-    harness.io.replies = ['not json at all']
+    // A malformed triage reply breaks the run: triage asks via `promptForJson`
+    // (which re-asks once), so two non-JSON replies fail the phase. PLANNING no
+    // longer prompts for a plan, so the break has to be upstream of it.
+    harness.io.replies = ['not json at all', 'still not json']
 
-    const result = await runPipeline({ event: comment('/approve'), deps: harness.deps })
+    const result = await runPipeline({ event: issueEvent(), deps: harness.deps })
 
     expect(result.status).toBe('failed')
     expect(reactionsOf(harness)).toEqual(['eyes', 'confused'])

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -571,6 +571,7 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
     // the server reads what a closed server answers.
     tokensUsed: () => agent.tokensUsed(),
     skills: () => Promise.resolve([]),
+    writeFile: (_path: string, _content: string) => Promise.resolve(),
     // The OpenSpec CLI driver fake (design D3). Records every call into `io` so
     // the capture/drafter/archive tests can assert the protocol; returns safe
     // defaults so a run that reaches it before its test sets up a canned

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -537,6 +537,14 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
       io.gitCalls.push(`ensureBranch:${branch}:${base}`)
       return Promise.resolve()
     },
+    resetBranchToBase: (branch, base) => {
+      io.gitCalls.push(`ensureBranch:${branch}:${base}`)
+      return Promise.resolve()
+    },
+    deleteRemoteBranch: (branch) => {
+      io.gitCalls.push(`deleteRemoteBranch:${branch}`)
+      return Promise.resolve()
+    },
     commitAll: (message) => {
       io.gitCalls.push(`commit:${message.split('\n')[0]}`)
       return Promise.resolve(io.committedTotals)
@@ -661,6 +669,8 @@ const hostileGit = (): Git => {
 
   return {
     ensureBranch: (): Promise<void> => refuse('ensureBranch'),
+    resetBranchToBase: (): Promise<void> => refuse('resetBranchToBase'),
+    deleteRemoteBranch: (): Promise<void> => refuse('deleteRemoteBranch'),
     commitAll: (): Promise<StagedTotals | null> => refuse('commit'),
     salvageAll: (): Promise<Salvage> => refuse('salvage'),
     push: (): Promise<void> => refuse('push'),
@@ -2325,11 +2335,15 @@ describe('commands and budgets', () => {
     expect(cancelled.status).toBe('completed')
     expect(harness.io.posted).toHaveLength(1)
     expect(latestPostedState(harness)?.phase).toBe('COMPLETE')
+    // D9 — /cancel deletes the agent branch (the mis-capture's work is gone).
+    expect(harness.io.gitCalls).toContain('deleteRemoteBranch:agent/issue-42')
 
     harness.io.posted.length = 0
+    harness.io.gitCalls.length = 0
     const after = await runPipeline({ event: comment('/approve'), deps: harness.deps })
 
     expect(after.status).toBe('skipped')
+    // The /approve alone produces no git work — the cancel is durable.
     expect(harness.io.gitCalls).toEqual([])
   })
 

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -215,6 +215,11 @@ interface PipelineIo {
   reviewCalls: string[]
   /** What `runReview` rejects with, when set: the loop crashing rather than exiting red. */
   reviewError: Error | null
+  /** OpenSpec CLI driver call log + canned responses (design D3). */
+  openspecCalls: string[]
+  openspecStatus: import('../../opencode-agent/src/openspec-driver.js').StatusResult
+  openspecInstructions: import('../../opencode-agent/src/openspec-driver.js').InstructionsResult
+  openspecValidate: import('../../opencode-agent/src/openspec-driver.js').ValidateResult
   /** What `git` would report as the remote's default branch. */
   detectedBranch: string | null
   /**
@@ -370,6 +375,18 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
     statusError: null,
     postError: null,
     nowMs: RUN_NOW_MS,
+    // OpenSpec driver fakes (design D3): safe defaults, overridden per-test.
+    openspecCalls: [],
+    openspecStatus: { schemaName: 'spec-driven', artifacts: {}, isPlanningComplete: false },
+    openspecInstructions: {
+      instruction: '',
+      template: undefined,
+      rules: [],
+      resolvedOutputPath: '',
+      existingOutputPaths: [],
+      dependencies: [],
+    },
+    openspecValidate: { ok: true, output: '' },
   }
 
   let nextCommentId = 100
@@ -550,6 +567,32 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
     // the server reads what a closed server answers.
     tokensUsed: () => agent.tokensUsed(),
     skills: () => Promise.resolve([]),
+    // The OpenSpec CLI driver fake (design D3). Records every call into `io` so
+    // the capture/drafter/archive tests can assert the protocol; returns safe
+    // defaults so a run that reaches it before its test sets up a canned
+    // response degrades rather than crashes.
+    openspec: {
+      newChange: (changeName) => {
+        io.openspecCalls.push(`newChange:${changeName}`)
+        return Promise.resolve({ changeName })
+      },
+      status: (changeName) => {
+        io.openspecCalls.push(`status:${changeName}`)
+        return Promise.resolve(io.openspecStatus)
+      },
+      instructions: (artifactId, changeName) => {
+        io.openspecCalls.push(`instructions:${artifactId}:${changeName}`)
+        return Promise.resolve(io.openspecInstructions)
+      },
+      validateStrict: (changeName) => {
+        io.openspecCalls.push(`validate:${changeName}`)
+        return Promise.resolve(io.openspecValidate)
+      },
+      archive: (changeName) => {
+        io.openspecCalls.push(`archive:${changeName}`)
+        return Promise.resolve()
+      },
+    },
     baseBranch: () => Promise.resolve(BASE_BRANCH),
     selfLogin: () => Promise.resolve(AGENT_LOGIN),
     // The same clock the status reporter reads, so a test that moves time moves it
@@ -1000,7 +1043,9 @@ describe('review conversation', () => {
 
     expect(result.status).toBe('waiting')
     expect(harness.io.posted[0]).toContain('### Answer')
-    expect(latestPostedState(harness)?.specRevision).toBe(1)
+    // Answering is phase-neutral and rewrites no artefact: it stays in DESIGN_SPEC
+    // (where the captured proposal is under review) rather than re-planning.
+    expect(latestPostedState(harness)?.phase).toBe('DESIGN_SPEC')
   })
 })
 
@@ -1113,7 +1158,7 @@ describe('plan review gate', () => {
     await runPipeline({ event: comment('/changes split step 1'), deps: harness.deps })
 
     expect(harness.io.posted[0]).toContain('### Plan (revision 2)')
-    expect(latestPostedState(harness)).toMatchObject({ phase: 'PLAN_REVIEW', specRevision: 1, planRevision: 2 })
+    expect(latestPostedState(harness)).toMatchObject({ phase: 'PLAN_REVIEW', planRevision: 2 })
   })
 
   test('/approve on the plan cascades through implementation and delivery', async () => {
@@ -1149,7 +1194,7 @@ describe('artefact revision numbering', () => {
     await runPipeline({ event: comment('/approve'), deps: harness.deps })
 
     expect(harness.io.posted[0]).toContain('### Plan (revision 1)')
-    expect(latestPostedState(harness)).toMatchObject({ specRevision: 1, planRevision: 1 })
+    expect(latestPostedState(harness)).toMatchObject({ planRevision: 1 })
   })
 
   test('revising the spec twice still leaves the first plan at revision 1', async () => {
@@ -1166,7 +1211,10 @@ describe('artefact revision numbering', () => {
     await runPipeline({ event: comment('/approve'), deps: harness.deps })
 
     expect(harness.io.posted[0]).toContain('### Plan (revision 1)')
-    expect(latestPostedState(harness)).toMatchObject({ specRevision: 3, planRevision: 1 })
+    expect(latestPostedState(harness)).toMatchObject({ planRevision: 1 })
+    // The spec block keeps its own revision in the thread (the folder's history
+    // under the full D1 rework); the state block no longer carries a spec counter.
+    expect(findArtifact(harness.io.thread, AGENT_LOGIN, SPEC_MARKER)?.revision).toBe(3)
   })
 
   test('revising the plan reaches revision 2 while the spec stays where it was', async () => {
@@ -1180,28 +1228,7 @@ describe('artefact revision numbering', () => {
     // written from the same local as the heading, so they cannot disagree.
     expect(findArtifact(harness.io.thread, AGENT_LOGIN, PLAN_MARKER)?.revision).toBe(2)
     expect(findArtifact(harness.io.thread, AGENT_LOGIN, SPEC_MARKER)?.revision).toBe(1)
-    expect(latestPostedState(harness)).toMatchObject({ specRevision: 1, planRevision: 2 })
-  })
-
-  test('a state block written before the counters split still drives the pipeline', async () => {
-    // Both fields default, so the split needed no `STATE_VERSION` bump and this
-    // issue is not stranded mid-conversation. What it loses is the old shared
-    // count, which was a sum of two artefacts and never the count of either —
-    // so its plan starts at 1, which is the number this change exists to make
-    // true.
-    const legacy = `<!-- ${STATE_MARKER}: {"v":2,"phase":"DESIGN_SPEC","issueId":${ISSUE},"revision":3} -->`
-    harness.io.thread.push({
-      id: 800,
-      body: [`earlier`, legacy, renderArtifact(SPEC_MARKER, 'Add a retry wrapper around fetch.', 3)].join('\n\n'),
-      authorLogin: AGENT_LOGIN,
-    })
-    harness.io.replies = [PLAN_REPLY]
-
-    const result = await runPipeline({ event: comment('/approve'), deps: harness.deps })
-
-    expect(result.status).toBe('waiting')
-    expect(harness.io.posted[0]).toContain('### Plan (revision 1)')
-    expect(latestPostedState(harness)).toMatchObject({ phase: 'PLAN_REVIEW', specRevision: 0, planRevision: 1 })
+    expect(latestPostedState(harness)).toMatchObject({ planRevision: 2 })
   })
 })
 

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -717,10 +717,12 @@ const toDesignSpec = async (harness: Harness): Promise<void> => {
   harness.io.posted.length = 0
   // Reactions and status edits too: these helpers exist to put an issue in a
   // starting position, and what the setup runs acknowledged is not part of the
-  // test that follows.
+  // test that follows. Git calls too — capture now branches and pushes the
+  // scaffold (D2), which is setup, not the phase under test.
   harness.io.reactions.length = 0
   harness.io.reactionRemovals.length = 0
   harness.io.reactionLog.length = 0
+  harness.io.gitCalls.length = 0
   harness.io.edits.length = 0
 }
 

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -572,6 +572,7 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
     tokensUsed: () => agent.tokensUsed(),
     skills: () => Promise.resolve([]),
     writeFile: (_path: string, _content: string) => Promise.resolve(),
+    readFile: (_path: string) => Promise.resolve(''),
     // The OpenSpec CLI driver fake (design D3). Records every call into `io` so
     // the capture/drafter/archive tests can assert the protocol; returns safe
     // defaults so a run that reaches it before its test sets up a canned

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -325,7 +325,11 @@ interface Harness {
   io: PipelineIo
 }
 
-const SPEC_REPLY = JSON.stringify({ status: 'spec', spec: 'Add a retry wrapper around fetch.' })
+const SPEC_REPLY = JSON.stringify({
+  status: 'capture',
+  changeName: 'add-retries',
+  spec: 'Add a retry wrapper around fetch.',
+})
 const PLAN_REPLY = JSON.stringify({
   steps: [{ title: 'Write retry tests', files: ['tests/retry.test.ts'], verification: 'bun test' }],
   summary: 'One step.',
@@ -822,7 +826,7 @@ describe('phase 1 — triage', () => {
       '',
       '- `src/a.ts`',
     ].join('\n')
-    harness.io.replies = [JSON.stringify({ status: 'spec', spec })]
+    harness.io.replies = [JSON.stringify({ status: 'capture', changeName: 'add-retries', spec })]
 
     await runPipeline({ event: issueEvent(), deps: harness.deps })
 
@@ -995,7 +999,9 @@ describe('review conversation', () => {
   })
 
   test('/changes revises the spec and reports a new revision', async () => {
-    harness.io.replies = [JSON.stringify({ status: 'spec', spec: 'Use the existing helper.' })]
+    harness.io.replies = [
+      JSON.stringify({ status: 'capture', changeName: 'add-retries', spec: 'Use the existing helper.' }),
+    ]
 
     const result = await runPipeline({ event: comment('/changes use the existing helper'), deps: harness.deps })
 
@@ -1005,7 +1011,7 @@ describe('review conversation', () => {
   })
 
   test('/changes threads the maintainer feedback into the rewrite prompt', async () => {
-    harness.io.replies = [JSON.stringify({ status: 'spec', spec: 'revised' })]
+    harness.io.replies = [JSON.stringify({ status: 'capture', changeName: 'add-retries', spec: 'revised' })]
     await runPipeline({ event: comment('/changes use the existing helper'), deps: harness.deps })
 
     expect(String(harness.io.prompts.at(-1)?.prompt)).toContain('use the existing helper')
@@ -1021,7 +1027,10 @@ describe('review conversation', () => {
   })
 
   test('a plain comment classified as a change request revises the spec', async () => {
-    harness.io.replies = [JSON.stringify({ intent: 'changes' }), JSON.stringify({ status: 'spec', spec: 'revised' })]
+    harness.io.replies = [
+      JSON.stringify({ intent: 'changes' }),
+      JSON.stringify({ status: 'capture', changeName: 'add-retries', spec: 'revised' }),
+    ]
 
     await runPipeline({ event: comment('please use the existing helper instead'), deps: harness.deps })
 
@@ -1199,9 +1208,9 @@ describe('artefact revision numbering', () => {
 
   test('revising the spec twice still leaves the first plan at revision 1', async () => {
     await toDesignSpec(harness)
-    harness.io.replies = [JSON.stringify({ status: 'spec', spec: 'Second attempt.' })]
+    harness.io.replies = [JSON.stringify({ status: 'capture', changeName: 'add-retries', spec: 'Second attempt.' })]
     await runPipeline({ event: comment('/changes use the existing helper'), deps: harness.deps })
-    harness.io.replies = [JSON.stringify({ status: 'spec', spec: 'Third attempt.' })]
+    harness.io.replies = [JSON.stringify({ status: 'capture', changeName: 'add-retries', spec: 'Third attempt.' })]
     await runPipeline({ event: comment('/changes name the helper'), deps: harness.deps })
 
     expect(harness.io.posted.at(-1)).toContain('### Design spec (revision 3)')

--- a/tests/opencode-agent/phases.test.ts
+++ b/tests/opencode-agent/phases.test.ts
@@ -5,10 +5,12 @@
 
 import { describe, expect, it } from 'bun:test'
 
-import { SPEC_MARKER, findArtifact } from '../../opencode-agent/src/artifacts.js'
+import { PLAN_MARKER, findArtifact } from '../../opencode-agent/src/artifacts.js'
 import type { IssueComment } from '../../opencode-agent/src/blocks.js'
 import type { ParsedCommand } from '../../opencode-agent/src/commands.js'
+import type { OpenSpecDriver } from '../../opencode-agent/src/openspec-driver.js'
 import type { PhaseInput } from '../../opencode-agent/src/phase-context.js'
+import { handlePlan } from '../../opencode-agent/src/phases/plan.js'
 import { handleTriage } from '../../opencode-agent/src/phases/triage.js'
 import type { TriggerEvent } from '../../opencode-agent/src/trigger-events.js'
 import type { AgentState } from '../../opencode-agent/src/types.js'
@@ -32,10 +34,6 @@ import type { StubIo } from './test-helpers.js'
  */
 
 const AGENT_LOGIN = 'agent-bot'
-
-/** The blocks a handler returned, as a thread `findArtifact` can walk. Module-level so the `??` is not "in test". */
-const blocksAsThread = (outcome: { blocks?: readonly string[] }): IssueComment[] =>
-  (outcome.blocks ?? []).map((body, index) => ({ id: index + 1, body, authorLogin: AGENT_LOGIN }))
 
 const baseState = (issueId = 42, over: Partial<AgentState> = {}): AgentState => ({
   v: 3,
@@ -137,11 +135,14 @@ describe('handleTriage · outcome: capture · D9 association gate', () => {
     const outcome = await handleTriage(input)
 
     expect(outcome.signal).toBe('CAPTURED')
-    expect(io.openspecCalls).toEqual(['newChange:add-retry-helper:spec-driven'])
+    expect(io.openspecCalls).toEqual([
+      'newChange:add-retry-helper:spec-driven',
+      'instructions:proposal:add-retry-helper',
+    ])
     expect(outcome.patch?.changeName).toBe('add-retry-helper')
-    // Bridge: the SPEC block still carries the spec text so PLANNING (not yet
-    // reworked) can read it. Slice B retires this block.
-    expect(findArtifact(blocksAsThread(outcome), AGENT_LOGIN, SPEC_MARKER)?.text).toContain('Add retries.')
+    // The spec is the proposal now: written into the folder, not a SPEC block.
+    expect(outcome.blocks).toBeUndefined()
+    expect(io.writes.some((w) => w.content.includes('Add retries.'))).toBe(true)
   })
 
   it.each(['MEMBER', 'COLLABORATOR'])('auto-captures for %s', async (association) => {
@@ -153,7 +154,7 @@ describe('handleTriage · outcome: capture · D9 association gate', () => {
     const outcome = await handleTriage(input)
 
     expect(outcome.signal).toBe('CAPTURED')
-    expect(io.openspecCalls).toEqual([`newChange:add-thing:spec-driven`])
+    expect(io.openspecCalls).toEqual([`newChange:add-thing:spec-driven`, `instructions:proposal:add-thing`])
   })
 
   it('posts a consent comment and parks (NEEDS_CLARIFICATION) for an untrusted author', async () => {
@@ -184,8 +185,158 @@ describe('handleTriage · outcome: capture · D9 association gate', () => {
     const outcome = await handleTriage(input)
 
     expect(outcome.signal).toBe('CAPTURED')
-    expect(io.openspecCalls).toEqual(['newChange:add-retry-helper:spec-driven'])
+    expect(io.openspecCalls).toEqual([
+      'newChange:add-retry-helper:spec-driven',
+      'instructions:proposal:add-retry-helper',
+    ])
     // Two prompts: the rejected reply, then the repaired one.
     expect(io.prompts).toHaveLength(2)
+  })
+})
+
+/**
+ * Design D3 — the PLANNING drafter loop, and D1 — the folder is truth.
+ *
+ * PLANNING reads the change's status from the folder, drafts each pending
+ * artifact (typed instruction → model composes → write → `validate --strict`
+ * → retry ≤2 with the complaint), commits confined to the folder, and signals
+ * `PLAN_POSTED`. The retired `AGENT_PLAN` block is gone — the plan lives in
+ * `tasks.md` on the branch.
+ */
+
+const CHANGE = 'add-retry-helper'
+
+/** A driver whose status evolves as the drafter writes each artifact. */
+const evolvingDriver = (drafted: Set<string>): OpenSpecDriver => ({
+  newChange: (n: string): Promise<{ changeName: string }> => Promise.resolve({ changeName: n }),
+  archive: (): Promise<void> => Promise.resolve(),
+  validateStrict: (): Promise<{ ok: boolean; output: string }> => Promise.resolve({ ok: true, output: '' }),
+  instructions: (
+    artifactId: string,
+  ): Promise<import('../../opencode-agent/src/openspec-driver.js').InstructionsResult> =>
+    Promise.resolve({
+      instruction: `Draft the ${artifactId}.`,
+      template: undefined,
+      rules: [],
+      resolvedOutputPath: `/repo/openspec/changes/${CHANGE}/${artifactId}.md`,
+      existingOutputPaths: [],
+      dependencies: [],
+    }),
+  status: (): Promise<import('../../opencode-agent/src/openspec-driver.js').StatusResult> => {
+    const artifacts: Record<string, string> = {
+      proposal: 'done',
+      design: drafted.has('design') ? 'done' : 'ready',
+      tasks: drafted.has('tasks') ? 'done' : drafted.has('design') ? 'ready' : 'blocked',
+    }
+    return Promise.resolve({
+      schemaName: 'spec-driven',
+      artifacts,
+      isPlanningComplete: drafted.has('design') && drafted.has('tasks'),
+    })
+  },
+})
+
+const planningState = (over: Partial<AgentState> = {}): AgentState => ({
+  v: 3,
+  phase: 'PLANNING',
+  issueId: 42,
+  resumeFrom: null,
+  attempts: 0,
+  ciAttempts: 0,
+  ciBudgetReported: false,
+  reviewAttempts: 0,
+  changedLines: 0,
+  stepsDone: 0,
+  changeName: CHANGE,
+  planRevision: 0,
+  tokensSpent: 0,
+  lastError: null,
+  prUrl: null,
+  prNumber: null,
+  ...over,
+})
+
+/** The artifact id a write path points at (`/x/design.md` → `design`). Module-level so the `?.`/`??` is not "in test". */
+const artifactIdOf = (path: string): string => {
+  const base = path.split('/').pop() ?? ''
+  return base.replace(/\.md$/u, '')
+}
+
+interface WireOptions {
+  validate?: (call: number) => { ok: boolean; output: string }
+  done?: string[]
+}
+
+/** Wires a drafter input whose driver status evolves as the model writes each artifact. */
+const wireDrafterInput = (replies: string[], opts: WireOptions = {}): { input: PhaseInput; io: StubIo } => {
+  const tracked = new Set<string>(['proposal', ...(opts.done ?? [])])
+  const built = stubPhaseDeps({ replies, selfLogin: AGENT_LOGIN })
+  const base = evolvingDriver(tracked)
+  const driver: OpenSpecDriver =
+    opts.validate === undefined
+      ? base
+      : (() => {
+          let calls = 0
+          return { ...base, validateStrict: () => Promise.resolve(opts.validate!(calls++)) }
+        })()
+  built.deps.openspec = driver
+  built.deps.writeFile = (path: string, content: string): Promise<void> => {
+    built.io.writes.push({ path, content })
+    tracked.add(artifactIdOf(path))
+    return Promise.resolve()
+  }
+  return {
+    input: {
+      state: planningState(),
+      issue: { number: 42, title: 't', body: 'b' },
+      trigger: issueTrigger('OWNER'),
+      command: null,
+      thread: built.io.thread,
+      deps: built.deps,
+    },
+    io: built.io,
+  }
+}
+
+const validateFailsOnce = (call: number): { ok: boolean; output: string } =>
+  call === 0 ? { ok: false, output: 'design.md: missing Deltas section' } : { ok: true, output: '' }
+
+describe('handlePlan · drafter loop (D3)', () => {
+  it('drafts each pending artifact, writes it to the folder, and signals PLAN_POSTED', async () => {
+    const { input, io } = wireDrafterInput([
+      JSON.stringify({ content: 'design body' }),
+      JSON.stringify({ content: 'tasks body' }),
+    ])
+
+    const outcome = await handlePlan(input)
+
+    expect(outcome.signal).toBe('PLAN_POSTED')
+    // The drafter wrote design then tasks, in dependency order.
+    expect(io.writes.map((w) => w.path)).toEqual([
+      `/repo/openspec/changes/${CHANGE}/design.md`,
+      `/repo/openspec/changes/${CHANGE}/tasks.md`,
+    ])
+    // The plan lives in the folder now — no AGENT_PLAN block rides on the issue.
+    expect(findArtifact(io.thread, AGENT_LOGIN, PLAN_MARKER)).toBeNull()
+    expect(outcome.blocks).toBeUndefined()
+    // A new plan bumps the plan-identity token.
+    expect(outcome.patch?.planRevision).toBe(1)
+  })
+
+  it('retries once when validate --strict fails, attaching the complaint', async () => {
+    // Only design pending (tasks already done) so the loop drafts one artifact.
+    const { input, io } = wireDrafterInput(
+      [JSON.stringify({ content: 'first attempt' }), JSON.stringify({ content: 'repaired attempt' })],
+      { done: ['tasks'], validate: validateFailsOnce },
+    )
+
+    const outcome = await handlePlan(input)
+
+    expect(outcome.signal).toBe('PLAN_POSTED')
+    // First validate failed → re-asked with the complaint. Two model turns, two
+    // writes (validate reads the folder, so each attempt is written before it).
+    expect(io.prompts).toHaveLength(2)
+    expect(io.writes).toHaveLength(2)
+    expect(io.writes.at(-1)?.content).toBe('repaired attempt')
   })
 })

--- a/tests/opencode-agent/phases.test.ts
+++ b/tests/opencode-agent/phases.test.ts
@@ -194,6 +194,23 @@ describe('handleTriage · outcome: capture · D9 association gate', () => {
     // Two prompts: the rejected reply, then the repaired one.
     expect(io.prompts).toHaveLength(2)
   })
+
+  it('renders the DESIGN_SPEC digest from the folder (D1): reads proposal.md back after writing it', async () => {
+    const { input, io } = makeInput({
+      association: 'OWNER',
+      replies: [JSON.stringify({ status: 'capture', changeName: 'add-retry-helper', spec: '# Goal\n\nAdd retries.' })],
+    })
+
+    const outcome = await handleTriage(input)
+
+    expect(outcome.signal).toBe('CAPTURED')
+    // The comment is a render of the folder, not a memory of the model reply:
+    // the proposal is read back after being written, and the digest carries the
+    // branch as the history of record (D1).
+    expect(io.reads).toEqual(['/repo/x.md'])
+    expect(outcome.comment).toContain('Add retries.')
+    expect(outcome.comment).toContain('agent/issue-42')
+  })
 })
 
 /**
@@ -284,6 +301,10 @@ const wireDrafterInput = (replies: string[], opts: WireOptions = {}): { input: P
   built.deps.openspec = driver
   built.deps.writeFile = (path: string, content: string): Promise<void> => {
     built.io.writes.push({ path, content })
+    // The folder is truth (D1): a write lands in the folder, and a later read
+    // of the same path returns what landed. Mirror the default stub's contract
+    // so the drafter's writes are what the digest reads back.
+    built.io.readContents[path] = content
     tracked.add(artifactIdOf(path))
     return Promise.resolve()
   }
@@ -341,6 +362,24 @@ describe('handlePlan · drafter loop (D3)', () => {
     expect(io.prompts).toHaveLength(2)
     expect(io.writes).toHaveLength(2)
     expect(io.writes.at(-1)?.content).toBe('repaired attempt')
+  })
+
+  it('renders the PLAN_REVIEW digest from the folder (D1): includes tasks.md read back', async () => {
+    const { input, io } = wireDrafterInput([
+      JSON.stringify({ content: 'design body' }),
+      JSON.stringify({ content: '- [ ] Write retry tests\n- [ ] Add the wrapper\n' }),
+    ])
+
+    const outcome = await handlePlan(input)
+
+    expect(outcome.signal).toBe('PLAN_POSTED')
+    // The plan digest is a render of the folder's tasks.md, read back after the
+    // drafter wrote it (D1) — not a memory of the model reply. The revision
+    // token (the machine's plan identity) and the branch ride out as metadata.
+    expect(outcome.comment).toContain('Write retry tests')
+    expect(outcome.comment).toContain('Add the wrapper')
+    expect(outcome.comment).toContain('agent/issue-42')
+    expect(io.reads).toContain(`/repo/openspec/changes/${CHANGE}/tasks.md`)
   })
 })
 

--- a/tests/opencode-agent/phases.test.ts
+++ b/tests/opencode-agent/phases.test.ts
@@ -381,6 +381,40 @@ describe('handlePlan · drafter loop (D3)', () => {
     expect(outcome.comment).toContain('agent/issue-42')
     expect(io.reads).toContain(`/repo/openspec/changes/${CHANGE}/tasks.md`)
   })
+
+  it('threads a steering comment into the artifact-update turn (D6)', async () => {
+    // Re-entering PLANNING from a steering comment in REVIEW_AND_MUTATE: the
+    // maintainer's scope-affecting prose reaches the drafter prompt so the model
+    // revises the artifacts rather than re-drafting them blind. The folder cannot
+    // rot relative to the conversation.
+    const built = wireDrafterInput(
+      [JSON.stringify({ content: '- [ ] Write retry tests\n- [ ] Also add structured logging\n' })],
+      { done: ['tasks'] },
+    )
+    const steerTrigger: TriggerEvent = {
+      kind: 'issue',
+      eventName: 'issue_comment',
+      action: 'created',
+      senderLogin: 'maintainer',
+      senderType: 'User',
+      authorAssociation: 'OWNER',
+      issueNumber: 42,
+      issueTitle: 'Add a retry helper',
+      issueBody: 'Please add a retry helper.',
+      isPullRequest: false,
+      commentBody: 'Also add structured logging to each retry.',
+      commentId: 7,
+      repositoryOwner: 'acme',
+      defaultBranch: 'main',
+    }
+    const { io } = built
+    const outcome = await handlePlan({ ...built.input, trigger: steerTrigger, command: null })
+
+    expect(outcome.signal).toBe('PLAN_POSTED')
+    // The steering feedback reached the drafter's prompt — the artifact-update
+    // turn is grounded in the maintainer's scope change, not a blind re-draft.
+    expect(io.prompts.some((p) => p.prompt.includes('structured logging'))).toBe(true)
+  })
 })
 
 /**

--- a/tests/opencode-agent/phases.test.ts
+++ b/tests/opencode-agent/phases.test.ts
@@ -211,6 +211,21 @@ describe('handleTriage · outcome: capture · D9 association gate', () => {
     expect(outcome.comment).toContain('Add retries.')
     expect(outcome.comment).toContain('agent/issue-42')
   })
+
+  it('resets agent/issue-<n> to base before the scaffold commit (D12 restart)', async () => {
+    // A restart lands on an issue whose agent/issue-<n> branch already exists
+    // (partial legacy work). The scaffold resets the branch to base so the new
+    // capture starts from zero rather than adopting the old diff.
+    const { input, io } = makeInput({
+      association: 'OWNER',
+      replies: [JSON.stringify({ status: 'capture', changeName: 'add-retry-helper', spec: 'spec' })],
+    })
+
+    await handleTriage(input)
+
+    // resetBranchToBase, not ensureBranch — restart means from zero.
+    expect(io.gitCalls).toContain('resetBranchToBase:agent/issue-42:main')
+  })
 })
 
 /**

--- a/tests/opencode-agent/phases.test.ts
+++ b/tests/opencode-agent/phases.test.ts
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import { SPEC_MARKER, findArtifact } from '../../opencode-agent/src/artifacts.js'
+import type { IssueComment } from '../../opencode-agent/src/blocks.js'
+import type { ParsedCommand } from '../../opencode-agent/src/commands.js'
+import type { PhaseInput } from '../../opencode-agent/src/phase-context.js'
+import { handleTriage } from '../../opencode-agent/src/phases/triage.js'
+import type { TriggerEvent } from '../../opencode-agent/src/trigger-events.js'
+import type { AgentState } from '../../opencode-agent/src/types.js'
+import { stubPhaseDeps } from './test-helpers.js'
+import type { StubIo } from './test-helpers.js'
+
+/**
+ * Design D9 — the triage capture model.
+ *
+ * Triage ends with a structured `clarify | capture | answer` outcome parsed via
+ * `promptForJson`. On `capture` the handler scaffolds a real
+ * `openspec/changes/<name>/` folder via the driver and sets `state.changeName`;
+ * the D9 association gate auto-captures for OWNER/MEMBER/COLLABORATOR and posts
+ * a consent comment for everybody else. These tests drive the handler through
+ * `PhaseDeps` directly (per the slice plan) rather than spinning the whole
+ * orchestrator harness — that sweep is the final step, not the guiding signal.
+ *
+ * Bridge note (slice A): `capture` still carries `spec` text and posts the
+ * `AGENT_SPEC` block, because PLANNING has not been reworked onto the folder
+ * yet. Slice B retires the SPEC block and drops `spec` from the schema.
+ */
+
+const AGENT_LOGIN = 'agent-bot'
+
+/** The blocks a handler returned, as a thread `findArtifact` can walk. Module-level so the `??` is not "in test". */
+const blocksAsThread = (outcome: { blocks?: readonly string[] }): IssueComment[] =>
+  (outcome.blocks ?? []).map((body, index) => ({ id: index + 1, body, authorLogin: AGENT_LOGIN }))
+
+const baseState = (issueId = 42, over: Partial<AgentState> = {}): AgentState => ({
+  v: 3,
+  phase: 'INIT_OR_CLARIFY',
+  issueId,
+  resumeFrom: null,
+  attempts: 0,
+  ciAttempts: 0,
+  ciBudgetReported: false,
+  reviewAttempts: 0,
+  changedLines: 0,
+  stepsDone: 0,
+  changeName: null,
+  planRevision: 0,
+  tokensSpent: 0,
+  lastError: null,
+  prUrl: null,
+  prNumber: null,
+  ...over,
+})
+
+const issueTrigger = (association: string): TriggerEvent => ({
+  kind: 'issue',
+  eventName: 'issues',
+  action: 'opened',
+  senderLogin: 'someone',
+  senderType: 'User',
+  authorAssociation: association,
+  issueNumber: 42,
+  issueTitle: 'Add a retry helper',
+  issueBody: 'Please add a retry helper to the HTTP client.',
+  isPullRequest: false,
+  commentBody: null,
+  commentId: null,
+  repositoryOwner: 'acme',
+  defaultBranch: 'main',
+})
+
+interface FakeOptions {
+  /** Model JSON replies, consumed in order by successive prompts. */
+  replies: string[]
+  /** Author association carried on the trigger event (the D9 gate input). */
+  association?: string
+  /** Pre-existing thread (oldest first). */
+  thread?: IssueComment[]
+  /** State to seed the input with. */
+  state?: Partial<AgentState>
+  command?: ParsedCommand | null
+}
+
+const makeInput = (options: FakeOptions): { input: PhaseInput; io: StubIo } => {
+  const recording = stubPhaseDeps({ replies: options.replies, thread: options.thread, selfLogin: AGENT_LOGIN })
+  const input: PhaseInput = {
+    state: baseState(42, options.state),
+    issue: { number: 42, title: 'Add a retry helper', body: 'Please add a retry helper to the HTTP client.' },
+    trigger: issueTrigger(options.association ?? 'OWNER'),
+    command: options.command ?? null,
+    thread: recording.io.thread,
+    deps: recording.deps,
+  }
+  return { input, io: recording.io }
+}
+
+describe('handleTriage · outcome: clarify', () => {
+  it('returns NEEDS_CLARIFICATION with the rendered questions and posts nothing', async () => {
+    const { input } = makeInput({
+      replies: [JSON.stringify({ status: 'clarify', questions: ['Which client?', 'How many retries?'] })],
+    })
+
+    const outcome = await handleTriage(input)
+
+    expect(outcome.signal).toBe('NEEDS_CLARIFICATION')
+    expect(outcome.comment).toContain('Which client?')
+    expect(outcome.comment).toContain('How many retries?')
+    expect(outcome.blocks).toBeUndefined()
+  })
+})
+
+describe('handleTriage · outcome: answer', () => {
+  it('returns ANSWERED with the model reply and stays phase-neutral', async () => {
+    const { input } = makeInput({
+      replies: [JSON.stringify({ status: 'answer', reply: 'The HTTP client already retries once.' })],
+    })
+
+    const outcome = await handleTriage(input)
+
+    expect(outcome.signal).toBe('ANSWERED')
+    expect(outcome.comment).toContain('The HTTP client already retries once.')
+  })
+})
+
+describe('handleTriage · outcome: capture · D9 association gate', () => {
+  it('auto-captures for OWNER: scaffolds the folder, sets changeName, emits CAPTURED', async () => {
+    const { input, io } = makeInput({
+      association: 'OWNER',
+      replies: [JSON.stringify({ status: 'capture', changeName: 'add-retry-helper', spec: '# Goal\n\nAdd retries.' })],
+    })
+
+    const outcome = await handleTriage(input)
+
+    expect(outcome.signal).toBe('CAPTURED')
+    expect(io.openspecCalls).toEqual(['newChange:add-retry-helper:spec-driven'])
+    expect(outcome.patch?.changeName).toBe('add-retry-helper')
+    // Bridge: the SPEC block still carries the spec text so PLANNING (not yet
+    // reworked) can read it. Slice B retires this block.
+    expect(findArtifact(blocksAsThread(outcome), AGENT_LOGIN, SPEC_MARKER)?.text).toContain('Add retries.')
+  })
+
+  it.each(['MEMBER', 'COLLABORATOR'])('auto-captures for %s', async (association) => {
+    const { input, io } = makeInput({
+      association,
+      replies: [JSON.stringify({ status: 'capture', changeName: 'add-thing', spec: 'spec' })],
+    })
+
+    const outcome = await handleTriage(input)
+
+    expect(outcome.signal).toBe('CAPTURED')
+    expect(io.openspecCalls).toEqual([`newChange:add-thing:spec-driven`])
+  })
+
+  it('posts a consent comment and parks (NEEDS_CLARIFICATION) for an untrusted author', async () => {
+    const { input, io } = makeInput({
+      association: 'NONE',
+      replies: [JSON.stringify({ status: 'capture', changeName: 'add-retry-helper', spec: 'spec' })],
+    })
+
+    const outcome = await handleTriage(input)
+
+    expect(outcome.signal).toBe('NEEDS_CLARIFICATION')
+    // The untrusted path does not scaffold: consent has not been given yet.
+    expect(io.openspecCalls).toEqual([])
+    expect(outcome.patch?.changeName).toBeUndefined()
+    expect(outcome.comment).toContain('add-retry-helper')
+    expect(outcome.comment.toLowerCase()).toContain('confirm')
+  })
+
+  it('rejects a non-kebab changeName (the schema re-asks once, then captures on the repair)', async () => {
+    const { input, io } = makeInput({
+      association: 'OWNER',
+      replies: [
+        JSON.stringify({ status: 'capture', changeName: 'Add Retry Helper', spec: 'spec' }),
+        JSON.stringify({ status: 'capture', changeName: 'add-retry-helper', spec: 'spec' }),
+      ],
+    })
+
+    const outcome = await handleTriage(input)
+
+    expect(outcome.signal).toBe('CAPTURED')
+    expect(io.openspecCalls).toEqual(['newChange:add-retry-helper:spec-driven'])
+    // Two prompts: the rejected reply, then the repaired one.
+    expect(io.prompts).toHaveLength(2)
+  })
+})

--- a/tests/opencode-agent/phases.test.ts
+++ b/tests/opencode-agent/phases.test.ts
@@ -5,13 +5,15 @@
 
 import { describe, expect, it } from 'bun:test'
 
-import { PLAN_MARKER, findArtifact } from '../../opencode-agent/src/artifacts.js'
 import type { IssueComment } from '../../opencode-agent/src/blocks.js'
 import type { ParsedCommand } from '../../opencode-agent/src/commands.js'
 import type { OpenSpecDriver } from '../../opencode-agent/src/openspec-driver.js'
 import type { PhaseInput } from '../../opencode-agent/src/phase-context.js'
+import { handleAnswer } from '../../opencode-agent/src/phases/answer.js'
 import { handlePlan } from '../../opencode-agent/src/phases/plan.js'
+import { handleReview } from '../../opencode-agent/src/phases/review.js'
 import { handleTriage } from '../../opencode-agent/src/phases/triage.js'
+import type { ReviewRunResult } from '../../opencode-agent/src/review-runner.js'
 import type { TriggerEvent } from '../../opencode-agent/src/trigger-events.js'
 import type { AgentState } from '../../opencode-agent/src/types.js'
 import { stubPhaseDeps } from './test-helpers.js'
@@ -316,9 +318,10 @@ describe('handlePlan · drafter loop (D3)', () => {
       `/repo/openspec/changes/${CHANGE}/design.md`,
       `/repo/openspec/changes/${CHANGE}/tasks.md`,
     ])
-    // The plan lives in the folder now — no AGENT_PLAN block rides on the issue.
-    expect(findArtifact(io.thread, AGENT_LOGIN, PLAN_MARKER)).toBeNull()
+    // The plan lives in the folder now — no AGENT_PLAN block rides on the
+    // issue, and the handler posts nothing to the thread itself.
     expect(outcome.blocks).toBeUndefined()
+    expect(io.thread).toEqual([])
     // A new plan bumps the plan-identity token.
     expect(outcome.patch?.planRevision).toBe(1)
   })
@@ -338,5 +341,126 @@ describe('handlePlan · drafter loop (D3)', () => {
     expect(io.prompts).toHaveLength(2)
     expect(io.writes).toHaveLength(2)
     expect(io.writes.at(-1)?.content).toBe('repaired attempt')
+  })
+})
+
+/**
+ * Design D1 — the folder is truth. `/ask` and `/review` no longer read a
+ * `AGENT_SPEC`/`AGENT_PLAN` block off the thread; they read the artifact the
+ * review is parked on straight out of `openspec/changes/<name>/`. These drive
+ * the two readers through `PhaseDeps` directly and pin the folder read.
+ */
+
+const folderDriver = (change: string): OpenSpecDriver => ({
+  newChange: (n: string): Promise<{ changeName: string }> => Promise.resolve({ changeName: n }),
+  archive: (): Promise<void> => Promise.resolve(),
+  validateStrict: (): Promise<{ ok: boolean; output: string }> => Promise.resolve({ ok: true, output: '' }),
+  status: (): Promise<import('../../opencode-agent/src/openspec-driver.js').StatusResult> =>
+    Promise.resolve({ schemaName: 'spec-driven', artifacts: {}, isPlanningComplete: true }),
+  instructions: (
+    artifactId: string,
+  ): Promise<import('../../opencode-agent/src/openspec-driver.js').InstructionsResult> =>
+    Promise.resolve({
+      instruction: `Draft the ${artifactId}.`,
+      template: undefined,
+      rules: [],
+      resolvedOutputPath: `/repo/openspec/changes/${change}/${artifactId}.md`,
+      existingOutputPaths: [],
+      dependencies: [],
+    }),
+})
+
+interface FolderReadOptions {
+  phase: 'DESIGN_SPEC' | 'PLAN_REVIEW' | 'CODE_REVIEW'
+  /** Content the folder read returns, keyed by artifact id (`proposal`, `tasks`). */
+  folder?: Record<string, string>
+  replies?: string[]
+  thread?: IssueComment[]
+}
+
+const folderReadInput = (options: FolderReadOptions): { input: PhaseInput; io: StubIo } => {
+  const built = stubPhaseDeps({ replies: options.replies ?? [''], selfLogin: AGENT_LOGIN, thread: options.thread })
+  built.deps.openspec = folderDriver(CHANGE)
+  built.io.readContents = {}
+  for (const [artifactId, content] of Object.entries(options.folder ?? {})) {
+    built.io.readContents[`/repo/openspec/changes/${CHANGE}/${artifactId}.md`] = content
+  }
+  const state = planningState({ phase: options.phase, changeName: CHANGE })
+  const trigger: TriggerEvent = {
+    kind: 'issue',
+    eventName: 'issue_comment',
+    action: 'created',
+    senderLogin: 'maintainer',
+    senderType: 'User',
+    authorAssociation: 'OWNER',
+    issueNumber: 42,
+    issueTitle: 'Add a retry helper',
+    issueBody: 'Please add a retry helper.',
+    isPullRequest: false,
+    commentBody: '/ask what is the plan?',
+    commentId: 1,
+    repositoryOwner: 'acme',
+    defaultBranch: 'main',
+  }
+  return {
+    input: {
+      state,
+      issue: { number: 42, title: 'Add a retry helper', body: 'Please add a retry helper.' },
+      trigger,
+      command: { command: '/ask', argument: 'what is the plan?' } as ParsedCommand,
+      thread: built.io.thread,
+      deps: built.deps,
+    },
+    io: built.io,
+  }
+}
+
+describe('handleAnswer · reads the artefact under review from the folder (D1)', () => {
+  it('at DESIGN_SPEC, reads proposal.md and grounds the answer in it', async () => {
+    const { input, io } = folderReadInput({
+      phase: 'DESIGN_SPEC',
+      folder: { proposal: '# Goal\n\nAdd a retry helper with exponential backoff.' },
+      replies: ['It will back off exponentially.'],
+    })
+
+    const outcome = await handleAnswer(input)
+
+    expect(outcome.signal).toBe('ANSWERED')
+    // The proposal content reached the prompt; no SPEC block read occurs.
+    expect(io.prompts[0]?.prompt).toContain('exponential backoff')
+    expect(io.reads).toEqual([`/repo/openspec/changes/${CHANGE}/proposal.md`])
+  })
+
+  it('at PLAN_REVIEW, reads tasks.md and grounds the answer in it', async () => {
+    const { input, io } = folderReadInput({
+      phase: 'PLAN_REVIEW',
+      folder: { tasks: '- [ ] Write retry tests\n- [ ] Add the wrapper\n' },
+      replies: ['Two steps.'],
+    })
+
+    const outcome = await handleAnswer(input)
+
+    expect(outcome.signal).toBe('ANSWERED')
+    expect(io.prompts[0]?.prompt).toContain('Add the wrapper')
+    expect(io.reads).toEqual([`/repo/openspec/changes/${CHANGE}/tasks.md`])
+  })
+})
+
+describe('handleReview · reads the plan from the folder (D1)', () => {
+  it('hands the loop the tasks.md content, not a block on the thread', async () => {
+    const tasks = '- [ ] Write retry tests\n- [ ] Add the wrapper\n'
+    const { input, io } = folderReadInput({ phase: 'CODE_REVIEW', folder: { tasks } })
+    const handed: string[] = []
+    input.deps.runReview = (plan: string): Promise<ReviewRunResult> => {
+      handed.push(plan)
+      return Promise.resolve({ outcome: 'passed', summary: '', exitCode: 0 })
+    }
+
+    const outcome = await handleReview(input)
+
+    expect(outcome.signal).toBe('REVIEW_DONE')
+    // The review loop was handed the folder's tasks.md verbatim.
+    expect(handed).toEqual([tasks])
+    expect(io.reads).toEqual([`/repo/openspec/changes/${CHANGE}/tasks.md`])
   })
 })

--- a/tests/opencode-agent/plan-steps.test.ts
+++ b/tests/opencode-agent/plan-steps.test.ts
@@ -5,137 +5,7 @@
 
 import { describe, expect, test } from 'bun:test'
 
-import {
-  findPlan,
-  PLAN_MARKER,
-  renderArtifact,
-  renderPlanArtifact,
-  requirePlan,
-} from '../../opencode-agent/src/artifacts.js'
-import { renderBlock } from '../../opencode-agent/src/blocks.js'
-import type { IssueComment } from '../../opencode-agent/src/blocks.js'
-import {
-  executionPlanSchema,
-  MAX_PLAN_STEPS,
-  parseTaskCheckboxes,
-  renderPlanMarkdown,
-  stepSubject,
-} from '../../opencode-agent/src/plan-steps.js'
-import type { ExecutionPlan, PlanStep } from '../../opencode-agent/src/plan-steps.js'
-
-const AGENT = 'agent-bot'
-
-const step = (title: string, overrides: Partial<PlanStep> = {}): PlanStep => ({
-  title,
-  files: ['src/retry.ts'],
-  verification: 'bun test',
-  ...overrides,
-})
-
-const PLAN: ExecutionPlan = {
-  summary: 'Add retries.',
-  steps: [step('Write the retry tests'), step('Implement the wrapper')],
-}
-
-const comment = (body: string, authorLogin = AGENT): IssueComment => ({ id: 1, body, authorLogin })
-
-const thread = (plan: ExecutionPlan, revision = 1): IssueComment[] => [
-  comment(renderPlanArtifact(renderPlanMarkdown(plan), revision, plan.steps)),
-]
-
-describe('the plan block', () => {
-  test('carries the steps as data and reads them back verbatim', () => {
-    // The whole of stage 3 rests on this: the implementation walks the steps the
-    // planner declared, and it must never recover them by parsing the markdown
-    // above them — the oldest rule in this workspace, and the one heading-scraping
-    // broke by truncating a spec at its first `---`.
-    const found = findPlan(thread(PLAN), AGENT)
-
-    expect(found?.steps).toEqual(PLAN.steps)
-    expect(found?.revision).toBe(1)
-  })
-
-  test('renders the comment from the same steps the block carries', () => {
-    // Two spellings of one plan is how the comment a maintainer approved and the
-    // steps the implementation walks come to disagree. One value feeds both.
-    const found = findPlan(thread(PLAN), AGENT)
-
-    expect(found?.text).toBe(renderPlanMarkdown(PLAN))
-    expect(found?.text).toContain('Write the retry tests')
-    expect(found?.text).toContain('Implement the wrapper')
-  })
-
-  test('a plan written before steps existed reads back as a one-shot', () => {
-    // Live issues carry plans with no steps in them, and they are not migrated:
-    // the fallback is permanent, because an old block is a *record* of what a
-    // maintainer approved and nothing may invent steps it never saw.
-    const older = [comment(renderArtifact(PLAN_MARKER, 'the plan, as prose', 2))]
-
-    expect(findPlan(older, AGENT)).toEqual({ text: 'the plan, as prose', revision: 2, steps: [] })
-  })
-
-  test('an unusable steps field degrades to a one-shot rather than losing the plan', () => {
-    // A hand-edited block is attacker-editable text like every other one. Losing
-    // the *plan* over a malformed step list would fail the phase outright, where
-    // falling back runs exactly what a pre-steps plan runs.
-    const hostile = renderBlock(PLAN_MARKER, { text: 'the plan', revision: 1, steps: 'all of them' })
-
-    expect(findPlan([comment(hostile)], AGENT)).toMatchObject({ text: 'the plan', steps: [] })
-  })
-
-  test('one malformed step drops the whole list, never a truncated plan', () => {
-    // The failure mode this workspace refuses: half a plan read as a whole one.
-    // A step list the schema cannot vouch for is no step list at all.
-    const half = renderPlanArtifact('the plan', 1, [step('good'), { title: '', files: [], verification: '' }])
-
-    expect(findPlan([comment(half)], AGENT)?.steps).toEqual([])
-  })
-
-  test('only the agent’s own plan is read, as with every other artefact', () => {
-    const planted = thread(PLAN).map((entry) => ({ ...entry, authorLogin: 'drive-by' }))
-
-    expect(findPlan(planted, AGENT)).toBeNull()
-  })
-
-  test('requirePlan throws through the caller’s own error when there is none', () => {
-    const boom = new Error('no plan')
-
-    expect(() => requirePlan([], AGENT, () => boom)).toThrow(boom)
-  })
-})
-
-describe('the plan the planner is asked for', () => {
-  test('refuses a plan with no steps at all', () => {
-    // A planner that produced no steps has not planned. `promptForJson` re-asks
-    // once with this complaint attached, which recovers most of them; twice is a
-    // model that cannot produce the shape, and the phase says so.
-    const empty = executionPlanSchema.safeParse({ steps: [], summary: 'nothing' })
-
-    expect(empty.success).toBe(false)
-    expect(empty.error?.message).toContain('>=1')
-  })
-
-  test('refuses more steps than one plan may declare, naming the ceiling', () => {
-    const many = { steps: Array.from({ length: MAX_PLAN_STEPS + 1 }, (_v, index) => step(`step ${index}`)) }
-    const parsed = executionPlanSchema.safeParse(many)
-
-    expect(parsed.success).toBe(false)
-    expect(parsed.error?.message).toContain(`<=${MAX_PLAN_STEPS}`)
-  })
-
-  test('accepts a plan at exactly the ceiling', () => {
-    const exact = { steps: Array.from({ length: MAX_PLAN_STEPS }, (_v, index) => step(`step ${index}`)) }
-
-    expect(executionPlanSchema.safeParse(exact).success).toBe(true)
-  })
-
-  test('defaults the parts of a step a planner left out', () => {
-    const sparse = executionPlanSchema.parse({ steps: [{ title: 'just a title' }] })
-
-    expect(sparse.steps[0]).toEqual({ title: 'just a title', files: [], verification: '' })
-    expect(sparse.summary).toBe('')
-  })
-})
+import { parseTaskCheckboxes, planBoxes, stepSubject } from '../../opencode-agent/src/plan-steps.js'
 
 describe('the commit subject a step earns', () => {
   test('is one line, however many the title had', () => {
@@ -196,5 +66,26 @@ describe('parseTaskCheckboxes (D5)', () => {
 
   test('returns an empty list for a tasks.md with no checkboxes', () => {
     expect(parseTaskCheckboxes('# Tasks\n\nNo steps yet.')).toEqual([])
+  })
+})
+
+/**
+ * The walk reads `tasks.md` as `planBoxes` — every checkbox with absolute
+ * numbering — so "step 3 of 5" stays honest across a run that ticks the boxes
+ * ahead of the cursor. Numbering among all boxes (not just the unchecked) is
+ * what keeps a `/continue` honest about which step it is on.
+ */
+describe('planBoxes (D5)', () => {
+  const TASKS_MD = ['- [x] 1.1 Done', '- [ ] 1.2 Next', '- [ ] 1.3 Later'].join('\n')
+
+  test('numbers every box absolutely, checked or not', () => {
+    const boxes = planBoxes(TASKS_MD)
+    expect(boxes.map((b) => b.number)).toEqual([1, 2, 3])
+    expect(boxes.every((b) => b.total === 3)).toBe(true)
+    expect(boxes.map((b) => b.checked)).toEqual([true, false, false])
+  })
+
+  test('carries the line number the box-check edit targets', () => {
+    expect(planBoxes(TASKS_MD).map((b) => b.line)).toEqual([1, 2, 3])
   })
 })

--- a/tests/opencode-agent/plan-steps.test.ts
+++ b/tests/opencode-agent/plan-steps.test.ts
@@ -17,6 +17,7 @@ import type { IssueComment } from '../../opencode-agent/src/blocks.js'
 import {
   executionPlanSchema,
   MAX_PLAN_STEPS,
+  parseTaskCheckboxes,
   renderPlanMarkdown,
   stepSubject,
 } from '../../opencode-agent/src/plan-steps.js'
@@ -148,5 +149,52 @@ describe('the commit subject a step earns', () => {
     const long = stepSubject('x'.repeat(200))
 
     expect(long.length).toBeLessThanOrEqual(72)
+  })
+})
+
+/**
+ * Design D5 — tasks.md is the plan's only shape.
+ *
+ * `REVIEW_AND_MUTATE` walks the change's `tasks.md` checkboxes; each step's
+ * commit checks its box in the same commit. These tests pin the parser that
+ * turns the file into the ordered checkbox list the walk reads, including the
+ * line number the box-check edit needs.
+ */
+describe('parseTaskCheckboxes (D5)', () => {
+  const TASKS_MD = [
+    '# Tasks: add retries',
+    '',
+    '- [x] 1.1 Add failing tests',
+    '- [ ] 1.2 Implement the wrapper',
+    '  - [ ] 1.2.1 Handle the timeout case',
+    '- [ ] 1.3 Verify',
+    '',
+    'Some prose note that is not a checkbox.',
+  ].join('\n')
+
+  test('returns the checkboxes in file order with their checked state', () => {
+    const boxes = parseTaskCheckboxes(TASKS_MD)
+    expect(boxes.map((b) => b.text)).toEqual([
+      '1.1 Add failing tests',
+      '1.2 Implement the wrapper',
+      '1.2.1 Handle the timeout case',
+      '1.3 Verify',
+    ])
+    expect(boxes.map((b) => b.checked)).toEqual([true, false, false, false])
+  })
+
+  test('records the 1-based line number so the box-check edit targets the right line', () => {
+    const boxes = parseTaskCheckboxes(TASKS_MD)
+    expect(boxes.map((b) => b.line)).toEqual([3, 4, 5, 6])
+  })
+
+  test('ignores lines that are not checkboxes', () => {
+    const boxes = parseTaskCheckboxes('just prose\n- [ ] a real task\nmore prose')
+    expect(boxes).toHaveLength(1)
+    expect(boxes[0]?.text).toBe('a real task')
+  })
+
+  test('returns an empty list for a tasks.md with no checkboxes', () => {
+    expect(parseTaskCheckboxes('# Tasks\n\nNo steps yet.')).toEqual([])
   })
 })

--- a/tests/opencode-agent/pr-trigger.test.ts
+++ b/tests/opencode-agent/pr-trigger.test.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import { evaluateGuardrails } from '../../opencode-agent/src/guardrails.js'
+import { parseTriggerEvent } from '../../opencode-agent/src/trigger-events.js'
+import type { PrMergedTriggerEvent } from '../../opencode-agent/src/trigger-events.js'
+
+/**
+ * Design D7 — the archive door.
+ *
+ * `pull_request.closed(merged)` on a branch the agent owns is the propose →
+ * apply → archive loop's closing half: the ARCHIVE phase runs `openspec
+ * archive` as a follow-up commit on master. These tests pin the door's three
+ * legs — parse, guardrails (foreign-repo refusal), and issue resolution via the
+ * head branch — following the existing `ci-trigger.ts` door pattern rather than
+ * the comment-on-PR one (no API call: the payload carries the head branch).
+ */
+
+const merged = (over: Record<string, unknown> = {}): unknown => ({
+  action: 'closed',
+  pull_request: {
+    merged: true,
+    number: 7,
+    head: { ref: 'agent/issue-42', repo: { full_name: 'acme/widgets' } },
+    base: { ref: 'main' },
+  },
+  repository: { full_name: 'acme/widgets', default_branch: 'main' },
+  sender: { login: 'maintainer', type: 'User' },
+  ...over,
+})
+
+describe('parseTriggerEvent · pull_request.closed(merged) (D7)', () => {
+  it('parses a merged agent-branch PR into a pr-merged event resolved via the head branch', () => {
+    const event = parseTriggerEvent('pull_request', merged())
+    expect(event).toMatchObject({
+      kind: 'pr-merged',
+      issueNumber: 42,
+      prNumber: 7,
+      baseBranch: 'main',
+    })
+  })
+
+  it('returns null for a close that was not a merge', () => {
+    const event = parseTriggerEvent(
+      'pull_request',
+      merged({ pull_request: { merged: false, number: 7, head: { ref: 'agent/issue-42' }, base: { ref: 'main' } } }),
+    )
+
+    expect(event).toBeNull()
+  })
+
+  it('returns null for a merged PR on a branch the agent does not own', () => {
+    const event = parseTriggerEvent(
+      'pull_request',
+      merged({ pull_request: { merged: true, number: 7, head: { ref: 'feature/x' }, base: { ref: 'main' } } }),
+    )
+
+    expect(event).toBeNull()
+  })
+
+  it('returns null for a non-closed action', () => {
+    const event = parseTriggerEvent(
+      'pull_request',
+      merged({
+        action: 'opened',
+        pull_request: { merged: false, number: 7, head: { ref: 'agent/issue-42' }, base: { ref: 'main' } },
+      }),
+    )
+
+    expect(event).toBeNull()
+  })
+})
+
+describe('evaluateGuardrails · pr-merged foreign-repo refusal (D7)', () => {
+  const options = { selfLogin: 'agent-bot', selfWorkflowName: 'OpenCode Issue Agent' }
+
+  const prMerged = (fromThisRepository: boolean): PrMergedTriggerEvent => ({
+    kind: 'pr-merged',
+    eventName: 'pull_request',
+    prNumber: 7,
+    issueNumber: 42,
+    baseBranch: 'main',
+    fromThisRepository,
+    defaultBranch: 'main',
+  })
+
+  it('allows a merged PR whose head is this repository', () => {
+    const decision = evaluateGuardrails(prMerged(true), options)
+    expect(decision.allowed).toBe(true)
+  })
+
+  it('refuses a merged PR merged from a fork (foreign repository)', () => {
+    const decision = evaluateGuardrails(prMerged(false), options)
+    expect(decision.allowed).toBe(false)
+    expect(decision).toMatchObject({ code: 'PR_FOREIGN_REPOSITORY' })
+  })
+})

--- a/tests/opencode-agent/state-manager.test.ts
+++ b/tests/opencode-agent/state-manager.test.ts
@@ -71,7 +71,7 @@ describe('blocks', () => {
 
 describe('serializeState / extractState', () => {
   test('round-trips a full state through the hidden comment block', () => {
-    const state = transition(initialState(42), 'SPEC_POSTED')
+    const state = transition(initialState(42), 'CAPTURED')
 
     expect(extractState(serializeState(state))).toEqual(state)
   })
@@ -91,11 +91,11 @@ describe('serializeState / extractState', () => {
     expect(extractState(body)?.issueId).toBe(9)
   })
 
-  test('applies schema defaults to a minimal state block', () => {
-    const parsed = extractState(`<!-- ${STATE_MARKER}: {"phase":"INIT_OR_CLARIFY","issueId":5} -->`)
+  test('applies schema defaults to a minimal current-version state block', () => {
+    const parsed = extractState(`<!-- ${STATE_MARKER}: {"v":3,"phase":"INIT_OR_CLARIFY","issueId":5} -->`)
 
     expect(parsed).toEqual({
-      v: 1,
+      v: STATE_VERSION,
       phase: 'INIT_OR_CLARIFY',
       issueId: 5,
       resumeFrom: null,
@@ -105,14 +105,18 @@ describe('serializeState / extractState', () => {
       reviewAttempts: 0,
       // Defaulted for the same reason, and 0 reads as "a small diff": it is
       // below every threshold `LINES_RANGE` lets an operator set, so a block
-      // written before the count existed recommends nothing.
+      // written without the count recommends nothing.
       changedLines: 0,
       // The plan-step cursor, defaulted for the same reason: 0 is "start at the
-      // first step", which is what every block written before it existed means.
+      // first step", which is what every block written without it means.
       stepsDone: 0,
-      specRevision: 0,
+      // The captured change folder, defaulted to `null` (uncaptured) for the
+      // same reason: a block is free to omit any field the schema can supply.
+      changeName: null,
+      // The plan-identity token, defaulted for the same reason. `specRevision`
+      // is gone under the OpenSpec rework — the proposal lives in the folder.
       planRevision: 0,
-      // Defaulted, which is why adding it needed no STATE_VERSION bump.
+      // Defaulted: a block is free to omit any field the schema can supply.
       tokensSpent: 0,
       lastError: null,
       prUrl: null,
@@ -120,47 +124,27 @@ describe('serializeState / extractState', () => {
     })
   })
 
-  test('a block written before the revision counters split still restores', () => {
-    // The two counters replaced one shared `revision`, and both default, so no
-    // STATE_VERSION bump was needed and an issue mid-conversation is not
-    // stranded. The old key is dropped rather than mapped onto either field: it
-    // was the sum of both artefacts' revisions and never the count of either.
-    const older = `<!-- ${STATE_MARKER}: {"v":2,"phase":"DESIGN_SPEC","issueId":5,"revision":3} -->`
+  test('drops an unknown key carried by a current-version block', () => {
+    // zod strips unknown keys, so a block that carries a stray field still
+    // restores. (Pre-D12 this was tested with a v2 block carrying the retired
+    // shared `revision`; the field-default intent is preserved here on a
+    // current-version block, and the legacy-version rejection is covered below.)
+    const block = `<!-- ${STATE_MARKER}: {"v":3,"phase":"DESIGN_SPEC","issueId":5,"revision":3} -->`
 
-    expect(extractState(older)).toMatchObject({ phase: 'DESIGN_SPEC', specRevision: 0, planRevision: 0 })
-    expect(extractState(older)).not.toHaveProperty('revision')
+    expect(extractState(block)).toMatchObject({ phase: 'DESIGN_SPEC', planRevision: 0 })
+    expect(extractState(block)).not.toHaveProperty('revision')
+    expect(extractState(block)).not.toHaveProperty('specRevision')
   })
 
-  test('a block written before a field existed still restores', () => {
-    // Fields are added with defaults precisely so a live issue is not stranded
-    // mid-flight by a deploy. `ciBudgetReported` is the most recent addition.
-    const older = `<!-- ${STATE_MARKER}: {"phase":"COMPLETE","issueId":5,"ciAttempts":3} -->`
+  test('applies defaults for fields omitted from a current-version block', () => {
+    // Fields are added with defaults so a current block is free to omit them.
+    const block = `<!-- ${STATE_MARKER}: {"v":3,"phase":"COMPLETE","issueId":5,"ciAttempts":3} -->`
 
-    expect(extractState(older)).toMatchObject({ phase: 'COMPLETE', ciAttempts: 3, ciBudgetReported: false })
-  })
-
-  test('a v2 block written before the review budget existed still restores', () => {
-    // `CODE_REVIEW` and `reviewAttempts` arrived together, and neither needed a
-    // `STATE_VERSION` bump: the phase is an *added* enum member, which no old
-    // block names, and the counter defaults. An issue delivered before the
-    // deploy is therefore reviewable straight away rather than stranded.
-    const older = `<!-- ${STATE_MARKER}: {"v":2,"phase":"COMPLETE","issueId":5,"prNumber":7} -->`
-
-    expect(extractState(older)).toMatchObject({ phase: 'COMPLETE', prNumber: 7, reviewAttempts: 0 })
-  })
-
-  test('a v2 block written before the plan-step cursor existed still restores', () => {
-    // `stepsDone` is additive with a default, so no `STATE_VERSION` bump — a bump
-    // strands every in-flight issue, and there is nothing here it would protect
-    // against: 0 means "start at the first step", and the plans those issues carry
-    // have no steps anyway, so they run as one turn exactly as they always did.
-    const older = `<!-- ${STATE_MARKER}: {"v":2,"phase":"REVIEW_AND_MUTATE","issueId":5} -->`
-
-    expect(extractState(older)).toMatchObject({ phase: 'REVIEW_AND_MUTATE', stepsDone: 0 })
+    expect(extractState(block)).toMatchObject({ phase: 'COMPLETE', ciAttempts: 3, ciBudgetReported: false })
   })
 
   test('stamps the current version on every write', () => {
-    expect(transition(initialState(1), 'SPEC_POSTED').v).toBe(STATE_VERSION)
+    expect(transition(initialState(1), 'CAPTURED').v).toBe(STATE_VERSION)
   })
 
   test.each([
@@ -173,51 +157,77 @@ describe('serializeState / extractState', () => {
   })
 })
 
-describe('a block written before the planning phase was renamed', () => {
-  test('restores EXECUTION_PLAN as the phase that replaced it', () => {
-    // `PLANNING` was `EXECUTION_PLAN`, and a phase name is written into every
-    // state block — so the rename is a persisted-shape change, and an unmigrated
-    // one would have `z.enum` reject the block outright: the scan would walk
-    // past it to an older comment, or start the conversation over.
-    const older = `<!-- ${STATE_MARKER}: {"v":2,"phase":"EXECUTION_PLAN","issueId":5} -->`
+describe('legacy state blocks are rejected (design D12)', () => {
+  test('a v2 block is rejected outright, so the scan restarts the issue fresh', () => {
+    // The opencode-agent rework retires `AGENT_SPEC`/`AGENT_PLAN` and moves
+    // planning onto a real openspec folder; a v2 state describes a pipeline
+    // that no longer exists. Rather than carry a dual format, the schema rejects
+    // every older `v`, the restore scan finds nothing valid, and the issue
+    // starts over at `INIT_OR_CLARIFY` under the compliant pipeline.
+    const legacy = `<!-- ${STATE_MARKER}: {"v":2,"phase":"REVIEW_AND_MUTATE","issueId":5,"stepsDone":3} -->`
 
-    expect(extractState(older)?.phase).toBe('PLANNING')
+    expect(extractState(legacy)).toBeNull()
   })
 
-  test('migrates the resume point too, so a parked failure is still resumable', () => {
-    // The field that would fail latest and quietest: an issue parked in FAILED
-    // carries the phase `/retry` re-enters, and a block rejected for naming the
-    // old one takes the resume point with it.
-    const parked = `<!-- ${STATE_MARKER}: {"v":2,"phase":"FAILED","issueId":5,"resumeFrom":"EXECUTION_PLAN"} -->`
-
-    expect(extractState(parked)?.resumeFrom).toBe('PLANNING')
+  test('a block that omits the version is rejected (no implicit v1)', () => {
+    // Pre-versioning blocks used to default to v1; D12 dropped the default, so a
+    // versionless block now fails the literal the schema requires.
+    expect(extractState(`<!-- ${STATE_MARKER}: {"phase":"COMPLETE","issueId":5} -->`)).toBeNull()
   })
 
-  test('needs no STATE_VERSION bump, so an in-flight issue is not stranded', () => {
-    const older = `<!-- ${STATE_MARKER}: {"v":2,"phase":"EXECUTION_PLAN","issueId":5,"tokensSpent":900} -->`
+  test('a v2 block naming the retired EXECUTION_PLAN phase is not migrated — the version gate rejects first', () => {
+    // The phase-rename migration (`LEGACY_PHASE_NAMES`) is unreachable from disk
+    // under D12: a legacy block dies at `v` before `phaseName` ever runs, so the
+    // restart happens rather than a migration of a state this code no longer
+    // serves. The migration transform itself is still covered below on a
+    // current-version block.
+    const legacy = `<!-- ${STATE_MARKER}: {"v":2,"phase":"EXECUTION_PLAN","issueId":5,"tokensSpent":900} -->`
 
-    // Everything else about the block is believed, including the spend — the
-    // one field a stranded issue would hand back to the next runner as zero.
-    expect(extractState(older)?.tokensSpent).toBe(900)
+    expect(extractState(legacy)).toBeNull()
+  })
+
+  test('findLatestState walks past a legacy block to a current one, or starts over', () => {
+    const agent = 'agent-bot'
+    const thread = [
+      comment(agent, `<!-- ${STATE_MARKER}: {"v":2,"phase":"PLANNING","issueId":5} -->`),
+      comment(agent, renderStateComment(' restarted', initialState(5))),
+    ]
+
+    // The newest comment is a valid current block; the v2 block behind it is
+    // skipped. Reverse the order and the scan finds nothing valid.
+    expect(findLatestState(thread, agent, 5)?.phase).toBe('INIT_OR_CLARIFY')
+    expect(findLatestState([thread[0]!], agent, 5)).toBeNull()
+  })
+})
+
+describe('the phase-name schema transform (still exercised on current-version blocks)', () => {
+  test('a current-version block naming the retired phase is still migrated', () => {
+    // D12 made the migration unreachable from disk (legacy `v` rejects first),
+    // but the transform remains in the schema. No real v3 block carries the old
+    // name; this covers the machinery so it cannot rot silently, and so a future
+    // removal is a deliberate decision rather than an accident.
+    const block = `<!-- ${STATE_MARKER}: {"v":3,"phase":"EXECUTION_PLAN","issueId":5} -->`
+
+    expect(extractState(block)?.phase).toBe('PLANNING')
   })
 
   test('a phase name that was never a phase is still rejected', () => {
     // The migration is a lookup over one retired name, not a loosening: a block
     // is attacker-editable text, and anything else must fail the enum as before.
-    expect(extractState(`<!-- ${STATE_MARKER}: {"v":2,"phase":"WHATEVER","issueId":5} -->`)).toBeNull()
+    expect(extractState(`<!-- ${STATE_MARKER}: {"v":3,"phase":"WHATEVER","issueId":5} -->`)).toBeNull()
   })
 
   test('an inherited property name is not a migration', () => {
     // Read through `Object.hasOwn`, never `in`: `'toString' in LEGACY_PHASE_NAMES`
     // is true through the prototype, and the value it would substitute is a
     // function.
-    expect(extractState(`<!-- ${STATE_MARKER}: {"v":2,"phase":"toString","issueId":5} -->`)).toBeNull()
-    expect(extractState(`<!-- ${STATE_MARKER}: {"v":2,"phase":"constructor","issueId":5} -->`)).toBeNull()
+    expect(extractState(`<!-- ${STATE_MARKER}: {"v":3,"phase":"toString","issueId":5} -->`)).toBeNull()
+    expect(extractState(`<!-- ${STATE_MARKER}: {"v":3,"phase":"constructor","issueId":5} -->`)).toBeNull()
   })
 
   test('a state the machine writes now carries the new name', () => {
-    // The other half of "no bump": blocks written after the rename must not
-    // keep the old spelling alive, or the migration becomes permanent.
+    // Blocks written after the rename must not keep the old spelling alive, or
+    // the migration becomes permanent.
     expect(transition(at('DESIGN_SPEC'), 'APPROVED').phase).toBe('PLANNING')
   })
 })
@@ -235,7 +245,7 @@ describe('state blocks survive hostile payload text', () => {
 
   test('a spec full of markdown rules and arrows still restores its state', () => {
     const spec = '## Goal\n\n---\n\n```mermaid\ngraph TD\n  A --> B\n```'
-    const state = transition(initialState(9), 'SPEC_POSTED')
+    const state = transition(initialState(9), 'CAPTURED')
     const body = [renderStateComment(`### Design spec\n\n${spec}`, state), renderArtifact(SPEC_MARKER, spec, 1)].join(
       '\n\n',
     )
@@ -357,7 +367,7 @@ describe('artifacts', () => {
 describe('transition', () => {
   test('walks the happy path end to end, through both review gates', () => {
     let state = initialState(42)
-    state = transition(state, 'SPEC_POSTED')
+    state = transition(state, 'CAPTURED')
     expect(state.phase).toBe('DESIGN_SPEC')
 
     state = transition(state, 'APPROVED')
@@ -376,38 +386,38 @@ describe('transition', () => {
     expect(state.phase).toBe('COMPLETE')
   })
 
-  test('bumps an artefact revision only when that artefact is rewritten', () => {
-    const spec = transition(initialState(1), 'SPEC_POSTED')
-    expect(spec).toMatchObject({ specRevision: 1, planRevision: 0 })
+  test('the plan-identity token bumps only when the plan is rewritten', () => {
+    // Under the OpenSpec rework (D1) only `PLAN_POSTED` bumps a counter, and
+    // that counter is the plan-identity token, not an artefact revision: the
+    // proposal's history is the folder's commits, and capturing it (`CAPTURED`)
+    // moves no counter at all.
+    const captured = transition(initialState(1), 'CAPTURED')
+    expect(captured).toMatchObject({ planRevision: 0 })
 
-    const approved = transition(spec, 'APPROVED')
-    expect(approved).toMatchObject({ specRevision: 1, planRevision: 0 })
+    const approved = transition(captured, 'APPROVED')
+    expect(approved).toMatchObject({ planRevision: 0 })
 
-    // The plan's first revision is 1, not 2. One counter served both, so the
-    // first plan on every issue was labelled with the spec's count
-    // plus its own.
-    expect(transition(approved, 'PLAN_POSTED')).toMatchObject({ specRevision: 1, planRevision: 1 })
+    expect(transition(approved, 'PLAN_POSTED')).toMatchObject({ planRevision: 1 })
   })
 
-  test('revising one artefact never moves the other one’s number', () => {
-    const twiceSpecced = transition(
-      transition(transition(initialState(1), 'SPEC_POSTED'), 'CHANGES_REQUESTED'),
-      'SPEC_POSTED',
+  test('re-capturing never moves the plan token, but re-planning does', () => {
+    const twiceCaptured = transition(
+      transition(transition(initialState(1), 'CAPTURED'), 'CHANGES_REQUESTED'),
+      'CAPTURED',
     )
-    const planned = transition(transition(twiceSpecced, 'APPROVED'), 'PLAN_POSTED')
-    expect(planned).toMatchObject({ specRevision: 2, planRevision: 1 })
+    const planned = transition(transition(twiceCaptured, 'APPROVED'), 'PLAN_POSTED')
+    expect(planned).toMatchObject({ planRevision: 1 })
 
     const replanned = transition(transition(planned, 'CHANGES_REQUESTED'), 'PLAN_POSTED')
-    expect(replanned).toMatchObject({ specRevision: 2, planRevision: 2 })
+    expect(replanned).toMatchObject({ planRevision: 2 })
   })
 
   test('a question is a self-loop that changes nothing else', () => {
-    const spec = transition(initialState(1), 'SPEC_POSTED')
-    const answered = transition(spec, 'ANSWERED')
+    const captured = transition(initialState(1), 'CAPTURED')
+    const answered = transition(captured, 'ANSWERED')
 
     expect(answered.phase).toBe('DESIGN_SPEC')
-    expect(answered.specRevision).toBe(spec.specRevision)
-    expect(answered.planRevision).toBe(spec.planRevision)
+    expect(answered.planRevision).toBe(captured.planRevision)
   })
 
   test.each<Phase>([...PHASES])('a question asked in %s is answered where it stands', (phase) => {
@@ -417,14 +427,13 @@ describe('transition', () => {
     // COMPLETE, FAILED or anywhere mid-pipeline threw InvalidTransitionError out
     // of the pipeline with the model turn already paid for. FAILED mattered
     // most: it is the phase a maintainer asks "why did this fail?" in.
-    const before: AgentState = { ...at(phase), attempts: 2, specRevision: 3, planRevision: 2, ciAttempts: 1 }
+    const before: AgentState = { ...at(phase), attempts: 2, planRevision: 2, ciAttempts: 1 }
     const answered = transition(before, 'ANSWERED')
 
     expect(canTransition(phase, 'ANSWERED')).toBe(true)
     expect(answered.phase).toBe(phase)
-    // No artefact was rewritten and no CI round was spent, but a handler did
+    // No plan was rewritten and no CI round was spent, but a handler did
     // succeed — the same patch the three table rows used to produce.
-    expect(answered.specRevision).toBe(3)
     expect(answered.planRevision).toBe(2)
     expect(answered.ciAttempts).toBe(1)
     expect(answered.attempts).toBe(0)
@@ -449,7 +458,7 @@ describe('transition', () => {
   test('rejects a signal the current phase does not accept', () => {
     expect(() => transition(initialState(1), 'APPROVED')).toThrow(InvalidTransitionError)
     expect(() => transition(at('DESIGN_SPEC'), 'PLAN_POSTED')).toThrow(InvalidTransitionError)
-    expect(() => transition(at('PLAN_REVIEW'), 'SPEC_POSTED')).toThrow(InvalidTransitionError)
+    expect(() => transition(at('PLAN_REVIEW'), 'CAPTURED')).toThrow(InvalidTransitionError)
   })
 
   test('FAILED records the resume phase, the error and an attempt', () => {
@@ -485,7 +494,7 @@ describe('transition', () => {
   test.each<[TransitionSignal, Phase]>([
     ['NEEDS_CLARIFICATION', 'INIT_OR_CLARIFY'],
     ['ANSWERED', 'INIT_OR_CLARIFY'],
-    ['SPEC_POSTED', 'INIT_OR_CLARIFY'],
+    ['CAPTURED', 'INIT_OR_CLARIFY'],
     ['CHANGES_REQUESTED', 'DESIGN_SPEC'],
     ['APPROVED', 'DESIGN_SPEC'],
     ['PLAN_POSTED', 'PLANNING'],
@@ -734,7 +743,7 @@ describe('transition', () => {
 
   test('returns a new object rather than mutating the input', () => {
     const before = initialState(42)
-    const after = transition(before, 'SPEC_POSTED')
+    const after = transition(before, 'CAPTURED')
 
     expect(before.phase).toBe('INIT_OR_CLARIFY')
     expect(after).not.toBe(before)

--- a/tests/opencode-agent/state-manager.test.ts
+++ b/tests/opencode-agent/state-manager.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, test } from 'bun:test'
 
-import { findArtifact, PLAN_MARKER, renderArtifact, SPEC_MARKER } from '../../opencode-agent/src/artifacts.js'
+import { HANDOFF_MARKER, REPORT_MARKER, findArtifact, renderArtifact } from '../../opencode-agent/src/artifacts.js'
 import { readBlock, renderBlock, stripBlocks } from '../../opencode-agent/src/blocks.js'
 import type { IssueComment } from '../../opencode-agent/src/blocks.js'
 import { hasHandler } from '../../opencode-agent/src/cascade.js'
@@ -243,15 +243,18 @@ describe('state blocks survive hostile payload text', () => {
     expect(extractState(renderStateComment('### Run failed', failed))).toEqual(failed)
   })
 
-  test('a spec full of markdown rules and arrows still restores its state', () => {
-    const spec = '## Goal\n\n---\n\n```mermaid\ngraph TD\n  A --> B\n```'
+  test('an artefact full of markdown rules and arrows still restores its state', () => {
+    // The proposal/spec no longer rides in a block (it lives in the folder under
+    // D1), but a report or handoff still can, and the restore scan must walk
+    // past any hidden block whose payload would confuse a brittle parser.
+    const report = '## Report\n\n---\n\n```mermaid\ngraph TD\n  A --> B\n```'
     const state = transition(initialState(9), 'CAPTURED')
-    const body = [renderStateComment(`### Design spec\n\n${spec}`, state), renderArtifact(SPEC_MARKER, spec, 1)].join(
+    const body = [renderStateComment(`### Report\n\n${report}`, state), renderArtifact(REPORT_MARKER, report, 1)].join(
       '\n\n',
     )
 
     expect(extractState(body)).toEqual(state)
-    expect(findArtifact([comment(agent, body)], agent, SPEC_MARKER)?.text).toBe(spec)
+    expect(findArtifact([comment(agent, body)], agent, REPORT_MARKER)?.text).toBe(report)
   })
 })
 
@@ -329,38 +332,40 @@ describe('findLatestState', () => {
 describe('artifacts', () => {
   const agent = 'agent-bot'
 
-  test('recovers a spec containing markdown rules verbatim', () => {
-    const spec = '## Goal\n\nDo the thing.\n\n---\n\n## Files\n\n- `src/a.ts`'
+  test('recovers a report containing markdown rules verbatim', () => {
+    const report = '## Report\n\nDo the thing.\n\n---\n\n## Files\n\n- `src/a.ts`'
     const body = [
-      `### Design spec\n\n${spec}\n\n---\n\nReply /approve`,
+      `### Report\n\n${report}\n\n---\n\nReply /review`,
       renderStateComment('', initialState(1)),
-      renderArtifact(SPEC_MARKER, spec, 1),
+      renderArtifact(REPORT_MARKER, report, 1),
     ].join('\n\n')
 
-    expect(findArtifact([comment(agent, body)], agent, SPEC_MARKER)?.text).toBe(spec)
+    expect(findArtifact([comment(agent, body)], agent, REPORT_MARKER)?.text).toBe(report)
   })
 
-  test('keeps spec and plan apart in one thread', () => {
+  test('keeps a report and a handoff apart in one thread', () => {
     const thread = [
-      comment(agent, renderArtifact(SPEC_MARKER, 'the spec', 1), 1),
-      comment(agent, renderArtifact(PLAN_MARKER, 'the plan', 1), 2),
+      comment(agent, renderArtifact(REPORT_MARKER, 'the report', 1), 1),
+      comment(agent, renderArtifact(HANDOFF_MARKER, 'the handoff', 1), 2),
     ]
 
-    expect(findArtifact(thread, agent, SPEC_MARKER)?.text).toBe('the spec')
-    expect(findArtifact(thread, agent, PLAN_MARKER)?.text).toBe('the plan')
+    expect(findArtifact(thread, agent, REPORT_MARKER)?.text).toBe('the report')
+    expect(findArtifact(thread, agent, HANDOFF_MARKER)?.text).toBe('the handoff')
   })
 
   test('takes the newest revision of an artefact', () => {
     const thread = [
-      comment(agent, renderArtifact(SPEC_MARKER, 'v1', 1), 1),
-      comment(agent, renderArtifact(SPEC_MARKER, 'v2', 2), 2),
+      comment(agent, renderArtifact(REPORT_MARKER, 'v1', 1), 1),
+      comment(agent, renderArtifact(REPORT_MARKER, 'v2', 2), 2),
     ]
 
-    expect(findArtifact(thread, agent, SPEC_MARKER)).toEqual({ text: 'v2', revision: 2 })
+    expect(findArtifact(thread, agent, REPORT_MARKER)).toEqual({ text: 'v2', revision: 2 })
   })
 
   test('ignores an artefact planted by someone else', () => {
-    expect(findArtifact([comment('attacker', renderArtifact(SPEC_MARKER, 'evil', 1))], agent, SPEC_MARKER)).toBeNull()
+    expect(
+      findArtifact([comment('attacker', renderArtifact(REPORT_MARKER, 'evil', 1))], agent, REPORT_MARKER),
+    ).toBeNull()
   })
 })
 

--- a/tests/opencode-agent/status.test.ts
+++ b/tests/opencode-agent/status.test.ts
@@ -125,12 +125,13 @@ describe('renderStatus', () => {
     expect(rowFor(body, 'Pull request')).toBe('| 📦 Pull request | ⬜ |')
   })
 
-  test('reads each artefact’s revision rather than recounting it', () => {
-    // The two counters were split apart because one number could not honestly
-    // label two artefacts; this table is the second place that would go wrong.
-    const body = renderStatus(view({ state: state({ phase: 'REVIEW_AND_MUTATE', specRevision: 3, planRevision: 1 }) }))
+  test('the plan row carries the plan-identity token; the design row carries no counter', () => {
+    // Under the OpenSpec rework the proposal lives in the folder whose history
+    // *is* its revision, so the "Design spec" row reports no counter and only
+    // the plan row carries the machine's plan-identity token (`planRevision`).
+    const body = renderStatus(view({ state: state({ phase: 'REVIEW_AND_MUTATE', planRevision: 1 }) }))
 
-    expect(rowFor(body, 'Design spec')).toContain('· revision 3')
+    expect(rowFor(body, 'Design spec')).not.toContain('· revision')
     expect(rowFor(body, 'Planning')).toContain('· revision 1')
   })
 
@@ -200,7 +201,7 @@ describe('renderStatus', () => {
     // `COMPLETE` alone says only that the conversation is over. Claiming every
     // step finished on an issue cancelled during spec review would be a lie the
     // table tells about work nobody did.
-    const cancelled = state({ phase: 'COMPLETE', specRevision: 1 })
+    const cancelled = state({ phase: 'COMPLETE', changeName: 'captured-but-unplanned' })
 
     const body = renderStatus(view({ state: cancelled, live: false }))
 

--- a/tests/opencode-agent/test-helpers.ts
+++ b/tests/opencode-agent/test-helpers.ts
@@ -272,6 +272,14 @@ export const stubPhaseDeps = (options: StubPhaseDepsOptions = {}): { deps: Phase
       io.gitCalls.push(`ensureBranch:${branch}:${base}`)
       return Promise.resolve()
     },
+    resetBranchToBase: (branch: string, base: string): Promise<void> => {
+      io.gitCalls.push(`resetBranchToBase:${branch}:${base}`)
+      return Promise.resolve()
+    },
+    deleteRemoteBranch: (branch: string): Promise<void> => {
+      io.gitCalls.push(`deleteRemoteBranch:${branch}`)
+      return Promise.resolve()
+    },
     commitAll: (message: string): Promise<StagedTotals | null> => {
       io.gitCalls.push(`commit:${message.split('\n')[0]}`)
       return Promise.resolve({ files: 1, lines: 1 })

--- a/tests/opencode-agent/test-helpers.ts
+++ b/tests/opencode-agent/test-helpers.ts
@@ -122,6 +122,8 @@ export interface StubIo {
   thread: IssueComment[]
   /** Git operations invoked, in order (`op:arg`). */
   gitCalls: string[]
+  /** Artifact writes via `writeFile` (`path::content-preview`). */
+  writes: { path: string; content: string }[]
 }
 
 export interface StubPhaseDepsOptions {
@@ -171,6 +173,7 @@ export const stubPhaseDeps = (options: StubPhaseDepsOptions = {}): { deps: Phase
     edits: [],
     thread: [...(options.thread ?? [])],
     gitCalls: [],
+    writes: [],
   }
   const replies = options.replies ?? []
   const login = options.selfLogin ?? 'agent-bot'
@@ -296,6 +299,10 @@ export const stubPhaseDeps = (options: StubPhaseDepsOptions = {}): { deps: Phase
     agent: (): Promise<OpenCodeAgent> => Promise.resolve(agent),
     tokensUsed: (): Promise<number> => Promise.resolve(0),
     skills: (): Promise<SkillDocument[]> => Promise.resolve([...(options.skills ?? [])]),
+    writeFile: (filePath: string, content: string): Promise<void> => {
+      io.writes.push({ path: filePath, content })
+      return Promise.resolve()
+    },
     openspec,
     baseBranch: (): Promise<string> => Promise.resolve('main'),
     selfLogin: (): Promise<string> => Promise.resolve(login),

--- a/tests/opencode-agent/test-helpers.ts
+++ b/tests/opencode-agent/test-helpers.ts
@@ -3,7 +3,45 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import type { OctokitLog } from '../../opencode-agent/src/github.js'
+import type { IssueComment } from '../../opencode-agent/src/blocks.js'
+import type { CheckRunner, CheckSpec } from '../../opencode-agent/src/check-loop.js'
+import type { CiGroups } from '../../opencode-agent/src/ci-groups.js'
+import { DEFAULT_CHECKS } from '../../opencode-agent/src/config-values.js'
+import type { PipelineConfig } from '../../opencode-agent/src/config.js'
+import type { StagedTotals } from '../../opencode-agent/src/diff-guard.js'
+import type { Salvage } from '../../opencode-agent/src/git-commit.js'
+import type { Git, PushOptions } from '../../opencode-agent/src/git.js'
+import type { LabelApi } from '../../opencode-agent/src/github-labels.js'
+import type {
+  PullRequestApi,
+  PullRequestHead,
+  PullRequestInput,
+  PullRequestPresentation,
+  PullRequestRef,
+  PullRequestStatus,
+} from '../../opencode-agent/src/github-pulls.js'
+import type {
+  ReactionApi,
+  ReactionContent,
+  ReactionRef,
+  ReactionTarget,
+} from '../../opencode-agent/src/github-reactions.js'
+import type { GitHubApi, OctokitLog, PostedComment } from '../../opencode-agent/src/github.js'
+import type { Logger } from '../../opencode-agent/src/logger.js'
+import type { SkillDocument } from '../../opencode-agent/src/obra-skills.js'
+import type { OpenCodeAgent, AgentPromptRequest } from '../../opencode-agent/src/opencode-adapter.js'
+import type {
+  InstructionsResult,
+  OpenSpecDriver,
+  StatusResult,
+  ValidateResult,
+} from '../../opencode-agent/src/openspec-driver.js'
+import type { IssueContext } from '../../opencode-agent/src/phase-context.js'
+import type { PhaseDeps, RunReview } from '../../opencode-agent/src/phase-context.js'
+import type { ReviewRunResult } from '../../opencode-agent/src/review-runner.js'
+import type { CommandResult } from '../../opencode-agent/src/shell.js'
+import type { StatusReporter } from '../../opencode-agent/src/status-reporter.js'
+import { noopStatusReporter } from '../../opencode-agent/src/status-reporter.js'
 
 /**
  * An Octokit logger that discards every level.
@@ -20,3 +58,238 @@ export const silentOctokitLog = (): OctokitLog => ({
   warn: (): void => {},
   error: (): void => {},
 })
+
+/** A silent pino-shaped logger for focused phase tests. */
+export const silentLogger = (): Logger => ({
+  debug: (): void => {},
+  info: (): void => {},
+  warn: (): void => {},
+  error: (): void => {},
+})
+
+/**
+ * A complete `PipelineConfig` literal — the same shape the orchestrator harness
+ * builds, centralised here so the focused phase/trigger tests do without `as`
+ * casts (the workspace lints forbid narrowing assertions).
+ */
+export const stubConfig = (repoRoot = '/repo'): PipelineConfig => ({
+  repoRoot,
+  owner: 'acme',
+  repo: 'widgets',
+  githubToken: 'token',
+  selfLoginOverride: 'agent-bot',
+  selfWorkflowName: 'OpenCode Issue Agent',
+  openai: { apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1', model: 'gpt-5' },
+  commitAuthorName: 'agent',
+  commitAuthorEmail: 'agent@example.com',
+  checkCommand: 'bun test',
+  reviewCommand: ['bun', 'run', 'review-loop/src/cli.ts'],
+  checks: DEFAULT_CHECKS,
+  reviewMaxRounds: 2,
+  reviewPoolSize: 1,
+  agentTimeoutMs: 1000,
+  jobDeadlineMs: null,
+  teardownReserveMs: 180_000,
+  wrapUpMs: 120_000,
+  ciFixMaxRounds: 2,
+  commitRepairMaxRounds: 3,
+  maxCiAttempts: 2,
+  maxAttempts: 3,
+  maxReviewAttempts: 2,
+  reviewHintLines: 200,
+  maxTokens: 5_000_000,
+  diffLimits: { maxFiles: 100, maxLines: 20_000 },
+  gitRemoteBase: 'https://github.com/',
+  runUrl: null,
+  labelPrefix: 'agent:',
+  logKey: null,
+  skillRoots: ['.opencode/skills', '.agents/skills', '.superpowers/skills', '.claude/skills'],
+})
+
+/** Recorded calls into a {@link stubPhaseDeps} fake, for assertions. */
+export interface StubIo {
+  /** OpenSpec CLI driver calls, in order (`method:arg`). */
+  openspecCalls: string[]
+  /** Agent prompts, in order — the prompts the model was asked. */
+  prompts: AgentPromptRequest[]
+  /** Reactions placed via the GitHub reaction channel. */
+  reactions: { target: ReactionTarget; content: ReactionContent }[]
+  /** Issue comments posted via `createComment`. */
+  posted: string[]
+  /** Comment edits via `updateComment`. */
+  edits: { id: number; body: string }[]
+  /** The thread the fake GitHub API surfaces to the next read. */
+  thread: IssueComment[]
+}
+
+export interface StubPhaseDepsOptions {
+  /** Model JSON replies, consumed in order by successive prompts. */
+  replies?: string[]
+  /** Skills returned by `deps.skills` (default: none). */
+  skills?: readonly SkillDocument[]
+  /** Override the OpenSpec driver (default: a recording no-op fake). */
+  openspec?: OpenSpecDriver
+  /** Override the agent (default: a reply-consuming fake). */
+  agent?: OpenCodeAgent
+  /** Pre-existing issue thread the fake `listIssueComments` returns. */
+  thread?: readonly IssueComment[]
+  /** Self login the fake reports (default `agent-bot`). */
+  selfLogin?: string
+  /** The repoRoot the fake config reports. */
+  repoRoot?: string
+}
+
+const emptyInstructions = (): InstructionsResult => ({
+  instruction: '',
+  template: undefined,
+  rules: [],
+  resolvedOutputPath: '/repo/x.md',
+  existingOutputPaths: [],
+  dependencies: [],
+})
+
+/**
+ * A complete, fully-typed {@link PhaseDeps} fake for the focused phase and
+ * trigger tests (per the slice plan: drive handlers through `PhaseDeps`
+ * directly, without spinning the orchestrator harness).
+ *
+ * Every external boundary is a working no-op that records into {@link StubIo};
+ * the unused ones return safe defaults so an accidental call does not crash.
+ * Fields a test wants to customise — `agent`, `openspec`, `skills` — come in
+ * via {@link StubPhaseDepsOptions}. The agent fake consumes `options.replies`
+ * in order, so a test sets up model output the way the orchestrator harness
+ * does, just smaller.
+ */
+export const stubPhaseDeps = (options: StubPhaseDepsOptions = {}): { deps: PhaseDeps; io: StubIo } => {
+  const io: StubIo = {
+    openspecCalls: [],
+    prompts: [],
+    reactions: [],
+    posted: [],
+    edits: [],
+    thread: [...(options.thread ?? [])],
+  }
+  const replies = options.replies ?? []
+  const login = options.selfLogin ?? 'agent-bot'
+
+  const defaultAgent: OpenCodeAgent = {
+    sessionId: 's',
+    prompt: (request: AgentPromptRequest): Promise<{ text: string; sessionId: string }> => {
+      io.prompts.push(request)
+      return Promise.resolve({ text: replies.shift() ?? '', sessionId: 's' })
+    },
+    tokensUsed: (): Promise<number> => Promise.resolve(0),
+    abort: (): Promise<boolean> => Promise.resolve(true),
+    close: (): Promise<void> => Promise.resolve(),
+  }
+  const agent: OpenCodeAgent = options.agent ?? defaultAgent
+
+  const defaultOpenspec: OpenSpecDriver = {
+    newChange: (changeName: string, schema: string): Promise<{ changeName: string }> => {
+      io.openspecCalls.push(`newChange:${changeName}:${schema}`)
+      return Promise.resolve({ changeName })
+    },
+    status: (changeName: string): Promise<StatusResult> => {
+      io.openspecCalls.push(`status:${changeName}`)
+      return Promise.resolve({ schemaName: 'spec-driven', artifacts: {}, isPlanningComplete: false })
+    },
+    instructions: (artifactId: string, changeName: string): Promise<InstructionsResult> => {
+      io.openspecCalls.push(`instructions:${artifactId}:${changeName}`)
+      return Promise.resolve(emptyInstructions())
+    },
+    validateStrict: (changeName: string): Promise<ValidateResult> => {
+      io.openspecCalls.push(`validate:${changeName}`)
+      return Promise.resolve({ ok: true, output: '' })
+    },
+    archive: (changeName: string): Promise<void> => {
+      io.openspecCalls.push(`archive:${changeName}`)
+      return Promise.resolve()
+    },
+  }
+  const openspec: OpenSpecDriver = options.openspec ?? defaultOpenspec
+
+  const reactionApi: ReactionApi = {
+    addReaction: (target: ReactionTarget, content: ReactionContent): Promise<ReactionRef> => {
+      io.reactions.push({ target, content })
+      return Promise.resolve({ id: io.reactions.length })
+    },
+    removeReaction: (_target: ReactionTarget, _reaction: ReactionRef): Promise<void> => Promise.resolve(),
+  }
+
+  const labelApi: LabelApi = {
+    listLabels: (_issueNumber: number): Promise<string[]> => Promise.resolve([]),
+    addLabels: (_issueNumber: number, _names: readonly string[]): Promise<void> => Promise.resolve(),
+    removeLabel: (_issueNumber: number, _name: string): Promise<void> => Promise.resolve(),
+    createLabel: (_name: string, _color: string): Promise<void> => Promise.resolve(),
+  }
+
+  const pullRequestApi: PullRequestApi = {
+    findPullRequest: (_head: string): Promise<PullRequestStatus | null> => Promise.resolve(null),
+    getPullRequestHead: (_prNumber: number): Promise<PullRequestHead> =>
+      Promise.resolve({ ref: '', repoFullName: '', state: 'open' }),
+    createPullRequest: (_input: PullRequestInput): Promise<PullRequestRef> =>
+      Promise.resolve({ number: 7, url: 'https://example.test/pull/7' }),
+    updatePullRequest: (_number: number, _patch: PullRequestPresentation): Promise<void> => Promise.resolve(),
+  }
+
+  const github: GitHubApi = {
+    listIssueComments: (_issueNumber: number): Promise<IssueComment[]> => Promise.resolve([...io.thread]),
+    createComment: (_issueNumber: number, body: string): Promise<PostedComment> => {
+      io.posted.push(body)
+      const id = io.thread.length + io.posted.length + 100
+      io.thread.push({ id, body, authorLogin: login })
+      return Promise.resolve({ id, url: `https://example.test/c/${id}`, authorLogin: login })
+    },
+    updateComment: (commentId: number, body: string): Promise<void> => {
+      io.edits.push({ id: commentId, body })
+      return Promise.resolve()
+    },
+    getIssue: (issueNumber: number): Promise<IssueContext> =>
+      Promise.resolve({ number: issueNumber, title: '', body: '' }),
+    getAuthenticatedLogin: (): Promise<string> => Promise.resolve(login),
+    ...reactionApi,
+    ...labelApi,
+    ...pullRequestApi,
+  }
+
+  const git: Git = {
+    ensureBranch: (_branch: string, _base: string): Promise<void> => Promise.resolve(),
+    commitAll: (_message: string): Promise<StagedTotals | null> => Promise.resolve({ files: 0, lines: 0 }),
+    salvageAll: (_message: string): Promise<Salvage> => Promise.resolve({ kind: 'clean' }),
+    push: (_branch: string, _options?: PushOptions): Promise<void> => Promise.resolve(),
+    defaultBranch: (): Promise<string | null> => Promise.resolve('main'),
+  }
+
+  const runCheck: CheckRunner = (_check: CheckSpec): Promise<CommandResult> =>
+    Promise.resolve({ command: '', stdout: '', stderr: '', exitCode: 0 })
+
+  const runReview: RunReview = (_plan: string): Promise<ReviewRunResult> =>
+    Promise.resolve({ outcome: 'passed', summary: '', exitCode: 0 })
+
+  const groups: CiGroups = {
+    startGroup: (_headline: string): void => {},
+    endGroup: (): void => {},
+  }
+
+  const status: StatusReporter = noopStatusReporter()
+
+  const deps: PhaseDeps = {
+    github,
+    git,
+    runCheck,
+    runReview,
+    agent: (): Promise<OpenCodeAgent> => Promise.resolve(agent),
+    tokensUsed: (): Promise<number> => Promise.resolve(0),
+    skills: (): Promise<SkillDocument[]> => Promise.resolve([...(options.skills ?? [])]),
+    openspec,
+    baseBranch: (): Promise<string> => Promise.resolve('main'),
+    selfLogin: (): Promise<string> => Promise.resolve(login),
+    status,
+    now: (): number => 0,
+    groups,
+    config: stubConfig(options.repoRoot),
+    log: silentLogger(),
+  }
+
+  return { deps, io }
+}

--- a/tests/opencode-agent/test-helpers.ts
+++ b/tests/opencode-agent/test-helpers.ts
@@ -120,6 +120,8 @@ export interface StubIo {
   edits: { id: number; body: string }[]
   /** The thread the fake GitHub API surfaces to the next read. */
   thread: IssueComment[]
+  /** Git operations invoked, in order (`op:arg`). */
+  gitCalls: string[]
 }
 
 export interface StubPhaseDepsOptions {
@@ -168,6 +170,7 @@ export const stubPhaseDeps = (options: StubPhaseDepsOptions = {}): { deps: Phase
     posted: [],
     edits: [],
     thread: [...(options.thread ?? [])],
+    gitCalls: [],
   }
   const replies = options.replies ?? []
   const login = options.selfLogin ?? 'agent-bot'
@@ -253,10 +256,22 @@ export const stubPhaseDeps = (options: StubPhaseDepsOptions = {}): { deps: Phase
   }
 
   const git: Git = {
-    ensureBranch: (_branch: string, _base: string): Promise<void> => Promise.resolve(),
-    commitAll: (_message: string): Promise<StagedTotals | null> => Promise.resolve({ files: 0, lines: 0 }),
-    salvageAll: (_message: string): Promise<Salvage> => Promise.resolve({ kind: 'clean' }),
-    push: (_branch: string, _options?: PushOptions): Promise<void> => Promise.resolve(),
+    ensureBranch: (branch: string, base: string): Promise<void> => {
+      io.gitCalls.push(`ensureBranch:${branch}:${base}`)
+      return Promise.resolve()
+    },
+    commitAll: (message: string): Promise<StagedTotals | null> => {
+      io.gitCalls.push(`commit:${message.split('\n')[0]}`)
+      return Promise.resolve({ files: 1, lines: 1 })
+    },
+    salvageAll: (message: string): Promise<Salvage> => {
+      io.gitCalls.push(`salvage:${message.split('\n')[0]}`)
+      return Promise.resolve({ kind: 'clean' })
+    },
+    push: (branch: string, _options?: PushOptions): Promise<void> => {
+      io.gitCalls.push(`push:${branch}`)
+      return Promise.resolve()
+    },
     defaultBranch: (): Promise<string | null> => Promise.resolve('main'),
   }
 

--- a/tests/opencode-agent/test-helpers.ts
+++ b/tests/opencode-agent/test-helpers.ts
@@ -124,6 +124,13 @@ export interface StubIo {
   gitCalls: string[]
   /** Artifact writes via `writeFile` (`path::content-preview`). */
   writes: { path: string; content: string }[]
+  /** File reads via `readFile`, in order. Tests seed `readContents` to reply. */
+  reads: string[]
+  /**
+   * Content the fake `readFile` returns, keyed by path; absent paths return ''.
+   * Set by a test before driving a handler that reads (e.g. tasks.md).
+   */
+  readContents: Record<string, string>
 }
 
 export interface StubPhaseDepsOptions {
@@ -174,6 +181,8 @@ export const stubPhaseDeps = (options: StubPhaseDepsOptions = {}): { deps: Phase
     thread: [...(options.thread ?? [])],
     gitCalls: [],
     writes: [],
+    reads: [],
+    readContents: {},
   }
   const replies = options.replies ?? []
   const login = options.selfLogin ?? 'agent-bot'
@@ -301,7 +310,12 @@ export const stubPhaseDeps = (options: StubPhaseDepsOptions = {}): { deps: Phase
     skills: (): Promise<SkillDocument[]> => Promise.resolve([...(options.skills ?? [])]),
     writeFile: (filePath: string, content: string): Promise<void> => {
       io.writes.push({ path: filePath, content })
+      io.readContents[filePath] = content
       return Promise.resolve()
+    },
+    readFile: (filePath: string): Promise<string> => {
+      io.reads.push(filePath)
+      return Promise.resolve(io.readContents[filePath] ?? '')
     },
     openspec,
     baseBranch: (): Promise<string> => Promise.resolve('main'),

--- a/tests/opencode-agent/triggers.test.ts
+++ b/tests/opencode-agent/triggers.test.ts
@@ -7,7 +7,8 @@ import { describe, expect, it } from 'bun:test'
 
 import { applyClarifyIntent } from '../../opencode-agent/src/comment-intent.js'
 import type { PhaseInput } from '../../opencode-agent/src/phase-context.js'
-import type { TriggerEvent } from '../../opencode-agent/src/trigger-events.js'
+import type { PrMergedTriggerEvent, TriggerEvent } from '../../opencode-agent/src/trigger-events.js'
+import { applyArchiveTrigger } from '../../opencode-agent/src/triggers.js'
 import type { AgentState } from '../../opencode-agent/src/types.js'
 import { stubPhaseDeps } from './test-helpers.js'
 
@@ -131,5 +132,59 @@ describe('applyClarifyIntent · consent completion (D9)', () => {
     // halt: null → triage runs. No classifier prompt was spent.
     expect(outcome.halt).toBeNull()
     expect(recording.io.prompts).toHaveLength(0)
+  })
+})
+
+describe('applyArchiveTrigger · the merged-PR door (D7)', () => {
+  const archiveState = (over: Partial<AgentState> = {}): AgentState => ({
+    ...baseState(),
+    phase: 'COMPLETE',
+    changeName: 'add-retries',
+    prNumber: 7,
+    ...over,
+  })
+
+  const mergedPrTrigger = (): PrMergedTriggerEvent => ({
+    kind: 'pr-merged',
+    eventName: 'pull_request',
+    prNumber: 7,
+    issueNumber: 42,
+    baseBranch: 'main',
+    fromThisRepository: true,
+    defaultBranch: 'main',
+  })
+
+  it('moves COMPLETE → ARCHIVE for a merged agent-branch pull request', () => {
+    const recording = stubPhaseDeps({ selfLogin: AGENT_LOGIN })
+    const input: PhaseInput = {
+      state: archiveState(),
+      issue: { number: 42, title: 't', body: 'b' },
+      trigger: mergedPrTrigger(),
+      command: null,
+      thread: recording.io.thread,
+      deps: recording.deps,
+    }
+
+    const outcome = applyArchiveTrigger(input)
+
+    expect(outcome.state.phase).toBe('ARCHIVE')
+    expect(outcome.halt).toBeNull()
+  })
+
+  it('skips a merge event that arrives anywhere but COMPLETE', () => {
+    const recording = stubPhaseDeps({ selfLogin: AGENT_LOGIN })
+    const input: PhaseInput = {
+      state: archiveState({ phase: 'PLAN_REVIEW' }),
+      issue: { number: 42, title: 't', body: 'b' },
+      trigger: mergedPrTrigger(),
+      command: null,
+      thread: recording.io.thread,
+      deps: recording.deps,
+    }
+
+    const outcome = applyArchiveTrigger(input)
+
+    expect(outcome.halt?.status).toBe('skipped')
+    expect(outcome.state.phase).toBe('PLAN_REVIEW')
   })
 })

--- a/tests/opencode-agent/triggers.test.ts
+++ b/tests/opencode-agent/triggers.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from 'bun:test'
 import { applyClarifyIntent } from '../../opencode-agent/src/comment-intent.js'
 import type { PhaseInput } from '../../opencode-agent/src/phase-context.js'
 import type { PrMergedTriggerEvent, TriggerEvent } from '../../opencode-agent/src/trigger-events.js'
-import { applyArchiveTrigger } from '../../opencode-agent/src/triggers.js'
+import { applyArchiveTrigger, applyTrigger } from '../../opencode-agent/src/triggers.js'
 import type { AgentState } from '../../opencode-agent/src/types.js'
 import { stubPhaseDeps } from './test-helpers.js'
 
@@ -186,5 +186,44 @@ describe('applyArchiveTrigger · the merged-PR door (D7)', () => {
 
     expect(outcome.halt?.status).toBe('skipped')
     expect(outcome.state.phase).toBe('PLAN_REVIEW')
+  })
+})
+
+describe('applyTrigger · /cancel cleanup (D9)', () => {
+  it('deletes the remote agent branch when /cancel succeeds', async () => {
+    const recording = stubPhaseDeps({ selfLogin: AGENT_LOGIN })
+    const input: PhaseInput = {
+      state: baseState({ phase: 'PLAN_REVIEW', changeName: 'add-x' }),
+      issue: { number: 42, title: 't', body: 'b' },
+      trigger: commentTrigger('/cancel', 'OWNER'),
+      command: { command: '/cancel', argument: '' },
+      thread: recording.io.thread,
+      deps: recording.deps,
+    }
+
+    const outcome = await applyTrigger(input)
+
+    expect(outcome.state.phase).toBe('COMPLETE')
+    // The branch + its change folder are the work of a mis-capture; /cancel
+    // removes them rather than leaving an orphaned agent branch behind.
+    expect(recording.io.gitCalls).toContain('deleteRemoteBranch:agent/issue-42')
+  })
+
+  it('cancels cleanly when there is no branch to delete (pre-capture)', async () => {
+    const recording = stubPhaseDeps({ selfLogin: AGENT_LOGIN })
+    const input: PhaseInput = {
+      state: baseState({ phase: 'INIT_OR_CLARIFY', changeName: null }),
+      issue: { number: 42, title: 't', body: 'b' },
+      trigger: commentTrigger('/cancel', 'OWNER'),
+      command: { command: '/cancel', argument: '' },
+      thread: recording.io.thread,
+      deps: recording.deps,
+    }
+
+    const outcome = await applyTrigger(input)
+
+    expect(outcome.state.phase).toBe('COMPLETE')
+    // No branch was ever created, so no deletion is attempted.
+    expect(recording.io.gitCalls).not.toContain('deleteRemoteBranch:agent/issue-42')
   })
 })

--- a/tests/opencode-agent/triggers.test.ts
+++ b/tests/opencode-agent/triggers.test.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import { applyClarifyIntent } from '../../opencode-agent/src/comment-intent.js'
+import type { PhaseInput } from '../../opencode-agent/src/phase-context.js'
+import type { TriggerEvent } from '../../opencode-agent/src/trigger-events.js'
+import type { AgentState } from '../../opencode-agent/src/types.js'
+import { stubPhaseDeps } from './test-helpers.js'
+
+/**
+ * The consent half of D9.
+ *
+ * An untrusted author whose issue triage wanted to capture is parked behind a
+ * consent comment. The capture completes when a maintainer replies
+ * affirmatively — and that reply arrives as a plain comment in
+ * `INIT_OR_CLARIFY`, which `applyClarifyIntent` reads. Anything the classifier
+ * does not positively call chatter (`none`) re-runs triage; the re-run sees the
+ * maintainer's trusted association and captures. So the contract this file
+ * pins is that the consent reply is **not** skipped: it must reach triage.
+ */
+
+const AGENT_LOGIN = 'agent-bot'
+
+const baseState = (over: Partial<AgentState> = {}): AgentState => ({
+  v: 3,
+  phase: 'INIT_OR_CLARIFY',
+  issueId: 42,
+  resumeFrom: null,
+  attempts: 0,
+  ciAttempts: 0,
+  ciBudgetReported: false,
+  reviewAttempts: 0,
+  changedLines: 0,
+  stepsDone: 0,
+  changeName: null,
+  planRevision: 0,
+  tokensSpent: 0,
+  lastError: null,
+  prUrl: null,
+  prNumber: null,
+  ...over,
+})
+
+const commentTrigger = (body: string, association: string): TriggerEvent => ({
+  kind: 'issue',
+  eventName: 'issue_comment',
+  action: 'created',
+  senderLogin: 'maintainer',
+  senderType: 'User',
+  authorAssociation: association,
+  issueNumber: 42,
+  issueTitle: 'Add a retry helper',
+  issueBody: 'Please add a retry helper.',
+  isPullRequest: false,
+  commentBody: body,
+  commentId: 99,
+  repositoryOwner: 'acme',
+  defaultBranch: 'main',
+})
+
+describe('applyClarifyIntent · consent completion (D9)', () => {
+  it('re-runs triage for an affirmative maintainer reply — the channel that completes capture', async () => {
+    // The maintainer confirmed the capture the agent asked consent for. The
+    // classifier reads this as a real reply (not chatter), so the outcome must
+    // hand control back to triage rather than skipping.
+    const recording = stubPhaseDeps({
+      replies: [JSON.stringify({ intent: 'approve' })],
+      selfLogin: AGENT_LOGIN,
+    })
+    const input: PhaseInput = {
+      state: baseState(),
+      issue: { number: 42, title: 't', body: 'b' },
+      trigger: commentTrigger('Yes, go ahead and capture this.', 'OWNER'),
+      command: null,
+      thread: recording.io.thread,
+      deps: recording.deps,
+    }
+
+    const outcome = await applyClarifyIntent(input)
+
+    // `halt: null` means "do not skip — run the phase handler", which is the
+    // triage re-run that captures on a trusted association.
+    expect(outcome.halt).toBeNull()
+    expect(outcome.answer).toBe(false)
+    expect(recording.io.prompts).toHaveLength(1)
+    expect(String(recording.io.prompts[0]?.prompt)).toContain('Classify this comment')
+  })
+
+  it('skips chatter so a 👍 does not re-run triage', async () => {
+    const recording = stubPhaseDeps({
+      replies: [JSON.stringify({ intent: 'none' })],
+      selfLogin: AGENT_LOGIN,
+    })
+    const input: PhaseInput = {
+      state: baseState(),
+      issue: { number: 42, title: 't', body: 'b' },
+      trigger: commentTrigger('👍', 'OWNER'),
+      command: null,
+      thread: recording.io.thread,
+      deps: recording.deps,
+    }
+
+    const outcome = await applyClarifyIntent(input)
+
+    expect(outcome.halt).not.toBeNull()
+    expect(outcome.halt?.status).toBe('skipped')
+  })
+
+  it('falls through to triage on a blank body (the issue-opened shape), never skipping', async () => {
+    // The consent comment's sibling is the original `issues.opened` event that
+    // starts every issue: a blank body must reach triage, not be classified.
+    const recording = stubPhaseDeps({
+      replies: [JSON.stringify({ intent: 'none' })],
+      selfLogin: AGENT_LOGIN,
+    })
+    const input: PhaseInput = {
+      state: baseState(),
+      issue: { number: 42, title: 't', body: 'b' },
+      trigger: commentTrigger('', 'OWNER'),
+      command: null,
+      thread: recording.io.thread,
+      deps: recording.deps,
+    }
+
+    const outcome = await applyClarifyIntent(input)
+
+    // halt: null → triage runs. No classifier prompt was spent.
+    expect(outcome.halt).toBeNull()
+    expect(recording.io.prompts).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

`opencode-agent` was the last entry point not on the repo's OpenSpec substrate: its `PHASE_SKILLS` routed triage to `brainstorming` and planning to `writing-plans`, producing freeform `AGENT_SPEC`/`AGENT_PLAN` blocks no `openspec validate` ever saw, and its branches shipped code without a change folder. This change brings it onto the same compliant pipeline as every other entry point.

**Change:** `openspec/changes/opencode-agent-openspec-compliance/` (design D1–D13, 23/23 tasks complete)

## What changed

**The folder is truth; comments are renders (D1).** The design spec and the plan no longer travel in `AGENT_SPEC`/`AGENT_PLAN` blocks on the issue — they live in `openspec/changes/<name>/` on `agent/issue-<n>`. The two human parks (`DESIGN_SPEC`, `PLAN_REVIEW`) review rendered digests (`renderDigest`) of the real folder, read back after each write.

**PLANNING is a CLI-driven drafter loop (D3).** `status --json` → model composes per template → `validate --strict` → retry ≤2 with the complaint attached. The model composes content only; TS drives the CLI protocol (re-implemented, not imported from `sdd-runner`).

**`tasks.md` is the implementation step source (D5).** `REVIEW_AND_MUTATE` walks the change's checkboxes, ticking each box in the same commit as the step's work.

**Steering-drift (D6).** A plain maintainer comment mid-implementation classified as scope-affecting routes back to `PLANNING` for an artifact-update turn before implementation continues — the folder cannot rot relative to the conversation.

**Merged PR is the archive door (D7).** `pull_request.closed(merged)` on an agent branch moves `COMPLETE → ARCHIVE`; the handler runs `openspec archive` as a follow-up commit on the base branch, closing the propose → apply → archive loop.

**Capture policy + restart semantics (D9/D12).** Auto-capture is gated by author association (OWNER/MEMBER/COLLABORATOR); untrusted authors get a consent comment. A deliberate `STATE_VERSION` bump retires the legacy block format outright — in-flight issues restart fresh, with the `agent/issue-<n>` branch reset to base before the scaffold commit. `/cancel` gains branch cleanup.

**Skill rewiring (D4/D11).** `INIT_OR_CLARIFY → openspec-explore`, `PLANNING → openspec-propose`; `brainstorming`/`writing-plans`/`executing-plans` gone. Loader roots: `.opencode/skills/`, then `.agents/skills/`, then the pinned `obra/superpowers` checkout.

## Workflow

- New `pull_request: [closed]` trigger + filter arm in `agent-pipeline.yml`.
- `@fission-ai/openspec` CLI installed and pinned beside the `opencode` CLI.

## Test plan

- [x] `bun run test` — 14033 pass / 0 fail / 7 skip (1351 files)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] Pre-commit hook (lint + typecheck + format + license-headers) 4/4 on every commit

The 18 commits are organized by task slice; each lands its own failing-test-first → implement → verify cycle. The change folder (`openspec/changes/opencode-agent-openspec-compliance/`) rides with the code on this branch per the `operations.apply` rule.

🤖 Generated with [opencode](https://opencode.ai)
