### PR TITLE
fix(opencode-agent): check out the branch before reading the change folder

### DIFF
--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -121,6 +121,24 @@ findings: `ROADMAP.md`.
   walks `tasks.md` checkboxes as the step source (D5). The retired block names
   and their revision counters (`specRevision`) are gone; no legacy restore path
   exists, and in-flight issues restart under the `STATE_VERSION` bump (D12).
+- **`ensureBranch` comes before the first read of the folder, in every phase that
+  reads one.** The workflow's `actions/checkout` names no ref and must not grow
+  one — `ARCHIVE` commits to the base branch, capture cuts a branch that does not
+  exist yet, and a checkout pinned to `agent/issue-<n>` fails outright on the
+  first event of an issue. So a job's workspace **starts on the base branch**, and
+  `openspec/changes/<name>/` — scaffolded and pushed by whichever earlier job
+  captured the issue — is not in it until `deps.git.ensureBranch` switches
+  branches. Every phase after capture runs in a different job by construction:
+  capture parks at `DESIGN_SPEC` and the `/approve` that enters `PLANNING` arrives
+  whenever a maintainer types it. `PLANNING`, `REVIEW_AND_MUTATE` and
+  `CODE_REVIEW` each read the folder one line **before** that call and each died
+  the same way — `openspec status` exit 1, "Change '<name>' not found", followed by
+  a list of the base branch's changes that reads like the folder was never
+  scaffolded. The ordering is not visible to a stub whose driver answers the same
+  on any branch, which is how three handlers acquired the same defect; the fake in
+  `phases.test.ts` refuses every driver call and every `readFile` until
+  `ensureBranch` has been called, so a phase that reads too early fails the test
+  the way it failed the run.
 - **The plan counts one identity token, not two artefact revisions.** Under D1
   only `planRevision` remains — a machine identity for "a new plan happened",
   bumped by `PLAN_POSTED` alone, not an artefact revision. The former

--- a/opencode-agent/src/phases/implement.ts
+++ b/opencode-agent/src/phases/implement.ts
@@ -39,12 +39,18 @@ import type { StepWalk } from './implement-steps.js'
 export const handleImplement: PhaseHandler = async (input): Promise<PhaseOutcome> => {
   const { deps, state } = input
   if (state.changeName === null) throw new Error('REVIEW_AND_MUTATE reached without a changeName on the state')
+  // The branch first, then the plan: `openspec/changes/<name>/` is on
+  // `agent/issue-<n>` and nowhere else, and this job's workspace starts on the
+  // base branch — the workflow's `actions/checkout` names no ref, because
+  // switching branches is this pipeline's job. Read a line earlier, `tasks.md`
+  // is read out of the base branch's folder set, which does not carry this
+  // change at all.
+  const branch = branchNameFor(state.issueId)
+  await deps.git.ensureBranch(branch, await deps.baseBranch())
+
   const tasksPath = (await deps.openspec.instructions('tasks', state.changeName)).resolvedOutputPath
   const tasksMd = await deps.readFile(tasksPath)
   const steps = planBoxes(tasksMd)
-
-  const branch = branchNameFor(state.issueId)
-  await deps.git.ensureBranch(branch, await deps.baseBranch())
 
   const envelope = mintEnvelope()
   // Minted and composed once per handler, then handed to every step and to the

--- a/opencode-agent/src/phases/plan.ts
+++ b/opencode-agent/src/phases/plan.ts
@@ -49,8 +49,16 @@ export const handlePlan: PhaseHandler = async (input): Promise<PhaseOutcome> => 
     'Drafting change artifacts',
   )
 
-  await draftUntilComplete(input, feedback)
+  // Before the drafter reads anything. The change folder was scaffolded by the
+  // job that captured the issue and pushed to `agent/issue-<n>`; this job — the
+  // one a maintainer's `/approve` started, minutes or days later — begins on the
+  // base branch, because the workflow's `actions/checkout` names no ref and
+  // moving onto the branch is this pipeline's own job. Drafting first asked
+  // `openspec status` about a change the base branch has never heard of, and the
+  // CLI answered by listing the changes it could see, exit 1.
   await deps.git.ensureBranch(branch, await deps.baseBranch())
+
+  await draftUntilComplete(input, feedback)
   await deps.git.commitAll(`docs(openspec): draft artifacts for ${changeName}`)
   await deps.git.push(branch)
 

