### PR TITLE
fix(agent-pipeline): a `#` inside the `if:` block scalar is expression text

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,41 @@
+# actionlint configuration. Read by `bun workflows:lint` (scripts/run-actionlint.ts)
+# and by the "Workflow Lint" job in ci.yml.
+#
+# The gate exists because a workflow file is the one thing in this repository
+# that CI cannot check by running it. An invalid one is not a red build — GitHub
+# rejects the file, starts no job, and reports a run that is `failure` a second
+# after it began with the file path where the workflow name should be. Nothing
+# else goes red, so the merge looks clean. That is exactly how the `#`-inside-a
+# -folded-block-scalar bug in agent-pipeline.yml's `if:` shipped and left the
+# OpenCode agent dead from 2026-08-09 to 2026-08-12, across every trigger,
+# noticed only because somebody opened the Actions tab.
+#
+# Suppressions are path-scoped on purpose. A global `-ignore` would hide the
+# same class of error everywhere it is genuinely wrong, and both entries below
+# are cases where actionlint is stricter than GitHub actually is — each was
+# checked against a real run before being written down, and each says which one.
+
+paths:
+  .github/workflows/ci.yml:
+    ignore:
+      # `queue` is a documented `concurrency` property — `single` (default) and
+      # `max` ("up to 100 jobs or workflow runs can be pending in the
+      # concurrency group"). actionlint 1.7.7 predates it and knows only `group`
+      # and `cancel-in-progress`. The key parses and takes effect: on 07ad7f9
+      # the job that carries it, "Mutation Testing (changed-files baseline
+      # seed)", ran to success (CI run 31602130473).
+      - 'unexpected key "queue" for "concurrency" section'
+
+  .github/workflows/agent-pipeline.yml:
+    ignore:
+      # `timeout-minutes: ${{ vars.AGENT_JOB_TIMEOUT_MINUTES || 90 }}`. actionlint
+      # wants a number and `vars` is typed string; GitHub coerces. Proven by run
+      # 31328255566 on 278d0db, which carries this exact line and whose "Run
+      # agent pipeline" job started and completed normally.
+      #
+      # The expression stays in this spelling rather than a `fromJSON(…)` one
+      # because the *same* text is forwarded to the pipeline as the
+      # `AGENT_JOB_TIMEOUT_MINUTES` env value, which is what makes the ceiling
+      # one value instead of two kept in step by hand. `workflow.test.ts` pins
+      # that the two are identical.
+      - 'must be number but found type string'

--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -109,6 +109,16 @@ jobs:
     # API call and is not attempted here. And the arm above keeps its
     # `pull_request == null`: it is what still drops a pull-request comment
     # carrying no `/review`.
+    #
+    # The fourth arm is Design D7's archive door: a merged pull request on an
+    # agent branch whose head is this repository. The in-process parse checks the
+    # same four things; this arm keeps a fork's `agent/issue-42` or an unmerged
+    # close from ever booting a runner with the API keys mounted.
+    #
+    # Everything below `if:` is a folded block scalar, so a `#` line in there is
+    # not a YAML comment — it folds into the expression, and GitHub rejects the
+    # whole file with no job ever starting. Commentary on the arms goes here,
+    # above the key.
     if: >-
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'failure' &&
@@ -127,10 +137,6 @@ jobs:
         github.event.sender.type != 'Bot' &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
        ||
