### PR TITLE
fix(opencode-agent): push what the review loop finds, and say what it did

### DIFF
--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -11,11 +11,12 @@ name: OpenCode Issue Agent
 # drop what does not apply, cheaply and with a reason in the log.
 #
 # On a **pull request** the trade runs the other way and the third arm of the
-# condition below does filter on the body. There is no conversation to strand
-# there: `/review` is the only command that door accepts, while every pull
-# request in a repository collects ordinary code-review comments, and each one
-# of those would otherwise start a job and buy an API call reading the pull
-# request's head.
+# condition below does filter on the body — on *every* command, not on `/review`
+# alone, because once a pull request exists it is the surface the issue is driven
+# from and a command typed on the issue is refused and pointed here. What is
+# still dropped is prose: every pull request in a repository collects ordinary
+# code-review comments, and each one would otherwise start a job and buy an API
+# call reading the pull request's head.
 on:
   issues:
     types: [opened]
@@ -95,12 +96,20 @@ jobs:
     #
     # The third arm is the pull-request door, and it mirrors what the pipeline
     # now accepts: `parsePullRequestEvent`'s shape filter, the resolver's
-    # `/review` test, and `checkSender`. Four things about it are deliberate.
+    # slash-command test, and `checkSender`. It admits **every** command rather
+    # than `/review` alone, because a pull request is now the surface an issue
+    # with one is driven from — `commandSurface` refuses a command typed on the
+    # issue there — so a narrower arm here would leave `/retry`, `/cancel` and
+    # `/ask` with nowhere to be typed at all. The list is spelled out one
+    # `contains` at a time because GitHub expressions have no way to ask "does
+    # this string start with any of these"; `workflow.test.ts` checks it against
+    # `SLASH_COMMANDS` so a new command cannot be added to the vocabulary and
+    # forgotten here. Four things about it are deliberate.
     # It reads `github.event.comment.author_association` outright, with none of
     # the `|| issue.author_association` fallback the arm above uses — that
     # payload always carries a comment, `parsePullRequestEvent` takes the
     # commenter's rights, and the pull request's own author has nothing to do
-    # with who may command the agent from it. The `contains(…, '/review')` is a
+    # with who may command the agent from it. The `contains` group is a
     # first-pass filter only: `parseSlashCommand` re-parses, requires the
     # command to start a line and ignores fenced code blocks, and none of that
     # is expressible here — the arm exists so an event that will be dropped
@@ -108,7 +117,7 @@ jobs:
     # closed or merged pull request, a branch the agent does not own — needs an
     # API call and is not attempted here. And the arm above keeps its
     # `pull_request == null`: it is what still drops a pull-request comment
-    # carrying no `/review`.
+    # carrying no command at all.
     #
     # The fourth arm is Design D7's archive door: a merged pull request on an
     # agent branch whose head is this repository. The in-process parse checks the
@@ -133,7 +142,13 @@ jobs:
        (github.event_name == 'issue_comment' &&
         github.event.action == 'created' &&
         github.event.issue.pull_request != null &&
-        contains(github.event.comment.body, '/review') &&
+        (contains(github.event.comment.body, '/approve') ||
+         contains(github.event.comment.body, '/changes') ||
+         contains(github.event.comment.body, '/ask') ||
+         contains(github.event.comment.body, '/retry') ||
+         contains(github.event.comment.body, '/cancel') ||
+         contains(github.event.comment.body, '/review') ||
+         contains(github.event.comment.body, '/continue')) &&
         github.event.sender.type != 'Bot' &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
        ||
@@ -687,6 +702,15 @@ jobs:
           # one. The empty test in the body stays — it is what makes this script
           # runnable on its own, and the test suite runs it.
           ISSUE_NUMBER: ${{ needs.resolve.outputs.issue }}
+          # The branch this run belongs to, which is the only handle this step
+          # has on the *pull request*. Once one exists the reconcile writes its
+          # labels there rather than on the issue (see `feedback-target.ts`), so
+          # a cleanup that only reached the issue would leave the marker exactly
+          # where it is now most likely to be. Resolved from the branch rather
+          # than passed down, because no event payload carries a pull request
+          # number for a run triggered from the issue or from CI.
+          BRANCH: ${{ needs.resolve.outputs.branch }}
+          GH_REPO: ${{ github.repository }}
           # Read exactly the way `labelPrefix()` in src/config-values.ts reads
           # it: trimmed, defaulted, and `none` compared case-insensitively. A
           # repository that switched labelling off must not have this step reach
@@ -718,4 +742,19 @@ jobs:
           # second thing Semgrep's bash grammar gives up on here.
           if ! gh issue edit "$ISSUE_NUMBER" --remove-label "${prefix}working"; then
             echo "Could not remove ${prefix}working; the next run's reconcile takes it off."
+          fi
+
+          # And on the pull request, which is where the marker lives once one is
+          # open. Both, not one or the other: which of the two carries it depends
+          # on how far the run got before it was killed, and this step cannot
+          # know that. Every part of this is best-effort — no branch, no open
+          # pull request, or a lookup that fails, are all "nothing to clean up".
+          if [ -z "$BRANCH" ]; then
+            exit 0
+          fi
+          pr="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' || true)"
+          if [ -n "$pr" ]; then
+            if ! gh pr edit "$pr" --remove-label "${prefix}working"; then
+              echo "Could not remove ${prefix}working from that pull request; the next run's reconcile takes it off."
+            fi
           fi

--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -619,6 +619,14 @@ jobs:
       # runner timeout, a cancelled job, a config error thrown before the first
       # comment could be posted, a crash.
       #
+      # It posts on the **issue** even for an issue whose commands have moved to
+      # its pull request, and that is the one place that asymmetry is right: this
+      # step speaks for the runs where the pipeline never got far enough to
+      # restore any state at all, so whether a pull request exists is precisely
+      # what it cannot know. The issue number is the one fact `resolve` computed
+      # before this job existed. What it *can* get right is the advice, which
+      # named a surface that would now refuse it.
+      #
       # `if: failure()` alone did not select that, though the comment here used
       # to claim it did. It selects every red job, and six pipeline paths exit 1
       # only *after* posting their own report — `failRun` and `failAnswer`, both
@@ -671,7 +679,7 @@ jobs:
           printf '%s\n\n%s\n\n%s\n' \
             '### Agent job did not finish' \
             "The workflow run failed or was cancelled before or during the pipeline. Logs: $RUN_URL" \
-            'The issue state is unchanged; reply `/retry` once the cause is addressed.' \
+            'The issue state is unchanged. Reply `/retry` once the cause is addressed — on the pull request, if this issue has one open.' \
             > /tmp/agent-failure.md
           gh issue comment "$ISSUE_NUMBER" --body-file /tmp/agent-failure.md
 

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -242,7 +242,11 @@ findings: `ROADMAP.md`.
   side of the pipe because the credential must never be visible to a subprocess
   whose children the model controls. Everything the loop prints is repeated into
   the **public** Actions log as it arrives and into the **encrypted** transcript
-  unabridged — a subprocess that runs for an hour in silence is indistinguishable
+  unabridged — and `review-transcript.ts` folds the loop's own `trace.jsonl` in
+  after the child exits, which is this phase's equivalent of the tool activity the
+  implement phase feeds the transcript from. It is encrypted rather than uploaded
+  as a file for the reason the transcript exists: an Actions artefact is
+  downloadable by anyone with repository read access — a subprocess that runs for an hour in silence is indistinguishable
   from a hang, which is how run 31704544065 came to be cancelled at minute 60 with
   nothing to show for it. A failed loop is described by `describeFailure`, never by
   its exit code: a build gate, a runner deadline, a missing binary, an unresolvable

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -299,7 +299,18 @@ findings: `ROADMAP.md`.
   block on a pull request is a second source of truth that scan cannot see. That
   split is why this is two functions rather than one `target()` every caller
   reads — the day the two questions are answered by one function is the day a
-  state block lands on a pull request. Three consequences not to undo. The label
+  state block lands on a pull request. **An answer is the exception, and it is
+  the exception because it is not a record at all**: `/ask` moves no phase,
+  spends no attempt and writes no artefact, so `postAnswer` replies on the
+  surface the question was typed on — a plain comment carrying no block, with
+  the spend written through `state-persist.ts`, which rewrites the issue's
+  newest block in place and posts nothing. Its accepted cost is that a question
+  answered on a pull request is invisible to the next run's prompt, since
+  `renderThread` reads the issue thread. Every other comment stays on the issue
+  and gains one line from `postAndAppend` naming where commands go: almost all
+  of them end by inviting one, and all of those became right-advice-wrong-page
+  at once — said on the write they share rather than threaded through eight
+  renderers, where any one of them could forget. Three consequences not to undo. The label
   reconcile **clears the issue** when it writes the pull request, because a copy
   left behind would freeze at whatever the state was that day and no later
   reconcile would ever look at it again. `applyPullRequestCommand` no longer

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -260,9 +260,9 @@ findings: `ROADMAP.md`.
   `resolvePullRequestTrigger` in `pr-trigger.ts` recovers the issue from the head
   branch, `agent/issue-<n>`, the same link a red CI run travels; that costs an API
   call, which is why it is a second step and not a branch of the pure
-  `parseTriggerEvent`. Its **order is the design**: the `/review` test is free and
-  comes first, so every ordinary code-review comment on every pull request in the
-  repository is dropped with no lookup at all — the head lookup that follows is
+  `parseTriggerEvent`. Its **order is the design**: the slash-command test is free
+  and comes first, so every ordinary code-review comment on every pull request in
+  the repository is dropped with no lookup at all — the head lookup that follows is
   not free, so nothing may be moved in front of it and nothing that reads its
   answer may be moved behind. The fork check is the one to get right. `head.ref`
   is attacker-controlled, so a pull request opened from a fork whose branch is
@@ -283,9 +283,29 @@ findings: `ROADMAP.md`.
   a compile error rather than a silent bucketing. The report and the state block
   still go to the issue whichever door was used, and that is not a preference: a
   block on the pull request is a second source of truth the restore scan cannot
-  see. `applyPullRequestCommand` keeps refusing everything but `/review` even
-  though the resolver means nothing else can reach it, because a decision enforced
-  only by whichever layer filters first is one a second door quietly repeals.
+  see.
+- **Once a pull request exists, it is the surface — but not the record.**
+  `feedback-target.ts` holds both halves. The **live** channels move the moment
+  `prNumber` is set: the status comment opens on the pull request, the labels are
+  reconciled there, and `commandSurface` refuses a command typed on the issue with
+  a reply naming where to type it — not "does not apply", which would be false
+  twice over, since the command applies perfectly and would have worked one page
+  over. The **record** does not move: `AGENT_STATE` and `AGENT_REPORT` stay in
+  blocks on the issue, because `findLatestState` scans exactly one thread and a
+  block on a pull request is a second source of truth that scan cannot see. That
+  split is why this is two functions rather than one `target()` every caller
+  reads — the day the two questions are answered by one function is the day a
+  state block lands on a pull request. Three consequences not to undo. The label
+  reconcile **clears the issue** when it writes the pull request, because a copy
+  left behind would freeze at whatever the state was that day and no later
+  reconcile would ever look at it again. `applyPullRequestCommand` no longer
+  narrows to `/review`: with the issue refusing commands, a narrowing there would
+  leave `/retry`, `/cancel` and `/ask` nowhere at all to be typed, and which
+  commands a state accepts is `applyCommand`'s one answer for both doors. And the
+  workflow's pull-request arm names **every** command in `SLASH_COMMANDS` (checked
+  against it by `workflow.test.ts`) while the label cleanup step reaches both the
+  issue and the pull request, since which of the two carries a stranded
+  `agent:working` depends on how far the killed run got.
 - **One model endpoint.** Everything goes through `openai-config.ts`; there are
   no provider-specific keys and no second place a model is named. OpenCode is
   never handed the real key: `provider-proxy.ts` holds it and `contain()` in

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -228,6 +228,27 @@ findings: `ROADMAP.md`.
   optional for the same reason the split is: this review usually runs in a job
   that implemented nothing, so the remote branch is the only copy of the work.
   `check-loop.ts` exists only for CI fixing, which the workspace does not cover.
+  **What the loop produces is pushed by the branch, not by the commit.** The loop
+  commits its fixes in its own worktree and merges them into this checkout itself,
+  so `commitAll` — which reports only what _this process_ staged — answers `null`
+  whether the loop found nothing or found twenty things, and reading that as
+  "nothing to apply" left every finding it ever made unpushed on a branch in a
+  checkout about to be deleted. `phases/review-push.ts` asks the **branch**
+  instead (`git.headSha` either side of the loop) and pushes when it moved; a
+  commit this process made needs no second opinion and is pushed on that alone.
+  It also pushes **as each fix lands**, on the `[review-loop] published` marker
+  the loop prints: `mergeEachFix` in the generated config makes the loop merge per
+  fix instead of once at the end behind its build gate, and the push stays on this
+  side of the pipe because the credential must never be visible to a subprocess
+  whose children the model controls. Everything the loop prints is repeated into
+  the **public** Actions log as it arrives and into the **encrypted** transcript
+  unabridged — a subprocess that runs for an hour in silence is indistinguishable
+  from a hang, which is how run 31704544065 came to be cancelled at minute 60 with
+  nothing to show for it. A failed loop is described by `describeFailure`, never by
+  its exit code: a build gate, a runner deadline, a missing binary, an unresolvable
+  plan path and a merge conflict are all `exit 1`, and each has a different remedy.
+  The loop's own deadline is `turnTimeoutMs`, the same shrink-to-fit-the-job bound
+  a model turn gets, so it stops while the pipeline can still report it.
   In that loop the first round runs every check — one repair prompt seeing every
   failure fixes more than a fail-fast round would — and later rounds re-run only
   what failed. Only a **full** pass may return `passed`: a narrowed round has not

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -185,13 +185,22 @@ no note at all — a pointer to the page you are already reading is noise — an
 is decided from the trigger kind, in `src/pull-request-note.ts`, because the phase
 cannot tell the two doors apart.
 
-**`/ask` from a pull request used to be deliberately absent**, on the argument
-that its answer would land on the issue while the reader was looking at the diff.
-That answer still lands on the issue — the record does not move — but refusing it
-no longer follows: with commands on the issue refused too, `/ask` would have had
-nowhere at all to be typed. `applyPullRequestCommand` now hands every command to
-`applyCommand`, which is the one place that decides what a state accepts, so the
-two doors cannot disagree about it.
+**`/ask` is answered where it was asked.** It used to be refused from a pull
+request altogether, on the argument that its answer would land on the issue while
+the reader was looking at the diff. With commands on the issue refused too that
+left it nowhere to be typed, so the answer moved instead: `postAnswer` replies on
+the surface the question came from. It is the one exception to "the record stays
+on the issue", and only because a question is not a record — it moves no phase,
+spends no attempt and writes no artefact, so the comment carries no state block
+and the spend is written through `state-persist.ts`, which rewrites the issue's
+newest block in place without posting. The cost is that a question answered on a
+pull request is invisible to the next run's prompt, since `renderThread` reads the
+issue thread.
+
+Every other comment still goes to the issue, and gains one line naming where
+commands go while a pull request is open. Almost all of them end by inviting one
+— "reply `/retry`", "raise the ceiling and reply `/review`" — and every one of
+those became right-advice-wrong-page the day the issue started refusing commands.
 
 `/review` is also the first command `COMPLETE` has ever accepted, and the only
 one whose availability the transition table cannot decide alone. `COMPLETE` is

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -122,9 +122,22 @@ moves the phase and the handler runs behind it in the same job, exactly as
 | `/continue`                 | `INCOMPLETE`                 | Pick up the phase the job ran out of time for                  |
 | `/cancel`                   | anything but `COMPLETE`      | Stop for good — a cancelled issue cannot be restarted          |
 
-**`/review` has two doors and one answer.** It is typed on the issue, where every
-other command works, or on the pull request, which is where the diff actually is.
-The pull request is the narrower door: it accepts `/review` and nothing else.
+**Where a command is typed depends on whether a pull request exists.** Until one
+does, the issue is the only surface and every command is typed there. From the
+moment `state.prNumber` is set, the pull request takes over: it is where the diff,
+the checks and the merge button are, so it is where the live status comment opens,
+where the `agent:*` labels are reconciled, and where commands are accepted. A
+command typed on the issue after that is refused with a comment naming the pull
+request — not "does not apply", which would be false twice over, since the command
+applies perfectly and would have worked one page over. `src/feedback-target.ts`
+holds both halves of that rule.
+
+**The record does not move.** `AGENT_STATE` and `AGENT_REPORT` stay in hidden
+blocks on the **issue**, whichever surface the command arrived on, because
+`findLatestState` scans exactly one thread and a block on a pull request would be
+a second source of truth that scan cannot see. So a `/review` typed on the pull
+request is answered by a report on the issue and a short note on the pull request
+pointing at it — see below.
 
 A comment typed on a pull request has to name its issue before anything else in
 this pipeline can run, and the payload does not carry one —
@@ -134,10 +147,12 @@ branch, exactly as it is for a red CI run: `head.ref` is `agent/issue-<n>`, and
 (`src/pr-trigger.ts`) reads the head through the API and recovers the issue from
 it, in an order that is the design rather than a preference:
 
-1. **`/review`, or nothing.** Parsed by the same `parseSlashCommand` the issue
-   path uses, so a command has to start a line and a fenced block is ignored.
-   Every other comment on every pull request in the repository is dropped here,
-   with no API call at all — which is the whole reason the test comes first.
+1. **A slash command, or nothing.** Parsed by the same `parseSlashCommand` the
+   issue path uses, so a command has to start a line and a fenced block is
+   ignored. Every other comment on every pull request in the repository is
+   dropped here, with no API call at all — which is the whole reason the test
+   comes first. The door used to admit `/review` alone; it cannot now that the
+   issue refuses commands, or `/retry` and `/cancel` would have nowhere to go.
 2. **The head, from the API**, because nothing on the payload carries it.
 3. **The head repository is this one**, or `PR_FOREIGN_REPOSITORY` — the fork
    guard, and the one check here that is not bookkeeping. See **Guardrails**.
@@ -170,14 +185,13 @@ no note at all — a pointer to the page you are already reading is noise — an
 is decided from the trigger kind, in `src/pull-request-note.ts`, because the phase
 cannot tell the two doors apart.
 
-**`/ask` from a pull request is deliberately absent**, though it would have been
-nearly free once this door existed. It widens the surface from "one command naming
-a branch the agent owns" to a conversation, and its answer would still be posted
-on the issue — confusing in a way `/review` is not, since `/review`'s real output
-is commits on the branch the reader is already looking at. `applyPullRequestCommand`
-refuses everything else anyway, although the resolver means nothing else can reach
-it: a decision enforced only by whichever layer filters first is one a second door
-quietly repeals.
+**`/ask` from a pull request used to be deliberately absent**, on the argument
+that its answer would land on the issue while the reader was looking at the diff.
+That answer still lands on the issue — the record does not move — but refusing it
+no longer follows: with commands on the issue refused too, `/ask` would have had
+nowhere at all to be typed. `applyPullRequestCommand` now hands every command to
+`applyCommand`, which is the one place that decides what a state accepts, so the
+two doors cannot disagree about it.
 
 `/review` is also the first command `COMPLETE` has ever accepted, and the only
 one whose availability the transition table cannot decide alone. `COMPLETE` is
@@ -1756,7 +1770,7 @@ under **Setup** is simply not written. Nothing else changes.
 | `src/agent-handle.ts`                         | The OpenCode session's lifetime within one job                          |
 | `src/orchestrator.ts`                         | The state machine: guardrails and the phase cascade                     |
 | `src/trigger-events.ts`                       | What a raw webhook payload becomes, for each of the three kinds         |
-| `src/pr-trigger.ts`                           | Resolving a `/review` typed on a pull request back to its issue         |
+| `src/pr-trigger.ts`                           | Resolving a command typed on a pull request back to its issue           |
 | `src/triggers.ts`                             | Turning a command or comment into the state move to make                |
 | `src/ci-trigger.ts`                           | Whether a red check run buys a fix round, a notice, or nothing          |
 | `src/run-report.ts`                           | Everything the orchestrator writes back to the issue                    |
@@ -1766,6 +1780,7 @@ under **Setup** is simply not written. Nothing else changes.
 | `src/presentation.ts`                         | One glyph, label, headline and whose-turn per state an issue can be in  |
 | `src/outcomes.ts`                             | The second vocabulary: one glyph per outcome a comment announces        |
 | `src/feedback.ts` / `src/labels.ts`           | The reaction channel, and the label reconcile                           |
