### PR TITLE
fix(opencode-agent): review with one worker, not two

### DIFF
--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -1465,7 +1465,7 @@ cannot drift.
 | `AGENT_REVIEW_COMMAND`                     | no       | detected                                        | JSON argv running the review loop; `none` disables it  |
 | `AGENT_CHECKS`                             | no       | lint / typecheck / test                         | JSON `[{ "name", "argv" }]` the CI-fix phase runs      |
 | `AGENT_REVIEW_MAX_ROUNDS`                  | no       | `4`                                             | review-loop rounds                                     |
-| `AGENT_REVIEW_POOL_SIZE`                   | no       | `2`                                             | review-loop worker pool                                |
+| `AGENT_REVIEW_POOL_SIZE`                   | no       | `1`                                             | review-loop worker pool                                |
 | `AGENT_CI_FIX_MAX_ROUNDS`                  | no       | `2`                                             | Repair rounds per CI-fix job                           |
 | `AGENT_COMMIT_REPAIR_MAX_ROUNDS`           | no       | `3`                                             | Commit attempts when the repo's own checks refuse one  |
 | `AGENT_MAX_CI_ATTEMPTS`                    | no       | `3`                                             | CI-fix jobs per pull request                           |
@@ -1513,7 +1513,11 @@ Every numeric knob is validated as an integer **and range-checked**, because
 rejecting non-integers only closes "not a number", never "a number that cannot
 work". Round counts accept 1–20, `AGENT_TIMEOUT_MS` accepts 1 000–7 200 000 (one
 second to two hours), `AGENT_MAX_TOKENS` accepts 50 000–1 000 000 000, and
-`AGENT_REVIEW_POOL_SIZE` accepts 1–16. `AGENT_TIMEOUT_MS=1`
+`AGENT_REVIEW_POOL_SIZE` accepts 1–16, and defaults to the bottom of that
+range deliberately: a review-loop worker is an `opencode run` **plus** a full
+`AGENT_CHECK_COMMAND`, so on a stock 4-vCPU runner two of them overlap into an
+OOM that takes the runner down before the pipeline can post anything. Raise it
+only where the build gate is cheap enough to overlap. `AGENT_TIMEOUT_MS=1`
 is a positive integer that kills every subprocess after a millisecond, so the
 pipeline reports every check as failing; `AGENT_REVIEW_MAX_ROUNDS=9007199254740991`
 is a positive integer that removes the bound the knob exists to impose. A