-       # Design D7 — the archive door. A merged pull request on an agent branch
-       # whose head is this repository. The in-process parse checks the same four
-       # things; this arm keeps a fork's `agent/issue-42` or an unmerged close
-       # from ever booting a runner with the API keys mounted.
        (github.event_name == 'pull_request' &&
         github.event.action == 'closed' &&
         github.event.pull_request.merged == true &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,26 @@ jobs:
         with:
           sarif_file: semgrep-results.sarif
 
+  # Deliberately `needs`-free and dependency-free: it is the one check whose
+  # subject is the workflow files themselves, and an invalid one is invisible
+  # everywhere else. GitHub rejects the file rather than failing a job, so no
+  # build goes red — agent-pipeline.yml sat broken from 2026-08-09 to
+  # 2026-08-12 with CI green over it. Running before `build` makes that the
+  # first thing the run says rather than the last.
+  workflows:
+    name: Workflow Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.13
+      # No `bun install`: the runner script imports nothing outside Bun's own
+      # builtins, and the linter it fetches is a pinned, checksum-verified
+      # release binary.
+      - name: Lint workflow files
+        run: bun workflows:lint
+
   check:
     name: Checks
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ opencode.json
 # opencode-agent: vendored superpowers checkout + generated run inputs
 .superpowers/
 .opencode-agent/
+
+# pinned actionlint binary, fetched and checksum-verified by scripts/run-actionlint.ts
+.actionlint/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,3 +136,5 @@ Shape queries with `kinds` (e.g. `["function_declaration", ...]`) and `scopeTier
 ## Workflow files
 
 `bun workflows:lint` (pinned, checksum-verified actionlint; also the `Workflow Lint` CI job). An invalid workflow is **not** a red build — GitHub rejects the file, starts no job, and every other check stays green, so this is the only thing that catches one. Suppressions live in `.github/actionlint.yaml`, path-scoped and each carrying the run that proves actionlint is wrong there. Note that `if: >-` opens a folded scalar: a `#` line inside it folds into the expression instead of being a comment, which is what broke `agent-pipeline.yml`.
+
+The shellcheck/pyflakes integrations are deliberately **off**: they run only where those binaries happen to be installed, so leaving them on makes the gate answer differently on a laptop than on a runner — and a bad `run:` block is already a red job, which is the opposite of what this gate is for.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,3 +132,7 @@ Shape queries with `kinds` (e.g. `["function_declaration", ...]`) and `scopeTier
 ## Security
 
 `bun security` (local Semgrep) / `bun security:ci`. Covers OWASP-style issues, TS/JS pitfalls, and AI/LLM concerns (prompt-injection-adjacent unsafe fetch, accidental secret exposure).
+
+## Workflow files
+
+`bun workflows:lint` (pinned, checksum-verified actionlint; also the `Workflow Lint` CI job). An invalid workflow is **not** a red build — GitHub rejects the file, starts no job, and every other check stays green, so this is the only thing that catches one. Suppressions live in `.github/actionlint.yaml`, path-scoped and each carrying the run that proves actionlint is wrong there. Note that `if: >-` opens a folded scalar: a `#` line inside it folds into the expression instead of being a comment, which is what broke `agent-pipeline.yml`.

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "format:check": "oxfmt --check . --ignore-path=.oxfmtignore",
     "security": "bun run scripts/run-semgrep.ts",
     "security:ci": "bun run scripts/run-semgrep.ts --ci",
+    "workflows:lint": "bun run scripts/run-actionlint.ts",
     "test": "bun scripts/test/run-cli.ts",
     "test:serial": "bun scripts/test/run-cli.ts --serial",
     "test:raw": "bun test --parallel",

--- a/scripts/run-actionlint.ts
+++ b/scripts/run-actionlint.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env bun
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { existsSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
+
+import { $ } from 'bun'
+
+const ACTIONLINT_VERSION = '1.7.7'
+
+/**
+ * sha256 of the official release tarballs, copied from
+ * `actionlint_1.7.7_checksums.txt` on the release. A pinned version on its own
+ * still runs whatever that URL serves next year; the digest is what makes it the
+ * same bytes every time, and this binary reads every workflow in the repository.
+ */
+const CHECKSUMS: Record<string, string> = {
+  darwin_amd64: '28e5de5a05fc558474f638323d736d822fff183d2d492f0aecb2b73cc44584f5',
+  darwin_arm64: '2693315b9093aeacb4ebd91a993fea54fc215057bf0da2659056b4bc033873db',
+  linux_amd64: '023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757',
+  linux_arm64: '401942f9c24ed71e4fe71b76c7d638f66d8633575c4016efd2977ce7c28317d0',
+}
+
+/** Gitignored; one extracted binary per pinned version, so a bump re-downloads. */
+const CACHE_DIR = '.actionlint'
+
+/** The release's platform suffix, or `null` where no build is published. */
+function platformKey(): string | null {
+  const os = process.platform === 'darwin' ? 'darwin' : process.platform === 'linux' ? 'linux' : null
+  const arch = process.arch === 'x64' ? 'amd64' : process.arch === 'arm64' ? 'arm64' : null
+
+  return os !== null && arch !== null ? `${os}_${arch}` : null
+}
+
+async function download(key: string, into: string): Promise<void> {
+  const url = `https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_${key}.tar.gz`
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Downloading actionlint ${ACTIONLINT_VERSION} failed: ${response.status} ${response.statusText}`)
+  }
+
+  const bytes = new Uint8Array(await response.arrayBuffer())
+  const digest = new Bun.CryptoHasher('sha256').update(bytes).digest('hex')
+  const expected = CHECKSUMS[key]
+  if (digest !== expected) {
+    throw new Error(
+      `Checksum mismatch for actionlint_${ACTIONLINT_VERSION}_${key}.tar.gz.\n` +
+        `  expected ${expected}\n  got      ${digest}\n` +
+        'Refusing to run a binary that is not the pinned release.',
+    )
+  }
+
+  await mkdir(into, { recursive: true })
+  const tarball = path.join(into, 'actionlint.tar.gz')
+  await Bun.write(tarball, bytes)
+  await $`tar -xzf ${tarball} -C ${into} actionlint`.quiet()
+}
+
+/**
+ * The pinned binary, downloaded and cached on first use.
+ *
+ * A system `actionlint` is used only where no release matches the platform: a
+ * different version reports a different set of findings, and a gate that says
+ * something different on a laptop than in CI is worse than no gate.
+ */
+async function resolveBinary(): Promise<string> {
+  const key = platformKey()
+  if (key === null) {
+    const system = Bun.which('actionlint')
+    if (system !== null) {
+      console.log(`⚠️  No pinned actionlint build for ${process.platform}/${process.arch}; using ${system}`)
+      return system
+    }
+    throw new Error(
+      `No actionlint release for ${process.platform}/${process.arch}, and none on PATH.\n` +
+        'Install actionlint (brew install actionlint) to lint workflows here.',
+    )
+  }
+
+  const dir = path.join(CACHE_DIR, ACTIONLINT_VERSION)
+  const binary = path.join(dir, 'actionlint')
+  if (!existsSync(binary)) {
+    console.log(`⬇️  Fetching actionlint ${ACTIONLINT_VERSION} (${key})...`)
+    await download(key, dir)
+  }
+
+  return binary
+}
+
+async function main(): Promise<void> {
+  try {
+    const binary = await resolveBinary()
+
+    console.log('\n🔍 Linting workflow files...\n')
+    // No file arguments: actionlint walks .github/workflows itself, which is the
+    // point — a gate that took a list would not see a newly added workflow.
+    // `.github/actionlint.yaml` is picked up from the repository root, and
+    // carries the path-scoped suppressions with the reason for each.
+    const result = await $`${binary} -color`.nothrow()
+
+    if (result.exitCode === 0) {
+      console.log('✅ Workflow lint passed')
+    } else {
+      console.log('\n❌ Workflow lint found problems.')
+      console.log('   An invalid workflow file does not show up as a red build: GitHub rejects')
+      console.log('   the file, starts no job, and the run reports `failure` a second after it')
+      console.log('   began. Fix these before merging.')
+      console.log('')
+      console.log('   Watch for `#` inside an `if: >-` block: that is a folded scalar, so the')
+      console.log('   line folds into the expression instead of being a comment. Commentary')
+      console.log('   belongs above the `if:` key.')
+    }
+
+    process.exit(result.exitCode)
+  } catch (error) {
+    console.error('❌ Fatal error:', error instanceof Error ? error.message : String(error))
+    process.exit(2)
+  }
+}
+
+void main()