+| `src/feedback-target.ts`                      | Which of the issue and its pull request a run speaks on, and takes from |
 | `src/status-comment.ts` / `-reporter.ts`      | What the run's live comment says, and when it is edited                 |
 | `src/state-persist.ts`                        | Recording what a run spent without posting a comment                    |
 | `src/step-output.ts`                          | The one thing a run tells the rest of its own workflow job              |

--- a/opencode-agent/src/cascade.ts
+++ b/opencode-agent/src/cascade.ts
@@ -14,7 +14,7 @@ import { handlePlan } from './phases/plan.js'
 import { handleReview } from './phases/review.js'
 import { handleTriage } from './phases/triage.js'
 import { presentationFor } from './presentation.js'
-import { postAndAppend, renderSettled } from './run-report.js'
+import { postAndAppend, postAnswer, renderSettled } from './run-report.js'
 import type { RunResult } from './run-result.js'
 import { stopIfOutOfTime } from './time-budget.js'
 import { recordSpend, stopIfOverBudget } from './token-budget.js'
@@ -134,7 +134,12 @@ export const driveMachine = async (input: MachineInput): Promise<RunResult> => {
   if (!attempt.ok) return input.answer ? failAnswer(input, attempt.error) : failRun(input, attempt.error)
 
   const { outcome, next } = attempt
-  const grown = await postAndAppend(thread, input, outcome.comment, next, outcome.blocks)
+  // An answer goes back to the surface the question was typed on; everything
+  // else is the record and goes to the issue. `handleAnswer` is the one handler
+  // that returns no blocks, which is what makes that split expressible at all.
+  const grown = input.answer
+    ? await postAnswer(thread, input, outcome.comment, next)
+    : await postAndAppend(thread, input, outcome.comment, next, outcome.blocks)
 
   if (PAUSE_SIGNALS.has(outcome.signal)) {
     return { status: 'waiting', reason: `Waiting for a maintainer in ${next.phase}`, state: next, reported: true }

--- a/opencode-agent/src/contain.ts
+++ b/opencode-agent/src/contain.ts
@@ -148,7 +148,19 @@ export const contain = (input: ContainInput): Contained => {
   const agent = memoizeAgent(() => create(sessionOptions({ input, contained, status, clock })))
 
   const env = options.env
-  const deps = assembleDeps({ config: contained, secrets, event, env, run, log, agent, github, status, now: clock })
+  const deps = assembleDeps({
+    config: contained,
+    secrets,
+    event,
+    env,
+    run,
+    log,
+    agent,
+    github,
+    status,
+    now: clock,
+    transcript: input.transcript,
+  })
 
   return { proxy, agent, deps }
 }

--- a/opencode-agent/src/deps.ts
+++ b/opencode-agent/src/deps.ts
@@ -20,9 +20,11 @@ import type { SkillDocument } from './obra-skills.js'
 import { opencodeConfigEnv } from './openai-config.js'
 import { createOpenSpecDriver } from './openspec-driver.js'
 import type { PhaseDeps, RunReview } from './phase-context.js'
+import type { TranscriptSink } from './progress.js'
 import { runReviewLoop } from './review-runner.js'
 import type { CommandRunner } from './shell.js'
 import type { StatusReporter } from './status-reporter.js'
+import { turnTimeoutMs } from './time-budget.js'
 import type { TriggerEvent } from './trigger-events.js'
 import type { Phase } from './types.js'
 
@@ -53,9 +55,17 @@ const makeCheckRunner =
   (check) =>
     run(check.argv, { cwd: config.repoRoot, timeoutMs: config.agentTimeoutMs })
 
+interface ReviewRunnerInput {
+  run: CommandRunner
+  config: PipelineConfig
+  log: Logger
+  now: () => number
+  transcript: TranscriptSink | undefined
+}
+
 const makeReviewRunner =
-  (run: CommandRunner, config: PipelineConfig, log: Logger): RunReview =>
-  (plan) =>
+  ({ run, config, log, now, transcript }: ReviewRunnerInput): RunReview =>
+  (plan, onFixMerged) =>
     runReviewLoop({
       settings: {
         repoRoot: config.repoRoot,
@@ -70,7 +80,13 @@ const makeReviewRunner =
       run,
       env: opencodeConfigEnv(config.openai),
       log,
-      timeoutMs: config.agentTimeoutMs,
+      // Shrunk to fit what is left of the job, exactly as a model turn's bound
+      // is and for the same reason: `AGENT_TIMEOUT_MS` alone let the loop run
+      // past the moment the runner is taken away, which posts nothing at all.
+      // A loop stopped by its own deadline is a failure the pipeline can report.
+      timeoutMs: turnTimeoutMs(config, now()),
+      transcript,
+      onFixMerged,
     })
 
 const makeSkillLoader = (config: PipelineConfig, log: Logger): ((phase: Phase) => Promise<SkillDocument[]>) => {
@@ -122,6 +138,16 @@ export interface DepsInput {
    * runs, and three readers of one clock have to be one clock.
    */
   now: () => number
+  /**
+   * The encrypted transcript, when the run has a key.
+   *
+   * Here as well as on the session, because the review phase opens no session:
+   * its work happens in `opencode run` subprocesses, so the only account of it
+   * this process ever sees is what they print — and without this the phase that
+   * can spend the whole job left nothing in the artefact a maintainer is told
+   * to read.
+   */
+  transcript?: TranscriptSink
 }
 
 export const assembleDeps = ({
@@ -135,6 +161,7 @@ export const assembleDeps = ({
   github,
   status,
   now,
+  transcript,
 }: DepsInput): PhaseDeps => {
   const git = createGit({
     run,
@@ -152,7 +179,7 @@ export const assembleDeps = ({
     status,
     git,
     runCheck: makeCheckRunner(run, config),
-    runReview: makeReviewRunner(run, config, log),
+    runReview: makeReviewRunner({ run, config, log, now, transcript }),
     openspec: createOpenSpecDriver({ runner: run, cwd: config.repoRoot }),
     agent: agent.get,
     tokensUsed: agent.tokensUsed,

--- a/opencode-agent/src/feedback-target.ts
+++ b/opencode-agent/src/feedback-target.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { AgentState } from './types.js'
+
+/**
+ * Where a run talks to a maintainer, and where a maintainer talks back.
+ *
+ * The issue is the conversation until there is a diff to look at. After that the
+ * pull request is: it carries the branch, the checks, the review threads and the
+ * merge button, and an issue whose work is all in a pull request is a page nobody
+ * has a reason to open. So the moment `prNumber` exists, the **live** channels
+ * move — the status comment and the labels — and the commands that drive the
+ * agent are accepted there and refused here.
+ *
+ * What does **not** move is the record. `AGENT_STATE` and `AGENT_REPORT` live in
+ * hidden blocks on the **issue**, `findLatestState` restores by scanning that one
+ * thread, and a block posted on a pull request would be a second source of truth
+ * the scan cannot see — so every report, every failure notice and every state
+ * block still goes to the issue, whichever surface the command arrived on. The
+ * split is deliberate and is the reason this is a two-function module rather than
+ * one `target()` everything reads: "where does this run *speak*" and "where does
+ * this run *remember*" are different questions, and the day they are answered by
+ * one function is the day a state block lands on a pull request.
+ */
+
+/**
+ * The number every live feedback channel writes against — the pull request once
+ * one exists, the issue before that.
+ *
+ * One number for both, because GitHub's issue endpoints serve pull requests
+ * too: labels, comments and reactions on a pull request are the same API as on
+ * an issue, which is what makes moving the channel a matter of the number alone.
+ */
+export const feedbackTarget = (state: AgentState): number => state.prNumber ?? state.issueId
+
+/** The two human surfaces a command can be typed on. */
+export type CommandOrigin = 'issue' | 'pull-request'
+
+/**
+ * Whether a command typed here is this run's to act on.
+ *
+ * `elsewhere` is not a refusal of the *command* — it is a statement about the
+ * surface, and the reply says where to type it again. That distinction matters
+ * to the reader: `/retry` on a delivered issue is a perfectly good command in the
+ * wrong place, and telling somebody their command "does not apply right now"
+ * when it does is how a maintainer concludes the agent is broken.
+ */
+export const commandSurface = (state: AgentState, origin: CommandOrigin): 'accepted' | 'elsewhere' => {
+  if (state.prNumber === null) return 'accepted'
+  return origin === 'pull-request' ? 'accepted' : 'elsewhere'
+}

--- a/opencode-agent/src/git.ts
+++ b/opencode-agent/src/git.ts
@@ -125,6 +125,17 @@ export interface Git {
   push(branch: string, options?: PushOptions): Promise<void>
   /** The remote's default branch, or `null` when the checkout cannot tell. */
   defaultBranch(): Promise<string | null>
+  /**
+   * The commit the checkout is on.
+   *
+   * The one question `commitAll` cannot answer: it reports what *this process*
+   * staged, and the review loop commits and merges through git of its own — so
+   * to the pipeline its findings look like a clean tree with nothing to do. Two
+   * reads either side of the loop are what tell "the loop found nothing" from
+   * "the loop found plenty and it is all sitting unpushed on a runner about to
+   * be deleted".
+   */
+  headSha(): Promise<string>
 }
 
 export interface PushOptions {
@@ -256,5 +267,6 @@ export const createGit = (options: GitOptions): Git => {
       await gitOrThrow('push', ...verify, '-u', 'origin', branch)
     },
     defaultBranch: () => defaultBranch(git),
+    headSha: () => gitOrThrow('rev-parse', 'HEAD').then((result) => result.stdout.trim()),
   }
 }

--- a/opencode-agent/src/labels.ts
+++ b/opencode-agent/src/labels.ts
@@ -4,6 +4,7 @@
 // See LICENSE in the project root for details.
 
 import type { PipelineConfig } from './config.js'
+import { feedbackTarget } from './feedback-target.js'
 import type { LabelApi } from './github-labels.js'
 import type { Logger } from './logger.js'
 import { NEEDS_YOU_LABEL, presentationFor, WORKING_LABEL } from './presentation.js'
@@ -104,6 +105,11 @@ export const desiredLabels = (state: AgentState, stance: RunStance, prefix: stri
  * Labels outside the prefix are never touched, in either direction. They are the
  * repository's own, this pipeline did not put them there, and removing one is
  * the worst thing this module could do.
+ *
+ * *Which* thing gets labelled is {@link feedbackTarget}'s answer: the pull
+ * request once one exists, because that is the surface a maintainer watches from
+ * the moment there is a diff, and an issue in a list view saying `agent:working`
+ * about work that lives in a pull request sends them to the wrong page.
  */
 export const reconcileLabels = async (deps: LabelDeps, state: AgentState, stance: RunStance): Promise<void> => {
   const prefix = deps.config.labelPrefix
@@ -144,23 +150,42 @@ export const settleLabels = async (deps: LabelDeps, result: RunResult, fallback:
   return result
 }
 
+/**
+ * Reconciles one target, then — when the labels have moved to a pull request —
+ * clears the issue.
+ *
+ * The clear is not tidiness. `desiredLabels` is what the state implies *on the
+ * surface a maintainer is watching*, and once a pull request exists that surface
+ * is the pull request; leaving the issue's copy behind would freeze it at
+ * whatever the state was the moment the pull request opened — `agent:working` on
+ * an issue nothing is working, for good, since no later reconcile would ever
+ * look at it again. Asking for an empty desired set on the issue reuses the
+ * repair the diff already is.
+ */
 const applyDiff = async (deps: LabelDeps, prefix: string, state: AgentState, stance: RunStance): Promise<void> => {
-  const current = await deps.github.listLabels(state.issueId)
-  const desired = desiredLabels(state, stance, prefix)
+  const target = feedbackTarget(state)
+  await diffOne(deps, prefix, target, desiredLabels(state, stance, prefix))
+  if (target !== state.issueId) await diffOne(deps, prefix, state.issueId, [])
+}
+
+const diffOne = async (
+  deps: LabelDeps,
+  prefix: string,
+  target: number,
+  desired: readonly QualifiedLabel[],
+): Promise<void> => {
+  const current = await deps.github.listLabels(target)
 
   const missing = desired.filter((label) => !current.includes(label.name))
   const stale = current.filter((name) => name.startsWith(prefix) && !desired.some((label) => label.name === name))
   if (missing.length === 0 && stale.length === 0) return
 
-  await addLabels(deps, state.issueId, missing)
+  await addLabels(deps, target, missing)
   // One at a time: there is no bulk delete, and the repo forbids awaiting in a
   // loop body.
-  await mapSeries(stale, (name) => deps.github.removeLabel(state.issueId, name))
+  await mapSeries(stale, (name) => deps.github.removeLabel(target, name))
 
-  deps.log.debug(
-    { issue: state.issueId, added: missing.map((label) => label.name), removed: stale },
-    'Reconciled the issue labels',
-  )
+  deps.log.debug({ target, added: missing.map((label) => label.name), removed: stale }, 'Reconciled the labels')
 }
 
 /**

--- a/opencode-agent/src/phase-context.ts
+++ b/opencode-agent/src/phase-context.ts
@@ -27,7 +27,13 @@ export interface IssueContext {
 }
 
 export interface RunReview {
-  (plan: string): Promise<ReviewRunResult>
+  /**
+   * @param onFixMerged Called each time the loop reports a fix landing on the
+   * working branch, while it is still running. The phase pushes on it — the
+   * pipeline holds the credential and the loop's subprocesses must never see
+   * it, so "make it durable" cannot happen inside the loop.
+   */
+  (plan: string, onFixMerged?: () => void): Promise<ReviewRunResult>
 }
 
 /**

--- a/opencode-agent/src/phase-failure.ts
+++ b/opencode-agent/src/phase-failure.ts
@@ -4,7 +4,7 @@
 // See LICENSE in the project root for details.
 
 import type { MachineInput } from './phase-context.js'
-import { postAndAppend, renderAnswerFailure, renderFailure } from './run-report.js'
+import { postAndAppend, postAnswer, renderAnswerFailure, renderFailure } from './run-report.js'
 import type { RunResult } from './run-result.js'
 import { recordSpend } from './token-budget.js'
 import { transition } from './transitions.js'
@@ -80,7 +80,10 @@ export const failAnswer = async (input: MachineInput, error: unknown): Promise<R
   deps.log.error({ issue: state.issueId, phase: state.phase, error: message }, 'Answering a question failed')
 
   const carried = { ...state, ...(await recordSpend(input)) }
-  await postAndAppend(thread, input, renderAnswerFailure(state.phase, message), carried)
+  // Where the question was asked, like the answer itself: a maintainer watching
+  // a pull request for a reply must not be left with silence because the apology
+  // went to a page they are not reading.
+  await postAnswer(thread, input, renderAnswerFailure(state.phase, message), carried)
 
   return { status: 'failed', reason: message, state: carried, reported: true }
 }

--- a/opencode-agent/src/phases/review-push.ts
+++ b/opencode-agent/src/phases/review-push.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { PhaseInput } from '../phase-context.js'
+import { errorMessage } from '../types.js'
+
+/**
+ * Making the loop's findings durable, as they land rather than at the end.
+ *
+ * Three facts force this shape. The loop's fixes are **commits it makes itself**,
+ * in a worktree of this checkout, merged onto the working branch by the loop —
+ * so `commitAll` has nothing to stage and cannot say whether anything happened;
+ * only `HEAD` can. An Actions working tree **dies with the job**, so a fix is
+ * worth nothing until it is pushed, and run 31704544065 lost an hour of review
+ * to a runner that went away. And the credential belongs to the **pipeline**,
+ * never to a subprocess whose children the model can read the environment of, so
+ * the push cannot happen inside the loop that produces the fixes — it happens
+ * here, on a marker the loop prints.
+ *
+ * The pushes ride a promise chain rather than being awaited at the call site:
+ * the marker arrives on the child's stdout, mid-turn, where nothing can be
+ * awaited, and two markers in quick succession must not push concurrently.
+ */
+export interface DurablePush {
+  /** Handed to the loop, called when a fix lands. Never throws. */
+  onFixMerged: () => void
+  /** Resolves once every push the markers asked for has been tried. */
+  settled: () => Promise<void>
+  /**
+   * Pushes if the branch has moved since the last push; resolves whether it ever
+   * moved.
+   *
+   * `committed` is what this process itself just did: a commit has moved `HEAD`
+   * by definition, so it needs no second opinion from the checkout — and asking
+   * for one would make a push conditional on a read that is allowed to fail.
+   */
+  push: (committed: boolean) => Promise<boolean>
+}
+
+/**
+ * `HEAD`, or `null` when the checkout would not say.
+ *
+ * `null` is "unknown", never "unchanged": it makes the comparison below fail
+ * open, so a checkout that cannot answer pushes rather than deciding on no
+ * evidence that there was nothing to push. Pushing an unmoved branch is free.
+ */
+const readHead = async (input: PhaseInput): Promise<string | null> => {
+  const { deps, state } = input
+  try {
+    return await deps.git.headSha()
+  } catch (error) {
+    deps.log.warn({ issue: state.issueId, error: errorMessage(error) }, 'Could not read HEAD; will push regardless')
+    return null
+  }
+}
+
+export const createPush = (input: PhaseInput, branch: string): DurablePush => {
+  const { deps, state } = input
+  // Read now — before the loop is started by the caller — because what every
+  // comparison below means is "since the review began".
+  let pushedAt: Promise<string | null> = readHead(input)
+  let advanced = false
+  let chain: Promise<void> = Promise.resolve()
+
+  const pushIfMoved = async (committed: boolean): Promise<boolean> => {
+    const [last, head] = await Promise.all([pushedAt, readHead(input)])
+    if (!committed && last !== null && head !== null && last === head) return advanced
+
+    await deps.git.push(branch)
+    pushedAt = Promise.resolve(head)
+    advanced = true
+    return advanced
+  }
+
+  return {
+    onFixMerged: (): void => {
+      chain = chain.then(async () => {
+        try {
+          await pushIfMoved(false)
+          deps.log.info({ issue: state.issueId, branch }, 'Pushed a review fix as it landed')
+        } catch (error) {
+          // Not the run's failure: the final push tries again, and a review that
+          // cannot reach the remote mid-loop is still worth finishing.
+          deps.log.warn({ issue: state.issueId, branch, error: errorMessage(error) }, 'Could not push a review fix')
+        }
+      })
+    },
+    settled: (): Promise<void> => chain,
+    push: (committed) => pushIfMoved(committed),
+  }
+}

--- a/opencode-agent/src/phases/review.ts
+++ b/opencode-agent/src/phases/review.ts
@@ -12,6 +12,7 @@ import { noteReview } from '../pull-request-note.js'
 import type { ReviewOutcome, ReviewRunResult } from '../review-runner.js'
 import { errorMessage } from '../types.js'
 import type { AgentState } from '../types.js'
+import { createPush } from './review-push.js'
 
 /**
  * The `review-loop/` workspace, as a phase of its own.
@@ -49,21 +50,7 @@ export const handleReview: PhaseHandler = async (input): Promise<PhaseOutcome> =
   // (design D1) rather than a block on the issue.
   const plan = await planFromFolder(input)
 
-  const review = await deps.runReview(plan)
-
-  // A clean tree is a **result**, not a failure: it means the loop found nothing
-  // to change, which is the outcome a reviewer most wants to hear. So it is
-  // reported and the phase still completes — and nothing is pushed, because
-  // there is nothing to push.
-  //
-  // `commitAll` hands back the totals it measured, and this phase deliberately
-  // does nothing with them: `changedLines` sizes the recommendation to run
-  // *this*, so a review updating it would have the hint describe the diff after
-  // the second pass it was arguing for.
-  const applied = (await deps.git.commitAll(reviewMessage(state.issueId))) !== null
-  if (applied) await deps.git.push(branch)
-
-  deps.log.info({ issue: state.issueId, branch, review: review.outcome, applied }, 'Review finished')
+  const { review, applied } = await runAndKeep(input, plan, branch)
 
   // One reading of the outcome table, handed to both renderers, so the note and
   // the report cannot describe the same loop differently.
@@ -77,6 +64,52 @@ export const handleReview: PhaseHandler = async (input): Promise<PhaseOutcome> =
   await noteReview(deps, input.trigger, { issueNumber: state.issueId, verdict, applied })
 
   return { signal: 'REVIEW_DONE', comment: report, blocks: [reportBlock(report, state)] }
+}
+
+/**
+ * Runs the loop and keeps whatever it produced, however it ended.
+ *
+ * A clean tree is a **result**, not a failure: it means the loop found nothing
+ * to change, which is the outcome a reviewer most wants to hear.
+ *
+ * But a clean tree is *also* what the loop leaves behind when it found plenty:
+ * it commits its fixes in its own worktree and merges them into this checkout
+ * itself, so `commitAll` — which reports only what *this process* staged —
+ * answers `null` for both. Reading that as "nothing to apply" is what left every
+ * finding the loop ever made unpushed, on a branch in a checkout that dies with
+ * the job. So the question is asked of the **branch**: did `HEAD` move, by
+ * anyone's hand, since before the loop ran.
+ *
+ * `commitAll` still runs, for whatever the loop left uncommitted, and this phase
+ * deliberately does nothing with the totals it hands back: `changedLines` sizes
+ * the recommendation to run *this*, so a review updating it would have the hint
+ * describe the diff after the second pass it was arguing for.
+ */
+const runAndKeep = async (
+  input: PhaseInput,
+  plan: string,
+  branch: string,
+): Promise<{ review: ReviewRunResult; applied: boolean }> => {
+  const { deps, state } = input
+
+  // Opened before the loop, because what it measures is the loop: the branch as
+  // it stood before any finding was applied.
+  const durable = createPush(input, branch)
+  const review = await deps.runReview(plan, durable.onFixMerged)
+  // Every push the loop's markers asked for, before anything reads the branch:
+  // they are issued on a chain rather than awaited at the call site, so that a
+  // fix becomes durable as it lands rather than at the end of the hour.
+  await durable.settled()
+
+  const staged = await deps.git.commitAll(reviewMessage(state.issueId))
+  const applied = await durable.push(staged !== null)
+
+  deps.log.info(
+    { issue: state.issueId, branch, review: review.outcome, applied, staged: staged !== null },
+    'Review finished',
+  )
+
+  return { review, applied }
 }
 
 /**
@@ -153,9 +186,13 @@ const reportBlock = (report: string, state: AgentState): string =>
 const reviewMessage = (issueNumber: number): string =>
   `fix(agent): apply review-loop findings for issue #${issueNumber}\n\nRefs #${issueNumber}`
 
-const REVIEW_LINE: Record<ReviewOutcome, (exitCode: number) => string> = {
+const REVIEW_LINE: Record<ReviewOutcome, (review: ReviewRunResult) => string> = {
   passed: () => '✅ clean',
-  failed: (exitCode) => `❌ exited ${exitCode}`,
+  // The exit code alone was the whole verdict here, and it is the one thing
+  // nobody can act on: a build gate, a runner deadline, a missing binary and an
+  // unresolvable plan path are all `exited 1`. `describeFailure` names which,
+  // and the fallback keeps the old wording for a failure it cannot classify.
+  failed: (review) => `❌ ${review.failure ?? `exited ${review.exitCode}`}`,
   // Not a failure: this repository simply has no review loop configured, and
   // saying "❌" for that would report every run elsewhere as permanently red.
   unavailable: () => '— not configured for this repository',
@@ -169,7 +206,7 @@ const REVIEW_LINE: Record<ReviewOutcome, (exitCode: number) => string> = {
  * for exactly this reason: one table with two readers cannot disagree with
  * itself, and a second table over `ReviewOutcome` eventually would.
  */
-const reviewLine = (review: ReviewRunResult): string => REVIEW_LINE[review.outcome](review.exitCode)
+const reviewLine = (review: ReviewRunResult): string => REVIEW_LINE[review.outcome](review)
 
 /**
  * A red loop is reported and does not block, exactly as it did inside phase 3.
@@ -185,6 +222,13 @@ const renderReport = (review: ReviewRunResult, applied: boolean, verdict: string
     `- Review loop: ${verdict}`,
     `- Findings applied: ${applied ? 'pushed as further commits on the branch' : 'nothing to apply'}`,
   ]
+
+  // Said once more, in its own line, when the loop broke *and* kept something:
+  // the verdict above reads as the loop's own summary of the review, and a
+  // reader who sees findings on the branch needs to know they are partial.
+  if (review.outcome === 'failed' && applied) {
+    lines.push('', 'The loop stopped early — what it had already fixed is on the branch, the rest is not.')
+  }
 
   if (review.outcome !== 'unavailable') {
     lines.push(

--- a/opencode-agent/src/pr-trigger.ts
+++ b/opencode-agent/src/pr-trigger.ts
@@ -69,7 +69,7 @@ export interface PendingPullRequestEvent extends PullRequestCommentFields {
 }
 
 /**
- * A resolved pull-request comment: a maintainer's `/review`, on a pull request
+ * A resolved pull-request comment: a maintainer's command, on a pull request
  * whose branch names the issue this run will answer on.
  *
  * A third member of `TriggerEvent` and deliberately not a flag on
@@ -84,16 +84,23 @@ export interface PullRequestTriggerEvent extends PullRequestCommentFields {
 }
 
 /**
- * The one command a pull request accepts.
+ * This door used to admit `/review` and nothing else, on the argument that a
+ * wider surface turns a command naming a branch into a conversation whose answer
+ * lands somewhere else.
  *
- * `/ask` from a pull request is a natural request and would be almost free once
- * this door exists, and it stays out deliberately: it widens the surface from
- * "one command naming a branch the agent owns" to "a conversation", and its
- * answer would still be posted on the issue — confusing in a way `/review` is
- * not, since `/review`'s real output is commits on the branch the reader is
- * already looking at.
+ * What changed is the other end: once a pull request exists it is the surface the
+ * agent labels, reports progress on and is watched from, and `triggers.ts` now
+ * refuses commands typed on the *issue* there. One command through this door and
+ * a refusal through the other would leave `/retry`, `/cancel` and `/ask` with
+ * nowhere at all to be typed. So the parse is "does this carry a command", and
+ * which commands the state accepts is decided once, by `applyCommand`, for both
+ * doors — a narrowing here would be a second, quieter answer to a question that
+ * already has one.
+ *
+ * The cheap-filter property this ordering exists for is unchanged: a comment
+ * with no command still costs one parse and no API call, which is what keeps
+ * every ordinary code-review comment on every pull request free.
  */
-const REVIEW_COMMAND = '/review'
 
 /**
  * Why a pull-request comment got no further than this module.
@@ -117,10 +124,10 @@ const refuse = (log: Logger, pending: PendingPullRequestEvent, code: PullRequest
  *
  * In this order, and the order is the point:
  *
- * 1. **`/review`, or nothing.** Parsed with `parseSlashCommand`, which requires
- *    the command to start a line and ignores fenced blocks, so quoting the
- *    agent's own instructions does not fire it. Anything else is dropped with no
- *    API call at all — every pull request in a repository gets ordinary review
+ * 1. **A slash command, or nothing.** Parsed with `parseSlashCommand`, which
+ *    requires the command to start a line and ignores fenced blocks, so quoting
+ *    the agent's own instructions does not fire it. Anything else is dropped with
+ *    no API call at all — every pull request in a repository gets ordinary review
  *    comments, and this is the filter that keeps every one of them free.
  * 2. **The head, from the API**, because nothing on the payload carries it.
  * 3. **The head repository is this one, or refuse.** This is the fork guard and
@@ -152,11 +159,11 @@ export const resolvePullRequestTrigger = async (
   log: Logger,
 ): Promise<PullRequestTriggerEvent | null> => {
   const command = parseSlashCommand(pending.commentBody)
-  if (command === null || command.command !== REVIEW_COMMAND) {
+  if (command === null) {
     // Not a `warn`, unlike every other exit here: this is the expected outcome
     // for almost every comment on almost every pull request, and it is what the
     // step above it buys — a log line rather than a lookup.
-    log.debug({ code: 'PR_NO_COMMAND', pr: pending.prNumber }, `Pull-request comment carries no ${REVIEW_COMMAND}`)
+    log.debug({ code: 'PR_NO_COMMAND', pr: pending.prNumber }, 'Pull-request comment carries no slash command')
     return null
   }
 

--- a/opencode-agent/src/review-runner.ts
+++ b/opencode-agent/src/review-runner.ts
@@ -9,7 +9,8 @@ import path from 'node:path'
 import type { Logger } from './logger.js'
 import { modelRef } from './openai-config.js'
 import type { OpenAiSettings } from './openai-config.js'
-import type { CommandResult, CommandRunner } from './shell.js'
+import type { TranscriptSink } from './progress.js'
+import type { CommandResult, CommandRunner, OutputStream } from './shell.js'
 
 /**
  * Drives the repository's own `review-loop/` workspace instead of a bespoke
@@ -55,6 +56,14 @@ export const buildReviewLoopConfig = (settings: ReviewLoopSettings): Record<stri
     buildTimeoutMs: settings.agentTimeoutMs,
     poolSize: settings.poolSize,
     checkCommand: settings.checkCommand,
+    // The one setting this pipeline needs and a laptop does not. The loop's
+    // ordinary shape is one atomic merge at the very end, behind a build gate —
+    // which on an Actions runner means a job that dies at minute 59, or a gate
+    // that goes red, takes every fix with it: the commits live on a branch in a
+    // checkout that is about to be deleted. Publishing each fix onto the working
+    // branch as it lands is what lets `phases/review.ts` push it while the loop
+    // is still running.
+    mergeEachFix: true,
     reviewer: agent,
     fixer: agent,
     matcher: agent,
@@ -77,7 +86,22 @@ export interface ReviewRunResult {
   /** The loop's own summary block, or the tail of its output when it crashed. */
   summary: string
   exitCode: number
+  /**
+   * One sentence naming *how* a failed loop failed, or `null` when it did not.
+   *
+   * The exit code alone is not an account of anything: a build gate that went
+   * red, a runner deadline, a missing `bun`, a plan path that does not resolve
+   * and a merge conflict are all `exit 1` with sixty lines of tail, and each has
+   * a different remedy. See {@link describeFailure}.
+   */
+  failure: string | null
 }
+
+/** Where the loop's inputs land. A seam, so a test needs no filesystem. */
+export type WriteReviewInputs = (
+  settings: ReviewLoopSettings,
+  plan: string,
+) => Promise<{ planPath: string; configPath: string }>
 
 export interface RunReviewLoopOptions {
   settings: ReviewLoopSettings
@@ -88,9 +112,46 @@ export interface RunReviewLoopOptions {
   env: Record<string, string>
   log: Logger
   timeoutMs: number
+  /**
+   * The maintainer-only transcript, when the run has an `AGENT_LOG_KEY`.
+   *
+   * The implement phase feeds this from the OpenCode event stream; the review
+   * phase opens no session at all, so without this its hour of work left no
+   * trace in the one artefact a maintainer debugging a run is told to read.
+   */
+  transcript?: TranscriptSink
+  /**
+   * Called each time the loop reports a fix landing on the working branch.
+   *
+   * The loop merges its own branch into the checkout as each fix passes
+   * ({@link buildReviewLoopConfig}'s `mergeEachFix`); pushing that is the
+   * caller's business, because the credential belongs to the pipeline and must
+   * never reach a subprocess the model can read the environment of.
+   */
+  onFixMerged?: () => void
+  /** Injected so a test can run the loop without touching a filesystem. */
+  writeInputs?: WriteReviewInputs
+  now?: () => number
 }
 
 const SUMMARY_TAIL_LINES = 60
+
+/**
+ * The marker the loop prints when a fix is on the working branch.
+ *
+ * A line rather than a file or an exit code, because the loop is a subprocess
+ * with one stream back to here and this has to arrive *while it runs* — the
+ * whole point is that the fix is durable before the thing that kills the job
+ * happens. `review-loop/src/cli.ts` writes it; the two are tested against this
+ * constant on both sides.
+ */
+export const FIX_MERGED_MARKER = '[review-loop] published'
+
+/** Longest line this repeats into the world-readable Actions log. */
+const PUBLIC_LINE_MAX = 500
+
+/** Longest line the encrypted transcript keeps. Generous — it is a debugging aid. */
+const TRANSCRIPT_LINE_MAX = 4_000
 
 /**
  * `review-loop` prints its summary to stdout before finalizing, so the tail of
@@ -120,6 +181,78 @@ export const writeReviewInputs = async (
   return { planPath, configPath }
 }
 
+/** The last line of `text` that says anything, or `null` for text that says nothing. */
+const lastMeaningfulLine = (text: string): string | null => {
+  const lines = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+  return lines.at(-1) ?? null
+}
+
+const minutes = (ms: number): string => `${Math.round(ms / 60_000)}m`
+
+/**
+ * What went wrong, in one sentence a maintainer can act on — or `null` for a
+ * loop that did not fail.
+ *
+ * Every branch here answers a failure that used to reach the issue as `exited 1`
+ * beside sixty lines of tail, which names neither the cause nor the remedy. The
+ * order matters: the deadline is asked first because a killed child's exit code
+ * is whatever the signal left behind and says nothing, and the two sentences the
+ * loop itself writes are matched before the fallback because they are the only
+ * ones that already know why they lost the work.
+ */
+export const describeFailure = (result: CommandResult, timeoutMs: number): string | null => {
+  if (result.exitCode === 0) return null
+
+  if (result.timedOut === true) {
+    return `the review loop timed out after ${minutes(timeoutMs)} and was killed; nothing it had not already published is lost`
+  }
+
+  if (result.exitCode === 127) {
+    return `the review command could not be started (${lastMeaningfulLine(result.stderr) ?? 'no output'})`
+  }
+
+  const combined = `${result.stdout}\n${result.stderr}`
+  if (combined.includes('Final build check failed')) {
+    return "the loop's own build gate failed at the end of the run, so it merged nothing further"
+  }
+  if (combined.includes('Merge conflict while bringing')) {
+    return 'the loop could not merge its branch back: it conflicts with the working branch'
+  }
+
+  const said = lastMeaningfulLine(result.stderr) ?? lastMeaningfulLine(result.stdout)
+  return said === null
+    ? `the review loop exited ${result.exitCode} silently`
+    : `the review loop exited ${result.exitCode}: ${said}`
+}
+
+/**
+ * Repeats one line of the loop into the two places it belongs.
+ *
+ * The **public** Actions log, because a subprocess that runs for an hour and
+ * prints nothing is indistinguishable from a hang and gets cancelled — which is
+ * exactly what happened to the review of #268. The loop's non-TTY output is its
+ * own progress vocabulary (rounds, decisions, counts) rather than model text,
+ * and the logger redacts this pipeline's credentials by value on the way out.
+ *
+ * And the **encrypted** transcript, unabridged, for the same reason the implement
+ * phase feeds one: the public log is bounded on purpose, and a maintainer holding
+ * the key should not have to guess what the bound removed.
+ */
+const reportLine = (options: RunReviewLoopOptions, now: () => number, line: string, stream: OutputStream): void => {
+  options.log.info({ source: 'review-loop', stream }, line.slice(0, PUBLIC_LINE_MAX))
+  options.transcript?.write({
+    time: new Date(now()).toISOString(),
+    tool: 'review-loop',
+    status: stream,
+    detail: line.slice(0, TRANSCRIPT_LINE_MAX),
+    durationMs: null,
+  })
+  if (line.startsWith(FIX_MERGED_MARKER)) options.onFixMerged?.()
+}
+
 /**
  * Runs the review loop over the working tree. A non-zero exit is not thrown
  * here: the caller decides whether a red loop blocks delivery, and either way
@@ -127,22 +260,40 @@ export const writeReviewInputs = async (
  */
 export const runReviewLoop = async (options: RunReviewLoopOptions): Promise<ReviewRunResult> => {
   const { settings, log } = options
+  const now = options.now ?? ((): number => Date.now())
 
   if (settings.command === null) {
     log.warn({ repoRoot: settings.repoRoot }, 'No review loop configured; skipping the review')
-    return { outcome: 'unavailable', summary: 'No review loop is configured for this repository.', exitCode: 0 }
+    return {
+      outcome: 'unavailable',
+      summary: 'No review loop is configured for this repository.',
+      exitCode: 0,
+      failure: null,
+    }
   }
 
-  const { planPath, configPath } = await writeReviewInputs(settings, options.plan)
-  log.info({ planPath, configPath, maxRounds: settings.maxRounds }, 'Starting review loop')
+  const write = options.writeInputs ?? writeReviewInputs
+  const { planPath, configPath } = await write(settings, options.plan)
+  log.info(
+    { planPath, configPath, maxRounds: settings.maxRounds, timeoutMs: options.timeoutMs },
+    'Starting review loop',
+  )
 
   const result = await options.run(
     [...settings.command, '--config', configPath, '--plan', planPath, '--repo', settings.repoRoot],
-    { cwd: settings.repoRoot, env: options.env, timeoutMs: options.timeoutMs },
+    {
+      cwd: settings.repoRoot,
+      env: options.env,
+      timeoutMs: options.timeoutMs,
+      onOutput: (line, stream): void => {
+        reportLine(options, now, line, stream)
+      },
+    },
   )
 
   const summary = extractSummary(result)
-  log.info({ exitCode: result.exitCode }, 'Review loop finished')
+  const failure = describeFailure(result, options.timeoutMs)
+  log.info({ exitCode: result.exitCode, timedOut: result.timedOut === true, failure }, 'Review loop finished')
 
-  return { outcome: result.exitCode === 0 ? 'passed' : 'failed', summary, exitCode: result.exitCode }
+  return { outcome: result.exitCode === 0 ? 'passed' : 'failed', summary, exitCode: result.exitCode, failure }
 }

--- a/opencode-agent/src/review-runner.ts
+++ b/opencode-agent/src/review-runner.ts
@@ -10,7 +10,9 @@ import type { Logger } from './logger.js'
 import { modelRef } from './openai-config.js'
 import type { OpenAiSettings } from './openai-config.js'
 import type { TranscriptSink } from './progress.js'
-import type { CommandResult, CommandRunner, OutputStream } from './shell.js'
+import { collectLoopTranscript, realTranscriptFiles, reportLine } from './review-transcript.js'
+import type { TranscriptFiles } from './review-transcript.js'
+import type { CommandResult, CommandRunner } from './shell.js'
 
 /**
  * Drives the repository's own `review-loop/` workspace instead of a bespoke
@@ -131,27 +133,12 @@ export interface RunReviewLoopOptions {
   onFixMerged?: () => void
   /** Injected so a test can run the loop without touching a filesystem. */
   writeInputs?: WriteReviewInputs
+  /** The same seam for the trace collection that follows the run. */
+  files?: TranscriptFiles
   now?: () => number
 }
 
 const SUMMARY_TAIL_LINES = 60
-
-/**
- * The marker the loop prints when a fix is on the working branch.
- *
- * A line rather than a file or an exit code, because the loop is a subprocess
- * with one stream back to here and this has to arrive *while it runs* — the
- * whole point is that the fix is durable before the thing that kills the job
- * happens. `review-loop/src/cli.ts` writes it; the two are tested against this
- * constant on both sides.
- */
-export const FIX_MERGED_MARKER = '[review-loop] published'
-
-/** Longest line this repeats into the world-readable Actions log. */
-const PUBLIC_LINE_MAX = 500
-
-/** Longest line the encrypted transcript keeps. Generous — it is a debugging aid. */
-const TRANSCRIPT_LINE_MAX = 4_000
 
 /**
  * `review-loop` prints its summary to stdout before finalizing, so the tail of
@@ -229,31 +216,6 @@ export const describeFailure = (result: CommandResult, timeoutMs: number): strin
 }
 
 /**
- * Repeats one line of the loop into the two places it belongs.
- *
- * The **public** Actions log, because a subprocess that runs for an hour and
- * prints nothing is indistinguishable from a hang and gets cancelled — which is
- * exactly what happened to the review of #268. The loop's non-TTY output is its
- * own progress vocabulary (rounds, decisions, counts) rather than model text,
- * and the logger redacts this pipeline's credentials by value on the way out.
- *
- * And the **encrypted** transcript, unabridged, for the same reason the implement
- * phase feeds one: the public log is bounded on purpose, and a maintainer holding
- * the key should not have to guess what the bound removed.
- */
-const reportLine = (options: RunReviewLoopOptions, now: () => number, line: string, stream: OutputStream): void => {
-  options.log.info({ source: 'review-loop', stream }, line.slice(0, PUBLIC_LINE_MAX))
-  options.transcript?.write({
-    time: new Date(now()).toISOString(),
-    tool: 'review-loop',
-    status: stream,
-    detail: line.slice(0, TRANSCRIPT_LINE_MAX),
-    durationMs: null,
-  })
-  if (line.startsWith(FIX_MERGED_MARKER)) options.onFixMerged?.()
-}
-
-/**
  * Runs the review loop over the working tree. A non-zero exit is not thrown
  * here: the caller decides whether a red loop blocks delivery, and either way
  * the summary belongs on the issue.
@@ -295,5 +257,25 @@ export const runReviewLoop = async (options: RunReviewLoopOptions): Promise<Revi
   const failure = describeFailure(result, options.timeoutMs)
   log.info({ exitCode: result.exitCode, timedOut: result.timedOut === true, failure }, 'Review loop finished')
 
+  await collectTrace(options, now)
+
   return { outcome: result.exitCode === 0 ? 'passed' : 'failed', summary, exitCode: result.exitCode, failure }
+}
+
+/**
+ * The loop's own trace, taken after the child is gone and before this workspace
+ * is: it is the review phase's equivalent of the tool activity the implement
+ * phase feeds the transcript from, and it lives in a directory the runner
+ * deletes. Skipped entirely on a keyless run, which is the ordinary case.
+ */
+const collectTrace = async (options: RunReviewLoopOptions, now: () => number): Promise<void> => {
+  if (options.transcript === undefined) return
+
+  await collectLoopTranscript({
+    workDir: path.join(options.settings.repoRoot, AGENT_WORK_DIR, 'review-loop'),
+    transcript: options.transcript,
+    files: options.files ?? realTranscriptFiles,
+    log: options.log,
+    now,
+  })
 }

--- a/opencode-agent/src/review-transcript.ts
+++ b/opencode-agent/src/review-transcript.ts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import type { Logger } from './logger.js'
+import type { TranscriptSink } from './progress.js'
+import type { OutputStream } from './shell.js'
+import { errorMessage } from './types.js'
+
+/**
+ * Everything the review loop says about itself, and where each of it goes.
+ *
+ * Two halves, both of which the review phase used to lack entirely. Line by line
+ * while it runs — into the **public** Actions log, because a subprocess that
+ * works for an hour in silence is indistinguishable from a hang and gets
+ * cancelled, and into the **encrypted** transcript unabridged. And the loop's own
+ * `trace.jsonl` once it has stopped, which is the second half:
+ *
+ * The implement phase leaves a transcript because it holds an OpenCode session and every
+ * tool call passes through `activity.ts` on the way out. The review phase holds
+ * no session at all — its work happens in `opencode run` subprocesses the
+ * `review-loop/` workspace spawns — so the only thing this process ever sees is
+ * what they print, and the detail a maintainer actually wants (which issue the
+ * reviewer raised, what the fixer decided, which round it was) is written by the
+ * loop to a file in the runner's workspace and deleted with it.
+ *
+ * That file is `trace.jsonl`, and this is what carries it out: **encrypted**,
+ * under `AGENT_LOG_KEY`, into the same artefact the implement phase's transcript
+ * rides in. It is not uploaded in the clear and must not be — an Actions artefact
+ * is downloadable by anyone with repository read access, which is the whole
+ * reason the transcript is encrypted at all, and a review trace carries
+ * model-authored text about a codebase.
+ *
+ * Everything here degrades to a `warn`. It is a debugging aid riding on a phase
+ * that has already done its work: a missing directory, an unreadable file or a
+ * run that never got as far as writing one are all "nothing to collect", and
+ * none of them is a reason to fail a review whose findings are already pushed.
+ */
+
+/**
+ * The marker the loop prints when a fix is on the working branch.
+ *
+ * A line rather than a file or an exit code, because the loop is a subprocess
+ * with one stream back to here and this has to arrive *while it runs* — the
+ * whole point is that the fix is durable before the thing that kills the job
+ * happens. `review-loop/src/cli.ts` writes it; the two are tested against this
+ * constant on both sides.
+ */
+export const FIX_MERGED_MARKER = '[review-loop] published'
+
+/** Longest line this repeats into the world-readable Actions log. */
+const PUBLIC_LINE_MAX = 500
+
+/** Longest line the encrypted transcript keeps. Generous — it is a debugging aid. */
+const TRANSCRIPT_LINE_MAX = 4_000
+
+/** What repeating one line needs, which `RunReviewLoopOptions` satisfies as it is. */
+export interface LineSink {
+  log: Logger
+  transcript?: TranscriptSink
+  onFixMerged?: () => void
+}
+
+/**
+ * Repeats one line of the loop into the two places it belongs.
+ *
+ * The **public** Actions log, because a subprocess that runs for an hour and
+ * prints nothing is indistinguishable from a hang and gets cancelled — which is
+ * exactly what happened to the review of #268. The loop's non-TTY output is its
+ * own progress vocabulary (rounds, decisions, counts) rather than model text,
+ * and the logger redacts this pipeline's credentials by value on the way out.
+ *
+ * And the **encrypted** transcript, unabridged, for the same reason the implement
+ * phase feeds one: the public log is bounded on purpose, and a maintainer holding
+ * the key should not have to guess what the bound removed.
+ */
+export const reportLine = (options: LineSink, now: () => number, line: string, stream: OutputStream): void => {
+  options.log.info({ source: 'review-loop', stream }, line.slice(0, PUBLIC_LINE_MAX))
+  options.transcript?.write({
+    time: new Date(now()).toISOString(),
+    tool: 'review-loop',
+    status: stream,
+    detail: line.slice(0, TRANSCRIPT_LINE_MAX),
+    durationMs: null,
+  })
+  if (line.startsWith(FIX_MERGED_MARKER)) options.onFixMerged?.()
+}
+
+/** The two filesystem reads this needs, injected so a test needs no fixtures. */
+export interface TranscriptFiles {
+  /** The run directories under `<workDir>/runs`, in any order. */
+  listRuns: (runsDir: string) => Promise<string[]>
+  readText: (filePath: string) => Promise<string>
+}
+
+export const realTranscriptFiles: TranscriptFiles = {
+  listRuns: (runsDir) => readdir(runsDir),
+  readText: (filePath) => readFile(filePath, 'utf8'),
+}
+
+/**
+ * How much of one run's trace is kept.
+ *
+ * A bound rather than the whole file, for the reason the prompt budget is a
+ * bound: the transcript is queued in memory and written line by line, and a
+ * four-hour run with a large pool can leave a very long trace. The **tail** is
+ * the half worth keeping — a run is read backwards from whatever went wrong.
+ */
+const DEFAULT_MAX_LINES = 2_000
+
+export interface CollectLoopTranscriptOptions {
+  /** `<repoRoot>/.opencode-agent/review-loop`, the loop's generated workDir. */
+  workDir: string
+  transcript: TranscriptSink
+  files: TranscriptFiles
+  log: Logger
+  now: () => number
+  maxLines?: number
+}
+
+/**
+ * The newest run directory, or `null`.
+ *
+ * Lexical maximum, which is not a shortcut: `makeRunId` in
+ * `review-loop/src/run-state.ts` prefixes the id with an ISO-8601 timestamp
+ * whose punctuation is replaced, so string order *is* time order. Sorting by
+ * mtime would need a `stat` per entry to learn the same thing.
+ */
+const newestRun = (entries: readonly string[]): string | null =>
+  entries.length === 0 ? null : ([...entries].sort().at(-1) ?? null)
+
+export const collectLoopTranscript = async (options: CollectLoopTranscriptOptions): Promise<void> => {
+  const runsDir = path.join(options.workDir, 'runs')
+
+  try {
+    const runId = newestRun(await options.files.listRuns(runsDir))
+    if (runId === null) return
+
+    const tracePath = path.join(runsDir, runId, 'trace.jsonl')
+    const lines = (await options.files.readText(tracePath))
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .slice(-(options.maxLines ?? DEFAULT_MAX_LINES))
+
+    const time = new Date(options.now()).toISOString()
+    for (const line of lines) {
+      options.transcript.write({ time, tool: 'review-loop-trace', status: 'trace', detail: line, durationMs: null })
+    }
+
+    options.log.debug({ runId, lines: lines.length }, "Collected the review loop's trace into the debug transcript")
+  } catch (error) {
+    options.log.warn(
+      { runsDir, error: errorMessage(error) },
+      "Could not collect the review loop's trace; the run is unaffected",
+    )
+  }
+}

--- a/opencode-agent/src/run-report.ts
+++ b/opencode-agent/src/run-report.ts
@@ -83,7 +83,10 @@ export const renderClosing = (state: AgentState): string =>
         `The work is in ${state.prUrl}.`,
         '',
         'If that pull request goes red I will still pick it up and push a fix.',
-        'Reply **`/review`** here to run the review loop over the branch and push whatever it finds.',
+        // Named there rather than here on purpose: with a pull request open, a
+        // command typed on this issue is refused and pointed at it — see
+        // `feedback-target.ts` — so inviting one here would be inviting a refusal.
+        'Comment **`/review`** *on the pull request* to run the review loop over the branch and push what it finds.',
       ].join('\n')
 
 /**
@@ -138,6 +141,31 @@ export const renderSettled = (state: AgentState): string =>
  * The accepted list is derived from the transition table rather than written
  * out here, so it cannot drift away from what the machine will actually take.
  */
+/**
+ * The reply to a command typed in the right words on the wrong page.
+ *
+ * Separate from {@link renderRefusedCommand} because that one's sentence — "I am
+ * parked in `X`, which does not accept it" — would be false here twice over: the
+ * phase accepts the command perfectly well, and nothing about the state is the
+ * reason. The only fact worth saying is where to type it again, so that is the
+ * whole comment.
+ *
+ * The pull request is named by URL when there is one and by nothing at all when
+ * there is not, which cannot happen — `commandSurface` returns `elsewhere` only
+ * when `prNumber` is set, and `prUrl` is written beside it — but a renderer that
+ * cannot be handed a broken state is one fewer thing to check.
+ */
+export const renderCommandElsewhere = (command: string, prUrl: string | null): string =>
+  [
+    outcomeHeading('COMMAND_REFUSED', `\`${command}\` belongs on the pull request now`),
+    '',
+    prUrl === null
+      ? 'This issue has a pull request open, and that is where I take commands from once one exists.'
+      : `This issue's work is in ${prUrl}, and that is where I take commands from once a pull request is open.`,
+    '',
+    `Type \`${command}\` there instead. Nothing has changed here — the report and the state still live on this issue.`,
+  ].join('\n')
+
 export const renderRefusedCommand = (command: string, phase: Phase, accepted: readonly string[]): string =>
   [
     outcomeHeading('COMMAND_REFUSED', `\`${command}\` does not apply right now`),

--- a/opencode-agent/src/run-report.ts
+++ b/opencode-agent/src/run-report.ts
@@ -11,6 +11,7 @@ import { outcomeHeading } from './outcomes.js'
 import type { PhaseInput } from './phase-context.js'
 import { phaseHeading, presentationFor } from './presentation.js'
 import { renderStateComment } from './state-manager.js'
+import { persistState } from './state-persist.js'
 import type { AgentState, Phase } from './types.js'
 
 /**
@@ -28,6 +29,24 @@ import type { AgentState, Phase } from './types.js'
  */
 
 /**
+ * The one line every issue comment gains once a pull request has taken the
+ * commands over.
+ *
+ * Almost everything this file renders ends by naming a command — "reply
+ * `/retry`", "reply `/cancel`", "raise the ceiling and reply `/review`" — and
+ * every one of those became wrong in the same way the day the issue started
+ * refusing commands: the advice is right, the page it is written on is not. The
+ * alternative was to thread a "where" through eight renderers and their
+ * signatures, where each one could forget; this is the same statement made once,
+ * on the write they all share, from the state they are all posted with.
+ *
+ * Empty while there is no pull request, which is most of an issue's life and all
+ * of a cancelled one's — so a run that never delivers reads exactly as it did.
+ */
+const commandPointer = (state: AgentState): string =>
+  state.prUrl === null ? '' : `\n\n_Commands for this issue go on its pull request: ${state.prUrl}_`
+
+/**
  * Posts a comment and mirrors it into the in-memory thread, so a later phase in
  * the same job can read an artefact the earlier phase just wrote without
  * re-fetching the issue.
@@ -40,7 +59,7 @@ export const postAndAppend = async (
   blocks?: readonly string[],
 ): Promise<IssueComment[]> => {
   const artifacts = blocks === undefined || blocks.length === 0 ? '' : `\n\n${blocks.join('\n\n')}`
-  const rendered = `${renderStateComment(body, state)}${artifacts}`
+  const rendered = `${renderStateComment(`${body}${commandPointer(state)}`, state)}${artifacts}`
 
   const posted = await input.deps.github.createComment(input.issue.number, rendered)
   // The recorded author, not the one the pipeline believes in: if they differ,
@@ -48,6 +67,51 @@ export const postAndAppend = async (
   reportIdentityDrift(await input.deps.selfLogin(), posted.authorLogin, input.deps.log)
 
   return [...thread, { id: posted.id, body: rendered, authorLogin: posted.authorLogin }]
+}
+
+/**
+ * Posts a reply to the surface the question was typed on.
+ *
+ * A question is the one thing this pipeline says that is *not* about the state
+ * of the work: it moves no phase, spends no attempt and produces no artefact, so
+ * it belongs in the conversation it answers rather than in the record. Typed on
+ * the issue it goes to the issue, exactly as before; typed on a pull request it
+ * goes there, where the person who asked is looking.
+ *
+ * Three things this must not do, and the shape follows from them.
+ *
+ * It must not put a **state block** on a pull request. `findLatestState` scans
+ * one thread and would never see it, so a block there is a second source of
+ * truth by construction — which is why this is not `postAndAppend` with a
+ * different number, but a plain comment plus {@link persistState}, the write
+ * that rewrites the issue's newest block *in place* and posts nothing. The spend
+ * is the one thing a question really does change, and it is still recorded.
+ *
+ * It must not post **twice**. A copy on the issue "for the record" would be two
+ * accounts of one exchange, free to disagree, on a page nobody asked anything on.
+ *
+ * And it must not swallow a **failed post**: the answer is the work here, so a
+ * rejected `createComment` throws exactly as it does on the issue path, leaving
+ * `reported` unset and the workflow's fallback comment in scope. Only the state
+ * rewrite beside it is best-effort, for the reason `persistState` states.
+ *
+ * The accepted cost is that a question answered on a pull request is invisible to
+ * the next run's prompt — `renderThread` reads the issue thread — so the model
+ * will not remember having answered it. That is the same trade the state block
+ * makes in the other direction, and a conversation about a diff is the one this
+ * pipeline can most afford to forget.
+ */
+export const postAnswer = async (
+  thread: readonly IssueComment[],
+  input: PhaseInput,
+  body: string,
+  state: AgentState,
+): Promise<readonly IssueComment[]> => {
+  if (input.trigger.kind !== 'pull-request') return postAndAppend(thread, input, body, state)
+
+  await input.deps.github.createComment(input.trigger.prNumber, body)
+  await persistState(input.deps, thread, state)
+  return thread
 }
 
 /**

--- a/opencode-agent/src/shell.ts
+++ b/opencode-agent/src/shell.ts
@@ -4,6 +4,7 @@
 // See LICENSE in the project root for details.
 
 import { spawn } from 'node:child_process'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 
 /** Result of one command invocation. Never throws on a non-zero exit. */
 export interface CommandResult {
@@ -11,12 +12,35 @@ export interface CommandResult {
   exitCode: number
   stdout: string
   stderr: string
+  /**
+   * Whether this run was killed by its own `timeoutMs` rather than exiting.
+   *
+   * A killed child arrives here as `exitCode: 1` with whatever it had written so
+   * far, which is indistinguishable from a command that failed on its merits —
+   * and the two earn completely different sentences on an issue. Optional
+   * because almost every producer of this shape is a stub in a test that cannot
+   * time out; absent means "not known to have timed out", never "did not".
+   */
+  timedOut?: boolean
 }
+
+/** Which of a child's two streams a line arrived on. */
+export type OutputStream = 'stdout' | 'stderr'
 
 export interface RunOptions {
   cwd: string
   env?: Record<string, string>
   timeoutMs?: number
+  /**
+   * Called with each complete line the child writes, as it writes it.
+   *
+   * The buffered `CommandResult` is still assembled — this is an addition, not a
+   * replacement. It exists because a subprocess that runs for an hour and is
+   * only read from after it exits is, in a CI log, indistinguishable from a hang:
+   * run 31704544065 spent 60 minutes inside the review loop and printed not one
+   * line before the runner was taken away, and the buffered output died with it.
+   */
+  onOutput?: (line: string, stream: OutputStream) => void
 }
 
 /**
@@ -29,6 +53,80 @@ export interface RunOptions {
 export type CommandRunner = (argv: readonly string[], options: RunOptions) => Promise<CommandResult>
 
 const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000
+
+/**
+ * Splits a stream into whole lines across chunk boundaries.
+ *
+ * A chunk is whatever the pipe happened to deliver, so a line routinely arrives
+ * in two of them and two lines routinely arrive in one. `flush` is what a child
+ * that ends without a final newline earns — dropping that last line is how a
+ * one-line error message becomes silence.
+ */
+const lineSplitter = (emit: (line: string) => void): { push: (chunk: string) => void; flush: () => void } => {
+  let pending = ''
+
+  return {
+    push: (chunk): void => {
+      const lines = `${pending}${chunk}`.split('\n')
+      pending = lines.pop() ?? ''
+      for (const line of lines) emit(line.replace(/\r$/u, ''))
+    },
+    flush: (): void => {
+      if (pending.length === 0) return
+      const line = pending
+      pending = ''
+      emit(line)
+    },
+  }
+}
+
+interface Capture {
+  stdout: () => string
+  stderr: () => string
+  /** Emits whatever the child left without a closing newline. */
+  flush: () => void
+}
+
+/**
+ * Buffers both of a child's streams, mirroring each whole line to `onOutput`.
+ *
+ * Both, not one or the other: the buffered form is what every caller has always
+ * read and the mirror is what makes a long run legible while it runs.
+ */
+const capture = (child: ChildProcessWithoutNullStreams, onOutput: RunOptions['onOutput']): Capture => {
+  let stdout = ''
+  let stderr = ''
+  // `null` when the caller wants no stream, so the split work is not done at all
+  // for the runs — every check, every git invocation — that only read the buffer.
+  const split = (stream: OutputStream): ReturnType<typeof lineSplitter> | null =>
+    onOutput === undefined
+      ? null
+      : lineSplitter((line): void => {
+          onOutput(line, stream)
+        })
+  const outLines = split('stdout')
+  const errLines = split('stderr')
+
+  child.stdout.on('data', (chunk: Buffer) => {
+    const text = chunk.toString()
+    stdout += text
+    outLines?.push(text)
+  })
+  child.stderr.on('data', (chunk: Buffer) => {
+    const text = chunk.toString()
+    stderr += text
+    errLines?.push(text)
+  })
+
+  return {
+    stdout: () => stdout,
+    stderr: () => stderr,
+    flush: (): void => {
+      outLines?.flush()
+      errLines?.flush()
+    },
+  }
+}
 
 export const runCommand: CommandRunner = (argv, options) =>
   new Promise((resolve, reject) => {
@@ -45,19 +143,20 @@ export const runCommand: CommandRunner = (argv, options) =>
       shell: false,
     })
 
-    let stdout = ''
-    let stderr = ''
-    child.stdout.on('data', (chunk: Buffer) => {
-      stdout += chunk.toString()
-    })
-    child.stderr.on('data', (chunk: Buffer) => {
-      stderr += chunk.toString()
-    })
+    const output = capture(child, options.onOutput)
 
     child.on('error', (error: Error) => {
-      resolve({ command: argv.join(' '), exitCode: 127, stdout, stderr: `${stderr}${error.message}` })
+      output.flush()
+      const stderr = `${output.stderr()}${error.message}`
+      resolve({ command: argv.join(' '), exitCode: 127, stdout: output.stdout(), stderr, timedOut: false })
     })
-    child.on('close', (code) => {
-      resolve({ command: argv.join(' '), exitCode: code ?? 1, stdout, stderr })
+    child.on('close', (code, signal) => {
+      output.flush()
+      // Node reports the deadline it enforced as a signal kill, and `killed` is
+      // set for any kill — including one this process never asked for — so the
+      // signal is read alongside it rather than instead of it.
+      const timedOut = child.killed && signal !== null && code === null
+      const result = { exitCode: code ?? 1, stdout: output.stdout(), stderr: output.stderr(), timedOut }
+      resolve({ command: argv.join(' '), ...result })
     })
   })

--- a/opencode-agent/src/status-reporter.ts
+++ b/opencode-agent/src/status-reporter.ts
@@ -4,6 +4,7 @@
 // See LICENSE in the project root for details.
 
 import type { PipelineConfig } from './config.js'
+import { feedbackTarget } from './feedback-target.js'
 import type { GitHubApi } from './github.js'
 import type { Logger } from './logger.js'
 import type { ProgressSnapshot } from './progress.js'
@@ -172,9 +173,15 @@ const open = async (run: RunStatus, state: AgentState): Promise<void> => {
   run.live = true
 
   const body = renderStatus(viewOf(run, state))
+  // The pull request once one exists — see `feedback-target.ts`. This is the one
+  // comment in the pipeline that is *about the run happening now* rather than
+  // about the issue, and once there is a diff, the page somebody is watching
+  // while it happens is the pull request. The report and the state block stay on
+  // the issue either way: they are the record, and the restore scan reads exactly
+  // one thread.
   const posted = await attempt(
     run,
-    () => run.deps.github.createComment(state.issueId, body),
+    () => run.deps.github.createComment(feedbackTarget(state), body),
     'Could not open the status comment; this run reports only when it ends',
   )
   if (posted === null) return

--- a/opencode-agent/src/time-budget.ts
+++ b/opencode-agent/src/time-budget.ts
@@ -5,7 +5,7 @@
 
 import type { PipelineConfig } from './config.js'
 import type { MachineInput } from './phase-context.js'
-import { postAndAppend } from './run-report.js'
+import { postAndAppend, postAnswer } from './run-report.js'
 import type { RunResult } from './run-result.js'
 import { renderAnswerOutOfTime, renderOutOfTime } from './time-notices.js'
 import { recordSpend } from './token-budget.js'
@@ -228,7 +228,7 @@ const answerOutOfTime = async (input: MachineInput, toDeadline: number, reason: 
   const carried = { ...state, ...(await recordSpend(input)) }
 
   const notice = renderAnswerOutOfTime(toDeadline, deps.config.teardownReserveMs, state.phase)
-  await postAndAppend(thread, input, notice, carried)
+  await postAnswer(thread, input, notice, carried)
 
   return { status: 'waiting', reason, state: carried, reported: true }
 }

--- a/opencode-agent/src/token-budget.ts
+++ b/opencode-agent/src/token-budget.ts
@@ -6,7 +6,7 @@
 import { renderAnswerOverBudget, renderOverBudget } from './budget-notices.js'
 import type { PipelineConfig } from './config.js'
 import type { MachineInput, PhaseDeps } from './phase-context.js'
-import { postAndAppend } from './run-report.js'
+import { postAndAppend, postAnswer } from './run-report.js'
 import type { RunResult } from './run-result.js'
 import { transition } from './transitions.js'
 import type { AgentState } from './types.js'
@@ -165,7 +165,7 @@ const answerOverBudget = async (input: MachineInput, spent: number, reason: stri
   const { state, deps, thread } = input
   const carried = { ...state, ...spendPatch(spent, {}) }
 
-  await postAndAppend(thread, input, renderAnswerOverBudget(spent, deps.config.maxTokens, state.phase), carried)
+  await postAnswer(thread, input, renderAnswerOverBudget(spent, deps.config.maxTokens, state.phase), carried)
 
   return { status: 'failed', reason, state: carried, reported: true }
 }

--- a/opencode-agent/src/triggers.ts
+++ b/opencode-agent/src/triggers.ts
@@ -6,12 +6,13 @@
 import { renderExhausted, renderReviewsExhausted } from './budget-notices.js'
 import { applyCiTrigger } from './ci-trigger.js'
 import { acceptedCommands, commandApplies, COMMAND_SIGNALS } from './commands.js'
-import type { ParsedCommand, SlashCommand } from './commands.js'
+import type { ParsedCommand } from './commands.js'
 import { applyClarifyIntent, applyIntent, applySteeringIntent, readAndSkip } from './comment-intent.js'
+import { commandSurface } from './feedback-target.js'
 import { react } from './feedback.js'
 import { branchNameFor } from './git.js'
 import type { PhaseInput } from './phase-context.js'
-import { postAndAppend, renderRefusedCommand } from './run-report.js'
+import { postAndAppend, renderCommandElsewhere, renderRefusedCommand } from './run-report.js'
 import { canTransition } from './transitions.js'
 import { moveOrSkip, skip } from './trigger-outcome.js'
 import type { TriggerOutcome } from './trigger-outcome.js'
@@ -63,6 +64,11 @@ export const applyTrigger = (input: PhaseInput): Promise<TriggerOutcome> => {
   // narrower door onto the same commands, and the narrowing is what §6.2 of the
   // plan settles. Everything after this line is the issue conversation.
   if (trigger.kind === 'pull-request') return applyPullRequestCommand(input, command)
+  // Everything below here is the issue conversation, and once a pull request
+  // exists the issue is no longer where this run is driven from — see
+  // `feedback-target.ts`. The refusal is about the *surface*, not the command:
+  // it names the pull request and posts nothing else.
+  if (command !== null && commandSurface(state, 'issue') === 'elsewhere') return commandBelongsOnPr(input, command)
   if (command !== null) return applyCommand(input, command)
   if (state.phase === 'INIT_OR_CLARIFY') return applyClarifyIntent(input)
   // Design D6 — a plain comment mid-implementation is read as steering: a
@@ -92,25 +98,23 @@ export const applyArchiveTrigger = (input: PhaseInput): TriggerOutcome => {
   return moveOrSkip(state, 'PR_MERGED', deps, 'a merged pull request')
 }
 
-/** The one command a pull request accepts. See {@link applyPullRequestCommand}. */
-const PULL_REQUEST_COMMAND: SlashCommand = '/review'
-
 /**
- * Narrows the pull-request door to that command, then hands the rest over.
+ * The pull-request door, which takes the same commands the issue does.
  *
- * Both refusals below are unreachable today by construction:
- * `resolvePullRequestTrigger` produces this kind only for a body
- * `parseSlashCommand` read as `/review`, so a comment carrying anything else
- * never becomes an event at all. They are here because "the pull request accepts
- * one command" is a decision (§6.2 — `/ask` there would widen the surface from a
- * command naming a branch the agent owns to a conversation, and its answer would
- * still land on the issue), and a decision enforced only by the layer that
- * happens to filter first is one a second door quietly repeals.
+ * It used to take `/review` and nothing else. That narrowing was right while the
+ * issue was still the surface a maintainer drove the agent from; it is wrong now
+ * that a delivered issue refuses commands and points here, because the two rules
+ * together would leave `/retry`, `/cancel` and `/ask` with nowhere to be typed.
  *
- * Everything past the narrowing goes through {@link applyCommand}, deliberately:
- * the `prNumber !== null` predicate, the review budget and the list a refusal
- * offers are one seam in `commands.ts` with two readers, and a pull-request door
- * that restated any of them would be a second spelling free to disagree.
+ * Everything goes through {@link applyCommand}, deliberately: the `prNumber`
+ * predicate, both budgets and the list a refusal offers are one seam in
+ * `commands.ts` with two readers, and a pull-request door that restated any of
+ * them would be a second spelling free to disagree.
+ *
+ * The `null` branch is unreachable by construction — `resolvePullRequestTrigger`
+ * produces this kind only for a body `parseSlashCommand` read as a command — and
+ * stays because a decision enforced only by whichever layer filters first is one
+ * a second door quietly repeals.
  */
 const applyPullRequestCommand = (input: PhaseInput, command: ParsedCommand | null): Promise<TriggerOutcome> => {
   const { state, deps } = input
@@ -120,11 +124,33 @@ const applyPullRequestCommand = (input: PhaseInput, command: ParsedCommand | nul
     return Promise.resolve({ state, halt: skip(state, 'A pull-request comment carrying no command'), answer: false })
   }
 
-  if (command.command !== PULL_REQUEST_COMMAND) {
-    return refuseCommand(input, command.command, `${command.command} is not accepted on a pull request`)
-  }
-
   return applyCommand(input, command)
+}
+
+/**
+ * The reply to a command typed on the issue after the pull request took over.
+ *
+ * Its own function rather than a branch of {@link refuseCommand}, for the reason
+ * `refuseExhausted` is its own: the sentence is different in kind. That one says
+ * "this phase does not accept that", which here would be a lie — the command is
+ * perfectly good and would have worked one page over. This one says where, and
+ * says nothing about the state, which has not moved.
+ *
+ * A `skipped` run, not a failure: nothing broke and nothing was spent. `reported`
+ * is true, because the issue does carry this run's account of what it did — it
+ * declined to act, and said so.
+ */
+const commandBelongsOnPr = async (input: PhaseInput, command: ParsedCommand): Promise<TriggerOutcome> => {
+  const { state, thread, deps } = input
+  deps.log.warn(
+    { issue: state.issueId, pr: state.prNumber, command: command.command },
+    'Refused a command typed on the issue: the pull request is where this issue is driven now',
+  )
+
+  await react(deps, input.trigger, 'confused')
+  await postAndAppend(thread, input, renderCommandElsewhere(command.command, state.prUrl), state)
+
+  return { state, halt: skip(state, `${command.command} belongs on the pull request`, true), answer: false }
 }
 
 const applyCommand = async (input: PhaseInput, command: ParsedCommand): Promise<TriggerOutcome> => {

--- a/review-loop/CLAUDE.md
+++ b/review-loop/CLAUDE.md
@@ -6,6 +6,14 @@
 
 Agent subprocess guards live in `src/spawn.ts` + `src/agent-runner.ts`: besides the wall-clock `timeout`, an optional `inactivityTimeoutMs` watchdog kills a child that produces no stdout (hung LLM stream) and reports `stalled: true`; `runAgent` retries a stall once but never retries a wall-clock timeout. Callers opt in by passing `inactivityTimeoutMs` through `RunAgentOptions` (mutation-improve wires it from `agent.inactivityTimeoutMs`; review-loop's own config does not yet).
 
+`mergeEachFix` (config, default off) moves the merge back into the checkout from
+"once at the end, behind the build gate" to "each fix, as it is accepted", and
+prints `[review-loop] published …` when it does — see `src/publish-fix.ts`. It is
+for unattended runs whose checkout is deleted when the job ends: there, an atomic
+merge means a red build gate or a killed runner takes every accepted fix with it,
+and the marker is what lets the caller push. The hook runs under the pool's
+primary lock and never throws; `finalizeRun` still does the final merge.
+
 ## Storage / Artifacts
 
 - The default `workDir` is `.review-loop/` relative to `repoRoot` (see `config.example.json`). The directory is created on demand via `mkdir`.

--- a/review-loop/src/cli.ts
+++ b/review-loop/src/cli.ts
@@ -15,6 +15,7 @@ import { createIssueLedger, loadIssueLedger, type IssueLedger } from './issue-le
 import { LiveRenderer, type RendererStream } from './live-renderer.js'
 import { runReviewLoop, type ReviewLoopResult } from './loop-controller.js'
 import type { ProgressReporter } from './progress-log.js'
+import { poolHooks } from './publish-fix.js'
 import { createRunState, loadRunState, type RunState } from './run-state.js'
 import { RunStats, PersistedStatsSchema, type PersistedStats } from './run-stats.js'
 import { realSpawn } from './spawn.js'
@@ -275,14 +276,7 @@ export async function runCli(argv: readonly string[], stdout: RendererStream = p
   const exec = createShellExec(runState.worktreePath, config.checkCommand, config.buildTimeoutMs)
   const trace = createFileTraceLogger(runState.tracePath)
   await cleanWorkerWorktrees(runState.worktreePath, args.resumeRunId)
-  const pool = await createWorkerPool(config, runState, {
-    onMergeDiff: (workerId, diff) => {
-      log.diff(`worker-${workerId}`, diff)
-    },
-    warn: (message) => {
-      log.event(message)
-    },
-  })
+  const pool = await createWorkerPool(config, runState, poolHooks(config, log))
 
   try {
     await executeReviewLoop(config, runState, ledger, exec, log, trace, pool, !args.noInspect, startedAt)

--- a/review-loop/src/config.ts
+++ b/review-loop/src/config.ts
@@ -26,6 +26,12 @@ export const ReviewLoopConfigSchema = z.object({
   buildTimeoutMs: z.number().int().min(0).default(600_000),
   checkCommand: z.string().min(1).default('bun check:full'),
   poolSize: z.number().int().positive().default(3),
+  /**
+   * Merge each accepted fix into the checkout as it lands, instead of once at
+   * the end behind the build gate. Off by default — see `publish-fix.ts` for
+   * why an unattended CI run wants it on and a laptop does not.
+   */
+  mergeEachFix: z.boolean().default(false),
   reviewer: AgentConfigSchema,
   fixer: AgentConfigSchema,
   inspector: AgentConfigSchema.optional(),

--- a/review-loop/src/publish-fix.ts
+++ b/review-loop/src/publish-fix.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { ReviewLoopConfig } from './config.js'
+import type { ProgressReporter } from './progress-log.js'
+import type { WorkerPoolHooks } from './worker-pool.js'
+import { mergeWorktree, type MergeResult } from './worktree.js'
+
+/**
+ * Making one fix visible outside the loop, the moment it lands.
+ *
+ * The loop's ordinary shape is atomic: every fix accumulates on
+ * `review-loop/<runId>`, and `finalizeRun` merges that branch into the checkout
+ * once, at the very end, behind the build gate. On a laptop that is exactly
+ * right — an interrupted run leaves the user's branch untouched and the loop's
+ * own branch is still there to merge by hand.
+ *
+ * In CI neither half of that holds. The checkout is deleted when the job ends,
+ * so a branch nobody pushed is a branch nobody will ever see again; and the job
+ * ends for reasons the loop does not get a say in — a runner taken away, a
+ * cancelled build, a wall clock. A red build gate has the same effect for a
+ * different reason: `finalizeRun` throws before the merge, and an hour of
+ * accepted, individually build-checked fixes goes with it.
+ *
+ * So `mergeEachFix` moves the merge forward to each fix, and this is what it
+ * does with one: fast-forward the checkout onto the loop's branch and say so on
+ * stdout. Saying so is half the point — the pipeline driving this loop reads the
+ * marker and pushes, because the credential that can reach the remote belongs to
+ * it and must never be visible to a subprocess whose children the model controls.
+ *
+ * Nothing here throws. Every failure it can meet is one `finalizeRun` will meet
+ * again at the end with the whole picture in view, and a fix that could not be
+ * published early is not a fix that failed.
+ */
+
+/**
+ * The line the caller matches on. Kept in step with `FIX_MERGED_MARKER` in
+ * `opencode-agent/src/review-runner.ts` — two spellings of one contract, each
+ * with a test standing on its own side of the pipe.
+ */
+export const FIX_PUBLISHED_MARKER = '[review-loop] published'
+
+export interface PublishFixDeps {
+  repoRoot: string
+  /** The loop's own branch, which the checkout is fast-forwarded onto. */
+  branch: string
+  merge: (repoRoot: string, branch: string) => Promise<MergeResult>
+  /** The progress channel. `event` prints in non-TTY mode, which CI always is. */
+  log: { event: (message: string) => void }
+}
+
+/**
+ * Everything the pool reports back to a run: the merge diff, its warnings, and
+ * — only when the config asks for it — publishing each fix.
+ *
+ * Assembled here rather than at the `createWorkerPool` call site because that is
+ * where the decision lives: the default is the atomic merge at the end, which is
+ * what a run somebody is watching should do to their working branch.
+ */
+export function poolHooks(config: ReviewLoopConfig, log: ProgressReporter): WorkerPoolHooks {
+  return {
+    onMergeDiff: (workerId, diff) => {
+      log.diff?.(`worker-${workerId}`, diff)
+    },
+    warn: (message) => {
+      log.event(message)
+    },
+    onPrimaryAdvanced: config.mergeEachFix
+      ? (branch): Promise<void> => publishFix({ repoRoot: config.repoRoot, branch, merge: mergeWorktree, log })
+      : undefined,
+  }
+}
+
+export async function publishFix(deps: PublishFixDeps): Promise<void> {
+  try {
+    const result = await deps.merge(deps.repoRoot, deps.branch)
+    if (!result.ok) {
+      deps.log.event(
+        `[review-loop] could not publish the fix: ${deps.branch} conflicts with the checkout (${result.conflictFiles.join(', ')})`,
+      )
+      return
+    }
+    deps.log.event(`${FIX_PUBLISHED_MARKER} fix to the working branch from ${deps.branch}`)
+  } catch (error) {
+    deps.log.event(`[review-loop] could not publish the fix: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}

--- a/review-loop/src/worker-pool.ts
+++ b/review-loop/src/worker-pool.ts
@@ -23,6 +23,19 @@ export interface Worker {
 export interface WorkerPoolHooks {
   onMergeDiff?: (workerId: number, diff: DiffStats) => void
   warn?: (message: string) => void
+  /**
+   * Called after a fix reaches the primary branch, **under the primary lock**.
+   *
+   * Under the lock deliberately: its one caller fast-forwards the checkout onto
+   * this branch, and a second worker merging into the branch while that runs is
+   * the race the lock already exists to prevent. It is awaited for the same
+   * reason — a hook that returned before it finished would put the two merges
+   * back in parallel through a longer route.
+   *
+   * Whatever it does, it must not throw: this is a fix that has already been
+   * accepted, and the merge that matters happens again in `finalizeRun`.
+   */
+  onPrimaryAdvanced?: (branch: string) => Promise<void>
 }
 
 export interface WorkerPool {
@@ -109,6 +122,9 @@ function mergeWorkerIntoPrimary(
         `[worker-${worker.id}] merge diff stats failed: ${error instanceof Error ? error.message : String(error)}`,
       )
     }
+    // After the diff and still inside the lock: this is where a fix stops being
+    // local to the run and becomes something a caller can push.
+    await hooks.onPrimaryAdvanced?.(primaryBranch)
     return { ok: true }
   })
 }

--- a/tests/opencode-agent/feedback-target.test.ts
+++ b/tests/opencode-agent/feedback-target.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { commandSurface, feedbackTarget } from '../../opencode-agent/src/feedback-target.js'
+import type { AgentState } from '../../opencode-agent/src/types.js'
+
+const state = (over: Partial<AgentState> = {}): AgentState => ({
+  v: 3,
+  phase: 'COMPLETE',
+  issueId: 42,
+  resumeFrom: null,
+  attempts: 0,
+  ciAttempts: 0,
+  ciBudgetReported: false,
+  reviewAttempts: 0,
+  changedLines: 0,
+  stepsDone: 0,
+  changeName: 'add-retries',
+  planRevision: 1,
+  tokensSpent: 0,
+  lastError: null,
+  prUrl: null,
+  prNumber: null,
+  ...over,
+})
+
+describe('feedbackTarget', () => {
+  test('is the issue while there is no pull request', () => {
+    expect(feedbackTarget(state())).toBe(42)
+  })
+
+  test('is the pull request once one exists', () => {
+    expect(feedbackTarget(state({ prNumber: 7, prUrl: 'https://example.invalid/pull/7' }))).toBe(7)
+  })
+})
+
+describe('commandSurface', () => {
+  test('the issue is where commands are typed until the pull request exists', () => {
+    expect(commandSurface(state(), 'issue')).toBe('accepted')
+    expect(commandSurface(state(), 'pull-request')).toBe('accepted')
+  })
+
+  test('the pull request takes over once it exists', () => {
+    const delivered = state({ prNumber: 7, prUrl: 'https://example.invalid/pull/7' })
+
+    expect(commandSurface(delivered, 'pull-request')).toBe('accepted')
+    expect(commandSurface(delivered, 'issue')).toBe('elsewhere')
+  })
+})

--- a/tests/opencode-agent/guardrails.test.ts
+++ b/tests/opencode-agent/guardrails.test.ts
@@ -358,18 +358,33 @@ describe('resolvePullRequestTrigger', () => {
     expect(resolved).toEqual(pullRequestEvent())
   })
 
-  test.each([['looks good to me'], ['/approve'], ['/ask why that file?'], ['/retry'], ['']])(
-    'drops %p with no API call at all',
+  test.each([['looks good to me'], ['nice, ship it'], ['']])('drops %p with no API call at all', async (body) => {
+    // The cheap filter that keeps every ordinary code-review comment free.
+    // Every pull request in a repository gets them; without this, every one of
+    // them would cost a pull-request lookup before being thrown away.
+    const api = lookup(head())
+
+    expect(
+      await resolvePullRequestTrigger(pendingPullRequest({ commentBody: body }), api.github, silentLogger()),
+    ).toBeNull()
+    expect(api.calls()).toBe(0)
+  })
+
+  test.each([['/approve'], ['/ask why that file?'], ['/retry'], ['/cancel']])(
+    'resolves %p, because the pull request is where an issue with one is driven from',
     async (body) => {
-      // The cheap filter that keeps every ordinary code-review comment free.
-      // Every pull request in a repository gets them; without this, every one of
-      // them would cost a pull-request lookup before being thrown away.
+      // The door used to admit `/review` alone. It cannot any more: commands
+      // typed on the issue are refused once a pull request exists, so a
+      // narrowing here would leave these with nowhere to be typed at all.
       const api = lookup(head())
 
-      expect(
-        await resolvePullRequestTrigger(pendingPullRequest({ commentBody: body }), api.github, silentLogger()),
-      ).toBeNull()
-      expect(api.calls()).toBe(0)
+      const resolved = await resolvePullRequestTrigger(
+        pendingPullRequest({ commentBody: body }),
+        api.github,
+        silentLogger(),
+      )
+
+      expect(resolved).toMatchObject({ kind: 'pull-request', issueNumber: 42 })
     },
   )
 

--- a/tests/opencode-agent/labels.test.ts
+++ b/tests/opencode-agent/labels.test.ts
@@ -233,3 +233,80 @@ describe('settleLabels', () => {
     expect(writes(io)).toEqual(['create:agent:needs-you:d4a72c', '+agent:needs-you', '-agent:working'])
   })
 })
+
+/**
+ * Where the labels go once there is a diff to look at.
+ *
+ * An issue whose work is all in a pull request is a page nobody opens: the
+ * branch, the checks and the merge button are on the pull request, so that is
+ * where "is the agent working, or is it waiting on me" has to be readable from a
+ * list view. Moving them is only half of it — the copy left on the issue would
+ * be frozen at whatever the state was when the pull request opened, and nothing
+ * would ever come back for it.
+ */
+describe('reconcileLabels · after a pull request exists', () => {
+  const ISSUE_NUMBER = 42
+  const PR_NUMBER = 7
+
+  const twoTargets = (
+    seed: Record<number, readonly string[]>,
+  ): [LabelDeps, { calls: string[]; labels: Record<number, string[]> }] => {
+    const labels: Record<number, string[]> = { [ISSUE_NUMBER]: [], [PR_NUMBER]: [] }
+    for (const [number, names] of Object.entries(seed)) labels[Number(number)] = [...names]
+    const calls: string[] = []
+
+    const github: LabelApi = {
+      listLabels: (number): Promise<string[]> => {
+        calls.push(`list:${number}`)
+        return Promise.resolve([...(labels[number] ?? [])])
+      },
+      addLabels: (number, names): Promise<void> => {
+        calls.push(`+${number}:${names.join(',')}`)
+        labels[number] = [...(labels[number] ?? []), ...names]
+        return Promise.resolve()
+      },
+      removeLabel: (number, name): Promise<void> => {
+        calls.push(`-${number}:${name}`)
+        labels[number] = (labels[number] ?? []).filter((existing) => existing !== name)
+        return Promise.resolve()
+      },
+      createLabel: (): Promise<void> => Promise.resolve(),
+    }
+    const log: Logger = { debug: (): void => {}, info: (): void => {}, warn: (): void => {}, error: (): void => {} }
+
+    return [
+      { github, log, config: { labelPrefix: 'agent:' } },
+      { calls, labels },
+    ]
+  }
+
+  /** An issue still carrying the labels an earlier, pre-pull-request run left. */
+  const delivered = (): ReturnType<typeof twoTargets> =>
+    twoTargets({ [ISSUE_NUMBER]: ['agent:implementing', 'agent:working'], [PR_NUMBER]: [] })
+
+  test('labels the pull request, not the issue', async () => {
+    const [deps, io] = delivered()
+
+    await reconcileLabels(deps, { ...stateIn('REVIEW_AND_MUTATE'), prNumber: PR_NUMBER }, 'working')
+
+    expect(io.labels[PR_NUMBER]).toEqual(['agent:implementing', 'agent:working'])
+  })
+
+  test('takes the agent labels off the issue, so it cannot freeze mid-run', async () => {
+    const [deps, io] = delivered()
+
+    await reconcileLabels(deps, { ...stateIn('REVIEW_AND_MUTATE'), prNumber: PR_NUMBER }, 'working')
+
+    expect(io.labels[ISSUE_NUMBER]).toEqual([])
+    expect(io.calls).toContain(`-${ISSUE_NUMBER}:agent:working`)
+  })
+
+  test('leaves labels the pipeline did not put there alone, on both', async () => {
+    const [deps, io] = twoTargets({ [ISSUE_NUMBER]: ['bug', 'agent:working'], [PR_NUMBER]: ['needs-triage'] })
+
+    await reconcileLabels(deps, { ...stateIn('COMPLETE'), prNumber: PR_NUMBER }, 'waiting')
+
+    expect(io.labels[ISSUE_NUMBER]).toEqual(['bug'])
+    expect(io.labels[PR_NUMBER]).toContain('needs-triage')
+  })
+})

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -1172,6 +1172,17 @@ describe('answering outside the review gates', () => {
     },
   )
 
+  test('says nothing about a pull request while there is none', async () => {
+    // Most of an issue's life, and all of a cancelled one's: the pointer is
+    // empty, so those comments read exactly as they always did.
+    seedState(harness, { phase: 'DESIGN_SPEC' })
+    harness.io.replies = ['Because the retry helper already exists there.']
+
+    await runPipeline({ event: comment('/ask why that file?'), deps: harness.deps })
+
+    expect(harness.io.posted[0]).not.toContain('Commands for this issue')
+  })
+
   test('/ask in FAILED answers without disturbing the parked failure', async () => {
     // The phase a maintainer most wants to ask a question in, and the one the
     // crash hurt most: the run had already failed, so this was the only thing
@@ -1622,6 +1633,18 @@ describe('/review — the review loop as a command', () => {
     expect(latestPostedState(harness)).toMatchObject({ phase: 'COMPLETE', reviewAttempts: 1 })
   })
 
+  test('every comment it posts on the issue says where commands go', async () => {
+    // Almost every comment this pipeline writes ends by naming a command, and
+    // all of them became wrong in the same way when the issue stopped accepting
+    // them — right advice, wrong page. Said once, on the write they share, from
+    // the state they are posted with, rather than threaded through eight
+    // renderers where any one of them could forget.
+    await runPipeline({ event: prComment('/review'), deps: harness.deps })
+
+    expect(harness.io.posted.at(-1)).toContain('Commands for this issue go on its pull request')
+    expect(harness.io.posted.at(-1)).toContain('https://example.test/pull/7')
+  })
+
   test('the same command typed on the issue is refused and points at the pull request', async () => {
     // Not "does not apply": `/review` applies perfectly and would have worked
     // one page over, and telling a maintainer otherwise is how they conclude the
@@ -1910,12 +1933,12 @@ describe('/review — typed on the pull request', () => {
     expect(harness.io.prTitles.at(-1)).toContain('Add retries')
   })
 
-  test('takes /ask, and answers it on the issue where the record lives', async () => {
-    // The door used to refuse this, on the argument that a conversation on the
-    // pull request would be answered somewhere else. That argument survives —
-    // the answer still goes to the issue, because that is the thread the restore
-    // scan reads — but refusing it does not: with the issue refusing commands
-    // too, `/ask` would have had nowhere left to be typed at all.
+  test('takes /ask, and answers it where it was asked', async () => {
+    // The door used to refuse this, on the argument that the answer would land
+    // somewhere the asker is not looking. Refusing it stopped making sense once
+    // the issue refused commands too — `/ask` would have had nowhere left to be
+    // typed — so the answer moved instead: a reply goes back to the surface the
+    // question came from.
     harness.io.replies = ['It retries three times, with backoff.']
 
     const result = await runPipeline({ event: prComment('/ask how many retries?'), deps: harness.deps })
@@ -1923,7 +1946,39 @@ describe('/review — typed on the pull request', () => {
     // `waiting`: answering moves no phase — it is a side conversation about work
     // that lives elsewhere, which is exactly why `/ask` is accepted everywhere.
     expect(result.status).toBe('waiting')
-    expect(harness.io.posted.at(-1)).toContain('It retries three times')
+    expect(harness.io.prNotes.at(-1)).toContain('It retries three times')
+    // And nowhere else. A second copy on the issue is two accounts of one
+    // exchange, and the issue is not where the question was asked.
+    expect(harness.io.posted.some((body) => body.includes('It retries three times'))).toBe(false)
+  })
+
+  test('the answer it posts there carries no state block', async () => {
+    // The invariant the whole split rests on: `findLatestState` scans the issue
+    // thread, so a block on the pull request is a second source of truth it
+    // cannot see. The spend is recorded by rewriting the issue's newest block in
+    // place instead — a write that posts nothing.
+    harness.io.replies = ['It retries three times, with backoff.']
+    const before = harness.io.edits.length
+
+    await runPipeline({ event: prComment('/ask how many retries?'), deps: harness.deps })
+
+    expect(harness.io.prNotes.at(-1)).not.toContain('AGENT_STATE')
+    // The rewrite, not merely some edit: the issue's newest block is where the
+    // restore scan will read this run's spend back from.
+    expect(harness.io.edits.length).toBeGreaterThan(before)
+    expect(harness.io.edits.at(-1)?.body).toContain('AGENT_STATE')
+  })
+
+  test('a failed answer is reported where the question was asked too', async () => {
+    // The failure path is the one that matters most here: a maintainer watching
+    // the pull request for a reply must not be left with silence because the
+    // apology went to a page they are not reading.
+    harness.deps.agent = (): Promise<OpenCodeAgent> => Promise.reject(new Error('the model endpoint rejected it'))
+
+    const result = await runPipeline({ event: prComment('/ask how many retries?'), deps: harness.deps })
+
+    expect(result.status).toBe('failed')
+    expect(harness.io.prNotes.at(-1)).toContain('the model endpoint rejected it')
   })
 
   test.each([['/approve'], ['/retry']])(

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -308,6 +308,15 @@ interface PipelineIo {
    */
   labels: string[]
   /**
+   * What the **pull request** carries, once the run has one.
+   *
+   * Two sets, because the reconcile now writes two targets: the labels a state
+   * implies go on the pull request from the moment one exists, and the issue's
+   * copy is cleared so it cannot freeze at whatever the state was that day. One
+   * shared set could not tell those apart — the clear would undo the move.
+   */
+  prLabels: string[]
+  /**
    * Every label *write*, in order, and deliberately not folded into `labels`:
    * the point of a diff is what it did not ask for, and a set that ends up
    * right cannot tell a single add from a clear-and-reapply.
@@ -395,6 +404,7 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
     reactionLog: [],
     reactionError: null,
     labels: [],
+    prLabels: [],
     labelWrites: [],
     labelsCreated: [],
     labelReads: 0,
@@ -518,17 +528,20 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
     // Reading is not a write, so it is not recorded as one — but it does fail
     // when the token cannot see the issue at all, which is a real 403 and the
     // one that reaches the reconcile before it has decided anything.
-    listLabels: () => {
+    listLabels: (issueNumber) => {
       io.labelReads += 1
-      return io.labelError === null ? Promise.resolve([...io.labels]) : Promise.reject(io.labelError)
+      const held = issueNumber === ISSUE ? io.labels : io.prLabels
+      return io.labelError === null ? Promise.resolve([...held]) : Promise.reject(io.labelError)
     },
-    addLabels: (_issueNumber, names) =>
+    addLabels: (issueNumber, names) =>
       label(`+${names.join(',')}`, () => {
-        io.labels.push(...names.filter((name) => !io.labels.includes(name)))
+        const held = issueNumber === ISSUE ? io.labels : io.prLabels
+        held.push(...names.filter((name) => !held.includes(name)))
       }),
-    removeLabel: (_issueNumber, name) =>
+    removeLabel: (issueNumber, name) =>
       label(`-${name}`, () => {
-        io.labels = io.labels.filter((existing) => existing !== name)
+        if (issueNumber === ISSUE) io.labels = io.labels.filter((existing) => existing !== name)
+        else io.prLabels = io.prLabels.filter((existing) => existing !== name)
       }),
     createLabel: (name, color) =>
       label(`create:${name}`, () => {
@@ -1577,6 +1590,14 @@ describe('implementation and delivery', () => {
  * `/retry` re-ran the model turn that had already succeeded. It is a phase of
  * its own now, entered by `/review` from `COMPLETE` and returning there.
  */
+/**
+ * `/review`, typed where the diff is.
+ *
+ * On the pull request rather than on the issue, and not by preference: once a
+ * pull request exists it is the surface this issue is driven from, so a command
+ * typed on the issue is refused and pointed here. What the run *answers* on is
+ * still the issue — see the door's own describe below.
+ */
 describe('/review — the review loop as a command', () => {
   let harness: Harness
 
@@ -1586,7 +1607,7 @@ describe('/review — the review loop as a command', () => {
   })
 
   test('runs the loop over the pushed branch and returns to COMPLETE', async () => {
-    const result = await runPipeline({ event: comment('/review'), deps: harness.deps })
+    const result = await runPipeline({ event: prComment('/review'), deps: harness.deps })
 
     expect(result.status).toBe('completed')
     expect(harness.io.reviewCalls).toHaveLength(1)
@@ -1601,17 +1622,21 @@ describe('/review — the review loop as a command', () => {
     expect(latestPostedState(harness)).toMatchObject({ phase: 'COMPLETE', reviewAttempts: 1 })
   })
 
-  test('draws no note on the pull request, because the report is already here', async () => {
-    // Decided from the trigger kind and not from the phase: `CODE_REVIEW` is
-    // reached identically through both doors, so a phase test would put a
-    // pointer on the pull request for a maintainer already reading the report.
-    await runPipeline({ event: comment('/review'), deps: harness.deps })
+  test('the same command typed on the issue is refused and points at the pull request', async () => {
+    // Not "does not apply": `/review` applies perfectly and would have worked
+    // one page over, and telling a maintainer otherwise is how they conclude the
+    // agent is broken. The state does not move and the loop does not run.
+    const result = await runPipeline({ event: comment('/review'), deps: harness.deps })
 
-    expect(harness.io.prNotes).toEqual([])
+    expect(result.status).toBe('skipped')
+    expect(harness.io.reviewCalls).toEqual([])
+    expect(harness.io.posted.at(-1)).toContain('belongs on the pull request')
+    expect(harness.io.posted.at(-1)).toContain('https://example.test/pull/7')
+    expect(latestPostedState(harness)?.phase).toBe('COMPLETE')
   })
 
   test('hands the loop the approved plan, not the issue body', async () => {
-    await runPipeline({ event: comment('/review'), deps: harness.deps })
+    await runPipeline({ event: prComment('/review'), deps: harness.deps })
 
     // The loop reads the plan from the folder's `tasks.md` verbatim (design D1)
     // — the step the implementation walked, not the issue body the plan came from.
@@ -1623,7 +1648,7 @@ describe('/review — the review loop as a command', () => {
     // exactly what a freshly opened one would. The handler passes the report it
     // has just built rather than reading it back: `postAndAppend` runs in the
     // orchestrator *after* the handler returns.
-    await runPipeline({ event: comment('/review'), deps: harness.deps })
+    await runPipeline({ event: prComment('/review'), deps: harness.deps })
 
     expect(harness.io.prBodies.at(-1)).toContain(`Closes #${ISSUE}`)
     expect(harness.io.prBodies.at(-1)).toContain('Review report')
@@ -1636,7 +1661,7 @@ describe('/review — the review loop as a command', () => {
     // and another round off `AGENT_MAX_REVIEW_ATTEMPTS` — for a failed body edit.
     harness.deps.github.updatePullRequest = (): Promise<void> => Promise.reject(new Error('422 Unprocessable'))
 
-    const result = await runPipeline({ event: comment('/review'), deps: harness.deps })
+    const result = await runPipeline({ event: prComment('/review'), deps: harness.deps })
 
     expect(result.status).toBe('completed')
     expect(harness.io.posted.at(-1)).toContain('Review report')
@@ -1646,7 +1671,7 @@ describe('/review — the review loop as a command', () => {
   test('a review that throws leaves the pull request open and parks in CODE_REVIEW', async () => {
     harness.io.reviewError = new Error('the review loop exploded')
 
-    const result = await runPipeline({ event: comment('/review'), deps: harness.deps })
+    const result = await runPipeline({ event: prComment('/review'), deps: harness.deps })
 
     expect(result.status).toBe('failed')
     // The branch was pushed by phase 3 and the pull request opened by phase 4,
@@ -1661,11 +1686,11 @@ describe('/review — the review loop as a command', () => {
 
   test('/retry after a failed review re-runs the review and re-implements nothing', async () => {
     harness.io.reviewError = new Error('the review loop exploded')
-    await runPipeline({ event: comment('/review'), deps: harness.deps })
+    await runPipeline({ event: prComment('/review'), deps: harness.deps })
     harness.io.reviewError = null
     harness.io.posted.length = 0
 
-    const retried = await runPipeline({ event: comment('/retry'), deps: harness.deps })
+    const retried = await runPipeline({ event: prComment('/retry'), deps: harness.deps })
 
     expect(retried.status).toBe('completed')
     expect(harness.io.reviewCalls).toHaveLength(2)
@@ -1685,7 +1710,7 @@ describe('/review — the review loop as a command', () => {
       failure: 'the review loop exited 1',
     }
 
-    const result = await runPipeline({ event: comment('/review'), deps: harness.deps })
+    const result = await runPipeline({ event: prComment('/review'), deps: harness.deps })
 
     expect(result.status).toBe('completed')
     expect(harness.io.posted[0]).toContain('❌ the review loop exited 1')
@@ -1703,7 +1728,7 @@ describe('/review — the review loop as a command', () => {
       failure: null,
     }
 
-    const result = await runPipeline({ event: comment('/review'), deps: harness.deps })
+    const result = await runPipeline({ event: prComment('/review'), deps: harness.deps })
 
     expect(result.status).toBe('completed')
     expect(harness.io.posted[0]).toContain('not configured for this repository')
@@ -1715,7 +1740,7 @@ describe('/review — the review loop as a command', () => {
     // to hear, so it is reported and the phase still completes.
     harness.deps.git.commitAll = (): Promise<StagedTotals | null> => Promise.resolve(null)
 
-    const result = await runPipeline({ event: comment('/review'), deps: harness.deps })
+    const result = await runPipeline({ event: prComment('/review'), deps: harness.deps })
 
     expect(result.status).toBe('completed')
     expect(harness.io.gitCalls).not.toContain(`push:agent/issue-${ISSUE}`)
@@ -1752,7 +1777,7 @@ describe('/review — where it does not apply', () => {
     async (phase) => {
       seedState(harness, { phase, prUrl: 'https://example.test/pull/7', prNumber: 7 })
 
-      const result = await runPipeline({ event: comment('/review'), deps: harness.deps })
+      const result = await runPipeline({ event: prComment('/review'), deps: harness.deps })
 
       expect(result.status).toBe('skipped')
       expect(harness.io.reviewCalls).toEqual([])
@@ -1769,7 +1794,7 @@ describe('/review — where it does not apply', () => {
     harness = makeHarness({ maxReviewAttempts: 2 })
     seedState(harness, { phase: 'COMPLETE', prUrl: 'https://example.test/pull/7', prNumber: 7, reviewAttempts: 2 })
 
-    const result = await runPipeline({ event: comment('/review'), deps: harness.deps })
+    const result = await runPipeline({ event: prComment('/review'), deps: harness.deps })
 
     expect(result.status).toBe('failed')
     expect(harness.io.reviewCalls).toEqual([])
@@ -1781,12 +1806,12 @@ describe('/review — where it does not apply', () => {
     harness = makeHarness({ maxReviewAttempts: 2 })
     seedState(harness, { phase: 'COMPLETE', prUrl: 'https://example.test/pull/7', prNumber: 7, reviewAttempts: 2 })
     seedTasks(harness)
-    await runPipeline({ event: comment('/review'), deps: harness.deps })
+    await runPipeline({ event: prComment('/review'), deps: harness.deps })
 
     harness.deps.config.maxReviewAttempts = 3
     harness.io.posted.length = 0
 
-    const result = await runPipeline({ event: comment('/review'), deps: harness.deps })
+    const result = await runPipeline({ event: prComment('/review'), deps: harness.deps })
 
     expect(result.status).toBe('completed')
     expect(harness.io.reviewCalls).toHaveLength(1)
@@ -1885,12 +1910,28 @@ describe('/review — typed on the pull request', () => {
     expect(harness.io.prTitles.at(-1)).toContain('Add retries')
   })
 
-  test.each([['/approve'], ['/cancel'], ['/retry'], ['/ask why that file?']])(
-    'refuses %p, because a pull request accepts one command',
+  test('takes /ask, and answers it on the issue where the record lives', async () => {
+    // The door used to refuse this, on the argument that a conversation on the
+    // pull request would be answered somewhere else. That argument survives —
+    // the answer still goes to the issue, because that is the thread the restore
+    // scan reads — but refusing it does not: with the issue refusing commands
+    // too, `/ask` would have had nowhere left to be typed at all.
+    harness.io.replies = ['It retries three times, with backoff.']
+
+    const result = await runPipeline({ event: prComment('/ask how many retries?'), deps: harness.deps })
+
+    // `waiting`: answering moves no phase — it is a side conversation about work
+    // that lives elsewhere, which is exactly why `/ask` is accepted everywhere.
+    expect(result.status).toBe('waiting')
+    expect(harness.io.posted.at(-1)).toContain('It retries three times')
+  })
+
+  test.each([['/approve'], ['/retry']])(
+    'refuses %p on its merits, not because of the surface it was typed on',
     async (body) => {
-      // Unreachable through the resolver, which drops anything but `/review`
-      // before it makes an API call — this is the door itself holding the same
-      // line, so a second way in cannot widen the surface by accident.
+      // The door takes every command now; what turns these down is the phase.
+      // `COMPLETE` accepts neither, and the refusal says exactly that — with the
+      // list of what does work, derived from the transition table.
       const result = await runPipeline({ event: prComment(body), deps: harness.deps })
 
       expect(result.status).toBe('skipped')
@@ -4570,14 +4611,20 @@ describe('labels — the state at a glance', () => {
     expect(harness.io.labels).not.toContain('agent:working')
   })
 
-  test('a delivered issue is labelled done, a cancelled one stopped', async () => {
+  test('a delivered issue is labelled done on its pull request, a cancelled one stopped on the issue', async () => {
+    // The delivered one has somewhere better to say it. Its labels move to the
+    // pull request the moment one exists — that is the page carrying the branch,
+    // the checks and the merge button — and the issue's copy is cleared rather
+    // than left frozen at `agent:implementing` for ever. A cancelled issue never
+    // opened one, so it keeps its own.
     const delivered = makeHarness()
     await driveDelivery(delivered)
 
     const cancelled = makeHarness()
     await toComplete(cancelled)
 
-    expect(delivered.io.labels).toEqual(['agent:done'])
+    expect(delivered.io.prLabels).toEqual(['agent:done'])
+    expect(delivered.io.labels).toEqual([])
     expect(cancelled.io.labels).toEqual(['agent:stopped'])
   })
 

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -226,6 +226,8 @@ interface PipelineIo {
   /** Tokens the fake session reports as spent this job. */
   tokensUsed: number
   reviewResult: ReviewRunResult
+  /** What `git rev-parse HEAD` answers; constant unless a test moves it. */
+  headSha: string
   /** Every plan the review loop was handed, in order — `/review` is now a phase. */
   reviewCalls: string[]
   /** What `runReview` rejects with, when set: the loop crashing rather than exiting red. */
@@ -373,7 +375,8 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
     checkResults: new Map(),
     replies: [],
     tokensUsed: 0,
-    reviewResult: { outcome: 'passed', summary: 'no issues found', exitCode: 0 },
+    reviewResult: { outcome: 'passed', summary: 'no issues found', exitCode: 0, failure: null },
+    headSha: 'head-sha',
     reviewCalls: [],
     reviewError: null,
     detectedBranch: BASE_BRANCH,
@@ -559,6 +562,10 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
       return Promise.resolve()
     },
     defaultBranch: () => Promise.resolve(io.detectedBranch),
+    // Constant, which is the ordinary case: the review loop is a fake here, so
+    // nothing moves the branch behind the pipeline's back. A test that wants the
+    // opposite overrides this — see the review-phase tests in `phases.test.ts`.
+    headSha: () => Promise.resolve(io.headSha),
   }
 
   const agent: OpenCodeAgent = {
@@ -676,6 +683,7 @@ const hostileGit = (): Git => {
     salvageAll: (): Promise<Salvage> => refuse('salvage'),
     push: (): Promise<void> => refuse('push'),
     defaultBranch: (): Promise<string | null> => refuse('symbolic-ref'),
+    headSha: (): Promise<string> => refuse('rev-parse'),
   }
 }
 
@@ -1670,12 +1678,17 @@ describe('/review — the review loop as a command', () => {
   test('a red review is reported and still reaches COMPLETE', async () => {
     // CI on the pull request is the gate, and the CI-fix loop is what acts on
     // it; a red review is a finding, not a blocker.
-    harness.io.reviewResult = { outcome: 'failed', summary: 'two issues left open', exitCode: 1 }
+    harness.io.reviewResult = {
+      outcome: 'failed',
+      summary: 'two issues left open',
+      exitCode: 1,
+      failure: 'the review loop exited 1',
+    }
 
     const result = await runPipeline({ event: comment('/review'), deps: harness.deps })
 
     expect(result.status).toBe('completed')
-    expect(harness.io.posted[0]).toContain('❌ exited 1')
+    expect(harness.io.posted[0]).toContain('❌ the review loop exited 1')
     expect(harness.io.posted[0]).toContain('two issues left open')
     expect(latestPostedState(harness)?.phase).toBe('COMPLETE')
   })
@@ -1683,7 +1696,12 @@ describe('/review — the review loop as a command', () => {
   test('reports a repository with no review loop as unconfigured, not as red', async () => {
     // A checkout without the workspace has no review configured; that is not a
     // review that failed, and calling it one made every run elsewhere red.
-    harness.io.reviewResult = { outcome: 'unavailable', summary: 'No review loop is configured.', exitCode: 0 }
+    harness.io.reviewResult = {
+      outcome: 'unavailable',
+      summary: 'No review loop is configured.',
+      exitCode: 0,
+      failure: null,
+    }
 
     const result = await runPipeline({ event: comment('/review'), deps: harness.deps })
 
@@ -1821,11 +1839,16 @@ describe('/review — typed on the pull request', () => {
   })
 
   test('a red loop is what the note says it is', async () => {
-    harness.io.reviewResult = { outcome: 'failed', summary: 'two issues left open', exitCode: 1 }
+    harness.io.reviewResult = {
+      outcome: 'failed',
+      summary: 'two issues left open',
+      exitCode: 1,
+      failure: 'the review loop exited 1',
+    }
 
     await runPipeline({ event: prComment('/review'), deps: harness.deps })
 
-    expect(harness.io.prNotes[0]).toContain('❌ exited 1')
+    expect(harness.io.prNotes[0]).toContain('❌ the review loop exited 1')
   })
 
   test('a note the pull request will not take costs the review nothing', async () => {

--- a/tests/opencode-agent/phases.test.ts
+++ b/tests/opencode-agent/phases.test.ts
@@ -632,7 +632,7 @@ describe('handleReview · reads the plan from the folder (D1)', () => {
     const handed: string[] = []
     input.deps.runReview = (plan: string): Promise<ReviewRunResult> => {
       handed.push(plan)
-      return Promise.resolve({ outcome: 'passed', summary: '', exitCode: 0 })
+      return Promise.resolve({ outcome: 'passed', summary: '', exitCode: 0, failure: null })
     }
 
     const outcome = await handleReview(input)
@@ -641,6 +641,97 @@ describe('handleReview · reads the plan from the folder (D1)', () => {
     // The review loop was handed the folder's tasks.md verbatim.
     expect(handed).toEqual([tasks])
     expect(io.reads).toEqual([`/repo/openspec/changes/${CHANGE}/tasks.md`])
+  })
+})
+
+/**
+ * The findings are commits, and a commit on an Actions runner is worth nothing
+ * until it is pushed.
+ *
+ * The loop merges its own branch into the checkout itself, so by the time this
+ * handler runs the tree is *clean* and the work is in `HEAD` — which is why
+ * asking `commitAll` whether anything changed answered "no" and the push was
+ * skipped, on every review that found something. The branch, and the pull
+ * request, showed the implementation and nothing else.
+ */
+/** Successive answers, repeating the last one — a `??` outside any test body. */
+const queued = (values: readonly string[]): (() => string) => {
+  const remaining = [...values]
+  let last = values.at(-1) ?? ''
+  return (): string => {
+    last = remaining.shift() ?? last
+    return last
+  }
+}
+
+describe('handleReview · pushes what the loop merged', () => {
+  const reviewInput = (
+    passing: boolean,
+    failure: string | null = null,
+  ): ReturnType<typeof folderReadInput> & { pushes: () => string[] } => {
+    const built = folderReadInput({ phase: 'CODE_REVIEW', folder: { tasks: '- [ ] one\n' } })
+    built.input.state = { ...built.input.state, prNumber: 7, prUrl: 'https://example.invalid/pull/7' }
+    built.input.deps.runReview = (): Promise<ReviewRunResult> =>
+      Promise.resolve({
+        outcome: passing ? 'passed' : 'failed',
+        summary: 'summary',
+        exitCode: passing ? 0 : 1,
+        failure,
+      })
+    return { ...built, pushes: (): string[] => built.io.gitCalls.filter((call) => call.startsWith('push:')) }
+  }
+
+  it('pushes when the loop advanced the branch and left a clean tree', async () => {
+    const built = reviewInput(true)
+    // What the loop actually leaves behind: its merge is already committed, so
+    // there is nothing for `commitAll` to stage.
+    built.input.deps.git.commitAll = (): Promise<null> => Promise.resolve(null)
+    const heads = queued(['before', 'after'])
+    built.input.deps.git.headSha = (): Promise<string> => Promise.resolve(heads())
+
+    const outcome = await handleReview(built.input)
+
+    expect(built.pushes()).toEqual(['push:agent/issue-42'])
+    expect(outcome.comment).toContain('pushed')
+  })
+
+  it('pushes nothing when the loop changed nothing at all', async () => {
+    const built = reviewInput(true)
+    built.input.deps.git.commitAll = (): Promise<null> => Promise.resolve(null)
+    built.input.deps.git.headSha = (): Promise<string> => Promise.resolve('same')
+
+    await handleReview(built.input)
+
+    expect(built.pushes()).toEqual([])
+  })
+
+  it('pushes each fix as the loop publishes it, not only at the end', async () => {
+    const built = reviewInput(true)
+    built.input.deps.git.commitAll = (): Promise<null> => Promise.resolve(null)
+    const heads = queued(['start', 'fix-1', 'fix-2', 'fix-2'])
+    built.input.deps.git.headSha = (): Promise<string> => Promise.resolve(heads())
+    built.input.deps.runReview = async (_plan: string, onFixMerged?: () => void): Promise<ReviewRunResult> => {
+      onFixMerged?.()
+      onFixMerged?.()
+      // The loop is still running here; the pushes must already have happened by
+      // the time it returns, which is what makes them survive a killed runner.
+      await Promise.resolve()
+      return { outcome: 'passed', summary: '', exitCode: 0, failure: null }
+    }
+
+    await handleReview(built.input)
+
+    expect(built.pushes()).toEqual(['push:agent/issue-42', 'push:agent/issue-42'])
+  })
+
+  it('names why a failed loop failed, in the report and on the pull request', async () => {
+    const built = reviewInput(false, "the loop's own build gate failed at the end of the run")
+
+    const outcome = await handleReview(built.input)
+
+    expect(outcome.comment).toContain('build gate')
+    const updated = built.io.pullRequestUpdates.at(-1)
+    expect(updated?.body).toContain('build gate')
   })
 })
 
@@ -745,7 +836,7 @@ describe('a phase checks out the branch carrying the folder before it reads the 
     const handed: string[] = []
     built.input.deps.runReview = (plan: string): Promise<ReviewRunResult> => {
       handed.push(plan)
-      return Promise.resolve({ outcome: 'passed', summary: '', exitCode: 0 })
+      return Promise.resolve({ outcome: 'passed', summary: '', exitCode: 0, failure: null })
     }
 
     const outcome = await handleReview(built.input)

--- a/tests/opencode-agent/review-runner.test.ts
+++ b/tests/opencode-agent/review-runner.test.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import type { TranscriptRow } from '../../opencode-agent/src/activity-detail.js'
+import type { LogFields, Logger } from '../../opencode-agent/src/logger.js'
+import { buildReviewLoopConfig, describeFailure, runReviewLoop } from '../../opencode-agent/src/review-runner.js'
+import type { ReviewLoopSettings } from '../../opencode-agent/src/review-runner.js'
+import type { CommandResult, CommandRunner, RunOptions } from '../../opencode-agent/src/shell.js'
+
+/** A logger that keeps what it was told, so "it reached the CI log" is assertable. */
+const recordingLogger = (): { logger: Logger; lines: Array<{ message: string; fields: LogFields }> } => {
+  const lines: Array<{ message: string; fields: LogFields }> = []
+  const record =
+    (): ((fields: LogFields, message: string) => void) =>
+    (fields, message): void => {
+      lines.push({ message, fields })
+    }
+  return { logger: { debug: record(), info: record(), warn: record(), error: record() }, lines }
+}
+
+const settings = (overrides: Partial<ReviewLoopSettings> = {}): ReviewLoopSettings => ({
+  repoRoot: '/tmp/does-not-need-to-exist',
+  command: ['bun', 'run', 'review-loop/src/cli.ts'],
+  openai: { apiKey: 'k', baseUrl: 'https://example.invalid/v1', model: 'm' },
+  checkCommand: 'bun check',
+  maxRounds: 2,
+  poolSize: 1,
+  agentTimeoutMs: 1_000,
+  ...overrides,
+})
+
+const result = (overrides: Partial<CommandResult> = {}): CommandResult => ({
+  command: 'review-loop',
+  exitCode: 0,
+  stdout: '',
+  stderr: '',
+  timedOut: false,
+  ...overrides,
+})
+
+/** A runner that replays lines through `onOutput` the way a real child would. */
+const replaying = (lines: readonly string[], exitCode = 0): CommandRunner => {
+  return (_argv: readonly string[], options: RunOptions): Promise<CommandResult> => {
+    for (const line of lines) options.onOutput?.(line, 'stdout')
+    return Promise.resolve(result({ stdout: `${lines.join('\n')}\n`, exitCode }))
+  }
+}
+
+describe('runReviewLoop output', () => {
+  test('reports every line of the loop in the public log as it arrives', async () => {
+    const log = recordingLogger()
+
+    await runReviewLoop({
+      settings: settings(),
+      plan: '- [ ] one',
+      run: replaying(['[round 1/2] Reviewing...', '[round 1] Fixed 1/1 issues']),
+      env: {},
+      log: log.logger,
+      timeoutMs: 1_000,
+      writeInputs: () => Promise.resolve({ planPath: '/tmp/plan.md', configPath: '/tmp/config.json' }),
+    })
+
+    const messages = log.lines.map((line) => line.message)
+    expect(messages).toContain('[round 1/2] Reviewing...')
+    expect(messages).toContain('[round 1] Fixed 1/1 issues')
+  })
+
+  test('feeds the same lines to the encrypted transcript', async () => {
+    const rows: TranscriptRow[] = []
+
+    await runReviewLoop({
+      settings: settings(),
+      plan: '- [ ] one',
+      run: replaying(['[round 1/2] Reviewing...']),
+      env: {},
+      log: recordingLogger().logger,
+      timeoutMs: 1_000,
+      transcript: {
+        write: (row): void => {
+          rows.push(row)
+        },
+      },
+      writeInputs: () => Promise.resolve({ planPath: '/tmp/plan.md', configPath: '/tmp/config.json' }),
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.tool).toBe('review-loop')
+    expect(rows[0]?.detail).toBe('[round 1/2] Reviewing...')
+  })
+
+  test('calls back when the loop says a fix landed on the branch', async () => {
+    let merged = 0
+
+    await runReviewLoop({
+      settings: settings(),
+      plan: '- [ ] one',
+      run: replaying([
+        '[review-loop] published fix to review-loop/run-1',
+        'noise',
+        '[review-loop] published fix again',
+      ]),
+      env: {},
+      log: recordingLogger().logger,
+      timeoutMs: 1_000,
+      onFixMerged: () => {
+        merged += 1
+      },
+      writeInputs: () => Promise.resolve({ planPath: '/tmp/plan.md', configPath: '/tmp/config.json' }),
+    })
+
+    expect(merged).toBe(2)
+  })
+
+  test('an unconfigured repository is unavailable, not failed', async () => {
+    const review = await runReviewLoop({
+      settings: settings({ command: null }),
+      plan: '',
+      run: replaying([]),
+      env: {},
+      log: recordingLogger().logger,
+      timeoutMs: 1_000,
+      writeInputs: () => Promise.resolve({ planPath: '/tmp/plan.md', configPath: '/tmp/config.json' }),
+    })
+
+    expect(review.outcome).toBe('unavailable')
+    expect(review.failure).toBeNull()
+  })
+})
+
+describe('describeFailure', () => {
+  test('says nothing about a loop that passed', () => {
+    expect(describeFailure(result({ exitCode: 0 }), 60_000)).toBeNull()
+  })
+
+  test('names the deadline that killed the loop', () => {
+    const failure = describeFailure(result({ exitCode: 1, timedOut: true }), 90 * 60_000)
+
+    expect(failure).toContain('90m')
+    expect(failure).toContain('timed out')
+  })
+
+  test('names a command that could not be started', () => {
+    const failure = describeFailure(result({ exitCode: 127, stderr: 'spawn bun ENOENT' }), 60_000)
+
+    expect(failure).toContain('could not be started')
+    expect(failure).toContain('spawn bun ENOENT')
+  })
+
+  test("names the loop's own build gate, which is the failure that keeps findings unmerged", () => {
+    const stdout = 'Final build check failed; worktree preserved at /x for inspection, merge skipped.'
+    const failure = describeFailure(result({ exitCode: 1, stdout }), 60_000)
+
+    expect(failure).toContain('build gate')
+  })
+
+  test('names a merge conflict', () => {
+    const stderr = 'Merge conflict while bringing review-loop/run-1 into HEAD; the merge was aborted.'
+    const failure = describeFailure(result({ exitCode: 1, stderr }), 60_000)
+
+    expect(failure).toContain('conflict')
+  })
+
+  test('falls back to the exit code and the last thing the loop said', () => {
+    const failure = describeFailure(result({ exitCode: 2, stderr: 'Plan file not found: /x/tasks.md' }), 60_000)
+
+    expect(failure).toContain('exited 2')
+    expect(failure).toContain('Plan file not found: /x/tasks.md')
+  })
+})
+
+describe('buildReviewLoopConfig', () => {
+  test('asks the loop to publish each fix, so a run that dies later keeps them', () => {
+    expect(buildReviewLoopConfig(settings())['mergeEachFix']).toBe(true)
+  })
+})

--- a/tests/opencode-agent/review-runner.test.ts
+++ b/tests/opencode-agent/review-runner.test.ts
@@ -92,6 +92,33 @@ describe('runReviewLoop output', () => {
     expect(rows[0]?.detail).toBe('[round 1/2] Reviewing...')
   })
 
+  test("collects the loop's own trace, which is the review phase's tool activity", async () => {
+    const rows: TranscriptRow[] = []
+
+    await runReviewLoop({
+      settings: settings(),
+      plan: '- [ ] one',
+      run: replaying(['[round 1/2] Reviewing...']),
+      env: {},
+      log: recordingLogger().logger,
+      timeoutMs: 1_000,
+      transcript: {
+        write: (row): void => {
+          rows.push(row)
+        },
+      },
+      files: {
+        listRuns: () => Promise.resolve(['2026-08-13T09-00-00-000Z-bbbb']),
+        readText: () => Promise.resolve('{"event":"fix_complete"}\n'),
+      },
+      writeInputs: () => Promise.resolve({ planPath: '/tmp/plan.md', configPath: '/tmp/config.json' }),
+    })
+
+    // The phase opens no OpenCode session, so without this the artefact a
+    // maintainer is told to read said nothing about the hour the loop spent.
+    expect(rows.map((row) => row.tool)).toEqual(['review-loop', 'review-loop-trace'])
+  })
+
   test('calls back when the loop says a fix landed on the branch', async () => {
     let merged = 0
 

--- a/tests/opencode-agent/review-transcript.test.ts
+++ b/tests/opencode-agent/review-transcript.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import type { TranscriptRow } from '../../opencode-agent/src/activity-detail.js'
+import type { LogFields, Logger } from '../../opencode-agent/src/logger.js'
+import { collectLoopTranscript } from '../../opencode-agent/src/review-transcript.js'
+import type { TranscriptFiles } from '../../opencode-agent/src/review-transcript.js'
+
+const quietLogger = (): { logger: Logger; warnings: string[] } => {
+  const warnings: string[] = []
+  const nothing = (): void => {}
+  return {
+    logger: {
+      debug: nothing,
+      info: nothing,
+      warn: (_fields: LogFields, message: string): void => {
+        warnings.push(message)
+      },
+      error: nothing,
+    },
+    warnings,
+  }
+}
+
+const collect = async (
+  files: TranscriptFiles,
+  maxLines?: number,
+): Promise<{ rows: TranscriptRow[]; warnings: string[] }> => {
+  const rows: TranscriptRow[] = []
+  const log = quietLogger()
+
+  await collectLoopTranscript({
+    workDir: '/repo/.opencode-agent/review-loop',
+    transcript: {
+      write: (row): void => {
+        rows.push(row)
+      },
+    },
+    files,
+    log: log.logger,
+    now: () => 0,
+    maxLines,
+  })
+
+  return { rows, warnings: log.warnings }
+}
+
+describe('collectLoopTranscript', () => {
+  test("folds the newest run's trace into the encrypted transcript", async () => {
+    const read: string[] = []
+    const files: TranscriptFiles = {
+      listRuns: () => Promise.resolve(['2026-08-13T03-00-00-000Z-aaaa', '2026-08-13T09-00-00-000Z-bbbb']),
+      readText: (path) => {
+        read.push(path)
+        return Promise.resolve('{"event":"round_start"}\n{"event":"fix_complete"}\n')
+      },
+    }
+
+    const { rows } = await collect(files)
+
+    // The newest run, picked lexically: the id starts with an ISO timestamp.
+    expect(read).toEqual(['/repo/.opencode-agent/review-loop/runs/2026-08-13T09-00-00-000Z-bbbb/trace.jsonl'])
+    expect(rows.map((row) => row.detail)).toEqual(['{"event":"round_start"}', '{"event":"fix_complete"}'])
+    expect(rows[0]?.tool).toBe('review-loop-trace')
+  })
+
+  test('keeps the tail when a long run wrote more than the bound', async () => {
+    const lines = Array.from({ length: 10 }, (_, index) => `line-${index}`).join('\n')
+    const files: TranscriptFiles = {
+      listRuns: () => Promise.resolve(['run-1']),
+      readText: () => Promise.resolve(lines),
+    }
+
+    const { rows } = await collect(files, 3)
+
+    expect(rows.map((row) => row.detail)).toEqual(['line-7', 'line-8', 'line-9'])
+  })
+
+  test('a run that left no trace is not an error', async () => {
+    const files: TranscriptFiles = {
+      listRuns: () => Promise.resolve([]),
+      readText: () => Promise.reject(new Error('should not be read')),
+    }
+
+    const { rows, warnings } = await collect(files)
+
+    expect(rows).toEqual([])
+    expect(warnings).toEqual([])
+  })
+
+  test('an unreadable trace warns once and never throws', async () => {
+    const files: TranscriptFiles = {
+      listRuns: () => Promise.resolve(['run-1']),
+      readText: () => Promise.reject(new Error('ENOENT')),
+    }
+
+    const { rows, warnings } = await collect(files)
+
+    expect(rows).toEqual([])
+    expect(warnings).toHaveLength(1)
+  })
+})

--- a/tests/opencode-agent/shell.test.ts
+++ b/tests/opencode-agent/shell.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { runCommand } from '../../opencode-agent/src/shell.js'
+
+/**
+ * The child-process boundary. Two properties matter here and neither is
+ * observable from the buffered result the runner used to hand back: that a long
+ * command's output reaches the caller *while it runs*, and that a command killed
+ * by its own deadline says so rather than looking like an ordinary non-zero exit.
+ */
+describe('runCommand', () => {
+  test('streams stdout line by line while the child is still running', async () => {
+    const lines: Array<{ line: string; stream: string }> = []
+
+    const result = await runCommand(['bash', '-c', 'echo one; echo two; echo three'], {
+      cwd: process.cwd(),
+      onOutput: (line, stream): void => {
+        lines.push({ line, stream })
+      },
+    })
+
+    expect(lines).toEqual([
+      { line: 'one', stream: 'stdout' },
+      { line: 'two', stream: 'stdout' },
+      { line: 'three', stream: 'stdout' },
+    ])
+    // The buffered form still holds everything: the stream is an addition, not a
+    // replacement — `extractSummary` and every check runner still read it.
+    expect(result.stdout).toBe('one\ntwo\nthree\n')
+    expect(result.exitCode).toBe(0)
+  })
+
+  test('reports stderr on its own stream', async () => {
+    const lines: Array<{ line: string; stream: string }> = []
+
+    await runCommand(['bash', '-c', 'echo out; echo err 1>&2'], {
+      cwd: process.cwd(),
+      onOutput: (line, stream): void => {
+        lines.push({ line, stream })
+      },
+    })
+
+    expect(lines).toContainEqual({ line: 'out', stream: 'stdout' })
+    expect(lines).toContainEqual({ line: 'err', stream: 'stderr' })
+  })
+
+  test('flushes a trailing line the child never terminated', async () => {
+    const lines: string[] = []
+
+    await runCommand(['bash', '-c', 'printf no-newline'], {
+      cwd: process.cwd(),
+      onOutput: (line): void => {
+        lines.push(line)
+      },
+    })
+
+    expect(lines).toEqual(['no-newline'])
+  })
+
+  test('marks a command its own deadline killed', async () => {
+    const result = await runCommand(['bash', '-c', 'sleep 5'], { cwd: process.cwd(), timeoutMs: 50 })
+
+    expect(result.timedOut).toBe(true)
+    expect(result.exitCode).not.toBe(0)
+  })
+
+  test('leaves timedOut false for a command that exited on its own', async () => {
+    const result = await runCommand(['bash', '-c', 'exit 3'], { cwd: process.cwd(), timeoutMs: 60_000 })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(3)
+  })
+})

--- a/tests/opencode-agent/status.test.ts
+++ b/tests/opencode-agent/status.test.ts
@@ -248,18 +248,21 @@ describe('renderStatus', () => {
 interface StatusIo {
   created: string[]
   edits: { id: number; body: string }[]
+  /** Which issue or pull request each comment was opened against. */
+  createdOn: number[]
   createError: Error | null
   editError: Error | null
   nowMs: number
 }
 
 const statusHarness = (overrides: Partial<PipelineConfig> = {}): { io: StatusIo; deps: StatusDeps } => {
-  const io: StatusIo = { created: [], edits: [], createError: null, editError: null, nowMs: STARTED }
+  const io: StatusIo = { created: [], createdOn: [], edits: [], createError: null, editError: null, nowMs: STARTED }
 
   const deps: StatusDeps = {
     github: {
-      createComment: (_issueNumber, body): Promise<PostedComment> => {
+      createComment: (issueNumber, body): Promise<PostedComment> => {
         if (io.createError !== null) return Promise.reject(io.createError)
+        io.createdOn.push(issueNumber)
         io.created.push(body)
         return Promise.resolve({ id: 900, url: 'https://example.test/c/900', authorLogin: AGENT_LOGIN })
       },
@@ -526,5 +529,31 @@ describe('persistState', () => {
     await persistState(persistDeps(edits), thread, state({ phase: 'DESIGN_SPEC', tokensSpent: 3 }))
 
     expect(edits[0]?.id).toBe(1)
+  })
+})
+
+/**
+ * Which page the live status comment opens on.
+ *
+ * The comment is about the *run happening now* — a progress table, edited as it
+ * moves — and once a pull request exists that is the page somebody watches while
+ * it happens. The record is the other half and does not move: the report and the
+ * `AGENT_STATE` block stay on the issue, where `findLatestState` scans.
+ */
+describe('createStatusReporter · where the comment lives', () => {
+  test('opens on the issue while there is no pull request', async () => {
+    const { io, deps } = statusHarness()
+
+    await createStatusReporter(deps).start(state({ phase: 'PLANNING' }))
+
+    expect(io.createdOn).toEqual([ISSUE])
+  })
+
+  test('opens on the pull request once one exists', async () => {
+    const { io, deps } = statusHarness()
+
+    await createStatusReporter(deps).start(state({ phase: 'CI_FIX', prNumber: 7, prUrl: 'https://x.test/pull/7' }))
+
+    expect(io.createdOn).toEqual([7])
   })
 })

--- a/tests/opencode-agent/test-helpers.ts
+++ b/tests/opencode-agent/test-helpers.ts
@@ -122,6 +122,8 @@ export interface StubIo {
   thread: IssueComment[]
   /** Git operations invoked, in order (`op:arg`). */
   gitCalls: string[]
+  /** Pull-request bodies written via `updatePullRequest`, in order. */
+  pullRequestUpdates: PullRequestPresentation[]
   /** Artifact writes via `writeFile` (`path::content-preview`). */
   writes: { path: string; content: string }[]
   /** File reads via `readFile`, in order. Tests seed `readContents` to reply. */
@@ -181,6 +183,7 @@ export const stubPhaseDeps = (options: StubPhaseDepsOptions = {}): { deps: Phase
     edits: [],
     thread: [...(options.thread ?? [])],
     gitCalls: [],
+    pullRequestUpdates: [],
     writes: [],
     reads: [],
     readContents: {},
@@ -245,7 +248,10 @@ export const stubPhaseDeps = (options: StubPhaseDepsOptions = {}): { deps: Phase
       Promise.resolve({ ref: '', repoFullName: '', state: 'open' }),
     createPullRequest: (_input: PullRequestInput): Promise<PullRequestRef> =>
       Promise.resolve({ number: 7, url: 'https://example.test/pull/7' }),
-    updatePullRequest: (_number: number, _patch: PullRequestPresentation): Promise<void> => Promise.resolve(),
+    updatePullRequest: (_number: number, patch: PullRequestPresentation): Promise<void> => {
+      io.pullRequestUpdates.push(patch)
+      return Promise.resolve()
+    },
   }
 
   const github: GitHubApi = {
@@ -294,13 +300,17 @@ export const stubPhaseDeps = (options: StubPhaseDepsOptions = {}): { deps: Phase
       return Promise.resolve()
     },
     defaultBranch: (): Promise<string | null> => Promise.resolve('main'),
+    headSha: (): Promise<string> => {
+      io.gitCalls.push('headSha')
+      return Promise.resolve('head-sha')
+    },
   }
 
   const runCheck: CheckRunner = (_check: CheckSpec): Promise<CommandResult> =>
     Promise.resolve({ command: '', stdout: '', stderr: '', exitCode: 0 })
 
   const runReview: RunReview = (_plan: string): Promise<ReviewRunResult> =>
-    Promise.resolve({ outcome: 'passed', summary: '', exitCode: 0 })
+    Promise.resolve({ outcome: 'passed', summary: '', exitCode: 0, failure: null })
 
   const groups: CiGroups = {
     startGroup: (_headline: string): void => {},

--- a/tests/opencode-agent/workflow.test.ts
+++ b/tests/opencode-agent/workflow.test.ts
@@ -10,6 +10,7 @@ import path from 'node:path'
 
 import { z } from 'zod'
 
+import { SLASH_COMMANDS } from '../../opencode-agent/src/commands.js'
 import { DEFAULT_LABEL_PREFIX } from '../../opencode-agent/src/config.js'
 import { issueNumberFromBranch } from '../../opencode-agent/src/git.js'
 import { WORKING_LABEL } from '../../opencode-agent/src/presentation.js'
@@ -189,33 +190,44 @@ describe('the job condition', () => {
     expect(issueArm).toContain('github.event.issue.pull_request == null')
   })
 
-  test('admits a maintainer /review typed on a pull request, and nothing else', () => {
+  test('admits a maintainer command typed on a pull request, and nothing else', () => {
     // The whole arm, clause by clause, because each clause refuses one thing and
     // a `toContain` per clause could not tell a missing one from a reordered one:
     //
     //   - `issue_comment` + `created` refuse an `issue_comment.edited` — an
     //     already-read command must not re-fire when its comment is edited;
     //   - `pull_request != null` is what makes this the pull-request door;
-    //   - the `/review` `contains` refuses every ordinary code-review comment,
-    //     and every pull request in a repository gets those. It is a first-pass
-    //     filter only: `parseSlashCommand` re-parses, requires the command to
-    //     start a line and ignores fenced blocks, and none of that is expressible
-    //     here. The arm exists so an event that will be dropped anyway never
-    //     boots a runner;
+    //   - the command `contains` group refuses every ordinary code-review
+    //     comment, and every pull request in a repository gets those. It is a
+    //     first-pass filter only: `parseSlashCommand` re-parses, requires the
+    //     command to start a line and ignores fenced blocks, and none of that is
+    //     expressible here. The arm exists so an event that will be dropped
+    //     anyway never boots a runner. Every command is named, not `/review`
+    //     alone: the pull request is the surface an issue with one is driven
+    //     from, so a narrower filter would strand `/retry` and `/cancel`;
     //   - `sender.type` refuses a bot, and the association refuses a
     //     non-maintainer.
     //
     // Everything `resolvePullRequestTrigger` refuses — a fork, a closed or merged
     // pull request, a branch the agent does not own — needs an API call and is
     // deliberately not attempted here.
-    expect(clausesOf(pullRequestArm)).toEqual([
+    const clauses = clausesOf(pullRequestArm)
+    expect([clauses[0], clauses[1], clauses[2], clauses.at(-2), clauses.at(-1)]).toEqual([
       "github.event_name == 'issue_comment'",
       "github.event.action == 'created'",
       'github.event.issue.pull_request != null',
-      "contains(github.event.comment.body, '/review')",
       "github.event.sender.type != 'Bot'",
       'contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'), github.event.comment.author_association)',
     ])
+    // The middle clause is the command group, and it is checked against the
+    // vocabulary rather than against a copy of itself: a command added to
+    // `SLASH_COMMANDS` and forgotten here is a command that silently never boots
+    // a runner from a pull request, which looks exactly like the agent ignoring
+    // somebody.
+    const commandGroup = clauses.slice(3, -2).join(' && ')
+    for (const command of SLASH_COMMANDS) {
+      expect(commandGroup).toContain(`contains(github.event.comment.body, '${command}')`)
+    }
   })
 
   test('reads the commenter rights on a pull request, never the fallback the issue arm uses', () => {

--- a/tests/review-loop/publish-fix.test.ts
+++ b/tests/review-loop/publish-fix.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { FIX_PUBLISHED_MARKER, publishFix } from '../../review-loop/src/publish-fix.js'
+import type { MergeResult } from '../../review-loop/src/worktree.js'
+
+const recorder = (): { events: string[]; log: { event: (message: string) => void } } => {
+  const events: string[] = []
+  return {
+    events,
+    log: {
+      event: (message): void => {
+        events.push(message)
+      },
+    },
+  }
+}
+
+describe('publishFix', () => {
+  test('merges the loop branch into the checkout and announces it on stdout', async () => {
+    const { events, log } = recorder()
+    const merged: Array<[string, string]> = []
+
+    await publishFix({
+      repoRoot: '/repo',
+      branch: 'review-loop/run-1',
+      log,
+      merge: (repoRoot, branch): Promise<MergeResult> => {
+        merged.push([repoRoot, branch])
+        return Promise.resolve({ ok: true })
+      },
+    })
+
+    expect(merged).toEqual([['/repo', 'review-loop/run-1']])
+    // The marker is the whole contract with the caller that runs this loop in
+    // CI: it is the moment a fix becomes something that can be pushed.
+    expect(events[0]?.startsWith(FIX_PUBLISHED_MARKER)).toBe(true)
+  })
+
+  test('a conflict is reported, not thrown: the run continues and the final merge decides', async () => {
+    const { events, log } = recorder()
+
+    await publishFix({
+      repoRoot: '/repo',
+      branch: 'review-loop/run-1',
+      log,
+      merge: (): Promise<MergeResult> => Promise.resolve({ ok: false, conflictFiles: ['src/a.ts'] }),
+    })
+
+    expect(events[0]).toContain('src/a.ts')
+    expect(events.some((event) => event.startsWith(FIX_PUBLISHED_MARKER))).toBe(false)
+  })
+
+  test('a merge that throws is reported, not thrown', async () => {
+    const { events, log } = recorder()
+
+    await publishFix({
+      repoRoot: '/repo',
+      branch: 'review-loop/run-1',
+      log,
+      merge: (): Promise<MergeResult> => Promise.reject(new Error('index.lock exists')),
+    })
+
+    expect(events[0]).toContain('index.lock exists')
+  })
+})

--- a/tests/review-loop/test-helpers.ts
+++ b/tests/review-loop/test-helpers.ts
@@ -52,6 +52,7 @@ export function createReviewLoopConfigFixture(
     workDir: path.join(repoRoot, '.review-loop'),
     maxRounds: 5,
     maxNoProgressRounds: 2,
+    mergeEachFix: false,
     agentTimeoutMs: 600_000,
     buildTimeoutMs: 600_000,
     checkCommand: 'bun check:full',

--- a/tests/review-loop/worker-pool.test.ts
+++ b/tests/review-loop/worker-pool.test.ts
@@ -205,6 +205,62 @@ test('mergeWorkerIntoPrimary reports numstat diff via onMergeDiff hook', async (
   await pool.close()
 })
 
+test('mergeWorkerIntoPrimary publishes the primary branch under the same lock', async () => {
+  const repoRoot = makeTempDir('pool-')
+  const config = createReviewLoopConfigFixture(repoRoot, { poolSize: 1 })
+  const runState = await createRunState(config, path.join(repoRoot, 'plan.md'))
+  await setupPrimary(repoRoot, runState.runId, runState.worktreePath)
+
+  const published: string[] = []
+  const pool = await createWorkerPool(config, runState, {
+    onPrimaryAdvanced: (branch: string) => {
+      published.push(branch)
+      return Promise.resolve()
+    },
+  })
+  const worker = await pool.acquire('src/a.ts')
+  writeFileSync(path.join(worker.worktreePath, 'src-a.ts'), 'one\n')
+  await execGit(worker.worktreePath, ['add', '.'])
+  await execGit(worker.worktreePath, ['commit', '-m', 'worker change'])
+
+  expect((await pool.mergeWorkerIntoPrimary(worker)).ok).toBe(true)
+  expect(published).toEqual([`review-loop/${runState.runId}`])
+
+  await pool.close()
+})
+
+test('a merge that conflicts publishes nothing', async () => {
+  const repoRoot = makeTempDir('pool-')
+  const config = createReviewLoopConfigFixture(repoRoot, { poolSize: 2 })
+  const runState = await createRunState(config, path.join(repoRoot, 'plan.md'))
+  await setupPrimary(repoRoot, runState.runId, runState.worktreePath)
+
+  const published: string[] = []
+  const pool = await createWorkerPool(config, runState, {
+    onPrimaryAdvanced: () => {
+      published.push('published')
+      return Promise.resolve()
+    },
+  })
+
+  // Two workers editing the same line of the same file: the second rebase
+  // conflicts, so nothing reaches the primary branch and nothing is announced.
+  const first = await pool.acquire('src/a.ts')
+  writeFileSync(path.join(first.worktreePath, 'shared.ts'), 'from-first\n')
+  await execGit(first.worktreePath, ['add', '.'])
+  await execGit(first.worktreePath, ['commit', '-m', 'first'])
+  const second = await pool.acquire('src/b.ts')
+  writeFileSync(path.join(second.worktreePath, 'shared.ts'), 'from-second\n')
+  await execGit(second.worktreePath, ['add', '.'])
+  await execGit(second.worktreePath, ['commit', '-m', 'second'])
+
+  expect((await pool.mergeWorkerIntoPrimary(first)).ok).toBe(true)
+  expect((await pool.mergeWorkerIntoPrimary(second)).ok).toBe(false)
+  expect(published).toEqual(['published'])
+
+  await pool.close()
+})
+
 test('mergeWorkerIntoPrimary without hooks still merges', async () => {
   const repoRoot = makeTempDir('pool-')
   const config = createReviewLoopConfigFixture(repoRoot, { poolSize: 1 })


### PR DESCRIPTION
The review phase never pushed the loop's findings. The loop commits its
fixes in its own worktree and merges them into the checkout itself, so
`commitAll` — which reports only what this process staged — answered
`null` whether it had found nothing or twenty things; the phase read that
as "nothing to apply", skipped the push, and the work died with the
runner. The branch is asked instead, either side of the loop.

Durability is now per fix rather than per run: `mergeEachFix` makes the
loop merge each accepted fix into the checkout as it lands and print
`[review-loop] published`, and the phase pushes on that marker. The push
stays on the pipeline's side of the pipe because the credential must
never be visible to a subprocess whose children the model controls.

The loop's output is streamed rather than buffered — into the public
Actions log as it arrives, and into the encrypted debug transcript
unabridged, which the review phase never fed at all because it opens no
OpenCode session. Run 31704544065 spent 60 minutes inside the loop
printing not one line before the runner was taken away.

A failed loop is described rather than numbered: a build gate, a runner
deadline, a missing binary, an unresolvable plan path and a merge
conflict were all `exited 1` beside sixty lines of tail. And the loop's
own deadline is now the shrink-to-fit-the-job bound a model turn gets,
so it stops while the pipeline can still report that it did.

Refs #268

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0182QRbdp7iMjASnNrrGRdJd