### PR TITLE
fix(opencode-agent): draft the glob `specs` artifact into per-capability files

### DIFF
--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -139,6 +139,30 @@ findings: `ROADMAP.md`.
   `phases.test.ts` refuses every driver call and every `readFile` until
   `ensureBranch` has been called, so a phase that reads too early fails the test
   the way it failed the run.
+- **An artifact's output path is not always a file, and a pattern is judged
+  rather than written.** Three of the `spec-driven` schema's four artifacts
+  resolve to a path the drafter can hand to `writeFile`; `specs` does not. A
+  change carries one delta spec per capability, so `openspec instructions specs`
+  answers with `<changeDir>/specs/**/*.md` — a **pattern** — and only the
+  proposal knows how many files that is. `phases/plan.ts` wrote it verbatim and
+  run 31664928683 died at PLANNING on `ENOENT … /specs/**/*.md`, after paying for
+  the turn that composed the content. So a glob artifact takes the second reply
+  shape in `phases/plan-draft.ts` (`{"files":[{"path","content"}]}`, paths
+  relative to the change folder, which is how the artifact instruction the model
+  is reading spells them) and `glob-output.ts` judges each path before anything
+  is written. Three things not to undo. A refused path is a **complaint**, not a
+  throw: it rides the retry that already exists for the `validate --strict`
+  verdict, because "you wrote outside `specs/`" is exactly what a second ask
+  fixes and failing outright discards a paid-for turn over a filename. The
+  judging is **containment plus the pattern's extension**, not a `**` matcher —
+  what protects the tree is that the file lands under the directory the pattern
+  collects from, and a hand-rolled picomatch would add no refusal. And it is
+  **all or nothing**: one bad path in a reply discards the whole reply, or
+  `validate --strict` would judge a half-written folder and the retry's complaint
+  would be about files that had already landed. `deps.writeFile` creates parent
+  directories for the same reason the pattern broke — `openspec new change`
+  scaffolds a folder holding `.openspec.yaml` and nothing else, so
+  `specs/<capability-path>/spec.md` is the first thing in its directory.
 - **The plan counts one identity token, not two artefact revisions.** Under D1
   only `planRevision` remains — a machine identity for "a new plan happened",
   bumped by `PLAN_POSTED` alone, not an artefact revision. The former

--- a/opencode-agent/src/deps.ts
+++ b/opencode-agent/src/deps.ts
@@ -3,7 +3,8 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { writeFile as writeFileNode, readFile as readFileNode } from 'node:fs/promises'
+import { mkdir, writeFile as writeFileNode, readFile as readFileNode } from 'node:fs/promises'
+import path from 'node:path'
 
 import type { AgentHandle } from './agent-handle.js'
 import type { CheckRunner } from './check-loop.js'
@@ -31,6 +32,21 @@ import type { Phase } from './types.js'
  * Split from `index.ts`, which owns the CLI entry — flags, credential
  * containment and process lifetime. The two change for different reasons.
  */
+
+/**
+ * Writes an artifact, creating the directories it needs.
+ *
+ * `openspec new change` scaffolds a folder holding `.openspec.yaml` and nothing
+ * else, so every artifact but the flat ones is the first thing in its directory
+ * — a delta spec lands at `specs/<capability-path>/spec.md`, up to two levels
+ * deep, and a bare `writeFile` there fails with the same `ENOENT` the glob path
+ * failed with. The drafter chooses the path (`glob-output.ts` judges it), so
+ * this is the one place that can know the directory has to exist.
+ */
+const writeArtifactFile = async (filePath: string, content: string): Promise<void> => {
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFileNode(filePath, content, 'utf8')
+}
 
 const makeCheckRunner =
   (run: CommandRunner, config: PipelineConfig): CheckRunner =>