--- a/scripts/run-actionlint.ts
+++ b/scripts/run-actionlint.ts
@@ -100,7 +100,27 @@ async function main(): Promise<void> {
     // point — a gate that took a list would not see a newly added workflow.
     // `.github/actionlint.yaml` is picked up from the repository root, and
     // carries the path-scoped suppressions with the reason for each.
-    const result = await $`${binary} -color`.nothrow()
+    //
+    // shellcheck and pyflakes are actionlint's optional external linters, run
+    // against `run:` blocks when those binaries happen to be on PATH. Both are
+    // disabled, for two reasons.
+    //
+    // The first is that this gate has to give one answer everywhere. Those
+    // integrations are silently on where the binary exists and silently off
+    // where it does not — ubuntu-latest ships shellcheck and a dev container
+    // may not, so the same commit passes locally and fails in CI. Pinning the
+    // actionlint binary and then leaving what it runs up to the host defeats
+    // the pin.
+    //
+    // The second is scope. A bad `run:` block is a red job, which CI already
+    // reports; this gate exists for the failure that reports nothing at all.
+    // Turning it on cost 12 findings across four workflows nobody had touched,
+    // all style or info except two warnings on deploy.yml's ssh block that were
+    // both wrong: the literal `~` is a remote path the server expands, and the
+    // unquoted heredoc is what interpolates the runner's secrets before they
+    // are sent. "Fixing" either would have broken the deploy.
+    const args = ['-color', '-shellcheck=', '-pyflakes=']
+    const result = await $`${binary} ${args}`.nothrow()
 
     if (result.exitCode === 0) {
       console.log('✅ Workflow lint passed')

--- a/tests/opencode-agent/workflow.test.ts
+++ b/tests/opencode-agent/workflow.test.ts
@@ -255,6 +255,30 @@ describe('the job condition', () => {
   })
 })
 
