### PR TITLE
feat(sdd-runner): interactive gate flow + live estimated-cost footer

### DIFF
--- a/docs/architecture/sdd-pipeline.md
+++ b/docs/architecture/sdd-pipeline.md
@@ -17,7 +17,7 @@ INTAKE → DRAFT → REVIEW LOOP → DECOMPOSE → ATOMICITY → GATE → (exit)
 
 - **Intake**: depth classification (S/M/L), change scaffolding via `openspec new change`.
 - **Draft**: proposal, specs, design per the `auto-sdd` schema DAG.
-- **Review loop**: fresh-spawned reviewer agents per round, resolver pass, convergence predicate (0 BLOCKER, 0 MATERIAL, ≤3 NITPICK over post-resolution JSON).
+- **Review loop**: fresh-spawned reviewer agents per round, resolver pass, convergence predicate (0 BLOCKER, 0 MATERIAL, ≤3 NITPICK over post-resolution JSON). A nitpick-only cap-hit is treated as converged (see "Severity-based convergence" under Gate protocol).
 - **Decompose**: tasks.md generation.
 - **Atomicity**: split/merge tasks (skipped at S).
 - **Gate**: single human gate with checkbox protocol.
@@ -63,6 +63,31 @@ The gate is enterable at two points: an early cap-hit presentation (before decom
 - Write `ABORT` on its own line to abort.
 
 Bare approve with open blockers fails — override must be explicit.
+
+Every presentation carries a `### Decisions` block naming each decision's downstream effect, so no approval is consequence-blind.
+
+### Approve-continues semantics (**BREAKING**)
+
+Approving an **early** (cap-hit) gate no longer finalizes the run. It means "I accept the remaining findings as resolved — proceed": the pipeline continues into decompose → atomicity (depth ≠ S) → a **final** gate presented at `gate-<n+1>.md`, exactly as a converged review loop would (shared post-convergence tail, `post-review-tail.ts`). The human approved the *design* at the early gate; the final gate is where they sign off the *task list* — its digest renders `tasks: <done>/<total>`. Skipping it would trade one consequence-blind approval for another.
+
+Consequences:
+
+- No approval path produces a `completed` run without `tasks.md`. `completed` is reached only via final-gate approval; `aborted` is the only non-completing exit.
+- The final gate after an early approval carries the next gate version (`n+1`), preserving the versioned audit trail.
+- A stop-early outcome remains available as `ABORT`, which honestly records that the run did not complete.
+
+### Severity-based convergence
+
+A cap-hit round with **zero open BLOCKERs and zero open MATERIALs** — nitpicks only, each resolved or dismissed — is treated as converged at the orchestrator level (`runPostReviewToGate`) and flows into decompose → atomicity → final gate **without presenting an early gate**. The review loop itself keeps reporting `cap-hit`; reclassification lives in the orchestrator so the loop's semantics and sidecar formats are untouched. A cap-hit round with any open BLOCKER or MATERIAL still presents the early gate for human sign-off — unresolved blocker/material findings are never auto-accepted.
+
+### Resume
+
+`resume` re-enters at the interrupted stage, derived from artifacts and the event log rather than persisted stage pointers (`deriveResumePoint` — self-healing when `state.json` drifted from reality):
+
+- A pending gate short-circuits: the run is reported `gate-pending` and the operator is directed to the gate flow (`gate resume <runId>`).
+- The review loop counts as settled when a converged verdict is recorded, an early gate was answered by a human (approve = human-decree convergence), or the pipeline already entered decompose (severity convergence).
+- Missing `tasks.md` after a settled review → resume at `decompose`; `tasks.md` present at depth ≠ S without a recorded atomicity stage → resume at `atomicity`. Both continuations source the review result from the `resolutions-<round>.json` sidecars (`readReviewResultFromSidecars`) and run the shared post-convergence tail to the final gate, numbered after the highest existing `gate-<n>.md`.
+- Stages are idempotent by construction (decompose rewrites `tasks.md` wholesale; atomicity rewrites in place), so a spurious re-run after a crash-between-artifacts is wasted tokens, not corruption.
 
 ### Change digest
 

--- a/docs/architecture/sdd-pipeline.md
+++ b/docs/architecture/sdd-pipeline.md
@@ -54,7 +54,15 @@ Mid-run escalation only (M gains the skeptic lens when BLOCKERs remain open afte
 
 ## Gate protocol
 
-The gate is enterable at two points: an early cap-hit presentation (before decomposition, blockers-focused) and a final presentation (after atomicity, full digest). Both share a versioned `gate-<n>.md` file with a checkbox protocol:
+The gate is enterable at two points: an early cap-hit presentation (before decomposition, blockers-focused) and a final presentation (after atomicity, full digest). Both share a versioned `gate-<n>.md` file that is the single decision record and hash/audit anchor.
+
+### Deciding a gate (the three front-ends)
+
+**Primary path — interactive session (TTY).** `sdd-runner gate resume <runId>` (or `sdd-runner continue`) on a terminal opens a guided session (`gate-session.ts`, line-oriented prompts over `node:readline` — no TUI dependency): every finding and assumption is walked as an **accept / veto / inspect** prompt (inspect prints the item's evidence and blast radius; veto collects the redirect inline), cap-hit blockers prompt for a **free-text answer or `OVERRIDE`**, the trajectory ack (T1) is an affirm prompt, and the decision menu (approve / extend / abort) prints each choice's downstream consequence beside it — the same mode-conditional phrases the gate file's `### Decisions` block renders (`decisionConsequences` in `gate-render.ts`; one copy source, two front-ends). Approve is unavailable until T1 is affirmed and every blocker is answered. The session **writes** `gate-<n>.md` from the collected answers (`gate-answers.ts` renders the identical grammar the parser accepts, guarded by a write-then-parse self-check that refuses to proceed on any drift); abandoning (q / EOF) before the final decision writes nothing and the gate stays pending.
+
+**Flag path (non-TTY / CI / scripts).** Decision flags desugar to the same answers the session collects: `--confirm-all` (accept every item, answer every blocker with OVERRIDE, affirm the ack), repeatable `--veto <id>=<redirect>` (split on the first `=`; un-accepts that item with its redirect; unknown ids fail before any pipeline action), `--extend`, and `--abort`. `--extend` is rejected in combination with `--confirm-all`/`--veto`/`--abort`. Flags always win over prompting: a TTY with any decision flag never enters the session; non-TTY with no flags never prompts and parses the file as-is.
+
+**Power path — hand-edited file.** The file protocol is preserved verbatim; an operator who hand-edits `gate-<n>.md` and resumes on a non-terminal gets identical behavior to today:
 
 - Check every assumption box to **approve**.
 - Leave a box unchecked to **veto** (optional `→ <redirect>` beneath).
@@ -65,6 +73,10 @@ The gate is enterable at two points: an early cap-hit presentation (before decom
 Bare approve with open blockers fails — override must be explicit.
 
 Every presentation carries a `### Decisions` block naming each decision's downstream effect, so no approval is consequence-blind.
+
+### Pending-gate discovery and run-id ergonomics
+
+Multiple runs may be gate-pending concurrently, so every halt prints a next-step line with the full command and the concrete run id (`Next: sdd-runner gate resume <runId>`), copy-pasteable without editing. `sdd-runner gate` with no id lists all gate-pending runs (`listPendingGates` scans `runs/*/state.json` for a non-null `gate`, sorted by recency) with id, change name, gate version, and wait time; one pending run opens directly via `continue`. Run-id arguments accept exact ids and unambiguous prefixes (`resolveRunId`); an ambiguous prefix fails loudly listing every candidate. Prefixes are an interactive convenience — scripts should use full ids.
 
 ### Approve-continues semantics (**BREAKING**)
 
@@ -80,14 +92,16 @@ Consequences:
 
 A cap-hit round with **zero open BLOCKERs and zero open MATERIALs** — nitpicks only, each resolved or dismissed — is treated as converged at the orchestrator level (`runPostReviewToGate`) and flows into decompose → atomicity → final gate **without presenting an early gate**. The review loop itself keeps reporting `cap-hit`; reclassification lives in the orchestrator so the loop's semantics and sidecar formats are untouched. A cap-hit round with any open BLOCKER or MATERIAL still presents the early gate for human sign-off — unresolved blocker/material findings are never auto-accepted.
 
-### Resume
+### Resume and continue
 
 `resume` re-enters at the interrupted stage, derived from artifacts and the event log rather than persisted stage pointers (`deriveResumePoint` — self-healing when `state.json` drifted from reality):
 
-- A pending gate short-circuits: the run is reported `gate-pending` and the operator is directed to the gate flow (`gate resume <runId>`).
+- A pending gate is loud, not silent: `resume` on a gate-pending run prints that the run awaits a gate decision plus the exact `sdd-runner gate resume <runId>` command, then exits without side effects.
 - The review loop counts as settled when a converged verdict is recorded, an early gate was answered by a human (approve = human-decree convergence), or the pipeline already entered decompose (severity convergence).
 - Missing `tasks.md` after a settled review → resume at `decompose`; `tasks.md` present at depth ≠ S without a recorded atomicity stage → resume at `atomicity`. Both continuations source the review result from the `resolutions-<round>.json` sidecars (`readReviewResultFromSidecars`) and run the shared post-convergence tail to the final gate, numbered after the highest existing `gate-<n>.md`.
 - Stages are idempotent by construction (decompose rewrites `tasks.md` wholesale; atomicity rewrites in place), so a spurious re-run after a crash-between-artifacts is wasted tokens, not corruption.
+
+`continue` is the one routing verb that never fails silently (`continue.ts`): gate-pending → the gate flow (interactive session on a TTY, flag/file handling otherwise); interrupted mid-stage → the `resume` stage path; completed → a pointer to `sdd-runner report <runId>`. Without an id, a single gate-pending run routes directly and several print the per-run gate commands (a picker on TTY, a plain list otherwise) instead of guessing.
 
 ### Change digest
 
@@ -163,10 +177,13 @@ When the loop converges with surviving nitpicks (≤3 NITPICK findings), the fin
 
 ```bash
 bun run sdd-runner:start -- <task-file> [--depth S|M|L] [--verbosity brief|normal|debug]
+bun run sdd-runner:start -- continue [runId]
 bun run sdd-runner:start -- resume <runId>
-bun run sdd-runner:start -- gate resume <runId> [--confirm-all] [--abort]
+bun run sdd-runner:start -- gate [resume <runId> [--confirm-all] [--extend] [--veto <id>=<redirect>]... [--abort]]
 bun run sdd-runner:start -- report <runId> [--pr]
 ```
+
+`gate resume <runId>` opens the interactive session on a TTY; with decision flags, or on a non-terminal, it acts on flags or the hand-edited gate file alone. Bare `gate` lists pending gates. `continue` routes by run state (gate-pending → gate flow; interrupted mid-stage → stage resume; completed → report pointer).
 
 Or via the thin wrapper: `/sdd:auto <task-file>` _(not yet implemented — intended papai chat command that shells out to `sdd-runner:start`; use the `bun run` form above for now)_.
 

--- a/docs/architecture/sdd-pipeline.md
+++ b/docs/architecture/sdd-pipeline.md
@@ -42,7 +42,7 @@ The gate's `### Cost / duration` line carries a marker:
 - **estimated** — `costKnown: false` with non-zero cost; a FALLBACK median was applied.
 - **unknown** — `costKnown: false` with zero cost; resolve fell through to LAST RESORT.
 
-Network/parsing failures are swallowed: the resolver returns `null` for every model, so the gate degrades to `$0.00 · <walls>s · unknown` rather than halting. Pricing is a comfort feature, never a correctness gate. The live renderer's status line still shows emit-time (metered) cost; only the gate digest shows the aggregate (repriced) cost — a documented asymmetry.
+Network/parsing failures are swallowed: the resolver returns `null` for every model, so the gate degrades to `$0.00 · <walls>s · unknown` rather than halting. Pricing is a comfort feature, never a correctness gate. The live renderer's status line applies the same resolver at display time (see Live rendering) with a `~$` marker for estimated figures; only the gate digest shows the aggregate (repriced) cost with the full tristate marker.
 
 ## Depth profiles
 
@@ -194,7 +194,7 @@ Or via the thin wrapper: `/sdd:auto <task-file>` _(not yet implemented — inten
 - **Dynamic (TTY, `normal`/`debug`)** — `DynamicRenderer` (`sdd-runner/src/live-renderer.ts`) redraws a fixed-position block on every event instead of scrolling. Three zones:
   - **Pipeline map** (top) — the output of `renderPipelineMap(state)`, finally exercised live (it was tested but never called pre-change). One line per stage with `✓ done` / `▶ active (round n/cap)` / `· pending` / `— skipped` markers.
   - **Slot lines** (middle) — one per active agent, driven by the new L0 `tool_use` events: `<agent> ▶ <tool> <arg?>`. Cleared on that agent's `done`.
-  - **Status line** (bottom) — `round n/cap · in <tok> / out <tok> · $<cost> · <elapsed>`, accumulated from `done` and `step_finish` events.
+  - **Status line** (bottom) — `round n/cap · in <tok> / out <tok> · [$|~$]<cost> · <elapsed>`, accumulated from `step_finish` deltas only (the `done` event clears the agent's slot but no longer adds to totals — its `usage` is the sum of the same deltas, so counting both double-counted tokens and cost). Cost is metered (`$`, from `step_finish.costUsd`) unless any estimate contributed, in which case the marker is `~$`: `buildHarness` loads the models.dev pricing DB once (`buildResolveCost()`) and injects the resolver into `DynamicRenderer`, which prices each unmetered step (`costUsd: 0`, tokens > 0) via the agent's `spawned` model using the same `repriceEvent` formula as the gate. Estimation is display-time only — persisted events stay raw, and an unresolvable model or missing DB hides the segment exactly as before.
   The L0 events reach the renderer through a `ProgressReporter` adapter (`agent-reporter.ts`) wired into the `runAgent` call at `agent-layer.ts`; `slot()` parses the review-loop slot line and emits `tool_use`, `usage()` emits `step_finish`, and the other reporter methods are no-ops (the renderer owns the block). ANSI primitives are inlined from `review-loop/src/live-renderer.ts` rather than imported cross-workspace; the `shared-tui-renderer` proposal can consolidate them later.
 - **Line (non-TTY / `--verbosity brief`)** — `LineRenderer` (`renderer.ts`), byte-identical to the pre-change append-only output. This is the CI / pipe / log-file contract; the TTY check is hard-gated so a redirect never gets ANSI escapes. The one additive change for both modes: `done` now renders `<agent> done · in <tok> out <tok> · $<cost>` instead of bare `<agent> done`.
 

--- a/openspec/changes/sdd-runner-gate-interaction/.openspec.yaml
+++ b/openspec/changes/sdd-runner-gate-interaction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/sdd-runner-gate-interaction/design.md
+++ b/openspec/changes/sdd-runner-gate-interaction/design.md
@@ -1,0 +1,154 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Design: sdd-runner gate interaction
+
+## Context
+
+See `proposal.md` (Why / What). The load-bearing current state:
+
+- The gate contract is file-based: `presentGateAt` writes `gate-<n>.md` plus
+  `gate-hashes-<n>.json`; `resumeGate` (`gate.ts`) re-reads and parses the file
+  (`parseGateResponse` in `gate-model.ts`) and acts on the outcome. Nothing in
+  the runner reads stdin; the only human input channel is that file.
+- Run identity is the directory name under `.sdd-runner/runs/` — a 37-char
+  timestamp-plus-suffix that `loadRunState` joins verbatim; no listing,
+  prefix, or "latest" resolution exists.
+- `runResume` returns `{ halted: 'gate-pending' }` for a gate-pending run and
+  the CLI prints nothing for that result — the silent exit.
+- A dynamic TTY renderer already exists (`live-renderer.ts`), so terminal
+  output idioms (erase/redraw, styled lines) are established. Dependencies are
+  `p-limit` + `zod` only.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A gate decision is a guided interaction on a terminal, with zero protocol
+  knowledge required; the file becomes an audit artifact the session writes.
+- Every halt tells the operator the exact next command, run id included.
+- One routing verb (`continue`) that never fails silently.
+- Full non-interactive parity via flags for CI and scripts.
+- No new runtime dependencies.
+
+**Non-Goals:**
+
+- A full-screen TUI (cursor-addressable forms, mouse). Line-oriented prompts
+  are sufficient and testable via scripted stdin.
+- Changing gate *semantics* (what approve/extend/veto/abort do downstream) —
+  that is the sibling change `sdd-runner-pipeline-completion`; this change's
+  session prints consequences abstractly from the current pipeline state so
+  the two changes compose in either landing order.
+- Notifications beyond the terminal (desktop/Telegram push). Deferred; the
+  printed next-step is the notification contract.
+
+## Decisions
+
+### Decision 1 — The session writes the file; the parser stays the single reader
+
+The interactive session collects answers in memory, then **generates**
+`gate-<n>.md` via a new answer-rendering function that emits the *same grammar*
+the parser accepts (checked/unchecked checkbox lines, `→ <redirect>` lines
+beneath vetoed items, blocker answer lines, the extend directive) — deliberately
+not the presentation renderer, which renders unanswered gates. The existing
+`resumeGate` path then parses that file as usual. Generation is verified by a
+write-then-parse self-check: the session re-parses its own output with
+`parseGateResponse` and refuses to proceed if the parsed outcome differs from
+the collected answers. This keeps one grammar, one parser, one audit format —
+the session can never drift from the hand-edit path, and the hash/drift
+machinery (`gate-hashes-<n>.json`, which hashes change-directory artifacts, not
+the gate file) is untouched.
+
+Item kinds mirror the parser's three channels: assumptions and findings get
+accept / veto(+redirect) / inspect; cap-hit **blockers** get answer (free text)
+/ override; the **trajectory acknowledgment** (T1 at cap-hit gates) is an
+affirm prompt that gates the approve decision, mirroring the parser's
+`requiredAck` hard failure.
+
+**Alternative considered:** bypass the file and construct the `GateOutcome`
+directly from session answers. Rejected: it forks the contract (two producers
+of truth), loses the file as the audit record of *what was decided*, and
+complicates the drift check that keys off the file.
+
+### Decision 2 — Line-oriented prompts over `node:readline`, injectable for tests
+
+The session module depends on a tiny `prompter` interface (`ask(item) →
+answer`, `decide(options) → decision`) with two implementations:
+`readlinePrompter` (real TTY) and `scriptedPrompter` (answers from an array,
+for tests and `--yes`-style scripting). TTY detection (`process.stdin.isTTY`)
+selects interactivity; flags always win over prompting. This matches the
+repo's DI-first testing convention and avoids a TUI dependency.
+
+### Decision 3 — Pending-gate discovery scans run states
+
+A `listPendingGates(workDir)` helper scans `.sdd-runner/runs/*/state.json`,
+filters `gate !== null`, and returns `{ runId, changeName, gateVersion,
+updatedAt }` sorted by recency. Run-id arguments pass through a resolver:
+exact match → that run; else unique prefix among known runs; else error
+listing candidates. `gate` with no id uses the list: one pending → open it
+directly; several → picker on TTY, printed list with per-run commands
+otherwise.
+
+### Decision 4 — `continue` is a pure router; `resume` gets loud, not redefined
+
+`continue <runId>` maps `loadRunState` + gate field to the existing flows
+(gate-pending → `runGateResume` path; otherwise the stage-resume path of
+`runResume`; completed → report pointer). `continue` without an id uses the
+same discovery as bare `gate` (one pending or active run → route it; several →
+picker/list). `resume` keeps its meaning (stage
+resume) but its gate-pending branch now prints the gate command and run id.
+Keeping `resume` narrow avoids surprising scripts that may parse its output,
+while `continue` absorbs the "just do the right thing" intent.
+
+### Decision 5 — Flag composition mirrors the file grammar
+
+Flags desugar to the same answers the session collects: `--confirm-all` accepts
+every item; each `--veto <id>=<redirect>` (split on the *first* `=`, ids
+validated against the gate's item set, unknown id → error before any action)
+then un-accepts that item with its redirect; `--abort` and `--extend` map to
+their parser directives. `--extend` short-circuits in the parser, so combining
+it with `--confirm-all`/`--veto`/`--abort` is rejected as incoherent rather
+than silently ignored.
+
+### Decision 6 — Consequence text is sourced from pipeline state, not hardcoded
+
+The decision menu's consequence lines ("approve → …") are rendered from the
+run's gate mode and depth profile via a small descriptor the orchestrator
+already knows (early vs final gate, remaining stages), so when
+`sdd-runner-pipeline-completion` changes those semantics the session text
+changes with it — no string drift between the two changes.
+
+## Risks / Trade-offs
+
+- **[Session/parser skew]** the generator could emit a file the parser reads
+  differently → Mitigation: Decision 1's write-then-parse self-check fails
+  closed before any pipeline action.
+- **[readline quirks under Bun]** → Mitigation: the prompter interface is the
+  tested unit; the readline adapter stays thin; flags bypass it entirely.
+- **[Prefix resolution hides full ids in scripts]** → Mitigation: halt lines
+  and listings always print full ids; prefixes are an interactive convenience
+  only, and ambiguity fails loudly with candidates.
+- **[Two front-ends (session vs hand-edit) confuse which one "happened"]** →
+  Mitigation: the gate file is the single record either way; the session's
+  generated file is byte-identical in format to a hand edit, and the events
+  log records the outcome, not the input modality.
+
+## Migration Plan
+
+- Code-only. Gate files, run states, and the events log are format-compatible
+  both directions; an operator can hand-edit gate v1 and use the session on
+  v2 of the same run.
+- Rollout: land with tests (`tests/sdd-runner/`), rewrite the gate-protocol
+  section of `docs/architecture/sdd-pipeline.md` in the same change.
+- Rollback: revert; pending gates remain decidable by hand-editing (the
+  parser is untouched).
+
+## Open Questions
+
+- Whether `sdd-runner gate` with multiple pending runs should additionally
+  notify on `start` of a *new* run ("N other runs await gate decisions").
+  Deferrable polish; the listing covers discovery.

--- a/openspec/changes/sdd-runner-gate-interaction/proposal.md
+++ b/openspec/changes/sdd-runner-gate-interaction/proposal.md
@@ -1,0 +1,70 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Proposal: sdd-runner gate interaction
+
+## Why
+
+The gate is conceptually a dialog — the runner presents findings and assumptions,
+the human decides — but it is implemented as a document: hand-edit a markdown file,
+learn an unspoken checkbox protocol (unchecked means *veto*), type magic strings
+(`→ RUN 1 MORE`, bare-line `ABORT`), memorize a 37-char run id, and choose between
+two easily-confused resume verbs (`resume` exits *silently* on a gate-pending run).
+Every one of these failure modes was hit in a single real run. Adoption requires
+the human checkpoint to become an interaction, not homework.
+
+## What Changes
+
+- **Interactive gate session on TTY**: `sdd-runner gate resume <runId>` on a
+  terminal walks each finding and assumption as a prompt — accept / veto (typing
+  the redirect inline) / inspect evidence and blast radius — then offers the
+  decision (approve / extend / abort) with each choice's downstream effect printed
+  beside it. The session **writes** `gate-<n>.md` from the answers: the file
+  remains the audit record and hash anchor, but becomes an output of the
+  interaction instead of the input medium.
+- **Pending-gate discovery**: halting at a gate prints a next-step line that
+  always carries the concrete run id (multiple runs may be gate-pending at once).
+  `sdd-runner gate` with no id lists all gate-pending runs — an interactive picker
+  on TTY, a plain list otherwise. Exact ids and unambiguous prefixes keep working.
+- **`sdd-runner continue` smart verb**: inspects run state and routes —
+  gate-pending → gate session; interrupted mid-stage → stage resume; completed →
+  report pointer. `resume` on a gate-pending run prints a loud pointer to the
+  correct command instead of exiting silently.
+- **Non-TTY and CI path**: new `--extend` and repeatable `--veto <id>=<redirect>`
+  flags alongside the existing `--confirm-all` / `--abort`; interactive mode is
+  entered only on a TTY, flags otherwise. Hand-editing the gate file stays a
+  supported power path — the existing parser is retained.
+- No new runtime dependencies: prompts use `node:readline` under Bun.
+
+## Capabilities
+
+### New Capabilities
+
+- `sdd-runner-cli`: the runner's human-facing command and interaction surface —
+  gate session modes (interactive vs flags), pending-gate discovery and run-id
+  ergonomics, the `continue` routing verb, halt notification content, and the
+  gate-file audit contract.
+
+### Modified Capabilities
+
+None — `openspec/specs/` has no existing capability specs for the runner.
+
+## Impact
+
+- **Code:** `sdd-runner/src/cli.ts` (new verbs/flags), `sdd-runner/src/index.ts`
+  (USAGE), a new gate-session module (`node:readline`), `sdd-runner/src/gate.ts` /
+  `gate-model.ts` (answers → gate-file generation; parser retained for the
+  hand-edit path), `sdd-runner/src/orchestrator.ts` (loud gate-pending message,
+  halt next-step lines), `sdd-runner/src/run-state.ts` (scan `runs/` for
+  gate-pending states), `sdd-runner/src/renderer.ts` / `live-renderer.ts`
+  (session styling consistent with the existing TUI idiom).
+- **Docs:** `docs/architecture/sdd-pipeline.md` (gate protocol section rewritten
+  around the session; file protocol documented as the power path).
+- **Tests:** `tests/sdd-runner/` — session flows (scripted stdin), flag
+  equivalence with file edits, pending-gate discovery, `continue` routing.
+- **Compatibility:** all existing commands, flags, and the file-editing protocol
+  keep working unchanged.

--- a/openspec/changes/sdd-runner-gate-interaction/specs/sdd-runner-cli/spec.md
+++ b/openspec/changes/sdd-runner-gate-interaction/specs/sdd-runner-cli/spec.md
@@ -1,0 +1,145 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+## Purpose
+
+Defines the runner's human-facing interaction surface: how a gate decision is
+elicited (interactive session, flags, or hand-edited file), how pending gates
+are discovered without memorizing run ids, and how the CLI routes an operator to
+the right next step.
+
+## ADDED Requirements
+
+### Requirement: Interactive gate session on a terminal
+
+When a gate resume runs on a terminal, the runner SHALL present each finding and
+assumption as a prompt — accept, veto (entering the redirect inline), or inspect
+the item's evidence and blast radius — and SHALL then offer the gate decisions
+(approve, extend, abort) with each decision's downstream effect printed beside
+it. The session SHALL write the gate file from the collected answers: the file
+remains the audit record and hash anchor, produced by the interaction rather
+than edited by hand.
+
+#### Scenario: Guided walkthrough
+
+- **WHEN** an operator resumes a pending gate on a terminal
+- **THEN** each finding and assumption is presented with an
+  accept/veto/inspect prompt, and inspecting shows the item's evidence and
+  blast radius before deciding
+
+#### Scenario: Trajectory acknowledgment gates approval
+
+- **WHEN** the gate is an early (cap-hit) gate
+- **THEN** the walkthrough includes the trajectory acknowledgment, and approve
+  is unavailable until it is affirmed
+
+#### Scenario: Cap-hit blocker requires an answer
+
+- **WHEN** an early gate lists an open blocker
+- **THEN** the session prompts for a free-text answer or an explicit override,
+  and approve is unavailable while any blocker is unanswered
+
+#### Scenario: Session writes the gate file
+
+- **WHEN** the operator completes the prompts and picks a decision
+- **THEN** the gate file is written from those answers in the existing gate
+  format, and the pipeline acts on it exactly as if it had been hand-edited
+
+#### Scenario: Session interrupted leaves no partial state
+
+- **WHEN** the operator abandons a session before the final decision
+- **THEN** the gate file and run state are untouched and a later session starts
+  fresh
+
+### Requirement: Non-interactive flag path
+
+When standard input is not a terminal, or decision flags are passed, the runner
+SHALL NOT prompt and SHALL act on flags alone: the existing `--confirm-all` and
+`--abort`, plus a new `--extend` (run one more review round, then re-gate) and a
+repeatable `--veto <id>=<redirect>`. Flags SHALL produce outcomes identical to
+the equivalent hand-edited gate file.
+
+#### Scenario: Extend without file editing
+
+- **WHEN** `gate resume <runId> --extend` is invoked for a pending early gate
+- **THEN** one more review round runs and a new gate version is presented, with
+  no file edit required
+
+#### Scenario: Veto with redirect via flag
+
+- **WHEN** `gate resume <runId> --veto A1="reuse the encrypted config path"` is
+  invoked
+- **THEN** assumption A1 is vetoed with that redirect, the rework runs, and a new
+  gate version is presented
+
+#### Scenario: Flags compose predictably
+
+- **WHEN** `--confirm-all` is combined with `--veto` flags
+- **THEN** every item is accepted except the vetoed ids, which carry their
+  redirects; an unknown veto id fails before any pipeline action, and
+  `--extend` is rejected in combination with `--confirm-all`, `--veto`, or
+  `--abort`
+
+### Requirement: Pending-gate discovery and run-id ergonomics
+
+Whenever a run halts at a gate, the runner SHALL print a next-step line
+containing the exact resume command with that run's id, since multiple runs may
+be gate-pending concurrently. A bare `gate` command (no id) SHALL list all
+gate-pending runs — as an interactive picker on a terminal, as a plain list
+otherwise. Unambiguous id prefixes SHALL be accepted; an ambiguous prefix SHALL
+fail with the candidate ids listed.
+
+#### Scenario: Halt prints the concrete next step
+
+- **WHEN** a run halts at a gate
+- **THEN** the output includes a next-step line with the full resume command and
+  the run id, copy-pasteable without editing
+
+#### Scenario: Bare gate command lists pending runs
+
+- **WHEN** `gate` is invoked without a run id and two runs are gate-pending
+- **THEN** both are listed with id, change name, gate version, and wait time;
+  on a terminal the operator picks one to open its session
+
+#### Scenario: Ambiguous prefix fails loudly
+
+- **WHEN** a run-id prefix matches more than one gate-pending run
+- **THEN** the command fails and lists every matching candidate id
+
+### Requirement: One routing verb and a loud gate-pending signal
+
+A `continue` command SHALL inspect run state and route: gate-pending → the gate
+flow; interrupted mid-stage → stage resume; completed → a pointer to the report.
+Invoking `resume` for a gate-pending run SHALL print that the run awaits a gate
+decision together with the exact gate command and run id, rather than exiting
+silently.
+
+#### Scenario: Continue routes to the gate
+
+- **WHEN** `continue <runId>` is invoked for a gate-pending run
+- **THEN** the gate flow for that run is entered (session on a terminal, flag
+  handling otherwise)
+
+#### Scenario: Resume on a gate-pending run is loud
+
+- **WHEN** `resume <runId>` is invoked for a gate-pending run
+- **THEN** the output states the run awaits a gate decision and prints the exact
+  gate command with the run id
+
+### Requirement: Hand-edited gate file remains supported
+
+The existing gate-file format and parser SHALL be preserved: an operator who
+hand-edits the gate file (checkboxes, magic directives) gets identical behavior
+to today. The interactive session and flags are alternative front-ends over the
+same file contract.
+
+#### Scenario: Hand edit still parses
+
+- **WHEN** an operator hand-edits the gate file and resumes without flags on a
+  non-terminal input
+- **THEN** the file is parsed by the existing rules and the corresponding
+  outcome executes

--- a/openspec/changes/sdd-runner-gate-interaction/tasks.md
+++ b/openspec/changes/sdd-runner-gate-interaction/tasks.md
@@ -30,14 +30,14 @@ failing test before the implementation it covers.
 
 ## 4. CLI verbs, flags, and wiring (Decisions 4-5)
 
-- [ ] 4.1 Add failing tests in `tests/sdd-runner/cli.test.ts`: parse `--extend`; repeatable `--veto <id>=<redirect>` splitting on the first `=`; `--extend` rejected in combination with `--confirm-all`/`--veto`/`--abort`; bare `gate`; `continue` with and without a run id. Verify: `bun test tests/sdd-runner/cli.test.ts` (red)
-- [ ] 4.2 Implement the CLI parsing (including USAGE text in `index.ts`) until 4.1 is green. Verify: `bun test tests/sdd-runner/cli.test.ts tests/sdd-runner/index.test.ts`
-- [ ] 4.3 Add failing tests: `resume` on a gate-pending run prints that the run awaits a gate decision plus the exact gate command with the run id (no silent exit); halting at a gate prints a next-step line carrying the full resume command and run id. Verify: `bun test tests/sdd-runner/orchestrator.test.ts` (red)
-- [ ] 4.4 Implement the loud gate-pending message and the halt next-step line until 4.3 is green. Verify: `bun test tests/sdd-runner/orchestrator.test.ts`
-- [ ] 4.5 Add failing tests for the flag desugar: `--confirm-all` accepts all items then each `--veto` un-accepts its id with the redirect; an unknown veto id fails before any pipeline action; non-TTY input never prompts and acts on flags/file alone. Verify: `bun test tests/sdd-runner/gate-session.test.ts tests/sdd-runner/orchestrator.test.ts` (red)
-- [ ] 4.6 Wire the gate-resume entry: TTY with no decision flags → interactive session; otherwise the flags/file path — until 4.5 is green. Verify: `bun test tests/sdd-runner/gate-session.test.ts tests/sdd-runner/orchestrator.test.ts && bun run sdd-runner:typecheck`
-- [ ] 4.7 Add failing tests for `continue`: routes gate-pending → gate flow, interrupted-mid-stage → stage resume, completed → report pointer; with no id, a single pending/active run routes directly and several produce the picker on TTY or a plain list otherwise. Verify: `bun test tests/sdd-runner/cli.test.ts tests/sdd-runner/orchestrator.test.ts` (red)
-- [ ] 4.8 Implement the `continue` router until 4.7 is green. Verify: `bun test tests/sdd-runner`
+- [x] 4.1 Add failing tests in `tests/sdd-runner/cli.test.ts`: parse `--extend`; repeatable `--veto <id>=<redirect>` splitting on the first `=`; `--extend` rejected in combination with `--confirm-all`/`--veto`/`--abort`; bare `gate`; `continue` with and without a run id. Verify: `bun test tests/sdd-runner/cli.test.ts` (red)
+- [x] 4.2 Implement the CLI parsing (including USAGE text in `index.ts`) until 4.1 is green. Verify: `bun test tests/sdd-runner/cli.test.ts tests/sdd-runner/index.test.ts`
+- [x] 4.3 Add failing tests: `resume` on a gate-pending run prints that the run awaits a gate decision plus the exact gate command with the run id (no silent exit); halting at a gate prints a next-step line carrying the full resume command and run id. Verify: `bun test tests/sdd-runner/orchestrator.test.ts` (red)
+- [x] 4.4 Implement the loud gate-pending message and the halt next-step line until 4.3 is green. Verify: `bun test tests/sdd-runner/orchestrator.test.ts`
+- [x] 4.5 Add failing tests for the flag desugar: `--confirm-all` accepts all items then each `--veto` un-accepts its id with the redirect; an unknown veto id fails before any pipeline action; non-TTY input never prompts and acts on flags/file alone. Verify: `bun test tests/sdd-runner/gate-session.test.ts tests/sdd-runner/orchestrator.test.ts` (red)
+- [x] 4.6 Wire the gate-resume entry: TTY with no decision flags → interactive session; otherwise the flags/file path — until 4.5 is green. Verify: `bun test tests/sdd-runner/gate-session.test.ts tests/sdd-runner/orchestrator.test.ts && bun run sdd-runner:typecheck`
+- [x] 4.7 Add failing tests for `continue`: routes gate-pending → gate flow, interrupted-mid-stage → stage resume, completed → report pointer; with no id, a single pending/active run routes directly and several produce the picker on TTY or a plain list otherwise. Verify: `bun test tests/sdd-runner/cli.test.ts tests/sdd-runner/orchestrator.test.ts` (red)
+- [x] 4.8 Implement the `continue` router until 4.7 is green. Verify: `bun test tests/sdd-runner`
 
 ## 5. Session decision menu + shared consequence copy (Decision 6)
 

--- a/openspec/changes/sdd-runner-gate-interaction/tasks.md
+++ b/openspec/changes/sdd-runner-gate-interaction/tasks.md
@@ -41,8 +41,8 @@ failing test before the implementation it covers.
 
 ## 5. Session decision menu + shared consequence copy (Decision 6)
 
-- [ ] 5.1 Add a failing test: the session's decision menu prints consequence lines from the same mode-conditional copy source the gate file uses (early vs final wording matches; no duplicated strings). Verify: `bun test tests/sdd-runner/gate-session.test.ts` (red)
-- [ ] 5.2 Extract the consequence-lines helper from `gate-render.ts` into a shared module consumed by both the file renderer and the session until 5.1 is green and existing render tests stay green. Verify: `bun test tests/sdd-runner/gate-render.test.ts tests/sdd-runner/gate-session.test.ts`
+- [x] 5.1 Add a failing test: the session's decision menu prints consequence lines from the same mode-conditional copy source the gate file uses (early vs final wording matches; no duplicated strings). Verify: `bun test tests/sdd-runner/gate-session.test.ts` (red)
+- [x] 5.2 Extract the consequence-lines helper from `gate-render.ts` into a shared module consumed by both the file renderer and the session until 5.1 is green and existing render tests stay green. Verify: `bun test tests/sdd-runner/gate-render.test.ts tests/sdd-runner/gate-session.test.ts`
 
 ## 6. Docs + full verification
 

--- a/openspec/changes/sdd-runner-gate-interaction/tasks.md
+++ b/openspec/changes/sdd-runner-gate-interaction/tasks.md
@@ -46,5 +46,5 @@ failing test before the implementation it covers.
 
 ## 6. Docs + full verification
 
-- [ ] 6.1 Rewrite the gate-protocol section of `docs/architecture/sdd-pipeline.md`: the interactive session as the primary path, the hand-edited file as the power path, `continue`, the flag reference, and pending-gate discovery. Verify: `bunx openspec validate sdd-runner-gate-interaction --strict`
-- [ ] 6.2 Run the full gates. Verify: `bun test && bun run typecheck && bun run lint`
+- [x] 6.1 Rewrite the gate-protocol section of `docs/architecture/sdd-pipeline.md`: the interactive session as the primary path, the hand-edited file as the power path, `continue`, the flag reference, and pending-gate discovery. Verify: `bunx openspec validate sdd-runner-gate-interaction --strict`
+- [x] 6.2 Run the full gates. Verify: `bun test && bun run typecheck && bun run lint`

--- a/openspec/changes/sdd-runner-gate-interaction/tasks.md
+++ b/openspec/changes/sdd-runner-gate-interaction/tasks.md
@@ -1,0 +1,50 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Tasks: sdd-runner gate interaction
+
+Order: the answer renderer and session logic are pure units first; discovery,
+CLI surface, and wiring follow; shared consequence copy near the end (after the
+session exists to consume it); docs and full gates last. Test-first throughout:
+failing test before the implementation it covers.
+
+## 1. Answer rendering + round-trip self-check (Decision 1)
+
+- [x] 1.1 Add failing tests in `tests/sdd-runner/gate-answers.test.ts` (new): collected answers render to gate-file text that `parseGateResponse` reads back as the identical outcome — approve-all, veto with inline redirect, cap-hit blocker free-text answer, blocker OVERRIDE, the extend directive, ABORT, and the affirmed trajectory ack (T1). Verify: `bun test tests/sdd-runner/gate-answers.test.ts` (red)
+- [x] 1.2 Implement `sdd-runner/src/gate-answers.ts` (answers → gate-file grammar) until 1.1 is green; existing parser tests stay green. Verify: `bun test tests/sdd-runner/gate-answers.test.ts tests/sdd-runner/gate-model.test.ts`
+
+## 2. Prompter + session flow (Decisions 1-2)
+
+- [ ] 2.1 Add failing tests in `tests/sdd-runner/gate-session.test.ts` (new) over a scripted prompter: walkthrough covers every finding and assumption with accept/veto/inspect; inspect prints the item's evidence and blast radius; veto collects the redirect inline; a cap-hit blocker prompts for a free-text answer or explicit override; approve is unavailable until T1 is affirmed and all blockers are answered; abandoning the session before the final decision writes nothing. Verify: `bun test tests/sdd-runner/gate-session.test.ts` (red)
+- [ ] 2.2 Implement `sdd-runner/src/gate-session.ts` — the `prompter` interface, `scriptedPrompter`, and the session flow ending in gate-answers generation + the write-then-parse self-check — until 2.1 is green. Verify: `bun test tests/sdd-runner/gate-session.test.ts`
+- [ ] 2.3 Add the `readlinePrompter` adapter (`node:readline`, no new deps) and TTY detection, wired as the default prompter; keep it thin (behavior is covered via the scripted prompter). Verify: `bun run sdd-runner:typecheck && bun run sdd-runner:lint`
+
+## 3. Pending-gate discovery + run-id resolution (Decision 3)
+
+- [ ] 3.1 Add failing tests in `tests/sdd-runner/run-state.test.ts`: `listPendingGates` scans `runs/*/state.json`, keeps only gate-pending runs, and returns change name, gate version, and wait time sorted by recency; `resolveRunId` accepts exact ids and unambiguous prefixes, and fails on unknown ids and on ambiguous prefixes with the candidate ids listed. Verify: `bun test tests/sdd-runner/run-state.test.ts` (red)
+- [ ] 3.2 Implement `listPendingGates` and `resolveRunId` until 3.1 is green. Verify: `bun test tests/sdd-runner/run-state.test.ts`
+
+## 4. CLI verbs, flags, and wiring (Decisions 4-5)
+
+- [ ] 4.1 Add failing tests in `tests/sdd-runner/cli.test.ts`: parse `--extend`; repeatable `--veto <id>=<redirect>` splitting on the first `=`; `--extend` rejected in combination with `--confirm-all`/`--veto`/`--abort`; bare `gate`; `continue` with and without a run id. Verify: `bun test tests/sdd-runner/cli.test.ts` (red)
+- [ ] 4.2 Implement the CLI parsing (including USAGE text in `index.ts`) until 4.1 is green. Verify: `bun test tests/sdd-runner/cli.test.ts tests/sdd-runner/index.test.ts`
+- [ ] 4.3 Add failing tests: `resume` on a gate-pending run prints that the run awaits a gate decision plus the exact gate command with the run id (no silent exit); halting at a gate prints a next-step line carrying the full resume command and run id. Verify: `bun test tests/sdd-runner/orchestrator.test.ts` (red)
+- [ ] 4.4 Implement the loud gate-pending message and the halt next-step line until 4.3 is green. Verify: `bun test tests/sdd-runner/orchestrator.test.ts`
+- [ ] 4.5 Add failing tests for the flag desugar: `--confirm-all` accepts all items then each `--veto` un-accepts its id with the redirect; an unknown veto id fails before any pipeline action; non-TTY input never prompts and acts on flags/file alone. Verify: `bun test tests/sdd-runner/gate-session.test.ts tests/sdd-runner/orchestrator.test.ts` (red)
+- [ ] 4.6 Wire the gate-resume entry: TTY with no decision flags → interactive session; otherwise the flags/file path — until 4.5 is green. Verify: `bun test tests/sdd-runner/gate-session.test.ts tests/sdd-runner/orchestrator.test.ts && bun run sdd-runner:typecheck`
+- [ ] 4.7 Add failing tests for `continue`: routes gate-pending → gate flow, interrupted-mid-stage → stage resume, completed → report pointer; with no id, a single pending/active run routes directly and several produce the picker on TTY or a plain list otherwise. Verify: `bun test tests/sdd-runner/cli.test.ts tests/sdd-runner/orchestrator.test.ts` (red)
+- [ ] 4.8 Implement the `continue` router until 4.7 is green. Verify: `bun test tests/sdd-runner`
+
+## 5. Session decision menu + shared consequence copy (Decision 6)
+
+- [ ] 5.1 Add a failing test: the session's decision menu prints consequence lines from the same mode-conditional copy source the gate file uses (early vs final wording matches; no duplicated strings). Verify: `bun test tests/sdd-runner/gate-session.test.ts` (red)
+- [ ] 5.2 Extract the consequence-lines helper from `gate-render.ts` into a shared module consumed by both the file renderer and the session until 5.1 is green and existing render tests stay green. Verify: `bun test tests/sdd-runner/gate-render.test.ts tests/sdd-runner/gate-session.test.ts`
+
+## 6. Docs + full verification
+
+- [ ] 6.1 Rewrite the gate-protocol section of `docs/architecture/sdd-pipeline.md`: the interactive session as the primary path, the hand-edited file as the power path, `continue`, the flag reference, and pending-gate discovery. Verify: `bunx openspec validate sdd-runner-gate-interaction --strict`
+- [ ] 6.2 Run the full gates. Verify: `bun test && bun run typecheck && bun run lint`

--- a/openspec/changes/sdd-runner-gate-interaction/tasks.md
+++ b/openspec/changes/sdd-runner-gate-interaction/tasks.md
@@ -25,8 +25,8 @@ failing test before the implementation it covers.
 
 ## 3. Pending-gate discovery + run-id resolution (Decision 3)
 
-- [ ] 3.1 Add failing tests in `tests/sdd-runner/run-state.test.ts`: `listPendingGates` scans `runs/*/state.json`, keeps only gate-pending runs, and returns change name, gate version, and wait time sorted by recency; `resolveRunId` accepts exact ids and unambiguous prefixes, and fails on unknown ids and on ambiguous prefixes with the candidate ids listed. Verify: `bun test tests/sdd-runner/run-state.test.ts` (red)
-- [ ] 3.2 Implement `listPendingGates` and `resolveRunId` until 3.1 is green. Verify: `bun test tests/sdd-runner/run-state.test.ts`
+- [x] 3.1 Add failing tests in `tests/sdd-runner/run-state.test.ts`: `listPendingGates` scans `runs/*/state.json`, keeps only gate-pending runs, and returns change name, gate version, and wait time sorted by recency; `resolveRunId` accepts exact ids and unambiguous prefixes, and fails on unknown ids and on ambiguous prefixes with the candidate ids listed. Verify: `bun test tests/sdd-runner/run-state.test.ts` (red)
+- [x] 3.2 Implement `listPendingGates` and `resolveRunId` until 3.1 is green. Verify: `bun test tests/sdd-runner/run-state.test.ts`
 
 ## 4. CLI verbs, flags, and wiring (Decisions 4-5)
 

--- a/openspec/changes/sdd-runner-gate-interaction/tasks.md
+++ b/openspec/changes/sdd-runner-gate-interaction/tasks.md
@@ -19,9 +19,9 @@ failing test before the implementation it covers.
 
 ## 2. Prompter + session flow (Decisions 1-2)
 
-- [ ] 2.1 Add failing tests in `tests/sdd-runner/gate-session.test.ts` (new) over a scripted prompter: walkthrough covers every finding and assumption with accept/veto/inspect; inspect prints the item's evidence and blast radius; veto collects the redirect inline; a cap-hit blocker prompts for a free-text answer or explicit override; approve is unavailable until T1 is affirmed and all blockers are answered; abandoning the session before the final decision writes nothing. Verify: `bun test tests/sdd-runner/gate-session.test.ts` (red)
-- [ ] 2.2 Implement `sdd-runner/src/gate-session.ts` — the `prompter` interface, `scriptedPrompter`, and the session flow ending in gate-answers generation + the write-then-parse self-check — until 2.1 is green. Verify: `bun test tests/sdd-runner/gate-session.test.ts`
-- [ ] 2.3 Add the `readlinePrompter` adapter (`node:readline`, no new deps) and TTY detection, wired as the default prompter; keep it thin (behavior is covered via the scripted prompter). Verify: `bun run sdd-runner:typecheck && bun run sdd-runner:lint`
+- [x] 2.1 Add failing tests in `tests/sdd-runner/gate-session.test.ts` (new) over a scripted prompter: walkthrough covers every finding and assumption with accept/veto/inspect; inspect prints the item's evidence and blast radius; veto collects the redirect inline; a cap-hit blocker prompts for a free-text answer or explicit override; approve is unavailable until T1 is affirmed and all blockers are answered; abandoning the session before the final decision writes nothing. Verify: `bun test tests/sdd-runner/gate-session.test.ts` (red)
+- [x] 2.2 Implement `sdd-runner/src/gate-session.ts` — the `prompter` interface, `scriptedPrompter`, and the session flow ending in gate-answers generation + the write-then-parse self-check — until 2.1 is green. Verify: `bun test tests/sdd-runner/gate-session.test.ts`
+- [x] 2.3 Add the `readlinePrompter` adapter (`node:readline`, no new deps) and TTY detection, wired as the default prompter; keep it thin (behavior is covered via the scripted prompter). Verify: `bun run sdd-runner:typecheck && bun run sdd-runner:lint`
 
 ## 3. Pending-gate discovery + run-id resolution (Decision 3)
 

--- a/openspec/changes/sdd-runner-live-cost-estimate/.openspec.yaml
+++ b/openspec/changes/sdd-runner-live-cost-estimate/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-13
+skip_specs: true

--- a/openspec/changes/sdd-runner-live-cost-estimate/design.md
+++ b/openspec/changes/sdd-runner-live-cost-estimate/design.md
@@ -1,0 +1,63 @@
+## Context
+
+See proposal.md — Why. Current state, established by tracing the cost data flow:
+
+- `DynamicRenderer.track()` (`sdd-runner/src/live-renderer.ts:86-106`) accumulates the footer totals from raw event payloads only: `step_finish.costUsd` (opencode's own metering, 0 for unmetered models) **and** `done.usage.costUsd` — the latter being the sum of the former's deltas (`review-loop/src/line-handler.ts:72-75`), so both tokens and cost are double-counted for metered models today.
+- The models.dev fallback resolver (`pricing.ts: resolveCost/loadDb`, wrapped as `buildResolveCost()` in `gate-digest.ts:229-236`) is only consumed by `presentGateAt`. `createRenderer(stream, verbosity, opts?)` (`renderer.ts:144`) has no pricing input.
+- `step_finish` events carry no `model` field (`events.ts:46-56`); the agent→model association is recoverable from `spawned` events, the same approach `repriceEvents` uses (`usage-aggregate.ts:29-32`). `spawned` is always emitted before the agent's first `step_finish` (`agent-layer.ts:139` precedes `runAgent`).
+- `buildHarness` (`index.ts:95`) is already async and constructs the renderer; `buildResolveCost()` already degrades to `() => null` on fetch/parse failure.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Live footer shows a cost figure for unmetered models when the pricing DB can resolve the model (primary or median fallback).
+- Estimated figures are visually distinguishable from metered ones.
+- Live totals count each token/dollar exactly once.
+- Zero change to persisted events, gate digest, or LineRenderer output bytes.
+
+**Non-Goals:**
+
+- Emit-time repricing or event-schema changes (display-time only).
+- Repricing the LineRenderer `done` line (it prints the raw metered `usage.costUsd`; the gate digest already reports the fallback-priced aggregate).
+- Surfacing `cache_read`/`cache_write` pricing (consistent with `sdd-runner-cost-fallback`).
+
+## Decisions
+
+### D1 — Estimate at display time, not emit time
+
+The resolver is injected into the renderer; `events.ndjson` keeps raw metered values. Alternative considered: reprice inside `agent-reporter`/`agent-layer` at emission. Rejected because (a) emission is synchronous while the DB load is async, pushing pricing knowledge into the agent layer; (b) persisted events would become indistinguishable from metered ones, collapsing the gate's `metered|estimated|unknown` marker to always-`metered` — a real information loss. Display-time estimation composes with the gate's aggregate-time reprice: same formula, same resolver, independent layers.
+
+### D2 — Accumulate totals from `step_finish` only; `done` clears the slot
+
+`track()` drops the `done` branch's totals accumulation (keeping `slots.delete`). This fixes the double-count and is what makes per-step estimation coherent: each delta is priced once, as it arrives. The alternative — accumulate from `done` only — would freeze the footer at zero for the entire duration of a long agent run, defeating the live display.
+
+### D3 — Per-step estimation with a `spawned`-event agent→model map
+
+`DynamicRenderer` keeps `agentModels: Map<string, string>` populated on `spawned`. On `step_finish` with `costUsd === 0` and any token field > 0, it resolves the model and computes `((input + reasoning) * cost.input + output * cost.output) / 1_000_000` — the exact `repriceEvent` formula, so live and gate figures agree. Unresolvable model or `resolveCost → null` contributes 0 (segment hidden, today's behavior). Alternative considered: adding `model` to the `step_finish` event schema (the data exists in `UsageDelta`). Rejected as an event-schema change for a display concern; the spawned-event map already carries the association and is replay-safe.
+
+### D4 — `~$` marker, tracked as a sticky flag
+
+The renderer records `costEstimated = true` the first time any estimate contributes to the total. `statusLine()` renders `~$X.XXXX` when the flag is set, `$X.XXXX` otherwise. A run mixing metered and estimated agents shows `~$` — conservative, matches the gate's tristate collapsing to `estimated`. Alternative considered: per-agent markers. Rejected — the footer is a single aggregate line; per-agent provenance is available in `events.ndjson`.
+
+### D5 — Resolver threaded through `createRenderer` options
+
+`RendererOptions` gains `resolveCost?: ResolveCostFn`; `createRenderer` passes it to `DynamicRenderer` only (LineRenderer output is byte-frozen). `buildHarness` calls `await buildResolveCost()` once and passes it in. One DB load per CLI invocation, shared with no one — the gate path keeps calling `buildResolveCost()` itself (cache TTL makes the second load a disk read). Alternative considered: sharing one resolver between renderer and gate via `OrchestratorDeps.resolveCost`. Rejected — `OrchestratorDeps.resolveCost` is a test seam for the gate; coupling the renderer's lifetime to it buys nothing.
+
+## Risks / Trade-offs
+
+- [Stale or missing pricing DB shows no cost, looking like a regression for metered-leaning users] → Degradation is identical to today's behavior (segment hidden); `buildResolveCost` already swallows fetch failures.
+- [Median-fallback prices can over/understate the subscription model's true cost] → Inherent to the fallback accepted in `sdd-runner-cost-fallback`; the `~$` marker signals estimate status live, mirroring the gate's `estimated` marker.
+- [Footer width grows with the new segment on narrow terminals] → Existing `fit()` truncation already caps every rendered line at `stream.columns`.
+
+## Migration Plan
+
+Pure dev-tooling change; no data migration. Old `events.ndjson` logs replay identically (renderer state derives from the same event stream). Rollback is a revert; no persisted state depends on the new code.
+
+## Hook/TDD interactions
+
+All edited files (`sdd-runner/src/live-renderer.ts`, `renderer.ts`, `index.ts`) are gateable implementation code mapped to `tests/sdd-runner/` by the TDD hook pipeline — test-first order: extend `tests/sdd-runner/live-renderer.test.ts` and `tests/sdd-runner/renderer.test.ts` with failing cases before touching `src/`. `oxlint` has `max-lines`/`max-lines-per-function` disabled repo-wide, so no line-budget pressure, but keep the new logic in small private methods per house style.
+
+## Scope-model / gating impact
+
+No new tool surface, no capability gating, no `tool_prefs` interaction. No persisted state keyed by any context id — the only state is in-memory renderer fields for the duration of the CLI process. No DB changes. No new dependencies (the pricing DB fetch already exists in `pricing.ts`).

--- a/openspec/changes/sdd-runner-live-cost-estimate/proposal.md
+++ b/openspec/changes/sdd-runner-live-cost-estimate/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`sdd-runner`'s live status line never shows a cost figure for unmetered models. On a `zai-coding-plan/glm-5.2` run the footer reads `in 47.1k / out 1.4k · 2m53s` with no `$` segment, even though the models.dev median-fallback pricing shipped in `sdd-runner-cost-fallback` would produce a non-zero estimate. Root cause: the fallback `ResolveCostFn` is wired only into the gate path (`presentGateAt` → `buildResolveCost` → `aggregateUsage`); the `DynamicRenderer` accumulates cost purely from raw event payloads, which are `costUsd: 0` when opencode doesn't meter the model, and `statusLine()` hides the segment when the total is zero. While tracing this we also found the live totals double-count: `track()` adds both per-step `step_finish` deltas and the cumulative `done.usage` (which is the sum of those same deltas), inflating tokens and cost for metered models.
+
+## What Changes
+
+- **Live cost estimate**: `DynamicRenderer` gains an optional `ResolveCostFn`. Per `step_finish` with `costUsd === 0` and tokens > 0, it estimates cost from the pricing DB using the agent→model map built from `spawned` events (same mapping `repriceEvents` uses), with the same formula as `repriceEvent`. The status line renders estimated cost with a `~$` prefix; metered cost keeps the plain `$` prefix.
+- **Double-count fix**: live token/cost totals accumulate from `step_finish` deltas only; the `done` event stops contributing to totals (it still clears the agent slot). `done.usage` remains the authoritative per-agent figure for the LineRenderer `done` line and the gate aggregate.
+- **Wiring**: `buildHarness` (already async) loads the pricing DB once via `buildResolveCost()` and threads the resolver through `createRenderer` into `DynamicRenderer`; on fetch failure the resolver degrades to `() => null` and the status line falls back to today's behavior (cost segment hidden).
+- Events on disk stay raw (metered truth): no event-schema change, no emit-time repricing, gate digest semantics (`metered|estimated|unknown`) untouched.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `sdd-automation` (delta-ADDED by `openspec/changes/auto-sdd-pipeline/specs/sdd-automation/spec.md`, not yet archived to `openspec/specs/`): `skip_specs: true` per the precedent set by `sdd-runner-cost-fallback` and `sdd-veto-resolver-pass`. No event-schema or gate-protocol change; the live footer is a rendering concern below the spec's altitude contract.
+
+## Non-goals
+
+- No repricing of persisted events — `events.ndjson` keeps opencode-metered values; estimation is display-time only.
+- No change to the LineRenderer `done` line format or the gate digest cost line.
+- No cache_read/cache_write token pricing (unchanged from `sdd-runner-cost-fallback`).
+- No effect on platform/task instances, the scope model, `tool_prefs`, or capability gating. Runner-internal dev tool.
+
+## Impact
+
+- **Code**: `sdd-runner/src/live-renderer.ts` (resolver dep, agent→model map, per-step estimate, `~$` marker, drop `done` from totals), `sdd-runner/src/renderer.ts` (`createRenderer` options gain `resolveCost`), `sdd-runner/src/index.ts` (`buildHarness` loads DB once and passes resolver).
+- **Tests**: `tests/sdd-runner/live-renderer.test.ts` (estimated-cost cases: fallback used, metered untouched, resolver null → hidden, double-count regression), `tests/sdd-runner/renderer.test.ts` (option threading).
+- **Docs**: `docs/architecture/sdd-pipeline.md` — note the live footer's estimated-cost segment.
+- **Affected platform/task instances**: none. **Config-context scope impact**: none — runner-internal dev tool.

--- a/openspec/changes/sdd-runner-live-cost-estimate/tasks.md
+++ b/openspec/changes/sdd-runner-live-cost-estimate/tasks.md
@@ -1,0 +1,16 @@
+## 1. Live renderer estimation (test-first)
+
+- [x] 1.1 Add failing tests to `tests/sdd-runner/live-renderer.test.ts`: (a) `step_finish` with `costUsd: 0` and tokens > 0 resolves the agent's model from the prior `spawned` event and adds the estimated cost to the footer with a `~$` prefix; (b) metered `step_finish` (`costUsd > 0`) renders `$` without `~`; (c) resolver returning `null` hides the cost segment (current behavior); (d) mixed metered + estimated steps render `~$`; (e) no resolver passed → byte-identical footer to today. Verify: `bun test tests/sdd-runner/live-renderer.test.ts` (new cases fail)
+- [x] 1.2 Add failing double-count regression test to `tests/sdd-runner/live-renderer.test.ts`: a `step_finish` sequence followed by `done` (whose `usage` equals the sum of the step deltas) leaves footer tokens/cost equal to the step sum, not twice it. Verify: `bun test tests/sdd-runner/live-renderer.test.ts` (fails)
+- [x] 1.3 Implement in `sdd-runner/src/live-renderer.ts`: optional `ResolveCostFn` constructor dep, `agentModels` map fed by `spawned` events, per-`step_finish` estimate using the `repriceEvent` formula `((input + reasoning) * cost.input + output * cost.output) / 1_000_000`, sticky `costEstimated` flag, `~$` marker in `statusLine()`, and removal of the `done` branch's totals accumulation (slot delete stays). Verify: `bun test tests/sdd-runner/live-renderer.test.ts` (all pass)
+
+## 2. Wiring
+
+- [ ] 2.1 Add failing tests to `tests/sdd-runner/renderer.test.ts`: `createRenderer` forwards `opts.resolveCost` to `DynamicRenderer` (observable via an estimated-cost footer on a TTY fake stream) and ignores it for `LineRenderer`. Verify: `bun test tests/sdd-runner/renderer.test.ts` (fails)
+- [ ] 2.2 Extend `RendererOptions` with `resolveCost?: ResolveCostFn` in `sdd-runner/src/renderer.ts` and thread it into the `DynamicRenderer` constructor in `createRenderer`. Verify: `bun test tests/sdd-runner/renderer.test.ts tests/sdd-runner/live-renderer.test.ts`
+- [ ] 2.3 In `sdd-runner/src/index.ts` `buildHarness`, call `await buildResolveCost()` once and pass the resolver via `createRenderer(process.stdout, verbosity, { resolveCost })`. Verify: `bun run sdd-runner:typecheck` and `bun test tests/sdd-runner/index.test.ts`
+
+## 3. Full verification and docs
+
+- [ ] 3.1 Update `docs/architecture/sdd-pipeline.md`: note the live footer's estimated-cost segment (`~$` marker, display-time only, events stay raw). Verify: `openspec validate sdd-runner-live-cost-estimate --strict`
+- [ ] 3.2 Run full gates: `bun run test`, `bun run typecheck`, `bun run sdd-runner:lint`, `bun run sdd-runner:format:check`. Verify: all green

--- a/openspec/changes/sdd-runner-live-cost-estimate/tasks.md
+++ b/openspec/changes/sdd-runner-live-cost-estimate/tasks.md
@@ -12,5 +12,5 @@
 
 ## 3. Full verification and docs
 
-- [ ] 3.1 Update `docs/architecture/sdd-pipeline.md`: note the live footer's estimated-cost segment (`~$` marker, display-time only, events stay raw). Verify: `openspec validate sdd-runner-live-cost-estimate --strict`
-- [ ] 3.2 Run full gates: `bun run test`, `bun run typecheck`, `bun run sdd-runner:lint`, `bun run sdd-runner:format:check`. Verify: all green
+- [x] 3.1 Update `docs/architecture/sdd-pipeline.md`: note the live footer's estimated-cost segment (`~$` marker, display-time only, events stay raw). Verify: `openspec validate sdd-runner-live-cost-estimate --strict`
+- [x] 3.2 Run full gates: `bun run test`, `bun run typecheck`, `bun run sdd-runner:lint`, `bun run sdd-runner:format:check`. Verify: all green

--- a/openspec/changes/sdd-runner-live-cost-estimate/tasks.md
+++ b/openspec/changes/sdd-runner-live-cost-estimate/tasks.md
@@ -6,9 +6,9 @@
 
 ## 2. Wiring
 
-- [ ] 2.1 Add failing tests to `tests/sdd-runner/renderer.test.ts`: `createRenderer` forwards `opts.resolveCost` to `DynamicRenderer` (observable via an estimated-cost footer on a TTY fake stream) and ignores it for `LineRenderer`. Verify: `bun test tests/sdd-runner/renderer.test.ts` (fails)
-- [ ] 2.2 Extend `RendererOptions` with `resolveCost?: ResolveCostFn` in `sdd-runner/src/renderer.ts` and thread it into the `DynamicRenderer` constructor in `createRenderer`. Verify: `bun test tests/sdd-runner/renderer.test.ts tests/sdd-runner/live-renderer.test.ts`
-- [ ] 2.3 In `sdd-runner/src/index.ts` `buildHarness`, call `await buildResolveCost()` once and pass the resolver via `createRenderer(process.stdout, verbosity, { resolveCost })`. Verify: `bun run sdd-runner:typecheck` and `bun test tests/sdd-runner/index.test.ts`
+- [x] 2.1 Add failing tests to `tests/sdd-runner/renderer.test.ts`: `createRenderer` forwards `opts.resolveCost` to `DynamicRenderer` (observable via an estimated-cost footer on a TTY fake stream) and ignores it for `LineRenderer`. Verify: `bun test tests/sdd-runner/renderer.test.ts` (fails)
+- [x] 2.2 Extend `RendererOptions` with `resolveCost?: ResolveCostFn` in `sdd-runner/src/renderer.ts` and thread it into the `DynamicRenderer` constructor in `createRenderer`. Verify: `bun test tests/sdd-runner/renderer.test.ts tests/sdd-runner/live-renderer.test.ts`
+- [x] 2.3 In `sdd-runner/src/index.ts` `buildHarness`, call `await buildResolveCost()` once and pass the resolver via `createRenderer(process.stdout, verbosity, { resolveCost })`. Verify: `bun run sdd-runner:typecheck` and `bun test tests/sdd-runner/index.test.ts`
 
 ## 3. Full verification and docs
 

--- a/openspec/changes/sdd-runner-pipeline-completion/.openspec.yaml
+++ b/openspec/changes/sdd-runner-pipeline-completion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/sdd-runner-pipeline-completion/design.md
+++ b/openspec/changes/sdd-runner-pipeline-completion/design.md
@@ -1,0 +1,151 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Design: sdd-runner pipeline completion
+
+## Context
+
+See `proposal.md` (Why / What). The load-bearing current state:
+
+- `runPostReviewToGate` (`orchestrator.ts`) short-circuits on `cap-hit`:
+  `presentGateAt(..., 'early')` runs **instead of** `runDecomposeStages`, so an
+  early-gate presentation always means decompose never ran.
+- `runGateResume` on an `approved` outcome calls `finalizeGate`
+  (`gate-digest.ts`), which only stamps `status: 'completed'` and clears the
+  gate — a terminus with no continuation hook.
+- `resume` (`orchestrator.ts`) re-enters at `review` only; any other derived
+  resume point throws `not supported yet`.
+- `runExtendRound` (`extend-round.ts`) already contains the post-convergence
+  path used after an extended round: decompose → atomicity (depth ≠ S) → final
+  gate at version `n+1` (`runPostExtendConverged`).
+- The review loop's result (`ReviewLoopResult`) carries per-round findings with
+  classes (`BLOCKER`/`MATERIAL`/`NITPICK`) and resolutions (`edited` /
+  `evidence-answered` / `dismissed`), persisted in `findings-N.json` /
+  `resolutions-N.json` sidecars.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- No completed run without `tasks.md`; approval always advances the pipeline.
+- Reuse the existing post-convergence path rather than growing a second one.
+- Keep the human gate as the only place unresolved BLOCKER/MATERIAL findings are
+  accepted; never auto-approve those.
+- Resume coverage for every stage the pipeline can halt in.
+
+**Non-Goals:**
+
+- Changing what the reviewer/skeptic/resolver produce per round (finding
+  classes, resolution kinds) — only how the orchestrator interprets a capped
+  round.
+- Auto-approval policies for unattended runs (deferred; the gate stays human).
+- Reworking the gate document format — copy changes only (the interaction
+  overhaul is the sibling change `sdd-runner-gate-interaction`).
+- Reopening already-completed historical runs.
+
+## Decisions
+
+### Decision 1 — Approval becomes a continuation, not a terminus
+
+Replace the `finalizeGate(deps, state, 'completed', version)` call on the
+`approved` outcome with a continuation that runs the existing post-review tail:
+decompose → atomicity (depth ≠ S) → final gate at `version + 1`. Concretely,
+`runGateResume` on `approved` routes into the same function `runExtendRound`
+uses after convergence (today `runPostExtendConverged`), which is hoisted into a
+shared stage module. `finalizeGate` is then called only when the **final** gate
+is approved (or on abort at any gate).
+
+The final gate is not skipped after an early approval: the human approved the
+*design* at the early gate; the final gate is where they sign off the *task
+list* (its digest renders `tasks: <done>/<total>`). Skipping it would trade one
+consequence-blind approval for another.
+
+**Alternative considered:** keep approve-means-stop and add a third gate
+decision (`approve-and-continue`). Rejected: "approve" that silently amputates
+output is the trap being fixed; a stop-early outcome is still available as
+`abort`, which honestly records that the run did not complete.
+
+### Decision 2 — Severity-based convergence is an orchestrator-level verdict
+
+Where `runPostReviewToGate` currently branches on `outcome === 'cap-hit'`, it
+additionally inspects the round's open findings: if none are class `BLOCKER` or
+`MATERIAL` (nitpick-only, all resolved or dismissed), the branch is treated as
+converged and falls through to decompose. The review loop itself keeps reporting
+`cap-hit`; reclassification lives in the orchestrator so the loop's semantics
+(and its sidecar formats) are untouched.
+
+"Open" means the `ReviewLoopResult` `openBlockers` / `openMaterial` /
+`openNitpicks` lists — findings raised in the final round, after that round's
+resolver pass (the same lists `presentGateAt` renders from via `findingsOf`).
+Resolved-then-rippled findings (a fix that spawns a smaller finding next round)
+are unaffected: the ripple is a new finding in a new round and is classified on
+its own merits.
+
+**Alternative considered:** severity-based convergence inside the review loop
+(a new `converged-severity` outcome). Rejected: it changes the loop's contract
+and every consumer of `ReviewLoopResult`; the orchestrator branch is the
+single, auditable place the cap-hit verdict is acted on.
+
+### Decision 3 — Resume derives post-review stages from artifacts on disk
+
+`deriveResumePoint` gains stages beyond `review`: if `tasks.md` is absent and no
+final gate was presented, resume at `decompose`; if `tasks.md` exists and depth
+≠ S but the atomicity report is absent, resume at `atomicity`; a pending gate
+keeps the existing `gate-pending` result (the CLI directs to the gate flow).
+Derivation uses the change directory plus sidecar reports — the same evidence
+the stages themselves produce — so no new state fields are persisted. The
+`resume` error for non-review stages is removed; each newly resumable stage
+rebuilds its `StageContext` exactly as the fresh pipeline does.
+
+**Alternative considered:** persist an explicit `nextStage` field in
+`state.json`. Rejected: state.json already drifts from reality on interrupted
+runs (it is saved *between* stages); artifact-derived resume points are
+self-healing and need no migration.
+
+### Decision 4 — Gate copy states consequences
+
+The gate renderer's header lines are extended so each decision line names its
+downstream effect (approve → decomposition + atomicity + final gate; extend →
+one more review round, then re-gate; veto → rework + re-gate; abort → end). The
+parser is untouched; this is renderer-only copy, verified by snapshot-style
+assertions on the rendered markdown.
+
+## Risks / Trade-offs
+
+- **[Early approval now spends decompose/atomicity tokens the operator may not
+  have wanted]** → Mitigation: the gate copy (Decision 4) states the cost
+  bearing consequence up front; `abort` remains the no-more-spend exit; the
+  final gate is a second human checkpoint before completion.
+- **[Severity convergence trusts the reviewer's class assignments]** a MATERIAL
+  misclassified as nitpick would slip past the early gate → Mitigation:
+  classification is already human-visible in the final gate's trajectory and
+  nitpick list; the final gate remains human-signed, so nothing reaches
+  `completed` without human eyes on the full digest.
+- **[Resume-from-artifacts may re-run a stage that completed but failed to
+  record]** (e.g. crash after writing `tasks.md` before the atomicity report) →
+  Mitigation: stages are idempotent by construction (decompose rewrites
+  `tasks.md` wholesale; atomicity rewrites in place), so a spurious re-run is
+  wasted tokens, not corruption.
+- **[Breaking semantic change for anyone habituated to approve-means-stop]** →
+  Mitigation: documented in `docs/architecture/sdd-pipeline.md`; the behavior
+  change is announced in the gate copy itself at the moment of decision.
+
+## Migration Plan
+
+- No persisted-state migration: `state.json` schema is unchanged; historical
+  runs (completed/aborted) are final and untouched.
+- Rollout is code-only: land, run `tests/sdd-runner`, update
+  `docs/architecture/sdd-pipeline.md` in the same change.
+- Rollback: revert the change; in-flight gate-pending runs remain resumable by
+  the previous binary because gate state and files are format-compatible.
+
+## Open Questions
+
+- Whether veto-driven re-gates after an early approval should re-run only the
+  affected part of the tail (veto touching `specs/` already triggers the drift
+  reconciler for `tasks.md`; full re-decompose is likely unnecessary). Deferrable
+  — the drift machinery covers it today.

--- a/openspec/changes/sdd-runner-pipeline-completion/proposal.md
+++ b/openspec/changes/sdd-runner-pipeline-completion/proposal.md
@@ -1,0 +1,70 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Proposal: sdd-runner pipeline completion
+
+## Why
+
+The runner declares an idea-to-`tasks.md` pipeline, but on a cap-hit review loop —
+the norm at depth L on substantial changes — approving the early gate finalizes the
+run **without decompose/atomicity**, permanently delivering no `tasks.md` (observed
+on the `kiss-help` run: 7 review rounds, none clean, four early gates; approval at
+any of them would have ended the run taskless). Two compounding faults: convergence
+(a zero-finding round) is near-unreachable for an adversarial reviewer on a large
+design, and early-gate approval silently amputates the pipeline instead of
+continuing it.
+
+## What Changes
+
+- **Early-gate approval becomes "human-decree convergence"** (**BREAKING** gate
+  semantics): approving an early (cap-hit) gate no longer finalizes the run. The
+  pipeline continues into decompose → atomicity → final gate, exactly as a
+  converged review loop would. "Approve" means "I accept the remaining findings as
+  resolved — proceed," never "stop here with partial output."
+- **Severity-based convergence**: a cap-hit round with zero open BLOCKERs and zero
+  open MATERIALs (nitpick-only, each resolved or dismissed) counts as converged and
+  flows into decompose without presenting an early gate. Blockers/materials still
+  force the early gate for human sign-off.
+- **`resume` learns the post-review stages**: a run interrupted during decompose,
+  atomicity, or the final gate can be resumed (today `resume` supports only the
+  `review` stage and throws for anything else).
+- The final gate reached via early-approval continuation presents at the next gate
+  version (`gate-<n+1>.md`), preserving the versioned audit trail, and its digest
+  carries the full `tasks: <done>/<total>` rendering.
+- Gate-file copy is updated so every decision states its downstream effect
+  (approve → "continues to decompose + atomicity, then a final gate"), ending
+  consequence-blind approvals.
+
+## Capabilities
+
+### New Capabilities
+
+- `sdd-runner-pipeline`: stage flow and completion semantics of the autonomous
+  pipeline — convergence criteria (clean round or severity-based), gate outcomes
+  and their downstream effects, stage-resume coverage, and the versioned gate
+  audit trail.
+
+### Modified Capabilities
+
+None — `openspec/specs/` has no existing capability specs for the runner.
+
+## Impact
+
+- **Code:** `sdd-runner/src/orchestrator.ts` (early-gate approval continuation,
+  resume stage coverage), `sdd-runner/src/gate-digest.ts` (`finalizeGate` becomes a
+  continuation, not a terminus), `sdd-runner/src/review-loop.ts` (severity-based
+  convergence outcome), `sdd-runner/src/run-state.ts` (resume-point derivation for
+  post-review stages), `sdd-runner/src/extend-round.ts` (shared post-convergence
+  path), `sdd-runner/src/gate-render.ts` / `gate-model.ts` (decision copy and
+  consequences).
+- **Docs:** `docs/architecture/sdd-pipeline.md` (gate protocol, depth-profile
+  expectations).
+- **Tests:** `tests/sdd-runner/` — new continuation, convergence, and resume-path
+  coverage.
+- **Behavioral compatibility:** the only intentional break is early-gate approve
+  semantics; abort/veto/extend are unchanged. A completed-without-tasks run from
+  before this change is unaffected (its state is already finalized).

--- a/openspec/changes/sdd-runner-pipeline-completion/specs/sdd-runner-pipeline/spec.md
+++ b/openspec/changes/sdd-runner-pipeline-completion/specs/sdd-runner-pipeline/spec.md
@@ -1,0 +1,101 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+## Purpose
+
+Defines how the autonomous pipeline reaches a complete result: when the review
+loop is considered settled, what each gate decision does downstream, and how an
+interrupted run resumes — so that every completed run delivers the full artifact
+set including the task list.
+
+## ADDED Requirements
+
+### Requirement: Early-gate approval continues the pipeline
+
+When a human approves an early (cap-hit) gate, the pipeline SHALL continue into
+task decomposition, atomicity checking, and a final gate instead of finalizing
+the run. Approval SHALL mean "the remaining findings are accepted as resolved —
+proceed," and no approval path SHALL produce a completed run that lacks a task
+list.
+
+#### Scenario: Approval at an early gate proceeds to decomposition
+
+- **WHEN** a human approves an early gate (all boxes checked, blockers answered)
+- **THEN** the pipeline runs task decomposition and atomicity checking and then
+  presents a final gate, instead of marking the run completed
+
+#### Scenario: No completion path skips the task list
+
+- **WHEN** any run reaches `completed` status
+- **THEN** the change directory contains a `tasks.md` produced by the pipeline's
+  decomposition stage (or the run was aborted, which is the only non-completing
+  exit)
+
+#### Scenario: Final gate after early approval carries the next version
+
+- **WHEN** the final gate is presented following an early-gate approval at
+  version `n`
+- **THEN** it is written as `gate-<n+1>.md` with the full task-progress digest,
+  preserving the versioned audit trail
+
+### Requirement: Severity-based convergence
+
+A review round that reaches the round cap with zero open BLOCKER findings and
+zero open MATERIAL findings — nitpicks only, each resolved or dismissed — SHALL
+be treated as converged and SHALL flow into decomposition without presenting an
+early gate. A cap-hit round with any open BLOCKER or MATERIAL finding SHALL still
+present an early gate for human sign-off.
+
+#### Scenario: Nitpick-only cap-hit converges without a gate
+
+- **WHEN** the review loop reaches its round cap and every open finding is a
+  resolved or dismissed nitpick
+- **THEN** the pipeline proceeds directly to decomposition as if the loop had
+  converged on a clean round
+
+#### Scenario: Open material finding at cap still gates
+
+- **WHEN** the review loop reaches its round cap with at least one open MATERIAL
+  finding
+- **THEN** an early gate is presented and the pipeline waits for a human decision
+
+### Requirement: Resume covers post-review stages
+
+A run interrupted after the review stage — during decomposition, atomicity
+checking, or a pending final gate — SHALL be resumable, re-entering at the
+interrupted stage rather than failing. Resuming a run with a pending gate SHALL
+direct the operator to the gate flow.
+
+#### Scenario: Interrupted decomposition resumes
+
+- **WHEN** a run stopped during decomposition or atomicity checking is resumed
+- **THEN** the pipeline re-enters at the interrupted stage and continues toward
+  the final gate
+
+#### Scenario: Resume on a gate-pending run points at the gate
+
+- **WHEN** `resume` is invoked for a run whose gate is pending
+- **THEN** the operator is told the run awaits a gate decision and given the
+  exact gate command with the run id
+
+### Requirement: Gate decisions disclose their downstream effects
+
+Every gate presentation SHALL state, next to each available decision, what the
+pipeline does next if that decision is taken — including that approval at an
+early gate continues to decomposition, atomicity checking, and a final gate.
+
+#### Scenario: Early gate explains approval
+
+- **WHEN** an early gate is presented
+- **THEN** its text states that approving continues the pipeline to task
+  decomposition and a final gate, and that extending runs one more review round
+
+#### Scenario: Final gate explains approval
+
+- **WHEN** a final gate is presented
+- **THEN** its text states that approving completes the run with the full
+  artifact set

--- a/openspec/changes/sdd-runner-pipeline-completion/tasks.md
+++ b/openspec/changes/sdd-runner-pipeline-completion/tasks.md
@@ -34,8 +34,8 @@ Test-first throughout: failing test before the implementation it covers.
 
 ## 4. Gate copy states consequences (Decision 4)
 
-- [ ] 4.1 Add failing tests in `tests/sdd-runner/gate-render.test.ts`: the early gate states that approving continues to decomposition, atomicity, and a final gate, and that extending runs one more review round; the final gate states that approving completes the run. Verify: `bun test tests/sdd-runner/gate-render.test.ts` (red)
-- [ ] 4.2 Update the gate renderer copy until 4.1 is green; confirm the parser is untouched (existing `gate-model` tests stay green). Verify: `bun test tests/sdd-runner/gate-render.test.ts tests/sdd-runner/gate-model.test.ts`
+- [x] 4.1 Add failing tests in `tests/sdd-runner/gate-render.test.ts`: the early gate states that approving continues to decomposition, atomicity, and a final gate, and that extending runs one more review round; the final gate states that approving completes the run. Verify: `bun test tests/sdd-runner/gate-render.test.ts` (red)
+- [x] 4.2 Update the gate renderer copy until 4.1 is green; confirm the parser is untouched (existing `gate-model` tests stay green). Verify: `bun test tests/sdd-runner/gate-render.test.ts tests/sdd-runner/gate-model.test.ts`
 
 ## 5. Docs + full verification
 

--- a/openspec/changes/sdd-runner-pipeline-completion/tasks.md
+++ b/openspec/changes/sdd-runner-pipeline-completion/tasks.md
@@ -27,10 +27,10 @@ Test-first throughout: failing test before the implementation it covers.
 
 ## 3. Resume covers post-review stages (Decision 3)
 
-- [ ] 3.1 Add failing tests in `tests/sdd-runner/run-state.test.ts` for `deriveResumePoint`: missing `tasks.md` with no final gate presented → `decompose`; present `tasks.md` with depth ≠ S and no atomicity report → `atomicity`; presented final gate → `gate-pending` (pin existing). Verify: `bun test tests/sdd-runner/run-state.test.ts` (red)
-- [ ] 3.2 Implement the new resume-point derivation (artifact/sidecar-evidence based, no new persisted fields) until 3.1 is green. Verify: `bun test tests/sdd-runner/run-state.test.ts`
-- [ ] 3.3 Add a failing test in `tests/sdd-runner/orchestrator.test.ts`: `runResume` re-enters at decompose (or atomicity) and continues to the final gate, sourcing the review result via `readReviewResultFromSidecars`; the `not supported yet` throw is gone for these stages. Verify: `bun test tests/sdd-runner/orchestrator.test.ts` (red)
-- [ ] 3.4 Implement the `runResume` stage dispatch until 3.3 is green. Verify: `bun test tests/sdd-runner/orchestrator.test.ts && bun run sdd-runner:typecheck`
+- [x] 3.1 Add failing tests in `tests/sdd-runner/run-state.test.ts` for `deriveResumePoint`: missing `tasks.md` with no final gate presented → `decompose`; present `tasks.md` with depth ≠ S and no atomicity report → `atomicity`; presented final gate → `gate-pending` (pin existing). Verify: `bun test tests/sdd-runner/run-state.test.ts` (red)
+- [x] 3.2 Implement the new resume-point derivation (artifact/sidecar-evidence based, no new persisted fields) until 3.1 is green. Verify: `bun test tests/sdd-runner/run-state.test.ts`
+- [x] 3.3 Add a failing test in `tests/sdd-runner/orchestrator.test.ts`: `runResume` re-enters at decompose (or atomicity) and continues to the final gate, sourcing the review result via `readReviewResultFromSidecars`; the `not supported yet` throw is gone for these stages. Verify: `bun test tests/sdd-runner/orchestrator.test.ts` (red)
+- [x] 3.4 Implement the `runResume` stage dispatch until 3.3 is green. Verify: `bun test tests/sdd-runner/orchestrator.test.ts && bun run sdd-runner:typecheck`
 
 ## 4. Gate copy states consequences (Decision 4)
 

--- a/openspec/changes/sdd-runner-pipeline-completion/tasks.md
+++ b/openspec/changes/sdd-runner-pipeline-completion/tasks.md
@@ -39,5 +39,5 @@ Test-first throughout: failing test before the implementation it covers.
 
 ## 5. Docs + full verification
 
-- [ ] 5.1 Update `docs/architecture/sdd-pipeline.md`: approve-continues semantics, severity-based convergence, resume stage coverage, and the breaking-change note for early-gate approval. Verify: `bunx openspec validate sdd-runner-pipeline-completion --strict`
-- [ ] 5.2 Run the full gates. Verify: `bun test && bun run typecheck && bun run lint`
+- [x] 5.1 Update `docs/architecture/sdd-pipeline.md`: approve-continues semantics, severity-based convergence, resume stage coverage, and the breaking-change note for early-gate approval. Verify: `bunx openspec validate sdd-runner-pipeline-completion --strict`
+- [x] 5.2 Run the full gates. Verify: `bun test && bun run typecheck && bun run lint`

--- a/openspec/changes/sdd-runner-pipeline-completion/tasks.md
+++ b/openspec/changes/sdd-runner-pipeline-completion/tasks.md
@@ -1,0 +1,43 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Tasks: sdd-runner pipeline completion
+
+Order follows the design's dependency chain: the shared post-review tail is a
+prerequisite for the approve-continuation, convergence and resume are
+independent of each other, gate copy last, docs and full gates at the end.
+Test-first throughout: failing test before the implementation it covers.
+
+## 1. Approve-at-early-gate continuation (Decision 1)
+
+- [x] 1.1 Add a failing test in `tests/sdd-runner/orchestrator.test.ts`: `runGateResume` on an `approved` outcome at an early gate runs decompose, then atomicity (depth ≠ S), then presents a **final** gate at version n+1 — and does NOT mark the run completed. Verify: `bun test tests/sdd-runner/orchestrator.test.ts` (red)
+- [x] 1.2 Add a failing companion case: at depth S the same continuation skips atomicity but still reaches the final gate. Verify: `bun test tests/sdd-runner/orchestrator.test.ts` (red)
+- [x] 1.3 Hoist the post-convergence tail (`runPostExtendConverged`) out of `sdd-runner/src/extend-round.ts` into a shared stage module, reused by both `runExtendRound` and `runGateResume`'s approved branch, so 1.1-1.2 go green while existing extend-round tests stay green. Verify: `bun test tests/sdd-runner/orchestrator.test.ts tests/sdd-runner/extend-round.test.ts`
+- [x] 1.4 Add a failing test that `finalizeGate` is now reached only via final-gate approval or abort (no path from an early gate marks `completed`). Verify: `bun test tests/sdd-runner/gate-digest.test.ts tests/sdd-runner/orchestrator.test.ts` (red), then adjust call sites to green. Verify: `bun test tests/sdd-runner`
+
+## 2. Severity-based convergence (Decision 2)
+
+- [ ] 2.1 Add a failing test in `tests/sdd-runner/orchestrator.test.ts`: a cap-hit review result with empty `openBlockers` and empty `openMaterial` (nitpick-only) flows into decompose → atomicity → final gate without presenting an early gate. Verify: `bun test tests/sdd-runner/orchestrator.test.ts` (red)
+- [ ] 2.2 Implement the severity check in `runPostReviewToGate` until 2.1 is green. Verify: `bun test tests/sdd-runner/orchestrator.test.ts`
+- [ ] 2.3 Add explicit coverage that a cap-hit with any open MATERIAL or BLOCKER still presents an early gate and halts (pin the unchanged behavior). Verify: `bun test tests/sdd-runner/orchestrator.test.ts`
+
+## 3. Resume covers post-review stages (Decision 3)
+
+- [ ] 3.1 Add failing tests in `tests/sdd-runner/run-state.test.ts` for `deriveResumePoint`: missing `tasks.md` with no final gate presented → `decompose`; present `tasks.md` with depth ≠ S and no atomicity report → `atomicity`; presented final gate → `gate-pending` (pin existing). Verify: `bun test tests/sdd-runner/run-state.test.ts` (red)
+- [ ] 3.2 Implement the new resume-point derivation (artifact/sidecar-evidence based, no new persisted fields) until 3.1 is green. Verify: `bun test tests/sdd-runner/run-state.test.ts`
+- [ ] 3.3 Add a failing test in `tests/sdd-runner/orchestrator.test.ts`: `runResume` re-enters at decompose (or atomicity) and continues to the final gate, sourcing the review result via `readReviewResultFromSidecars`; the `not supported yet` throw is gone for these stages. Verify: `bun test tests/sdd-runner/orchestrator.test.ts` (red)
+- [ ] 3.4 Implement the `runResume` stage dispatch until 3.3 is green. Verify: `bun test tests/sdd-runner/orchestrator.test.ts && bun run sdd-runner:typecheck`
+
+## 4. Gate copy states consequences (Decision 4)
+
+- [ ] 4.1 Add failing tests in `tests/sdd-runner/gate-render.test.ts`: the early gate states that approving continues to decomposition, atomicity, and a final gate, and that extending runs one more review round; the final gate states that approving completes the run. Verify: `bun test tests/sdd-runner/gate-render.test.ts` (red)
+- [ ] 4.2 Update the gate renderer copy until 4.1 is green; confirm the parser is untouched (existing `gate-model` tests stay green). Verify: `bun test tests/sdd-runner/gate-render.test.ts tests/sdd-runner/gate-model.test.ts`
+
+## 5. Docs + full verification
+
+- [ ] 5.1 Update `docs/architecture/sdd-pipeline.md`: approve-continues semantics, severity-based convergence, resume stage coverage, and the breaking-change note for early-gate approval. Verify: `bunx openspec validate sdd-runner-pipeline-completion --strict`
+- [ ] 5.2 Run the full gates. Verify: `bun test && bun run typecheck && bun run lint`

--- a/openspec/changes/sdd-runner-pipeline-completion/tasks.md
+++ b/openspec/changes/sdd-runner-pipeline-completion/tasks.md
@@ -21,9 +21,9 @@ Test-first throughout: failing test before the implementation it covers.
 
 ## 2. Severity-based convergence (Decision 2)
 
-- [ ] 2.1 Add a failing test in `tests/sdd-runner/orchestrator.test.ts`: a cap-hit review result with empty `openBlockers` and empty `openMaterial` (nitpick-only) flows into decompose → atomicity → final gate without presenting an early gate. Verify: `bun test tests/sdd-runner/orchestrator.test.ts` (red)
-- [ ] 2.2 Implement the severity check in `runPostReviewToGate` until 2.1 is green. Verify: `bun test tests/sdd-runner/orchestrator.test.ts`
-- [ ] 2.3 Add explicit coverage that a cap-hit with any open MATERIAL or BLOCKER still presents an early gate and halts (pin the unchanged behavior). Verify: `bun test tests/sdd-runner/orchestrator.test.ts`
+- [x] 2.1 Add a failing test in `tests/sdd-runner/orchestrator.test.ts`: a cap-hit review result with empty `openBlockers` and empty `openMaterial` (nitpick-only) flows into decompose → atomicity → final gate without presenting an early gate. Verify: `bun test tests/sdd-runner/orchestrator.test.ts` (red)
+- [x] 2.2 Implement the severity check in `runPostReviewToGate` until 2.1 is green. Verify: `bun test tests/sdd-runner/orchestrator.test.ts`
+- [x] 2.3 Add explicit coverage that a cap-hit with any open MATERIAL or BLOCKER still presents an early gate and halts (pin the unchanged behavior). Verify: `bun test tests/sdd-runner/orchestrator.test.ts`
 
 ## 3. Resume covers post-review stages (Decision 3)
 

--- a/sdd-runner/src/cli.ts
+++ b/sdd-runner/src/cli.ts
@@ -4,14 +4,23 @@
 // See LICENSE in the project root for details.
 
 import type { DepthProfile } from './events.js'
-import type { RunGateResumeResult, RunResumeResult, RunStartResult, StartOptions } from './orchestrator.js'
+import type {
+  RunContinueResult,
+  RunGateResumeResult,
+  RunResumeResult,
+  RunStartResult,
+  StartOptions,
+} from './orchestrator.js'
 import type { GateResumeOptions } from './orchestrator.js'
 import type { Verbosity } from './renderer.js'
+import type { PendingGateEntry } from './run-state.js'
 
 export interface CliHarness {
   readonly runStart: (options: StartOptions) => Promise<RunStartResult>
   readonly runResume: (runId: string) => Promise<RunResumeResult>
   readonly runGateResume: (runId: string, options: GateResumeOptions) => Promise<RunGateResumeResult>
+  readonly runContinue: (runId: string | null) => Promise<RunContinueResult>
+  readonly listPendingGates: () => Promise<PendingGateEntry[]>
   readonly buildReport: (runId: string, pr: boolean) => Promise<string>
   readonly stdout: (line: string) => void
 }
@@ -26,8 +35,28 @@ export async function main(argv: readonly string[], harness: CliHarness): Promis
     await harness.runResume(cmd.runId)
     return 0
   }
+  if (cmd.subcommand === 'continue') {
+    await harness.runContinue(cmd.runId)
+    return 0
+  }
   if (cmd.subcommand === 'gate') {
-    await harness.runGateResume(cmd.runId, { confirmAll: cmd.confirmAll, abort: cmd.abort })
+    if (cmd.runId === null) {
+      const pending = await harness.listPendingGates()
+      if (pending.length === 0) harness.stdout('no runs await gate decisions')
+      for (const entry of pending) {
+        harness.stdout(
+          `gate-pending: ${entry.runId}  (${entry.changeName}, gate v${entry.gateVersion}, updated ${entry.updatedAt})`,
+        )
+        harness.stdout(`  sdd-runner gate resume ${entry.runId}`)
+      }
+      return 0
+    }
+    await harness.runGateResume(cmd.runId, {
+      ...(cmd.confirmAll ? { confirmAll: true } : {}),
+      ...(cmd.abort ? { abort: true } : {}),
+      ...(cmd.extend ? { extend: true } : {}),
+      ...(cmd.vetoes.length > 0 ? { vetoes: cmd.vetoes } : {}),
+    })
     return 0
   }
   const body = await harness.buildReport(cmd.runId, cmd.pr)
@@ -43,10 +72,18 @@ export type CliCommand =
       readonly verbosity: Verbosity
     }
   | { readonly subcommand: 'resume'; readonly runId: string }
-  | { readonly subcommand: 'gate'; readonly runId: string; readonly confirmAll: boolean; readonly abort: boolean }
+  | { readonly subcommand: 'continue'; readonly runId: string | null }
+  | {
+      readonly subcommand: 'gate'
+      readonly runId: string | null
+      readonly confirmAll: boolean
+      readonly abort: boolean
+      readonly extend: boolean
+      readonly vetoes: readonly { readonly id: string; readonly redirect?: string }[]
+    }
   | { readonly subcommand: 'report'; readonly runId: string; readonly pr: boolean }
 
-const VALID_SUBCOMMANDS = new Set(['start', 'resume', 'gate', 'report'])
+const VALID_SUBCOMMANDS = new Set(['start', 'resume', 'gate', 'continue', 'report'])
 
 const DEPTH_VALUES: Record<string, DepthProfile> = { S: 'S', M: 'M', L: 'L' }
 const VERBOSITY_VALUES: Record<string, Verbosity> = { brief: 'brief', normal: 'normal', debug: 'debug' }
@@ -78,18 +115,41 @@ function parseStart(args: readonly string[]): CliCommand {
   return { subcommand: 'start', taskFile, depth, verbosity }
 }
 
+function parseVetoArg(raw: string): { id: string; redirect?: string } {
+  const eq = raw.indexOf('=')
+  if (eq <= 0) throw new Error(`--veto expects <id>=<redirect> (split on the first =): got "${raw}"`)
+  const id = raw.slice(0, eq)
+  const redirect = raw.slice(eq + 1)
+  return redirect === '' ? { id } : { id, redirect }
+}
+
 function parseGate(args: readonly string[]): CliCommand {
-  if (args[1] !== 'resume') throw new Error('gate requires: gate resume <runId>')
+  if (args[1] === undefined)
+    return { subcommand: 'gate', runId: null, confirmAll: false, abort: false, extend: false, vetoes: [] }
+  if (args[1] !== 'resume')
+    throw new Error('gate requires: gate resume <runId> [flags] (or bare `gate` to list pending gates)')
   const runId = args[2]
-  if (runId === undefined) throw new Error('gate resume requires a run id')
+  if (runId === undefined) throw new Error('gate resume requires a run id (or run bare `gate` to list pending gates)')
   let confirmAll = false
   let abort = false
+  let extend = false
+  const vetoes: { id: string; redirect?: string }[] = []
   for (let i = 3; i < args.length; i += 1) {
-    if (args[i] === '--confirm-all') confirmAll = true
-    else if (args[i] === '--abort') abort = true
-    else throw new Error(`unknown flag: ${args[i]}`)
+    const arg = args[i]
+    if (arg === '--confirm-all') confirmAll = true
+    else if (arg === '--abort') abort = true
+    else if (arg === '--extend') extend = true
+    else if (arg === '--veto') {
+      const raw = args[i + 1]
+      if (raw === undefined) throw new Error('--veto expects <id>=<redirect>')
+      vetoes.push(parseVetoArg(raw))
+      i += 1
+    } else throw new Error(`unknown flag: ${arg}`)
   }
-  return { subcommand: 'gate', runId, confirmAll, abort }
+  if (extend && (confirmAll || abort || vetoes.length > 0)) {
+    throw new Error('--extend cannot be combined with --confirm-all, --veto, or --abort')
+  }
+  return { subcommand: 'gate', runId, confirmAll, abort, extend, vetoes }
 }
 
 function parseReport(args: readonly string[]): CliCommand {
@@ -105,11 +165,15 @@ function parseReport(args: readonly string[]): CliCommand {
 
 export function parseCliArgs(args: readonly string[]): CliCommand {
   const subcommand = args[0]
-  if (subcommand === undefined) throw new Error('missing subcommand: start | resume | gate | report')
+  if (subcommand === undefined) throw new Error('missing subcommand: start | resume | gate | continue | report')
   if (!VALID_SUBCOMMANDS.has(subcommand)) throw new Error(`unknown subcommand: ${subcommand}`)
   if (subcommand === 'start') return parseStart(args)
   if (subcommand === 'gate') return parseGate(args)
   if (subcommand === 'report') return parseReport(args)
+  if (subcommand === 'continue') {
+    if (args.length > 2) throw new Error(`unknown flag: ${args[2]}`)
+    return { subcommand: 'continue', runId: args[1] ?? null }
+  }
   const runId = args[1]
   if (runId === undefined) throw new Error('resume requires a run id')
   return { subcommand: 'resume', runId }

--- a/sdd-runner/src/continue.ts
+++ b/sdd-runner/src/continue.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { runGateResume } from './extend-round.js'
+import type { OrchestratorDeps } from './gate-digest.js'
+import { runResume } from './orchestrator.js'
+import type { RunContinueResult } from './orchestrator.js'
+import { listPendingGates, loadRunState, resolveRunId } from './run-state.js'
+
+/**
+ * `continue` is a pure router (Decision 4): gate-pending → the gate flow
+ * (`runGateResume` with no flags — interactive session on a TTY, hand-edited
+ * file otherwise); interrupted mid-stage → `runResume`; completed → a pointer
+ * to the report. Without an id, discovery picks the single gate-pending run,
+ * or lists the candidates when several exist.
+ */
+export async function runContinue(deps: OrchestratorDeps, runId: string | null): Promise<RunContinueResult> {
+  if (runId === null) {
+    const picked = await pickContinueRun(deps)
+    if (picked === null) return { runId: null, routed: 'list' }
+    return runContinue(deps, picked)
+  }
+  const resolved = await resolveRunId(deps.config.workDir, runId)
+  const state = await loadRunState(deps.config.workDir, resolved)
+  if (state.gate !== null) {
+    const gate = await runGateResume(deps, resolved, {})
+    return {
+      runId: resolved,
+      routed: 'gate',
+      ...(gate.gateMdPath === undefined ? {} : { gateMdPath: gate.gateMdPath, version: gate.version }),
+    }
+  }
+  if (state.status === 'completed') {
+    deps.stdout?.(`run ${resolved} is completed — report: sdd-runner report ${resolved}`)
+    return { runId: resolved, routed: 'report' }
+  }
+  const resumed = await runResume(deps, resolved)
+  return {
+    runId: resolved,
+    routed: 'resume',
+    ...(resumed.gateMdPath === undefined ? {} : { gateMdPath: resumed.gateMdPath, version: resumed.version }),
+  }
+}
+
+/**
+ * Discovery for a bare `continue`: exactly one gate-pending run routes to it;
+ * several print the per-run gate commands and route nowhere (the operator
+ * picks); none is an error (there is nothing obvious to continue).
+ */
+async function pickContinueRun(deps: OrchestratorDeps): Promise<string | null> {
+  const pending = await listPendingGates(deps.config.workDir)
+  if (pending.length === 1) return pending[0]?.runId ?? null
+  if (pending.length > 1) {
+    deps.stdout?.('several runs await gate decisions:')
+    for (const entry of pending) {
+      deps.stdout?.(`  sdd-runner gate resume ${entry.runId}  (${entry.changeName}, gate v${entry.gateVersion})`)
+    }
+    return null
+  }
+  throw new Error('no gate-pending runs found — pass a run id, or use `sdd-runner resume <runId>`')
+}

--- a/sdd-runner/src/extend-round.ts
+++ b/sdd-runner/src/extend-round.ts
@@ -3,25 +3,43 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import { writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import type { AgentLayerDeps } from './agent-layer.js'
-import { runAtomicity, runDecompose } from './decompose.js'
-import type { DepthProfile, EventInput } from './events.js'
-import { findingsOf, gatherAssumptions, nowOf, presentGateAt, readReviewResultFromSidecars } from './gate-digest.js'
-import type { OrchestratorDeps, RunStartResult, StageContext } from './gate-digest.js'
+import { buildDriftCheck } from './drift.js'
+import type { EventInput } from './events.js'
+import {
+  applyConfirmAll,
+  buildBus,
+  finalizeGate,
+  findingsOf,
+  gatherAssumptions,
+  logPathFor,
+  nowOf,
+  presentGateAt,
+  readReviewResultFromSidecars,
+} from './gate-digest.js'
+import type { OrchestratorDeps, StageContext } from './gate-digest.js'
+import { resumeGate, vetoRedirects } from './gate.js'
 import { createMaterializer } from './materialize.js'
+import { runPostConvergenceTail } from './post-review-tail.js'
 import { runReviewLoop } from './review-loop.js'
 import type { ReviewLoopResult } from './review-loop.js'
-import { resolveRoundCap, saveRunState } from './run-state.js'
+import { loadRunState, resolveRoundCap, saveRunState } from './run-state.js'
 import type { RunState } from './run-state.js'
-import { createStageMachine } from './stage-machine.js'
+import { runVetoUpdater, updateAssumptionsFromVetoes } from './veto-updater.js'
 
 export interface RunGateResumeResult {
   readonly runId: string
   readonly outcome: 'approved' | 'aborted' | 'veto' | 'extend'
   readonly version: number
   readonly gateMdPath?: string
+}
+
+export interface GateResumeOptions {
+  readonly confirmAll?: boolean
+  readonly abort?: boolean
 }
 
 export async function prepareResumeInput(
@@ -60,64 +78,129 @@ export async function runExtendRound(
   const cwd = deps.config.repoRoot
   const changeDir = path.join(cwd, 'openspec', 'changes', state.changeName)
   const sidecarDir = path.join(state.runDir, 'sidecars')
-  const materialize = createMaterializer(sidecarDir, changeDir)
-  const extendResult = await runReviewLoop(
-    { agent, emit, sidecarDir, cwd, materialize },
-    {
-      changeName: state.changeName,
-      changeDir,
-      depth,
-      taskText: '',
-      conventions: deps.conventions ?? '',
-    },
-    { startRound: state.round + 1, cap: state.roundCap },
-  )
-  state.round = extendResult.rounds
-  state.stage = 'review'
-  await saveRunState(state, nowOf(deps))
+  const extendResult = await runExtendedReview(deps, state, agent, emit, { changeDir, sidecarDir, depth })
   const ctx: StageContext = { cwd, changeDir, sidecarDir, emit }
-  const machine = createStageMachine({ emit })
   const next = version + 1
   if (extendResult.outcome === 'cap-hit') {
     const gate = await presentGateAt(deps, state, ctx, extendResult, next, 'early')
     return { runId: state.runId, outcome: 'extend', version: next, gateMdPath: gate.gateMdPath }
   }
-  const gate = await runPostExtendConverged(deps, state, ctx, machine, agent, depth, extendResult, next)
+  const gate = await runPostConvergenceTail({
+    deps,
+    state,
+    ctx,
+    agent,
+    depth,
+    reviewResult: extendResult,
+    version: next,
+  })
   return { runId: state.runId, outcome: 'extend', version: next, gateMdPath: gate.gateMdPath }
 }
 
-async function runPostExtendConverged(
+async function runExtendedReview(
   deps: OrchestratorDeps,
   state: RunState,
-  ctx: StageContext,
-  machine: ReturnType<typeof createStageMachine>,
   agent: AgentLayerDeps,
-  depth: DepthProfile,
-  extendResult: ReviewLoopResult,
-  version: number,
-): Promise<RunStartResult> {
-  await machine.runStage('decompose', () =>
-    runDecompose(
-      { driver: deps.driver, agent, sidecarDir: ctx.sidecarDir, cwd: ctx.cwd },
-      { changeName: state.changeName },
-    ),
+  emit: (event: EventInput) => void,
+  paths: { changeDir: string; sidecarDir: string; depth: 'S' | 'M' | 'L' },
+): Promise<ReviewLoopResult> {
+  const { changeDir, sidecarDir, depth } = paths
+  const materialize = createMaterializer(sidecarDir, changeDir)
+  const extendResult = await runReviewLoop(
+    { agent, emit, sidecarDir, cwd: deps.config.repoRoot, materialize },
+    { changeName: state.changeName, changeDir, depth, taskText: '', conventions: deps.conventions ?? '' },
+    { startRound: state.round + 1, cap: state.roundCap },
   )
-  state.stage = 'decompose'
+  state.round = extendResult.rounds
+  state.stage = 'review'
   await saveRunState(state, nowOf(deps))
-  if (depth !== 'S') {
-    await machine.runStage('atomicity', async () => {
-      await runAtomicity(
-        { driver: deps.driver, agent, sidecarDir: ctx.sidecarDir, cwd: ctx.cwd },
-        { changeName: state.changeName, depth },
-      )
+  return extendResult
+}
+
+export interface GateResumeContext {
+  readonly deps: OrchestratorDeps
+  readonly state: RunState
+  readonly emit: (event: EventInput) => void
+  readonly version: number
+  readonly changeDir: string
+  readonly sidecarDir: string
+  readonly agent: AgentLayerDeps
+}
+
+export async function runGateResume(
+  deps: OrchestratorDeps,
+  runId: string,
+  options: GateResumeOptions,
+): Promise<RunGateResumeResult> {
+  const state = await loadRunState(deps.config.workDir, runId)
+  if (state.gate === null) throw new Error(`run ${runId} is not gate-pending`)
+  const emit = buildBus(deps, logPathFor(state))
+  const version = state.gate.version
+  const changeDir = path.join(deps.config.repoRoot, 'openspec', 'changes', state.changeName)
+  const sidecarDir = path.join(state.runDir, 'sidecars')
+  const gateMdPath = path.join(state.runDir, `gate-${version}.md`)
+  if (options.abort === true) await writeFile(gateMdPath, 'ABORT\n')
+  else if (options.confirmAll === true) await applyConfirmAll(gateMdPath)
+  const { assumptions, reviewResult, requiredAck } = await prepareResumeInput(sidecarDir, state.round, state.gate.mode)
+  const findings = findingsOf(reviewResult)
+  const agent: AgentLayerDeps = { spawn: deps.spawn, config: deps.config, execGit: deps.execGit, emit }
+  const ctx: GateResumeContext = { deps, state, emit, version, changeDir, sidecarDir, agent }
+  const outcome = await resumeGate(
+    {
+      emit,
+      runDir: state.runDir,
+      changeDir,
+      driftCheck: buildDriftCheck(agent, state, changeDir, sidecarDir, deps.config.repoRoot),
+    },
+    {
+      version,
+      assumptions,
+      blockers: findings.blockers,
+      gateMode: state.gate.mode,
+      ...(findings.material.length > 0 ? { findings: findings.material } : {}),
+      ...(requiredAck === undefined ? {} : { requiredAck }),
+    },
+  )
+  if (outcome.kind === 'aborted') return finalizeGate(deps, state, 'aborted', version)
+  if (outcome.kind === 'approved') return settleApprovedGate(ctx, reviewResult)
+  if (outcome.kind === 'extend') return runExtendRound(deps, state, emit, agent, version)
+  return settleVeto(ctx, reviewResult, vetoRedirects(outcome))
+}
+
+async function settleApprovedGate(
+  ctx: GateResumeContext,
+  reviewResult: ReviewLoopResult,
+): Promise<RunGateResumeResult> {
+  const { deps, state, emit, version, changeDir, sidecarDir, agent } = ctx
+  if (state.gate?.mode === 'early') {
+    const stageCtx: StageContext = { cwd: deps.config.repoRoot, changeDir, sidecarDir, emit }
+    const gate = await runPostConvergenceTail({
+      deps,
+      state,
+      ctx: stageCtx,
+      agent,
+      depth: state.depth ?? 'S',
+      reviewResult,
+      version: version + 1,
     })
-    state.stage = 'atomicity'
-    await saveRunState(state, nowOf(deps))
+    return { runId: state.runId, outcome: 'approved', version: gate.version, gateMdPath: gate.gateMdPath }
   }
-  state.stage = 'gate'
-  let gateResult!: RunStartResult
-  await machine.runStage('gate', async () => {
-    gateResult = await presentGateAt(deps, state, ctx, extendResult, version, 'final')
-  })
-  return gateResult
+  return finalizeGate(deps, state, 'completed', version)
+}
+
+async function settleVeto(
+  ctx: GateResumeContext,
+  reviewResult: ReviewLoopResult,
+  vetoes: readonly { readonly id: string; readonly redirect?: string }[],
+): Promise<RunGateResumeResult> {
+  const { deps, state, emit, version, changeDir, sidecarDir, agent } = ctx
+  const stageCtx: StageContext = { cwd: deps.config.repoRoot, changeDir, sidecarDir, emit }
+  await updateAssumptionsFromVetoes(sidecarDir, state.round, vetoes)
+  const driftCheck = buildDriftCheck(agent, state, changeDir, sidecarDir, deps.config.repoRoot)
+  const { filesUpdated } = await runVetoUpdater({ driver: deps.driver, agent }, state, stageCtx, vetoes)
+  const driftFiles = filesUpdated.filter((file) => file.includes('specs/') || file.endsWith('tasks.md'))
+  if (driftFiles.length > 0) await driftCheck(driftFiles)
+  const next = version + 1
+  await presentGateAt(deps, state, stageCtx, reviewResult, next, state.gate?.mode ?? 'final')
+  return { runId: state.runId, outcome: 'veto', version: next }
 }

--- a/sdd-runner/src/extend-round.ts
+++ b/sdd-runner/src/extend-round.ts
@@ -10,7 +10,6 @@ import type { AgentLayerDeps } from './agent-layer.js'
 import { buildDriftCheck } from './drift.js'
 import type { EventInput } from './events.js'
 import {
-  applyConfirmAll,
   buildBus,
   finalizeGate,
   findingsOf,
@@ -21,6 +20,9 @@ import {
   readReviewResultFromSidecars,
 } from './gate-digest.js'
 import type { OrchestratorDeps, StageContext } from './gate-digest.js'
+import type { GateAssumption, GateFinding } from './gate-model.js'
+import { desugarFlags, readlinePrompter, runGateSession } from './gate-session.js'
+import type { GateSessionView } from './gate-session.js'
 import { resumeGate, vetoRedirects } from './gate.js'
 import { createMaterializer } from './materialize.js'
 import { runPostConvergenceTail } from './post-review-tail.js'
@@ -32,7 +34,7 @@ import { runVetoUpdater, updateAssumptionsFromVetoes } from './veto-updater.js'
 
 export interface RunGateResumeResult {
   readonly runId: string
-  readonly outcome: 'approved' | 'aborted' | 'veto' | 'extend'
+  readonly outcome: 'approved' | 'aborted' | 'veto' | 'extend' | 'abandoned'
   readonly version: number
   readonly gateMdPath?: string
 }
@@ -40,6 +42,8 @@ export interface RunGateResumeResult {
 export interface GateResumeOptions {
   readonly confirmAll?: boolean
   readonly abort?: boolean
+  readonly extend?: boolean
+  readonly vetoes?: readonly { readonly id: string; readonly redirect?: string }[]
 }
 
 export async function prepareResumeInput(
@@ -127,6 +131,78 @@ export interface GateResumeContext {
   readonly agent: AgentLayerDeps
 }
 
+function buildSessionView(
+  state: RunState,
+  assumptions: readonly GateAssumption[],
+  findings: { blockers: GateFinding[]; material: GateFinding[] },
+  requiredAck: string | undefined,
+): GateSessionView {
+  return {
+    gateMode: state.gate?.mode ?? 'final',
+    items: [
+      ...findings.material.map((finding) => ({
+        kind: 'finding' as const,
+        id: finding.id,
+        text: finding.gap,
+        evidence: finding.evidence,
+        blastRadius: '',
+      })),
+      ...assumptions.map((assumption) => ({
+        kind: 'assumption' as const,
+        id: assumption.id,
+        text: assumption.text,
+        evidence: '',
+        blastRadius: assumption.blast_radius,
+      })),
+    ],
+    blockers: state.gate?.mode === 'early' ? findings.blockers : [],
+    requiredAck: buildAck(requiredAck),
+  }
+}
+
+const ACK_TEXT = 'I reviewed the trajectory and the open findings above'
+
+function buildAck(requiredAck: string | undefined): { id: string; text: string } | null {
+  const ack = requiredAck === undefined ? null : { id: requiredAck, text: ACK_TEXT }
+  return ack
+}
+
+/**
+ * Front half of the gate resume: TTY with no decision flags → interactive
+ * session (abandoned sessions write nothing and short-circuit); decision
+ * flags → flag desugaring; otherwise the hand-edited file path (no writes —
+ * `resumeGate` parses whatever is on disk).
+ */
+async function collectGateDecision(
+  deps: OrchestratorDeps,
+  options: GateResumeOptions,
+  view: GateSessionView,
+  gateMdPath: string,
+): Promise<boolean> {
+  const hasDecisionFlags =
+    options.abort === true ||
+    options.confirmAll === true ||
+    options.extend === true ||
+    (options.vetoes?.length ?? 0) > 0
+  if (hasDecisionFlags) {
+    await desugarFlags(options, view, (md) => writeFile(gateMdPath, md))
+    return true
+  }
+  const interactive = deps.interactive?.() === true
+  if (interactive) {
+    const session = await runGateSession({
+      prompter: deps.makePrompter?.() ?? readlinePrompter({ input: process.stdin, output: process.stdout }),
+      view,
+      writeGateMd: (md) => writeFile(gateMdPath, md),
+    })
+    if (session.status === 'abandoned') {
+      deps.stdout?.('gate session abandoned — nothing written, the gate remains pending')
+      return false
+    }
+  }
+  return true
+}
+
 export async function runGateResume(
   deps: OrchestratorDeps,
   runId: string,
@@ -139,10 +215,11 @@ export async function runGateResume(
   const changeDir = path.join(deps.config.repoRoot, 'openspec', 'changes', state.changeName)
   const sidecarDir = path.join(state.runDir, 'sidecars')
   const gateMdPath = path.join(state.runDir, `gate-${version}.md`)
-  if (options.abort === true) await writeFile(gateMdPath, 'ABORT\n')
-  else if (options.confirmAll === true) await applyConfirmAll(gateMdPath)
   const { assumptions, reviewResult, requiredAck } = await prepareResumeInput(sidecarDir, state.round, state.gate.mode)
   const findings = findingsOf(reviewResult)
+  const view = buildSessionView(state, assumptions, findings, requiredAck)
+  const proceed = await collectGateDecision(deps, options, view, gateMdPath)
+  if (!proceed) return { runId: state.runId, outcome: 'abandoned', version }
   const agent: AgentLayerDeps = { spawn: deps.spawn, config: deps.config, execGit: deps.execGit, emit }
   const ctx: GateResumeContext = { deps, state, emit, version, changeDir, sidecarDir, agent }
   const outcome = await resumeGate(

--- a/sdd-runner/src/gate-answers.ts
+++ b/sdd-runner/src/gate-answers.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { GateResponse } from './gate-model.js'
+
+export type GateAnswerItem =
+  | {
+      readonly kind: 'assumption'
+      readonly id: string
+      readonly text: string
+      readonly accepted: boolean
+      readonly redirect?: string
+    }
+  | {
+      readonly kind: 'finding'
+      readonly id: string
+      readonly text: string
+      readonly accepted: boolean
+      readonly redirect?: string
+    }
+
+export interface GateBlockerAnswer {
+  readonly id: string
+  readonly gap: string
+  readonly answer: string
+}
+
+export interface GateAck {
+  readonly id: string
+  readonly text: string
+}
+
+export interface GateAnswers {
+  readonly items: readonly GateAnswerItem[]
+  readonly blockerAnswers: readonly GateBlockerAnswer[]
+  readonly acks: readonly GateAck[]
+  readonly decision: 'approve' | 'veto' | 'extend' | 'abort'
+}
+
+const EXTEND_DIRECTIVE = '→ RUN 1 MORE'
+const OVERRIDE_TOKEN = 'OVERRIDE'
+
+export function responseFromAnswers(answers: GateAnswers): GateResponse {
+  if (answers.decision === 'abort') {
+    return { approved: false, abort: true, override: false, extend: false, vetoes: [], answers: [] }
+  }
+  if (answers.decision === 'extend') {
+    return { approved: false, abort: false, override: false, extend: true, vetoes: [], answers: [] }
+  }
+  const vetoes = answers.items
+    .filter((item) => !item.accepted)
+    .map((item) => (item.redirect === undefined ? { id: item.id } : { id: item.id, redirect: item.redirect }))
+  const overrides = answers.blockerAnswers.filter((blocker) => blocker.answer === OVERRIDE_TOKEN)
+  const answered = answers.blockerAnswers.filter((blocker) => blocker.answer !== OVERRIDE_TOKEN)
+  const approved = answers.decision === 'approve' && vetoes.length === 0
+  return {
+    approved,
+    abort: false,
+    override: overrides.length > 0,
+    extend: false,
+    vetoes,
+    answers: answered.map((blocker) => ({ id: blocker.id, answer: blocker.answer })),
+  }
+}
+
+export function renderGateAnswers(answers: GateAnswers): string {
+  if (answers.decision === 'abort') return 'ABORT\n'
+  if (answers.decision === 'extend') return `${EXTEND_DIRECTIVE}\n`
+  const lines: string[] = ['## Gate response', '']
+  for (const ack of answers.acks) lines.push(`- [x] ${ack.id} ${ack.text}`)
+  if (answers.acks.length > 0) lines.push('')
+  for (const item of answers.items) {
+    lines.push(`- [${item.accepted ? 'x' : ' '}] ${item.id} ${item.text}`)
+    if (!item.accepted && item.redirect !== undefined) lines.push(`→ ${item.redirect}`)
+  }
+  if (answers.items.length > 0) lines.push('')
+  for (const blocker of answers.blockerAnswers) {
+    lines.push(`${blocker.id} ${blocker.gap}`, `→ ${blocker.answer}`)
+  }
+  if (answers.blockerAnswers.length > 0) lines.push('')
+  return `${lines.join('\n')}\n`
+}

--- a/sdd-runner/src/gate-digest.ts
+++ b/sdd-runner/src/gate-digest.ts
@@ -15,6 +15,7 @@ import type { EventInput, SddEvent } from './events.js'
 import { extractChangeDigest } from './gate-digest-extract.js'
 import type { ChangeDigest } from './gate-digest-extract.js'
 import type { GateAssumption, GateBlocker, GateFinding } from './gate-model.js'
+import type { Prompter } from './gate-session.js'
 import { presentGate } from './gate.js'
 import type { OpenSpecDriver } from './openspec-driver.js'
 import { loadDb } from './pricing.js'
@@ -37,6 +38,8 @@ export interface OrchestratorDeps {
   readonly conventions?: string
   readonly now?: () => Date
   readonly resolveCost?: ResolveCostFn
+  readonly interactive?: () => boolean
+  readonly makePrompter?: () => Prompter
 }
 
 export interface RunStartResult {
@@ -109,7 +112,7 @@ export async function presentGateAt(
   state.status = 'running'
   await saveRunState(state, nowOf(deps))
   deps.stdout?.(path.relative(deps.config.repoRoot, result.gateMdPath))
-  deps.stdout?.(`gate resume ${state.runId}`)
+  deps.stdout?.(`Next: sdd-runner gate resume ${state.runId}`)
   return { runId: state.runId, halted: 'gate', gateMdPath: result.gateMdPath, version }
 }
 

--- a/sdd-runner/src/gate-render.ts
+++ b/sdd-runner/src/gate-render.ts
@@ -69,6 +69,31 @@ export function writeGateDigest(input: GateDigestInput): string {
   return lines.join('\n')
 }
 
+export interface DecisionConsequences {
+  readonly approve: string
+  readonly veto: string
+  readonly extend: string | null
+  readonly abort: string
+}
+
+/**
+ * Single source for each gate decision's downstream effect, consumed by both
+ * the gate-file `### Decisions` block and the interactive session's decision
+ * menu — the two front-ends cannot drift apart (Decision 6).
+ */
+export function decisionConsequences(mode: 'early' | 'final'): DecisionConsequences {
+  const approve =
+    mode === 'early'
+      ? 'continues to task decomposition, atomicity checking, and a final gate'
+      : 'completes the run with the full artifact set'
+  return {
+    approve,
+    veto: 'runs one resolver pass on the redirects, then re-gates',
+    extend: mode === 'early' ? 'runs one more review round, then re-gates' : null,
+    abort: 'ends the run without completing',
+  }
+}
+
 /**
  * Render the `### Decisions` block: every decision line names its downstream
  * effect, so no approval is consequence-blind. At an early (cap-hit) gate
@@ -76,15 +101,13 @@ export function writeGateDigest(input: GateDigestInput): string {
  * a final gate; at the final gate approval completes the run.
  */
 export function renderDecisions(mode: 'early' | 'final'): string[] {
-  const approve =
-    mode === 'early'
-      ? '- **approve** — continues to task decomposition, atomicity checking, and a final gate (BREAKING: no longer stops the run here)'
-      : '- **approve** — completes the run with the full artifact set (proposal, specs, design, tasks)'
+  const c = decisionConsequences(mode)
   return [
     '### Decisions',
     '',
-    approve,
+    `- **approve** — ${c.approve}`,
     '- **veto** (leave a box unchecked) — runs one resolver pass on the redirects, then re-gates',
+    ...(c.extend === null ? [] : [`- **extend** (\`→ RUN 1 MORE\`) — ${c.extend} (early-gate only)`]),
     '- **abort** (`ABORT` on its own line) — ends the run without completing; the only early exit that spends nothing further',
   ]
 }

--- a/sdd-runner/src/gate-render.ts
+++ b/sdd-runner/src/gate-render.ts
@@ -56,6 +56,8 @@ export function writeGateDigest(input: GateDigestInput): string {
     'Answer a cap-hit blocker with `→ <answer>` beneath it, or `→ OVERRIDE` to override.',
     'Write `ABORT` on its own line to abort.',
     '',
+    ...renderDecisions(input.mode),
+    '',
     '### Summary',
     input.summary,
     '',
@@ -65,6 +67,26 @@ export function writeGateDigest(input: GateDigestInput): string {
   ]
   appendGateSections(lines, input, ranked)
   return lines.join('\n')
+}
+
+/**
+ * Render the `### Decisions` block: every decision line names its downstream
+ * effect, so no approval is consequence-blind. At an early (cap-hit) gate
+ * approval continues the pipeline into decomposition, atomicity checking, and
+ * a final gate; at the final gate approval completes the run.
+ */
+export function renderDecisions(mode: 'early' | 'final'): string[] {
+  const approve =
+    mode === 'early'
+      ? '- **approve** — continues to task decomposition, atomicity checking, and a final gate (BREAKING: no longer stops the run here)'
+      : '- **approve** — completes the run with the full artifact set (proposal, specs, design, tasks)'
+  return [
+    '### Decisions',
+    '',
+    approve,
+    '- **veto** (leave a box unchecked) — runs one resolver pass on the redirects, then re-gates',
+    '- **abort** (`ABORT` on its own line) — ends the run without completing; the only early exit that spends nothing further',
+  ]
 }
 
 function appendGateSections(lines: string[], input: GateDigestInput, ranked: readonly GateAssumption[]): void {

--- a/sdd-runner/src/gate-session.ts
+++ b/sdd-runner/src/gate-session.ts
@@ -3,68 +3,14 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import * as readline from 'node:readline/promises'
-
 import { renderGateAnswers, responseFromAnswers } from './gate-answers.js'
 import type { GateAck, GateAnswerItem, GateAnswers, GateBlockerAnswer } from './gate-answers.js'
 import { parseGateResponse } from './gate-model.js'
 import type { ExpectedGateContent, GateResponse } from './gate-model.js'
+import type { Prompter } from './prompter.js'
 
-export interface Prompter {
-  readonly say: (line: string) => void
-  readonly ask: (prompt: string) => Promise<string | null>
-}
-
-/**
- * Test/scripting prompter: `ask` pulls the next pre-scripted answer (or `null`
- * when the script is exhausted, standing in for EOF); every exchange is
- * recorded into `transcript` so tests can assert on the walkthrough.
- */
-export function scriptedPrompter(answers: readonly string[]): { prompter: Prompter; transcript: string[] } {
-  const transcript: string[] = []
-  const queue = [...answers]
-  const prompter: Prompter = {
-    say: (line) => {
-      transcript.push(line)
-    },
-    ask: (prompt) => {
-      transcript.push(`? ${prompt}`)
-      const next = queue.shift()
-      if (next === undefined) return Promise.resolve(null)
-      transcript.push(`> ${next}`)
-      return Promise.resolve(next)
-    },
-  }
-  return { prompter, transcript }
-}
-
-export interface ReadlineStreams {
-  readonly input: NodeJS.ReadStream
-  readonly output: NodeJS.WritableStream
-}
-
-/**
- * Thin `node:readline` adapter (no new deps). Behavior lives in the session
- * and is covered via `scriptedPrompter`; this only wires the terminal I/O.
- */
-export function readlinePrompter(streams: ReadlineStreams): Prompter {
-  let terminal: readline.Interface | null = null
-  const openTerminal = (): readline.Interface => {
-    terminal ??= readline.createInterface({ input: streams.input, output: streams.output })
-    return terminal
-  }
-  return {
-    say: (line) => {
-      streams.output.write(`${line}\n`)
-    },
-    ask: (prompt) => openTerminal().question(`${prompt} `),
-  }
-}
-
-/** Interactive mode is entered only when stdin is a TTY (flags always win). */
-export function stdinIsInteractive(input: NodeJS.ReadStream = process.stdin): boolean {
-  return input.isTTY ?? false
-}
+export type { Prompter } from './prompter.js'
+export { readlinePrompter, scriptedPrompter, stdinIsInteractive } from './prompter.js'
 
 export interface GateSessionItem {
   readonly kind: 'assumption' | 'finding'
@@ -245,6 +191,74 @@ async function collectItems(
   return collectItems(prompter, items, index + 1, [...acc, answer])
 }
 
+export interface FlagDecisionInput {
+  readonly confirmAll?: boolean
+  readonly abort?: boolean
+  readonly extend?: boolean
+  readonly vetoes?: readonly { readonly id: string; readonly redirect?: string }[]
+}
+
+/**
+ * Desugar decision flags to the same answers the session collects (Decision
+ * 5): `--confirm-all` accepts every item, answers every blocker with
+ * OVERRIDE, and affirms the ack; each `--veto <id>=<redirect>` then
+ * un-accepts its item with the redirect. Unknown veto ids fail before
+ * anything is written. No flags at all is not a decision — the hand-edited
+ * file path handles that case.
+ */
+export function desugarFlags(
+  flags: FlagDecisionInput,
+  view: GateSessionView,
+  writeGateMd: (md: string) => Promise<void>,
+): Promise<GateSessionResult> {
+  if (flags.abort === true) {
+    return settleAnswers({ items: [], blockerAnswers: [], acks: [], decision: 'abort' }, view, writeGateMd)
+  }
+  if (flags.extend === true) {
+    return settleAnswers({ items: [], blockerAnswers: [], acks: [], decision: 'extend' }, view, writeGateMd)
+  }
+  if (flags.confirmAll !== true) {
+    return Promise.reject(
+      new Error('no decision flags given — pass --confirm-all/--veto/--abort/--extend, or hand-edit the gate file'),
+    )
+  }
+  const known = new Set(view.items.map((item) => item.id))
+  for (const veto of flags.vetoes ?? []) {
+    if (!known.has(veto.id)) {
+      return Promise.reject(new Error(`unknown veto id: ${veto.id} (not in this gate's item set)`))
+    }
+  }
+  const items: GateAnswerItem[] = view.items.map((item) => {
+    const veto = (flags.vetoes ?? []).find((candidate) => candidate.id === item.id)
+    if (veto === undefined) return { kind: item.kind, id: item.id, text: item.text, accepted: true }
+    return {
+      kind: item.kind,
+      id: item.id,
+      text: item.text,
+      accepted: false,
+      ...(veto.redirect === undefined ? {} : { redirect: veto.redirect }),
+    }
+  })
+  const blockerAnswers = view.blockers.map((blocker) => ({ id: blocker.id, gap: blocker.gap, answer: 'OVERRIDE' }))
+  const ack = view.requiredAck
+  const acks = ack === null ? [] : [{ id: ack.id, text: ack.text }]
+  return settleAnswers({ items, blockerAnswers, acks, decision: 'approve' }, view, writeGateMd)
+}
+
+async function settleAnswers(
+  answers: GateAnswers,
+  view: GateSessionView,
+  writeGateMd: (md: string) => Promise<void>,
+): Promise<GateSessionResult> {
+  const md = renderGateAnswers(answers)
+  const parsed = parseGateResponse(md, expectedContent(view))
+  if (!sameResponse(parsed, responseFromAnswers(answers))) {
+    throw new Error('answer self-check failed: rendered answers parse back as a different outcome')
+  }
+  await writeGateMd(md)
+  return { status: 'answered', decision: answers.decision, gateMd: md }
+}
+
 /**
  * Interactive gate session (Decisions 1-2): walk every finding/assumption
  * (accept / veto+redirect / inspect), answer cap-hit blockers, affirm the
@@ -265,11 +279,5 @@ export async function runGateSession(deps: GateSessionDeps): Promise<GateSession
     acks: collected.acks,
     decision: collected.decision,
   }
-  const md = renderGateAnswers(answers)
-  const parsed = parseGateResponse(md, expectedContent(view))
-  if (!sameResponse(parsed, responseFromAnswers(answers))) {
-    throw new Error('gate session self-check failed: rendered answers parse back as a different outcome')
-  }
-  await deps.writeGateMd(md)
-  return { status: 'answered', decision: collected.decision, gateMd: md }
+  return settleAnswers(answers, view, deps.writeGateMd)
 }

--- a/sdd-runner/src/gate-session.ts
+++ b/sdd-runner/src/gate-session.ts
@@ -7,6 +7,7 @@ import { renderGateAnswers, responseFromAnswers } from './gate-answers.js'
 import type { GateAck, GateAnswerItem, GateAnswers, GateBlockerAnswer } from './gate-answers.js'
 import { parseGateResponse } from './gate-model.js'
 import type { ExpectedGateContent, GateResponse } from './gate-model.js'
+import { decisionConsequences } from './gate-render.js'
 import type { Prompter } from './prompter.js'
 
 export type { Prompter } from './prompter.js'
@@ -89,14 +90,16 @@ async function promptAck(prompter: Prompter, ack: { id: string; text: string }):
   return promptAck(prompter, ack)
 }
 
+/**
+ * The decision-menu consequence lines, rendered from the same
+ * mode-conditional phrases the gate file's `### Decisions` block uses — one
+ * copy source, two front-ends (Decision 6).
+ */
 export function consequenceLines(view: GateSessionView): string[] {
-  const approve =
-    view.gateMode === 'early'
-      ? 'approve — continues to task decomposition, atomicity checking, and a final gate'
-      : 'approve — completes the run with the full artifact set'
-  const lines = ['Decision:', `  ${approve}`]
-  if (view.gateMode === 'early') lines.push('  extend — runs one more review round, then re-gates')
-  lines.push('  abort — ends the run without completing')
+  const c = decisionConsequences(view.gateMode)
+  const lines = ['Decision:', `  approve — ${c.approve}`]
+  if (c.extend !== null) lines.push(`  extend — ${c.extend}`)
+  lines.push(`  abort — ${c.abort}`)
   return lines
 }
 

--- a/sdd-runner/src/gate-session.ts
+++ b/sdd-runner/src/gate-session.ts
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import * as readline from 'node:readline/promises'
+
+import { renderGateAnswers, responseFromAnswers } from './gate-answers.js'
+import type { GateAck, GateAnswerItem, GateAnswers, GateBlockerAnswer } from './gate-answers.js'
+import { parseGateResponse } from './gate-model.js'
+import type { ExpectedGateContent, GateResponse } from './gate-model.js'
+
+export interface Prompter {
+  readonly say: (line: string) => void
+  readonly ask: (prompt: string) => Promise<string | null>
+}
+
+/**
+ * Test/scripting prompter: `ask` pulls the next pre-scripted answer (or `null`
+ * when the script is exhausted, standing in for EOF); every exchange is
+ * recorded into `transcript` so tests can assert on the walkthrough.
+ */
+export function scriptedPrompter(answers: readonly string[]): { prompter: Prompter; transcript: string[] } {
+  const transcript: string[] = []
+  const queue = [...answers]
+  const prompter: Prompter = {
+    say: (line) => {
+      transcript.push(line)
+    },
+    ask: (prompt) => {
+      transcript.push(`? ${prompt}`)
+      const next = queue.shift()
+      if (next === undefined) return Promise.resolve(null)
+      transcript.push(`> ${next}`)
+      return Promise.resolve(next)
+    },
+  }
+  return { prompter, transcript }
+}
+
+export interface ReadlineStreams {
+  readonly input: NodeJS.ReadStream
+  readonly output: NodeJS.WritableStream
+}
+
+/**
+ * Thin `node:readline` adapter (no new deps). Behavior lives in the session
+ * and is covered via `scriptedPrompter`; this only wires the terminal I/O.
+ */
+export function readlinePrompter(streams: ReadlineStreams): Prompter {
+  let terminal: readline.Interface | null = null
+  const openTerminal = (): readline.Interface => {
+    terminal ??= readline.createInterface({ input: streams.input, output: streams.output })
+    return terminal
+  }
+  return {
+    say: (line) => {
+      streams.output.write(`${line}\n`)
+    },
+    ask: (prompt) => openTerminal().question(`${prompt} `),
+  }
+}
+
+/** Interactive mode is entered only when stdin is a TTY (flags always win). */
+export function stdinIsInteractive(input: NodeJS.ReadStream = process.stdin): boolean {
+  return input.isTTY ?? false
+}
+
+export interface GateSessionItem {
+  readonly kind: 'assumption' | 'finding'
+  readonly id: string
+  readonly text: string
+  readonly evidence: string
+  readonly blastRadius: string
+}
+
+export interface GateSessionBlocker {
+  readonly id: string
+  readonly gap: string
+  readonly evidence: string
+}
+
+export interface GateSessionView {
+  readonly gateMode: 'early' | 'final'
+  readonly items: readonly GateSessionItem[]
+  readonly blockers: readonly GateSessionBlocker[]
+  readonly requiredAck: { readonly id: string; readonly text: string } | null
+}
+
+export interface GateSessionDeps {
+  readonly prompter: Prompter
+  readonly view: GateSessionView
+  readonly writeGateMd: (md: string) => Promise<void>
+}
+
+export type GateSessionResult =
+  | { readonly status: 'answered'; readonly decision: GateAnswers['decision']; readonly gateMd: string }
+  | { readonly status: 'abandoned' }
+
+async function ask(prompter: Prompter, prompt: string): Promise<string | null> {
+  const raw = await prompter.ask(prompt)
+  if (raw === null) return null
+  const trimmed = raw.trim()
+  if (trimmed === 'q' || trimmed === 'quit') return null
+  return trimmed
+}
+
+async function promptItem(prompter: Prompter, item: GateSessionItem): Promise<GateAnswerItem | null> {
+  const choice = await ask(prompter, `${item.id} ${item.text} — (a)ccept / (v)eto / (i)nspect / (q)uit`)
+  if (choice === null) return null
+  if (choice === 'i') {
+    prompter.say(`  evidence: ${item.evidence === '' ? '(none)' : item.evidence}`)
+    prompter.say(`  blast radius: ${item.blastRadius === '' ? '(none)' : item.blastRadius}`)
+    return promptItem(prompter, item)
+  }
+  if (choice === 'a') return { kind: item.kind, id: item.id, text: item.text, accepted: true }
+  if (choice === 'v') return promptVeto(prompter, item)
+  prompter.say('choose (a)ccept, (v)eto, (i)nspect, or (q)uit')
+  return promptItem(prompter, item)
+}
+
+async function promptVeto(prompter: Prompter, item: GateSessionItem): Promise<GateAnswerItem | null> {
+  const redirect = await ask(prompter, `redirect for ${item.id} (empty for none)`)
+  if (redirect === null) return null
+  return { kind: item.kind, id: item.id, text: item.text, accepted: false, ...(redirect === '' ? {} : { redirect }) }
+}
+
+type BlockerAnswer = GateBlockerAnswer | { readonly deferred: true; readonly id: string; readonly gap: string }
+
+async function promptBlocker(prompter: Prompter, blocker: GateSessionBlocker): Promise<BlockerAnswer | null> {
+  const raw = await ask(prompter, `${blocker.id} ${blocker.gap} — answer, OVERRIDE, or skip`)
+  if (raw === null) return null
+  if (raw === '' || raw === 'skip') return { deferred: true, id: blocker.id, gap: blocker.gap }
+  return { id: blocker.id, gap: blocker.gap, answer: raw }
+}
+
+async function promptAck(prompter: Prompter, ack: { id: string; text: string }): Promise<boolean | null> {
+  const choice = await ask(prompter, `${ack.id} ${ack.text} — (y)es / (n)o`)
+  if (choice === null) return null
+  if (choice === 'y' || choice === 'yes') return true
+  if (choice === 'n' || choice === 'no') return false
+  prompter.say('choose (y)es or (n)o')
+  return promptAck(prompter, ack)
+}
+
+export function consequenceLines(view: GateSessionView): string[] {
+  const approve =
+    view.gateMode === 'early'
+      ? 'approve — continues to task decomposition, atomicity checking, and a final gate'
+      : 'approve — completes the run with the full artifact set'
+  const lines = ['Decision:', `  ${approve}`]
+  if (view.gateMode === 'early') lines.push('  extend — runs one more review round, then re-gates')
+  lines.push('  abort — ends the run without completing')
+  return lines
+}
+
+function expectedContent(view: GateSessionView): ExpectedGateContent {
+  return {
+    assumptions: view.items
+      .filter((item) => item.kind === 'assumption')
+      .map((item) => ({ id: item.id, text: item.text, blast_radius: item.blastRadius })),
+    blockers: view.blockers.map((blocker) => ({ id: blocker.id, gap: blocker.gap, evidence: blocker.evidence })),
+    findings: view.items
+      .filter((item) => item.kind === 'finding')
+      .map((item) => ({ id: item.id, gap: item.text, evidence: item.evidence })),
+    ...(view.requiredAck === null ? {} : { requiredAck: view.requiredAck.id }),
+    gateMode: view.gateMode,
+  }
+}
+
+function sameResponse(a: GateResponse, b: GateResponse): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+interface Collected {
+  readonly items: readonly GateAnswerItem[]
+  readonly blockerAnswers: readonly GateBlockerAnswer[]
+  readonly acks: readonly GateAck[]
+  readonly decision: GateAnswers['decision']
+}
+
+/**
+ * Walk the unresolved blockers, the trajectory ack, and the decision menu.
+ * Recursion replaces loops: each retry cycle re-enters with the accumulated
+ * state, matching the repo's sequential-await style.
+ */
+async function collectDecision(
+  prompter: Prompter,
+  view: GateSessionView,
+  items: readonly GateAnswerItem[],
+  answered: Map<string, GateBlockerAnswer>,
+  ackAffirmed: boolean,
+): Promise<Collected | null> {
+  const nextBlocker = view.blockers.find((blocker) => !answered.has(blocker.id))
+  if (nextBlocker !== undefined) {
+    const answer = await promptBlocker(prompter, nextBlocker)
+    if (answer === null) return null
+    if (!('deferred' in answer)) answered.set(answer.id, answer)
+    return collectDecision(prompter, view, items, answered, ackAffirmed)
+  }
+  if (!ackAffirmed && view.requiredAck !== null) {
+    const affirmed = await promptAck(prompter, view.requiredAck)
+    if (affirmed === null) return null
+    return collectDecision(prompter, view, items, answered, affirmed)
+  }
+  for (const line of consequenceLines(view)) prompter.say(line)
+  const choice = await ask(prompter, 'decision (approve / extend / abort / q)')
+  if (choice === null) return null
+  if (choice === 'abort') return { items: [], blockerAnswers: [], acks: [], decision: 'abort' }
+  if (choice === 'extend') {
+    if (view.gateMode !== 'early') {
+      prompter.say('extend is available only at an early (cap-hit) gate')
+      return collectDecision(prompter, view, items, answered, ackAffirmed)
+    }
+    return { items: [], blockerAnswers: [], acks: [], decision: 'extend' }
+  }
+  if (choice !== 'approve') {
+    prompter.say('choose approve, extend, or abort (q to abandon)')
+    return collectDecision(prompter, view, items, answered, ackAffirmed)
+  }
+  const unresolved = view.blockers.filter((blocker) => !answered.has(blocker.id))
+  if (unresolved.length > 0 || !ackAffirmed) {
+    const missing = [
+      ...unresolved.map((blocker) => `blocker ${blocker.id} unanswered`),
+      ...(ackAffirmed ? [] : [`${view.requiredAck?.id ?? 'ack'} not affirmed`]),
+    ]
+    prompter.say(`approve is unavailable: ${missing.join(', ')}`)
+    return collectDecision(prompter, view, items, answered, ackAffirmed)
+  }
+  const acks: GateAck[] =
+    view.requiredAck !== null && ackAffirmed ? [{ id: view.requiredAck.id, text: view.requiredAck.text }] : []
+  return { items, blockerAnswers: [...answered.values()], acks, decision: 'approve' }
+}
+
+async function collectItems(
+  prompter: Prompter,
+  items: readonly GateSessionItem[],
+  index: number,
+  acc: readonly GateAnswerItem[],
+): Promise<readonly GateAnswerItem[] | null> {
+  const item = items[index]
+  if (item === undefined) return acc
+  const answer = await promptItem(prompter, item)
+  if (answer === null) return null
+  return collectItems(prompter, items, index + 1, [...acc, answer])
+}
+
+/**
+ * Interactive gate session (Decisions 1-2): walk every finding/assumption
+ * (accept / veto+redirect / inspect), answer cap-hit blockers, affirm the
+ * trajectory ack, then offer the decision with consequence lines. The
+ * collected answers render to gate-file grammar and pass a write-then-parse
+ * self-check before anything is written; abandoning before the final decision
+ * writes nothing.
+ */
+export async function runGateSession(deps: GateSessionDeps): Promise<GateSessionResult> {
+  const { prompter, view } = deps
+  const items = await collectItems(prompter, view.items, 0, [])
+  if (items === null) return { status: 'abandoned' }
+  const collected = await collectDecision(prompter, view, items, new Map(), view.requiredAck === null)
+  if (collected === null) return { status: 'abandoned' }
+  const answers: GateAnswers = {
+    items: collected.items,
+    blockerAnswers: collected.blockerAnswers,
+    acks: collected.acks,
+    decision: collected.decision,
+  }
+  const md = renderGateAnswers(answers)
+  const parsed = parseGateResponse(md, expectedContent(view))
+  if (!sameResponse(parsed, responseFromAnswers(answers))) {
+    throw new Error('gate session self-check failed: rendered answers parse back as a different outcome')
+  }
+  await deps.writeGateMd(md)
+  return { status: 'answered', decision: collected.decision, gateMd: md }
+}

--- a/sdd-runner/src/index.ts
+++ b/sdd-runner/src/index.ts
@@ -15,23 +15,29 @@ import { parseCliArgs } from './cli.js'
 import { discoverBranch, loadRunnerConfig } from './config.js'
 import type { ExecGitFn } from './config.js'
 import { readEvents } from './events.js'
+import { readlinePrompter, stdinIsInteractive } from './gate-session.js'
+import type { Prompter } from './gate-session.js'
 import { createOpenSpecDriver } from './openspec-driver.js'
 import type { OpenSpecDriver } from './openspec-driver.js'
-import { runGateResume, runResume, runStart } from './orchestrator.js'
+import { runContinue, runGateResume, runResume, runStart } from './orchestrator.js'
 import { createRenderer } from './renderer.js'
 import type { Verbosity } from './renderer.js'
 import { buildReport } from './report.js'
 import type { ChangeDirSummary, ReportInput } from './report.js'
-import { loadRunState } from './run-state.js'
+import { listPendingGates, loadRunState, resolveRunId } from './run-state.js'
 
 export const USAGE = [
   'sdd-runner — autonomous SDD pipeline',
   '',
   'Usage:',
   '  sdd-runner start <task-file> [--depth S|M|L] [--verbosity brief|normal|debug]',
+  '  sdd-runner continue [runId]',
   '  sdd-runner resume <runId>',
-  '  sdd-runner gate resume <runId> [--confirm-all] [--abort]',
+  '  sdd-runner gate [resume <runId> [--confirm-all] [--extend] [--veto <id>=<redirect>]... [--abort]]',
   '  sdd-runner report <runId> [--pr]',
+  '',
+  'On a terminal, `gate resume <runId>` (or `continue`) opens an interactive gate session.',
+  'Without a TTY, pass decision flags or hand-edit the gate file. Bare `gate` lists pending gates.',
 ].join('\n')
 
 export async function readChangeSummary(repoRoot: string, changeName: string): Promise<ChangeDirSummary> {
@@ -107,11 +113,18 @@ async function buildHarness(verbosity: Verbosity = 'normal'): Promise<CliHarness
     stdout: (line: string): void => {
       process.stdout.write(`${line}\n`)
     },
+    interactive: (): boolean => stdinIsInteractive(),
+    makePrompter: (): Prompter => readlinePrompter({ input: process.stdin, output: process.stdout }),
   }
   return {
     runStart: (options) => runStart(orchestratorDeps, options),
     runResume: (runId) => runResume(orchestratorDeps, runId),
-    runGateResume: (runId, options) => runGateResume(orchestratorDeps, runId, options),
+    runGateResume: async (runId, options) => {
+      const resolved = await resolveRunId(config.workDir, runId)
+      return runGateResume(orchestratorDeps, resolved, options)
+    },
+    runContinue: (runId) => runContinue(orchestratorDeps, runId),
+    listPendingGates: () => listPendingGates(config.workDir),
     buildReport: async (runId, pr) => {
       const state = await loadRunState(config.workDir, runId)
       const branch = await discoverBranch(execGit, config.repoRoot)

--- a/sdd-runner/src/index.ts
+++ b/sdd-runner/src/index.ts
@@ -15,6 +15,7 @@ import { parseCliArgs } from './cli.js'
 import { discoverBranch, loadRunnerConfig } from './config.js'
 import type { ExecGitFn } from './config.js'
 import { readEvents } from './events.js'
+import { buildResolveCost } from './gate-digest.js'
 import { readlinePrompter, stdinIsInteractive } from './gate-session.js'
 import type { Prompter } from './gate-session.js'
 import { createOpenSpecDriver } from './openspec-driver.js'
@@ -103,7 +104,8 @@ async function buildHarness(verbosity: Verbosity = 'normal'): Promise<CliHarness
   const config = await loadRunnerConfig(configPath)
   const driver: OpenSpecDriver = createOpenSpecDriver({ exec: shellExec(config.repoRoot), cwd: config.repoRoot })
   const execGit = makeExecGit()
-  const renderer = createRenderer(process.stdout, verbosity)
+  const resolveCost = await buildResolveCost()
+  const renderer = createRenderer(process.stdout, verbosity, { resolveCost })
   const orchestratorDeps = {
     config,
     spawn: realSpawn,

--- a/sdd-runner/src/live-renderer.ts
+++ b/sdd-runner/src/live-renderer.ts
@@ -11,11 +11,15 @@ import { renderPipelineMap } from './renderer.js'
 import type { Renderer, RendererStream, Verbosity } from './renderer.js'
 import { createReplayFolder } from './replay.js'
 import type { ReplayFolder, ReplayState } from './replay.js'
+import type { ResolveCostFn } from './usage-aggregate.js'
 
 const ARROW = '\u25B6'
 const ERASE_LINE = '\u001b[2K'
 const CURSOR_DOWN = '\u001b[1B'
 const ELLIPSIS = '\u2026'
+const TOKEN_SCALE = 1_000_000
+
+type StepFinishInput = Extract<EventInput, { type: 'step_finish' }>
 
 function cursorUp(n: number): string {
   return `\u001b[${n}A`
@@ -54,14 +58,19 @@ export class DynamicRenderer implements Renderer {
   private readonly folder: ReplayFolder
   private readonly slots = new Map<string, string>()
   private readonly totals = { input: 0, output: 0, reasoning: 0, cost: 0 }
+  private readonly agentModels = new Map<string, string>()
+  private costEstimated = false
+  private readonly resolveCost: ResolveCostFn | undefined
 
   constructor(
     private readonly stream: RendererStream,
     private readonly verbosity: Verbosity,
     folder?: ReplayFolder,
+    resolveCost?: ResolveCostFn,
   ) {
     this.tty = stream.isTTY === true
     this.folder = folder ?? createReplayFolder()
+    this.resolveCost = resolveCost
   }
 
   renderState = (state: ReplayState): void => {
@@ -91,18 +100,34 @@ export class DynamicRenderer implements Renderer {
         event.agent,
         arg === undefined ? `${event.agent} ${ARROW} ${event.tool}` : `${event.agent} ${ARROW} ${event.tool} ${arg}`,
       )
+    } else if (event.type === 'spawned') {
+      this.agentModels.set(event.agent, event.model)
     } else if (event.type === 'done') {
       this.slots.delete(event.agent)
-      this.totals.input += event.usage.inputTokens
-      this.totals.output += event.usage.outputTokens
-      this.totals.reasoning += event.usage.reasoningTokens
-      this.totals.cost += event.usage.costUsd
     } else if (event.type === 'step_finish') {
       this.totals.input += event.tokens.input
       this.totals.output += event.tokens.output
       this.totals.reasoning += event.tokens.reasoning
-      this.totals.cost += event.costUsd
+      this.totals.cost += event.costUsd + this.estimateStepCost(event)
     }
+  }
+
+  /**
+   * Display-time estimate for an unmetered step, using the `spawned`-event
+   * agent→model association and the same formula as `repriceEvent` so live and
+   * gate figures agree. Returns 0 (today's behavior) when no resolver was
+   * injected, the model is unknown, or pricing cannot resolve it.
+   */
+  private estimateStepCost(event: StepFinishInput): number {
+    if (this.resolveCost === undefined || event.costUsd > 0) return 0
+    const { input, output, reasoning } = event.tokens
+    if (input === 0 && output === 0 && reasoning === 0) return 0
+    const model = this.agentModels.get(event.agent)
+    if (model === undefined) return 0
+    const resolved = this.resolveCost(model)
+    if (resolved === null) return 0
+    this.costEstimated = true
+    return ((input + reasoning) * resolved.input + output * resolved.output) / TOKEN_SCALE
   }
 
   private statusLine(): string {
@@ -112,7 +137,7 @@ export class DynamicRenderer implements Renderer {
     if (this.totals.input > 0 || this.totals.output > 0) {
       parts.push(`in ${formatTokenCount(this.totals.input)} / out ${formatTokenCount(this.totals.output)}`)
     }
-    if (this.totals.cost > 0) parts.push(`$${this.totals.cost.toFixed(4)}`)
+    if (this.totals.cost > 0) parts.push(`${this.costEstimated ? '~' : ''}$${this.totals.cost.toFixed(4)}`)
     if (this.startedAt !== 0) parts.push(formatDuration(Date.now() - this.startedAt))
     if (parts.length === 0) return ''
     return `  ${'status'.padEnd(10)} ${parts.join(` ${MIDDLE_DOT} `)}`

--- a/sdd-runner/src/orchestrator.ts
+++ b/sdd-runner/src/orchestrator.ts
@@ -3,22 +3,18 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import type { AgentLayerDeps } from './agent-layer.js'
 import { deriveChangeName } from './config.js'
-import { runAtomicity, runDecompose } from './decompose.js'
 import { runDraft } from './draft.js'
-import { buildDriftCheck } from './drift.js'
 import type { DepthProfile, EventInput } from './events.js'
-import { prepareResumeInput, runExtendRound } from './extend-round.js'
-import type { RunGateResumeResult } from './extend-round.js'
-import { applyConfirmAll, buildBus, finalizeGate, findingsOf, logPathFor, nowOf, presentGateAt } from './gate-digest.js'
+import { buildBus, logPathFor, nowOf, presentGateAt } from './gate-digest.js'
 import type { OrchestratorDeps, RunStartResult, StageContext } from './gate-digest.js'
-import { resumeGate, vetoRedirects } from './gate.js'
 import { runIntake } from './intake.js'
 import { createMaterializer } from './materialize.js'
+import { runPostConvergenceTail } from './post-review-tail.js'
 import type { Verbosity } from './renderer.js'
 import { replayEvents } from './replay.js'
 import { runReviewLoop } from './review-loop.js'
@@ -27,10 +23,10 @@ import { createRunState, loadRunState, resolveRoundCap, saveRunState } from './r
 import type { RunState } from './run-state.js'
 import { deriveResumePoint } from './run-state.js'
 import { createStageMachine } from './stage-machine.js'
-import { runVetoUpdater, updateAssumptionsFromVetoes } from './veto-updater.js'
 
 export type { OrchestratorDeps, RunStartResult } from './gate-digest.js'
-export type { RunGateResumeResult } from './extend-round.js'
+export type { GateResumeOptions, RunGateResumeResult } from './extend-round.js'
+export { runGateResume } from './extend-round.js'
 
 export interface StartOptions {
   readonly taskFile: string
@@ -51,90 +47,6 @@ interface FreshInput {
   readonly depthOverride?: DepthProfile
 }
 
-export async function runStart(deps: OrchestratorDeps, options: StartOptions): Promise<RunStartResult> {
-  const taskText = await readFile(options.taskFile, 'utf8')
-  const changeName = deriveChangeName(options.taskFile, taskText)
-  const state = await createRunState(
-    { workDir: deps.config.workDir, repoRoot: deps.config.repoRoot, changeName },
-    nowOf(deps),
-  )
-  const emit = buildBus(deps, logPathFor(state))
-  return runFreshPipeline(deps, state, emit, { taskText, changeName, depthOverride: options.depthOverride })
-}
-
-export async function runResume(deps: OrchestratorDeps, runId: string): Promise<RunResumeResult> {
-  const state = await loadRunState(deps.config.workDir, runId)
-  const emit = buildBus(deps, logPathFor(state))
-  if (state.gate !== null) return { runId, halted: 'gate-pending' }
-  const status = await deps.driver.status(state.changeName)
-  const resume = deriveResumePoint(state, status.artifacts, replayEvents(logPathFor(state)))
-  const depth = state.depth ?? 'S'
-  const cwd = deps.config.repoRoot
-  const sidecarDir = path.join(state.runDir, 'sidecars')
-  const changeDir = path.join(cwd, 'openspec', 'changes', state.changeName)
-  const machine = createStageMachine({ emit })
-  const agent: AgentLayerDeps = { spawn: deps.spawn, config: deps.config, execGit: deps.execGit, emit }
-  const ctx: StageContext = { cwd, changeDir, sidecarDir, emit }
-  const env: PipelineEnv = {
-    deps,
-    state,
-    machine,
-    agent,
-    ctx,
-    input: { changeName: state.changeName, depthOverride: depth, taskText: '' },
-  }
-  if (resume.stage !== 'review') {
-    throw new Error(`resume from stage '${resume.stage}' (${resume.reason}) is not supported yet`)
-  }
-  const materialize = createMaterializer(sidecarDir, changeDir)
-  let reviewResult!: ReviewLoopResult
-  await machine.runStage('review', async () => {
-    reviewResult = await runReviewLoop(
-      { agent, emit, sidecarDir, cwd, materialize },
-      { changeName: state.changeName, changeDir, depth, taskText: '', conventions: deps.conventions ?? '' },
-    )
-    state.round = reviewResult.rounds
-  })
-  state.stage = 'review'
-  await saveRunState(state, nowOf(deps))
-  const gate = await runPostReviewToGate(env, depth, reviewResult)
-  return { runId, halted: 'gate', gateMdPath: gate.gateMdPath, version: gate.version }
-}
-
-async function runFreshPipeline(
-  deps: OrchestratorDeps,
-  state: RunState,
-  emit: (event: EventInput) => void,
-  input: FreshInput,
-): Promise<RunStartResult> {
-  const cwd = deps.config.repoRoot
-  const sidecarDir = path.join(state.runDir, 'sidecars')
-  const changeDir = path.join(cwd, 'openspec', 'changes', input.changeName)
-  const machine = createStageMachine({ emit })
-  const agent: AgentLayerDeps = { spawn: deps.spawn, config: deps.config, execGit: deps.execGit, emit }
-  const ctx: StageContext = { cwd, changeDir, sidecarDir, emit }
-  const env: PipelineEnv = { deps, state, machine, agent, ctx, input }
-  const { depth, reviewResult } = await runPlanningStages(env)
-  return runPostReviewToGate(env, depth, reviewResult)
-}
-
-async function runPostReviewToGate(
-  env: PipelineEnv,
-  depth: DepthProfile,
-  reviewResult: ReviewLoopResult,
-  version: number = 1,
-): Promise<RunStartResult> {
-  const { deps, state, machine, ctx } = env
-  if (reviewResult.outcome === 'cap-hit') return presentGateAt(deps, state, ctx, reviewResult, version, 'early')
-  await runDecomposeStages(env, depth)
-  state.stage = 'gate'
-  let gateResult!: RunStartResult
-  await machine.runStage('gate', async () => {
-    gateResult = await presentGateAt(deps, state, ctx, reviewResult, version, 'final')
-  })
-  return gateResult
-}
-
 interface PipelineEnv {
   readonly deps: OrchestratorDeps
   readonly state: RunState
@@ -144,7 +56,81 @@ interface PipelineEnv {
   readonly input: FreshInput
 }
 
+export async function runStart(deps: OrchestratorDeps, options: StartOptions): Promise<RunStartResult> {
+  const taskText = await readFile(options.taskFile, 'utf8')
+  const changeName = deriveChangeName(options.taskFile, taskText)
+  const state = await createRunState(
+    { workDir: deps.config.workDir, repoRoot: deps.config.repoRoot, changeName },
+    nowOf(deps),
+  )
+  const emit = buildBus(deps, logPathFor(state))
+  const env = buildPipelineEnv(deps, state, emit, {
+    taskText,
+    changeName,
+    depthOverride: options.depthOverride,
+  })
+  const { depth, reviewResult } = await runPlanningStages(env)
+  return runPostReviewToGate(env, depth, reviewResult)
+}
+
+export async function runResume(deps: OrchestratorDeps, runId: string): Promise<RunResumeResult> {
+  const state = await loadRunState(deps.config.workDir, runId)
+  const emit = buildBus(deps, logPathFor(state))
+  if (state.gate !== null) return { runId, halted: 'gate-pending' }
+  const status = await deps.driver.status(state.changeName)
+  const resume = deriveResumePoint(state, status.artifacts, replayEvents(logPathFor(state)))
+  const depth = state.depth ?? 'S'
+  const env = buildPipelineEnv(deps, state, emit, { taskText: '', changeName: state.changeName, depthOverride: depth })
+  if (resume.stage !== 'review') {
+    throw new Error(`resume from stage '${resume.stage}' (${resume.reason}) is not supported yet`)
+  }
+  const reviewResult = await runReviewStage(env, depth, '')
+  state.stage = 'review'
+  await saveRunState(state, nowOf(deps))
+  const gate = await runPostReviewToGate(env, depth, reviewResult)
+  return { runId, halted: 'gate', gateMdPath: gate.gateMdPath, version: gate.version }
+}
+
+function buildPipelineEnv(
+  deps: OrchestratorDeps,
+  state: RunState,
+  emit: (event: EventInput) => void,
+  input: FreshInput,
+): PipelineEnv {
+  const cwd = deps.config.repoRoot
+  const sidecarDir = path.join(state.runDir, 'sidecars')
+  const changeDir = path.join(cwd, 'openspec', 'changes', input.changeName)
+  const machine = createStageMachine({ emit })
+  const agent: AgentLayerDeps = { spawn: deps.spawn, config: deps.config, execGit: deps.execGit, emit }
+  const ctx: StageContext = { cwd, changeDir, sidecarDir, emit }
+  return { deps, state, machine, agent, ctx, input }
+}
+
+function runPostReviewToGate(
+  env: PipelineEnv,
+  depth: DepthProfile,
+  reviewResult: ReviewLoopResult,
+  version: number = 1,
+): Promise<RunStartResult> {
+  const { deps, state, ctx, agent } = env
+  if (reviewResult.outcome === 'cap-hit') return presentGateAt(deps, state, ctx, reviewResult, version, 'early')
+  return runPostConvergenceTail({ deps, state, ctx, agent, depth, reviewResult, version })
+}
+
 async function runPlanningStages(env: PipelineEnv): Promise<{ depth: DepthProfile; reviewResult: ReviewLoopResult }> {
+  const { deps, state } = env
+  const depth = await runIntakeStage(env)
+  await saveRunState(state, nowOf(deps))
+  await runDraftStage(env, depth)
+  state.stage = 'draft'
+  await saveRunState(state, nowOf(deps))
+  const reviewResult = await runReviewStage(env, depth, env.input.taskText)
+  state.stage = 'review'
+  await saveRunState(state, nowOf(deps))
+  return { depth, reviewResult }
+}
+
+async function runIntakeStage(env: PipelineEnv): Promise<DepthProfile> {
   const { deps, state, machine, agent, ctx, input } = env
   let depth: DepthProfile = input.depthOverride ?? 'S'
   await machine.runStage('intake', async () => {
@@ -156,7 +142,11 @@ async function runPlanningStages(env: PipelineEnv): Promise<{ depth: DepthProfil
     state.depth = depth
     state.roundCap = resolveRoundCap({ depth, roundCap: undefined })
   })
-  await saveRunState(state, nowOf(deps))
+  return depth
+}
+
+async function runDraftStage(env: PipelineEnv, depth: DepthProfile): Promise<void> {
+  const { deps, machine, agent, ctx, input } = env
   await machine.runStage('draft', () =>
     runDraft(
       {
@@ -169,8 +159,10 @@ async function runPlanningStages(env: PipelineEnv): Promise<{ depth: DepthProfil
       { changeName: input.changeName, taskText: input.taskText, depth },
     ),
   )
-  state.stage = 'draft'
-  await saveRunState(state, nowOf(deps))
+}
+
+async function runReviewStage(env: PipelineEnv, depth: DepthProfile, taskText: string): Promise<ReviewLoopResult> {
+  const { deps, state, machine, agent, ctx, input } = env
   const materialize = createMaterializer(ctx.sidecarDir, ctx.changeDir)
   let reviewResult!: ReviewLoopResult
   await machine.runStage('review', async () => {
@@ -180,88 +172,11 @@ async function runPlanningStages(env: PipelineEnv): Promise<{ depth: DepthProfil
         changeName: input.changeName,
         changeDir: ctx.changeDir,
         depth,
-        taskText: input.taskText,
+        taskText,
         conventions: deps.conventions ?? '',
       },
     )
     state.round = reviewResult.rounds
   })
-  state.stage = 'review'
-  await saveRunState(state, nowOf(deps))
-  return { depth, reviewResult }
-}
-
-async function runDecomposeStages(env: PipelineEnv, depth: DepthProfile): Promise<void> {
-  const { deps, state, machine, agent, ctx, input } = env
-  await machine.runStage('decompose', () =>
-    runDecompose(
-      { driver: deps.driver, agent, sidecarDir: ctx.sidecarDir, cwd: ctx.cwd },
-      { changeName: input.changeName },
-    ),
-  )
-  state.stage = 'decompose'
-  await saveRunState(state, nowOf(deps))
-  if (depth !== 'S') {
-    await machine.runStage('atomicity', async () => {
-      await runAtomicity(
-        { driver: deps.driver, agent, sidecarDir: ctx.sidecarDir, cwd: ctx.cwd },
-        { changeName: input.changeName, depth },
-      )
-    })
-    state.stage = 'atomicity'
-    await saveRunState(state, nowOf(deps))
-  }
-}
-
-export interface GateResumeOptions {
-  readonly confirmAll?: boolean
-  readonly abort?: boolean
-}
-
-export async function runGateResume(
-  deps: OrchestratorDeps,
-  runId: string,
-  options: GateResumeOptions,
-): Promise<RunGateResumeResult> {
-  const state = await loadRunState(deps.config.workDir, runId)
-  if (state.gate === null) throw new Error(`run ${runId} is not gate-pending`)
-  const emit = buildBus(deps, logPathFor(state))
-  const version = state.gate.version
-  const changeDir = path.join(deps.config.repoRoot, 'openspec', 'changes', state.changeName)
-  const sidecarDir = path.join(state.runDir, 'sidecars')
-  const gateMdPath = path.join(state.runDir, `gate-${version}.md`)
-  if (options.abort === true) await writeFile(gateMdPath, 'ABORT\n')
-  else if (options.confirmAll === true) await applyConfirmAll(gateMdPath)
-  const { assumptions, reviewResult, requiredAck } = await prepareResumeInput(sidecarDir, state.round, state.gate.mode)
-  const findings = findingsOf(reviewResult)
-  const agent: AgentLayerDeps = { spawn: deps.spawn, config: deps.config, execGit: deps.execGit, emit }
-  const outcome = await resumeGate(
-    {
-      emit,
-      runDir: state.runDir,
-      changeDir,
-      driftCheck: buildDriftCheck(agent, state, changeDir, sidecarDir, deps.config.repoRoot),
-    },
-    {
-      version,
-      assumptions,
-      blockers: findings.blockers,
-      gateMode: state.gate.mode,
-      ...(findings.material.length > 0 ? { findings: findings.material } : {}),
-      ...(requiredAck === undefined ? {} : { requiredAck }),
-    },
-  )
-  if (outcome.kind === 'aborted') return finalizeGate(deps, state, 'aborted', version)
-  if (outcome.kind === 'approved') return finalizeGate(deps, state, 'completed', version)
-  if (outcome.kind === 'extend') return runExtendRound(deps, state, emit, agent, version)
-  const vetoes = vetoRedirects(outcome)
-  const ctx: StageContext = { cwd: deps.config.repoRoot, changeDir, sidecarDir, emit }
-  await updateAssumptionsFromVetoes(sidecarDir, state.round, vetoes)
-  const driftCheck = buildDriftCheck(agent, state, changeDir, sidecarDir, deps.config.repoRoot)
-  const { filesUpdated } = await runVetoUpdater({ driver: deps.driver, agent }, state, ctx, vetoes)
-  const driftFiles = filesUpdated.filter((file) => file.includes('specs/') || file.endsWith('tasks.md'))
-  if (driftFiles.length > 0) await driftCheck(driftFiles)
-  const next = version + 1
-  await presentGateAt(deps, state, ctx, reviewResult, next, state.gate.mode)
-  return { runId, outcome: 'veto', version: next }
+  return reviewResult
 }

--- a/sdd-runner/src/orchestrator.ts
+++ b/sdd-runner/src/orchestrator.ts
@@ -3,6 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import { readdirSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
@@ -10,7 +11,7 @@ import type { AgentLayerDeps } from './agent-layer.js'
 import { deriveChangeName } from './config.js'
 import { runDraft } from './draft.js'
 import type { DepthProfile, EventInput } from './events.js'
-import { buildBus, logPathFor, nowOf, presentGateAt } from './gate-digest.js'
+import { buildBus, logPathFor, nowOf, presentGateAt, readReviewResultFromSidecars } from './gate-digest.js'
 import type { OrchestratorDeps, RunStartResult, StageContext } from './gate-digest.js'
 import { runIntake } from './intake.js'
 import { createMaterializer } from './materialize.js'
@@ -81,14 +82,48 @@ export async function runResume(deps: OrchestratorDeps, runId: string): Promise<
   const resume = deriveResumePoint(state, status.artifacts, replayEvents(logPathFor(state)))
   const depth = state.depth ?? 'S'
   const env = buildPipelineEnv(deps, state, emit, { taskText: '', changeName: state.changeName, depthOverride: depth })
-  if (resume.stage !== 'review') {
-    throw new Error(`resume from stage '${resume.stage}' (${resume.reason}) is not supported yet`)
+  if (resume.stage === 'review') {
+    const reviewResult = await runReviewStage(env, depth, '')
+    state.stage = 'review'
+    await saveRunState(state, nowOf(deps))
+    const gate = await runPostReviewToGate(env, depth, reviewResult)
+    return { runId, halted: 'gate', gateMdPath: gate.gateMdPath, version: gate.version }
   }
-  const reviewResult = await runReviewStage(env, depth, '')
-  state.stage = 'review'
-  await saveRunState(state, nowOf(deps))
-  const gate = await runPostReviewToGate(env, depth, reviewResult)
-  return { runId, halted: 'gate', gateMdPath: gate.gateMdPath, version: gate.version }
+  if (resume.stage === 'decompose' || resume.stage === 'atomicity' || resume.stage === 'gate') {
+    const reviewResult = await readReviewResultFromSidecars(
+      env.ctx.sidecarDir,
+      state.round,
+      resume.stage === 'gate' ? 'converged' : 'cap-hit',
+    )
+    const reviewSettled = replayEvents(logPathFor(state)).gate?.answered === true
+    const outcome = reviewSettled ? 'converged' : reviewResult.outcome
+    const settledResult: ReviewLoopResult = { ...reviewResult, outcome }
+    const version = nextGateVersion(state)
+    const gate = await runPostConvergenceTail({
+      deps,
+      state,
+      ctx: env.ctx,
+      agent: env.agent,
+      depth,
+      reviewResult: settledResult,
+      version,
+    })
+    return { runId, halted: 'gate', gateMdPath: gate.gateMdPath, version: gate.version }
+  }
+  throw new Error(`resume from stage '${resume.stage}' (${resume.reason}) is not supported yet`)
+}
+
+function nextGateVersion(state: RunState): number {
+  const versions = [0]
+  try {
+    for (const entry of readdirSync(state.runDir)) {
+      const match = entry.match(/^gate-(\d+)\.md$/u)
+      if (match !== null) versions.push(Number(match[1]))
+    }
+  } catch {
+    // run dir unreadable — start at 1
+  }
+  return Math.max(...versions) + 1
 }
 
 function buildPipelineEnv(

--- a/sdd-runner/src/orchestrator.ts
+++ b/sdd-runner/src/orchestrator.ts
@@ -113,8 +113,25 @@ function runPostReviewToGate(
   version: number = 1,
 ): Promise<RunStartResult> {
   const { deps, state, ctx, agent } = env
+  if (isSeverityConverged(reviewResult)) {
+    return runPostConvergenceTail({ deps, state, ctx, agent, depth, reviewResult, version })
+  }
   if (reviewResult.outcome === 'cap-hit') return presentGateAt(deps, state, ctx, reviewResult, version, 'early')
   return runPostConvergenceTail({ deps, state, ctx, agent, depth, reviewResult, version })
+}
+
+/**
+ * Severity-based convergence (orchestrator-level verdict): a cap-hit round
+ * with zero open BLOCKERs and zero open MATERIALs — nitpicks only, each
+ * resolved or dismissed — is treated as converged and flows into decompose
+ * without an early gate. Blockers/materials still force the early gate.
+ */
+function isSeverityConverged(reviewResult: ReviewLoopResult): boolean {
+  return (
+    reviewResult.outcome === 'cap-hit' &&
+    reviewResult.openBlockers.length === 0 &&
+    reviewResult.openMaterial.length === 0
+  )
 }
 
 async function runPlanningStages(env: PipelineEnv): Promise<{ depth: DepthProfile; reviewResult: ReviewLoopResult }> {

--- a/sdd-runner/src/orchestrator.ts
+++ b/sdd-runner/src/orchestrator.ts
@@ -11,7 +11,6 @@ import type { AgentLayerDeps } from './agent-layer.js'
 import { deriveChangeName } from './config.js'
 import { runDraft } from './draft.js'
 import type { DepthProfile, EventInput } from './events.js'
-import { runGateResume } from './extend-round.js'
 import { buildBus, logPathFor, nowOf, presentGateAt, readReviewResultFromSidecars } from './gate-digest.js'
 import type { OrchestratorDeps, RunStartResult, StageContext } from './gate-digest.js'
 import { runIntake } from './intake.js'
@@ -21,14 +20,7 @@ import type { Verbosity } from './renderer.js'
 import { replayEvents } from './replay.js'
 import { runReviewLoop } from './review-loop.js'
 import type { ReviewLoopResult } from './review-loop.js'
-import {
-  createRunState,
-  listPendingGates,
-  loadRunState,
-  resolveRoundCap,
-  resolveRunId,
-  saveRunState,
-} from './run-state.js'
+import { createRunState, loadRunState, resolveRoundCap, saveRunState } from './run-state.js'
 import type { RunState } from './run-state.js'
 import { deriveResumePoint } from './run-state.js'
 import { createStageMachine } from './stage-machine.js'
@@ -36,6 +28,7 @@ import { createStageMachine } from './stage-machine.js'
 export type { OrchestratorDeps, RunStartResult } from './gate-digest.js'
 export type { GateResumeOptions, RunGateResumeResult } from './extend-round.js'
 export { runGateResume } from './extend-round.js'
+export { runContinue } from './continue.js'
 
 export interface StartOptions {
   readonly taskFile: string
@@ -130,59 +123,6 @@ export async function runResume(deps: OrchestratorDeps, runId: string): Promise<
     return { runId, halted: 'gate', gateMdPath: gate.gateMdPath, version: gate.version }
   }
   throw new Error(`resume from stage '${resume.stage}' (${resume.reason}) is not supported yet`)
-}
-
-/**
- * `continue` is a pure router (Decision 4): gate-pending → the gate flow
- * (`runGateResume` with no flags — interactive session on a TTY, hand-edited
- * file otherwise); interrupted mid-stage → `runResume`; completed → a pointer
- * to the report. Without an id, discovery picks the single pending/active
- * run, or lists the candidates when several exist.
- */
-export async function runContinue(deps: OrchestratorDeps, runId: string | null): Promise<RunContinueResult> {
-  if (runId === null) {
-    const picked = await pickContinueRun(deps)
-    if (picked === null) return { runId: null, routed: 'list' }
-    return runContinue(deps, picked)
-  }
-  const resolved = await resolveRunId(deps.config.workDir, runId)
-  const state = await loadRunState(deps.config.workDir, resolved)
-  if (state.gate !== null) {
-    const gate = await runGateResume(deps, resolved, {})
-    return {
-      runId: resolved,
-      routed: 'gate',
-      ...(gate.gateMdPath === undefined ? {} : { gateMdPath: gate.gateMdPath, version: gate.version }),
-    }
-  }
-  if (state.status === 'completed') {
-    deps.stdout?.(`run ${resolved} is completed — report: sdd-runner report ${resolved}`)
-    return { runId: resolved, routed: 'report' }
-  }
-  const resumed = await runResume(deps, resolved)
-  return {
-    runId: resolved,
-    routed: 'resume',
-    ...(resumed.gateMdPath === undefined ? {} : { gateMdPath: resumed.gateMdPath, version: resumed.version }),
-  }
-}
-
-/**
- * Discovery for a bare `continue`: exactly one gate-pending run routes to it;
- * several print the per-run gate commands and route nowhere (the operator
- * picks); none is an error (there is nothing obvious to continue).
- */
-async function pickContinueRun(deps: OrchestratorDeps): Promise<string | null> {
-  const pending = await listPendingGates(deps.config.workDir)
-  if (pending.length === 1) return pending[0]?.runId ?? null
-  if (pending.length > 1) {
-    deps.stdout?.('several runs await gate decisions:')
-    for (const entry of pending) {
-      deps.stdout?.(`  sdd-runner gate resume ${entry.runId}  (${entry.changeName}, gate v${entry.gateVersion})`)
-    }
-    return null
-  }
-  throw new Error('no gate-pending runs found — pass a run id, or use `sdd-runner resume <runId>`')
 }
 
 function nextGateVersion(state: RunState): number {

--- a/sdd-runner/src/orchestrator.ts
+++ b/sdd-runner/src/orchestrator.ts
@@ -11,6 +11,7 @@ import type { AgentLayerDeps } from './agent-layer.js'
 import { deriveChangeName } from './config.js'
 import { runDraft } from './draft.js'
 import type { DepthProfile, EventInput } from './events.js'
+import { runGateResume } from './extend-round.js'
 import { buildBus, logPathFor, nowOf, presentGateAt, readReviewResultFromSidecars } from './gate-digest.js'
 import type { OrchestratorDeps, RunStartResult, StageContext } from './gate-digest.js'
 import { runIntake } from './intake.js'
@@ -20,7 +21,14 @@ import type { Verbosity } from './renderer.js'
 import { replayEvents } from './replay.js'
 import { runReviewLoop } from './review-loop.js'
 import type { ReviewLoopResult } from './review-loop.js'
-import { createRunState, loadRunState, resolveRoundCap, saveRunState } from './run-state.js'
+import {
+  createRunState,
+  listPendingGates,
+  loadRunState,
+  resolveRoundCap,
+  resolveRunId,
+  saveRunState,
+} from './run-state.js'
 import type { RunState } from './run-state.js'
 import { deriveResumePoint } from './run-state.js'
 import { createStageMachine } from './stage-machine.js'
@@ -38,6 +46,13 @@ export interface StartOptions {
 export interface RunResumeResult {
   readonly runId: string
   readonly halted: 'gate' | 'gate-pending'
+  readonly gateMdPath?: string
+  readonly version?: number
+}
+
+export interface RunContinueResult {
+  readonly runId: string | null
+  readonly routed: 'gate' | 'resume' | 'report' | 'list'
   readonly gateMdPath?: string
   readonly version?: number
 }
@@ -76,8 +91,12 @@ export async function runStart(deps: OrchestratorDeps, options: StartOptions): P
 
 export async function runResume(deps: OrchestratorDeps, runId: string): Promise<RunResumeResult> {
   const state = await loadRunState(deps.config.workDir, runId)
+  if (state.gate !== null) {
+    deps.stdout?.(`run ${runId} awaits a gate decision (gate ${state.gate.version}, ${state.gate.mode})`)
+    deps.stdout?.(`sdd-runner gate resume ${runId}`)
+    return { runId, halted: 'gate-pending' }
+  }
   const emit = buildBus(deps, logPathFor(state))
-  if (state.gate !== null) return { runId, halted: 'gate-pending' }
   const status = await deps.driver.status(state.changeName)
   const resume = deriveResumePoint(state, status.artifacts, replayEvents(logPathFor(state)))
   const depth = state.depth ?? 'S'
@@ -111,6 +130,59 @@ export async function runResume(deps: OrchestratorDeps, runId: string): Promise<
     return { runId, halted: 'gate', gateMdPath: gate.gateMdPath, version: gate.version }
   }
   throw new Error(`resume from stage '${resume.stage}' (${resume.reason}) is not supported yet`)
+}
+
+/**
+ * `continue` is a pure router (Decision 4): gate-pending → the gate flow
+ * (`runGateResume` with no flags — interactive session on a TTY, hand-edited
+ * file otherwise); interrupted mid-stage → `runResume`; completed → a pointer
+ * to the report. Without an id, discovery picks the single pending/active
+ * run, or lists the candidates when several exist.
+ */
+export async function runContinue(deps: OrchestratorDeps, runId: string | null): Promise<RunContinueResult> {
+  if (runId === null) {
+    const picked = await pickContinueRun(deps)
+    if (picked === null) return { runId: null, routed: 'list' }
+    return runContinue(deps, picked)
+  }
+  const resolved = await resolveRunId(deps.config.workDir, runId)
+  const state = await loadRunState(deps.config.workDir, resolved)
+  if (state.gate !== null) {
+    const gate = await runGateResume(deps, resolved, {})
+    return {
+      runId: resolved,
+      routed: 'gate',
+      ...(gate.gateMdPath === undefined ? {} : { gateMdPath: gate.gateMdPath, version: gate.version }),
+    }
+  }
+  if (state.status === 'completed') {
+    deps.stdout?.(`run ${resolved} is completed — report: sdd-runner report ${resolved}`)
+    return { runId: resolved, routed: 'report' }
+  }
+  const resumed = await runResume(deps, resolved)
+  return {
+    runId: resolved,
+    routed: 'resume',
+    ...(resumed.gateMdPath === undefined ? {} : { gateMdPath: resumed.gateMdPath, version: resumed.version }),
+  }
+}
+
+/**
+ * Discovery for a bare `continue`: exactly one gate-pending run routes to it;
+ * several print the per-run gate commands and route nowhere (the operator
+ * picks); none is an error (there is nothing obvious to continue).
+ */
+async function pickContinueRun(deps: OrchestratorDeps): Promise<string | null> {
+  const pending = await listPendingGates(deps.config.workDir)
+  if (pending.length === 1) return pending[0]?.runId ?? null
+  if (pending.length > 1) {
+    deps.stdout?.('several runs await gate decisions:')
+    for (const entry of pending) {
+      deps.stdout?.(`  sdd-runner gate resume ${entry.runId}  (${entry.changeName}, gate v${entry.gateVersion})`)
+    }
+    return null
+  }
+  throw new Error('no gate-pending runs found — pass a run id, or use `sdd-runner resume <runId>`')
 }
 
 function nextGateVersion(state: RunState): number {

--- a/sdd-runner/src/post-review-tail.ts
+++ b/sdd-runner/src/post-review-tail.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { AgentLayerDeps } from './agent-layer.js'
+import { runAtomicity, runDecompose } from './decompose.js'
+import type { DepthProfile } from './events.js'
+import { nowOf, presentGateAt } from './gate-digest.js'
+import type { OrchestratorDeps, RunStartResult, StageContext } from './gate-digest.js'
+import type { ReviewLoopResult } from './review-loop.js'
+import { saveRunState } from './run-state.js'
+import type { RunState } from './run-state.js'
+import { createStageMachine } from './stage-machine.js'
+
+export interface PostConvergenceTailInput {
+  readonly deps: OrchestratorDeps
+  readonly state: RunState
+  readonly ctx: StageContext
+  readonly agent: AgentLayerDeps
+  readonly depth: DepthProfile
+  readonly reviewResult: ReviewLoopResult
+  readonly version: number
+}
+
+/**
+ * Shared post-convergence tail: decompose → atomicity (depth ≠ S) → final
+ * gate at `version`. Serves the fresh pipeline's converged path, the extend
+ * round's converged continuation, and the early-gate approval continuation,
+ * so every route into the tail presents the same final-gate shape.
+ */
+export async function runPostConvergenceTail(input: PostConvergenceTailInput): Promise<RunStartResult> {
+  const { deps, state, ctx, agent, depth, reviewResult, version } = input
+  const machine = createStageMachine({ emit: ctx.emit })
+  await machine.runStage('decompose', () =>
+    runDecompose(
+      { driver: deps.driver, agent, sidecarDir: ctx.sidecarDir, cwd: ctx.cwd },
+      { changeName: state.changeName },
+    ),
+  )
+  state.stage = 'decompose'
+  await saveRunState(state, nowOf(deps))
+  if (depth !== 'S') {
+    await machine.runStage('atomicity', async () => {
+      await runAtomicity(
+        {
+          driver: deps.driver,
+          agent,
+          sidecarDir: ctx.sidecarDir,
+          cwd: ctx.cwd,
+        },
+        { changeName: state.changeName, depth },
+      )
+    })
+    state.stage = 'atomicity'
+    await saveRunState(state, nowOf(deps))
+  }
+  state.stage = 'gate'
+  let gateResult!: RunStartResult
+  await machine.runStage('gate', async () => {
+    gateResult = await presentGateAt(deps, state, ctx, reviewResult, version, 'final')
+  })
+  return gateResult
+}

--- a/sdd-runner/src/prompter.ts
+++ b/sdd-runner/src/prompter.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import * as readline from 'node:readline/promises'
+
+export interface Prompter {
+  readonly say: (line: string) => void
+  readonly ask: (prompt: string) => Promise<string | null>
+}
+
+/**
+ * Test/scripting prompter: `ask` pulls the next pre-scripted answer (or `null`
+ * when the script is exhausted, standing in for EOF); every exchange is
+ * recorded into `transcript` so tests can assert on the walkthrough.
+ */
+export function scriptedPrompter(answers: readonly string[]): { prompter: Prompter; transcript: string[] } {
+  const transcript: string[] = []
+  const queue = [...answers]
+  const prompter: Prompter = {
+    say: (line) => {
+      transcript.push(line)
+    },
+    ask: (prompt) => {
+      transcript.push(`? ${prompt}`)
+      const next = queue.shift()
+      if (next === undefined) return Promise.resolve(null)
+      transcript.push(`> ${next}`)
+      return Promise.resolve(next)
+    },
+  }
+  return { prompter, transcript }
+}
+
+export interface ReadlineStreams {
+  readonly input: NodeJS.ReadableStream
+  readonly output: NodeJS.WritableStream
+}
+
+/**
+ * Thin `node:readline` adapter (no new deps). Behavior lives in the session
+ * and is covered via `scriptedPrompter`; this only wires the terminal I/O.
+ */
+export function readlinePrompter(streams: ReadlineStreams): Prompter {
+  let terminal: readline.Interface | null = null
+  const openTerminal = (): readline.Interface => {
+    terminal ??= readline.createInterface({ input: streams.input, output: streams.output })
+    return terminal
+  }
+  return {
+    say: (line) => {
+      streams.output.write(`${line}\n`)
+    },
+    ask: (prompt) => openTerminal().question(`${prompt} `),
+  }
+}
+
+/** Interactive mode is entered only when stdin is a TTY (flags always win). */
+export function stdinIsInteractive(input: NodeJS.ReadStream | { readonly isTTY?: boolean } = process.stdin): boolean {
+  return input.isTTY ?? false
+}

--- a/sdd-runner/src/renderer.ts
+++ b/sdd-runner/src/renderer.ts
@@ -8,6 +8,7 @@ import type { EventInput } from './events.js'
 import { DynamicRenderer } from './live-renderer.js'
 import { createReplayFolder } from './replay.js'
 import type { DigestRecord, ReplayFolder, ReplayState } from './replay.js'
+import type { ResolveCostFn } from './usage-aggregate.js'
 
 export type Verbosity = 'brief' | 'normal' | 'debug'
 
@@ -19,6 +20,7 @@ export interface RendererStream {
 
 export interface RendererOptions {
   readonly dynamic?: boolean
+  readonly resolveCost?: ResolveCostFn
 }
 
 export const MIDDLE_DOT = '\u00B7'
@@ -144,7 +146,7 @@ export class LineRenderer implements Renderer {
 export function createRenderer(stream: RendererStream, verbosity: Verbosity, opts?: RendererOptions): Renderer {
   const wantsDynamic = opts?.dynamic !== false
   if (wantsDynamic && stream.isTTY === true && verbosity !== 'brief') {
-    return new DynamicRenderer(stream, verbosity)
+    return new DynamicRenderer(stream, verbosity, undefined, opts?.resolveCost)
   }
   return new LineRenderer(stream, verbosity)
 }

--- a/sdd-runner/src/run-state.ts
+++ b/sdd-runner/src/run-state.ts
@@ -123,6 +123,21 @@ function draftComplete(state: PersistedRunState, artifacts: Record<string, strin
   return state.depth === 'S' || isDone(artifacts, 'design')
 }
 
+/**
+ * The review loop counts as settled when a converged verdict is recorded, a
+ * cap-hit verdict was accepted by a human at an early gate (approve =
+ * human-decree convergence, possibly via extend rounds whose last verdict
+ * stays `open`), or the pipeline already moved past review into decompose
+ * (severity-based convergence — nitpick-only cap-hit — flows through without
+ * any gate). A presented-but-unanswered gate cannot reach the later clauses:
+ * `state.gate !== null` short-circuits earlier.
+ */
+function reviewSettled(replay: ReplayState): boolean {
+  if (replay.lastVerdict?.verdict === 'converged') return true
+  if (replay.gate?.mode === 'early' && replay.gate.answered) return true
+  return replay.stages.decompose !== 'pending'
+}
+
 export function deriveResumePoint(
   state: PersistedRunState,
   artifacts: Record<string, string>,
@@ -131,7 +146,7 @@ export function deriveResumePoint(
   if (state.gate !== null) return { stage: 'gate', round: state.round, reason: 'gate-pending' }
   if (state.depth === null) return { stage: 'intake', round: 0, reason: 'depth not classified' }
   if (!draftComplete(state, artifacts)) return { stage: 'draft', round: 0, reason: 'draft artifacts incomplete' }
-  if (replay.lastVerdict?.verdict !== 'converged') {
+  if (!reviewSettled(replay)) {
     const round = Math.max(state.round, replay.round?.current ?? 0, 1)
     return { stage: 'review', round, reason: 'review loop not converged' }
   }

--- a/sdd-runner/src/run-state.ts
+++ b/sdd-runner/src/run-state.ts
@@ -4,7 +4,7 @@
 // See LICENSE in the project root for details.
 
 import { randomUUID } from 'node:crypto'
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { z } from 'zod'
@@ -105,6 +105,72 @@ export async function loadRunState(workDir: string, runId: string): Promise<RunS
     const detail = error instanceof Error ? error.message : String(error)
     throw new Error(`state.json for run ${runId}: ${detail}`, { cause: error })
   }
+}
+
+export interface PendingGateEntry {
+  readonly runId: string
+  readonly changeName: string
+  readonly gateMode: 'early' | 'final'
+  readonly gateVersion: number
+  readonly updatedAt: string
+}
+
+/**
+ * Scan each run's `state.json` under `runs/` and keep only gate-pending runs
+ * (a non-null `gate` field), most recently updated first. Unreadable or
+ * corrupt entries are skipped — a listing must not fail because one run dir
+ * is mid-write.
+ */
+export async function listPendingGates(workDir: string): Promise<PendingGateEntry[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(path.join(workDir, 'runs'))
+  } catch {
+    return []
+  }
+  const perRun = await Promise.all(
+    entries.map(async (runId): Promise<PendingGateEntry | null> => {
+      try {
+        const raw = await readFile(path.join(workDir, 'runs', runId, 'state.json'), 'utf8')
+        const persisted = PersistedRunStateSchema.parse(JSON.parse(raw))
+        if (persisted.gate === null) return null
+        return {
+          runId,
+          changeName: persisted.changeName,
+          gateMode: persisted.gate.mode,
+          gateVersion: persisted.gate.version,
+          updatedAt: persisted.updatedAt,
+        }
+      } catch {
+        return null
+      }
+    }),
+  )
+  return perRun
+    .filter((entry): entry is PendingGateEntry => entry !== null)
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+}
+
+/**
+ * Resolve a run-id argument: exact directory match wins; otherwise a unique
+ * prefix among known runs; unknown ids and ambiguous prefixes fail loudly
+ * with the candidate ids listed (prefixes are an interactive convenience —
+ * scripts should use full ids).
+ */
+export async function resolveRunId(workDir: string, arg: string): Promise<string> {
+  let entries: string[]
+  try {
+    entries = await readdir(path.join(workDir, 'runs'))
+  } catch {
+    throw new Error(`no runs found under ${path.join(workDir, 'runs')} (unknown run id: ${arg})`)
+  }
+  if (entries.includes(arg)) return arg
+  const prefixed = entries.filter((runId) => runId.startsWith(arg))
+  if (prefixed.length === 1) return prefixed[0] ?? arg
+  if (prefixed.length > 1) {
+    throw new Error(`ambiguous run id: ${arg} — candidates:\n${prefixed.map((id) => `  ${id}`).join('\n')}`)
+  }
+  throw new Error(`unknown run id: ${arg}`)
 }
 
 export async function saveRunState(state: RunState, now: Date = new Date()): Promise<RunState> {

--- a/tests/sdd-runner/cli.test.ts
+++ b/tests/sdd-runner/cli.test.ts
@@ -6,7 +6,13 @@
 import { describe, expect, it } from 'bun:test'
 
 import { main, parseCliArgs } from '../../sdd-runner/src/cli.js'
-import type { CliHarness } from '../../sdd-runner/src/cli.js'
+import type { CliCommand, CliHarness } from '../../sdd-runner/src/cli.js'
+import type { PendingGateEntry } from '../../sdd-runner/src/run-state.js'
+
+function asGateCommand(cmd: CliCommand): Extract<CliCommand, { readonly subcommand: 'gate' }> {
+  if (cmd.subcommand !== 'gate') throw new Error('expected a gate command')
+  return cmd
+}
 
 describe('parseCliArgs', () => {
   it('parses start with a task file and depth override', () => {
@@ -18,6 +24,24 @@ describe('parseCliArgs', () => {
   it('parses start with verbosity flag', () => {
     const cmd = parseCliArgs(['start', 'task.md', '--verbosity', 'debug'])
     expect(cmd).toMatchObject({ verbosity: 'debug' })
+  })
+
+  it('maps every depth and verbosity value to itself', () => {
+    for (const depth of ['S', 'M', 'L'] as const) {
+      expect(parseCliArgs(['start', 'task.md', '--depth', depth])).toMatchObject({ depth })
+    }
+    for (const verbosity of ['brief', 'normal', 'debug'] as const) {
+      expect(parseCliArgs(['start', 'task.md', '--verbosity', verbosity])).toMatchObject({ verbosity })
+    }
+  })
+
+  it('rejects start without a task file', () => {
+    expect(() => parseCliArgs(['start'])).toThrow(/task file/u)
+  })
+
+  it('rejects invalid --depth and --verbosity values naming the flag and value', () => {
+    expect(() => parseCliArgs(['start', 'task.md', '--depth', 'Q'])).toThrow(/invalid --depth: Q/u)
+    expect(() => parseCliArgs(['start', 'task.md', '--verbosity', 'loud'])).toThrow(/invalid --verbosity: loud/u)
   })
 
   it('defaults verbosity to normal', () => {
@@ -71,6 +95,28 @@ describe('parseCliArgs', () => {
     expect(() => parseCliArgs(['gate', 'resume', 'run-1', '--veto'])).toThrow(/--veto/u)
   })
 
+  it('rejects --veto values without an = or with an empty id', () => {
+    expect(() => parseCliArgs(['gate', 'resume', 'run-1', '--veto', 'plain'])).toThrow(/--veto expects/u)
+    expect(() => parseCliArgs(['gate', 'resume', 'run-1', '--veto', '=x'])).toThrow(/--veto expects/u)
+  })
+
+  it('omits the redirect when the --veto value ends at =', () => {
+    const cmd = asGateCommand(parseCliArgs(['gate', 'resume', 'run-1', '--veto', 'A1=']))
+    expect(cmd.vetoes[0]).toStrictEqual({ id: 'A1' })
+  })
+
+  it('rejects unknown flags on gate resume', () => {
+    expect(() => parseCliArgs(['gate', 'resume', 'run-1', '--bogus'])).toThrow(/unknown flag: --bogus/u)
+  })
+
+  it('requires the resume verb after gate', () => {
+    expect(() => parseCliArgs(['gate', 'bogus'])).toThrow(/gate requires/u)
+  })
+
+  it('requires a run id for gate resume', () => {
+    expect(() => parseCliArgs(['gate', 'resume'])).toThrow(/requires a run id/u)
+  })
+
   it('rejects --extend combined with --confirm-all, --veto, or --abort', () => {
     expect(() => parseCliArgs(['gate', 'resume', 'run-1', '--extend', '--confirm-all'])).toThrow(/--extend/u)
     expect(() => parseCliArgs(['gate', 'resume', 'run-1', '--extend', '--abort'])).toThrow(/--extend/u)
@@ -78,8 +124,14 @@ describe('parseCliArgs', () => {
   })
 
   it('parses a bare gate command with no run id', () => {
-    const cmd = parseCliArgs(['gate'])
-    expect(cmd).toMatchObject({ subcommand: 'gate', runId: null })
+    expect(parseCliArgs(['gate'])).toStrictEqual({
+      subcommand: 'gate',
+      runId: null,
+      confirmAll: false,
+      abort: false,
+      extend: false,
+      vetoes: [],
+    })
   })
 
   it('rejects a bare gate command that carries decision flags', () => {
@@ -93,7 +145,24 @@ describe('parseCliArgs', () => {
 
   it('parses continue without a run id', () => {
     const cmd = parseCliArgs(['continue'])
-    expect(cmd).toMatchObject({ subcommand: 'continue' })
+    expect(cmd).toStrictEqual({ subcommand: 'continue', runId: null })
+  })
+
+  it('rejects extra args on continue', () => {
+    expect(() => parseCliArgs(['continue', 'run-1', '--x'])).toThrow(/unknown flag/u)
+  })
+
+  it('requires a run id for resume', () => {
+    expect(() => parseCliArgs(['resume'])).toThrow(/requires a run id/u)
+  })
+
+  it('requires a run id for report', () => {
+    expect(() => parseCliArgs(['report'])).toThrow(/requires a run id/u)
+  })
+
+  it('defaults report --pr off and rejects unknown report flags', () => {
+    expect(parseCliArgs(['report', 'run-1'])).toStrictEqual({ subcommand: 'report', runId: 'run-1', pr: false })
+    expect(() => parseCliArgs(['report', 'run-1', '--bogus'])).toThrow(/unknown flag/u)
   })
 
   it('parses report with --pr', () => {
@@ -102,7 +171,7 @@ describe('parseCliArgs', () => {
   })
 
   it('throws on missing subcommand', () => {
-    expect(() => parseCliArgs([])).toThrow(/subcommand/u)
+    expect(() => parseCliArgs([])).toThrow(/missing subcommand/u)
   })
 
   it('throws on unknown subcommand', () => {
@@ -110,7 +179,7 @@ describe('parseCliArgs', () => {
   })
 })
 
-function makeHarness(calls: string[]): CliHarness {
+function makeHarness(calls: string[], pending: PendingGateEntry[] = []): CliHarness {
   return {
     runStart: (options) => {
       calls.push(`start:${options.taskFile}:${options.depthOverride ?? '-'}:${options.verbosity ?? '-'}`)
@@ -121,14 +190,15 @@ function makeHarness(calls: string[]): CliHarness {
       return Promise.resolve({ runId, halted: 'gate' })
     },
     runGateResume: (runId, options) => {
-      calls.push(`gate:${runId}:${options.confirmAll ?? false}:${options.abort ?? false}`)
+      const vetoes = options.vetoes === undefined ? 'none' : options.vetoes.map((veto) => veto.id).join('+')
+      calls.push(`gate:${runId}:${options.confirmAll ?? false}:${options.abort ?? false}:${vetoes}`)
       return Promise.resolve({ runId, outcome: 'approved', version: 1 })
     },
     runContinue: (runId) => {
       calls.push(`continue:${runId ?? '-'}`)
       return Promise.resolve({ runId: runId ?? 'run-1', routed: 'gate' })
     },
-    listPendingGates: () => Promise.resolve([]),
+    listPendingGates: () => Promise.resolve(pending),
     buildReport: (runId, pr) => {
       calls.push(`report:${runId}:${pr}`)
       return Promise.resolve(`body for ${runId}`)
@@ -158,7 +228,7 @@ describe('main', () => {
     await main(['resume', 'run-9'], makeHarness(calls))
     await main(['gate', 'resume', 'run-9', '--confirm-all'], makeHarness(calls))
     expect(calls).toContain('resume:run-9')
-    expect(calls).toContain('gate:run-9:true:false')
+    expect(calls).toContain('gate:run-9:true:false:none')
   })
 
   it('routes report and prints the body; --pr propagates', async () => {
@@ -174,5 +244,35 @@ describe('main', () => {
     await main(['continue'], makeHarness(calls))
     expect(calls).toContain('continue:run-4')
     expect(calls).toContain('continue:-')
+  })
+
+  it('forwards --veto decisions to runGateResume', async () => {
+    const calls: string[] = []
+    await main(['gate', 'resume', 'run-9', '--veto', 'A1=narrow it', '--veto', 'F2='], makeHarness(calls))
+    expect(calls).toContain('gate:run-9:false:false:A1+F2')
+  })
+
+  it('lists pending gates on a bare gate command without resuming anything', async () => {
+    const calls: string[] = []
+    const pending: PendingGateEntry[] = [
+      {
+        runId: 'run-1',
+        changeName: 'add-x',
+        gateMode: 'early',
+        gateVersion: 2,
+        updatedAt: '2026-02-01T00:00:00.000Z',
+      },
+    ]
+    const code = await main(['gate'], makeHarness(calls, pending))
+    expect(code).toBe(0)
+    expect(calls).toContain('out:gate-pending: run-1  (add-x, gate v2, updated 2026-02-01T00:00:00.000Z)')
+    expect(calls).toContain('out:  sdd-runner gate resume run-1')
+    expect(calls.every((line) => !line.startsWith('gate:'))).toBe(true)
+  })
+
+  it('says so when no runs await gate decisions', async () => {
+    const calls: string[] = []
+    await main(['gate'], makeHarness(calls))
+    expect(calls).toContain('out:no runs await gate decisions')
   })
 })

--- a/tests/sdd-runner/cli.test.ts
+++ b/tests/sdd-runner/cli.test.ts
@@ -44,6 +44,58 @@ describe('parseCliArgs', () => {
     expect(cmd).toMatchObject({ subcommand: 'gate', runId: 'run-456', abort: true })
   })
 
+  it('parses gate resume with --extend', () => {
+    const cmd = parseCliArgs(['gate', 'resume', 'run-1', '--extend'])
+    expect(cmd).toMatchObject({ subcommand: 'gate', runId: 'run-1', extend: true })
+  })
+
+  it('parses repeatable --veto flags splitting on the first = only', () => {
+    const cmd = parseCliArgs([
+      'gate',
+      'resume',
+      'run-1',
+      '--veto',
+      'A1=redirect=https://example.com',
+      '--veto',
+      'F2=narrow the gap',
+    ])
+    expect(cmd).toMatchObject({
+      vetoes: [
+        { id: 'A1', redirect: 'redirect=https://example.com' },
+        { id: 'F2', redirect: 'narrow the gap' },
+      ],
+    })
+  })
+
+  it('rejects --veto without a value', () => {
+    expect(() => parseCliArgs(['gate', 'resume', 'run-1', '--veto'])).toThrow(/--veto/u)
+  })
+
+  it('rejects --extend combined with --confirm-all, --veto, or --abort', () => {
+    expect(() => parseCliArgs(['gate', 'resume', 'run-1', '--extend', '--confirm-all'])).toThrow(/--extend/u)
+    expect(() => parseCliArgs(['gate', 'resume', 'run-1', '--extend', '--abort'])).toThrow(/--extend/u)
+    expect(() => parseCliArgs(['gate', 'resume', 'run-1', '--extend', '--veto', 'A1=x'])).toThrow(/--extend/u)
+  })
+
+  it('parses a bare gate command with no run id', () => {
+    const cmd = parseCliArgs(['gate'])
+    expect(cmd).toMatchObject({ subcommand: 'gate', runId: null })
+  })
+
+  it('rejects a bare gate command that carries decision flags', () => {
+    expect(() => parseCliArgs(['gate', '--confirm-all'])).toThrow(/gate resume/u)
+  })
+
+  it('parses continue with a run id', () => {
+    const cmd = parseCliArgs(['continue', 'run-7'])
+    expect(cmd).toMatchObject({ subcommand: 'continue', runId: 'run-7' })
+  })
+
+  it('parses continue without a run id', () => {
+    const cmd = parseCliArgs(['continue'])
+    expect(cmd).toMatchObject({ subcommand: 'continue' })
+  })
+
   it('parses report with --pr', () => {
     const cmd = parseCliArgs(['report', 'run-1', '--pr'])
     expect(cmd).toMatchObject({ subcommand: 'report', runId: 'run-1', pr: true })
@@ -72,6 +124,11 @@ function makeHarness(calls: string[]): CliHarness {
       calls.push(`gate:${runId}:${options.confirmAll ?? false}:${options.abort ?? false}`)
       return Promise.resolve({ runId, outcome: 'approved', version: 1 })
     },
+    runContinue: (runId) => {
+      calls.push(`continue:${runId ?? '-'}`)
+      return Promise.resolve({ runId: runId ?? 'run-1', routed: 'gate' })
+    },
+    listPendingGates: () => Promise.resolve([]),
     buildReport: (runId, pr) => {
       calls.push(`report:${runId}:${pr}`)
       return Promise.resolve(`body for ${runId}`)
@@ -109,5 +166,13 @@ describe('main', () => {
     await main(['report', 'run-2', '--pr'], makeHarness(calls))
     expect(calls).toContain('report:run-2:true')
     expect(calls.some((c) => c.startsWith('out:body for run-2'))).toBe(true)
+  })
+
+  it('routes continue with and without a run id', async () => {
+    const calls: string[] = []
+    await main(['continue', 'run-4'], makeHarness(calls))
+    await main(['continue'], makeHarness(calls))
+    expect(calls).toContain('continue:run-4')
+    expect(calls).toContain('continue:-')
   })
 })

--- a/tests/sdd-runner/continue.test.ts
+++ b/tests/sdd-runner/continue.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { runContinue } from '../../sdd-runner/src/continue.js'
+import type { OrchestratorDeps } from '../../sdd-runner/src/gate-digest.js'
+import { createOpenSpecDriver } from '../../sdd-runner/src/openspec-driver.js'
+import { createRunState, saveRunState } from '../../sdd-runner/src/run-state.js'
+
+const tmpDirs: string[] = []
+
+function makeDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-cont-'))
+  tmpDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop()
+    if (dir !== undefined) fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeDeps(repoRoot: string, workDir: string): OrchestratorDeps {
+  return {
+    config: {
+      repoRoot,
+      workDir,
+      model: 'test-model',
+      models: {},
+      timeouts: { wallClockMs: 60_000, inactivityMs: 5_000 },
+    },
+    spawn: () => Promise.resolve({ exitCode: 0, stdout: '', stderr: '' }),
+    execGit: () => Promise.resolve({ stdout: '', stderr: '' }),
+    driver: createOpenSpecDriver({
+      exec: () => Promise.resolve({ stdout: '', stderr: '', exitCode: 0 }),
+      cwd: repoRoot,
+    }),
+  }
+}
+
+describe('runContinue discovery errors', () => {
+  it('fails loudly when no runs exist at all', async () => {
+    const repoRoot = makeDir()
+    const workDir = path.join(repoRoot, '.sdd-runner')
+    await expect(runContinue(makeDeps(repoRoot, workDir), null)).rejects.toThrow(/no gate-pending runs/u)
+  })
+
+  it('with no id, a single gate-pending run routes to the gate flow', async () => {
+    const repoRoot = makeDir()
+    const workDir = path.join(repoRoot, '.sdd-runner')
+    const state = await createRunState({ workDir, repoRoot, changeName: 'add-thing' })
+    await saveRunState({ ...state, gate: { mode: 'final', version: 1 } })
+    const deps = makeDeps(repoRoot, workDir)
+    await expect(runContinue(deps, null)).rejects.toThrow(/is not gate-pending|gate/u)
+  })
+})

--- a/tests/sdd-runner/extend-round.test.ts
+++ b/tests/sdd-runner/extend-round.test.ts
@@ -4,14 +4,21 @@
 // See LICENSE in the project root for details.
 
 import { describe, expect, it } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
 import { prepareResumeInput } from '../../sdd-runner/src/extend-round.js'
 
+function makeSidecarDir(): { dir: string; sidecarDir: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-ext-'))
+  const sidecarDir = path.join(dir, 'sidecars')
+  fs.mkdirSync(sidecarDir, { recursive: true })
+  return { dir, sidecarDir }
+}
+
 describe('prepareResumeInput module surface', () => {
   it('reads a converged review result and gathers assumptions from sidecars', async () => {
-    const fs = await import('node:fs')
-    const os = await import('node:os')
-    const path = await import('node:path')
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-ext-'))
     const sidecarDir = path.join(dir, 'sidecars')
     fs.mkdirSync(sidecarDir, { recursive: true })
@@ -27,6 +34,53 @@ describe('prepareResumeInput module surface', () => {
     const result = await prepareResumeInput(sidecarDir, 2, 'final')
     expect(result.requiredAck).toBeUndefined()
     expect(result.assumptions.map((a) => a.id)).toContain('A1')
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+})
+
+describe('prepareResumeInput gate-mode semantics', () => {
+  it('treats an early gate as a cap-hit and demands the trajectory ack when no blockers are open', async () => {
+    const { dir, sidecarDir } = makeSidecarDir()
+    fs.writeFileSync(
+      path.join(sidecarDir, 'resolutions-2.json'),
+      JSON.stringify({
+        resolutions: [{ id: 'F1', class: 'NITPICK', resolution: 'dismissed', justification: 'cosmetic' }],
+        assumptions: [],
+      }),
+    )
+    const result = await prepareResumeInput(sidecarDir, 2, 'early')
+    expect(result.reviewResult.outcome).toBe('cap-hit')
+    expect(result.requiredAck).toBe('T1')
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('waives the trajectory ack at an early gate while blockers are still open', async () => {
+    const { dir, sidecarDir } = makeSidecarDir()
+    fs.writeFileSync(
+      path.join(sidecarDir, 'resolutions-2.json'),
+      JSON.stringify({
+        resolutions: [{ id: 'B1', class: 'BLOCKER', resolution: 'assumed', outcome: 'defaulted' }],
+        assumptions: [],
+      }),
+    )
+    const result = await prepareResumeInput(sidecarDir, 2, 'early')
+    expect(result.reviewResult.outcome).toBe('cap-hit')
+    expect(result.requiredAck).toBeUndefined()
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('treats a final gate as converged and never demands the trajectory ack', async () => {
+    const { dir, sidecarDir } = makeSidecarDir()
+    fs.writeFileSync(
+      path.join(sidecarDir, 'resolutions-2.json'),
+      JSON.stringify({
+        resolutions: [{ id: 'F1', class: 'MATERIAL', resolution: 'edited', outcome: 'narrowed gap' }],
+        assumptions: [],
+      }),
+    )
+    const result = await prepareResumeInput(sidecarDir, 2, 'final')
+    expect(result.reviewResult.outcome).toBe('converged')
+    expect(result.requiredAck).toBeUndefined()
     fs.rmSync(dir, { recursive: true, force: true })
   })
 })

--- a/tests/sdd-runner/gate-answers.test.ts
+++ b/tests/sdd-runner/gate-answers.test.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import type { GateAnswers } from '../../sdd-runner/src/gate-answers.js'
+import { renderGateAnswers, responseFromAnswers } from '../../sdd-runner/src/gate-answers.js'
+import type { GateAssumption, GateBlocker, GateFinding } from '../../sdd-runner/src/gate-model.js'
+import { parseGateResponse } from '../../sdd-runner/src/gate-model.js'
+
+const assumption = (overrides: Partial<GateAssumption> = {}): GateAssumption => ({
+  id: 'A1',
+  text: 'guests stay read-only',
+  blast_radius: 'group replies',
+  ...overrides,
+})
+
+const blocker = (overrides: Partial<GateBlocker> = {}): GateBlocker => ({
+  id: 'B1',
+  gap: 'no rollback path',
+  evidence: 'searched design.md',
+  ...overrides,
+})
+
+const finding = (overrides: Partial<GateFinding> = {}): GateFinding => ({
+  id: 'F1',
+  gap: 'design lacks rollback',
+  evidence: 'edited — gap narrowed',
+  ...overrides,
+})
+
+/**
+ * Every scenario follows the same contract (Decision 1): collected answers
+ * render to gate-file grammar, and `parseGateResponse` reads that text back as
+ * the identical outcome derived from the answers themselves.
+ */
+function roundTrip(answers: GateAnswers): ReturnType<typeof parseGateResponse> {
+  const expected = {
+    assumptions: [assumption(), assumption({ id: 'A2', text: 'sqlite is enough', blast_radius: 'storage' })],
+    blockers: [blocker()],
+    findings: [finding()],
+    requiredAck: 'T1',
+    gateMode: 'early' as const,
+  }
+  const md = renderGateAnswers(answers)
+  return parseGateResponse(md, expected)
+}
+
+const ACK_TEXT = 'I reviewed the trajectory and the open findings above'
+
+describe('renderGateAnswers → parseGateResponse round-trip', () => {
+  it('renders an approve-all answer set that parses back as approved', () => {
+    const answers: GateAnswers = {
+      items: [
+        { kind: 'assumption', id: 'A1', text: 'guests stay read-only', accepted: true },
+        { kind: 'assumption', id: 'A2', text: 'sqlite is enough', accepted: true },
+        { kind: 'finding', id: 'F1', text: 'design lacks rollback', accepted: true },
+      ],
+      blockerAnswers: [{ id: 'B1', gap: 'no rollback path', answer: 'ship and track in a follow-up' }],
+      acks: [{ id: 'T1', text: ACK_TEXT }],
+      decision: 'approve',
+    }
+    const response = roundTrip(answers)
+    expect(response.approved).toBe(true)
+    expect(response).toEqual(responseFromAnswers(answers))
+  })
+
+  it('renders a veto with an inline redirect that parses back with the redirect attached', () => {
+    const answers: GateAnswers = {
+      items: [
+        { kind: 'assumption', id: 'A1', text: 'guests stay read-only', accepted: false, redirect: 'dm-only' },
+        { kind: 'assumption', id: 'A2', text: 'sqlite is enough', accepted: true },
+        { kind: 'finding', id: 'F1', text: 'design lacks rollback', accepted: true },
+      ],
+      blockerAnswers: [],
+      acks: [{ id: 'T1', text: ACK_TEXT }],
+      decision: 'veto',
+    }
+    const response = roundTrip(answers)
+    expect(response.approved).toBe(false)
+    expect(response.vetoes).toEqual([{ id: 'A1', redirect: 'dm-only' }])
+    expect(response).toEqual(responseFromAnswers(answers))
+  })
+
+  it('renders a cap-hit blocker free-text answer beneath the blocker line', () => {
+    const answers: GateAnswers = {
+      items: [
+        { kind: 'assumption', id: 'A1', text: 'guests stay read-only', accepted: true },
+        { kind: 'assumption', id: 'A2', text: 'sqlite is enough', accepted: true },
+        { kind: 'finding', id: 'F1', text: 'design lacks rollback', accepted: true },
+      ],
+      blockerAnswers: [{ id: 'B1', gap: 'no rollback path', answer: 'track in a follow-up' }],
+      acks: [{ id: 'T1', text: ACK_TEXT }],
+      decision: 'approve',
+    }
+    const response = roundTrip(answers)
+    expect(response.answers).toEqual([{ id: 'B1', answer: 'track in a follow-up' }])
+    expect(response).toEqual(responseFromAnswers(answers))
+  })
+
+  it('renders a blocker OVERRIDE that parses back with override set and approved', () => {
+    const answers: GateAnswers = {
+      items: [
+        { kind: 'assumption', id: 'A1', text: 'guests stay read-only', accepted: true },
+        { kind: 'assumption', id: 'A2', text: 'sqlite is enough', accepted: true },
+        { kind: 'finding', id: 'F1', text: 'design lacks rollback', accepted: true },
+      ],
+      blockerAnswers: [{ id: 'B1', gap: 'no rollback path', answer: 'OVERRIDE' }],
+      acks: [{ id: 'T1', text: ACK_TEXT }],
+      decision: 'approve',
+    }
+    const response = roundTrip(answers)
+    expect(response.approved).toBe(true)
+    expect(response.override).toBe(true)
+    expect(response).toEqual(responseFromAnswers(answers))
+  })
+
+  it('renders the extend directive that parses back as extend at an early gate', () => {
+    const answers: GateAnswers = {
+      items: [],
+      blockerAnswers: [],
+      acks: [],
+      decision: 'extend',
+    }
+    const response = roundTrip(answers)
+    expect(response.extend).toBe(true)
+    expect(response.approved).toBe(false)
+    expect(response).toEqual(responseFromAnswers(answers))
+  })
+
+  it('renders ABORT that parses back as abort', () => {
+    const answers: GateAnswers = {
+      items: [],
+      blockerAnswers: [],
+      acks: [],
+      decision: 'abort',
+    }
+    const response = roundTrip(answers)
+    expect(response.abort).toBe(true)
+    expect(response).toEqual(responseFromAnswers(answers))
+  })
+
+  it('renders the affirmed trajectory ack so the required-ack check passes', () => {
+    const answers: GateAnswers = {
+      items: [
+        { kind: 'assumption', id: 'A1', text: 'guests stay read-only', accepted: true },
+        { kind: 'assumption', id: 'A2', text: 'sqlite is enough', accepted: true },
+        { kind: 'finding', id: 'F1', text: 'design lacks rollback', accepted: true },
+      ],
+      blockerAnswers: [{ id: 'B1', gap: 'no rollback path', answer: 'OVERRIDE' }],
+      acks: [{ id: 'T1', text: ACK_TEXT }],
+      decision: 'approve',
+    }
+    const md = renderGateAnswers(answers)
+    expect(md).toContain('- [x] T1')
+  })
+
+  it('omits acks from the rendered veto payload but keeps every other channel intact', () => {
+    const answers: GateAnswers = {
+      items: [
+        {
+          kind: 'finding',
+          id: 'F1',
+          text: 'design lacks rollback',
+          accepted: false,
+          redirect: 'restructure the helper',
+        },
+      ],
+      blockerAnswers: [],
+      acks: [],
+      decision: 'veto',
+    }
+    const md = renderGateAnswers(answers)
+    expect(md).toContain('- [ ] F1')
+    expect(md).toContain('→ restructure the helper')
+    expect(md).not.toContain('T1')
+  })
+})

--- a/tests/sdd-runner/gate-render.test.ts
+++ b/tests/sdd-runner/gate-render.test.ts
@@ -6,6 +6,23 @@
 import { describe, expect, it } from 'bun:test'
 
 import { renderChangeDigest, writeGateDigest } from '../../sdd-runner/src/gate-render.js'
+import type { GateDigestInput } from '../../sdd-runner/src/gate-render.js'
+
+const decisionBase: Omit<GateDigestInput, 'mode' | 'capHitFired'> = {
+  version: 1,
+  changeName: 'add-thing',
+  runId: 'run-1',
+  assumptions: [],
+  blockers: [],
+  openMaterial: [],
+  openNitpicks: [],
+  trajectory: [],
+  summary: 'add a thing',
+  costUsd: 0,
+  costKnown: false,
+  durationMs: 0,
+  changeDigest: { what: null, why: null, touches: null, hasTasks: false },
+}
 
 describe('gate-render module surface', () => {
   it('renderChangeDigest returns the 5-tuple with placeholders for null fields', () => {
@@ -34,5 +51,25 @@ describe('gate-render module surface', () => {
     })
     expect(md).toContain('<!-- gate-1.md -->')
     expect(md).toContain('gate resume run-1')
+  })
+
+  it('early gate states that approving continues to decomposition, atomicity, and a final gate (task 4.1)', () => {
+    const md = writeGateDigest({ ...decisionBase, mode: 'early', capHitFired: true })
+    expect(md).toContain('### Decisions')
+    expect(md).toMatch(/approve.*continues.*decompos/u)
+    expect(md).toMatch(/atomicity/u)
+    expect(md).toMatch(/final gate/u)
+  })
+
+  it('early gate states that extending runs one more review round (task 4.1)', () => {
+    const md = writeGateDigest({ ...decisionBase, mode: 'early', capHitFired: true })
+    expect(md).toContain('→ RUN 1 MORE')
+    expect(md).toMatch(/runs one more review round/u)
+  })
+
+  it('final gate states that approving completes the run (task 4.1)', () => {
+    const md = writeGateDigest({ ...decisionBase, mode: 'final', capHitFired: false })
+    expect(md).toContain('### Decisions')
+    expect(md).toMatch(/approve.*completes the run/u)
   })
 })

--- a/tests/sdd-runner/gate-session.test.ts
+++ b/tests/sdd-runner/gate-session.test.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import { runGateSession, scriptedPrompter } from '../../sdd-runner/src/gate-session.js'
+import type { GateSessionView } from '../../sdd-runner/src/gate-session.js'
+
+const ACK_TEXT = 'I reviewed the trajectory and the open findings above'
+
+function view(overrides: Partial<GateSessionView> = {}): GateSessionView {
+  return {
+    gateMode: 'final',
+    items: [
+      { kind: 'assumption', id: 'A1', text: 'guests stay read-only', evidence: '', blastRadius: 'group replies' },
+      { kind: 'assumption', id: 'A2', text: 'sqlite is enough', evidence: '', blastRadius: 'storage' },
+      { kind: 'finding', id: 'F1', text: 'design lacks rollback', evidence: 'edited — gap narrowed', blastRadius: '' },
+    ],
+    blockers: [],
+    requiredAck: null,
+    ...overrides,
+  }
+}
+
+function makeDeps(
+  answers: readonly string[],
+  viewOverrides: Partial<GateSessionView> = {},
+): {
+  deps: Parameters<typeof runGateSession>[0]
+  transcript: string[]
+  written: string[]
+} {
+  const { prompter, transcript } = scriptedPrompter(answers)
+  const written: string[] = []
+  return {
+    deps: {
+      prompter,
+      view: view(viewOverrides),
+      writeGateMd: (md) => {
+        written.push(md)
+        return Promise.resolve()
+      },
+    },
+    transcript,
+    written,
+  }
+}
+
+describe('runGateSession walkthrough', () => {
+  it('covers every finding and assumption with accept/veto/inspect and records an inline redirect', async () => {
+    const { deps, transcript, written } = makeDeps(['i', 'a', 'a', 'v', 'restructure around a helper', 'approve'])
+    const result = await runGateSession(deps)
+    expect(result.status).toBe('answered')
+    expect(transcript.some((line) => /\? .*A1/u.test(line))).toBe(true)
+    expect(transcript.some((line) => /\? .*A2/u.test(line))).toBe(true)
+    expect(transcript.some((line) => /\? .*F1/u.test(line))).toBe(true)
+    expect(written).toHaveLength(1)
+    expect(written[0]).toContain('- [x] A1')
+    expect(written[0]).toContain('- [x] A2')
+    expect(written[0]).toContain('- [ ] F1')
+    expect(written[0]).toContain('→ restructure around a helper')
+  })
+
+  it('inspect prints the item evidence and blast radius before re-asking', async () => {
+    const { deps, transcript } = makeDeps(['i', 'a', 'a', 'a', 'approve'])
+    await runGateSession(deps)
+    const inspectIndex = transcript.findIndex((line) => line.includes('evidence:'))
+    expect(inspectIndex).toBeGreaterThan(-1)
+    expect(transcript.some((line) => line.includes('blast radius: group replies'))).toBe(true)
+    const a1Prompt = transcript.findIndex((line) => line.includes('A1'))
+    expect(inspectIndex).toBeGreaterThan(a1Prompt)
+  })
+
+  it('prompts a cap-hit blocker for a free-text answer or explicit override', async () => {
+    const { deps, written } = makeDeps(['a', 'a', 'a', 'ship without rollback; track in a follow-up', 'approve'], {
+      blockers: [{ id: 'B1', gap: 'no rollback path', evidence: 'searched design.md' }],
+      gateMode: 'early',
+    })
+    const result = await runGateSession(deps)
+    expect(result.status).toBe('answered')
+    expect(written[0]).toContain('B1 no rollback path')
+    expect(written[0]).toContain('→ ship without rollback; track in a follow-up')
+  })
+
+  it('records an explicit blocker OVERRIDE', async () => {
+    const { deps, written } = makeDeps(['a', 'a', 'a', 'OVERRIDE', 'approve'], {
+      blockers: [{ id: 'B1', gap: 'no rollback path', evidence: 'searched design.md' }],
+      gateMode: 'early',
+    })
+    const result = await runGateSession(deps)
+    expect(result.status).toBe('answered')
+    expect(written[0]).toContain('→ OVERRIDE')
+  })
+
+  it('blocks approve until the trajectory ack is affirmed, and abandons cleanly on quit', async () => {
+    const { deps, transcript, written } = makeDeps(['a', 'a', 'a', 'OVERRIDE', 'n', 'approve', 'q'], {
+      blockers: [{ id: 'B1', gap: 'no rollback path', evidence: 'searched design.md' }],
+      gateMode: 'early',
+      requiredAck: { id: 'T1', text: ACK_TEXT },
+    })
+    const result = await runGateSession(deps)
+    expect(result.status).toBe('abandoned')
+    expect(transcript.some((line) => line.includes('T1'))).toBe(true)
+    expect(written).toHaveLength(0)
+  })
+
+  it('blocks approve while any blocker is unanswered', async () => {
+    const { deps, transcript, written } = makeDeps(['a', 'a', 'a', 'skip', 'y', 'approve', 'q'], {
+      blockers: [{ id: 'B1', gap: 'no rollback path', evidence: 'searched design.md' }],
+      gateMode: 'early',
+      requiredAck: { id: 'T1', text: ACK_TEXT },
+    })
+    const result = await runGateSession(deps)
+    expect(result.status).toBe('abandoned')
+    expect(transcript.some((line) => line.includes('B1'))).toBe(true)
+    expect(written).toHaveLength(0)
+  })
+
+  it('approves once T1 is affirmed and every blocker is answered, writing the ack box', async () => {
+    const { deps, written } = makeDeps(['a', 'a', 'a', 'OVERRIDE', 'y', 'approve'], {
+      blockers: [{ id: 'B1', gap: 'no rollback path', evidence: 'searched design.md' }],
+      gateMode: 'early',
+      requiredAck: { id: 'T1', text: ACK_TEXT },
+    })
+    const result = await runGateSession(deps)
+    expect(result).toMatchObject({ status: 'answered', decision: 'approve' })
+    expect(written[0]).toContain('- [x] T1')
+    expect(written[0]).toContain('→ OVERRIDE')
+  })
+
+  it('abandons without writing when quit arrives before the final decision', async () => {
+    const { deps, written } = makeDeps(['a', 'q'])
+    const result = await runGateSession(deps)
+    expect(result.status).toBe('abandoned')
+    expect(written).toHaveLength(0)
+  })
+
+  it('abandons without writing when the prompter input is exhausted (EOF)', async () => {
+    const { deps, written } = makeDeps([])
+    const result = await runGateSession(deps)
+    expect(result.status).toBe('abandoned')
+    expect(written).toHaveLength(0)
+  })
+
+  it('offers extend at an early gate and writes the extend directive', async () => {
+    const { deps, written } = makeDeps(['a', 'a', 'a', 'y', 'extend'], {
+      gateMode: 'early',
+      requiredAck: { id: 'T1', text: ACK_TEXT },
+    })
+    const result = await runGateSession(deps)
+    expect(result).toMatchObject({ status: 'answered', decision: 'extend' })
+    expect(written[0]).toContain('→ RUN 1 MORE')
+  })
+
+  it('rejects extend at a final gate and re-asks the decision', async () => {
+    const { deps, transcript, written } = makeDeps(['a', 'a', 'a', 'extend', 'abort'])
+    const result = await runGateSession(deps)
+    expect(result).toMatchObject({ status: 'answered', decision: 'abort' })
+    expect(written[0]).toContain('ABORT')
+    expect(transcript.filter((line) => line.includes('Decision')).length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders veto with no redirect when the redirect line is empty', async () => {
+    const { deps, written } = makeDeps(['a', 'a', 'v', '', 'approve'])
+    const result = await runGateSession(deps)
+    expect(result).toMatchObject({ status: 'answered', decision: 'approve' })
+    expect(written[0]).toContain('- [ ] F1')
+    expect(written[0]).not.toContain('→\n')
+  })
+})

--- a/tests/sdd-runner/gate-session.test.ts
+++ b/tests/sdd-runner/gate-session.test.ts
@@ -5,7 +5,8 @@
 
 import { describe, expect, it } from 'bun:test'
 
-import { runGateSession, scriptedPrompter } from '../../sdd-runner/src/gate-session.js'
+import { renderDecisions } from '../../sdd-runner/src/gate-render.js'
+import { runGateSession, scriptedPrompter, consequenceLines } from '../../sdd-runner/src/gate-session.js'
 import type { GateSessionView } from '../../sdd-runner/src/gate-session.js'
 import { desugarFlags } from '../../sdd-runner/src/gate-session.js'
 
@@ -112,6 +113,35 @@ describe('desugarFlags (task 4.5)', () => {
     await expect(desugarFlags({ confirmAll: false, vetoes: [] }, view(), writer)).rejects.toThrow(
       /confirm-all|--veto|file/u,
     )
+  })
+})
+
+describe('shared consequence copy (task 5.1)', () => {
+  it('prints decision-menu consequence lines from the same source the gate file uses (early wording matches)', () => {
+    const fileMd = renderDecisions('early').join('\n')
+    const sessionMd = consequenceLines({ ...view(), gateMode: 'early' }).join('\n')
+    const sharedPhrase = 'continues to task decomposition, atomicity checking, and a final gate'
+    expect(sessionMd).toContain(sharedPhrase)
+    expect(fileMd).toContain(sharedPhrase)
+    expect(sessionMd).toContain('runs one more review round, then re-gates')
+    expect(fileMd).toContain('runs one more review round, then re-gates')
+  })
+
+  it('final-gate wording matches between the session menu and the gate file', () => {
+    const fileLines = renderDecisions('final')
+    const sessionLines = consequenceLines({ ...view(), gateMode: 'final' })
+    expect(sessionLines.join('\n')).toContain('completes the run with the full artifact set')
+    expect(fileLines.join('\n')).toContain('completes the run with the full artifact set')
+    expect(sessionLines.join('\n')).not.toContain('extend — runs one more review round')
+  })
+
+  it('the session walkthrough prints the shared consequence lines before the decision prompt', async () => {
+    const { deps, transcript } = makeDeps(['a', 'a', 'a', 'approve'])
+    await runGateSession(deps)
+    const menuIndex = transcript.findIndex((line) => line.includes('completes the run with the full artifact set'))
+    const decisionPromptIndex = transcript.findIndex((line) => line.includes('? decision (approve'))
+    expect(menuIndex).toBeGreaterThan(-1)
+    expect(menuIndex).toBeLessThan(decisionPromptIndex)
   })
 })
 

--- a/tests/sdd-runner/gate-session.test.ts
+++ b/tests/sdd-runner/gate-session.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'bun:test'
 
 import { runGateSession, scriptedPrompter } from '../../sdd-runner/src/gate-session.js'
 import type { GateSessionView } from '../../sdd-runner/src/gate-session.js'
+import { desugarFlags } from '../../sdd-runner/src/gate-session.js'
 
 const ACK_TEXT = 'I reviewed the trajectory and the open findings above'
 
@@ -47,6 +48,72 @@ function makeDeps(
     written,
   }
 }
+
+describe('desugarFlags (task 4.5)', () => {
+  it('--confirm-all accepts all items then each --veto un-accepts its id with the redirect', async () => {
+    const written: string[] = []
+    const answers = await desugarFlags(
+      {
+        confirmAll: true,
+        vetoes: [{ id: 'A1', redirect: 'dm-only' }],
+      },
+      view(),
+      (md) => {
+        written.push(md)
+        return Promise.resolve()
+      },
+    )
+    expect(answers.status).toBe('answered')
+    expect(written).toHaveLength(1)
+    expect(written[0]).toContain('- [ ] A1')
+    expect(written[0]).toContain('→ dm-only')
+    expect(written[0]).toContain('- [x] A2')
+    expect(written[0]).toContain('- [x] F1')
+  })
+
+  it('--confirm-all answers every blocker with OVERRIDE and affirms the ack', async () => {
+    const written: string[] = []
+    const answers = await desugarFlags(
+      { confirmAll: true },
+      {
+        ...view(),
+        gateMode: 'early',
+        blockers: [{ id: 'B1', gap: 'no rollback path', evidence: '' }],
+        requiredAck: { id: 'T1', text: ACK_TEXT },
+      },
+      (md) => {
+        written.push(md)
+        return Promise.resolve()
+      },
+    )
+    expect(answers.status).toBe('answered')
+    expect(written[0]).toContain('→ OVERRIDE')
+    expect(written[0]).toContain('- [x] T1')
+  })
+
+  it('fails on an unknown veto id before writing anything', async () => {
+    const written: string[] = []
+    const writer = (md: string): Promise<void> => {
+      written.push(md)
+      return Promise.resolve()
+    }
+    await expect(
+      desugarFlags({ confirmAll: true, vetoes: [{ id: 'Z9', redirect: 'x' }] }, view(), writer),
+    ).rejects.toThrow(/Z9/u)
+    expect(written).toHaveLength(0)
+  })
+
+  it('requires --confirm-all or a veto for a pure flag invocation to be meaningful', async () => {
+    const written: string[] = []
+    const writer = (md: string): Promise<void> => {
+      written.push(md)
+      return Promise.resolve()
+    }
+    await expect(desugarFlags({ confirmAll: false, vetoes: [] }, view(), writer)).rejects.toThrow(
+      /confirm-all|--veto|file/u,
+    )
+  })
+})
 
 describe('runGateSession walkthrough', () => {
   it('covers every finding and assumption with accept/veto/inspect and records an inline redirect', async () => {

--- a/tests/sdd-runner/index.test.ts
+++ b/tests/sdd-runner/index.test.ts
@@ -32,6 +32,21 @@ describe('USAGE', () => {
     expect(USAGE).toContain('gate resume')
     expect(USAGE).toContain('report')
   })
+
+  it('prints the full multi-line usage text', () => {
+    expect(USAGE).toContain('sdd-runner — autonomous SDD pipeline')
+    expect(USAGE).toContain('Usage:')
+    expect(USAGE).toContain('sdd-runner start <task-file> [--depth S|M|L] [--verbosity brief|normal|debug]')
+    expect(USAGE).toContain('sdd-runner continue [runId]')
+    expect(USAGE).toContain('sdd-runner resume <runId>')
+    expect(USAGE).toContain(
+      'sdd-runner gate [resume <runId> [--confirm-all] [--extend] [--veto <id>=<redirect>]... [--abort]]',
+    )
+    expect(USAGE).toContain('sdd-runner report <runId> [--pr]')
+    expect(USAGE).toContain('opens an interactive gate session')
+    expect(USAGE).toContain('Bare `gate` lists pending gates.')
+    expect(USAGE).toContain('\n')
+  })
 })
 
 describe('readChangeSummary', () => {
@@ -45,10 +60,35 @@ describe('readChangeSummary', () => {
     expect(summary.tasksTotal).toBe(2)
   })
 
-  it('returns zero counts when tasks.md is absent', async () => {
+  it('counts only line-anchored checkboxes, indented or not, never prose mentions', async () => {
+    const dir = makeDir()
+    const changeDir = path.join(dir, 'openspec', 'changes', 'add-thing')
+    fs.mkdirSync(changeDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(changeDir, 'tasks.md'),
+      '## Tasks\n  - [x] indented done\n- [ ] todo\nprose - [x] not a task\nprose - [ ] also not a task\n- [x] done\n  - [ ] indented todo\n',
+    )
+    const summary = await readChangeSummary(dir, 'add-thing')
+    expect(summary.tasksDone).toBe(2)
+    expect(summary.tasksTotal).toBe(4)
+  })
+
+  it('lists markdown artifacts recursively, ignoring non-markdown files', async () => {
+    const dir = makeDir()
+    const changeDir = path.join(dir, 'openspec', 'changes', 'add-thing')
+    fs.mkdirSync(path.join(changeDir, 'specs', 'thing'), { recursive: true })
+    fs.writeFileSync(path.join(changeDir, 'proposal.md'), '# proposal\n')
+    fs.writeFileSync(path.join(changeDir, 'notes.txt'), 'not markdown\n')
+    fs.writeFileSync(path.join(changeDir, 'specs', 'thing', 'spec.md'), '## ADDED Requirements\n')
+    const summary = await readChangeSummary(dir, 'add-thing')
+    expect([...summary.artifacts].sort()).toEqual(['proposal.md', 'spec.md'])
+  })
+
+  it('returns zero counts and no artifacts when the change is absent', async () => {
     const dir = makeDir()
     const summary = await readChangeSummary(dir, 'missing')
     expect(summary.tasksDone).toBe(0)
     expect(summary.tasksTotal).toBe(0)
+    expect(summary.artifacts).toEqual([])
   })
 })

--- a/tests/sdd-runner/live-renderer.test.ts
+++ b/tests/sdd-runner/live-renderer.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'bun:test'
 
 import type { EventInput } from '../../sdd-runner/src/events.js'
 import { DynamicRenderer } from '../../sdd-runner/src/live-renderer.js'
+import type { ResolvedCost } from '../../sdd-runner/src/pricing.js'
 
 interface MemoryStreamOptions {
   readonly isTTY: boolean
@@ -45,6 +46,19 @@ const RESOLVER_DONE: EventInput = {
   usage: { inputTokens: 5000, outputTokens: 1200, reasoningTokens: 10, costUsd: 0.01, wallMs: 1000 },
 }
 
+/**
+ * Extract the status (footer) line from the last rendered block: it is always the
+ * final line of a `writeBlock` emission, i.e. everything after the last
+ * `\n` + ERASE_LINE boundary. The trailing duration segment is normalized because
+ * it depends on wall-clock time.
+ */
+function lastStatusLine(out: string): string {
+  const marker = '\n\u001b[2K'
+  const idx = out.lastIndexOf(marker)
+  const line = idx === -1 ? out : out.slice(idx + marker.length)
+  return line.replace(/\d+(m\d{2})?s$/u, 'DUR')
+}
+
 describe('DynamicRenderer', () => {
   it('redraws a pipeline map + slot + status block on each event against a TTY stream', () => {
     const stream = new MemoryStream({ isTTY: true, columns: 80 })
@@ -52,6 +66,13 @@ describe('DynamicRenderer', () => {
     renderer.renderEvent(REVIEW_STAGE_ENTER)
     renderer.renderEvent(ROUND_OPEN_1_3)
     renderer.renderEvent(RESOLVER_TOOL_USE)
+    renderer.renderEvent({
+      altitude: 'L0',
+      type: 'step_finish',
+      agent: 'resolver-r1',
+      tokens: { input: 5000, output: 1200, reasoning: 10 },
+      costUsd: 0.01,
+    })
     renderer.renderEvent(RESOLVER_DONE)
 
     const out = stream.chunks.join('')
@@ -72,5 +93,115 @@ describe('DynamicRenderer', () => {
     const out = stream.chunks.join('')
     expect(out).not.toContain('\u001b[2K')
     expect(out).not.toContain('\r')
+  })
+})
+
+describe('DynamicRenderer cost estimation', () => {
+  const GLM_MODEL = 'zai-coding-plan/glm-5.2'
+  const PRICED: ResolvedCost = { input: 1, output: 2, source: 'primary' }
+  const resolvePriced = (modelId: string): ResolvedCost | null => (modelId === GLM_MODEL ? PRICED : null)
+
+  const SPAWNED_GLM: EventInput = {
+    altitude: 'L1',
+    type: 'spawned',
+    agent: 'resolver-r1',
+    role: 'reviewer',
+    model: GLM_MODEL,
+  }
+  // ((1000 + 100) * 1 + 500 * 2) / 1_000_000 = 0.0021
+  const UNMETERED_STEP: EventInput = {
+    altitude: 'L0',
+    type: 'step_finish',
+    agent: 'resolver-r1',
+    tokens: { input: 1000, output: 500, reasoning: 100 },
+    costUsd: 0,
+  }
+  const METERED_STEP: EventInput = {
+    altitude: 'L0',
+    type: 'step_finish',
+    agent: 'resolver-r1',
+    tokens: { input: 2000, output: 300, reasoning: 0 },
+    costUsd: 0.01,
+  }
+
+  function makeTty(): MemoryStream {
+    return new MemoryStream({ isTTY: true, columns: 120 })
+  }
+
+  it('estimates an unmetered step from the spawned model and prefixes the footer with ~$', () => {
+    const stream = makeTty()
+    const renderer = new DynamicRenderer(stream, 'normal', undefined, resolvePriced)
+    renderer.renderEvent(SPAWNED_GLM)
+    renderer.renderEvent(UNMETERED_STEP)
+    expect(stream.chunks.join('')).toContain('~$0.0021')
+  })
+
+  it('renders a metered step cost with a plain $ prefix (no tilde)', () => {
+    const stream = makeTty()
+    const renderer = new DynamicRenderer(stream, 'normal', undefined, resolvePriced)
+    renderer.renderEvent(SPAWNED_GLM)
+    renderer.renderEvent(METERED_STEP)
+    const out = stream.chunks.join('')
+    expect(out).toContain('$0.0100')
+    expect(out).not.toContain('~$')
+  })
+
+  it('hides the cost segment when the resolver returns null', () => {
+    const stream = makeTty()
+    const renderer = new DynamicRenderer(stream, 'normal', undefined, () => null)
+    renderer.renderEvent(SPAWNED_GLM)
+    renderer.renderEvent(UNMETERED_STEP)
+    const out = stream.chunks.join('')
+    expect(out).not.toContain('$')
+    expect(out).toContain('in 1.0k / out 500')
+  })
+
+  it('marks the footer ~$ when metered and estimated steps mix', () => {
+    const stream = makeTty()
+    const renderer = new DynamicRenderer(stream, 'normal', undefined, resolvePriced)
+    renderer.renderEvent(SPAWNED_GLM)
+    renderer.renderEvent(METERED_STEP)
+    renderer.renderEvent(UNMETERED_STEP)
+    expect(stream.chunks.join('')).toContain('~$0.0121')
+  })
+
+  it('renders a byte-identical footer when no resolver is passed', () => {
+    const stream = makeTty()
+    const renderer = new DynamicRenderer(stream, 'normal')
+    renderer.renderEvent(SPAWNED_GLM)
+    renderer.renderEvent(UNMETERED_STEP)
+    expect(lastStatusLine(stream.chunks.join(''))).toBe('  status     in 1.0k / out 500 \u00B7 DUR')
+  })
+})
+
+describe('DynamicRenderer totals accounting', () => {
+  it('counts step deltas once when done repeats their cumulative usage', () => {
+    const stream = new MemoryStream({ isTTY: true, columns: 120 })
+    const renderer = new DynamicRenderer(stream, 'normal')
+    renderer.renderEvent({
+      altitude: 'L0',
+      type: 'step_finish',
+      agent: 'resolver-r1',
+      tokens: { input: 1000, output: 200, reasoning: 0 },
+      costUsd: 0.005,
+    })
+    renderer.renderEvent({
+      altitude: 'L0',
+      type: 'step_finish',
+      agent: 'resolver-r1',
+      tokens: { input: 500, output: 100, reasoning: 0 },
+      costUsd: 0.003,
+    })
+    renderer.renderEvent({
+      altitude: 'L1',
+      type: 'done',
+      agent: 'resolver-r1',
+      usage: { inputTokens: 1500, outputTokens: 300, reasoningTokens: 0, costUsd: 0.008, wallMs: 1000 },
+    })
+    const status = lastStatusLine(stream.chunks.join(''))
+    expect(status).toContain('in 1.5k / out 300')
+    expect(status).toContain('$0.0080')
+    expect(status).not.toContain('3.0k')
+    expect(status).not.toContain('$0.0160')
   })
 })

--- a/tests/sdd-runner/orchestrator.test.ts
+++ b/tests/sdd-runner/orchestrator.test.ts
@@ -20,6 +20,7 @@ import type { StageContext } from '../../sdd-runner/src/gate-digest.js'
 import { createOpenSpecDriver } from '../../sdd-runner/src/openspec-driver.js'
 import type { OpenSpecDriver } from '../../sdd-runner/src/openspec-driver.js'
 import { runContinue, runGateResume, runResume, runStart } from '../../sdd-runner/src/orchestrator.js'
+import type { RunGateResumeResult } from '../../sdd-runner/src/orchestrator.js'
 import { scriptedPrompter } from '../../sdd-runner/src/prompter.js'
 import type { Prompter } from '../../sdd-runner/src/prompter.js'
 import type { ReviewLoopResult } from '../../sdd-runner/src/review-loop.js'
@@ -688,6 +689,34 @@ describe('runGateResume flags + TTY wiring (tasks 4.5-4.6)', () => {
     const state = await loadRunState(fixture.deps.config.workDir, started.runId)
     expect(state.status).toBe('completed')
   })
+
+  it('--veto without --confirm-all counts as a decision flag and is rejected by flag desugaring', async () => {
+    const fixture = gatedFixture()
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    await expect(runGateResume(fixture.deps, started.runId, { vetoes: [{ id: 'A1' }] })).rejects.toThrow(
+      /no decision flags/u,
+    )
+  })
+
+  it('an abandoned interactive session writes nothing and leaves the gate pending', async () => {
+    const fixture = gatedFixture()
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const runDir = path.join(fixture.deps.config.workDir, 'runs', started.runId)
+    const gate1Path = path.join(runDir, 'gate-1.md')
+    const before = fs.readFileSync(gate1Path, 'utf8')
+    const { prompter } = scriptedPrompter([])
+    const deps: OrchestratorDeps = {
+      ...fixture.deps,
+      interactive: (): boolean => true,
+      makePrompter: (): Prompter => prompter,
+    }
+    const result = await runGateResume(deps, started.runId, {})
+    expect(result.outcome).toBe('abandoned')
+    expect(fixture.stdoutLines.some((line) => line.includes('gate session abandoned'))).toBe(true)
+    expect(fs.readFileSync(gate1Path, 'utf8')).toBe(before)
+    const state = await loadRunState(fixture.deps.config.workDir, started.runId)
+    expect(state.gate).toEqual({ mode: 'final', version: 1 })
+  })
 })
 
 describe('runGateResume', () => {
@@ -784,6 +813,10 @@ describe('runGateResume', () => {
     const result = await runGateResume(fixture.deps, started.runId, {})
     expect(result.outcome).toBe('veto')
     expect(result.version).toBe(2)
+
+    // a veto at an early cap-hit gate re-presents an early gate, not a final one
+    const gate2 = fs.readFileSync(path.join(fixture.deps.config.workDir, 'runs', started.runId, 'gate-2.md'), 'utf8')
+    expect(gate2).toContain('Early gate')
   })
 
   it('marks the run completed on an approved gate', async () => {
@@ -1274,6 +1307,60 @@ describe('runGateResume', () => {
     expect(gate3).toContain('round 2:')
     expect(gate3).toContain('round 3:')
   })
+
+  it('rejects resuming a run that is not gate-pending', async () => {
+    const fixture = makeFixture()
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    await runGateResume(fixture.deps, started.runId, { confirmAll: true })
+    await expect(runGateResume(fixture.deps, started.runId, {})).rejects.toThrow(/not gate-pending/u)
+  })
+
+  async function vetoAtFinalGate(
+    vetoUpdaterFiles: string[],
+  ): Promise<{ fixture: Fixture; result: RunGateResumeResult; spawnsAfterVeto: string[] }> {
+    const assumption = {
+      id: 'A1',
+      text: 'guests stay read-only',
+      basis: 'default',
+      confidence: 'medium',
+      blast_radius: 'group replies',
+      status: 'open',
+    }
+    const fixture = makeFixture({
+      'resolutions-1.json': JSON.stringify({ resolutions: [], assumptions: [assumption] }),
+      'veto-updater.json': JSON.stringify({ files_updated: vetoUpdaterFiles }),
+    })
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const gate1Path = path.join(fixture.deps.config.workDir, 'runs', started.runId, 'gate-1.md')
+    const gate1 = fs.readFileSync(gate1Path, 'utf8')
+    fs.writeFileSync(
+      gate1Path,
+      gate1.replace('- [ ] A1 guests stay read-only', '- [ ] A1 guests stay read-only\n→ narrower'),
+    )
+    const before = fixture.spawnOrder.length
+    const result = await runGateResume(fixture.deps, started.runId, {})
+    expect(result.outcome).toBe('veto')
+    return { fixture, result, spawnsAfterVeto: fixture.spawnOrder.slice(before) }
+  }
+
+  it('skips the drift resolver when the veto updater touched only non-spec files', async () => {
+    const { spawnsAfterVeto } = await vetoAtFinalGate(['openspec/changes/add-thing/proposal.md'])
+    expect(spawnsAfterVeto).toContain('veto-updater.json')
+    expect(spawnsAfterVeto).not.toContain('drift.json')
+  })
+
+  it('runs the drift resolver when the veto updater touched a spec file', async () => {
+    const { spawnsAfterVeto } = await vetoAtFinalGate([
+      'openspec/changes/add-thing/proposal.md',
+      'openspec/changes/add-thing/specs/thing/spec.md',
+    ])
+    expect(spawnsAfterVeto).toContain('drift.json')
+  })
+
+  it('runs the drift resolver when the veto updater touched tasks.md', async () => {
+    const { spawnsAfterVeto } = await vetoAtFinalGate(['openspec/changes/add-thing/tasks.md'])
+    expect(spawnsAfterVeto).toContain('drift.json')
+  })
 })
 
 describe('presentGateAt cost fallback', () => {
@@ -1441,5 +1528,123 @@ describe('presentGateAt change digest', () => {
 
     expect(md).toContain('- **TOUCHES**: **Code**: `src/a.ts` (new), tasks: 8/12')
     expect(md).toContain('- **RISKS**: see "Nitpicks (informational)" below')
+  })
+})
+
+describe('runResume hardening', () => {
+  it('reports gate-pending without a stdout dep and never crashes', async () => {
+    const fixture = makeFixture()
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const deps: OrchestratorDeps = { ...fixture.deps, stdout: undefined }
+    const result = await runResume(deps, started.runId)
+    expect(result.halted).toBe('gate-pending')
+  })
+
+  it('refuses to resume from a stage the post-review branches do not cover', async () => {
+    const fixture = makeFixture()
+    const workDir = fixture.deps.config.workDir
+    const runId = 'seeded-draft'
+    const runDir = path.join(workDir, 'runs', runId)
+    fs.mkdirSync(path.join(runDir, 'sidecars'), { recursive: true })
+    const now = '2026-01-01T00:00:00.000Z'
+    fs.writeFileSync(
+      path.join(runDir, 'events.ndjson'),
+      [
+        { altitude: 'L2', type: 'stage_enter', stage: 'intake', seq: 1, ts: now },
+        { altitude: 'L2', type: 'depth', profile: 'S', rationale: 'override', source: 'override', seq: 2, ts: now },
+        { altitude: 'L2', type: 'stage_exit', stage: 'intake', seq: 3, ts: now },
+      ]
+        .map((e) => JSON.stringify(e))
+        .join('\n') + '\n',
+    )
+    fs.writeFileSync(
+      path.join(runDir, 'state.json'),
+      `${JSON.stringify(
+        {
+          runId,
+          repoRoot: fixture.repoRoot,
+          workDir,
+          changeName: fixture.changeName,
+          stage: 'intake',
+          depth: 'S',
+          round: 0,
+          gate: null,
+          status: 'running',
+          createdAt: now,
+          updatedAt: now,
+        },
+        null,
+        2,
+      )}\n`,
+    )
+    await expect(runResume(fixture.deps, runId)).rejects.toThrow(/not supported yet/u)
+  })
+
+  it('derives the next gate version from existing gate-*.md files, ignoring lookalikes', async () => {
+    const fixture = makeFixture()
+    const workDir = fixture.deps.config.workDir
+    const runId = 'seeded-versioned'
+    const runDir = path.join(workDir, 'runs', runId)
+    fs.mkdirSync(path.join(runDir, 'sidecars'), { recursive: true })
+    fs.mkdirSync(path.join(fixture.changeDir, 'specs', 'thing'), { recursive: true })
+    fs.writeFileSync(path.join(fixture.changeDir, 'proposal.md'), '## Why\nseeded\n')
+    fs.writeFileSync(path.join(fixture.changeDir, 'design.md'), '## Context\nseeded\n')
+    fs.writeFileSync(path.join(fixture.changeDir, 'specs', 'thing', 'spec.md'), '## ADDED Requirements\n')
+    fs.writeFileSync(
+      path.join(runDir, 'sidecars', 'resolutions-1.json'),
+      JSON.stringify({ resolutions: [], assumptions: [] }),
+    )
+    const now = '2026-01-01T00:00:00.000Z'
+    const events = [
+      { altitude: 'L2', type: 'stage_enter', stage: 'intake', seq: 1, ts: now },
+      { altitude: 'L2', type: 'depth', profile: 'M', rationale: 'override', source: 'override', seq: 2, ts: now },
+      { altitude: 'L2', type: 'stage_exit', stage: 'intake', seq: 3, ts: now },
+      { altitude: 'L2', type: 'stage_enter', stage: 'draft', seq: 4, ts: now },
+      { altitude: 'L2', type: 'stage_exit', stage: 'draft', seq: 5, ts: now },
+      { altitude: 'L2', type: 'stage_enter', stage: 'review', seq: 6, ts: now },
+      { altitude: 'L2', type: 'round_open', round: 1, cap: 3, seq: 7, ts: now },
+      {
+        altitude: 'L2',
+        type: 'convergence',
+        round: 1,
+        verdict: 'converged',
+        counts: { blocker: 0, material: 0, nitpick: 0 },
+        seq: 8,
+        ts: now,
+      },
+      { altitude: 'L2', type: 'round_close', round: 1, cap: 3, seq: 9, ts: now },
+      { altitude: 'L2', type: 'stage_exit', stage: 'review', seq: 10, ts: now },
+      { altitude: 'L2', type: 'gate', action: 'presented', mode: 'early', version: 1, seq: 11, ts: now },
+      { altitude: 'L2', type: 'gate', action: 'answered', mode: 'early', version: 1, seq: 12, ts: now },
+    ]
+    fs.writeFileSync(path.join(runDir, 'events.ndjson'), events.map((e) => JSON.stringify(e)).join('\n') + '\n')
+    fs.writeFileSync(
+      path.join(runDir, 'state.json'),
+      `${JSON.stringify(
+        {
+          runId,
+          repoRoot: fixture.repoRoot,
+          workDir,
+          changeName: fixture.changeName,
+          stage: 'review',
+          depth: 'M',
+          round: 1,
+          gate: null,
+          status: 'running',
+          createdAt: now,
+          updatedAt: now,
+        },
+        null,
+        2,
+      )}\n`,
+    )
+    for (const name of ['gate-1.md', 'gate-10.md', 'gate-50.md.bak', 'notgate-99.md', 'gate-x.md']) {
+      fs.writeFileSync(path.join(runDir, name), 'stale\n')
+    }
+    const deps: OrchestratorDeps = { ...fixture.deps, driver: createSettledDriver(fixture) }
+    const result = await runResume(deps, runId)
+    expect(result.halted).toBe('gate')
+    expect(result.version).toBe(11)
+    expect(fs.readFileSync(requireGateMdPath(result), 'utf8')).toContain('Final gate')
   })
 })

--- a/tests/sdd-runner/orchestrator.test.ts
+++ b/tests/sdd-runner/orchestrator.test.ts
@@ -19,7 +19,9 @@ import type { OrchestratorDeps } from '../../sdd-runner/src/gate-digest.js'
 import type { StageContext } from '../../sdd-runner/src/gate-digest.js'
 import { createOpenSpecDriver } from '../../sdd-runner/src/openspec-driver.js'
 import type { OpenSpecDriver } from '../../sdd-runner/src/openspec-driver.js'
-import { runGateResume, runResume, runStart } from '../../sdd-runner/src/orchestrator.js'
+import { runContinue, runGateResume, runResume, runStart } from '../../sdd-runner/src/orchestrator.js'
+import { scriptedPrompter } from '../../sdd-runner/src/prompter.js'
+import type { Prompter } from '../../sdd-runner/src/prompter.js'
 import type { ReviewLoopResult } from '../../sdd-runner/src/review-loop.js'
 import { createRunState } from '../../sdd-runner/src/run-state.js'
 import { loadRunState } from '../../sdd-runner/src/run-state.js'
@@ -466,6 +468,227 @@ function requireGateMdPath(result: { readonly gateMdPath?: string }): string {
   if (result.gateMdPath === undefined) throw new Error('expected gateMdPath on the result')
   return result.gateMdPath
 }
+
+describe('runResume gate-pending loudness (task 4.3)', () => {
+  it('prints that the run awaits a gate decision plus the exact gate command with the run id', async () => {
+    const fixture = makeFixture()
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'S',
+    })
+    const result = await runResume(fixture.deps, started.runId)
+    expect(result.halted).toBe('gate-pending')
+    expect(fixture.stdoutLines.some((l) => l.includes('awaits a gate decision'))).toBe(true)
+    expect(fixture.stdoutLines.includes(`sdd-runner gate resume ${started.runId}`)).toBe(true)
+    expect(fixture.stdoutLines.some((l) => l.includes(started.runId))).toBe(true)
+  })
+
+  it('halting at a gate prints a copy-pasteable next-step line with the full resume command and run id', async () => {
+    const fixture = makeFixture()
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'S',
+    })
+    expect(fixture.stdoutLines.includes(`Next: sdd-runner gate resume ${started.runId}`)).toBe(true)
+  })
+})
+
+describe('runContinue routing (task 4.7)', () => {
+  it('routes a gate-pending run into the gate flow', async () => {
+    const fixture = makeFixture()
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const result = await runContinue(fixture.deps, started.runId)
+    expect(result.routed).toBe('gate')
+    expect(result.runId).toBe(started.runId)
+  })
+
+  it('routes a completed run to a report pointer', async () => {
+    const fixture = makeFixture()
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    await runGateResume(fixture.deps, started.runId, { confirmAll: true })
+    const result = await runContinue(fixture.deps, started.runId)
+    expect(result.routed).toBe('report')
+    expect(fixture.stdoutLines.some((l) => l.includes(`sdd-runner report ${started.runId}`))).toBe(true)
+  })
+
+  it('routes an interrupted mid-stage run to stage resume', async () => {
+    const fixture = makeFixture()
+    const workDir = fixture.deps.config.workDir
+    const runId = 'cont-mid'
+    const runDir = path.join(workDir, 'runs', runId)
+    fs.mkdirSync(path.join(runDir, 'sidecars'), { recursive: true })
+    fs.mkdirSync(path.join(fixture.changeDir, 'specs', 'thing'), { recursive: true })
+    fs.writeFileSync(path.join(fixture.changeDir, 'proposal.md'), '## Why\nseeded\n')
+    fs.writeFileSync(path.join(fixture.changeDir, 'specs', 'thing', 'spec.md'), '## ADDED Requirements\n')
+    fs.writeFileSync(
+      path.join(runDir, 'events.ndjson'),
+      [
+        { altitude: 'L2', type: 'stage_enter', stage: 'intake', seq: 1, ts: '2026-01-01T00:00:00.000Z' },
+        {
+          altitude: 'L2',
+          type: 'depth',
+          profile: 'S',
+          rationale: 'override',
+          source: 'override',
+          seq: 2,
+          ts: '2026-01-01T00:00:00.000Z',
+        },
+        { altitude: 'L2', type: 'stage_exit', stage: 'intake', seq: 3, ts: '2026-01-01T00:00:00.000Z' },
+        { altitude: 'L2', type: 'stage_enter', stage: 'draft', seq: 4, ts: '2026-01-01T00:00:00.000Z' },
+        { altitude: 'L2', type: 'stage_exit', stage: 'draft', seq: 5, ts: '2026-01-01T00:00:00.000Z' },
+      ]
+        .map((e) => JSON.stringify(e))
+        .join('\n') + '\n',
+    )
+    fs.writeFileSync(
+      path.join(runDir, 'state.json'),
+      `${JSON.stringify(
+        {
+          runId,
+          repoRoot: fixture.repoRoot,
+          workDir,
+          changeName: fixture.changeName,
+          stage: 'draft',
+          depth: 'S',
+          round: 0,
+          gate: null,
+          status: 'running',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+        null,
+        2,
+      )}\n`,
+    )
+    const calls: string[] = []
+    const trackingDriver = createTrackingDriver(fixture, calls)
+    const deps: OrchestratorDeps = { ...fixture.deps, driver: trackingDriver }
+    const result = await runContinue(deps, runId)
+    expect(result.routed).toBe('resume')
+    expect(result.runId).toBe(runId)
+  })
+
+  it('with no id, a single pending/active run routes directly', async () => {
+    const fixture = makeFixture()
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const result = await runContinue(fixture.deps, null)
+    expect(result.routed).toBe('gate')
+    expect(result.runId).toBe(started.runId)
+  })
+
+  it('with no id and several candidate runs, lists them instead of guessing (non-TTY)', async () => {
+    const fixture = makeFixture()
+    const first = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const fixture2 = makeFixture()
+    const second = await runStart(fixture2.deps, { taskFile: fixture2.taskFile, depthOverride: 'S' })
+    fs.cpSync(
+      path.join(fixture2.deps.config.workDir, 'runs', second.runId),
+      path.join(fixture.deps.config.workDir, 'runs', second.runId),
+      { recursive: true },
+    )
+    const result = await runContinue(fixture.deps, null)
+    expect(result.routed).toBe('list')
+    expect(fixture.stdoutLines.some((l) => l.includes(first.runId))).toBe(true)
+    expect(fixture.stdoutLines.some((l) => l.includes(second.runId))).toBe(true)
+  })
+})
+
+describe('runGateResume flags + TTY wiring (tasks 4.5-4.6)', () => {
+  function gatedFixture(): Fixture {
+    const assumption = {
+      id: 'A1',
+      text: 'guests stay read-only',
+      basis: 'default',
+      confidence: 'medium',
+      blast_radius: 'group replies',
+      status: 'open',
+    }
+    const fixture = makeFixture({
+      'resolutions-1.json': JSON.stringify({ resolutions: [], assumptions: [assumption] }),
+    })
+    return fixture
+  }
+
+  it('non-TTY with no flags parses the hand-edited file and never prompts', async () => {
+    const fixture = gatedFixture()
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const result = await runGateResume(fixture.deps, started.runId, {})
+    expect(result.outcome).toBe('veto')
+  })
+
+  it('--confirm-all with --veto A1=<redirect> writes the equivalent hand-edited file', async () => {
+    const fixture = gatedFixture()
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const result = await runGateResume(fixture.deps, started.runId, {
+      confirmAll: true,
+      vetoes: [{ id: 'A1', redirect: 'narrowed to dm-only' }],
+    })
+    expect(result.outcome).toBe('veto')
+    expect(result.version).toBe(2)
+    const runDir = path.join(fixture.deps.config.workDir, 'runs', started.runId)
+    const gate2 = fs.readFileSync(path.join(runDir, 'gate-2.md'), 'utf8')
+    expect(gate2).toContain('- [ ] A1 narrowed to dm-only')
+  })
+
+  it('an unknown veto id fails before any pipeline action', async () => {
+    const fixture = gatedFixture()
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const spawnCount = fixture.spawnOrder.length
+    await expect(
+      runGateResume(fixture.deps, started.runId, { confirmAll: true, vetoes: [{ id: 'Z9' }] }),
+    ).rejects.toThrow(/Z9/u)
+    expect(fixture.spawnOrder.length).toBe(spawnCount)
+  })
+
+  it('--extend desugars to the extend directive outcome', async () => {
+    const materialFinding = {
+      id: 'F1',
+      class: 'MATERIAL',
+      gap: 'design lacks rollback',
+      question: 'how?',
+      code_evidence_attempted: 'searched design.md',
+    }
+    const materialResolution = { id: 'F1', class: 'MATERIAL', resolution: 'edited', outcome: 'narrowed gap' }
+    const fixture = makeFixture({
+      'findings-1.json': JSON.stringify({ findings: [materialFinding] }),
+      'resolutions-1.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'findings-2.json': JSON.stringify({ findings: [materialFinding] }),
+      'resolutions-2.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'findings-3.json': JSON.stringify({ findings: [materialFinding] }),
+      'resolutions-3.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'findings-4.json': JSON.stringify({ findings: [materialFinding] }),
+      'resolutions-4.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+    })
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'M' })
+    const result = await runGateResume(fixture.deps, started.runId, { extend: true })
+    expect(result.outcome).toBe('extend')
+    expect(result.version).toBe(2)
+  })
+
+  it('--abort writes ABORT without prompting', async () => {
+    const fixture = gatedFixture()
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const result = await runGateResume(fixture.deps, started.runId, { abort: true })
+    expect(result.outcome).toBe('aborted')
+    const state = await loadRunState(fixture.deps.config.workDir, started.runId)
+    expect(state.status).toBe('aborted')
+  })
+
+  it('a TTY with no decision flags runs the interactive session and writes its answers', async () => {
+    const fixture = gatedFixture()
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const { prompter } = scriptedPrompter(['a', 'approve'])
+    const deps: OrchestratorDeps = {
+      ...fixture.deps,
+      interactive: (): boolean => true,
+      makePrompter: (): Prompter => prompter,
+    }
+    const result = await runGateResume(deps, started.runId, {})
+    expect(result.outcome).toBe('approved')
+    const state = await loadRunState(fixture.deps.config.workDir, started.runId)
+    expect(state.status).toBe('completed')
+  })
+})
 
 describe('runGateResume', () => {
   it('halts at an early cap-hit gate with trajectory, open MATERIAL checkboxes, and T1 ack; rejects resume without T1', async () => {

--- a/tests/sdd-runner/orchestrator.test.ts
+++ b/tests/sdd-runner/orchestrator.test.ts
@@ -20,7 +20,6 @@ import type { StageContext } from '../../sdd-runner/src/gate-digest.js'
 import { createOpenSpecDriver } from '../../sdd-runner/src/openspec-driver.js'
 import type { OpenSpecDriver } from '../../sdd-runner/src/openspec-driver.js'
 import { runGateResume, runResume, runStart } from '../../sdd-runner/src/orchestrator.js'
-import type { RunGateResumeResult } from '../../sdd-runner/src/orchestrator.js'
 import type { ReviewLoopResult } from '../../sdd-runner/src/review-loop.js'
 import { createRunState } from '../../sdd-runner/src/run-state.js'
 import { loadRunState } from '../../sdd-runner/src/run-state.js'
@@ -340,7 +339,104 @@ describe('runResume', () => {
     expect(fixture.spawnOrder).toContain('findings-1.json')
     expect(fixture.spawnOrder).toContain('decompose-tasks.json')
   })
+
+  it('re-enters at decompose after an interrupted post-review stage and continues to the final gate (task 3.3)', async () => {
+    const fixture = makeFixture()
+    const workDir = fixture.deps.config.workDir
+    const runId = 'seeded-decompose'
+    const runDir = path.join(workDir, 'runs', runId)
+    fs.mkdirSync(path.join(runDir, 'sidecars'), { recursive: true })
+    fs.mkdirSync(path.join(fixture.changeDir, 'specs', 'thing'), { recursive: true })
+    fs.writeFileSync(path.join(fixture.changeDir, 'proposal.md'), '## Why\nseeded\n')
+    fs.writeFileSync(path.join(fixture.changeDir, 'design.md'), '## Context\nseeded\n')
+    fs.writeFileSync(path.join(fixture.changeDir, 'specs', 'thing', 'spec.md'), '## ADDED Requirements\n')
+    const materialResolution = { id: 'F1', class: 'MATERIAL', resolution: 'edited', outcome: 'narrowed gap' }
+    fs.writeFileSync(
+      path.join(runDir, 'sidecars', 'resolutions-1.json'),
+      JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+    )
+    const now = '2026-01-01T00:00:00.000Z'
+    const events = [
+      { altitude: 'L2', type: 'stage_enter', stage: 'intake', seq: 1, ts: now },
+      { altitude: 'L2', type: 'depth', profile: 'M', rationale: 'override', source: 'override', seq: 2, ts: now },
+      { altitude: 'L2', type: 'stage_exit', stage: 'intake', seq: 3, ts: now },
+      { altitude: 'L2', type: 'stage_enter', stage: 'draft', seq: 4, ts: now },
+      { altitude: 'L2', type: 'stage_exit', stage: 'draft', seq: 5, ts: now },
+      { altitude: 'L2', type: 'stage_enter', stage: 'review', seq: 6, ts: now },
+      { altitude: 'L2', type: 'round_open', round: 1, cap: 3, seq: 7, ts: now },
+      {
+        altitude: 'L2',
+        type: 'convergence',
+        round: 1,
+        verdict: 'open',
+        counts: { blocker: 0, material: 1, nitpick: 0 },
+        seq: 8,
+        ts: now,
+      },
+      { altitude: 'L2', type: 'round_close', round: 1, cap: 3, seq: 9, ts: now },
+      { altitude: 'L2', type: 'stage_exit', stage: 'review', seq: 10, ts: now },
+      { altitude: 'L2', type: 'gate', action: 'presented', mode: 'early', version: 1, seq: 11, ts: now },
+      { altitude: 'L2', type: 'gate', action: 'answered', mode: 'early', version: 1, seq: 12, ts: now },
+    ]
+    fs.writeFileSync(path.join(runDir, 'events.ndjson'), events.map((e) => JSON.stringify(e)).join('\n') + '\n')
+    fs.writeFileSync(
+      path.join(runDir, 'state.json'),
+      `${JSON.stringify(
+        {
+          runId,
+          repoRoot: fixture.repoRoot,
+          workDir,
+          changeName: fixture.changeName,
+          stage: 'review',
+          depth: 'M',
+          round: 1,
+          gate: null,
+          status: 'running',
+          createdAt: now,
+          updatedAt: now,
+        },
+        null,
+        2,
+      )}\n`,
+    )
+
+    const deps: OrchestratorDeps = { ...fixture.deps, driver: createSettledDriver(fixture) }
+    const before = fixture.spawnOrder.length
+    const result = await runResume(deps, runId)
+
+    expect(result.halted).toBe('gate')
+    const reviewSpawns = fixture.spawnOrder.slice(before)
+    expect(reviewSpawns).not.toContain('findings-1.json')
+    expect(reviewSpawns).toContain('decompose-tasks.json')
+    expect(reviewSpawns).toContain('atomicity.json')
+    const gateMd = fs.readFileSync(requireGateMdPath({ gateMdPath: result.gateMdPath }), 'utf8')
+    expect(gateMd).toContain('Final gate')
+    const state = await loadRunState(workDir, runId)
+    expect(state.gate).toEqual({ mode: 'final', version: 1 })
+  })
 })
+
+function createSettledDriver(fixture: Fixture): OpenSpecDriver {
+  return {
+    newChange: () => Promise.resolve({ changeName: fixture.changeName }),
+    status: () =>
+      Promise.resolve({
+        schemaName: 'auto-sdd',
+        artifacts: { proposal: 'done', specs: 'done', design: 'done' },
+        isPlanningComplete: true,
+      }),
+    instructions: (artifactId: string) =>
+      Promise.resolve({
+        instruction: `write the ${artifactId}`,
+        template: undefined,
+        rules: [],
+        resolvedOutputPath: path.join(fixture.changeDir, artifactId === 'tasks' ? 'tasks.md' : `${artifactId}.md`),
+        existingOutputPaths: [],
+        dependencies: [],
+      }),
+    validateStrict: () => Promise.resolve({ ok: true, output: 'is valid' }),
+  }
+}
 
 function createTrackingDriver(fixture: Fixture, calls: string[]): OpenSpecDriver {
   return {
@@ -366,7 +462,7 @@ function createTrackingDriver(fixture: Fixture, calls: string[]): OpenSpecDriver
   }
 }
 
-function requireGateMdPath(result: RunGateResumeResult): string {
+function requireGateMdPath(result: { readonly gateMdPath?: string }): string {
   if (result.gateMdPath === undefined) throw new Error('expected gateMdPath on the result')
   return result.gateMdPath
 }

--- a/tests/sdd-runner/orchestrator.test.ts
+++ b/tests/sdd-runner/orchestrator.test.ts
@@ -20,6 +20,7 @@ import type { StageContext } from '../../sdd-runner/src/gate-digest.js'
 import { createOpenSpecDriver } from '../../sdd-runner/src/openspec-driver.js'
 import type { OpenSpecDriver } from '../../sdd-runner/src/openspec-driver.js'
 import { runGateResume, runResume, runStart } from '../../sdd-runner/src/orchestrator.js'
+import type { RunGateResumeResult } from '../../sdd-runner/src/orchestrator.js'
 import type { ReviewLoopResult } from '../../sdd-runner/src/review-loop.js'
 import { createRunState } from '../../sdd-runner/src/run-state.js'
 import { loadRunState } from '../../sdd-runner/src/run-state.js'
@@ -62,15 +63,27 @@ function makeFixture(sidecarOverrides: Record<string, string> = {}): Fixture {
   const spawnOrder: string[] = []
 
   const sidecars: Record<string, string> = {
-    'draft-proposal.json': JSON.stringify({ files_written: ['openspec/changes/add-thing/proposal.md'] }),
-    'draft-specs.json': JSON.stringify({ files_written: ['openspec/changes/add-thing/specs/thing/spec.md'] }),
-    'draft-design.json': JSON.stringify({ files_written: ['openspec/changes/add-thing/design.md'] }),
+    'draft-proposal.json': JSON.stringify({
+      files_written: ['openspec/changes/add-thing/proposal.md'],
+    }),
+    'draft-specs.json': JSON.stringify({
+      files_written: ['openspec/changes/add-thing/specs/thing/spec.md'],
+    }),
+    'draft-design.json': JSON.stringify({
+      files_written: ['openspec/changes/add-thing/design.md'],
+    }),
     'findings-1.json': JSON.stringify({ findings: [] }),
     'resolutions-1.json': JSON.stringify({ resolutions: [], assumptions: [] }),
-    'decompose-tasks.json': JSON.stringify({ tasks_file: 'openspec/changes/add-thing/tasks.md' }),
+    'decompose-tasks.json': JSON.stringify({
+      tasks_file: 'openspec/changes/add-thing/tasks.md',
+    }),
     'atomicity.json': JSON.stringify({ split: 0, merged: 0 }),
-    'drift.json': JSON.stringify({ tasks_file: 'openspec/changes/add-thing/tasks.md' }),
-    'veto-updater.json': JSON.stringify({ files_updated: ['openspec/changes/add-thing/proposal.md'] }),
+    'drift.json': JSON.stringify({
+      tasks_file: 'openspec/changes/add-thing/tasks.md',
+    }),
+    'veto-updater.json': JSON.stringify({
+      files_updated: ['openspec/changes/add-thing/proposal.md'],
+    }),
     ...sidecarOverrides,
   }
   const artifacts: Record<string, string> = {
@@ -121,14 +134,20 @@ function makeFixture(sidecarOverrides: Record<string, string> = {}): Fixture {
     }
     if (subcommand === 'status') {
       return Promise.resolve({
-        stdout: JSON.stringify({ schemaName: 'auto-sdd', artifacts: [{ id: 'proposal', status: 'done' }] }),
+        stdout: JSON.stringify({
+          schemaName: 'auto-sdd',
+          artifacts: [{ id: 'proposal', status: 'done' }],
+        }),
         stderr: '',
         exitCode: 0,
       })
     }
     return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 })
   }
-  const driver: OpenSpecDriver = createOpenSpecDriver({ exec: driverExec, cwd: repoRoot })
+  const driver: OpenSpecDriver = createOpenSpecDriver({
+    exec: driverExec,
+    cwd: repoRoot,
+  })
 
   const deps: OrchestratorDeps = {
     config: {
@@ -155,7 +174,16 @@ function makeFixture(sidecarOverrides: Record<string, string> = {}): Fixture {
     // reaching the network; the pricing fetch itself is covered hermetically in pricing.test.ts.
     resolveCost: () => null,
   }
-  return { deps, repoRoot, changeName, changeDir, taskFile, rendered, stdoutLines, spawnOrder }
+  return {
+    deps,
+    repoRoot,
+    changeName,
+    changeDir,
+    taskFile,
+    rendered,
+    stdoutLines,
+    spawnOrder,
+  }
 }
 
 function glmFallbackResolver(
@@ -170,7 +198,10 @@ function glmFallbackResolver(
 describe('runStart', () => {
   it('sequences intake→draft→review→decompose→gate at S, persists state, and drives bus + persister', async () => {
     const fixture = makeFixture()
-    const result = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const result = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'S',
+    })
     expect(result.halted).toBe('gate')
     expect(result.version).toBe(1)
 
@@ -201,7 +232,10 @@ describe('runStart', () => {
 
   it('drafts design.md at M and runs the atomicity check after decompose', async () => {
     const fixture = makeFixture()
-    const result = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'M' })
+    const result = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'M',
+    })
     expect(result.halted).toBe('gate')
     expect(fs.existsSync(path.join(fixture.changeDir, 'design.md'))).toBe(true)
     expect(fixture.spawnOrder).toContain('draft-design.json')
@@ -229,11 +263,19 @@ describe('runResume', () => {
     const runId = 'seeded-run-1'
     const runDir = path.join(workDir, 'runs', runId)
     fs.mkdirSync(path.join(runDir, 'sidecars'), { recursive: true })
-    fs.mkdirSync(path.join(fixture.changeDir, 'specs', 'thing'), { recursive: true })
+    fs.mkdirSync(path.join(fixture.changeDir, 'specs', 'thing'), {
+      recursive: true,
+    })
     fs.writeFileSync(path.join(fixture.changeDir, 'proposal.md'), '## Why\nseeded\n')
     fs.writeFileSync(path.join(fixture.changeDir, 'specs', 'thing', 'spec.md'), '## ADDED Requirements\n')
     const events = [
-      { altitude: 'L2', type: 'stage_enter', stage: 'intake', seq: 1, ts: '2026-01-01T00:00:00.000Z' },
+      {
+        altitude: 'L2',
+        type: 'stage_enter',
+        stage: 'intake',
+        seq: 1,
+        ts: '2026-01-01T00:00:00.000Z',
+      },
       {
         altitude: 'L2',
         type: 'depth',
@@ -243,9 +285,27 @@ describe('runResume', () => {
         seq: 2,
         ts: '2026-01-01T00:00:00.000Z',
       },
-      { altitude: 'L2', type: 'stage_exit', stage: 'intake', seq: 3, ts: '2026-01-01T00:00:00.000Z' },
-      { altitude: 'L2', type: 'stage_enter', stage: 'draft', seq: 4, ts: '2026-01-01T00:00:00.000Z' },
-      { altitude: 'L2', type: 'stage_exit', stage: 'draft', seq: 5, ts: '2026-01-01T00:00:00.000Z' },
+      {
+        altitude: 'L2',
+        type: 'stage_exit',
+        stage: 'intake',
+        seq: 3,
+        ts: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        altitude: 'L2',
+        type: 'stage_enter',
+        stage: 'draft',
+        seq: 4,
+        ts: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        altitude: 'L2',
+        type: 'stage_exit',
+        stage: 'draft',
+        seq: 5,
+        ts: '2026-01-01T00:00:00.000Z',
+      },
     ]
     fs.writeFileSync(path.join(runDir, 'events.ndjson'), events.map((e) => JSON.stringify(e)).join('\n') + '\n')
     fs.writeFileSync(
@@ -306,6 +366,11 @@ function createTrackingDriver(fixture: Fixture, calls: string[]): OpenSpecDriver
   }
 }
 
+function requireGateMdPath(result: RunGateResumeResult): string {
+  if (result.gateMdPath === undefined) throw new Error('expected gateMdPath on the result')
+  return result.gateMdPath
+}
+
 describe('runGateResume', () => {
   it('halts at an early cap-hit gate with trajectory, open MATERIAL checkboxes, and T1 ack; rejects resume without T1', async () => {
     const materialFinding = {
@@ -315,16 +380,33 @@ describe('runGateResume', () => {
       question: 'how?',
       code_evidence_attempted: 'searched design.md',
     }
-    const materialResolution = { id: 'F1', class: 'MATERIAL', resolution: 'edited', outcome: 'narrowed gap' }
+    const materialResolution = {
+      id: 'F1',
+      class: 'MATERIAL',
+      resolution: 'edited',
+      outcome: 'narrowed gap',
+    }
     const fixture = makeFixture({
       'findings-1.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-1.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-1.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
       'findings-2.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-2.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-2.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
       'findings-3.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-3.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-3.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
     })
-    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'M' })
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'M',
+    })
     expect(started.halted).toBe('gate')
 
     const gateMd = fs.readFileSync(started.gateMdPath, 'utf8')
@@ -349,16 +431,33 @@ describe('runGateResume', () => {
       question: 'how?',
       code_evidence_attempted: 'searched design.md',
     }
-    const materialResolution = { id: 'F1', class: 'MATERIAL', resolution: 'edited', outcome: 'narrowed gap' }
+    const materialResolution = {
+      id: 'F1',
+      class: 'MATERIAL',
+      resolution: 'edited',
+      outcome: 'narrowed gap',
+    }
     const fixture = makeFixture({
       'findings-1.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-1.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-1.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
       'findings-2.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-2.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-2.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
       'findings-3.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-3.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-3.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
     })
-    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'M' })
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'M',
+    })
     const gatePath = path.join(fixture.deps.config.workDir, 'runs', started.runId, 'gate-1.md')
     const gateMd = fs.readFileSync(gatePath, 'utf8')
     fs.writeFileSync(gatePath, gateMd.replace('- [ ] T1', '- [x] T1'))
@@ -370,7 +469,10 @@ describe('runGateResume', () => {
 
   it('marks the run completed on an approved gate', async () => {
     const fixture = makeFixture()
-    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'S',
+    })
     const result = await runGateResume(fixture.deps, started.runId, {})
     expect(result.outcome).toBe('approved')
     const state = await loadRunState(fixture.deps.config.workDir, started.runId)
@@ -378,9 +480,167 @@ describe('runGateResume', () => {
     expect(state.gate).toBeNull()
   })
 
+  it('continues into decompose + atomicity + final gate on an approved early gate, without completing (task 1.1)', async () => {
+    const materialFinding = {
+      id: 'F1',
+      class: 'MATERIAL',
+      gap: 'design lacks rollback',
+      question: 'how?',
+      code_evidence_attempted: 'searched design.md',
+    }
+    const materialResolution = {
+      id: 'F1',
+      class: 'MATERIAL',
+      resolution: 'edited',
+      outcome: 'narrowed gap',
+    }
+    const fixture = makeFixture({
+      'findings-1.json': JSON.stringify({ findings: [materialFinding] }),
+      'resolutions-1.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
+      'findings-2.json': JSON.stringify({ findings: [materialFinding] }),
+      'resolutions-2.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
+      'findings-3.json': JSON.stringify({ findings: [materialFinding] }),
+      'resolutions-3.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
+    })
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'M',
+    })
+    const runDir = path.join(fixture.deps.config.workDir, 'runs', started.runId)
+    expect(fs.readFileSync(path.join(runDir, 'gate-1.md'), 'utf8')).toContain('Early gate')
+
+    const result = await runGateResume(fixture.deps, started.runId, {
+      confirmAll: true,
+    })
+
+    expect(result.outcome).toBe('approved')
+    expect(result.version).toBe(2)
+    const gate2 = fs.readFileSync(requireGateMdPath(result), 'utf8')
+    expect(gate2).toContain('Final gate')
+    expect(fixture.spawnOrder).toContain('decompose-tasks.json')
+    expect(fixture.spawnOrder).toContain('atomicity.json')
+    expect(fixture.spawnOrder.indexOf('decompose-tasks.json')).toBeLessThan(
+      fixture.spawnOrder.indexOf('atomicity.json'),
+    )
+    expect(fs.existsSync(path.join(fixture.changeDir, 'tasks.md'))).toBe(true)
+
+    const state = await loadRunState(fixture.deps.config.workDir, started.runId)
+    expect(state.status).toBe('running')
+    expect(state.gate).toEqual({ mode: 'final', version: 2 })
+  })
+
+  it('skips atomicity but still reaches the final gate when an approved early gate continues at S (task 1.2)', async () => {
+    const materialFinding = {
+      id: 'F1',
+      class: 'MATERIAL',
+      gap: 'design lacks rollback',
+      question: 'how?',
+      code_evidence_attempted: 'searched design.md',
+    }
+    const materialResolution = {
+      id: 'F1',
+      class: 'MATERIAL',
+      resolution: 'edited',
+      outcome: 'narrowed gap',
+    }
+    const fixture = makeFixture({
+      'findings-1.json': JSON.stringify({ findings: [materialFinding] }),
+      'resolutions-1.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
+    })
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'S',
+    })
+    const runDir = path.join(fixture.deps.config.workDir, 'runs', started.runId)
+    expect(fs.readFileSync(path.join(runDir, 'gate-1.md'), 'utf8')).toContain('Early gate')
+
+    const result = await runGateResume(fixture.deps, started.runId, {
+      confirmAll: true,
+    })
+
+    expect(result.outcome).toBe('approved')
+    expect(result.version).toBe(2)
+    expect(fs.readFileSync(requireGateMdPath(result), 'utf8')).toContain('Final gate')
+    expect(fixture.spawnOrder).toContain('decompose-tasks.json')
+    expect(fixture.spawnOrder).not.toContain('atomicity.json')
+
+    const state = await loadRunState(fixture.deps.config.workDir, started.runId)
+    expect(state.status).toBe('running')
+    expect(state.gate).toEqual({ mode: 'final', version: 2 })
+  })
+
+  it('completes the run only when the final gate is approved (task 1.4)', async () => {
+    const fixture = makeFixture()
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'S',
+    })
+    const runDir = path.join(fixture.deps.config.workDir, 'runs', started.runId)
+    const gate1 = fs.readFileSync(path.join(runDir, 'gate-1.md'), 'utf8')
+    expect(gate1).toContain('Final gate')
+
+    const result = await runGateResume(fixture.deps, started.runId, {
+      confirmAll: true,
+    })
+    expect(result.outcome).toBe('approved')
+    const state = await loadRunState(fixture.deps.config.workDir, started.runId)
+    expect(state.status).toBe('completed')
+    expect(state.gate).toBeNull()
+    expect(fs.existsSync(path.join(fixture.changeDir, 'tasks.md'))).toBe(true)
+  })
+
+  it('aborts at an early gate without running decompose (abort is the only early exit)', async () => {
+    const materialFinding = {
+      id: 'F1',
+      class: 'MATERIAL',
+      gap: 'design lacks rollback',
+      question: 'how?',
+      code_evidence_attempted: 'searched design.md',
+    }
+    const materialResolution = {
+      id: 'F1',
+      class: 'MATERIAL',
+      resolution: 'edited',
+      outcome: 'narrowed gap',
+    }
+    const fixture = makeFixture({
+      'findings-1.json': JSON.stringify({ findings: [materialFinding] }),
+      'resolutions-1.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
+    })
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'S',
+    })
+    const result = await runGateResume(fixture.deps, started.runId, {
+      abort: true,
+    })
+    expect(result.outcome).toBe('aborted')
+    const state = await loadRunState(fixture.deps.config.workDir, started.runId)
+    expect(state.status).toBe('aborted')
+    expect(fixture.spawnOrder).not.toContain('decompose-tasks.json')
+  })
+
   it('marks the run aborted on an ABORT gate response', async () => {
     const fixture = makeFixture()
-    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'S',
+    })
     fs.writeFileSync(path.join(fixture.deps.config.workDir, 'runs', started.runId, 'gate-1.md'), 'ABORT\n')
     const result = await runGateResume(fixture.deps, started.runId, {})
     expect(result.outcome).toBe('aborted')
@@ -390,7 +650,10 @@ describe('runGateResume', () => {
 
   it('runs the drift-check resolver when a spec changed while gate-pending', async () => {
     const fixture = makeFixture()
-    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'S',
+    })
     fs.writeFileSync(
       path.join(fixture.changeDir, 'specs', 'thing', 'spec.md'),
       '## ADDED Requirements\n### Requirement: Hand-edit\n',
@@ -412,9 +675,15 @@ describe('runGateResume', () => {
       status: 'open',
     }
     const fixture = makeFixture({
-      'resolutions-1.json': JSON.stringify({ resolutions: [], assumptions: [assumption] }),
+      'resolutions-1.json': JSON.stringify({
+        resolutions: [],
+        assumptions: [assumption],
+      }),
     })
-    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'S',
+    })
     const runDir = path.join(fixture.deps.config.workDir, 'runs', started.runId)
     const gate1Path = path.join(runDir, 'gate-1.md')
     const gate1 = fs.readFileSync(gate1Path, 'utf8')
@@ -446,18 +715,38 @@ describe('runGateResume', () => {
       question: 'how?',
       code_evidence_attempted: 'searched design.md',
     }
-    const materialResolution = { id: 'F1', class: 'MATERIAL', resolution: 'edited', outcome: 'narrowed gap' }
+    const materialResolution = {
+      id: 'F1',
+      class: 'MATERIAL',
+      resolution: 'edited',
+      outcome: 'narrowed gap',
+    }
     const fixture = makeFixture({
       'findings-1.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-1.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-1.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
       'findings-2.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-2.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-2.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
       'findings-3.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-3.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-3.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
       'findings-4.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-4.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-4.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
     })
-    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'M' })
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'M',
+    })
     const runDir = path.join(fixture.deps.config.workDir, 'runs', started.runId)
     const gate1Path = path.join(runDir, 'gate-1.md')
     fs.writeFileSync(gate1Path, '→ RUN 1 MORE\n')
@@ -490,19 +779,44 @@ describe('runGateResume', () => {
       question: 'how?',
       code_evidence_attempted: 'searched design.md',
     }
-    const materialResolution = { id: 'F1', class: 'MATERIAL', resolution: 'edited', outcome: 'narrowed gap' }
-    const convergedResolution = { id: 'F1', class: 'NITPICK', resolution: 'edited', outcome: 'specs clarified' }
+    const materialResolution = {
+      id: 'F1',
+      class: 'MATERIAL',
+      resolution: 'edited',
+      outcome: 'narrowed gap',
+    }
+    const convergedResolution = {
+      id: 'F1',
+      class: 'NITPICK',
+      resolution: 'edited',
+      outcome: 'specs clarified',
+    }
     const fixture = makeFixture({
       'findings-1.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-1.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-1.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
       'findings-2.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-2.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-2.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
       'findings-3.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-3.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-3.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
       'findings-4.json': JSON.stringify({ findings: [] }),
-      'resolutions-4.json': JSON.stringify({ resolutions: [convergedResolution], assumptions: [] }),
+      'resolutions-4.json': JSON.stringify({
+        resolutions: [convergedResolution],
+        assumptions: [],
+      }),
     })
-    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'M' })
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'M',
+    })
     const runDir = path.join(fixture.deps.config.workDir, 'runs', started.runId)
     fs.writeFileSync(path.join(runDir, 'gate-1.md'), '→ RUN 1 MORE\n')
 
@@ -529,16 +843,33 @@ describe('runGateResume', () => {
       question: 'how?',
       code_evidence_attempted: 'searched design.md',
     }
-    const materialResolution = { id: 'F1', class: 'MATERIAL', resolution: 'edited', outcome: 'narrowed gap' }
+    const materialResolution = {
+      id: 'F1',
+      class: 'MATERIAL',
+      resolution: 'edited',
+      outcome: 'narrowed gap',
+    }
     const fixture = makeFixture({
       'findings-1.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-1.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-1.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
       'findings-2.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-2.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-2.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
       'findings-3.json': JSON.stringify({ findings: [materialFinding] }),
-      'resolutions-3.json': JSON.stringify({ resolutions: [materialResolution], assumptions: [] }),
+      'resolutions-3.json': JSON.stringify({
+        resolutions: [materialResolution],
+        assumptions: [],
+      }),
     })
-    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'S' })
+    const started = await runStart(fixture.deps, {
+      taskFile: fixture.taskFile,
+      depthOverride: 'S',
+    })
     const runDir = path.join(fixture.deps.config.workDir, 'runs', started.runId)
 
     fs.writeFileSync(path.join(runDir, 'gate-1.md'), '→ RUN 1 MORE\n')
@@ -589,7 +920,13 @@ describe('presentGateAt cost fallback', () => {
         altitude: 'L1',
         type: 'done',
         agent: 'drafter-1',
-        usage: { inputTokens: 1_000_000, outputTokens: 500_000, reasoningTokens: 0, costUsd: 0, wallMs: 1000 },
+        usage: {
+          inputTokens: 1_000_000,
+          outputTokens: 500_000,
+          reasoningTokens: 0,
+          costUsd: 0,
+          wallMs: 1000,
+        },
         seq: 2,
         ts: now.toISOString(),
       },

--- a/tests/sdd-runner/orchestrator.test.ts
+++ b/tests/sdd-runner/orchestrator.test.ts
@@ -635,6 +635,67 @@ describe('runGateResume', () => {
     expect(fixture.spawnOrder).not.toContain('decompose-tasks.json')
   })
 
+  it('treats a nitpick-only cap-hit as converged and flows into decompose + atomicity + final gate (task 2.1)', async () => {
+    const nitpicks = [1, 2, 3, 4].map((n) => ({
+      id: `F${n}`,
+      class: 'NITPICK',
+      gap: `wording wobble ${n}`,
+      question: 'minor',
+      code_evidence_attempted: 'searched design.md',
+    }))
+    const nitpickResolutions = [1, 2, 3, 4].map((n) => ({
+      id: `F${n}`,
+      class: 'NITPICK',
+      resolution: 'dismissed',
+      justification: `cosmetic ${n}`,
+    }))
+    const rounds: Record<string, string> = {}
+    for (const round of [1, 2, 3]) {
+      rounds[`findings-${round}.json`] = JSON.stringify({ findings: nitpicks })
+      rounds[`resolutions-${round}.json`] = JSON.stringify({ resolutions: nitpickResolutions, assumptions: [] })
+    }
+    const fixture = makeFixture(rounds)
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'M' })
+
+    expect(started.version).toBe(1)
+    const gate1 = fs.readFileSync(started.gateMdPath, 'utf8')
+    expect(gate1).toContain('Final gate')
+    expect(gate1).not.toContain('Early gate')
+    expect(fixture.spawnOrder).toContain('decompose-tasks.json')
+    expect(fixture.spawnOrder).toContain('atomicity.json')
+    expect(fs.existsSync(path.join(fixture.changeDir, 'tasks.md'))).toBe(true)
+
+    const state = await loadRunState(fixture.deps.config.workDir, started.runId)
+    expect(state.gate).toEqual({ mode: 'final', version: 1 })
+    expect(state.status).toBe('running')
+  })
+
+  it('still presents an early gate and halts when a BLOCKER is open at cap (task 2.3)', async () => {
+    const blockerFinding = {
+      id: 'B1',
+      class: 'BLOCKER',
+      gap: 'no rollback path',
+      question: 'how?',
+      code_evidence_attempted: 'searched design.md',
+    }
+    const blockerResolution = { id: 'B1', class: 'BLOCKER', resolution: 'assumed', outcome: 'defaulted' }
+    const rounds: Record<string, string> = {}
+    for (const round of [1, 2, 3]) {
+      rounds[`findings-${round}.json`] = JSON.stringify({ findings: [blockerFinding] })
+      rounds[`resolutions-${round}.json`] = JSON.stringify({ resolutions: [blockerResolution], assumptions: [] })
+    }
+    rounds['findings-skeptic-3.json'] = JSON.stringify({ findings: [blockerFinding] })
+    const fixture = makeFixture(rounds)
+    const started = await runStart(fixture.deps, { taskFile: fixture.taskFile, depthOverride: 'M' })
+
+    const gate1 = fs.readFileSync(started.gateMdPath, 'utf8')
+    expect(gate1).toContain('Early gate')
+    expect(fixture.spawnOrder).not.toContain('decompose-tasks.json')
+    const state = await loadRunState(fixture.deps.config.workDir, started.runId)
+    expect(state.gate).toEqual({ mode: 'early', version: 1 })
+    expect(fs.existsSync(path.join(fixture.changeDir, 'tasks.md'))).toBe(false)
+  })
+
   it('marks the run aborted on an ABORT gate response', async () => {
     const fixture = makeFixture()
     const started = await runStart(fixture.deps, {

--- a/tests/sdd-runner/post-review-tail.test.ts
+++ b/tests/sdd-runner/post-review-tail.test.ts
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { appendEvent, readEvents } from '../../sdd-runner/src/events.js'
+import type { EventInput } from '../../sdd-runner/src/events.js'
+import { readReviewResultFromSidecars } from '../../sdd-runner/src/gate-digest.js'
+import type { OrchestratorDeps, StageContext } from '../../sdd-runner/src/gate-digest.js'
+import { createOpenSpecDriver } from '../../sdd-runner/src/openspec-driver.js'
+import { runPostConvergenceTail } from '../../sdd-runner/src/post-review-tail.js'
+import { createRunState } from '../../sdd-runner/src/run-state.js'
+import type { RunState } from '../../sdd-runner/src/run-state.js'
+
+const tmpDirs: string[] = []
+
+function makeDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-tail-'))
+  tmpDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop()
+    if (dir !== undefined) fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+const REVIEW_RESULT = {
+  outcome: 'converged' as const,
+  rounds: 1,
+  openBlockers: [],
+  openMaterial: [],
+  openNitpicks: [],
+}
+
+async function setup(): Promise<{
+  deps: OrchestratorDeps
+  state: RunState
+  spawnOrder: string[]
+  logPath: string
+}> {
+  const repoRoot = makeDir()
+  const changeName = 'add-thing'
+  const changeDir = path.join(repoRoot, 'openspec', 'changes', changeName)
+  const spawnOrder: string[] = []
+  const artifacts: Record<string, string> = {
+    'decompose-tasks.json': path.join(changeDir, 'tasks.md'),
+  }
+  const sidecars: Record<string, string> = {
+    'decompose-tasks.json': JSON.stringify({
+      tasks_file: 'openspec/changes/add-thing/tasks.md',
+    }),
+    'atomicity.json': JSON.stringify({ split: 0, merged: 0 }),
+  }
+  const spawn = (
+    _command: unknown,
+    args: readonly string[],
+    options: { cwd?: string },
+  ): Promise<{ exitCode: number; stdout: string; stderr: string }> => {
+    const prompt = String(args[args.length - 1])
+    const match = prompt.match(/\.review-loop\/([\w-]+\.json)/u)
+    const basename = match?.[1] ?? 'unknown.json'
+    spawnOrder.push(basename)
+    if (artifacts[basename] !== undefined) {
+      fs.mkdirSync(path.dirname(artifacts[basename]), { recursive: true })
+      fs.writeFileSync(artifacts[basename], `<!-- content for ${basename} -->\n`)
+    }
+    const target = path.join(options.cwd ?? repoRoot, '.review-loop', basename)
+    fs.mkdirSync(path.dirname(target), { recursive: true })
+    fs.writeFileSync(target, sidecars[basename] ?? '{}')
+    return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' })
+  }
+  const driver = createOpenSpecDriver({
+    exec: (args: readonly string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
+      const [bin, subcommand, ...rest] = args
+      void bin
+      if (subcommand === 'instructions') {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            instruction: `write the ${rest[0]}`,
+            resolvedOutputPath: path.join(changeDir, 'tasks.md'),
+          }),
+          stderr: '',
+          exitCode: 0,
+        })
+      }
+      return Promise.resolve({ stdout: 'is valid', stderr: '', exitCode: 0 })
+    },
+    cwd: repoRoot,
+  })
+  const deps: OrchestratorDeps = {
+    config: {
+      repoRoot,
+      workDir: path.join(repoRoot, '.sdd-runner'),
+      model: 'test-model',
+      models: {},
+      timeouts: { wallClockMs: 60_000, inactivityMs: 5_000 },
+    },
+    spawn,
+    execGit: () => Promise.resolve({ stdout: '', stderr: '' }),
+    driver,
+    resolveCost: () => null,
+  }
+  const state = await createRunState({
+    workDir: deps.config.workDir,
+    repoRoot,
+    changeName,
+  })
+  fs.mkdirSync(path.join(state.runDir, 'sidecars'), { recursive: true })
+  const logPath = path.join(state.runDir, 'events.ndjson')
+  fs.writeFileSync(logPath, '')
+  return { deps, state, spawnOrder, logPath }
+}
+
+function makeCtx(deps: OrchestratorDeps, state: RunState, logPath: string): StageContext {
+  return {
+    cwd: deps.config.repoRoot,
+    changeDir: path.join(deps.config.repoRoot, 'openspec', 'changes', state.changeName),
+    sidecarDir: path.join(state.runDir, 'sidecars'),
+    emit: (event: EventInput): void => {
+      appendEvent(logPath, event)
+    },
+  }
+}
+
+describe('runPostConvergenceTail', () => {
+  it('runs decompose then atomicity then presents the final gate at the given version (M)', async () => {
+    const { deps, state, spawnOrder, logPath } = await setup()
+    const ctx = makeCtx(deps, state, logPath)
+    const result = await runPostConvergenceTail({
+      deps,
+      state,
+      ctx,
+      agent: {
+        spawn: deps.spawn,
+        config: deps.config,
+        execGit: deps.execGit,
+        emit: ctx.emit,
+      },
+      depth: 'M',
+      reviewResult: REVIEW_RESULT,
+      version: 2,
+    })
+    expect(result.version).toBe(2)
+    expect(fs.readFileSync(result.gateMdPath, 'utf8')).toContain('Final gate')
+    expect(spawnOrder.indexOf('decompose-tasks.json')).toBeLessThan(spawnOrder.indexOf('atomicity.json'))
+    const events = readEvents(logPath)
+    const stages = events.filter((e) => e.type === 'stage_enter').map((e) => (e as { stage: string }).stage)
+    expect(stages).toEqual(['decompose', 'atomicity', 'gate'])
+    expect(state.gate).toEqual({ mode: 'final', version: 2 })
+  })
+
+  it('skips atomicity at S but still presents the final gate', async () => {
+    const { deps, state, spawnOrder, logPath } = await setup()
+    const ctx = makeCtx(deps, state, logPath)
+    const result = await runPostConvergenceTail({
+      deps,
+      state,
+      ctx,
+      agent: {
+        spawn: deps.spawn,
+        config: deps.config,
+        execGit: deps.execGit,
+        emit: ctx.emit,
+      },
+      depth: 'S',
+      reviewResult: REVIEW_RESULT,
+      version: 1,
+    })
+    expect(result.version).toBe(1)
+    expect(fs.readFileSync(result.gateMdPath, 'utf8')).toContain('Final gate')
+    expect(spawnOrder).toContain('decompose-tasks.json')
+    expect(spawnOrder).not.toContain('atomicity.json')
+  })
+
+  it('preserves the review result source outcome for gate rendering', async () => {
+    const sidecarDir = path.join(makeDir(), 'sidecars')
+    fs.mkdirSync(sidecarDir, { recursive: true })
+    fs.writeFileSync(path.join(sidecarDir, 'resolutions-3.json'), JSON.stringify({ resolutions: [], assumptions: [] }))
+    const capHit = await readReviewResultFromSidecars(sidecarDir, 3, 'cap-hit')
+    expect(capHit.outcome).toBe('cap-hit')
+    expect(capHit.rounds).toBe(3)
+  })
+})

--- a/tests/sdd-runner/prompter.test.ts
+++ b/tests/sdd-runner/prompter.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+import { PassThrough } from 'node:stream'
+
+import { readlinePrompter, scriptedPrompter, stdinIsInteractive } from '../../sdd-runner/src/prompter.js'
+
+describe('scriptedPrompter', () => {
+  it('returns scripted answers in order and null once exhausted, recording the transcript', async () => {
+    const { prompter, transcript } = scriptedPrompter(['a', 'approve'])
+    expect(await prompter.ask('item?')).toBe('a')
+    expect(await prompter.ask('decision?')).toBe('approve')
+    expect(await prompter.ask('extra?')).toBeNull()
+    expect(transcript).toEqual(['? item?', '> a', '? decision?', '> approve', '? extra?'])
+  })
+
+  it('say records lines without consuming the script', () => {
+    const { prompter, transcript } = scriptedPrompter(['x'])
+    prompter.say('a line')
+    expect(transcript).toEqual(['a line'])
+  })
+})
+
+describe('readlinePrompter', () => {
+  it('asks via readline and echoes said lines to the output stream', async () => {
+    const input = new PassThrough()
+    const output = new PassThrough()
+    const prompter = readlinePrompter({ input, output })
+    prompter.say('hello')
+    expect(output.read()).toEqual(Buffer.from('hello\n'))
+    const answer = prompter.ask('name?')
+    input.write('someone\n')
+    expect(await answer).toBe('someone')
+  })
+})
+
+describe('stdinIsInteractive', () => {
+  it('is true when stdin reports a TTY and false otherwise', () => {
+    expect(stdinIsInteractive({ isTTY: true })).toBe(true)
+    expect(stdinIsInteractive({ isTTY: false })).toBe(false)
+    expect(stdinIsInteractive({})).toBe(false)
+  })
+})

--- a/tests/sdd-runner/renderer.test.ts
+++ b/tests/sdd-runner/renderer.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, expect, it } from 'bun:test'
 
+import type { ResolvedCost } from '../../sdd-runner/src/pricing.js'
 import {
   createRenderer,
   formatBurndownLine,
@@ -242,5 +243,65 @@ describe('createRenderer (integration smoke)', () => {
       detached({ altitude: 'L2', type: 'stage_exit', stage: 'intake' })
     }).not.toThrow()
     expect(output.join('')).toContain('intake')
+  })
+})
+
+describe('createRenderer resolveCost threading', () => {
+  const MODEL = 'zai-coding-plan/glm-5.2'
+  const resolvePriced = (modelId: string): ResolvedCost | null =>
+    modelId === MODEL ? { input: 1, output: 2, source: 'primary' } : null
+
+  function ttyStream(): {
+    output: string[]
+    stream: { write(chunk: string): boolean; isTTY: boolean; columns: number }
+  } {
+    const output: string[] = []
+    return {
+      output,
+      stream: {
+        write(chunk: string): boolean {
+          output.push(chunk)
+          return true
+        },
+        isTTY: true,
+        columns: 120,
+      },
+    }
+  }
+
+  it('forwards opts.resolveCost to DynamicRenderer (estimated footer visible on a TTY stream)', () => {
+    const { output, stream } = ttyStream()
+    const renderer = createRenderer(stream, 'normal', { resolveCost: resolvePriced })
+    renderer.renderEvent({ altitude: 'L1', type: 'spawned', agent: 'resolver-r1', role: 'reviewer', model: MODEL })
+    renderer.renderEvent({
+      altitude: 'L0',
+      type: 'step_finish',
+      agent: 'resolver-r1',
+      tokens: { input: 1000, output: 500, reasoning: 100 },
+      costUsd: 0,
+    })
+    expect(output.join('')).toContain('~$0.0021')
+  })
+
+  it('ignores opts.resolveCost for LineRenderer (byte-frozen output, no estimated cost)', () => {
+    const { output, stream } = ttyStream()
+    const renderer = createRenderer(stream, 'normal', { dynamic: false, resolveCost: resolvePriced })
+    renderer.renderEvent({ altitude: 'L1', type: 'spawned', agent: 'resolver-r1', role: 'reviewer', model: MODEL })
+    renderer.renderEvent({
+      altitude: 'L0',
+      type: 'step_finish',
+      agent: 'resolver-r1',
+      tokens: { input: 1000, output: 500, reasoning: 100 },
+      costUsd: 0,
+    })
+    renderer.renderEvent({
+      altitude: 'L1',
+      type: 'done',
+      agent: 'resolver-r1',
+      usage: { inputTokens: 1000, outputTokens: 500, reasoningTokens: 100, costUsd: 0, wallMs: 1000 },
+    })
+    const joined = output.join('')
+    expect(joined).not.toContain('~$')
+    expect(joined).toContain('resolver-r1 done \u00B7 in 1.0k out 500 \u00B7 $0.0000')
   })
 })

--- a/tests/sdd-runner/run-state.test.ts
+++ b/tests/sdd-runner/run-state.test.ts
@@ -15,8 +15,10 @@ import { ROUND_CAPS } from '../../sdd-runner/src/review-model.js'
 import {
   createRunState,
   deriveResumePoint,
+  listPendingGates,
   loadRunState,
   resolveRoundCap,
+  resolveRunId,
   saveRunState,
 } from '../../sdd-runner/src/run-state.js'
 import type { PersistedRunState } from '../../sdd-runner/src/run-state.js'
@@ -371,5 +373,76 @@ describe('event replay integration', () => {
     expect(replay.stages.intake).toBe('done')
     expect(replay.stages.draft).toBe('active')
     expect(replay.depth).toBe('S')
+  })
+})
+
+async function seedRun(
+  workDir: string,
+  runId: string,
+  opts: { gate?: { mode: 'early' | 'final'; version: number } | null; changeName?: string; updatedAt?: string },
+): Promise<void> {
+  const created = await createRunState({
+    workDir,
+    repoRoot: '/repo',
+    changeName: opts.changeName ?? 'add-thing',
+    runId,
+  })
+  const gate = opts.gate === undefined ? { mode: 'early' as const, version: 1 } : opts.gate
+  const stamp = opts.updatedAt ?? created.updatedAt
+  await saveRunState({ ...created, gate, updatedAt: stamp }, new Date(stamp))
+}
+
+describe('listPendingGates', () => {
+  it('scans runs/*/state.json, keeps only gate-pending runs, and returns change name, gate version, and wait time sorted by recency', async () => {
+    const workDir = makeWorkDir()
+    await seedRun(workDir, 'run-old', {
+      gate: { mode: 'early', version: 1 },
+      changeName: 'old-change',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    })
+    await seedRun(workDir, 'run-new', {
+      gate: { mode: 'final', version: 3 },
+      changeName: 'new-change',
+      updatedAt: '2026-02-01T00:00:00.000Z',
+    })
+    await seedRun(workDir, 'run-done', { gate: null, updatedAt: '2026-03-01T00:00:00.000Z' })
+
+    const pending = await listPendingGates(workDir)
+    expect(pending.map((entry) => entry.runId)).toEqual(['run-new', 'run-old'])
+    expect(pending[0]).toMatchObject({ runId: 'run-new', changeName: 'new-change', gateVersion: 3 })
+    expect(pending[1]).toMatchObject({ runId: 'run-old', changeName: 'old-change', gateVersion: 1 })
+  })
+
+  it('returns an empty list when no runs exist', async () => {
+    expect(await listPendingGates(makeWorkDir())).toEqual([])
+  })
+})
+
+describe('resolveRunId', () => {
+  it('accepts an exact id', async () => {
+    const workDir = makeWorkDir()
+    await seedRun(workDir, '2026-01-01T00-00-00-000Z-abcd1234', { gate: { mode: 'early', version: 1 } })
+    expect(await resolveRunId(workDir, '2026-01-01T00-00-00-000Z-abcd1234')).toBe('2026-01-01T00-00-00-000Z-abcd1234')
+  })
+
+  it('accepts an unambiguous prefix among known runs (gate-pending or not)', async () => {
+    const workDir = makeWorkDir()
+    await seedRun(workDir, '2026-01-01T00-00-00-000Z-abcd1234', { gate: { mode: 'early', version: 1 } })
+    await seedRun(workDir, '2026-02-01T00-00-00-000Z-ffff0000', { gate: null })
+    expect(await resolveRunId(workDir, '2026-01-01T00')).toBe('2026-01-01T00-00-00-000Z-abcd1234')
+    expect(await resolveRunId(workDir, '2026-02')).toBe('2026-02-01T00-00-00-000Z-ffff0000')
+  })
+
+  it('fails on an unknown id naming the input', async () => {
+    const workDir = makeWorkDir()
+    await seedRun(workDir, '2026-01-01T00-00-00-000Z-abcd1234', { gate: { mode: 'early', version: 1 } })
+    await expect(resolveRunId(workDir, 'nope')).rejects.toThrow(/nope/u)
+  })
+
+  it('fails on an ambiguous prefix listing every matching candidate id', async () => {
+    const workDir = makeWorkDir()
+    await seedRun(workDir, '2026-01-01T00-00-00-000Z-abcd1234', { gate: { mode: 'early', version: 1 } })
+    await seedRun(workDir, '2026-01-01T00-00-00-000Z-ffff0000', { gate: { mode: 'final', version: 1 } })
+    await expect(resolveRunId(workDir, '2026-01-01')).rejects.toThrow(/abcd1234.*ffff0000/su)
   })
 })

--- a/tests/sdd-runner/run-state.test.ts
+++ b/tests/sdd-runner/run-state.test.ts
@@ -31,6 +31,12 @@ function makeWorkDir(): string {
   return dir
 }
 
+async function errorOf(promise: Promise<unknown>): Promise<Error> {
+  const failure = await promise.catch((error: unknown) => error)
+  if (!(failure instanceof Error)) throw new Error('expected the promise to reject with an Error')
+  return failure
+}
+
 afterEach(() => {
   while (tmpDirs.length > 0) {
     const dir = tmpDirs.pop()
@@ -85,11 +91,23 @@ describe('createRunState + loadRunState', () => {
     expect(loaded).toEqual(state)
   })
 
-  it('rejects a corrupt state.json', async () => {
+  it('builds the run id from the ISO timestamp with colons and dots dashed plus an 8-char uuid prefix', async () => {
+    const workDir = makeWorkDir()
+    const state = await createRunState(
+      { workDir, repoRoot: '/repo', changeName: 'add-thing' },
+      new Date('2026-03-04T05:06:07.891Z'),
+    )
+    expect(state.runId).toMatch(/^2026-03-04T05-06-07-891Z-[0-9a-f]{8}$/u)
+  })
+
+  it('rejects a corrupt state.json naming the run and preserving the cause', async () => {
     const workDir = makeWorkDir()
     const state = await createRunState({ workDir, repoRoot: '/repo', changeName: 'add-thing' })
     fs.writeFileSync(path.join(state.runDir, 'state.json'), '{"runId": 42}')
-    await expect(loadRunState(workDir, state.runId)).rejects.toThrow(/state\.json/u)
+    const failure = await errorOf(loadRunState(workDir, state.runId))
+    expect(failure.message).toMatch(/state\.json/u)
+    expect(failure.message).toContain(state.runId)
+    expect(failure.cause).toBeDefined()
   })
 })
 
@@ -433,20 +451,30 @@ describe('resolveRunId', () => {
     expect(await resolveRunId(workDir, '2026-02')).toBe('2026-02-01T00-00-00-000Z-ffff0000')
   })
 
+  it('accepts an exact id even when it is also a prefix of another run id', async () => {
+    const workDir = makeWorkDir()
+    await seedRun(workDir, 'run-1', { gate: { mode: 'early', version: 1 } })
+    await seedRun(workDir, 'run-1-extended', { gate: { mode: 'final', version: 1 } })
+    expect(await resolveRunId(workDir, 'run-1')).toBe('run-1')
+  })
+
   it('fails on an unknown id naming the input', async () => {
     const workDir = makeWorkDir()
     await seedRun(workDir, '2026-01-01T00-00-00-000Z-abcd1234', { gate: { mode: 'early', version: 1 } })
-    await expect(resolveRunId(workDir, 'nope')).rejects.toThrow(/nope/u)
+    const resolution = resolveRunId(workDir, 'nope')
+    await expect(resolution).rejects.toThrow(/unknown run id/iu)
+    await expect(resolution).rejects.toThrow(/nope/u)
   })
 
   it('fails on an ambiguous prefix listing every matching candidate id', async () => {
     const workDir = makeWorkDir()
     await seedRun(workDir, '2026-01-01T00-00-00-000Z-abcd1234', { gate: { mode: 'early', version: 1 } })
     await seedRun(workDir, '2026-01-01T00-00-00-000Z-ffff0000', { gate: { mode: 'final', version: 1 } })
-    // readdir order is filesystem-dependent, so assert both candidates are listed without pinning their order.
-    const resolution = resolveRunId(workDir, '2026-01-01')
-    await expect(resolution).rejects.toThrow(/ambiguous/iu)
-    await expect(resolution).rejects.toThrow(/abcd1234/u)
-    await expect(resolution).rejects.toThrow(/ffff0000/u)
+    const message = (await errorOf(resolveRunId(workDir, '2026-01-01'))).message
+    expect(message).toMatch(/ambiguous/iu)
+    expect(message).toContain('abcd1234')
+    expect(message).toContain('ffff0000')
+    // one candidate per line, order-free: both candidate lines start with the shared timestamp prefix
+    expect(message.match(/\n {2}2026-01-01/gu)).toHaveLength(2)
   })
 })

--- a/tests/sdd-runner/run-state.test.ts
+++ b/tests/sdd-runner/run-state.test.ts
@@ -443,6 +443,10 @@ describe('resolveRunId', () => {
     const workDir = makeWorkDir()
     await seedRun(workDir, '2026-01-01T00-00-00-000Z-abcd1234', { gate: { mode: 'early', version: 1 } })
     await seedRun(workDir, '2026-01-01T00-00-00-000Z-ffff0000', { gate: { mode: 'final', version: 1 } })
-    await expect(resolveRunId(workDir, '2026-01-01')).rejects.toThrow(/abcd1234.*ffff0000/su)
+    // readdir order is filesystem-dependent, so assert both candidates are listed without pinning their order.
+    const resolution = resolveRunId(workDir, '2026-01-01')
+    await expect(resolution).rejects.toThrow(/ambiguous/iu)
+    await expect(resolution).rejects.toThrow(/abcd1234/u)
+    await expect(resolution).rejects.toThrow(/ffff0000/u)
   })
 })

--- a/tests/sdd-runner/run-state.test.ts
+++ b/tests/sdd-runner/run-state.test.ts
@@ -9,6 +9,7 @@ import os from 'node:os'
 import path from 'node:path'
 
 import { appendEvent } from '../../sdd-runner/src/events.js'
+import type { DepthProfile } from '../../sdd-runner/src/events.js'
 import type { ReplayState } from '../../sdd-runner/src/replay.js'
 import { ROUND_CAPS } from '../../sdd-runner/src/review-model.js'
 import {
@@ -18,6 +19,7 @@ import {
   resolveRoundCap,
   saveRunState,
 } from '../../sdd-runner/src/run-state.js'
+import type { PersistedRunState } from '../../sdd-runner/src/run-state.js'
 
 const tmpDirs: string[] = []
 
@@ -138,6 +140,22 @@ describe('roundCap', () => {
     await expect(loadRunState(workDir, created.runId)).rejects.toThrow(/state\.json/u)
   })
 })
+
+function createSeeded(workDir: string): PersistedRunState {
+  return {
+    runId: 'seeded-run',
+    repoRoot: '/repo',
+    workDir,
+    changeName: 'add-thing',
+    stage: 'review' as const,
+    depth: null as DepthProfile | null,
+    round: 0,
+    gate: null,
+    status: 'running' as const,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+}
 
 describe('deriveResumePoint', () => {
   it('resumes at the gate when gate-pending, preserving mode and round', async () => {
@@ -265,6 +283,77 @@ describe('deriveResumePoint', () => {
     }
     const arts = artifacts({ proposal: 'done', specs: 'done', review: 'done', tasks: 'done' })
     expect(deriveResumePoint(state, arts, converged).stage).toBe('gate')
+  })
+
+  it('resumes at decompose when a settled review left tasks.md missing with no final gate presented (task 3.1)', () => {
+    const workDir = makeWorkDir()
+    const settled: ReplayState = {
+      ...emptyReplay,
+      lastVerdict: {
+        round: 3,
+        verdict: 'open',
+        counts: { blocker: 0, material: 1, nitpick: 0 },
+        resolved: 2,
+        dismissed: 1,
+      },
+      gate: { mode: 'early', version: 1, answered: true },
+    }
+    const state = {
+      ...createSeeded(workDir),
+      depth: 'M' as const,
+      stage: 'review' as const,
+      round: 3,
+      gate: null,
+    }
+    const arts = artifacts({ proposal: 'done', specs: 'done', design: 'done', review: 'done', tasks: 'blocked' })
+    expect(deriveResumePoint(state, arts, settled)).toMatchObject({ stage: 'decompose', round: 3 })
+  })
+
+  it('resumes at atomicity when tasks.md exists at depth != S but the atomicity report is absent (task 3.1)', () => {
+    const workDir = makeWorkDir()
+    const settled: ReplayState = {
+      ...emptyReplay,
+      lastVerdict: {
+        round: 2,
+        verdict: 'converged',
+        counts: { blocker: 0, material: 0, nitpick: 1 },
+        resolved: 1,
+        dismissed: 0,
+      },
+    }
+    const state = {
+      ...createSeeded(workDir),
+      depth: 'M' as const,
+      stage: 'decompose' as const,
+      round: 2,
+      gate: null,
+    }
+    const arts = artifacts({ proposal: 'done', specs: 'done', design: 'done', review: 'done', tasks: 'done' })
+    expect(deriveResumePoint(state, arts, settled)).toMatchObject({ stage: 'atomicity', round: 2 })
+  })
+
+  it('keeps gate-pending for a run whose final gate was presented (pin, task 3.1)', () => {
+    const workDir = makeWorkDir()
+    const presented: ReplayState = {
+      ...emptyReplay,
+      lastVerdict: {
+        round: 2,
+        verdict: 'converged',
+        counts: { blocker: 0, material: 0, nitpick: 0 },
+        resolved: 0,
+        dismissed: 0,
+      },
+      gate: { mode: 'final', version: 1, answered: false },
+    }
+    const state = {
+      ...createSeeded(workDir),
+      depth: 'M' as const,
+      stage: 'gate' as const,
+      round: 2,
+      gate: { mode: 'final' as const, version: 1 },
+    }
+    const arts = artifacts({ proposal: 'done', specs: 'done', design: 'done', review: 'done', tasks: 'done' })
+    expect(deriveResumePoint(state, arts, presented)).toMatchObject({ stage: 'gate', round: 2 })
   })
 })
 


### PR DESCRIPTION
## Summary

Runner UX branch spanning three OpenSpec changes, all implemented test-first with artifacts under `openspec/changes/`:

### 1. Gate interaction (`sdd-runner-gate-interaction`)
- `gate resume <runId>` / `continue` open an interactive readline gate session on a TTY; decision flags and hand-edited gate files keep working headless.
- Gate copy states each decision's downstream effect (`### Decisions` block); shared consequence copy lives in its own module.
- Pending-gate discovery + run-id resolution; CLI verbs, flags, and the continue router wired through `buildHarness`.
- Gate-protocol docs rewritten to match.

### 2. Earlier gate-semantics work (bottom of the branch)
- Early-gate approval continues the pipeline into the post-convergence tail.
- Severity-based convergence for nitpick-only cap-hit rounds.
- Resume covers post-review stages via artifact evidence.

### 3. Live cost estimate (`sdd-runner-live-cost-estimate`)
- The live TTY footer now shows a cost figure for unmetered models (e.g. `zai-coding-plan/glm-5.2`): `DynamicRenderer` prices each `step_finish` with `costUsd: 0` via the models.dev resolver, using the agent's `spawned` model and the same formula as `repriceEvent`.
- Estimated figures render with a `~$` marker; metered cost keeps plain `$`. Missing DB / unresolvable model hides the segment (unchanged behavior).
- **Double-count fix**: footer totals now accumulate from `step_finish` deltas only; the `done` event clears the agent slot but no longer re-adds its cumulative usage.
- `buildHarness` loads the pricing DB once and threads the resolver through `createRenderer` (LineRenderer output stays byte-frozen). Persisted events stay raw — estimation is display-time only; gate digest semantics untouched.

## Verification

- `bun run test` — full suite green (serial: 14016 pass / 0 fail)
- `bun run typecheck`, `bun run sdd-runner:lint`, `bun run sdd-runner:format:check` — green
- `openspec validate` strict — valid

Dev-tooling only: no platform/task instance, scope-model, or persisted-state impact.