--- a/opencode-agent/src/phases/review.ts
+++ b/opencode-agent/src/phases/review.ts
@@ -30,18 +30,24 @@ import type { AgentState } from '../types.js'
  */
 export const handleReview: PhaseHandler = async (input): Promise<PhaseOutcome> => {
   const { deps, state } = input
-  // The plan, exactly as the implementation phase reads it: the loop reviews
-  // the work against what was approved, read from the folder's `tasks.md`
-  // (design D1) rather than a block on the issue.
-  const plan = await planFromFolder(input)
-
   // Not optional, and this is the difference from the review that used to run
   // inside phase 3: that one always had the tree it had just written, while this
   // one usually runs in a job that implemented nothing at all, where the remote
   // branch is the only copy. `ensureBranch` fast-forwards an existing remote
   // branch and cuts a fresh one otherwise, so the same call serves both.
+  //
+  // It comes **first**, before the plan is read: the folder that plan is in is
+  // on this branch and nowhere else, and the job's workspace starts on the base
+  // branch (`actions/checkout` takes no ref — switching branches is this
+  // pipeline's job, not the workflow's). Reading it a line earlier read the base
+  // branch's `openspec/changes/`, where this change does not exist.
   const branch = branchNameFor(state.issueId)
   await deps.git.ensureBranch(branch, await deps.baseBranch())
+
+  // The plan, exactly as the implementation phase reads it: the loop reviews
+  // the work against what was approved, read from the folder's `tasks.md`
+  // (design D1) rather than a block on the issue.
+  const plan = await planFromFolder(input)
 
   const review = await deps.runReview(plan)
 

--- a/tests/opencode-agent/phases.test.ts
+++ b/tests/opencode-agent/phases.test.ts
@@ -7,9 +7,15 @@ import { describe, expect, it } from 'bun:test'
 
 import type { IssueComment } from '../../opencode-agent/src/blocks.js'
 import type { ParsedCommand } from '../../opencode-agent/src/commands.js'
-import type { OpenSpecDriver } from '../../opencode-agent/src/openspec-driver.js'
+import type {
+  InstructionsResult,
+  OpenSpecDriver,
+  StatusResult,
+  ValidateResult,
+} from '../../opencode-agent/src/openspec-driver.js'
 import type { PhaseInput } from '../../opencode-agent/src/phase-context.js'
 import { handleAnswer } from '../../opencode-agent/src/phases/answer.js'
+import { handleImplement } from '../../opencode-agent/src/phases/implement.js'
 import { handlePlan } from '../../opencode-agent/src/phases/plan.js'
 import { handleReview } from '../../opencode-agent/src/phases/review.js'
 import { handleTriage } from '../../opencode-agent/src/phases/triage.js'
@@ -550,5 +556,118 @@ describe('handleReview · reads the plan from the folder (D1)', () => {
     // The review loop was handed the folder's tasks.md verbatim.
     expect(handed).toEqual([tasks])
     expect(io.reads).toEqual([`/repo/openspec/changes/${CHANGE}/tasks.md`])
+  })
+})
+
+/**
+ * Design D1 again, from the other side: the folder is truth, and a job that has
+ * not checked out the branch carrying it holds no truth at all.
+ *
+ * `actions/checkout` in `agent-pipeline.yml` takes no ref on purpose — the
+ * workspace starts on the base branch and `ensureBranch` is what moves it onto
+ * `agent/issue-<n>`. So `openspec/changes/<name>/` is *absent* until that call,
+ * and every phase after the capture that scaffolded it runs in a different job:
+ * capture parks at `DESIGN_SPEC`, and the `/approve` that enters `PLANNING`
+ * arrives whenever a maintainer types it, on a fresh runner.
+ *
+ * The stub deps cannot show that on their own — their driver answers the same
+ * whatever the workspace is checked out at — which is exactly how three handlers
+ * came to read the folder one line before switching to it. Run 31630109348 is
+ * what that costs: `openspec status` exited 1 with "Change 'context-vault-plugin'
+ * not found. Available changes: …", listing master's folders, and the run died
+ * with the plan undrafted.
+ */
+const startedOnBaseBranch = (input: PhaseInput): void => {
+  const { deps } = input
+  const { git, openspec, readFile } = deps
+  let onBranch = false
+
+  // What the OpenSpec CLI says about a change folder that is on another branch,
+  // and what `readFile` says about a path that is not in the tree: both are the
+  // absence of the same folder, so both refuse until the branch is checked out.
+  const refuse = (command: string): never => {
+    throw new Error(`${command} failed (exit 1): Change '${CHANGE}' not found.`)
+  }
+
+  deps.git = {
+    ...git,
+    ensureBranch: (branch: string, base: string): Promise<void> => {
+      onBranch = true
+      return git.ensureBranch(branch, base)
+    },
+  }
+  deps.openspec = {
+    ...openspec,
+    status: (changeName: string): Promise<StatusResult> =>
+      onBranch ? openspec.status(changeName) : refuse('openspec status'),
+    instructions: (artifactId: string, changeName: string): Promise<InstructionsResult> =>
+      onBranch ? openspec.instructions(artifactId, changeName) : refuse('openspec instructions'),
+    validateStrict: (changeName: string): Promise<ValidateResult> =>
+      onBranch ? openspec.validateStrict(changeName) : refuse('openspec validate --strict'),
+  }
+  deps.readFile = (filePath: string): Promise<string> => (onBranch ? readFile(filePath) : refuse(`reading ${filePath}`))
+}
+
+/** An input parked where `REVIEW_AND_MUTATE` is entered: an approved plan in the folder. */
+const implementInput = (tasks: string): { input: PhaseInput; io: StubIo } => {
+  const built = stubPhaseDeps({ replies: ['Implemented.'], selfLogin: AGENT_LOGIN })
+  built.deps.openspec = folderDriver(CHANGE)
+  built.io.readContents = { [`/repo/openspec/changes/${CHANGE}/tasks.md`]: tasks }
+  return {
+    input: {
+      state: planningState({ phase: 'REVIEW_AND_MUTATE' }),
+      issue: { number: 42, title: 'Add a retry helper', body: 'Please add a retry helper.' },
+      trigger: issueTrigger('OWNER'),
+      command: null,
+      thread: built.io.thread,
+      deps: built.deps,
+    },
+    io: built.io,
+  }
+}
+
+describe('a phase checks out the branch carrying the folder before it reads the folder', () => {
+  it('handlePlan drafts after ensureBranch, not before (run 31630109348)', async () => {
+    const built = wireDrafterInput([
+      JSON.stringify({ content: 'design body' }),
+      JSON.stringify({ content: 'tasks body' }),
+    ])
+    startedOnBaseBranch(built.input)
+
+    const outcome = await handlePlan(built.input)
+
+    expect(outcome.signal).toBe('PLAN_POSTED')
+    // Not merely "ensureBranch was called": it was called *first*, before the
+    // drafter asked the driver anything. That order is the whole fix.
+    expect(built.io.gitCalls[0]).toBe('ensureBranch:agent/issue-42:main')
+  })
+
+  it('handleImplement reads the plan after ensureBranch, not before', async () => {
+    const built = implementInput('- [ ] Add the wrapper\n')
+    startedOnBaseBranch(built.input)
+
+    const outcome = await handleImplement(built.input)
+
+    expect(outcome.signal).toBe('CHANGES_COMMITTED')
+    expect(built.io.gitCalls[0]).toBe('ensureBranch:agent/issue-42:main')
+  })
+
+  it('handleReview reads the plan after ensureBranch, not before', async () => {
+    const tasks = '- [ ] Write retry tests\n- [ ] Add the wrapper\n'
+    const built = folderReadInput({ phase: 'CODE_REVIEW', folder: { tasks } })
+    startedOnBaseBranch(built.input)
+    const handed: string[] = []
+    built.input.deps.runReview = (plan: string): Promise<ReviewRunResult> => {
+      handed.push(plan)
+      return Promise.resolve({ outcome: 'passed', summary: '', exitCode: 0 })
+    }
+
+    const outcome = await handleReview(built.input)
+
+    expect(outcome.signal).toBe('REVIEW_DONE')
+    // The loop still gets the folder's plan — the read moved behind the
+    // checkout, it did not become a read of something else.
+    expect(handed).toEqual([tasks])
+    expect(built.io.gitCalls[0]).toBe('ensureBranch:agent/issue-42:main')
   })
 })


### PR DESCRIPTION
A job's workspace starts on the base branch: the workflow's `actions/checkout`
names no ref, because switching branches is the pipeline's own job — ARCHIVE
commits to the base branch and capture cuts a branch that does not exist yet, so
a pinned ref would break both. `openspec/changes/<name>/` therefore is not in the
tree until `ensureBranch` runs, and every phase after capture runs in a different
job by construction: capture parks at DESIGN_SPEC and the `/approve` that enters
PLANNING arrives whenever a maintainer types it.

PLANNING, REVIEW_AND_MUTATE and CODE_REVIEW each read the folder one line before
that call. PLANNING is the one that fires first, and issue #268's run died on it:
`openspec status` exit 1, "Change 'context-vault-plugin' not found", followed by
the base branch's change list — which reads as if the scaffold had never
happened, when it was sitting on agent/issue-268 all along. Capture escaped only
because `openspec new` writes the folder untracked, and untracked files survive
`git checkout -B`.

The fake in phases.test.ts is the part that was missing: the stub driver answered
the same on any branch, which is how three handlers acquired one defect. It now
refuses every driver call and every read until `ensureBranch` has been called, so
a phase that reads too early fails the test the way it failed the run.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B95vdNwZpReKo6b3Z6m5CX