+/** Every `if:` the document carries, job conditions and step conditions alike. */
+const everyCondition: Array<[where: string, expression: string]> = Object.entries(workflow.jobs).flatMap(
+  ([id, job]) => [
+    [`jobs.${id}.if`, job.if] as [string, string],
+    ...job.steps.map((step, index): [string, string] => [`jobs.${id}.steps[${index}].if`, step.if]),
+  ],
+)
+
+describe('a condition is expression text, not YAML', () => {
+  test('no `if:` folds a `#` comment line into its expression', () => {
+    // `if: >-` opens a folded block scalar, and inside one a `#` line is not a
+    // comment — it folds into the expression. GitHub then fails to lex the
+    // condition and rejects the *whole file*: run 31602129342 died that way,
+    // with zero jobs, `failure` a second after it started, and the file path
+    // where the workflow name should have been. Every other assertion here
+    // stayed green through it, because `Bun.YAML.parse` reads that `#` as
+    // ordinary text and so does every YAML parser. Commentary about an arm goes
+    // above the `if:` key, where `#` means what it looks like it means.
+    const folded = everyCondition.filter(([, expression]) => expression.includes('#')).map(([where]) => where)
+
+    expect(folded).toEqual([])
+  })
+})
+
 /** The group the workflow computes for a resolved issue number: the agent job's
  *  template, with `needs.resolve.outputs.branch` filled in the way the resolve
  *  job's own `branch` output fills it. */


### PR DESCRIPTION
The D7 archive-door arm arrived with its explanation written as four `#`
lines *inside* the job condition. `if: >-` opens a folded block scalar, so
those lines were never comments — they folded into the expression, and
GitHub failed to lex `# Design D7 …` as an Actions expression and rejected
the whole file. Run 31602129342 is what that looks like: `failure` one
second after it started, zero jobs, and `.github/workflows/agent-pipeline.yml`
where the workflow name should be, on a `push` event the workflow does not
even subscribe to. Every trigger since has been dead the same way.

The explanation moves above the `if:` key, where `#` means what it looks
like it means, and the arm itself is unchanged — all four still gate the
door exactly as before.

The reason this shipped green is that YAML is perfectly happy with it: the
document parses, and `workflow.test.ts` asserted against a condition string
that silently carried prose. So the guard is a test that no `if:` in the
document — job or step — contains a `#` at all.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tgk85LXm5zZcwkHxAQqzu4