--- a/opencode-agent/src/config-values.ts
+++ b/opencode-agent/src/config-values.ts
@@ -3,6 +3,8 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import type { DiffLimits } from './diff-guard.js'
+
 /** Raised when the environment cannot produce a runnable configuration. */
 export class ConfigError extends Error {
   constructor(message: string) {
@@ -73,8 +75,36 @@ export const ROUND_RANGE: IntRange = { min: 1, max: 20 }
 export const FILES_RANGE: IntRange = { min: 1, max: 5_000 }
 export const LINES_RANGE: IntRange = { min: 1, max: 1_000_000 }
 
+/** Both halves of that shape, read together because neither means anything alone. */
+export const buildDiffLimits = (env: Env): DiffLimits => ({
+  maxFiles: boundedInt(env, 'AGENT_MAX_CHANGED_FILES', 100, FILES_RANGE),
+  maxLines: boundedInt(env, 'AGENT_MAX_CHANGED_LINES', 20_000, LINES_RANGE),
+})
+
 /** Concurrent `opencode run` subprocesses one runner can actually serve. */
 export const POOL_RANGE: IntRange = { min: 1, max: 16 }
+
+/**
+ * How many of those the review loop starts by default: one, the bottom of the
+ * range above.
+ *
+ * A review worker is not one `opencode run` — it is that plus a full
+ * `AGENT_CHECK_COMMAND`, and this repository's is `bun check:full`, which fans
+ * lint, typecheck, knip, format and the whole test suite out *in parallel* on
+ * its own. Two of those on one 4-vCPU runner is the OOM `scripts/check.sh`
+ * already documents for `bun test --parallel`, and it does not merely fail the
+ * gate: it takes the runner with it. Runs 31704544065 and 31745493737 both
+ * ended with the VM gone mid-review — exit 143 and "the runner has received a
+ * shutdown signal" on the first, and on the second not even a log, because
+ * nothing was left alive to upload one. No post-mortem, no transcript, no state
+ * comment; the issue simply stops.
+ *
+ * A serial pool is slower, and that is the whole trade. Review is bounded by
+ * `AGENT_REVIEW_MAX_ROUNDS` and the job deadline, and both of those report where
+ * they stopped; a killed runner reports nothing. `AGENT_REVIEW_POOL_SIZE` opens
+ * it back up for a repository whose build gate is cheap enough to overlap.
+ */
+export const DEFAULT_REVIEW_POOL_SIZE = 1
 
 /**
  * Model tokens one issue may spend across every job it runs.

--- a/opencode-agent/src/config.ts
+++ b/opencode-agent/src/config.ts
@@ -10,9 +10,10 @@ import { resolveReviewCommand } from './config-discovery.js'
 import {
   boundedInt,
   boundedIntOrNull,
+  buildDiffLimits,
+  DEFAULT_REVIEW_POOL_SIZE,
   DEFAULT_TURN_TIMEOUT_MS,
   EPOCH_MS_RANGE,
-  FILES_RANGE,
   JOB_MINUTES_RANGE,
   labelPrefix,
   LINES_RANGE,
@@ -275,7 +276,7 @@ export const loadConfig = (env: Env, repoRoot: string): PipelineConfig => {
     reviewCommand: resolveReviewCommand(env['AGENT_REVIEW_COMMAND'], repoRoot, existsSync),
     checks: parseChecks(env['AGENT_CHECKS']),
     reviewMaxRounds: boundedInt(env, 'AGENT_REVIEW_MAX_ROUNDS', 4, ROUND_RANGE),
-    reviewPoolSize: boundedInt(env, 'AGENT_REVIEW_POOL_SIZE', 2, POOL_RANGE),
+    reviewPoolSize: boundedInt(env, 'AGENT_REVIEW_POOL_SIZE', DEFAULT_REVIEW_POOL_SIZE, POOL_RANGE),
     agentTimeoutMs: boundedInt(env, 'AGENT_TIMEOUT_MS', DEFAULT_TURN_TIMEOUT_MS, TIMEOUT_RANGE),
     jobDeadlineMs: buildJobDeadline(env),
     teardownReserveMs: boundedInt(env, 'AGENT_TEARDOWN_RESERVE_MS', 180_000, RESERVE_RANGE),
@@ -291,10 +292,7 @@ export const loadConfig = (env: Env, repoRoot: string): PipelineConfig => {
     reviewHintLines: boundedInt(env, 'AGENT_REVIEW_HINT_LINES', 200, LINES_RANGE),
     maxAttempts: boundedInt(env, 'AGENT_MAX_ATTEMPTS', 5, ROUND_RANGE),
     maxTokens: boundedInt(env, 'AGENT_MAX_TOKENS', 5_000_000, TOKEN_RANGE),
-    diffLimits: {
-      maxFiles: boundedInt(env, 'AGENT_MAX_CHANGED_FILES', 100, FILES_RANGE),
-      maxLines: boundedInt(env, 'AGENT_MAX_CHANGED_LINES', 20_000, LINES_RANGE),
-    },
+    diffLimits: buildDiffLimits(env),
     skillRoots: DEFAULT_SKILL_ROOTS,
   }
 }

--- a/tests/opencode-agent/adapters.test.ts
+++ b/tests/opencode-agent/adapters.test.ts
@@ -1582,6 +1582,14 @@ describe('config', () => {
     expect(() => loadConfig({ ...baseEnv, AGENT_REVIEW_POOL_SIZE: '64' }, '/repo')).toThrow('between 1 and 16')
   })
 
+  test('the review pool defaults to one worker, because a second one kills the runner', () => {
+    // Not a preference: every fixer runs `check:full`, which itself fans its
+    // checks out in parallel, so a pool of 2 puts two of those on one 4-vCPU
+    // runner and the VM is OOM-killed mid-job. Runs 31704544065 and
+    // 31745493737 both died that way, and neither left a post-mortem.
+    expect(loadConfig(baseEnv, '/repo').reviewPoolSize).toBe(1)
+  })
+
   test.each([
     ['AGENT_REVIEW_MAX_ROUNDS', 'reviewMaxRounds'],
     ['AGENT_REVIEW_POOL_SIZE', 'reviewPoolSize'],


### PR DESCRIPTION
Two `/review` runs died with the runner gone rather than the phase failed —
31704544065 at minute 60 with exit 143 and "the runner has received a shutdown
signal", 31745493737 at minute 107 with no log uploaded at all, because nothing
was left alive to upload one. Neither left a post-mortem, a transcript or a
state comment; the issue simply stopped, and the only thing the second run's
job page carries is a step still marked in-progress.

A review worker is not one `opencode run` — it is that plus a full
`AGENT_CHECK_COMMAND`, and this repository's is `bun check:full`, which fans
lint, typecheck, knip, format and the whole test suite out in parallel on its
own. Two of those on one 4-vCPU runner is the OOM `scripts/check.sh` already
documents for `bun test --parallel`, and it takes the runner with it.

So the pool defaults to 1. Slower, and that is the whole trade: review is
bounded by `AGENT_REVIEW_MAX_ROUNDS` and the job deadline, and both of those
report where they stopped, where a killed runner reports nothing.
`AGENT_REVIEW_POOL_SIZE` still opens it back up for a repository whose build
gate is cheap enough to overlap.

`buildDiffLimits` moves to `config-values.ts` beside the two ranges it reads,
which is where the rest of the per-knob reading already lives.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PJpbvB4KRxpaDte67bM2m3