@@ -141,7 +157,7 @@ export const assembleDeps = ({
     agent: agent.get,
     tokensUsed: agent.tokensUsed,
     skills: makeSkillLoader(config, log),
-    writeFile: (filePath, content) => writeFileNode(filePath, content, 'utf8'),
+    writeFile: (filePath, content) => writeArtifactFile(filePath, content),
     readFile: (filePath) => readFileNode(filePath, 'utf8'),
     baseBranch: memoize(() =>
       resolveBaseBranch(env, { fromEvent: event.defaultBranch, fromGit: () => git.defaultBranch() }),

--- a/opencode-agent/src/glob-output.ts
+++ b/opencode-agent/src/glob-output.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import path from 'node:path'
+
+/**
+ * Where a **glob** artifact's files go — the one loose end in design D3's
+ * "TypeScript owns the paths, the model owns the content" split.
+ *
+ * Every artifact of the `spec-driven` schema resolves to a file the drafter can
+ * write, except one: `specs`, whose `resolvedOutputPath` is
+ * `<changeDir>/specs/**\/*.md` — a **pattern**, because a change carries one
+ * delta spec per capability and only the proposal knows how many that is. The
+ * drafter wrote it verbatim and run 31664928683 died on
+ * `ENOENT ... /specs/**\/*.md` at PLANNING, after paying for the model turn that
+ * composed the content.
+ *
+ * So the path becomes something the drafter asks for and this module judges. The
+ * judging is deliberately not a glob matcher: what protects the tree is
+ * **containment** — the file must land under the directory the pattern collects
+ * from — plus the extension the pattern admits, and a hand-rolled `**` matcher
+ * would add a reimplementation of picomatch without adding a single refusal.
+ * Every rejection is a sentence rather than a throw, because the drafter already
+ * has a retry that re-asks with a complaint attached (the one `openspec validate
+ * --strict` uses), and a bad path is exactly the kind of mistake a second ask
+ * fixes.
+ */
+
+/** The characters that make a path segment a pattern rather than a name. */
+const MAGIC = /[*?[\]]/u
+
+/** Whether an artifact's resolved output path names a pattern, not a file. */
+export const isGlobOutputPath = (pattern: string): boolean => MAGIC.test(pattern)
+
+/**
+ * The deepest directory the pattern is anchored to — everything up to the first
+ * segment carrying a glob character (`<changeDir>/specs` for the `specs`
+ * artifact). This is the boundary a drafted file may not escape.
+ */
+export const globStaticRoot = (pattern: string): string => {
+  const segments = pattern.split('/')
+  const magic = segments.findIndex((segment) => MAGIC.test(segment))
+  return (magic === -1 ? segments.slice(0, -1) : segments.slice(0, magic)).join('/')
+}
+
+/**
+ * What the drafter's paths are relative to.
+ *
+ * The change folder when the driver reported one, because that is how the
+ * artifact instruction itself spells the path the model is being asked for
+ * (`specs/<capability-path>/spec.md`) — an answer relative to anything else
+ * would be the model reading two different rules. When `changeDir` is absent the
+ * base is derived, and the pattern the drafter is shown is computed from
+ * whichever base was chosen, so the fallback is the same contract re-anchored
+ * rather than a second one.
+ */
+export const globOutputBase = (pattern: string, changeDir: string | undefined): string =>
+  changeDir ?? path.dirname(globStaticRoot(pattern))
+
+export type GlobOutputResolution =
+  | { readonly ok: true; readonly path: string }
+  | { readonly ok: false; readonly reason: string }
+
+/**
+ * The literal tail of the pattern's last segment — `.md` for `*.md`, and empty
+ * for a bare `*`, which admits anything.
+ */
+const literalSuffix = (pattern: string): string => {
+  const last = pattern.split('/').at(-1) ?? ''
+  return last.replace(/^.*[*?[\]]/u, '')
+}
+
+/**
+ * Turns one drafter-chosen relative path into an absolute one, or says why it
+ * cannot be used. The reason is written to be read by the model on the retry.
+ */
+export const resolveGlobOutput = (pattern: string, base: string, relative: string): GlobOutputResolution => {
+  const candidate = relative.trim()
+  if (candidate.length === 0) return { ok: false, reason: 'the file path is empty' }
+  if (path.isAbsolute(candidate)) {
+    return { ok: false, reason: `"${candidate}" is absolute; give a path relative to ${base}` }
+  }
+
+  const root = globStaticRoot(pattern)
+  const resolved = path.resolve(base, candidate)
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) {
+    return { ok: false, reason: `"${candidate}" resolves outside ${root}, which is where ${pattern} collects files` }
+  }
+
+  const suffix = literalSuffix(pattern)
+  if (suffix.length > 0 && !resolved.endsWith(suffix)) {
+    return { ok: false, reason: `"${candidate}" does not end in "${suffix}", which ${pattern} requires` }
+  }
+  return { ok: true, path: resolved }
+}

--- a/opencode-agent/src/openspec-driver.ts
+++ b/opencode-agent/src/openspec-driver.ts
@@ -51,6 +51,22 @@ export interface InstructionsResult {
   readonly template: string | undefined
   readonly rules: readonly string[]
   readonly resolvedOutputPath: string
+  /**
+   * The change folder, when the CLI reported one.
+   *
+   * Only one artifact needs it and that is the point: the `spec-driven` schema's
+   * `specs` artifact resolves to a **pattern** (`<changeDir>/specs/**\/*.md`),
+   * because a change carries one delta spec per capability, so the drafter has
+   * to choose the concrete paths — and it chooses them relative to this, which
+   * is how the artifact instruction itself spells them
+   * (`specs/<capability-path>/spec.md`).
+   *
+   * Optional rather than required, like every other field here but
+   * `resolvedOutputPath`: every phase reads `instructions`, so a field only the
+   * glob artifact needs must not be what fails them all on a CLI that stops
+   * emitting it. `glob-output.ts` derives a base when it is absent.
+   */
+  readonly changeDir: string | undefined
   readonly existingOutputPaths: readonly string[]
   readonly dependencies: readonly InstructionDependency[]
 }
@@ -89,6 +105,7 @@ const InstructionsPayloadSchema = z.object({
   template: z.string().optional(),
   rules: z.array(z.string()).optional(),
   resolvedOutputPath: z.string().min(1),
+  changeDir: z.string().min(1).optional(),
   existingOutputPaths: z.array(z.string()).optional(),
   dependencies: z.array(InstructionDependencySchema).optional(),
 })
@@ -146,6 +163,7 @@ export function createOpenSpecDriver(deps: OpenSpecDriverDeps): OpenSpecDriver {
         template: payload.template,
         rules: payload.rules ?? [],
         resolvedOutputPath: payload.resolvedOutputPath,
+        changeDir: payload.changeDir,
         existingOutputPaths: payload.existingOutputPaths ?? [],
         dependencies: payload.dependencies ?? [],
       }

--- a/opencode-agent/src/phases/plan-draft.ts
+++ b/opencode-agent/src/phases/plan-draft.ts
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { z } from 'zod'
+
+import { promptForJson } from '../ask-json.js'
+import { globOutputBase, isGlobOutputPath, resolveGlobOutput } from '../glob-output.js'
+import { composeSystemPrompt } from '../obra-skills.js'
+import type { InstructionsResult } from '../openspec-driver.js'
+import type { PhaseInput } from '../phase-context.js'
+import type { UntrustedEnvelope } from '../prompts.js'
+import { mintEnvelope } from './envelope.js'
+
+/**
+ * One artifact, composed — the model half of the PLANNING drafter loop (design
+ * D3), split from `plan.ts`, which keeps the loop, the commit and the digest.
+ *
+ * The split is what the **glob** artifact costs. Every artifact of the
+ * `spec-driven` schema resolves to a file the drafter can write, except `specs`:
+ * a change carries one delta spec per capability, so its output path is a
+ * pattern and the paths are part of what the model has to decide. That makes two
+ * reply shapes, two prompts and a path-judging step where there used to be one
+ * `{"content": …}` and a `writeFile`, which is a phase's worth of prose in a file
+ * that already had one.
+ */
+
+/** A flat artifact: one file, at the path the driver already resolved. */
+const draftReplySchema = z.object({ content: z.string().min(1) })
+
+/**
+ * A glob artifact: the model names each file as well as writing it.
+ *
+ * The path is asked for **relative to the change folder**, because that is how
+ * the artifact instruction the model is reading spells it
+ * (`specs/<capability-path>/spec.md`) — an answer anchored anywhere else would be
+ * the model reconciling two different rules. `glob-output.ts` judges each one.
+ */
+const draftFilesReplySchema = z.object({
+  files: z.array(z.object({ path: z.string().min(1), content: z.string().min(1) })).min(1),
+})
+
+export interface DraftedFile {
+  readonly path: string
+  readonly content: string
+}
+
+/**
+ * What the model produced, or why it cannot be used.
+ *
+ * A refused path is a **complaint**, not a throw: the drafter already re-asks
+ * once with the `openspec validate --strict` verdict attached, and "you wrote
+ * outside `specs/`" is exactly the kind of mistake a second ask fixes. Failing
+ * outright would throw away a paid-for turn over a filename.
+ */
+export type ComposedArtifact =
+  | { readonly ok: true; readonly files: readonly DraftedFile[] }
+  | { readonly ok: false; readonly complaint: string }
+
+const PROPOSE_INSTRUCTIONS = [
+  'You are drafting one artifact of an OpenSpec change folder.',
+  'Use the instruction, template and rules below; the artifact must satisfy `openspec validate --strict`.',
+  'Reply with a single JSON object and nothing else: {"content":"<markdown>"}',
+  'Write only the artifact asked for. Do not invent capabilities or deltas the change does not claim.',
+].join('\n')
+
+/**
+ * The same standing instructions for an artifact whose output path is a pattern:
+ * the reply carries the files, each with the path it belongs at.
+ */
+const PROPOSE_FILES_INSTRUCTIONS = [
+  'You are drafting one artifact of an OpenSpec change folder.',
+  'This artifact is a set of files, not a single document: the instruction below says how many and where.',
+  'Use the instruction, template and rules below; the artifact must satisfy `openspec validate --strict`.',
+  'Reply with a single JSON object and nothing else: {"files":[{"path":"<path>","content":"<markdown>"}]}',
+  'Each path is relative to the change folder named in the prompt. Do not use absolute paths or `..`.',
+  'Write only the artifact asked for. Do not invent capabilities or deltas the change does not claim.',
+].join('\n')
+
+export const composeArtifact = async (
+  input: PhaseInput,
+  instruction: InstructionsResult,
+  complaint: string | null,
+  feedback: string | null,
+): Promise<ComposedArtifact> => {
+  if (!isGlobOutputPath(instruction.resolvedOutputPath)) {
+    const reply = await ask(input, draftReplySchema, PROPOSE_INSTRUCTIONS, (envelope) =>
+      draftPrompt(envelope, instruction, complaint, feedback),
+    )
+    return { ok: true, files: [{ path: instruction.resolvedOutputPath, content: reply.content }] }
+  }
+
+  const base = globOutputBase(instruction.resolvedOutputPath, instruction.changeDir)
+  const reply = await ask(input, draftFilesReplySchema, PROPOSE_FILES_INSTRUCTIONS, (envelope) =>
+    globDraftPrompt(envelope, instruction, base, complaint, feedback),
+  )
+  return placeFiles(instruction.resolvedOutputPath, base, reply.files)
+}
+
+/** Judges every drafted path before a single one is written. */
+const placeFiles = (pattern: string, base: string, drafted: readonly DraftedFile[]): ComposedArtifact => {
+  const placed: DraftedFile[] = []
+  const refused: string[] = []
+  for (const file of drafted) {
+    const resolution = resolveGlobOutput(pattern, base, file.path)
+    if (resolution.ok) placed.push({ path: resolution.path, content: file.content })
+    else refused.push(resolution.reason)
+  }
+  // All or nothing: a half-written artifact would be validated as if it were
+  // whole, and the complaint the retry carries would be about files that landed.
+  if (refused.length > 0) {
+    return { ok: false, complaint: `These file paths cannot be used:\n${refused.map((r) => `- ${r}`).join('\n')}` }
+  }
+  return { ok: true, files: placed }
+}
+
+const ask = async <T>(
+  input: PhaseInput,
+  schema: z.ZodType<T>,
+  instructions: string,
+  prompt: (envelope: UntrustedEnvelope) => string,
+): Promise<T> => {
+  const { deps } = input
+  const envelope = mintEnvelope()
+  return promptForJson({
+    agent: await deps.agent(),
+    schema,
+    envelope,
+    log: deps.log,
+    request: {
+      system: composeSystemPrompt({
+        phase: 'PLANNING',
+        skills: await deps.skills('PLANNING'),
+        repoRoot: deps.config.repoRoot,
+        nonce: envelope.nonce,
+        instructions,
+      }),
+      prompt: prompt(envelope),
+      agent: 'propose',
+    },
+  })
+}
+
+/** What the artifact is, before where it goes: instruction, template, rules. */
+const headSections = (envelope: UntrustedEnvelope, instruction: InstructionsResult): string[] =>
+  [
+    `Instruction: ${instruction.instruction}`,
+    instruction.template === undefined ? '' : envelope.wrap('template', instruction.template),
+    instruction.rules.length === 0 ? '' : `Rules:\n${instruction.rules.map((rule) => `- ${rule}`).join('\n')}`,
+  ].filter((section) => section.length > 0)
+
+/** What a re-draft is grounded in, after the destination: feedback, complaint. */
+const tailSections = (envelope: UntrustedEnvelope, complaint: string | null, feedback: string | null): string[] => {
+  const sections: string[] = []
+  if (feedback !== null) {
+    sections.push(
+      'A maintainer requested the following changes — revise the artifact to address them (design D6: the folder cannot rot relative to the conversation).',
+      envelope.wrap('revision-feedback', feedback),
+    )
+  }
+  if (complaint !== null) {
+    sections.push(
+      'Your previous draft was rejected with the complaint below. Revise the artifact so it is accepted.',
+      envelope.wrap('draft-complaint', complaint),
+    )
+  }
+  return sections
+}
+
+const draftPrompt = (
+  envelope: UntrustedEnvelope,
+  instruction: InstructionsResult,
+  complaint: string | null,
+  feedback: string | null,
+): string =>
+  [
+    ...headSections(envelope, instruction),
+    `Write to: ${instruction.resolvedOutputPath}`,
+    ...tailSections(envelope, complaint, feedback),
+  ].join('\n\n')
+
+const globDraftPrompt = (
+  envelope: UntrustedEnvelope,
+  instruction: InstructionsResult,
+  base: string,
+  complaint: string | null,
+  feedback: string | null,
+): string =>
+  [
+    ...headSections(envelope, instruction),
+    [
+      `Write the files under: ${base}`,
+      `Every path must match the pattern ${instruction.resolvedOutputPath}, and is given in the reply`,
+      'relative to that folder — for example `specs/<capability-path>/spec.md`.',
+    ].join('\n'),
+    ...tailSections(envelope, complaint, feedback),
+  ].join('\n\n')

--- a/opencode-agent/src/phases/plan.ts
+++ b/opencode-agent/src/phases/plan.ts
@@ -3,16 +3,13 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { z } from 'zod'
-
 import { renderDigest } from '../artifacts.js'
-import { promptForJson } from '../ask-json.js'
 import { branchNameFor } from '../git.js'
-import { composeSystemPrompt } from '../obra-skills.js'
 import type { InstructionsResult } from '../openspec-driver.js'
 import type { PhaseHandler, PhaseInput, PhaseOutcome } from '../phase-context.js'
-import type { UntrustedEnvelope } from '../prompts.js'
-import { mintEnvelope } from './envelope.js'
+import { mapSeries } from '../sequence.js'
+import { composeArtifact } from './plan-draft.js'
+import type { DraftedFile } from './plan-draft.js'
 
 /**
  * Phase 2 — the PLANNING drafter loop (design D3).
@@ -27,16 +24,10 @@ import { mintEnvelope } from './envelope.js'
  * writes it, so the model's edit capability is not exercised — but the profile
  * is the one a future model-writes-files drafter would take, and the diff
  * guard's `outsidePrefix` confines whatever lands in the index to the folder.
+ *
+ * `plan-draft.ts` owns the model half — which reply shape an artifact takes, and
+ * where a **glob** artifact's files are allowed to land.
  */
-
-const draftReplySchema = z.object({ content: z.string().min(1) })
-
-const PROPOSE_INSTRUCTIONS = [
-  'You are drafting one artifact of an OpenSpec change folder.',
-  'Use the instruction, template and rules below; the artifact must satisfy `openspec validate --strict`.',
-  'Reply with a single JSON object and nothing else: {"content":"<markdown>"}',
-  'Write only the artifact asked for. Do not invent capabilities or deltas the change does not claim.',
-].join('\n')
 
 export const handlePlan: PhaseHandler = async (input): Promise<PhaseOutcome> => {
   const { deps, state } = input
@@ -155,9 +146,17 @@ const readyArtifact = (artifacts: Record<string, string>): string | null => {
 const MAX_DRAFT_ITERATIONS = 16
 
 /**
- * Composes one artifact, writes it, and validates the change. On a validation
- * failure re-asks **once** with the complaint attached, exactly the
- * `promptForJson` pattern generalised to the validate-strict verdict.
+ * Composes one artifact, writes it, and validates the change. On a rejection
+ * re-asks **once** with the complaint attached, exactly the `promptForJson`
+ * pattern generalised to the validate-strict verdict.
+ *
+ * Two things can be wrong with a draft and both take the same retry: the content
+ * (`openspec validate --strict` says so) and, for a glob artifact, the paths the
+ * model chose for it (`glob-output.ts` says so, before anything is written).
+ * They are one complaint channel rather than two because the remedy is
+ * identical — ask again, saying what was wrong — and because a second failure
+ * mode with its own escape hatch is how the drafter would acquire a path that
+ * fails silently.
  */
 const composeAndValidate = async (
   input: PhaseInput,
@@ -165,83 +164,31 @@ const composeAndValidate = async (
   complaint: string | null,
   feedback: string | null,
 ): Promise<void> => {
-  const { deps } = input
-  const content = await composeArtifact(input, instruction, complaint, feedback)
-  await deps.writeFile(instruction.resolvedOutputPath, content)
-
-  const changeName = input.state.changeName
-  if (changeName === null) return
-  const verdict = await deps.openspec.validateStrict(changeName)
-  if (verdict.ok) return
+  const composed = await composeArtifact(input, instruction, complaint, feedback)
+  const problem = composed.ok ? await writeAndValidate(input, composed.files) : composed.complaint
+  if (problem === null) return
 
   if (complaint !== null) {
-    // Second attempt still invalid: the strict complaint is the failure reason.
-    throw new Error(`openspec validate --strict failed after retry: ${verdict.output}`)
+    // Second attempt still rejected: that rejection is the failure reason.
+    throw new Error(`the drafter's second attempt was rejected: ${problem}`)
   }
-  await composeAndValidate(input, instruction, verdict.output, feedback)
+  await composeAndValidate(input, instruction, problem, feedback)
 }
 
 /**
- * Asks the model for the artifact content. `complaint` is null on the first
- * attempt and the validate-strict output on the repair, so the model sees what
- * it got wrong. `feedback` is the maintainer's revision request when the draft
- * is a re-plan (D6), null on a fresh plan.
+ * Writes what the model composed and asks the CLI what it thinks; `null` when
+ * the change validates, and the complaint to re-ask with when it does not.
+ *
+ * Sequential rather than concurrent: the files share a working tree, which is
+ * the reason everything else in this pipeline that iterates does too.
  */
-const composeArtifact = async (
-  input: PhaseInput,
-  instruction: InstructionsResult,
-  complaint: string | null,
-  feedback: string | null,
-): Promise<string> => {
-  const { deps } = input
-  const envelope = mintEnvelope()
-  const reply = await promptForJson({
-    agent: await deps.agent(),
-    schema: draftReplySchema,
-    envelope,
-    log: deps.log,
-    request: {
-      system: composeSystemPrompt({
-        phase: 'PLANNING',
-        skills: await deps.skills('PLANNING'),
-        repoRoot: deps.config.repoRoot,
-        nonce: envelope.nonce,
-        instructions: PROPOSE_INSTRUCTIONS,
-      }),
-      prompt: draftPrompt(envelope, instruction, complaint, feedback),
-      agent: 'propose',
-    },
-  })
-  return reply.content
-}
+const writeAndValidate = async (input: PhaseInput, files: readonly DraftedFile[]): Promise<string | null> => {
+  await mapSeries(files, (file) => input.deps.writeFile(file.path, file.content))
 
-const draftPrompt = (
-  envelope: UntrustedEnvelope,
-  instruction: InstructionsResult,
-  complaint: string | null,
-  feedback: string | null,
-): string => {
-  const sections = [
-    `Instruction: ${instruction.instruction}`,
-    instruction.template === undefined ? '' : envelope.wrap('template', instruction.template),
-    instruction.rules.length === 0 ? '' : `Rules:\n${instruction.rules.map((rule) => `- ${rule}`).join('\n')}`,
-    `Write to: ${instruction.resolvedOutputPath}`,
-  ].filter((section) => section.length > 0)
-
-  if (feedback !== null) {
-    sections.push(
-      'A maintainer requested the following changes — revise the artifact to address them (design D6: the folder cannot rot relative to the conversation).',
-      envelope.wrap('revision-feedback', feedback),
-    )
-  }
-
-  if (complaint !== null) {
-    sections.push(
-      'Your previous draft failed `openspec validate --strict` with the complaint below. Revise the artifact so it validates.',
-      envelope.wrap('validate-complaint', complaint),
-    )
-  }
-  return sections.join('\n\n')
+  const changeName = input.state.changeName
+  if (changeName === null) return null
+  const verdict = await input.deps.openspec.validateStrict(changeName)
+  return verdict.ok ? null : `openspec validate --strict failed: ${verdict.output}`
 }
 
 const renderPlanComment = (changeName: string, branch: string, revision: number, tasks: string): string =>

--- a/tests/opencode-agent/glob-output.test.ts
+++ b/tests/opencode-agent/glob-output.test.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import {
+  globOutputBase,
+  globStaticRoot,
+  isGlobOutputPath,
+  resolveGlobOutput,
+} from '../../opencode-agent/src/glob-output.js'
+import type { GlobOutputResolution } from '../../opencode-agent/src/glob-output.js'
+
+/** The refusal's sentence, or '' when the path was accepted. Module-level so the narrowing is not "in test". */
+const reasonOf = (result: GlobOutputResolution): string => (result.ok ? '' : result.reason)
+
+/**
+ * The `specs` artifact of the `spec-driven` schema is the one whose
+ * `resolvedOutputPath` is a **pattern** rather than a file:
+ * `<changeDir>/specs/**\/*.md`, recorded from `openspec instructions specs
+ * --change <name> --json` on the pinned `@fission-ai/openspec@1.8.0`. Writing to
+ * it verbatim is what failed run 31664928683 with
+ * `ENOENT ... openspec/changes/context-vault-plugin/specs/**\/*.md`.
+ */
+const SPECS_GLOB = '/repo/openspec/changes/add-thing/specs/**/*.md'
+const CHANGE_DIR = '/repo/openspec/changes/add-thing'
+
+describe('isGlobOutputPath', () => {
+  it('tells the `specs` pattern apart from a concrete artifact path', () => {
+    expect(isGlobOutputPath(SPECS_GLOB)).toBe(true)
+    expect(isGlobOutputPath(`${CHANGE_DIR}/tasks.md`)).toBe(false)
+    expect(isGlobOutputPath(`${CHANGE_DIR}/proposal.md`)).toBe(false)
+  })
+
+  it('treats every glob metacharacter as magic, not just `*`', () => {
+    expect(isGlobOutputPath(`${CHANGE_DIR}/spec?.md`)).toBe(true)
+    expect(isGlobOutputPath(`${CHANGE_DIR}/spec[12].md`)).toBe(true)
+  })
+})
+
+describe('globStaticRoot', () => {
+  it('stops at the first segment carrying a glob character', () => {
+    expect(globStaticRoot(SPECS_GLOB)).toBe(`${CHANGE_DIR}/specs`)
+  })
+
+  it('is the containing directory when nothing is magic', () => {
+    expect(globStaticRoot(`${CHANGE_DIR}/tasks.md`)).toBe(CHANGE_DIR)
+  })
+})
+
+describe('globOutputBase', () => {
+  it('is the change folder the driver reported, when it reported one', () => {
+    expect(globOutputBase(SPECS_GLOB, CHANGE_DIR)).toBe(CHANGE_DIR)
+  })
+
+  it('falls back to the static root’s parent, so the pattern shown stays relative to the base', () => {
+    // Without `changeDir` the base is derived, and the relative pattern the
+    // drafter is shown is computed from whichever base was chosen — so the
+    // fallback is the same rule with a different anchor, not a second contract.
+    expect(globOutputBase(SPECS_GLOB, undefined)).toBe(CHANGE_DIR)
+  })
+})
+
+describe('resolveGlobOutput', () => {
+  it('accepts the per-capability path the artifact instruction asks for', () => {
+    const result = resolveGlobOutput(SPECS_GLOB, CHANGE_DIR, 'specs/user-auth/spec.md')
+
+    expect(result).toEqual({ ok: true, path: `${CHANGE_DIR}/specs/user-auth/spec.md` })
+  })
+
+  it('accepts a nested capability path (`identity/user-auth`)', () => {
+    const result = resolveGlobOutput(SPECS_GLOB, CHANGE_DIR, 'specs/identity/user-auth/spec.md')
+
+    expect(result).toEqual({ ok: true, path: `${CHANGE_DIR}/specs/identity/user-auth/spec.md` })
+  })
+
+  it('refuses a path that climbs out of the change folder', () => {
+    const result = resolveGlobOutput(SPECS_GLOB, CHANGE_DIR, '../../../../etc/passwd')
+
+    expect(result.ok).toBe(false)
+    // The reason is the drafter's retry complaint, so it has to name the path.
+    expect(reasonOf(result)).toContain('../../../../etc/passwd')
+  })
+
+  it('refuses an absolute path', () => {
+    const result = resolveGlobOutput(SPECS_GLOB, CHANGE_DIR, '/etc/passwd')
+
+    expect(result.ok).toBe(false)
+  })
+
+  it('refuses a path outside the pattern’s own directory', () => {
+    // `design.md` is inside the change folder but is not a spec file; letting it
+    // through would have the drafter overwrite another artifact.
+    const result = resolveGlobOutput(SPECS_GLOB, CHANGE_DIR, 'design.md')
+
+    expect(result.ok).toBe(false)
+  })
+
+  it('refuses a file the pattern’s extension does not admit', () => {
+    const result = resolveGlobOutput(SPECS_GLOB, CHANGE_DIR, 'specs/user-auth/spec.txt')
+
+    expect(result.ok).toBe(false)
+    expect(reasonOf(result)).toContain('.md')
+  })
+
+  it('refuses an empty path rather than resolving it to the base directory', () => {
+    const result = resolveGlobOutput(SPECS_GLOB, CHANGE_DIR, '   ')
+
+    expect(result.ok).toBe(false)
+  })
+})

--- a/tests/opencode-agent/openspec-driver.test.ts
+++ b/tests/opencode-agent/openspec-driver.test.ts
@@ -132,6 +132,35 @@ describe('openspec driver · instructions', () => {
     ])
   })
 
+  it('carries `changeDir`, which is what a glob output path is resolved against', async () => {
+    // Recorded from `openspec instructions specs --change <name> --json` on the
+    // pinned 1.8.0: the `specs` artifact resolves to a **pattern**, and the
+    // change folder beside it is the base the drafter's per-capability paths are
+    // relative to. Without it the drafter wrote the pattern itself and PLANNING
+    // died on ENOENT.
+    const payload = JSON.stringify({
+      instruction: 'Create specification files.',
+      changeDir: '/repo/openspec/changes/add-thing',
+      outputPath: 'specs/**/*.md',
+      resolvedOutputPath: '/repo/openspec/changes/add-thing/specs/**/*.md',
+    })
+    const { runner } = fakeRunner({ 'instructions specs': { stdout: payload } })
+    const driver = createOpenSpecDriver(deps(runner))
+    const result = await driver.instructions('specs', 'add-thing')
+    expect(result.changeDir).toBe('/repo/openspec/changes/add-thing')
+    expect(result.resolvedOutputPath).toBe('/repo/openspec/changes/add-thing/specs/**/*.md')
+  })
+
+  it('leaves `changeDir` undefined when the CLI omits it, rather than rejecting the payload', async () => {
+    // Every phase reads `instructions`, so a field that is merely useful must
+    // never be the thing that fails them all on a CLI that stops emitting it.
+    const payload = JSON.stringify({ instruction: 'Do the thing.', resolvedOutputPath: '/repo/x.md' })
+    const { runner } = fakeRunner({ 'instructions design': { stdout: payload } })
+    const driver = createOpenSpecDriver(deps(runner))
+    const result = await driver.instructions('design', 'add-thing')
+    expect(result.changeDir).toBeUndefined()
+  })
+
   it('defaults template/rules/paths to empty when the CLI omits them', async () => {
     const payload = JSON.stringify({ instruction: 'Do the thing.', resolvedOutputPath: '/repo/x.md' })
     const { runner } = fakeRunner({ 'instructions design': { stdout: payload } })

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -409,6 +409,7 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
       template: undefined,
       rules: [],
       resolvedOutputPath: '',
+      changeDir: undefined,
       existingOutputPaths: [],
       dependencies: [],
     },

--- a/tests/opencode-agent/phases.test.ts
+++ b/tests/opencode-agent/phases.test.ts
@@ -246,6 +246,30 @@ describe('handleTriage · outcome: capture · D9 association gate', () => {
 
 const CHANGE = 'add-retry-helper'
 
+const CHANGE_DIR = `/repo/openspec/changes/${CHANGE}`
+
+/**
+ * What `openspec instructions <id> --change <name> --json` answers, recorded
+ * from the pinned 1.8.0 for the `spec-driven` schema.
+ *
+ * `specs` is the one that is not a file: a change carries one delta spec per
+ * capability, so its `resolvedOutputPath` is the pattern `specs/**\/*.md`. The
+ * fake said `specs.md` like every other artifact, which is why nothing here
+ * noticed the drafter writing the pattern verbatim until run 31664928683 died on
+ * `ENOENT ... /specs/**\/*.md` at PLANNING.
+ */
+const instructionsFor = (
+  artifactId: string,
+): import('../../opencode-agent/src/openspec-driver.js').InstructionsResult => ({
+  instruction: `Draft the ${artifactId}.`,
+  template: undefined,
+  rules: [],
+  resolvedOutputPath: artifactId === 'specs' ? `${CHANGE_DIR}/specs/**/*.md` : `${CHANGE_DIR}/${artifactId}.md`,
+  changeDir: CHANGE_DIR,
+  existingOutputPaths: [],
+  dependencies: [],
+})
+
 /** A driver whose status evolves as the drafter writes each artifact. */
 const evolvingDriver = (drafted: Set<string>): OpenSpecDriver => ({
   newChange: (n: string): Promise<{ changeName: string }> => Promise.resolve({ changeName: n }),
@@ -254,24 +278,19 @@ const evolvingDriver = (drafted: Set<string>): OpenSpecDriver => ({
   instructions: (
     artifactId: string,
   ): Promise<import('../../opencode-agent/src/openspec-driver.js').InstructionsResult> =>
-    Promise.resolve({
-      instruction: `Draft the ${artifactId}.`,
-      template: undefined,
-      rules: [],
-      resolvedOutputPath: `/repo/openspec/changes/${CHANGE}/${artifactId}.md`,
-      existingOutputPaths: [],
-      dependencies: [],
-    }),
+    Promise.resolve(instructionsFor(artifactId)),
   status: (): Promise<import('../../opencode-agent/src/openspec-driver.js').StatusResult> => {
+    // The real schema's dependency order: proposal → specs → design → tasks.
     const artifacts: Record<string, string> = {
       proposal: 'done',
-      design: drafted.has('design') ? 'done' : 'ready',
+      specs: drafted.has('specs') ? 'done' : 'ready',
+      design: drafted.has('design') ? 'done' : drafted.has('specs') ? 'ready' : 'blocked',
       tasks: drafted.has('tasks') ? 'done' : drafted.has('design') ? 'ready' : 'blocked',
     }
     return Promise.resolve({
       schemaName: 'spec-driven',
       artifacts,
-      isPlanningComplete: drafted.has('design') && drafted.has('tasks'),
+      isPlanningComplete: drafted.has('specs') && drafted.has('design') && drafted.has('tasks'),
     })
   },
 })
@@ -296,8 +315,15 @@ const planningState = (over: Partial<AgentState> = {}): AgentState => ({
   ...over,
 })
 
-/** The artifact id a write path points at (`/x/design.md` → `design`). Module-level so the `?.`/`??` is not "in test". */
+/**
+ * The artifact id a write path points at (`/x/design.md` → `design`).
+ *
+ * A delta spec lands at `specs/<capability-path>/spec.md`, so the id is the
+ * folder there rather than the filename — the glob artifact is the one whose
+ * files are not named after it. Module-level so the `?.`/`??` is not "in test".
+ */
 const artifactIdOf = (path: string): string => {
+  if (path.startsWith(`${CHANGE_DIR}/specs/`)) return 'specs'
   const base = path.split('/').pop() ?? ''
   return base.replace(/\.md$/u, '')
 }
@@ -348,6 +374,7 @@ const validateFailsOnce = (call: number): { ok: boolean; output: string } =>
 describe('handlePlan · drafter loop (D3)', () => {
   it('drafts each pending artifact, writes it to the folder, and signals PLAN_POSTED', async () => {
     const { input, io } = wireDrafterInput([
+      JSON.stringify({ files: [{ path: 'specs/retry/spec.md', content: 'spec body' }] }),
       JSON.stringify({ content: 'design body' }),
       JSON.stringify({ content: 'tasks body' }),
     ])
@@ -355,8 +382,11 @@ describe('handlePlan · drafter loop (D3)', () => {
     const outcome = await handlePlan(input)
 
     expect(outcome.signal).toBe('PLAN_POSTED')
-    // The drafter wrote design then tasks, in dependency order.
+    // The drafter wrote specs, design then tasks, in dependency order — and the
+    // glob artifact landed at the concrete per-capability path it chose, not at
+    // the pattern the driver resolved.
     expect(io.writes.map((w) => w.path)).toEqual([
+      `/repo/openspec/changes/${CHANGE}/specs/retry/spec.md`,
       `/repo/openspec/changes/${CHANGE}/design.md`,
       `/repo/openspec/changes/${CHANGE}/tasks.md`,
     ])
@@ -369,10 +399,10 @@ describe('handlePlan · drafter loop (D3)', () => {
   })
 
   it('retries once when validate --strict fails, attaching the complaint', async () => {
-    // Only design pending (tasks already done) so the loop drafts one artifact.
+    // Only design pending (specs and tasks already done) so the loop drafts one artifact.
     const { input, io } = wireDrafterInput(
       [JSON.stringify({ content: 'first attempt' }), JSON.stringify({ content: 'repaired attempt' })],
-      { done: ['tasks'], validate: validateFailsOnce },
+      { done: ['specs', 'tasks'], validate: validateFailsOnce },
     )
 
     const outcome = await handlePlan(input)
@@ -385,8 +415,62 @@ describe('handlePlan · drafter loop (D3)', () => {
     expect(io.writes.at(-1)?.content).toBe('repaired attempt')
   })
 
+  it('writes one file per capability for the glob artifact, never the pattern itself', async () => {
+    // The failure of run 31664928683: `specs` resolves to `specs/**\/*.md`, the
+    // drafter wrote that string, and PLANNING died on ENOENT after paying for
+    // the turn that composed the content. The paths are the model's to choose
+    // here — one per capability — and TypeScript's to judge and write.
+    const { input, io } = wireDrafterInput(
+      [
+        JSON.stringify({
+          files: [
+            { path: 'specs/retry-helper/spec.md', content: '## ADDED Requirements' },
+            { path: 'specs/identity/user-auth/spec.md', content: '## MODIFIED Requirements' },
+          ],
+        }),
+      ],
+      { done: ['design', 'tasks'] },
+    )
+
+    const outcome = await handlePlan(input)
+
+    expect(outcome.signal).toBe('PLAN_POSTED')
+    expect(io.writes.map((w) => w.path)).toEqual([
+      `/repo/openspec/changes/${CHANGE}/specs/retry-helper/spec.md`,
+      `/repo/openspec/changes/${CHANGE}/specs/identity/user-auth/spec.md`,
+    ])
+  })
+
+  it('re-asks with a complaint when a drafted spec path escapes the change folder, writing nothing', async () => {
+    // A path is the other thing a draft can get wrong, and it takes the same one
+    // retry the validate-strict verdict takes. All-or-nothing: the first
+    // attempt's good file is not written either, or the retry's complaint would
+    // be about a folder that had already half-landed.
+    const { input, io } = wireDrafterInput(
+      [
+        JSON.stringify({
+          files: [
+            { path: 'specs/retry-helper/spec.md', content: 'fine' },
+            { path: '../../../../etc/passwd', content: 'not fine' },
+          ],
+        }),
+        JSON.stringify({ files: [{ path: 'specs/retry-helper/spec.md', content: 'repaired' }] }),
+      ],
+      { done: ['design', 'tasks'] },
+    )
+
+    const outcome = await handlePlan(input)
+
+    expect(outcome.signal).toBe('PLAN_POSTED')
+    expect(io.prompts).toHaveLength(2)
+    expect(io.prompts.at(-1)?.prompt).toContain('../../../../etc/passwd')
+    expect(io.writes.map((w) => w.path)).toEqual([`/repo/openspec/changes/${CHANGE}/specs/retry-helper/spec.md`])
+    expect(io.writes.at(-1)?.content).toBe('repaired')
+  })
+
   it('renders the PLAN_REVIEW digest from the folder (D1): includes tasks.md read back', async () => {
     const { input, io } = wireDrafterInput([
+      JSON.stringify({ files: [{ path: 'specs/retry/spec.md', content: 'spec body' }] }),
       JSON.stringify({ content: 'design body' }),
       JSON.stringify({ content: '- [ ] Write retry tests\n- [ ] Add the wrapper\n' }),
     ])
@@ -410,7 +494,7 @@ describe('handlePlan · drafter loop (D3)', () => {
     // rot relative to the conversation.
     const built = wireDrafterInput(
       [JSON.stringify({ content: '- [ ] Write retry tests\n- [ ] Also add structured logging\n' })],
-      { done: ['tasks'] },
+      { done: ['specs', 'tasks'] },
     )
     const steerTrigger: TriggerEvent = {
       kind: 'issue',
@@ -459,6 +543,7 @@ const folderDriver = (change: string): OpenSpecDriver => ({
       template: undefined,
       rules: [],
       resolvedOutputPath: `/repo/openspec/changes/${change}/${artifactId}.md`,
+      changeDir: `/repo/openspec/changes/${change}`,
       existingOutputPaths: [],
       dependencies: [],
     }),
@@ -629,6 +714,7 @@ const implementInput = (tasks: string): { input: PhaseInput; io: StubIo } => {
 describe('a phase checks out the branch carrying the folder before it reads the folder', () => {
   it('handlePlan drafts after ensureBranch, not before (run 31630109348)', async () => {
     const built = wireDrafterInput([
+      JSON.stringify({ files: [{ path: 'specs/retry/spec.md', content: 'spec body' }] }),
       JSON.stringify({ content: 'design body' }),
       JSON.stringify({ content: 'tasks body' }),
     ])

--- a/tests/opencode-agent/test-helpers.ts
+++ b/tests/opencode-agent/test-helpers.ts
@@ -155,6 +155,7 @@ const emptyInstructions = (): InstructionsResult => ({
   template: undefined,
   rules: [],
   resolvedOutputPath: '/repo/x.md',
+  changeDir: undefined,
   existingOutputPaths: [],
   dependencies: [],
 })


### PR DESCRIPTION
`openspec instructions specs` resolves to a pattern, not a path:
`<changeDir>/specs/**/*.md`, because a change carries one delta spec per
capability. The PLANNING drafter handed that string to `writeFile`, so run
31664928683 died on `ENOENT ... /specs/**/*.md` after paying for the turn
that composed the content.

A glob artifact now takes a second reply shape — `{"files":[{"path",
"content"}]}`, paths relative to the change folder, which is how the
artifact instruction the model reads spells them — and `glob-output.ts`
judges each path (containment under the directory the pattern collects
from, plus the pattern's extension) before anything is written. A refused
path becomes the complaint on the retry that already existed for the
`validate --strict` verdict, all-or-nothing so a half-written folder is
never validated as if it were whole.

`deps.writeFile` creates parent directories: `openspec new change`
scaffolds a folder holding `.openspec.yaml` and nothing else, so
`specs/<capability-path>/spec.md` is the first thing in its directory.

The fake driver in `phases.test.ts` said `specs.md` like every other
artifact, which is why nothing caught this; it now carries the real
schema's four artifacts, the glob among them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pw2e1Zi6qmyEmefjCkrixG