### PR TITLE
Admit cleanup findings and carry minimality rule across agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Mandatory; pino with structured metadata-first calls. `debug` — function entry
 - Use `p-limit` for bounded concurrency over remote ops, not unbounded `Promise.all`.
 - **Never add lint-disable or type-ignore comments** — hook policy blocks them; fix the underlying issue.
 - A `max-lines` / `max-lines-per-function` failure is a **design signal**: split the file or extract functions; do not game the limit by deleting blank lines or compressing formatting.
+- **Smallest thing that works.** After you understand the problem, and before you write code, in order: does this need to exist at all; is it already in this codebase; does the stdlib or an installed dependency already do it; can it be one line. Only then write something new, and write the least of it that resolves the issue. A smaller diff is **not** the goal — never cut validation, error handling, security, or a test to reach one, and never keep code in one file to reach one (that is what the `max-lines` rule above is for). The same rule reaches the review-loop fixer and `opencode-agent` as `MINIMALITY_LADDER` / `MINIMALITY_RULE`, pinned equal by `tests/opencode-agent/minimality-rule.test.ts`.
 
 ## Testing Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ all sub-second. `bun run test:raw` is the unwrapped escape hatch and writes no r
 
 When the harness supports `obra/superpowers` skills, preserve that workflow for what it still owns (see the routing table). Load `using-superpowers` at session start before acting; load any other applicable skill before responding, editing, or running commands; do not rely on memory of skill contents — load the current text each time.
 
-Planning runs on OpenSpec in this repo: code-behavior work enters through `/opsx:explore` / `/opsx:propose` and lives under `openspec/changes/<name>/`; `brainstorming` keeps non-code creative work only.
+Planning runs on OpenSpec in this repo: code-behavior work enters through `/opsx:explore` / `/opsx:propose` and lives under `openspec/changes/<name>/`; `brainstorming` keeps non-code creative work only. A proposal must justify each capability it declares and route declined scope into Non-goals (`openspec/config.yaml` `rules.proposal`); that governs what a change **admits**, never how tasks are divided — see [Admission vs division](docs/architecture/sdd-pipeline.md#admission-vs-division).
 
 | Trigger                                         | Route                                                                                |
 | ----------------------------------------------- | ------------------------------------------------------------------------------------ |

--- a/docs/architecture/sdd-pipeline.md
+++ b/docs/architecture/sdd-pipeline.md
@@ -22,6 +22,34 @@ INTAKE → DRAFT → REVIEW LOOP → DECOMPOSE → ATOMICITY → GATE → (exit)
 - **Atomicity**: split/merge tasks (skipped at S).
 - **Gate**: single human gate with checkbox protocol.
 
+### Admission vs division
+
+Two of the project's rule sets pull in opposite directions on size, and read together
+they look like a contradiction. They are not: they answer different questions, at
+different stages.
+
+```
+   ADMISSION                          │  DIVISION
+   does this scope exist at all?      │  how is admitted work broken up?
+   ── DRAFT ──────────────────────▶   │  ── DECOMPOSE → ATOMICITY ──────▶
+   openspec/config.yaml               │  openspec/config.yaml
+     rules.proposal, rules.design     │    rules.tasks
+   "state what breaks without it";    │  "independently verifiable chunks";
+   "name what already covers it"      │  sdd-runner/src/decompose.ts splits
+                                      │  any task bundling several
+```
+
+`rules.proposal` asks a drafter to justify each declared capability and routes scope
+that fails that test into the proposal's Non-goals, where it stays visible as
+declined. Nothing there argues for fewer tasks. Once scope is admitted, the atomicity
+checker is free to split it as finely as the work warrants — splitting is this
+repository's settled answer to size, the same answer `max-lines` gives for a file.
+
+A minimality rule must therefore never be added to `rules.tasks`: it would argue with
+a checker built to split. Nothing enforces that boundary — it is a rule about prose,
+and a test matching phrasing in YAML would fail legitimate rewordings while missing
+a rule worded differently. This section is the guard.
+
 ## Event model
 
 Three altitudes in `<runDir>/events.ndjson`:

--- a/mutation-improve/CLAUDE.md
+++ b/mutation-improve/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-`mutation-improve/` is a standalone Bun workspace for the autonomous mutation-coverage improvement runner. Each iteration spawns two `opencode run` agent subprocesses (a SELECT agent that picks the highest-ROI file from `scripts/mutation/baseline.json`, then an IMPROVE agent that writes spec/plan/tests for it), gates the result, ratchets the baseline, and merges per-iteration worktree branches into the checked-out integration branch (the CLI refuses to start on `base` or a detached HEAD); a final step pushes that branch and opens a PR to `base` via `gh`. It is local developer tooling, not a papai runtime dependency.
+`mutation-improve/` is a standalone Bun workspace for the autonomous mutation-coverage improvement runner. Each iteration spawns two `opencode run` agent subprocesses (a SELECT agent that picks the highest-ROI file from `scripts/mutation/baseline.json`, then an IMPROVE agent that writes tests for it), gates the result, ratchets the baseline, and merges per-iteration worktree branches into the checked-out integration branch (the CLI refuses to start on `base` or a detached HEAD); a final step pushes that branch and opens a PR to `base` via `gh`. It is local developer tooling, not a papai runtime dependency.
 
 ## Pipeline
 
@@ -10,7 +10,10 @@
 
 1. SELECT — runner reads the baseline; the agent only suggests. Picks outside the baseline, already in `doneSet`, already failed this run, or present in the cross-run capped registry (`<workDir>/capped.json`) are rejected as agent mistakes.
 2. CAPTURE BEFORE — runner-measured score; already ≥ `threshold` → iteration is `skipped` and the file joins `doneSet`.
-3. IMPROVE — agent writes spec/plan/tests; its declared score is never trusted. Residual declarations must name the Stryker mutant ids they cover (`mutantIds`).
+3. IMPROVE — agent runs a three-step procedure: MEASURE (`bun test:mutate:file <file>`, read `reports/paired/`), TESTS (extend the companion test file, one test per mutant class, exact-equality `toBe(...)`), RESIDUALS. Its declared score is never trusted. Residual declarations must name the Stryker mutant ids they cover (`mutantIds`), and the runner set-matches their union against its own measurement.
+
+   It writes **only tests**. The runner used to mandate a seven-section `design.md` and a task-per-mutant `tasks.md` per improved file — two of five steps, paid out of the agent's turn every iteration. Every section restated something held somewhere stronger: the gap analysis restated the report the runner re-measures itself, the accepted residuals restated `result.residuals`, which it set-matches, and the tests section restated the tests. Nothing walked the checkboxes; this runner has no step machinery. `specPath`/`planPath` remain **optional** on `ResultSchema` and on the merged run-state entry so a `--resume-run` of a run started before that still loads, and are not rendered. The diff-guard still whitelists `openspec/changes/` — an agent that writes there is not refused, it is simply not asked to.
+
 4. GATES, in order: diff-guard (`src/diff-guard.ts`: agent may only touch `tests/` and `openspec/changes/`) → build check (`checkCommand`) → runner-measured after-score via `mutateFileCommand <file>`, read from `reports/paired/<stem>.stryker-report.json` (`src/score-reader.ts`, one retry on missing/corrupt report). Below `threshold` there are three outcomes: the residual escape hatch passes as `improved` when residuals are declared AND the score lands within `epsilon` of the threshold; otherwise the iteration merges as `capped` when the score improved AND the declared residual `mutantIds` exactly equal the runner-measured surviving ids (the file is at its tests-only ceiling — baseline ratchets to the measured score and the file enters the capped registry); otherwise it fails. A failed build check does NOT fail the iteration outright: the failed check output is fed back to the agent (`buildFixAttempts` times, default 2; diff-guard re-runs after each fix) before the iteration is failed at the build gate.
 5. RATCHET + MERGE — the baseline bump is committed on the iteration branch inside the worktree, then merged into the integration branch. A merge conflict aborts the whole run (`gate: 'merge'`) so no later iteration chains off a stale base.
 
@@ -30,6 +33,8 @@ Live output: every phase of an iteration renders into the single `'iter'` slot (
 - `iter/<N>/build-output.log` — full combined stdout+stderr of a failed build gate (the recorded reason is tail-bounded).
 - `<workDir>/worktrees/<runId>-iter<N>` on branches `mutation-improve/<runId>-iter<N>` (kept on merge conflict, removed otherwise).
 - `finalize.log` in the run dir if `gh pr create` fails (includes a re-run command).
+
+The pull-request body `src/finalize.ts` renders reports **accepted residuals and their reasoning** per file, not two document links. That array is the one the runner set-matched against its own surviving mutant ids, so a reviewer sees the checked answer for why a file merged below target rather than prose no gate ever read. `residuals` therefore has to survive a `--resume-run`: a run resumed after its last iteration would otherwise publish a table saying every file was accepted for no reason.
 
 ## Scripts
 

--- a/mutation-improve/src/finalize.ts
+++ b/mutation-improve/src/finalize.ts
@@ -32,11 +32,19 @@ export interface FinalizeResult {
   pushed: boolean
 }
 
+interface MergedResidual {
+  loc: string
+  why: string
+  mutantIds?: readonly string[]
+}
+
 interface MergedRow {
   file: string
   beforeScore: number
   afterScore: number
   iter: number
+  residuals?: readonly MergedResidual[]
+  /** Carried by rows stored before the runner stopped mandating documents; not rendered. */
   specPath?: string
   planPath?: string
 }
@@ -48,10 +56,18 @@ interface FailedRow {
 }
 
 export function buildSummaryBody(merged: readonly MergedRow[], failed: readonly FailedRow[]): string {
+  // Residuals rather than two document links. That array is the one the runner
+  // set-matched against its own surviving mutant ids, so a reader sees the
+  // checked answer for why a file was accepted below target — where the links
+  // pointed at prose no gate ever read.
   const rows = merged
-    .map((m) => `| ${m.file} | ${m.beforeScore} | ${m.afterScore} | ${m.specPath ?? ''} | ${m.planPath ?? ''} |`)
+    .map((m) => {
+      const residuals = m.residuals ?? []
+      const why = residuals.length === 0 ? '—' : residuals.map((r) => `${r.loc}: ${r.why}`).join('; ')
+      return `| ${m.file} | ${m.beforeScore} | ${m.afterScore} | ${residuals.length} | ${why} |`
+    })
     .join('\n')
-  const header = '| File | Before | After | Spec | Plan |\n|---|---|---|---|---|\n'
+  const header = '| File | Before | After | Residuals | Accepted because |\n|---|---|---|---|---|\n'
   let body = `## mutation-improve\n\n${header}${rows}\n`
   if (failed.length > 0) {
     body += `\n## Failed iterations\n\n| Iter | Gate | Reason |\n|---|---|---|\n`

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -119,7 +119,6 @@ async function improvePhase(
       file,
       beforeScore,
       threshold: deps.config.threshold,
-      date: new Date().toISOString().slice(0, 10),
       outputPath: agentWritePath(worktreePath, improveOut),
     }),
     improveOut,

--- a/mutation-improve/src/pipeline.ts
+++ b/mutation-improve/src/pipeline.ts
@@ -190,8 +190,7 @@ async function finalizePhase(
     beforeScore,
     afterScore,
     iter,
-    specPath: result.specPath,
-    planPath: result.planPath,
+    residuals: result.residuals,
     ...(gate.capped ? { capped: true } : {}),
   })
   return { iter, outcome: gate.capped ? 'capped' : 'improved', file, beforeScore, afterScore }

--- a/mutation-improve/src/prompt-templates.ts
+++ b/mutation-improve/src/prompt-templates.ts
@@ -10,7 +10,7 @@ import type { CappedEntry } from './capped-registry.js'
 // the agent is still told to produce after it stopped being asked for — costs a
 // whole iteration to a validation error.
 const RESULT_SCHEMA_LINE =
-  'Schema: { testPaths: string[] (>=1),\n' + 'residuals: [{loc, why, mutantIds: string[]}], notes: string }.'
+  'Schema: { testPaths: string[] (>=1),\nresiduals: [{loc, why, mutantIds: string[]}], notes: string }.'
 
 // Both header forms spelled out verbatim: agents default to the // style they
 // see in source, but check.sh requires the HTML-comment form for docs/*.md and

--- a/mutation-improve/src/prompt-templates.ts
+++ b/mutation-improve/src/prompt-templates.ts
@@ -3,18 +3,14 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import path from 'node:path'
-
 import type { CappedEntry } from './capped-registry.js'
 
-const stemFrom = (file: string): string => {
-  const base = path.basename(file).replace(/\.ts$/u, '')
-  return base
-}
-
+// Kept in step with `result-schema.ts` by hand, and asserted against it: the
+// prompt states the shape as a literal, so a field the parser rejects — or one
+// the agent is still told to produce after it stopped being asked for — costs a
+// whole iteration to a validation error.
 const RESULT_SCHEMA_LINE =
-  'Schema: { specPath: string, planPath: string, testPaths: string[] (>=1),\n' +
-  'residuals: [{loc, why, mutantIds: string[]}], notes: string }.'
+  'Schema: { testPaths: string[] (>=1),\n' + 'residuals: [{loc, why, mutantIds: string[]}], notes: string }.'
 
 // Both header forms spelled out verbatim: agents default to the // style they
 // see in source, but check.sh requires the HTML-comment form for docs/*.md and
@@ -103,19 +99,12 @@ export function buildFixPrompt(input: {
   ].join('\n')
 }
 
-const improveChangePaths = (input: { file: string; date: string }): { specPath: string; planPath: string } => {
-  const changeDir = `openspec/changes/mutation-coverage-${input.date}-${stemFrom(input.file)}`
-  return { specPath: `${changeDir}/design.md`, planPath: `${changeDir}/tasks.md` }
-}
-
 export function buildImprovePrompt(input: {
   file: string
   beforeScore: number
   threshold: number
-  date: string
   outputPath: string
 }): string {
-  const { specPath, planPath } = improveChangePaths(input)
   return [
     `You are the IMPROVE phase of an autonomous mutation-coverage improvement runner.`,
     `Target file: ${input.file} (current mutation score: ${input.beforeScore}; target: >= ${input.threshold})`,
@@ -124,14 +113,10 @@ export function buildImprovePrompt(input: {
     '',
     '1. MEASURE. Run `bun test:mutate:file ' + input.file + '` and inspect reports/paired/ to enumerate',
     '   the ACTUAL surviving mutants. Ground every later step in the real report, not speculation.',
-    '2. SPEC. Write ' + specPath + ' with sections: Summary / Why this file / Non-goals / Gap analysis',
-    '   (a table of surviving mutant classes, one row per class) / Design - tests to add (mapped one-to-one',
-    '   onto the gap classes) / Verification / Accepted residuals.',
-    '3. PLAN. Write ' + planPath + ' with task-per-mutant-class checkboxes and global constraints.',
-    '4. TESTS. Extend the existing companion test file (tests/.../<stem>.test.ts). Every new assertion',
+    '2. TESTS. Extend the existing companion test file (tests/.../<stem>.test.ts). Every new assertion',
     '   MUST use exact equality toBe(...) - never startsWith/endsWith/toContain where a full string is',
     '   knowable. One test per mutant class.',
-    '5. RESIDUALS. Enumerate equivalent mutants that survive and genuinely cannot be killed, with per-loc',
+    '3. RESIDUALS. Enumerate equivalent mutants that survive and genuinely cannot be killed, with per-loc',
     '   reasoning. Each entry MUST list the Stryker mutant ids it covers (mutantIds: string[]) exactly as',
     '   they appear in your measured report (reports/paired/<stem>.stryker-report.json, "id" fields with',
     '   status Survived or NoCoverage). The runner re-measures and set-matches the UNION of your mutantIds',

--- a/mutation-improve/src/result-schema.ts
+++ b/mutation-improve/src/result-schema.ts
@@ -15,8 +15,14 @@ const ResidualSchema = z.object({
 })
 
 export const ResultSchema = z.object({
-  specPath: z.string().min(1),
-  planPath: z.string().min(1),
+  // Optional rather than removed. The runner no longer asks for a design.md or
+  // a tasks.md per improved file — every section of them restated something it
+  // already measures or set-matches — but `--resume-run` reads results stored
+  // by an earlier run, which carry both paths. Removing the fields outright
+  // would reject a run in flight the day this shipped; permitting `''` instead
+  // would encode "absent" as a sentinel every later reader has to know.
+  specPath: z.string().min(1).optional(),
+  planPath: z.string().min(1).optional(),
   testPaths: z.array(z.string().min(1)).min(1),
   residuals: z.array(ResidualSchema),
   notes: z.string().default(''),

--- a/mutation-improve/src/run-state.ts
+++ b/mutation-improve/src/run-state.ts
@@ -17,8 +17,15 @@ const MergedEntrySchema = z.object({
   beforeScore: z.number(),
   afterScore: z.number(),
   iter: z.number().int(),
+  // Carried by entries stored before the runner stopped mandating documents.
   specPath: z.string().optional(),
   planPath: z.string().optional(),
+  // Why a file was accepted below target, in the form the runner set-matched
+  // against its own surviving mutant ids. This is what the end-of-run report
+  // renders; it used to render two links to prose no gate ever read.
+  residuals: z
+    .array(z.object({ loc: z.string(), why: z.string(), mutantIds: z.array(z.string()).optional() }))
+    .optional(),
   // true when the iteration merged below threshold at its declared residual
   // ceiling (outcome 'capped'); absent/false on fully-threshold-passing merges.
   capped: z.boolean().optional(),

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -803,6 +803,23 @@ not permitted to create or approve pull requests` is a repository or
   `PROTECTED_PREFIXES` is a privilege decision: an agent that can rewrite
   `agent-pipeline.yml` can rewrite the permissions, concurrency group and secret
   wiring that bound it, in a job that job itself defines.
+- **The minimality rule reaches the code-writing blocks and stops there.**
+  `MINIMALITY_RULE` in `prompts.ts` is carried verbatim by
+  `IMPLEMENT_INSTRUCTIONS` and `CI_FIX_INSTRUCTIONS`, and deliberately **not** by
+  `plan-draft.ts`'s two — `instructions.test.ts` asserts both halves, so an edit
+  that hands it to a drafter fails rather than passing quietly. Artifact scope is
+  a different question and already has an answer: `openspec/config.yaml`'s `rules`
+  reach those blocks through the instructions payload, and a rule about stdlib and
+  one-liners would be noise in a prompt that writes no code. The text is
+  **duplicated** from `review-loop/src/prompt-templates.ts`'s `MINIMALITY_LADDER`
+  rather than imported — that workspace is a subprocess here, not a module, and a
+  runtime import for one paragraph is a boundary to defend at every later
+  refactor. `tests/opencode-agent/minimality-rule.test.ts` pins the two equal, and
+  is where a reworded rule surfaces. Note what it does **not** say: nothing about
+  minimising file count. The phrasing this rule descends from says "fewest files
+  possible", and in the papai repository a `max-lines` failure means split the
+  file — adopting that clause would put the prompt in conflict with an enforced
+  convention.
 - **A drop is reported, never only logged, and `null` is not a verdict.**
   `commitAll` answers `CommitOutcome` — `clean | blocked | committed` — because
   `StagedTotals | null` made `null` mean both "the tree was already clean" and

--- a/opencode-agent/src/implement-prompts.ts
+++ b/opencode-agent/src/implement-prompts.ts
@@ -5,6 +5,7 @@
 
 import { describeStep } from './plan-steps.js'
 import type { PlanStep, StepMarker } from './plan-steps.js'
+import { MINIMALITY_RULE } from './prompts.js'
 import type { UntrustedEnvelope } from './prompts.js'
 import { PROTECTED_PATHS_RULE } from './protected-paths.js'
 
@@ -42,6 +43,7 @@ export const IMPLEMENT_INSTRUCTIONS = [
   'Implement the approved plan in the working tree, test-first.',
   'Never weaken or delete a test to make a check pass, and never add lint-disable or type-ignore comments.',
   'Leave committing, pushing and pull-request creation to the pipeline.',
+  MINIMALITY_RULE,
   PROTECTED_PATHS_RULE,
   'This job runs under a wall-clock deadline and you may be stopped at any moment: prefer finishing the file you ' +
     'are editing over starting another, so that whatever is on disk when you stop is worth keeping.',

--- a/opencode-agent/src/phases/ci-fix.ts
+++ b/opencode-agent/src/phases/ci-fix.ts
@@ -11,7 +11,7 @@ import { branchNameFor } from '../git.js'
 import { composeSystemPrompt } from '../obra-skills.js'
 import type { OpenCodeAgent } from '../opencode-adapter.js'
 import type { PhaseHandler, PhaseInput, PhaseOutcome } from '../phase-context.js'
-import { buildCiFixPrompt } from '../prompts.js'
+import { buildCiFixPrompt, MINIMALITY_RULE } from '../prompts.js'
 import type { UntrustedEnvelope } from '../prompts.js'
 import { PROTECTED_PATHS_RULE } from '../protected-paths.js'
 import { mintEnvelope } from './envelope.js'
@@ -27,6 +27,7 @@ export const CI_FIX_INSTRUCTIONS = [
   'Reproduce the failure from the check output before changing anything.',
   'Never weaken, skip, or delete a test to make a check pass, and never add lint-disable or type-ignore comments.',
   'If the failure is unrelated to this branch, say so in your summary rather than papering over it.',
+  MINIMALITY_RULE,
   PROTECTED_PATHS_RULE,
 ].join('\n')
 

--- a/opencode-agent/src/prompts.ts
+++ b/opencode-agent/src/prompts.ts
@@ -80,6 +80,31 @@ export interface PromptContext {
   thread: readonly IssueComment[]
 }
 
+/**
+ * The minimality rule, carried verbatim by every instruction block that asks
+ * the model to write production code — `IMPLEMENT_INSTRUCTIONS` and
+ * `CI_FIX_INSTRUCTIONS`, asserted against this constant by
+ * `instructions.test.ts` so a softened copy cannot pass. The drafting blocks in
+ * `phases/plan-draft.ts` deliberately do **not** carry it: artifact scope is a
+ * different question, governed by `openspec/config.yaml`'s `rules`.
+ *
+ * It is duplicated from `review-loop/src/prompt-templates.ts` rather than
+ * imported — that workspace is a subprocess here, not a module — and
+ * `tests/opencode-agent/minimality-rule.test.ts` pins the two texts equal.
+ *
+ * Two clauses are load-bearing and must survive any rewording. "After you
+ * understand the problem" keeps this a rule about solutions, not about reading
+ * less. And the sentence naming what is never cut is what stops the rest being
+ * read as licence to drop a safeguard for a shorter diff.
+ */
+export const MINIMALITY_RULE = [
+  'Smallest thing that works. After you understand the problem, and before you write code, in order:',
+  'does this need to exist at all; is it already in this codebase; does the stdlib or an installed',
+  'dependency already do it; can it be one line. Only then write something new, and write the least',
+  'of it that resolves the issue. A smaller diff is not the goal — never cut validation, error',
+  'handling, security, or a test to reach one.',
+].join(' ')
+
 export const TRIAGE_INSTRUCTIONS = [
   'Decide whether the request below is a question, needs more detail, or is ready to capture as a change.',
   'Explore the repository before deciding — do not assume a file layout.',

--- a/openspec/changes/agent-minimality-ladder/.openspec.yaml
+++ b/openspec/changes/agent-minimality-ladder/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/agent-minimality-ladder/design.md
+++ b/openspec/changes/agent-minimality-ladder/design.md
@@ -1,0 +1,130 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Design: Carrying the minimality ladder across workspaces
+
+## Context
+
+See `proposal.md` — Why. What this design has to settle is where one paragraph of
+prompt text lives when its readers sit in two workspaces that deliberately do not
+share a runtime boundary.
+
+The current state:
+
+- `MINIMALITY_LADDER` is a module-private constant in
+  `review-loop/src/prompt-templates.ts:33`, used by three fix prompts, and asserted
+  by `tests/review-loop/prompt-templates.test.ts` on obligations rather than wording.
+- `opencode-agent` treats `review-loop/` as a **subprocess**, not a module: it drives
+  it through `review-runner.ts` and imports nothing from it.
+- `mutation-improve` does the opposite — it imports `review-loop/src/*` by relative
+  path — so a cross-workspace source import has precedent, but not from this consumer.
+- `PROTECTED_PATHS_RULE` (`opencode-agent/src/protected-paths.ts:64`) is the
+  established shape for "one rule, several instruction blocks":
+  `tests/opencode-agent/instructions.test.ts:36` asserts every carrier `toContain` the
+  constant, so a softened copy cannot pass.
+
+## Goals / Non-Goals
+
+**Goals.** One authority for the rule's text. A failing test when any carrier drifts
+from it. No new runtime dependency between workspaces.
+
+**Non-Goals.** Unifying the two workspaces' prompt-assembly styles. Sharing anything
+beyond this one constant. Changing what `review-loop`'s three fix prompts already say.
+
+## Decisions
+
+### D1: Two constants, one equality test — not a shared module
+
+Each workspace keeps its own exported constant; a test in `tests/` imports both and
+asserts they are equal.
+
+```
+        review-loop/src/                opencode-agent/src/
+        prompt-templates.ts             prompts.ts
+        MINIMALITY_LADDER               MINIMALITY_RULE
+              │                                │
+              │  carried by                    │  carried by
+              ▼                                ▼
+        buildFixPrompt                   IMPLEMENT_INSTRUCTIONS
+        buildRetryFixPrompt              CI_FIX_INSTRUCTIONS
+        buildRetryFixWith…Prompt               │
+              │                                │
+              └────────────┬───────────────────┘
+                           ▼
+             tests/…/minimality-rule.test.ts
+             asserts the two texts are equal,
+             and that each carrier contains its own
+```
+
+*Why not a shared module (option B).* It would be a new file whose only content is a
+string, imported across a boundary `opencode-agent` maintains on purpose — its
+`CLAUDE.md` records that the review loop is a subprocess and "must not grow back" into
+the pipeline's own modules. A runtime import for one paragraph buys nothing a test
+does not, and costs a coupling that has to be defended at every later refactor.
+
+*Why not a relative-path import from `review-loop` (option A).* Same coupling, with a
+direction that makes `opencode-agent`'s CI install order matter for a string. The
+`mutation-improve` precedent exists because that workspace reuses real machinery —
+agent runner, worktrees, diff stats — not a constant.
+
+*Why the test is the right home for the coupling.* `tests/` already reaches across
+every workspace, and there is precedent for exactly this shape:
+`tests/review-loop/diff-stats.test.ts:117` imports the repo's own `isTestFile` from
+`.hooks/tdd/test-resolver.mjs` and asserts the loop's pattern against it. Drift
+pinning is a test's job here, and it is already how this repository pins drift.
+
+### D2: The constant's home in `opencode-agent` is `prompts.ts`, not a new file
+
+`implement-prompts.ts` and `phases/ci-fix.ts` both already import `prompts.js` — the
+first for `UntrustedEnvelope`, the second for `buildCiFixPrompt` as well. The rule's
+second rung is "already in this codebase"; a new `minimality-rule.ts` would fail it.
+
+### D3: Carriers are the code-writing blocks only
+
+`IMPLEMENT_INSTRUCTIONS` and `CI_FIX_INSTRUCTIONS` carry it. `PROPOSE_INSTRUCTIONS`
+and `PROPOSE_FILES_INSTRUCTIONS` (`phases/plan-draft.ts`) do not: they draft OpenSpec
+artifacts, where the minimality question is about admitted scope rather than written
+code, and where a rule about stdlib and one-liners would be noise. That boundary is
+specced, not merely observed, so a later edit that adds the rule to a drafting block
+fails a test rather than passing quietly.
+
+### D4: Assertions match the constant, not the prose
+
+`review-loop`'s existing tests deliberately assert obligations rather than wording, so
+rewording the prompt does not fail the suite. The new assertions are the opposite
+shape — `toContain(CONSTANT)` — and that is not a contradiction: the existing tests
+check that the *loop still requires* minimality, the new ones check that *every
+carrier says the same thing*. Keep both. Losing the first makes a reworded rule
+untested; losing the second lets a carrier drift.
+
+## Risks / Trade-offs
+
+**Two constants can be edited in one workspace and not the other, and the test then
+fails on a change that is correct** → That failure is the mechanism working: the fix
+is to make the same edit in both, which is one line and is what a shared module would
+have forced anyway. The test names both files.
+
+**A `toContain` assertion passes on a carrier that also says the opposite two lines
+later** → Real and unmitigated by containment alone. The spec's third requirement is
+the guard: the brake clause is part of the constant, so a carrier cannot keep the
+ladder and drop the clause. A carrier that adds *contradicting* text is a review
+problem, not a test problem, and inventing a lint for it would be the over-build this
+change is about.
+
+**`CLAUDE.md` prose cannot be pinned by a test** → Accepted. It is one paragraph, it
+is read by a human on every edit to that file, and the alternative is generating
+Markdown from a TypeScript constant, which is machinery for a paragraph.
+
+## Migration Plan
+
+Additive throughout: no persisted shape, no schema, no config key, no data. Rollback
+is deleting the paragraph and the two carriers. Nothing in flight is affected — the
+prompts change what future agent turns are told, and no stored state records what a
+past turn was told.
+
+Order matters only in that `review-loop`'s constant becomes exported before the
+equality test can import it.

--- a/openspec/changes/agent-minimality-ladder/proposal.md
+++ b/openspec/changes/agent-minimality-ladder/proposal.md
@@ -1,0 +1,80 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Proposal: Carry the minimality ladder to every agent that writes production code
+
+## Why
+
+`review-loop` teaches its fixer to reach for the smallest thing that works
+(`MINIMALITY_LADDER`, `prompt-templates.ts:33`, shipped in `8d22c58`). The other two
+agents in this repository that write production code are told nothing of the kind.
+`CLAUDE.md` has no rule about scope at all — no ladder, no reuse-before-build, no
+question about whether the code needs to exist — and it is read by the agent that
+writes most of the code here. `opencode-agent`'s `IMPLEMENT_INSTRUCTIONS` is five
+lines, one of which warns that the job may be killed at any moment: a prompt that
+raises urgency and says nothing about size.
+
+The rule is written, tested and in use. What is missing is its reach.
+
+## What Changes
+
+- **One rule, one definition.** The ladder's text becomes a named constant with a
+  single home, carried verbatim by every instruction block that asks an agent to
+  write production code, and asserted against that constant by a test — the pattern
+  `PROTECTED_PATHS_RULE` already establishes in `opencode-agent`, where
+  `instructions.test.ts` makes a softened copy fail.
+- **New carriers:** `IMPLEMENT_INSTRUCTIONS` (`implement-prompts.ts:41`) and
+  `CI_FIX_INSTRUCTIONS` (`phases/ci-fix.ts:25`). The two `plan-draft.ts` blocks are
+  deliberately excluded — they draft OpenSpec artifacts, which is a different rule
+  and a different change.
+- **`CLAUDE.md` / `AGENTS.md`** gain one Key Conventions paragraph, sitting beside
+  the existing `max-lines` note so the two are read together.
+- **The ladder keeps its brake.** The clause that a smaller diff is not the goal, and
+  that validation, error handling, security and tests are never cut to reach one,
+  travels with it everywhere. A carrier missing the brake fails the test.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-minimality-instructions`: the minimality rule's single definition, which
+  agent instruction surfaces must carry it, and what it may never be read to permit.
+
+### Modified Capabilities
+
+None. `review-loop-fix-quality` (in `openspec/changes/review-loop-fix-proportionality/`)
+already requires the review loop's fix prompts to carry the ladder; this change moves
+where the text lives without changing that requirement's behaviour.
+
+## Impact
+
+`review-loop/src/prompt-templates.ts` (the constant's current home),
+`opencode-agent/src/implement-prompts.ts`, `opencode-agent/src/phases/ci-fix.ts`,
+`CLAUDE.md`, `AGENTS.md`; tests under `tests/review-loop/` and
+`tests/opencode-agent/`. Docs: `review-loop/CLAUDE.md`, `opencode-agent/CLAUDE.md`.
+
+Whether `opencode-agent` imports the constant from `review-loop/src` (the relative-path
+precedent `mutation-improve` already sets) or the two workspaces keep separate copies
+pinned by a drift test is a design decision, not a scope one — see `design.md`.
+
+**Scope impact: none.** Local developer tooling and agent instructions. No platform
+instance, no task instance, and no per-user, group-shared or thread-isolated state.
+
+## Non-goals
+
+- **"Fewest files possible."** The upstream phrasing of this rule says it; this repo's
+  `max-lines` convention says a length failure means *split the file*. The repo's rule
+  wins and the phrase is not adopted.
+- **Marker comments** (`ponytail:` or otherwise) recording deliberate simplifications.
+  Hook policy blocks suppression comments and nothing would read a new vocabulary.
+- **Intensity levels or an off switch.** A discipline that can be turned off mid-run is
+  not one the loop can rely on.
+- **Measuring the rule by diff size.** Already rejected, with a named counter-example,
+  in `review-loop-fix-proportionality`'s non-goals.
+- **`mutation-improve`'s IMPROVE agent.** It cannot touch `src/` at all; the ladder is
+  a no-op there. Its own over-build is addressed separately.
+- Installing the upstream plugin, or any session-wide prompt injection.

--- a/openspec/changes/agent-minimality-ladder/specs/agent-minimality-instructions/spec.md
+++ b/openspec/changes/agent-minimality-ladder/specs/agent-minimality-instructions/spec.md
@@ -1,0 +1,85 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+## Purpose
+
+Defines the minimality rule this repository gives an agent before it writes production
+code — its single definition, which instruction surfaces must carry it, and the two
+things it may never be read to permit.
+
+## ADDED Requirements
+
+### Requirement: The minimality rule has one definition
+
+The repository SHALL hold the minimality rule's text in exactly one named constant.
+Every instruction surface that carries the rule SHALL carry that constant's text
+rather than a restatement of it, and a test SHALL fail when a carrier's text and the
+constant diverge.
+
+#### Scenario: A carrier softens the rule
+
+- **WHEN** an instruction block that must carry the rule is edited to paraphrase,
+  shorten, or weaken it
+- **THEN** the test asserting that carrier against the constant fails
+- **AND** the divergence is reported as a failure of that carrier, naming it
+
+#### Scenario: A new instruction surface is added
+
+- **WHEN** a new instruction block asks an agent to write production code
+- **THEN** it carries the constant's text
+- **AND** it is covered by the same assertion as the existing carriers
+
+### Requirement: Agents that write production code receive the rule
+
+The instruction surfaces that ask an agent to write or change production code SHALL
+carry the minimality rule. This covers the review loop's fix and retry prompts, the
+autonomous pipeline's implementation phase, and its CI-fix phase.
+
+#### Scenario: Implementation work is dispatched
+
+- **WHEN** an agent is instructed to implement a plan step or to fix a red check
+- **THEN** the instructions it receives carry the minimality rule
+- **AND** the rule is stated as applying after comprehension, never as a reason to
+  read less of the affected code
+
+#### Scenario: Artifact drafting is dispatched
+
+- **WHEN** an agent is instructed to draft a proposal, design, spec or task list
+- **THEN** those instructions do not carry this rule
+- **AND** the omission is deliberate, because artifact scope is governed separately
+
+### Requirement: The rule never authorises cutting a safeguard
+
+The minimality rule SHALL state that a smaller diff is not the goal, and that input
+validation at trust boundaries, error handling, security, and tests are never reduced
+to reach one. A carrier that omits this clause SHALL fail its assertion.
+
+#### Scenario: An agent could satisfy an instruction by removing a check
+
+- **WHEN** an agent applying the rule could produce a smaller change by dropping
+  validation, error handling, a security control, or a test
+- **THEN** the rule it was given forbids that reading explicitly
+
+#### Scenario: The brake is edited out of a carrier
+
+- **WHEN** a carrier retains the ladder but omits the clause naming what is never cut
+- **THEN** the assertion for that carrier fails
+
+### Requirement: Repository conventions override the rule where they conflict
+
+Where the minimality rule and an enforced repository convention disagree, the
+convention SHALL win and the rule as adopted SHALL NOT contain the conflicting
+guidance. In particular, the rule SHALL NOT instruct an agent to minimise file count,
+because a `max-lines` failure in this repository is a signal to split a file.
+
+#### Scenario: An agent faces a file that has grown past the lint limit
+
+- **WHEN** an agent applying the rule encounters a `max-lines` or
+  `max-lines-per-function` failure
+- **THEN** nothing in the rule it was given advises keeping the code in one file
+- **AND** the repository convention to split the file or extract functions stands
+  unopposed

--- a/openspec/changes/agent-minimality-ladder/tasks.md
+++ b/openspec/changes/agent-minimality-ladder/tasks.md
@@ -1,0 +1,57 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Tasks: Carry the minimality ladder to every agent that writes production code
+
+## 1. One definition, pinned across workspaces
+
+- [ ] 1.1 Export `MINIMALITY_LADDER` from `review-loop/src/prompt-templates.ts` (it is
+      module-private today) and add a case to `tests/review-loop/prompt-templates.test.ts`
+      asserting each of the three fix prompts `toContain` the exported constant. This is
+      additive to the existing obligation-shaped assertions — do not replace them; they
+      cover a different failure (see `design.md` D4).
+      Verify: `bun test tests/review-loop/prompt-templates.test.ts`
+- [ ] 1.2 Write a failing case in a new `tests/opencode-agent/minimality-rule.test.ts`
+      asserting that `opencode-agent`'s `MINIMALITY_RULE` equals `review-loop`'s
+      `MINIMALITY_LADDER`, then add the constant to `opencode-agent/src/prompts.ts` to
+      make it pass. Both texts imported directly; no copy in the test.
+      Verify: `bun test tests/opencode-agent/minimality-rule.test.ts`
+- [ ] 1.3 Extend that suite with a failing case that the constant contains the clause
+      naming what is never cut — validation, error handling, security, tests — and that
+      it does not advise minimising file count, then confirm the constant satisfies both.
+      Verify: `bun test tests/opencode-agent/minimality-rule.test.ts`
+
+## 2. New carriers
+
+- [ ] 2.1 Add failing cases to `tests/opencode-agent/instructions.test.ts` asserting that
+      `IMPLEMENT_INSTRUCTIONS` and `CI_FIX_INSTRUCTIONS` each `toContain(MINIMALITY_RULE)`,
+      following the `PROTECTED_PATHS_RULE` cases already in that file, then carry the
+      constant in both blocks.
+      Verify: `bun test tests/opencode-agent/instructions.test.ts`
+- [ ] 2.2 Add a failing case asserting that `PROPOSE_INSTRUCTIONS` and
+      `PROPOSE_FILES_INSTRUCTIONS` do **not** contain the rule, so that a later edit
+      adding it to a drafting block fails rather than passing quietly (`design.md` D3).
+      Verify: `bun test tests/opencode-agent/instructions.test.ts`
+- [ ] 2.3 Confirm the implement and CI-fix phases still assemble a prompt end to end with
+      the longer instruction block, and that no prompt-budget cap now truncates it.
+      Verify: `bun test tests/opencode-agent/phases.test.ts tests/opencode-agent/prompt-budget.test.ts`
+
+## 3. Main-agent conventions
+
+- [ ] 3.1 Add one Key Conventions paragraph to `CLAUDE.md`, placed adjacent to the
+      existing `max-lines` bullet so the two are read together: the ladder, the clause
+      naming what is never cut, and no file-count guidance. Mirror it into `AGENTS.md`.
+      Verify: `bun run format:check`
+- [ ] 3.2 Record the rule and its carriers in `review-loop/CLAUDE.md` (which already
+      documents the fix instruction contract) and `opencode-agent/CLAUDE.md` (beside the
+      `PROTECTED_PATHS_RULE` note), naming the equality test as the drift pin.
+      Verify: `bun run format:check`
+
+## 4. Full gate
+
+- [ ] 4.1 Run the full gate and fix anything it surfaces.
+      Verify: `bun run test && bun run typecheck && bun run lint && bun run review-loop:test && bun run opencode-agent:typecheck`

--- a/openspec/changes/agent-minimality-ladder/tasks.md
+++ b/openspec/changes/agent-minimality-ladder/tasks.md
@@ -54,5 +54,5 @@ See LICENSE in the project root for details.
 
 ## 4. Full gate
 
-- [ ] 4.1 Run the full gate and fix anything it surfaces.
+- [x] 4.1 Run the full gate and fix anything it surfaces.
       Verify: `bun run test && bun run typecheck && bun run lint && bun run review-loop:test && bun run opencode-agent:typecheck`

--- a/openspec/changes/agent-minimality-ladder/tasks.md
+++ b/openspec/changes/agent-minimality-ladder/tasks.md
@@ -9,18 +9,18 @@ See LICENSE in the project root for details.
 
 ## 1. One definition, pinned across workspaces
 
-- [ ] 1.1 Export `MINIMALITY_LADDER` from `review-loop/src/prompt-templates.ts` (it is
+- [x] 1.1 Export `MINIMALITY_LADDER` from `review-loop/src/prompt-templates.ts` (it is
       module-private today) and add a case to `tests/review-loop/prompt-templates.test.ts`
       asserting each of the three fix prompts `toContain` the exported constant. This is
       additive to the existing obligation-shaped assertions — do not replace them; they
       cover a different failure (see `design.md` D4).
       Verify: `bun test tests/review-loop/prompt-templates.test.ts`
-- [ ] 1.2 Write a failing case in a new `tests/opencode-agent/minimality-rule.test.ts`
+- [x] 1.2 Write a failing case in a new `tests/opencode-agent/minimality-rule.test.ts`
       asserting that `opencode-agent`'s `MINIMALITY_RULE` equals `review-loop`'s
       `MINIMALITY_LADDER`, then add the constant to `opencode-agent/src/prompts.ts` to
       make it pass. Both texts imported directly; no copy in the test.
       Verify: `bun test tests/opencode-agent/minimality-rule.test.ts`
-- [ ] 1.3 Extend that suite with a failing case that the constant contains the clause
+- [x] 1.3 Extend that suite with a failing case that the constant contains the clause
       naming what is never cut — validation, error handling, security, tests — and that
       it does not advise minimising file count, then confirm the constant satisfies both.
       Verify: `bun test tests/opencode-agent/minimality-rule.test.ts`

--- a/openspec/changes/agent-minimality-ladder/tasks.md
+++ b/openspec/changes/agent-minimality-ladder/tasks.md
@@ -43,11 +43,11 @@ See LICENSE in the project root for details.
 
 ## 3. Main-agent conventions
 
-- [ ] 3.1 Add one Key Conventions paragraph to `CLAUDE.md`, placed adjacent to the
+- [x] 3.1 Add one Key Conventions paragraph to `CLAUDE.md`, placed adjacent to the
       existing `max-lines` bullet so the two are read together: the ladder, the clause
       naming what is never cut, and no file-count guidance. Mirror it into `AGENTS.md`.
       Verify: `bun run format:check`
-- [ ] 3.2 Record the rule and its carriers in `review-loop/CLAUDE.md` (which already
+- [x] 3.2 Record the rule and its carriers in `review-loop/CLAUDE.md` (which already
       documents the fix instruction contract) and `opencode-agent/CLAUDE.md` (beside the
       `PROTECTED_PATHS_RULE` note), naming the equality test as the drift pin.
       Verify: `bun run format:check`

--- a/openspec/changes/agent-minimality-ladder/tasks.md
+++ b/openspec/changes/agent-minimality-ladder/tasks.md
@@ -27,18 +27,19 @@ See LICENSE in the project root for details.
 
 ## 2. New carriers
 
-- [ ] 2.1 Add failing cases to `tests/opencode-agent/instructions.test.ts` asserting that
+- [x] 2.1 Add failing cases to `tests/opencode-agent/instructions.test.ts` asserting that
       `IMPLEMENT_INSTRUCTIONS` and `CI_FIX_INSTRUCTIONS` each `toContain(MINIMALITY_RULE)`,
       following the `PROTECTED_PATHS_RULE` cases already in that file, then carry the
       constant in both blocks.
       Verify: `bun test tests/opencode-agent/instructions.test.ts`
-- [ ] 2.2 Add a failing case asserting that `PROPOSE_INSTRUCTIONS` and
+- [x] 2.2 Add a failing case asserting that `PROPOSE_INSTRUCTIONS` and
       `PROPOSE_FILES_INSTRUCTIONS` do **not** contain the rule, so that a later edit
       adding it to a drafting block fails rather than passing quietly (`design.md` D3).
       Verify: `bun test tests/opencode-agent/instructions.test.ts`
-- [ ] 2.3 Confirm the implement and CI-fix phases still assemble a prompt end to end with
+- [x] 2.3 Confirm the implement and CI-fix phases still assemble a prompt end to end with
       the longer instruction block, and that no prompt-budget cap now truncates it.
-      Verify: `bun test tests/opencode-agent/phases.test.ts tests/opencode-agent/prompt-budget.test.ts`
+      (`prompt-budget.ts` has no suite of its own; `adapters.test.ts` is what covers it.)
+      Verify: `bun test tests/opencode-agent/phases.test.ts tests/opencode-agent/adapters.test.ts`
 
 ## 3. Main-agent conventions
 

--- a/openspec/changes/mutation-improve-artifact-ceremony/.openspec.yaml
+++ b/openspec/changes/mutation-improve-artifact-ceremony/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/mutation-improve-artifact-ceremony/design.md
+++ b/openspec/changes/mutation-improve-artifact-ceremony/design.md
@@ -102,12 +102,30 @@ surfaces as a failed iteration rather than as a silently worse one.
 
 **A run in flight when this ships** → Covered by D3: stored results with paths still load.
 
-## Open Questions
+## Answered before implementation
 
-- **Why no `mutation-coverage-*` folder appears in this repository's history.** The
-  diff-guard whitelists `openspec/changes/`, and iteration branches merge into the
-  integration branch, so a completed run should have left one. Either no run has been
-  merged, or the folders do not survive the flow. It is worth one look before implementing,
-  because "the runner has never merged a run here" would change how much weight to put on
-  every other signal in this proposal — but not what this change does, since the documents
-  are redundant whether or not they ever landed.
+- **Why no `mutation-coverage-*` folder appears in this repository's history: the runner
+  has never merged a run here.** Not "the folders do not survive the flow." The evidence:
+  no `mutation-improve/*` branch exists; no commit anywhere in history touches both
+  `scripts/mutation/baseline.json` and `tests/`, which every merged iteration would; and
+  all eleven `chore(mutation): ratchet baseline` commits touch `baseline.json` **alone** —
+  they are the master-side seeding path (`test:mutate:changed --update-baseline`) that
+  `CLAUDE.md` documents, not runner output.
+
+  **This weakens one argument in the proposal and leaves the rest standing.** The absence
+  of those folders is no longer evidence that nothing reads them — it is explained by the
+  runner not having been used to completion here, and should not be cited as support. What
+  the change actually rests on is unaffected and was never the absence:
+
+  1. `finalize.ts:52` is the only consumer in the codebase, and it renders the two paths as
+     two cells of a markdown table.
+  2. Every section of the mandated `design.md` restates something already verified
+     elsewhere — the gap analysis restates the measured Stryker report, the accepted
+     residuals restate `result.residuals`, which the runner **set-matches** against its own
+     measurement.
+  3. Nothing walks the `tasks.md` checkboxes; this runner has no step machinery.
+
+  Those are properties of the code as it stands, not of what has been merged. One
+  consequence for implementation: with no merged run to inspect, `finalize.ts`'s table has
+  never been seen rendered against real data, so task 3's cases carry more weight than they
+  would otherwise — they are the only description of that output.

--- a/openspec/changes/mutation-improve-artifact-ceremony/design.md
+++ b/openspec/changes/mutation-improve-artifact-ceremony/design.md
@@ -1,0 +1,113 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Design: Removing two mandated documents without losing what they were meant to carry
+
+## Context
+
+See `proposal.md` — Why. What has to be preserved, and where each piece actually lives:
+
+```
+  buildImprovePrompt's five steps          where the content is verified
+  ─────────────────────────────────        ────────────────────────────────
+  1. MEASURE  reports/paired/…      ──▶    the runner re-measures itself
+  2. SPEC     design.md (7 sections)       ✗ nothing verifies it
+       ├ Gap analysis               ──▶    duplicate of the measured report
+       ├ Design – tests to add      ──▶    duplicate of the tests themselves
+       ├ Verification               ──▶    duplicate of the runner's gates
+       └ Accepted residuals         ──▶    duplicate of result.residuals
+  3. PLAN     tasks.md checkboxes          ✗ nothing walks them
+  4. TESTS    tests/…test.ts        ──▶    diff-guard, build check, score
+  5. RESIDUALS result.residuals     ──▶    set-matched against measured ids
+```
+
+Steps 2 and 3 are the only two whose output no gate reads. Every section of the document
+they produce has a verified counterpart elsewhere.
+
+The consumers of the two paths: `result-schema.ts:18-19` requires them
+(`z.string().min(1)`), `run-state.ts:20-21` already stores them optionally,
+`pipeline.ts:194` threads them through, and `finalize.ts:52` renders them as two cells of
+the pull-request table. That is the whole graph.
+
+## Goals / Non-Goals
+
+**Goals.** Remove the two mandated documents. Keep every verified fact. Keep a reviewer able
+to see what residuals were accepted and why. Break no resumable run.
+
+**Non-Goals.** Any change to the gates, the capped path, the baseline ratchet, the select
+phase, or the test-quality rules. Removing `openspec/changes/` from the diff-guard whitelist.
+
+## Decisions
+
+### D1: Remove both, rather than slimming one
+
+*Alternative considered: keep a single short note replacing both.* Rejected. The note's only
+non-duplicate content is residual reasoning, and `result.residuals[].why` is a field that
+already exists, is already required, and is already validated per residual. A file that
+holds the same reasoning unvalidated beside a validated field is the weaker of two copies —
+and this change exists because unvalidated copies are what the ceremony was.
+
+*Alternative considered: keep `design.md`, drop `tasks.md`.* The checkbox list is the more
+obviously inert of the two, so this is the tempting half-step. But the gap-analysis table
+is the section most likely to drift from the measured report — the agent writes it from the
+same report the runner re-reads, and only the runner's read is authoritative. Keeping the
+document keeps the drift.
+
+### D2: `finalize.ts` reports residuals inline instead of linking files
+
+The table loses two path cells and gains the residual count with reasoning. This is the one
+place where removing the documents would otherwise cost a reviewer something real: the
+links were how a pull-request reader saw why a file was accepted below target.
+
+Reading it from `result.residuals` is strictly better than a link, because that array is
+the thing the runner set-matched — the reviewer sees the checked answer rather than the
+prose next to it.
+
+### D3: `specPath` / `planPath` become optional, not removed
+
+Removing the fields outright would reject a stored result from a run started before this
+change, which `--resume-run` reads. Optional accepts both shapes, matching what
+`run-state.ts` already does with the same two fields — the asymmetry between the two
+schemas today is itself a small sign that the required-ness was never load-bearing.
+
+This is the same narrow-envelope reasoning the review loop relies on for older
+`metrics.json` files, pinned there by `cli.test.ts:602`.
+
+*Why not keep them required and have the agent emit empty strings.* `z.string().min(1)`
+would reject them, and relaxing to `z.string()` to permit `""` encodes "absent" as a
+sentinel, which every later reader has to know.
+
+### D4: `improveChangePaths` is deleted, not left unused
+
+It exists only to compute the two paths. `knip` runs `--strict` in this repository and an
+unused non-exported helper is a lint failure rather than dead weight left lying around.
+
+## Risks / Trade-offs
+
+**The documents were serving a human review purpose nobody recorded** → The real risk, and
+D2 is the mitigation: the residual reasoning reaches the pull-request body directly rather
+than through a link. If a reviewer wants more than that, the gap is visible immediately on
+the first run and the remedy is to enrich the report, not to restore a document the agent
+pays for per file.
+
+**Shortening the procedure from five steps to three changes how the agent behaves on the
+steps that remain** → Plausible in either direction and worth watching. MEASURE is the step
+whose skipping would be most damaging, and it is now first of three rather than first of
+five, which is if anything a better position. The gates are unchanged, so a regression
+surfaces as a failed iteration rather than as a silently worse one.
+
+**A run in flight when this ships** → Covered by D3: stored results with paths still load.
+
+## Open Questions
+
+- **Why no `mutation-coverage-*` folder appears in this repository's history.** The
+  diff-guard whitelists `openspec/changes/`, and iteration branches merge into the
+  integration branch, so a completed run should have left one. Either no run has been
+  merged, or the folders do not survive the flow. It is worth one look before implementing,
+  because "the runner has never merged a run here" would change how much weight to put on
+  every other signal in this proposal — but not what this change does, since the documents
+  are redundant whether or not they ever landed.

--- a/openspec/changes/mutation-improve-artifact-ceremony/proposal.md
+++ b/openspec/changes/mutation-improve-artifact-ceremony/proposal.md
@@ -1,0 +1,90 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Proposal: Stop the mutation runner mandating two documents nothing reads
+
+## Why
+
+`buildImprovePrompt` (`mutation-improve/src/prompt-templates.ts:111`) makes the IMPROVE
+agent write, per improved file, a seven-section `design.md` and a `tasks.md` of
+task-per-mutant-class checkboxes, inside an `openspec/changes/mutation-coverage-<date>-<stem>/`
+folder. Two of the runner's five mandated steps produce them.
+
+Their content is already held somewhere stronger. The gap analysis restates the Stryker
+report the runner measures itself. The accepted-residuals section restates
+`residuals: [{loc, why, mutantIds}]`, which the result JSON already carries and which the
+runner **set-matches against its own surviving mutant ids** — a declaration that is
+verified, unlike the prose beside it. The per-mutant-class task list is walked by nothing:
+this runner has no step machinery, and its gates are the diff-guard, the build check and
+the measured score.
+
+Their only consumer is `finalize.ts:52`, which renders the two paths as two cells of a
+markdown table in the pull-request body. And no `mutation-coverage-*` folder appears
+anywhere in this repository's history — see Open Questions in `design.md`, because that is
+a signal about what survives rather than proof of what is read.
+
+The runner's own contract is rigorous and mechanical. The documents beside it are ceremony,
+and they are paid for in agent turns on every improved file.
+
+## What Changes
+
+- **The mandated `design.md` and `tasks.md` are removed** from the IMPROVE procedure. The
+  five-step procedure becomes three: MEASURE, TESTS, RESIDUALS.
+- **The residual reasoning stays and gets more room.** It moves entirely into the result
+  JSON, which already schemas it and already has a free-text `notes` field. Nothing that is
+  verified is lost; only the unverified restatement of it is.
+- **`specPath` / `planPath` become optional** in `result-schema.ts` (they are
+  `z.string().min(1)` today, and already optional in `run-state.ts`), so a result carrying
+  neither is valid rather than a gate failure.
+- **The pull-request table reports the residual count and reasoning inline** instead of
+  linking two files, so `finalize.ts` still tells a reviewer what was accepted and why.
+- **BREAKING for in-flight runs only**: a `--resume-run` of a run started before this
+  change carries results whose `specPath`/`planPath` are set; the optional shape reads them
+  fine, so this breaks nothing in practice. Called out because `result-schema.ts` is the
+  agent contract.
+
+## Capabilities
+
+### New Capabilities
+
+- `mutation-improve-artifact-scope`: what the mutation runner requires an IMPROVE agent to
+  produce, and where residual reasoning is recorded.
+
+### Modified Capabilities
+
+None. No existing capability spec under `openspec/specs/` describes the runner's agent
+contract.
+
+## Impact
+
+`mutation-improve/src/`: `prompt-templates.ts` (`buildImprovePrompt`, and
+`improveChangePaths` which becomes unused), `result-schema.ts`, `finalize.ts`; possibly
+`pipeline.ts` and `run-state.ts` where the two paths are threaded through. Tests under
+`tests/mutation-improve/`. Docs: `mutation-improve/CLAUDE.md`.
+
+`src/diff-guard.ts` needs no change: it whitelists `tests/` and `openspec/changes/`, so an
+agent that writes only under `tests/` still passes.
+
+**Scope impact: none.** Local developer tooling — no platform instance, no task instance,
+and no per-user, group-shared or thread-isolated state.
+
+## Non-goals
+
+- **Weakening the residual contract.** The declared `mutantIds` must still exactly equal
+  the runner-measured surviving ids — every survivor declared, nothing extra. That check is
+  the reason the prose is redundant, not a casualty of removing it.
+- **Changing the test-quality rules**: one test per mutant class, exact-equality
+  assertions, extend the existing companion file. Those are the runner's real minimality
+  contract and they are stricter than anything proposed here.
+- **Touching the gates** — diff-guard, build check, measured after-score, the capped path,
+  the baseline ratchet, or `epsilon`.
+- **Adding the production-code minimality ladder to this agent.** It cannot edit `src/` at
+  all; the ladder would be a no-op. That is `agent-minimality-ladder`, which excludes this
+  workspace by name.
+- **Removing the OpenSpec write permission from the diff-guard.** Keeping `openspec/changes/`
+  whitelisted costs nothing and keeps the guard's shape stable.
+- Any change to how `select`, the capped registry, or the PR finalisation flow work.

--- a/openspec/changes/mutation-improve-artifact-ceremony/specs/mutation-improve-artifact-scope/spec.md
+++ b/openspec/changes/mutation-improve-artifact-ceremony/specs/mutation-improve-artifact-scope/spec.md
@@ -1,0 +1,80 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+## Purpose
+
+Defines what the mutation-coverage runner requires an improvement agent to produce for each
+file it improves, and where the reasoning about accepted residual mutants is recorded.
+
+## ADDED Requirements
+
+### Requirement: The runner requires no planning documents per improved file
+
+The mutation-coverage runner SHALL NOT require an improvement agent to author a design
+document or a task list for a file it improves. Its required output SHALL be the measured
+report it works from, the tests it adds, and its structured result.
+
+#### Scenario: Agent improves a file
+
+- **WHEN** the runner dispatches an improvement agent for a file
+- **THEN** the procedure it receives requires no design document and no task list
+- **AND** an agent that produces neither is not failed for their absence
+
+#### Scenario: Agent writes such a document anyway
+
+- **WHEN** an agent writes a planning document despite not being asked
+- **THEN** the iteration is judged on its gates alone
+- **AND** the document's presence neither satisfies nor violates any check
+
+### Requirement: Residual reasoning is recorded in the structured result
+
+The runner SHALL require reasoning about accepted residual mutants in its structured result
+rather than in prose beside it. Each residual SHALL name the mutant ids it covers, and the
+runner SHALL continue to require that the union of declared ids exactly equals the ids it
+measured as surviving.
+
+#### Scenario: A file lands below target with declared residuals
+
+- **WHEN** an agent declares residuals covering every surviving mutant id and no others
+- **THEN** the declaration is accepted exactly as it is today
+- **AND** the reasoning for each residual is present in the result
+
+#### Scenario: Declared residual ids do not match the measurement
+
+- **WHEN** the declared ids omit a survivor or name one that did not survive
+- **THEN** the iteration fails, unchanged from current behaviour
+
+### Requirement: A result without document paths is valid
+
+The runner SHALL accept a result that carries no design or task document path. A result
+carrying such paths, written before this requirement existed, SHALL remain valid.
+
+#### Scenario: Agent returns a result naming no documents
+
+- **WHEN** an improvement agent returns its result with no document paths
+- **THEN** the result validates and the iteration proceeds to its gates
+
+#### Scenario: A run started earlier is resumed
+
+- **WHEN** a run is resumed whose stored results carry document paths
+- **THEN** those results load without error
+
+### Requirement: The run's report states what residuals were accepted
+
+The runner SHALL report, for each improved file, what residual mutants were accepted and
+why, in the report it publishes at the end of a run. The report SHALL NOT depend on a
+document authored by the agent.
+
+#### Scenario: A run finishes with accepted residuals
+
+- **WHEN** a run completes having accepted residuals on one or more files
+- **THEN** the published report states the residuals and their reasoning per file
+
+#### Scenario: A run finishes with no residuals accepted
+
+- **WHEN** every improved file reached the target with no residuals declared
+- **THEN** the report says so and names no documents

--- a/openspec/changes/mutation-improve-artifact-ceremony/tasks.md
+++ b/openspec/changes/mutation-improve-artifact-ceremony/tasks.md
@@ -57,9 +57,9 @@ See LICENSE in the project root for details.
 
 ## 4. Documentation and full gate
 
-- [ ] 4.1 Update `mutation-improve/CLAUDE.md`: the IMPROVE phase's procedure is three steps,
+- [x] 4.1 Update `mutation-improve/CLAUDE.md`: the IMPROVE phase's procedure is three steps,
       the agent writes only under `tests/`, and residual reasoning lives in the result. Keep
       the diff-guard description accurate — `openspec/changes/` stays whitelisted.
       Verify: `bun run format:check`
-- [ ] 4.2 Run the full gate and fix anything it surfaces.
+- [x] 4.2 Run the full gate and fix anything it surfaces.
       Verify: `bun run test && bun run typecheck && bun run lint && bun run mutation-improve:test`

--- a/openspec/changes/mutation-improve-artifact-ceremony/tasks.md
+++ b/openspec/changes/mutation-improve-artifact-ceremony/tasks.md
@@ -30,16 +30,16 @@ See LICENSE in the project root for details.
 
 ## 2. The procedure
 
-- [ ] 2.1 Write failing cases in `tests/mutation-improve/prompt-templates.test.ts` that
+- [x] 2.1 Write failing cases in `tests/mutation-improve/prompt-templates.test.ts` that
       `buildImprovePrompt` requires MEASURE, TESTS and RESIDUALS and requires neither a
       design document nor a task list; and that it still requires the residual `mutantIds`
       set-match, the one-test-per-mutant-class rule, exact-equality assertions, and the
       hard constraints. Assert the obligations, not the wording. Then rewrite the procedure.
       Verify: `bun test tests/mutation-improve/prompt-templates.test.ts`
-- [ ] 2.2 Write a failing case that the residual reasoning requirement is stated on the
+- [x] 2.2 Write a failing case that the residual reasoning requirement is stated on the
       result rather than on a document, then implement.
       Verify: `bun test tests/mutation-improve/prompt-templates.test.ts`
-- [ ] 2.3 Delete `improveChangePaths`, now unused (`design.md` D4). Confirm the SPDX
+- [x] 2.3 Delete `improveChangePaths`, now unused (`design.md` D4). Confirm the SPDX
       licence-header lines stay in the prompt — new test files still need them.
       Verify: `bun run knip && bun test tests/mutation-improve/prompt-templates.test.ts`
 

--- a/openspec/changes/mutation-improve-artifact-ceremony/tasks.md
+++ b/openspec/changes/mutation-improve-artifact-ceremony/tasks.md
@@ -9,7 +9,7 @@ See LICENSE in the project root for details.
 
 ## 0. Answer the open question first
 
-- [ ] 0.1 Determine why no `mutation-coverage-*` change folder appears in this
+- [x] 0.1 Determine why no `mutation-coverage-*` change folder appears in this
       repository's history — no merged run, or folders that do not survive the flow
       (`design.md`, Open Questions). Record the answer in the change; it does not alter
       the tasks below, but it changes how much weight later work should put on the
@@ -18,12 +18,12 @@ See LICENSE in the project root for details.
 
 ## 1. The result contract accepts a document-free result
 
-- [ ] 1.1 Write failing cases in `tests/mutation-improve/result-schema.test.ts` that a
+- [x] 1.1 Write failing cases in `tests/mutation-improve/result-schema.test.ts` that a
       result omitting `specPath` and `planPath` validates, and that a result carrying both
       still validates. Then make the two fields optional in
       `mutation-improve/src/result-schema.ts`.
       Verify: `bun test tests/mutation-improve/result-schema.test.ts`
-- [ ] 1.2 Write a failing case that a run resumed from state whose stored results carry
+- [x] 1.2 Write a failing case that a run resumed from state whose stored results carry
       both paths loads without error, then confirm `run-state.ts` and `pipeline.ts` need no
       change (both already treat them as optional).
       Verify: `bun test tests/mutation-improve/run-state.test.ts`

--- a/openspec/changes/mutation-improve-artifact-ceremony/tasks.md
+++ b/openspec/changes/mutation-improve-artifact-ceremony/tasks.md
@@ -1,0 +1,65 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Tasks: Stop the mutation runner mandating two documents nothing reads
+
+## 0. Answer the open question first
+
+- [ ] 0.1 Determine why no `mutation-coverage-*` change folder appears in this
+      repository's history — no merged run, or folders that do not survive the flow
+      (`design.md`, Open Questions). Record the answer in the change; it does not alter
+      the tasks below, but it changes how much weight later work should put on the
+      artifacts' absence.
+      Verify: `git log --all --diff-filter=A --name-only -- 'openspec/changes/mutation-coverage-*'`
+
+## 1. The result contract accepts a document-free result
+
+- [ ] 1.1 Write failing cases in `tests/mutation-improve/result-schema.test.ts` that a
+      result omitting `specPath` and `planPath` validates, and that a result carrying both
+      still validates. Then make the two fields optional in
+      `mutation-improve/src/result-schema.ts`.
+      Verify: `bun test tests/mutation-improve/result-schema.test.ts`
+- [ ] 1.2 Write a failing case that a run resumed from state whose stored results carry
+      both paths loads without error, then confirm `run-state.ts` and `pipeline.ts` need no
+      change (both already treat them as optional).
+      Verify: `bun test tests/mutation-improve/run-state.test.ts`
+
+## 2. The procedure
+
+- [ ] 2.1 Write failing cases in `tests/mutation-improve/prompt-templates.test.ts` that
+      `buildImprovePrompt` requires MEASURE, TESTS and RESIDUALS and requires neither a
+      design document nor a task list; and that it still requires the residual `mutantIds`
+      set-match, the one-test-per-mutant-class rule, exact-equality assertions, and the
+      hard constraints. Assert the obligations, not the wording. Then rewrite the procedure.
+      Verify: `bun test tests/mutation-improve/prompt-templates.test.ts`
+- [ ] 2.2 Write a failing case that the residual reasoning requirement is stated on the
+      result rather than on a document, then implement.
+      Verify: `bun test tests/mutation-improve/prompt-templates.test.ts`
+- [ ] 2.3 Delete `improveChangePaths`, now unused (`design.md` D4). Confirm the SPDX
+      licence-header lines stay in the prompt — new test files still need them.
+      Verify: `bun run knip && bun test tests/mutation-improve/prompt-templates.test.ts`
+
+## 3. Reporting
+
+- [ ] 3.1 Write failing cases in `tests/mutation-improve/finalize.test.ts` that the
+      pull-request table reports accepted residuals and their reasoning per file instead of
+      two document paths, and that a file with no residuals renders without an empty cell.
+      Then implement in `mutation-improve/src/finalize.ts`.
+      Verify: `bun test tests/mutation-improve/finalize.test.ts`
+- [ ] 3.2 Write a failing case that a result carrying document paths (a resumed older run)
+      renders the same way as one without — the report reads residuals, not paths. Then
+      confirm.
+      Verify: `bun test tests/mutation-improve/finalize.test.ts`
+
+## 4. Documentation and full gate
+
+- [ ] 4.1 Update `mutation-improve/CLAUDE.md`: the IMPROVE phase's procedure is three steps,
+      the agent writes only under `tests/`, and residual reasoning lives in the result. Keep
+      the diff-guard description accurate — `openspec/changes/` stays whitelisted.
+      Verify: `bun run format:check`
+- [ ] 4.2 Run the full gate and fix anything it surfaces.
+      Verify: `bun run test && bun run typecheck && bun run lint && bun run mutation-improve:test`

--- a/openspec/changes/mutation-improve-artifact-ceremony/tasks.md
+++ b/openspec/changes/mutation-improve-artifact-ceremony/tasks.md
@@ -45,12 +45,12 @@ See LICENSE in the project root for details.
 
 ## 3. Reporting
 
-- [ ] 3.1 Write failing cases in `tests/mutation-improve/finalize.test.ts` that the
+- [x] 3.1 Write failing cases in `tests/mutation-improve/finalize.test.ts` that the
       pull-request table reports accepted residuals and their reasoning per file instead of
       two document paths, and that a file with no residuals renders without an empty cell.
       Then implement in `mutation-improve/src/finalize.ts`.
       Verify: `bun test tests/mutation-improve/finalize.test.ts`
-- [ ] 3.2 Write a failing case that a result carrying document paths (a resumed older run)
+- [x] 3.2 Write a failing case that a result carrying document paths (a resumed older run)
       renders the same way as one without — the report reads residuals, not paths. Then
       confirm.
       Verify: `bun test tests/mutation-improve/finalize.test.ts`

--- a/openspec/changes/openspec-scope-minimality/.openspec.yaml
+++ b/openspec/changes/openspec-scope-minimality/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/openspec-scope-minimality/design.md
+++ b/openspec/changes/openspec-scope-minimality/design.md
@@ -1,0 +1,123 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Design: One YAML edit, and the boundary that keeps it from contradicting a checker
+
+## Context
+
+See `proposal.md` — Why. What matters for the approach is the delivery path, which already
+exists end to end:
+
+```
+  openspec/config.yaml
+     rules:
+       proposal: [...]
+       design:   [...]
+       tasks:    [...]
+            │
+            ▼
+  openspec instructions <artifact> --change <name> --json
+     → { instruction, template, rules[], context, dependencies }
+            │
+     ┌──────┴───────────────────────────┬───────────────────────┐
+     ▼                                  ▼                       ▼
+  sdd-runner                      opencode-agent          Claude Code skills
+  draft.ts:59                     plan-draft.ts:159       openspec-propose,
+  "Project rules:" + rules        "Rules:" + rules        openspec-update-change
+```
+
+Both TypeScript drafters parse `rules` from the CLI payload (`openspec-driver.ts` in each
+workspace, `rules: payload.rules ?? []`) and forward every entry verbatim. Neither filters,
+reorders, or rewrites them.
+
+The tension to resolve sits one artifact over: `rules.tasks` asks for independently
+verifiable chunks, and `decompose.ts:92` runs a second agent whose entire job is to *split*
+any task bundling several atomic pieces.
+
+## Goals / Non-Goals
+
+**Goals.** Ask the necessity question wherever a proposal is drafted. Keep declined scope
+visible. Leave task decomposition alone, and say so where both rules are read.
+
+**Non-Goals.** Enforcing the answer. Reaching intake, depth profiles, or the gate protocol.
+Any change to how rules are delivered.
+
+## Decisions
+
+### D1: Configuration, not code
+
+The rule is added to `openspec/config.yaml` and nothing else ships. Rung 2 of the ladder
+this change is descended from — is it already in this codebase — answers itself: the
+delivery mechanism exists, is used by both drafters, and is covered by their tests.
+
+*Alternative considered: a shared prompt constant carried by each drafter*, as
+`agent-minimality-ladder` does for production code. Rejected here because that change has
+no configuration path to use — instruction blocks are TypeScript — while this one does. Two
+mechanisms for two problems that genuinely differ is not duplication.
+
+### D2: Two rungs only — necessity and existing coverage
+
+The production-code ladder has seven rungs. Five of them (stdlib, native platform feature,
+installed dependency, one line, minimum implementation) are about *how code is written* and
+mean nothing to a proposal, which describes behaviour. Rung 5 already has an artifact-level
+form in `rules.design` ("justify why existing stack cannot cover the need") and stays there.
+
+Adding the full ladder to an artifact rule would be the over-build the ladder exists to
+prevent, and would produce proposals arguing about standard libraries.
+
+### D3: The boundary is documented, not enforced
+
+```
+   ADMISSION                     │  DIVISION
+   ── does this scope exist? ──▶ │ ── how is it broken up? ──▶
+   rules.proposal                │  rules.tasks
+   rules.design                  │  decompose.ts atomicity checker
+   (this change)                 │  (unchanged)
+```
+
+*Why not a test asserting `rules.tasks` never gains a minimality rule.* It would have to
+match on phrasing in YAML, which is brittle in the direction that matters — a rule worded
+differently slips through, and a legitimate future edit fails for using a banned word. The
+honest mechanism for a rule about prose is a sentence in the architecture doc, read by the
+person editing the rules. This change deliberately does not build machinery it cannot make
+reliable.
+
+*What is pinned by a test* is the delivery contract: a rule present in the configuration
+reaches the drafter. That is mechanical, already nearly covered, and is what actually
+breaks silently.
+
+### D4: Declined scope goes to Non-goals, which already exists
+
+`rules.proposal` already requires a Non-goals section. The new rule routes rejected scope
+into it rather than creating a second place for the same information. Without that routing
+the necessity question makes proposals *shorter and less informative* — scope disappears
+with no record — which is the failure mode of every minimality rule applied carelessly.
+
+## Risks / Trade-offs
+
+**A drafter answers the necessity question with boilerplate** → Likely at first, and not
+separable from every other prose rule in this file. The mitigation is that the answer is
+visible in the proposal a human reads at the gate, where a boilerplate justification is
+more obvious than a silently admitted capability is today.
+
+**Non-goals sections grow long** → Accepted, and preferable to the alternative. A long
+Non-goals list is a record of decisions; the same change with a short one is the same
+decisions, unrecorded.
+
+**The two rule sets are read as contradictory before anyone finds the doc** → The reason
+the boundary sentence is a task in this change rather than a follow-up. It goes in the same
+commit as the rules.
+
+**A future rule added to `rules.tasks` reintroduces the contradiction** → Unmitigated by
+machinery, by choice (D3). The doc sentence and review are the guard.
+
+## Migration Plan
+
+Configuration only: no persisted shape, no schema, no code path. Changes in flight are
+unaffected — `rules` are read when an artifact is drafted, so the 21 open changes keep the
+artifacts they already have and only new drafting sees the rule. Rollback is deleting the
+two entries.

--- a/openspec/changes/openspec-scope-minimality/proposal.md
+++ b/openspec/changes/openspec-scope-minimality/proposal.md
@@ -1,0 +1,83 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Proposal: Ask whether a piece of scope needs to exist, before anything divides it
+
+## Why
+
+Every rule this repository gives an artifact drafter is about how work is *shaped*, never
+about whether it should be admitted. `rules.tasks` says to break work into independently
+verifiable chunks, and `sdd-runner`'s atomicity checker (`decompose.ts:92`) splits any task
+that bundles several — both push toward more. `rules.design` already asks a drafter to
+justify a new dependency against the existing stack, which is one rung of the minimality
+ladder arriving early and on its own. Nothing anywhere asks the first and cheapest
+question: does this capability need to be built at all.
+
+The leverage is unusual. `openspec instructions` returns `rules` alongside the instruction,
+and **both** drafters in this repository already forward them verbatim — `sdd-runner`'s
+`buildDrafterPrompt` (`draft.ts:59`) and `opencode-agent`'s `artifactBrief`
+(`plan-draft.ts:159`). The Claude Code planning skills read the same file. So one edit to
+`openspec/config.yaml` reaches every agent that drafts a proposal here, with no code
+change in any of them.
+
+## What Changes
+
+- **`rules.proposal`** gains two rungs, and only two: state what breaks if a capability is
+  not built, and name the existing capability or module that already covers it if one
+  does. Scope that survives neither goes into the `Non-goals` section the rules already
+  require — it is not dropped silently, it is recorded as declined.
+- **`rules.design`** gains the reuse rung explicitly, beside the dependency rule that is
+  already there and is the same question one level out.
+- **`rules.tasks` gains nothing**, deliberately. Admission and division are different
+  questions and this change touches only the first.
+- **The boundary is written down** in `docs/architecture/sdd-pipeline.md`: scope minimality
+  governs what is admitted, atomicity governs how admitted work is divided. Without that
+  sentence the next person to read both rules together sees a contradiction.
+
+## Capabilities
+
+### New Capabilities
+
+- `sdd-scope-minimality`: the necessity question every drafted proposal must answer, where
+  declined scope is recorded, and the boundary against task atomicity.
+
+### Modified Capabilities
+
+None. No existing capability spec under `openspec/specs/` describes the drafting rules.
+
+## Impact
+
+`openspec/config.yaml` (`rules.proposal`, `rules.design`) and
+`docs/architecture/sdd-pipeline.md`. No source change: both drafters already forward
+`rules`, and `tests/sdd-runner/` and `tests/opencode-agent/` already cover that forwarding
+— this change adds a case pinning that a rule reaching the drafter is not silently dropped,
+rather than new machinery to deliver one.
+
+Every agent that drafts an artifact here is affected — `sdd-runner`'s drafter,
+`opencode-agent`'s `PROPOSE_INSTRUCTIONS` path, and the `openspec-propose` /
+`openspec-update-change` skills — because all of them read the same `rules` array.
+
+**Scope impact: none.** Planning-time tooling. No platform instance, no task instance, and
+no per-user, group-shared or thread-isolated state.
+
+## Non-goals
+
+- **Any rule that reduces task count.** `rules.tasks` and the atomicity checker stay
+  exactly as they are; a "fewer tasks" rule would contradict a checker that exists to split
+  them, and splitting is this repository's settled answer to size.
+- **Word, section or task-count limits.** `rules.proposal` already caps proposals at 500
+  words; a second numeric limit measures length, not necessity.
+- **Changing the `spec-driven` schema**, its artifact set, or their dependency order.
+- **A gate.** Nothing validates that the necessity question was answered well;
+  `openspec validate --strict` keeps checking structure only. A drafter that answers it
+  badly is a review problem, and inventing a checker for prose would be the over-build this
+  change argues against.
+- **The minimality ladder for production code** — that is `agent-minimality-ladder`, which
+  deliberately excludes the two artifact-drafting instruction blocks this change covers.
+- **`sdd-runner`'s intake scope estimator and depth profiles.** They size the pipeline, not
+  the change; a necessity rule there would be answering the question before the proposal
+  that frames it exists.

--- a/openspec/changes/openspec-scope-minimality/specs/sdd-scope-minimality/spec.md
+++ b/openspec/changes/openspec-scope-minimality/specs/sdd-scope-minimality/spec.md
@@ -1,0 +1,98 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+## Purpose
+
+Defines the necessity question a drafted proposal must answer before scope is admitted into
+a change, where declined scope is recorded, and the boundary between admitting scope and
+dividing it.
+
+## ADDED Requirements
+
+### Requirement: A proposed capability states what breaks without it
+
+The planning rules SHALL require every capability a proposal declares to state the concrete
+consequence of not building it. A capability whose only stated justification is a future or
+speculative need SHALL NOT be admitted as scope.
+
+#### Scenario: Drafter proposes a capability for an anticipated need
+
+- **WHEN** a drafter proposes a capability justified by a need that has not arisen
+- **THEN** the rules it received require a stated consequence of omitting it
+- **AND** a capability with no such consequence belongs in Non-goals rather than in scope
+
+#### Scenario: Drafter proposes a capability with a present consequence
+
+- **WHEN** omitting a capability would leave a described behaviour broken or absent
+- **THEN** the capability is admitted and the consequence is stated in the proposal
+
+### Requirement: A proposal names existing coverage before adding scope
+
+The planning rules SHALL require a drafter to name the existing capability, module, or
+dependency that already covers a proposed capability, where one exists, rather than
+introducing a parallel one.
+
+#### Scenario: Proposed capability duplicates an existing one
+
+- **WHEN** a proposed capability is already covered by something in the codebase
+- **THEN** the proposal names it
+- **AND** the proposal either extends that capability or records why a separate one is needed
+
+#### Scenario: Nothing existing covers the capability
+
+- **WHEN** a drafter finds no existing coverage
+- **THEN** stating that is a complete answer and the capability proceeds
+
+### Requirement: Declined scope is recorded, not dropped
+
+Scope considered and rejected on necessity grounds SHALL be recorded in the proposal's
+Non-goals section rather than omitted silently, so that a later reader can tell declined
+scope from scope nobody considered.
+
+#### Scenario: A drafter rejects scope during drafting
+
+- **WHEN** a drafter considers a capability and rejects it as unnecessary
+- **THEN** it appears in Non-goals with the reason
+
+#### Scenario: A reader revisits the change later
+
+- **WHEN** a reader asks why an obvious adjacent capability is absent
+- **THEN** the Non-goals section distinguishes a deliberate decline from an oversight
+
+### Requirement: Scope minimality does not govern task division
+
+The planning rules SHALL apply the necessity question to what a change admits, and SHALL
+NOT apply it to how admitted work is divided into tasks. The task rules and the pipeline's
+atomicity check SHALL remain unchanged, and the boundary SHALL be documented.
+
+#### Scenario: A task list is decomposed
+
+- **WHEN** admitted work is broken into tasks, or the atomicity check splits a task that
+  bundles several
+- **THEN** no minimality rule opposes the split
+- **AND** the task rules the drafter receives are unchanged by this capability
+
+#### Scenario: A reader compares the two rule sets
+
+- **WHEN** a reader reads the scope rules and the task rules together
+- **THEN** the documented boundary states that one governs admission and the other division
+
+### Requirement: Planning rules reach every artifact drafter unchanged
+
+The planning rules SHALL be delivered to every agent that drafts a change artifact, carried
+verbatim from the project configuration rather than restated per drafter.
+
+#### Scenario: An artifact is drafted by any pipeline
+
+- **WHEN** an agent is asked to draft a proposal or design artifact
+- **THEN** the rules it receives are the project's configured rules for that artifact
+- **AND** no drafter substitutes its own wording for them
+
+#### Scenario: A rule is added to the project configuration
+
+- **WHEN** a rule is added for an artifact
+- **THEN** every drafter of that artifact receives it without a change to that drafter

--- a/openspec/changes/openspec-scope-minimality/tasks.md
+++ b/openspec/changes/openspec-scope-minimality/tasks.md
@@ -48,9 +48,9 @@ See LICENSE in the project root for details.
 
 ## 4. Validate against a real change
 
-- [ ] 4.1 Run `openspec validate --strict` across every change in `openspec/changes/` to
+- [x] 4.1 Run `openspec validate --strict` across every change in `openspec/changes/` to
       confirm the added rules break no existing artifact — rules shape drafting, but a
       malformed entry surfaces at validation.
       Verify: `openspec list --json` then `openspec validate <name> --strict` per change
-- [ ] 4.2 Run the full gate and fix anything it surfaces.
+- [x] 4.2 Run the full gate and fix anything it surfaces.
       Verify: `bun run test && bun run typecheck && bun run lint && bun run sdd-runner:typecheck`

--- a/openspec/changes/openspec-scope-minimality/tasks.md
+++ b/openspec/changes/openspec-scope-minimality/tasks.md
@@ -1,0 +1,56 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Tasks: Ask whether a piece of scope needs to exist
+
+## 1. Pin the delivery contract before relying on it
+
+- [ ] 1.1 `tests/sdd-runner/draft.test.ts:129` already asserts rules reach the drafter
+      prompt. Read it and confirm it covers `rules.proposal` specifically; extend it only
+      if it does not. Do not duplicate an assertion that already holds.
+      Verify: `bun test tests/sdd-runner/draft.test.ts`
+- [ ] 1.2 `tests/opencode-agent/phases.test.ts` stubs the driver with `rules: []`, so the
+      forwarding in `plan-draft.ts:159` is never exercised. Write a failing case with a
+      non-empty rules array asserting each entry reaches the drafted artifact brief
+      verbatim, then confirm the existing implementation satisfies it.
+      Verify: `bun test tests/opencode-agent/phases.test.ts`
+
+## 2. The rules
+
+- [ ] 2.1 Add two entries to `rules.proposal` in `openspec/config.yaml`: state the concrete
+      consequence of not building each declared capability, and name the existing
+      capability or module that already covers it where one does. Route scope rejected on
+      those grounds into the `Non-goals` section the rules already require.
+      Verify: `bun run format:check`
+- [ ] 2.2 Add the reuse rung to `rules.design`, beside the existing new-dependency rule it
+      generalises. Do not restate the dependency rule — the two are one question at two
+      levels and the existing wording stays.
+      Verify: `bun run format:check`
+- [ ] 2.3 Confirm `rules.tasks` is untouched, and that `openspec instructions tasks` for an
+      existing change returns exactly the rules it returned before.
+      Verify: `openspec instructions tasks --change agent-minimality-ladder --json`
+
+## 3. The boundary, written down
+
+- [ ] 3.1 Add a short section to `docs/architecture/sdd-pipeline.md` stating that scope
+      minimality governs what a change admits and task atomicity governs how admitted work
+      is divided, naming `rules.proposal` and `decompose.ts`'s atomicity checker as the two
+      sides. This ships in the same commit as task 2, not as a follow-up
+      (`design.md` D3, Risks).
+      Verify: `bun run format:check`
+- [ ] 3.2 Cross-reference the boundary from `CLAUDE.md`'s Pi Workflow routing table entry
+      for `/opsx:propose`, one line, so a reader arriving from the routing table finds it.
+      Verify: `bun run format:check`
+
+## 4. Validate against a real change
+
+- [ ] 4.1 Run `openspec validate --strict` across every change in `openspec/changes/` to
+      confirm the added rules break no existing artifact — rules shape drafting, but a
+      malformed entry surfaces at validation.
+      Verify: `openspec list --json` then `openspec validate <name> --strict` per change
+- [ ] 4.2 Run the full gate and fix anything it surfaces.
+      Verify: `bun run test && bun run typecheck && bun run lint && bun run sdd-runner:typecheck`

--- a/openspec/changes/openspec-scope-minimality/tasks.md
+++ b/openspec/changes/openspec-scope-minimality/tasks.md
@@ -21,16 +21,16 @@ See LICENSE in the project root for details.
 
 ## 2. The rules
 
-- [ ] 2.1 Add two entries to `rules.proposal` in `openspec/config.yaml`: state the concrete
+- [x] 2.1 Add two entries to `rules.proposal` in `openspec/config.yaml`: state the concrete
       consequence of not building each declared capability, and name the existing
       capability or module that already covers it where one does. Route scope rejected on
       those grounds into the `Non-goals` section the rules already require.
       Verify: `bun run format:check`
-- [ ] 2.2 Add the reuse rung to `rules.design`, beside the existing new-dependency rule it
+- [x] 2.2 Add the reuse rung to `rules.design`, beside the existing new-dependency rule it
       generalises. Do not restate the dependency rule — the two are one question at two
       levels and the existing wording stays.
       Verify: `bun run format:check`
-- [ ] 2.3 Confirm `rules.tasks` is untouched, and that `openspec instructions tasks` for an
+- [x] 2.3 Confirm `rules.tasks` is untouched, and that `openspec instructions tasks` for an
       existing change returns exactly the rules it returned before.
       Verify: `openspec instructions tasks --change agent-minimality-ladder --json`
 

--- a/openspec/changes/openspec-scope-minimality/tasks.md
+++ b/openspec/changes/openspec-scope-minimality/tasks.md
@@ -9,11 +9,11 @@ See LICENSE in the project root for details.
 
 ## 1. Pin the delivery contract before relying on it
 
-- [ ] 1.1 `tests/sdd-runner/draft.test.ts:129` already asserts rules reach the drafter
+- [x] 1.1 `tests/sdd-runner/draft.test.ts:129` already asserts rules reach the drafter
       prompt. Read it and confirm it covers `rules.proposal` specifically; extend it only
       if it does not. Do not duplicate an assertion that already holds.
       Verify: `bun test tests/sdd-runner/draft.test.ts`
-- [ ] 1.2 `tests/opencode-agent/phases.test.ts` stubs the driver with `rules: []`, so the
+- [x] 1.2 `tests/opencode-agent/phases.test.ts` stubs the driver with `rules: []`, so the
       forwarding in `plan-draft.ts:159` is never exercised. Write a failing case with a
       non-empty rules array asserting each entry reaches the drafted artifact brief
       verbatim, then confirm the existing implementation satisfies it.

--- a/openspec/changes/openspec-scope-minimality/tasks.md
+++ b/openspec/changes/openspec-scope-minimality/tasks.md
@@ -36,13 +36,13 @@ See LICENSE in the project root for details.
 
 ## 3. The boundary, written down
 
-- [ ] 3.1 Add a short section to `docs/architecture/sdd-pipeline.md` stating that scope
+- [x] 3.1 Add a short section to `docs/architecture/sdd-pipeline.md` stating that scope
       minimality governs what a change admits and task atomicity governs how admitted work
       is divided, naming `rules.proposal` and `decompose.ts`'s atomicity checker as the two
       sides. This ships in the same commit as task 2, not as a follow-up
       (`design.md` D3, Risks).
       Verify: `bun run format:check`
-- [ ] 3.2 Cross-reference the boundary from `CLAUDE.md`'s Pi Workflow routing table entry
+- [x] 3.2 Cross-reference the boundary from `CLAUDE.md`'s Pi Workflow routing table entry
       for `/opsx:propose`, one line, so a reader arriving from the routing table finds it.
       Verify: `bun run format:check`
 

--- a/openspec/changes/review-loop-deletion-findings/.openspec.yaml
+++ b/openspec/changes/review-loop-deletion-findings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/review-loop-deletion-findings/design.md
+++ b/openspec/changes/review-loop-deletion-findings/design.md
@@ -1,0 +1,141 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Design: Admitting cleanups without displacing defects
+
+## Context
+
+See `proposal.md` — Why. The mechanics this design has to fit into:
+
+- `filterActionable` (`review-round.ts:47`) admits on ledger **status** only — it filters
+  terminal statuses and nothing else. There is no severity or worth gate to hang a
+  cleanup rule on, and adding one is out of scope here.
+- `orderByExposure` (`issue-processor.ts:185`) is a single-key sort on exposure rank. It
+  is the loop's only ordering of any kind.
+- `MAX_ATTEMPTS = 2` is unified across verdict and build retries
+  (`issue-processor-attempts.ts`); a second rejection is `needs_human`. ADR-0303 records
+  why, and the fix-proportionality change re-affirmed it as a non-goal to split.
+- The ledger persists across `--resume-run` and is Zod-validated on read.
+- A run has a soft stop (`stop-controller.ts`) honoured **between two issues**. Ordering
+  therefore decides what a stopped run spends its budget on.
+
+## Goals / Non-Goals
+
+**Goals.** Cleanups become reportable. A defect is never delayed by one. A ledger written
+before this change still loads. The effect is measurable afterwards.
+
+**Non-Goals.** Changing admission (`filterActionable` keeps admitting on status). Splitting
+retry budgets. Any new config knob. Making the fixer behave differently per kind.
+
+## Decisions
+
+### D1: `kind` on the issue, not a severity level or a title convention
+
+```
+  reviewer emits ─┬─ kind: 'defect'   ← everything reportable today
+                  └─ kind: 'cleanup'  ← the five admitted forms
+                                          delete · stdlib · native · yagni · shrink
+```
+
+*Why not a sixth severity ("trivial").* Severity already has one meaning — what happens
+if the code is reached — and the exposure work was careful to keep that meaning separate
+from reachability. Overloading it a third time with "is this a bug at all" would make all
+three unreadable, and `SeverityCountsSchema` is already surfaced per round.
+
+*Why not a title prefix.* Ordering has to read it, and parsing an agent-authored string
+to decide dispatch order is exactly the "scrape prose to recover an artefact" failure
+`opencode-agent`'s local rules record.
+
+*Why the five forms are a closed set rather than free text.* An open category collects
+everything a reviewer mildly dislikes, which is the failure mode the existing prompt
+already guards against by excluding "correct but I would write it differently". Five
+named forms, each with a mandatory replacement, is the same discipline the exposure rule
+uses: a citation, not a rating.
+
+### D2: Ordering is kind-then-exposure, keeping `orderByExposure` intact underneath
+
+```
+  before:  sort(exposureRank)
+           cleanup(cited) ─── critical defect(none) ─── …
+              ▲ wrong: a cleanup fixed first
+
+  after:   sort(kindRank, then exposureRank)
+           ┌──────── defects ────────┐┌─────── cleanups ───────┐
+            cited → unknown → none     cited → unknown → none
+```
+
+The exposure comparator is not rewritten — it becomes the tiebreak. That keeps the
+existing ordering behaviour and its tests exactly as they are, and makes the new rule one
+comparison in front of them.
+
+*Why not simply cap cleanups at `medium` and let severity order them.* Severity does not
+order anything today; making it do so would change how defects are ordered as a side
+effect of a change about cleanups.
+
+### D3: `kind` is optional on read, required on write
+
+`z.enum(['defect','cleanup']).default('defect')` on the ledger read path. A ledger written
+before this change loads and reads as all-defects, which is true. This is the same
+narrow-envelope reasoning `readPersistedRunStats` already relies on and that
+`cli.test.ts:602` pins — an older artifact must keep loading, and the test says so in as
+many words.
+
+No `STATE_VERSION`-style bump: nothing in flight is stranded, and rollback is one-way only
+in the sense that older code ignores a field it does not know.
+
+### D4: The severity cap is applied on ingest, not asked of the reviewer
+
+The prompt states the rule, and the ingest path clamps. A rule stated only in a prompt is
+a courtesy; the clamp is the mechanism — the same split `PROTECTED_PATHS_RULE` makes
+between what the prompts say and what `stageAllowed` enforces.
+
+### D5: The fixer prompt is unchanged
+
+`buildFixPrompt` already says "Edit only what is necessary — no drive-by refactors; scope
+edits to targetFiles." For a cleanup, the deletion *is* the necessary edit and the target
+files *are* its scope, so the existing sentence is correct for both kinds. Adding a
+kind-conditional branch to the fix prompt would be new machinery to say the same thing.
+
+Note what this means for `CHECK_BEHIND_RULE`: a cleanup that deletes code introduces no
+non-trivial logic, so the rule does not fire, and the advisory check-behind signal will
+record `without-check` for it. That is accurate rather than a false negative — but it does
+mean the `Checks left behind:` ratio moves when cleanups are admitted, which is why the
+counts are reported per kind (spec, final requirement) rather than pooled.
+
+## Risks / Trade-offs
+
+**Cleanup findings flood a round and the ledger fills with low-value entries** → Ordering
+means they are fixed last and dropped first by a stopped run. If volume is still wrong,
+the measurement added here is what says so; a gate invented now would be guessing at a
+threshold. Watch the per-kind counts over the first runs.
+
+**A cleanup is wrong and deletes something reachable** → The path is unchanged: the fixer
+verifies before acting and can return `invalid`, the build gate runs, and the inspector
+still sees the fix. A wrong cleanup costs the same as a wrong defect finding and is
+refused the same way.
+
+**The reviewer mislabels a defect as a cleanup, delaying a real bug** → Possible, and the
+cap makes it cheaper rather than free: a mislabelled defect loses its severity as well as
+its place in the queue. Mitigated by the kinds being narrow and each requiring a named
+replacement — a null-dereference does not have one.
+
+**`Checks left behind:` becomes harder to read across kinds** → Addressed by reporting per
+kind; the pooled ratio is not preserved.
+
+## Migration Plan
+
+Additive: one optional-on-read field, one comparator key, one prompt section, per-kind
+counters alongside the existing ones. No migration of stored ledgers — the default handles
+them. Rollback is removing the prompt section; issues already tagged `cleanup` load fine
+under a schema that ignores the field.
+
+## Open Questions
+
+- Whether `shrink` earns its place. It is the least objective of the five and the only one
+  whose replacement is "the same logic, written shorter" rather than a name. If the first
+  runs show it producing most of the noise, dropping it is a one-line change to the prompt
+  and the closed set — it does not alter the ordering, the schema, or any task here.

--- a/openspec/changes/review-loop-deletion-findings/proposal.md
+++ b/openspec/changes/review-loop-deletion-findings/proposal.md
@@ -1,0 +1,82 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Proposal: Let the reviewer report over-engineering, without letting it outrank a defect
+
+## Why
+
+The loop is asymmetric. Its fixer was taught to reach for the smallest thing that works
+(`MINIMALITY_LADDER`, shipped in `8d22c58`), but its reviewer cannot report that the code
+*already there* is over-built. `buildReviewPrompt` (`prompt-templates.ts:70`) scopes findings
+to "bugs, security, error-handling gaps, plan-conformance, and violations of the repo
+conventions in AGENTS.md", and explicitly puts "correct but I would write it differently"
+out of scope. A single-implementation interface, a hand-rolled reimplementation of something
+`zod` or the standard library ships, or a helper with no caller are none of the admitted
+kinds and are all plainly not style preferences.
+
+So the ladder only ever shrinks fixes the loop was already making. Nothing it reads gets
+smaller.
+
+## What Changes
+
+- **A bounded deletion vocabulary.** The reviewer may report five kinds — `delete`,
+  `stdlib`, `native`, `yagni`, `shrink` — and each finding must name what replaces the cut.
+  A finding that cannot name a replacement is not reportable, the same discipline the
+  exposure rule already imposes by demanding a cited caller rather than a rating.
+- **A `kind` on every issue.** `defect` (everything the reviewer reports today) or
+  `cleanup` (the five above). The reviewer sets it; the fixer never changes it.
+- **Ordering becomes kind-first.** `orderByExposure` (`issue-processor.ts:185`) sorts on
+  exposure alone today, so a cleanup with a cited caller would be dispatched *ahead of* a
+  critical bug whose caller nobody found. Every defect is dispatched before any cleanup;
+  exposure orders within each group, exactly as it does now.
+- **Cleanups are capped at `medium` severity.** Severity grades what happens if the code
+  is reached; an abstraction with one implementation does not crash.
+- **A run that stops early loses cleanups first**, which is the intended behaviour rather
+  than a regression: `runTimeoutMs` and `SIGINT` stop the loop between issues, and ordering
+  is the whole of what a stopped run spends.
+
+## Capabilities
+
+### New Capabilities
+
+- `review-loop-deletion-findings`: what the reviewer may report as over-engineering, the
+  evidence a cleanup finding must carry, and how cleanups are ordered against defects.
+
+### Modified Capabilities
+
+None. `review-loop-fix-quality` (in `openspec/changes/review-loop-fix-proportionality/`)
+governs what the *fixer* is told; nothing there changes. The fixer's existing "edit only
+what is necessary — no drive-by refactors; scope edits to targetFiles" already contains a
+cleanup correctly: for these findings the cleanup *is* the necessary edit.
+
+## Impact
+
+`review-loop/src/`: `prompt-templates.ts` (`buildReviewPrompt`), `issue-schema.ts` (the
+`kind` field), `issue-processor.ts` (ordering), `issue-ledger.ts`, `loop-trace.ts` and
+`summary.ts` (per-kind tallies). Tests under `tests/review-loop/`. Docs:
+`review-loop/CLAUDE.md`.
+
+`issue-schema.ts` is read by the fixer result path and the ledger, which persists across
+`--resume-run`; `kind` must be optional-with-default on read so a ledger written before
+this change still loads. See `design.md`.
+
+**Scope impact: none.** Local developer tooling — no platform instance, no task instance,
+and no per-user, group-shared or thread-isolated state.
+
+## Non-goals
+
+- **A repo-wide audit command.** `knip` already finds unused exports and `jscpd` runs at a
+  zero-tolerance duplication threshold; a third, weaker, LLM-driven sweep over the same
+  ground earns nothing.
+- **Auto-applying deletions outside the review loop**, or any batch "delete everything
+  flagged" mode. A cleanup goes through the same verify/fix/build path as a defect.
+- **Letting a cleanup consume the `needs_human` budget differently.** `MAX_ATTEMPTS = 2`
+  is unified deliberately (ADR-0303); a second rejection is `needs_human` for both kinds.
+- **Blocking a merge on cleanup count**, or any gate derived from it.
+- **Making the fixer hunt for cleanups on its own.** It fixes the issue it was given.
+- Diff-size measurement, already rejected with a named counter-example in
+  `review-loop-fix-proportionality`'s non-goals.

--- a/openspec/changes/review-loop-deletion-findings/specs/review-loop-deletion-findings/spec.md
+++ b/openspec/changes/review-loop-deletion-findings/specs/review-loop-deletion-findings/spec.md
@@ -1,0 +1,129 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+## Purpose
+
+Defines what the review loop may report as over-engineering in the code under review —
+the bounded set of kinds, the evidence such a finding must carry, and the order in which
+those findings are fixed relative to defects.
+
+## ADDED Requirements
+
+### Requirement: The reviewer may report a bounded set of over-engineering kinds
+
+The review loop SHALL admit findings that code is more than it needs to be, restricted to
+a closed set: code with no reason to exist, a hand-rolled reimplementation of the standard
+library, a dependency or hand-rolled code doing what the platform provides natively, an
+abstraction with a single implementation, and the same logic expressible in materially
+fewer lines. The set SHALL be closed: a finding that fits none of these is not a cleanup.
+
+#### Scenario: Reviewer finds an abstraction with one implementation
+
+- **WHEN** the reviewer finds an interface, factory, or configuration layer with exactly
+  one implementation and no second caller
+- **THEN** it may report it as a cleanup finding
+- **AND** the finding names which of the admitted kinds it is
+
+#### Scenario: Reviewer dislikes the code but cannot name a kind
+
+- **WHEN** the reviewer would report code as "correct but I would write it differently"
+- **THEN** it does not report it
+- **AND** the existing exclusion of style and naming preferences is unchanged
+
+### Requirement: A cleanup finding names what replaces the code it cuts
+
+The review loop SHALL require every cleanup finding to state what stands in place of the
+removed code — a named standard-library function, a named platform feature, an existing
+helper in this codebase, a shorter form of the same logic, or nothing at all for code that
+is simply unused. A cleanup finding that cannot name its replacement SHALL NOT be reported.
+
+#### Scenario: Reviewer reports a hand-rolled utility
+
+- **WHEN** the reviewer reports that code reimplements something already available
+- **THEN** the finding names the specific function or feature that replaces it
+
+#### Scenario: Reviewer reports unused code
+
+- **WHEN** the reviewer reports code that nothing reaches
+- **THEN** the finding states that nothing replaces it
+- **AND** that is a complete answer, not a missing one
+
+#### Scenario: Reviewer cannot name a replacement
+
+- **WHEN** the reviewer believes code is over-built but can name no replacement
+- **THEN** it omits the finding rather than reporting it without one
+
+### Requirement: Every issue records whether it is a defect or a cleanup
+
+The review loop SHALL record on each issue which of the two kinds it is. The reviewer
+SHALL set it; the fixer SHALL NOT change it. An issue restored from a ledger written
+before this distinction existed SHALL load and SHALL be treated as a defect.
+
+#### Scenario: Ledger written before the kind existed is resumed
+
+- **WHEN** a run resumes from a ledger whose issues carry no kind
+- **THEN** the ledger loads without error
+- **AND** every issue in it is treated as a defect
+
+#### Scenario: Fixer returns a result disagreeing about the kind
+
+- **WHEN** a fixer result asserts a different kind than the reviewer recorded
+- **THEN** the recorded kind is unchanged
+
+### Requirement: Defects are dispatched before cleanups
+
+The review loop SHALL dispatch every actionable defect before any cleanup. Within each of
+the two groups, the existing exposure ordering SHALL be preserved unchanged.
+
+#### Scenario: A cleanup cites a caller and a defect does not
+
+- **WHEN** a round holds a cleanup whose exposure cites a caller and a defect whose
+  exposure is none
+- **THEN** the defect is dispatched first
+
+#### Scenario: Two cleanups differ only in exposure
+
+- **WHEN** a round holds two cleanups, one citing a caller and one reporting none
+- **THEN** the one citing a caller is dispatched first
+
+#### Scenario: A run stops before its queue is empty
+
+- **WHEN** a run reaches its stop budget with issues still pending
+- **THEN** the issues left unfixed are cleanups before defects
+
+### Requirement: A cleanup is never graded above medium severity
+
+The review loop SHALL cap the severity of a cleanup finding at medium. Severity grades
+what happens if the code is reached, and code that is merely more than it needs to be does
+not lose data, breach security, or crash.
+
+#### Scenario: Reviewer grades a cleanup as critical
+
+- **WHEN** the reviewer reports a cleanup at a severity above medium
+- **THEN** the recorded severity is medium
+
+#### Scenario: Code is both over-built and defective
+
+- **WHEN** code contains a genuine defect and is also over-built
+- **THEN** the defect is reportable at its own severity as a defect finding
+- **AND** the cap applies only to the cleanup finding
+
+### Requirement: Cleanups are counted separately in the run's record
+
+The review loop SHALL report cleanup and defect counts separately in the run summary and
+run metrics, so the effect of admitting cleanups can be read after the fact. The counts
+SHALL NOT gate a merge, change a verdict, or consume any part of the retry budget.
+
+#### Scenario: A run fixes both kinds
+
+- **WHEN** a run closes both defect and cleanup issues
+- **THEN** the summary and metrics report each kind's count separately
+
+#### Scenario: A run admits no cleanups
+
+- **WHEN** a run's reviewer reports no cleanup findings
+- **THEN** the run behaves exactly as it did before cleanups were admitted

--- a/openspec/changes/review-loop-deletion-findings/tasks.md
+++ b/openspec/changes/review-loop-deletion-findings/tasks.md
@@ -72,9 +72,9 @@ See LICENSE in the project root for details.
 
 ## 6. Documentation and full gate
 
-- [ ] 6.1 Add a "Deletion findings" section to `review-loop/CLAUDE.md` covering the closed
+- [x] 6.1 Add a "Deletion findings" section to `review-loop/CLAUDE.md` covering the closed
       set, the mandatory replacement, kind-then-exposure ordering, and the medium cap.
       Note the open question on `shrink` from `design.md`.
       Verify: `bun run format:check`
-- [ ] 6.2 Run the full gate and fix anything it surfaces.
+- [x] 6.2 Run the full gate and fix anything it surfaces.
       Verify: `bun run test && bun run typecheck && bun run lint && bun run review-loop:test`

--- a/openspec/changes/review-loop-deletion-findings/tasks.md
+++ b/openspec/changes/review-loop-deletion-findings/tasks.md
@@ -9,16 +9,16 @@ See LICENSE in the project root for details.
 
 ## 1. The kind, and an older ledger that still loads
 
-- [ ] 1.1 Write failing cases in `tests/review-loop/issue-schema.test.ts` that an issue
+- [x] 1.1 Write failing cases in `tests/review-loop/issue-schema.test.ts` that an issue
       carries `kind: 'defect' | 'cleanup'`, that a payload omitting it parses as `defect`,
       and that a value outside the two is rejected. Then add the field to
       `review-loop/src/issue-schema.ts` as optional-on-read with a `defect` default.
       Verify: `bun test tests/review-loop/issue-schema.test.ts`
-- [ ] 1.2 Write a failing case in `tests/review-loop/issue-ledger.test.ts` that a ledger
+- [x] 1.2 Write a failing case in `tests/review-loop/issue-ledger.test.ts` that a ledger
       written before this change (no `kind` on any issue) loads and reads as all-defects,
       then confirm the read path satisfies it.
       Verify: `bun test tests/review-loop/issue-ledger.test.ts`
-- [ ] 1.3 Write a failing case that a fixer result asserting a different kind leaves the
+- [x] 1.3 Write a failing case that a fixer result asserting a different kind leaves the
       recorded kind unchanged, then implement.
       Verify: `bun test tests/review-loop/issue-ledger.test.ts`
 

--- a/openspec/changes/review-loop-deletion-findings/tasks.md
+++ b/openspec/changes/review-loop-deletion-findings/tasks.md
@@ -36,7 +36,7 @@ See LICENSE in the project root for details.
 
 ## 3. Severity cap on ingest
 
-- [ ] 3.1 Write failing cases that a cleanup arriving at `critical` or `high` is recorded
+- [x] 3.1 Write failing cases that a cleanup arriving at `critical` or `high` is recorded
       as `medium`, that a cleanup at `low` is left alone, and that a defect at `critical`
       is untouched. Then clamp on the ingest path — not in the prompt alone
       (`design.md` D4).

--- a/openspec/changes/review-loop-deletion-findings/tasks.md
+++ b/openspec/changes/review-loop-deletion-findings/tasks.md
@@ -1,0 +1,80 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Tasks: Let the reviewer report over-engineering
+
+## 1. The kind, and an older ledger that still loads
+
+- [ ] 1.1 Write failing cases in `tests/review-loop/issue-schema.test.ts` that an issue
+      carries `kind: 'defect' | 'cleanup'`, that a payload omitting it parses as `defect`,
+      and that a value outside the two is rejected. Then add the field to
+      `review-loop/src/issue-schema.ts` as optional-on-read with a `defect` default.
+      Verify: `bun test tests/review-loop/issue-schema.test.ts`
+- [ ] 1.2 Write a failing case in `tests/review-loop/issue-ledger.test.ts` that a ledger
+      written before this change (no `kind` on any issue) loads and reads as all-defects,
+      then confirm the read path satisfies it.
+      Verify: `bun test tests/review-loop/issue-ledger.test.ts`
+- [ ] 1.3 Write a failing case that a fixer result asserting a different kind leaves the
+      recorded kind unchanged, then implement.
+      Verify: `bun test tests/review-loop/issue-ledger.test.ts`
+
+## 2. Ordering
+
+- [ ] 2.1 Write failing cases in `tests/review-loop/issue-processor.test.ts`: a cleanup
+      citing a caller is dispatched after a defect reporting no exposure; two cleanups
+      order between themselves by exposure exactly as two defects do. Assert the existing
+      exposure-ordering cases still pass unchanged. Then make `orderByExposure` sort on
+      kind first with the existing exposure comparator as the tiebreak.
+      Verify: `bun test tests/review-loop/issue-processor.test.ts`
+- [ ] 2.2 Write a failing case that a run stopped with issues pending leaves cleanups
+      unfixed before defects, then confirm it follows from 2.1 without further change.
+      Verify: `bun test tests/review-loop/issue-processor.test.ts`
+
+## 3. Severity cap on ingest
+
+- [ ] 3.1 Write failing cases that a cleanup arriving at `critical` or `high` is recorded
+      as `medium`, that a cleanup at `low` is left alone, and that a defect at `critical`
+      is untouched. Then clamp on the ingest path — not in the prompt alone
+      (`design.md` D4).
+      Verify: `bun test tests/review-loop/review-round.test.ts`
+
+## 4. Reviewer prompt
+
+- [ ] 4.1 Add failing cases to `tests/review-loop/prompt-templates.test.ts` that
+      `buildReviewPrompt` admits the five kinds by name, requires a named replacement for
+      each, requires `kind` on every issue, and states the medium cap. Assert the
+      obligations, not the wording. Then implement in `buildReviewPrompt`.
+      Verify: `bun test tests/review-loop/prompt-templates.test.ts`
+- [ ] 4.2 Add a failing case that the existing exclusions survive — style, naming, and
+      "correct but I would write it differently" are still out of scope, and a cleanup
+      with no nameable replacement is to be omitted rather than reported. Then implement.
+      Verify: `bun test tests/review-loop/prompt-templates.test.ts`
+- [ ] 4.3 Confirm the issue JSON schema in the prompt matches `issue-schema.ts` after the
+      `kind` addition — the prompt embeds the schema as a literal and the two drift
+      silently.
+      Verify: `bun test tests/review-loop/prompt-templates.test.ts tests/review-loop/issue-schema.test.ts`
+
+## 5. Per-kind counts
+
+- [ ] 5.1 Write failing cases in `tests/review-loop/trace-log.test.ts` and
+      `tests/review-loop/summary.test.ts` that defect and cleanup counts are reported
+      separately in `metrics.json` and the run summary, and that a run admitting no
+      cleanups reads as it did before. Then implement.
+      Verify: `bun test tests/review-loop/trace-log.test.ts tests/review-loop/summary.test.ts`
+- [ ] 5.2 Write a failing case that the `Checks left behind:` line reports per kind, so a
+      cleanup deleting code does not depress the defect ratio (`design.md` D5), then
+      implement.
+      Verify: `bun test tests/review-loop/summary.test.ts`
+
+## 6. Documentation and full gate
+
+- [ ] 6.1 Add a "Deletion findings" section to `review-loop/CLAUDE.md` covering the closed
+      set, the mandatory replacement, kind-then-exposure ordering, and the medium cap.
+      Note the open question on `shrink` from `design.md`.
+      Verify: `bun run format:check`
+- [ ] 6.2 Run the full gate and fix anything it surfaces.
+      Verify: `bun run test && bun run typecheck && bun run lint && bun run review-loop:test`

--- a/openspec/changes/review-loop-deletion-findings/tasks.md
+++ b/openspec/changes/review-loop-deletion-findings/tasks.md
@@ -44,16 +44,16 @@ See LICENSE in the project root for details.
 
 ## 4. Reviewer prompt
 
-- [ ] 4.1 Add failing cases to `tests/review-loop/prompt-templates.test.ts` that
+- [x] 4.1 Add failing cases to `tests/review-loop/prompt-templates.test.ts` that
       `buildReviewPrompt` admits the five kinds by name, requires a named replacement for
       each, requires `kind` on every issue, and states the medium cap. Assert the
       obligations, not the wording. Then implement in `buildReviewPrompt`.
       Verify: `bun test tests/review-loop/prompt-templates.test.ts`
-- [ ] 4.2 Add a failing case that the existing exclusions survive — style, naming, and
+- [x] 4.2 Add a failing case that the existing exclusions survive — style, naming, and
       "correct but I would write it differently" are still out of scope, and a cleanup
       with no nameable replacement is to be omitted rather than reported. Then implement.
       Verify: `bun test tests/review-loop/prompt-templates.test.ts`
-- [ ] 4.3 Confirm the issue JSON schema in the prompt matches `issue-schema.ts` after the
+- [x] 4.3 Confirm the issue JSON schema in the prompt matches `issue-schema.ts` after the
       `kind` addition — the prompt embeds the schema as a literal and the two drift
       silently.
       Verify: `bun test tests/review-loop/prompt-templates.test.ts tests/review-loop/issue-schema.test.ts`

--- a/openspec/changes/review-loop-deletion-findings/tasks.md
+++ b/openspec/changes/review-loop-deletion-findings/tasks.md
@@ -24,13 +24,13 @@ See LICENSE in the project root for details.
 
 ## 2. Ordering
 
-- [ ] 2.1 Write failing cases in `tests/review-loop/issue-processor.test.ts`: a cleanup
+- [x] 2.1 Write failing cases in `tests/review-loop/issue-processor.test.ts`: a cleanup
       citing a caller is dispatched after a defect reporting no exposure; two cleanups
       order between themselves by exposure exactly as two defects do. Assert the existing
       exposure-ordering cases still pass unchanged. Then make `orderByExposure` sort on
       kind first with the existing exposure comparator as the tiebreak.
       Verify: `bun test tests/review-loop/issue-processor.test.ts`
-- [ ] 2.2 Write a failing case that a run stopped with issues pending leaves cleanups
+- [x] 2.2 Write a failing case that a run stopped with issues pending leaves cleanups
       unfixed before defects, then confirm it follows from 2.1 without further change.
       Verify: `bun test tests/review-loop/issue-processor.test.ts`
 

--- a/openspec/changes/review-loop-deletion-findings/tasks.md
+++ b/openspec/changes/review-loop-deletion-findings/tasks.md
@@ -60,12 +60,12 @@ See LICENSE in the project root for details.
 
 ## 5. Per-kind counts
 
-- [ ] 5.1 Write failing cases in `tests/review-loop/trace-log.test.ts` and
+- [x] 5.1 Write failing cases in `tests/review-loop/trace-log.test.ts` and
       `tests/review-loop/summary.test.ts` that defect and cleanup counts are reported
       separately in `metrics.json` and the run summary, and that a run admitting no
       cleanups reads as it did before. Then implement.
       Verify: `bun test tests/review-loop/trace-log.test.ts tests/review-loop/summary.test.ts`
-- [ ] 5.2 Write a failing case that the `Checks left behind:` line reports per kind, so a
+- [x] 5.2 Write a failing case that the `Checks left behind:` line reports per kind, so a
       cleanup deleting code does not depress the defect ratio (`design.md` D5), then
       implement.
       Verify: `bun test tests/review-loop/summary.test.ts`

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -63,6 +63,12 @@ rules:
     - Name the affected platform/task instances and state the config-context
       scope impact (per-user vs group-shared vs thread-isolated)
     - Include a "Non-goals" section listing explicitly out-of-scope behavior
+    - For each declared capability, state what concretely breaks or stays
+      missing without it; a capability justified only by an anticipated need
+      belongs in Non-goals rather than in scope, recorded as declined
+    - Name the existing capability or module that already covers a declared
+      capability where one does, and either extend it or say why a separate
+      one is needed
     - Reference existing capability specs under openspec/specs/ that the
       change modifies, and docs/architecture/*.md docs it affects
     - Keep proposals under 500 words; detail belongs in design.md
@@ -86,6 +92,8 @@ rules:
       for existing rows
     - For new dependencies, justify why existing stack (AI SDK, Grammy,
       discord.js, Zod, drizzle) cannot cover the need
+    - Before introducing a new module, name the existing one that covers the
+      need or state that none does — the dependency question one level in
     - Note hook/TDD interactions — which new files the Write/Edit TDD hook
       pipeline will gate, and the test-first order of work
   tasks:

--- a/review-loop/CLAUDE.md
+++ b/review-loop/CLAUDE.md
@@ -70,6 +70,45 @@ unreadable diff is not a fix that skipped its test. See the `Checks left behind:
 and [ADR-0425](../docs/adr/0425-review-loop-fix-minimality-and-check-behind.md), which records
 why the inspector was the wrong host for any of this.
 
+## Deletion findings
+
+The fixer was taught to reach for the smallest thing that works before the reviewer could
+report that the code already there is over-built, so for a while the ladder only ever shrank
+fixes the loop was already making and nothing it read got smaller. It can now report both:
+every issue carries `kind` — `defect` or `cleanup` — and a cleanup is one of exactly **five**
+forms, `delete` / `stdlib` / `native` / `yagni` / `shrink`.
+
+The set is **closed**, and that is the guard. An open category collects everything a reviewer
+mildly dislikes, which is what the standing "correct but I would write it differently"
+exclusion exists to prevent and which a deletion vocabulary is uniquely able to reopen — that
+exclusion survives verbatim, pinned by a test. Every cleanup must **name what replaces** the
+code it cuts: a named function, a named platform feature, an existing helper, the shorter
+form, or nothing at all for code nothing reaches. "Nothing replaces it" is a complete answer;
+being unable to name one is a reason to omit the finding. Same discipline as exposure — a
+citation, not a rating.
+
+**Ordering is kind-first** (`orderByExposure`, `issue-processor.ts`). Every defect is
+dispatched before any cleanup; exposure orders within each group exactly as it did, as the
+tiebreak. Without that, a cleanup whose caller was found would be dispatched ahead of a
+critical defect whose caller nobody found — exposure grades reachability, never worth. What it
+buys is what a stopped run spends: the soft stop is honoured between two issues, so the tail
+the run drops is now cleanups.
+
+A cleanup is **never above medium**. `capCleanupSeverity` (`review-round.ts`) clamps at ingest,
+before matching and before the ledger — the prompt states the rule, the clamp makes it true.
+
+Counts are reported per kind (`Findings:` line, `reviewerKind` in `metrics.json`), and
+`Checks left behind:` reports the **defect** ratio with cleanups named beside it rather than
+folded in: a cleanup that deletes code introduces no non-trivial logic, so it leaves no check
+and is right not to. Pooled, cleanups would drag down the very ratio the check-behind rule is
+measured by. Nothing here gates anything; it exists so the effect can be read afterwards.
+
+Open question carried from the change's `design.md`: whether **`shrink`** earns its place. It
+is the least objective of the five and the only one whose replacement is "the same logic,
+written shorter" rather than a name. If the first runs show it producing most of the noise,
+dropping it is one line in `CLEANUP_FINDINGS` and one in the closed set — it touches neither
+the ordering, the schema, nor the counts. The per-kind numbers are how that gets decided.
+
 ## Exposure
 
 Severity grades what happens _if_ the code is reached; **exposure** records whether it is

--- a/review-loop/CLAUDE.md
+++ b/review-loop/CLAUDE.md
@@ -45,6 +45,13 @@ smaller diff is not the goal, so it cannot be read as licence to drop validation
 handling, security, or a test. Both retry prompts carry it too — a second attempt is where scope
 creeps, because the first failed and more feels like the answer.
 
+That constant is **exported and shared beyond this workspace**. `opencode-agent` carries the
+same text as `MINIMALITY_RULE` in its own `prompts.ts` — duplicated rather than imported,
+because it drives this workspace as a subprocess and imports nothing from it — and
+`tests/opencode-agent/minimality-rule.test.ts` asserts the two are equal. `CLAUDE.md` states it
+a third time for the main agent, in prose no test can pin. Reword it here and that test fails;
+that is the intended way to find every carrier.
+
 **Check-behind** (`CHECK_BEHIND_RULE`) requires non-trivial logic to leave one runnable check in
 the test path this repo already maps the file to, and states that a scratch reproduction deleted
 afterwards does not count.

--- a/review-loop/src/commit-attempt.ts
+++ b/review-loop/src/commit-attempt.ts
@@ -79,7 +79,7 @@ function recordAcceptedFix(
   recordFixAttempt(deps.ledger, record.id)
   // No per-fix log for `unmeasured`: the summary already reports the count, and
   // nothing pinned a line that fires only when a diff cannot be read.
-  tallyCheckBehind(collector, checkBehind)
+  tallyCheckBehind(collector, checkBehind, record.issue.kind)
   tallyDecision(collector, fixerResult.verdict, fixerResult.fixed)
   tallyFixerOutcome(collector, record, fixerResult)
   emitDecision(deps.log, record, 'fixed', attempt === 1 ? undefined : 'after retry')

--- a/review-loop/src/issue-processor.ts
+++ b/review-loop/src/issue-processor.ts
@@ -182,8 +182,24 @@ const exposureRank = (record: LedgerIssueRecord): number => {
   return kind === undefined ? 1 : 2
 }
 
+/**
+ * Kind outranks exposure, and the ordering below it is untouched.
+ *
+ * Exposure grades whether code is reached, never whether the finding is worth
+ * fixing — so on a queue holding two kinds of thing it is the wrong first
+ * question: a cleanup whose caller was found would be dispatched ahead of a
+ * critical defect whose caller nobody found. A defect is always the better use
+ * of the next fixer, whatever either one's reachability.
+ *
+ * This is one comparison in front of `exposureRank`, not a rewrite of it: the
+ * exposure ordering keeps its behaviour and its tests, and becomes the tiebreak
+ * within each group. Stability still holds, so a run over the same ledger
+ * dispatches identically.
+ */
+const kindRank = (record: LedgerIssueRecord): number => (record.issue.kind === 'cleanup' ? 1 : 0)
+
 export function orderByExposure(pending: readonly LedgerIssueRecord[]): readonly LedgerIssueRecord[] {
-  return [...pending].sort((a, b) => exposureRank(a) - exposureRank(b))
+  return [...pending].sort((a, b) => kindRank(a) - kindRank(b) || exposureRank(a) - exposureRank(b))
 }
 
 export async function processPendingIssues(

--- a/review-loop/src/issue-schema.ts
+++ b/review-loop/src/issue-schema.ts
@@ -24,8 +24,21 @@ export const ExposureSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('none') }),
 ])
 
+/**
+ * What an issue *is*, which is a different question from how bad it is
+ * (`severity`) or whether anything reaches it (`exposure`). A `cleanup` says the
+ * code is more than it needs to be; a `defect` says it is wrong.
+ *
+ * Defaulted rather than optional, and the difference from `exposure` is the
+ * point: absent exposure is a real third state — nobody answered — whereas a
+ * ledger written before cleanups were admitted holds only defects, so the
+ * default states a truth instead of papering over a gap.
+ */
+export const IssueKindSchema = z.enum(['defect', 'cleanup']).default('defect')
+
 export const ReviewerIssueSchema = z.object({
   title: z.string().min(1),
+  kind: IssueKindSchema,
   severity: z.enum(['critical', 'high', 'medium', 'low']),
   summary: z.string().min(1),
   whyItMatters: z.string().min(1),
@@ -73,6 +86,7 @@ export const IssueMatchesSchema = z.object({
 })
 
 export type Exposure = z.infer<typeof ExposureSchema>
+export type IssueKind = z.infer<typeof IssueKindSchema>
 export type ReviewerIssue = z.infer<typeof ReviewerIssueSchema>
 export type ReviewerIssues = z.infer<typeof ReviewerIssuesSchema>
 export type VerifierDecision = z.infer<typeof VerifierDecisionSchema>

--- a/review-loop/src/loop-controller.ts
+++ b/review-loop/src/loop-controller.ts
@@ -87,6 +87,7 @@ function pushRoundMetric(
     reviewerExposure: collector.reviewerExposure,
     fixerExposure: collector.fixerExposure,
     exposureDivergent: collector.exposureDivergent,
+    reviewerKind: collector.reviewerKind,
     checkBehind: collector.checkBehind,
     phaseMs: collector.phaseMs,
     usage: collector.usage,

--- a/review-loop/src/loop-trace.ts
+++ b/review-loop/src/loop-trace.ts
@@ -4,13 +4,15 @@
 // See LICENSE in the project root for details.
 
 import type { CheckBehind } from './commit-attempt.js'
-import type { Exposure, ReviewerIssue } from './issue-schema.js'
+import type { Exposure, IssueKind, ReviewerIssue } from './issue-schema.js'
 import {
-  emptyCheckBehindCounts,
+  emptyCheckBehindByKind,
+  emptyKindCounts,
   emptyDecisions,
   emptyExposureCounts,
   emptySeverityCounts,
-  type CheckBehindCounts,
+  type CheckBehindByKind,
+  type KindCounts,
   type Decisions,
   type ExposureCounts,
   type ExposureKind,
@@ -30,7 +32,8 @@ export interface RoundCollector {
   reviewerExposure: ExposureCounts
   fixerExposure: ExposureCounts
   exposureDivergent: number
-  checkBehind: CheckBehindCounts
+  reviewerKind: KindCounts
+  checkBehind: CheckBehindByKind
   phaseMs: PhaseMs
   usage: UsageTotals
 }
@@ -44,7 +47,8 @@ export function newCollector(): RoundCollector {
     reviewerExposure: emptyExposureCounts(),
     fixerExposure: emptyExposureCounts(),
     exposureDivergent: 0,
-    checkBehind: emptyCheckBehindCounts(),
+    reviewerKind: emptyKindCounts(),
+    checkBehind: emptyCheckBehindByKind(),
     phaseMs: { review: 0, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 },
     usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0 },
   }
@@ -103,10 +107,11 @@ export function tallyExposure(collector: RoundCollector, reviewer: ExposureKind,
  * blocks a merge, changes a verdict, or touches the retry budget — it exists to
  * say whether the rule the fix prompt states is actually being followed.
  */
-export function tallyCheckBehind(collector: RoundCollector, outcome: CheckBehind): void {
-  if (outcome === 'with-check') collector.checkBehind.withCheck += 1
-  else if (outcome === 'without-check') collector.checkBehind.withoutCheck += 1
-  else collector.checkBehind.unmeasured += 1
+export function tallyCheckBehind(collector: RoundCollector, outcome: CheckBehind, kind: IssueKind): void {
+  const counts = collector.checkBehind[kind]
+  if (outcome === 'with-check') counts.withCheck += 1
+  else if (outcome === 'without-check') counts.withoutCheck += 1
+  else counts.unmeasured += 1
 }
 
 export function tallyFixerSeverity(collector: RoundCollector, severity: Severity | undefined): void {
@@ -118,6 +123,7 @@ export function tallyFixerSeverity(collector: RoundCollector, severity: Severity
 export function tallyReviewerIssues(collector: RoundCollector, newIssues: readonly ReviewerIssue[]): void {
   for (const issue of newIssues) {
     collector.reviewerSeverity[issue.severity] += 1
+    collector.reviewerKind[issue.kind] += 1
   }
 }
 

--- a/review-loop/src/prompt-templates.ts
+++ b/review-loop/src/prompt-templates.ts
@@ -61,6 +61,30 @@ const NO_PROSE_RULE = [
   'here would catch it.',
 ].join(' ')
 
+/**
+ * Over-engineering is reportable, as a closed set of five forms rather than an
+ * open category — an open one collects everything a reviewer mildly dislikes,
+ * which is what the "correct but I would write it differently" exclusion above
+ * already guards against and which a deletion vocabulary is uniquely able to
+ * reopen.
+ *
+ * The mandatory replacement is the same discipline `exposure` uses: a citation,
+ * not a rating. "Nothing replaces it" is a complete answer for code nothing
+ * reaches; being unable to name one at all is a reason to stay quiet.
+ */
+const CLEANUP_FINDINGS = [
+  'Also in scope — code that is more than it needs to be. Report these as `"kind": "cleanup"`; everything else above is `"kind": "defect"`, and every issue must carry one of the two.',
+  'A cleanup is one of exactly five forms, and a finding that fits none of them is not a cleanup:',
+  '- delete: code nothing reaches, or flexibility nothing uses. Nothing replaces it — say so; that is a complete answer, not a missing one.',
+  '- stdlib: a hand-rolled thing the standard library already ships. Name the function.',
+  '- native: a dependency, or code, doing what the platform already does. Name the feature.',
+  '- yagni: an abstraction with one implementation, a config nobody sets, a layer with one caller.',
+  '- shrink: the same logic in materially fewer lines. Show the shorter form.',
+  'Every cleanup MUST name what stands in place of the code it cuts — a named function, a named platform feature, an existing helper in this codebase, the shorter form, or nothing at all for code that is simply unused. If you cannot name one, omit the finding rather than reporting it without.',
+  'A cleanup is never above medium severity: severity grades what happens if the code is reached, and code that is merely over-built does not lose data, breach security, or crash. Grade a genuine defect as a defect, at whatever severity it deserves — the ceiling applies to the cleanup finding only.',
+  'Cleanups are fixed after every defect, so reporting one never delays a bug. Report the ones you are confident in and omit the rest.',
+].join('\n')
+
 export function buildReviewPrompt(planPath: string, outputPath: string): string {
   return [
     `Review the current implementation against the implementation plan at: ${planPath}.`,
@@ -69,6 +93,8 @@ export function buildReviewPrompt(planPath: string, outputPath: string): string 
     '',
     'In scope: bugs, security, error-handling gaps, plan-conformance, and violations of the repo conventions in AGENTS.md (already in your context) — e.g. the logging rules, the no-lint-disable rule, .js import paths, and the max-lines design signal.',
     'NOT in scope (do not report): style/formatting a linter owns, naming preferences, or "correct but I would write it differently."',
+    '',
+    CLEANUP_FINDINGS,
     '',
     'Evidence rule: only report an issue for files/lines you have actually opened and read. `evidence` must quote the offending source line(s); `file`/`lineStart`/`lineEnd` must point at code you opened. Before raising an issue, verify the impact you claim (e.g. check .gitignore before asserting something "will be committed by git add -A"; trace the control flow before claiming a missing keyword matters). If you cannot cite exact evidence or verify the impact, lower `confidence` or omit the issue.',
     '',
@@ -79,7 +105,7 @@ export function buildReviewPrompt(planPath: string, outputPath: string): string 
     'Severity calibration — critical: data loss / security / crash / blocks the plan goal; high: likely bug or breaks a requirement; medium: conditional correctness risk or maintainability; low: minor. Include all severity levels.',
     '',
     'Use this exact schema:',
-    '{"issues": [{"title": string, "severity": "critical" | "high" | "medium" | "low", "summary": string, "whyItMatters": string, "evidence": string, "file": string, "lineStart": number, "lineEnd": number, "suggestedFix": string, "confidence": number, "exposure": ' +
+    '{"issues": [{"title": string, "kind": "defect" | "cleanup", "severity": "critical" | "high" | "medium" | "low", "summary": string, "whyItMatters": string, "evidence": string, "file": string, "lineStart": number, "lineEnd": number, "suggestedFix": string, "confidence": number, "exposure": ' +
       EXPOSURE_SCHEMA +
       '}]}',
     '`confidence` is a probability between 0 and 1 (e.g. 0.85), NOT a 1-5 rating.',

--- a/review-loop/src/prompt-templates.ts
+++ b/review-loop/src/prompt-templates.ts
@@ -30,7 +30,7 @@ const FIXER_EXPOSURE_RULE = [
  * Carried by the retry prompts too — a second attempt is where scope creeps,
  * because the first one already failed and more feels like the answer.
  */
-const MINIMALITY_LADDER = [
+export const MINIMALITY_LADDER = [
   'Smallest thing that works. After you understand the problem, and before you write code, in order:',
   'does this need to exist at all; is it already in this codebase; does the stdlib or an installed',
   'dependency already do it; can it be one line. Only then write something new, and write the least',

--- a/review-loop/src/review-round.ts
+++ b/review-loop/src/review-round.ts
@@ -43,6 +43,27 @@ export const TERMINAL_STATUSES = new Set<LedgerIssueRecord['status']>(['rejected
 
 const MATCHER_RECENT_ROUNDS = 2
 
+/**
+ * Severity grades what happens *if* the code is reached. Code that is merely
+ * more than it needs to be does not lose data, breach security or crash, so a
+ * cleanup graded above medium is a mis-grade rather than an emergency.
+ *
+ * Clamped here rather than trusted from the prompt, for the reason `exposure`
+ * is a citation instead of a rating: severity is this loop's standing proof
+ * that a self-assigned grade inflates. The prompt states the rule; this is what
+ * makes it true.
+ *
+ * Applied at ingest, before matching and before the ledger, so a resumed run
+ * never re-reads an ungraded cleanup and nothing downstream needs to know.
+ */
+export function capCleanupSeverity(issues: readonly ReviewerIssue[]): readonly ReviewerIssue[] {
+  return issues.map((issue) =>
+    issue.kind === 'cleanup' && (issue.severity === 'critical' || issue.severity === 'high')
+      ? { ...issue, severity: 'medium' }
+      : issue,
+  )
+}
+
 export function filterActionable(records: readonly LedgerIssueRecord[]): readonly LedgerIssueRecord[] {
   return records.filter((r) => !TERMINAL_STATUSES.has(r.status))
 }
@@ -97,7 +118,7 @@ export async function runReviewStep(
   tallyPhaseMs(collector, 'review', Date.now() - reviewStart)
   tallyUsage(collector, reviewResult.usage)
 
-  return reviewResult.value.issues
+  return capCleanupSeverity(reviewResult.value.issues)
 }
 
 export async function runMatchAndRecord(

--- a/review-loop/src/summary-lines.ts
+++ b/review-loop/src/summary-lines.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { formatDuration } from './live-format.js'
+import { aggregatePhaseMs, aggregateUsage, PHASE_KEYS } from './summary-metrics.js'
+import type { RoundMetric } from './trace-log.js'
+
+/**
+ * The summary lines derived from round metrics, split out of `summary.ts` when
+ * that file passed `max-lines`. They share one shape — read the metrics, return
+ * a line or `null` when there is nothing worth saying — and none of them knows
+ * anything about the ledger, the run directory or the verdict.
+ *
+ * `buildInspectorLine` takes `inspect` rather than `SummaryOptions` on purpose:
+ * that type lives in `summary.ts`, and importing it back would make a cycle
+ * (`import/no-cycle` is an error here).
+ */
+
+export function msToSeconds(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+export function formatCount(n: number): string {
+  return n.toLocaleString('en-US')
+}
+
+export function buildTimingLine(metrics: readonly RoundMetric[], wallMs: number): string {
+  const phaseMs = aggregatePhaseMs(metrics)
+  const totalMs = PHASE_KEYS.reduce((s, k) => s + phaseMs[k], 0)
+  const parts = PHASE_KEYS.filter((k) => phaseMs[k] > 0).map((k) => `${k} ${msToSeconds(phaseMs[k])}`)
+  const breakdown = parts.length === 0 ? 'no phase timing recorded' : parts.join(', ')
+  const usage = aggregateUsage(metrics)
+  const tokens = `in ${formatCount(usage.inputTokens)} / out ${formatCount(usage.outputTokens)} / reasoning ${formatCount(usage.reasoningTokens)}`
+  const cost = usage.costUsd > 0 ? `Cost: $${usage.costUsd.toFixed(3)} (${tokens})` : `Tokens: ${tokens}`
+  return `Duration: ${formatDuration(wallMs)} wall · phases ${formatDuration(totalMs)} (${breakdown}) · ${cost}`
+}
+
+export function buildInspectorLine(metrics: readonly RoundMetric[], inspect: boolean): string | null {
+  if (!inspect) return null
+  const runs = metrics.reduce((s, m) => s + m.inspector.runs, 0)
+  if (runs === 0) return null
+  const rejected = metrics.reduce((s, m) => s + m.inspector.rejected, 0)
+  const rate = `${((100 * rejected) / runs).toFixed(1)}%`
+  return `Inspector: ${runs} runs, ${rejected} rejected (${rate} reject rate)`
+}
+
+/**
+ * Reported from the reviewer's answers, with the fixer's second opinion folded
+ * in only as the divergence count — the two distributions side by side would
+ * invite reading one as a correction of the other, and neither is authoritative.
+ *
+ * Omitted entirely when nobody answered: a row of zeros reads as "nothing is
+ * reachable" rather than "nobody was asked".
+ */
+export function buildExposureLine(metrics: readonly RoundMetric[]): string | null {
+  const cited = metrics.reduce((s, m) => s + m.reviewerExposure.caller, 0)
+  const none = metrics.reduce((s, m) => s + m.reviewerExposure.none, 0)
+  if (cited + none === 0) return null
+  const divergent = metrics.reduce((s, m) => s + m.exposureDivergent, 0)
+  return `Exposure: ${cited} cited, ${none} none, ${divergent} divergent (advisory — orders dispatch, gates nothing)`
+}
+
+/**
+ * Counted over accepted fixes only — a rejected fix leaving no test behind is
+ * not a finding. `unmeasured` is reported separately rather than folded into
+ * the denominator, so a run whose diffs could not be read does not read as a
+ * run whose fixer skipped its tests.
+ */
+export function buildCheckBehindLine(metrics: readonly RoundMetric[]): string | null {
+  const withCheck = metrics.reduce((s, m) => s + m.checkBehind.defect.withCheck, 0)
+  const measured = withCheck + metrics.reduce((s, m) => s + m.checkBehind.defect.withoutCheck, 0)
+  const unmeasured = metrics.reduce((s, m) => s + m.checkBehind.defect.unmeasured, 0)
+  const cleanups = metrics.reduce(
+    (s, m) =>
+      s + m.checkBehind.cleanup.withCheck + m.checkBehind.cleanup.withoutCheck + m.checkBehind.cleanup.unmeasured,
+    0,
+  )
+  if (measured + unmeasured + cleanups === 0) return null
+  const tail = unmeasured > 0 ? ` (${unmeasured} unmeasured)` : ''
+  // Cleanups are counted, never folded in: deleting code introduces no
+  // non-trivial logic, so a cleanup that leaves no check is following the rule
+  // rather than breaking it, and averaging the two hides both answers.
+  const cleanupTail = cleanups > 0 ? `; ${cleanups} cleanup ${cleanups === 1 ? 'fix' : 'fixes'} not counted` : ''
+  return `Checks left behind: ${withCheck} of ${measured} accepted defect fixes${tail}${cleanupTail}`
+}
+
+/**
+ * What the reviewer reported, split by kind. Reported so the effect of
+ * admitting cleanups can be read after the fact — it gates nothing.
+ */
+export function buildKindLine(metrics: readonly RoundMetric[]): string | null {
+  const cleanup = metrics.reduce((s, m) => s + m.reviewerKind.cleanup, 0)
+  const defect = metrics.reduce((s, m) => s + m.reviewerKind.defect, 0)
+  if (cleanup === 0) return null
+  return `Findings: ${defect} defect, ${cleanup} cleanup`
+}

--- a/review-loop/src/summary.ts
+++ b/review-loop/src/summary.ts
@@ -12,11 +12,17 @@ import {
   type IssueGroup,
 } from './issue-format.js'
 import type { IssueLedgerSnapshot, LedgerIssueRecord } from './issue-ledger.js'
-import { formatDuration } from './live-format.js'
 import type { ReviewLoopResult } from './loop-controller.js'
 import type { PersistedStats, StatsSnapshot } from './run-stats.js'
 import { burndownBlock } from './summary-burndown.js'
-import { aggregatePhaseMs, aggregateUsage, PHASE_KEYS, sumDecisions } from './summary-metrics.js'
+import {
+  buildCheckBehindLine,
+  buildExposureLine,
+  buildInspectorLine,
+  buildKindLine,
+  buildTimingLine,
+} from './summary-lines.js'
+import { aggregatePhaseMs, aggregateUsage, sumDecisions } from './summary-metrics.js'
 import type { PhaseMs, RoundMetric, UsageTotals } from './trace-log.js'
 
 const GROUP_CAP = 20
@@ -123,69 +129,10 @@ function buildVerdict(input: SummaryInput, counts: IssueCounts, total: number): 
   return `Review loop finished: done — ${plural(total, 'issue')}: ${breakdown}.`
 }
 
-function msToSeconds(ms: number): string {
-  return `${(ms / 1000).toFixed(1)}s`
-}
-
-function formatCount(n: number): string {
-  return n.toLocaleString('en-US')
-}
-
-function buildTimingLine(metrics: readonly RoundMetric[], wallMs: number): string {
-  const phaseMs = aggregatePhaseMs(metrics)
-  const totalMs = PHASE_KEYS.reduce((s, k) => s + phaseMs[k], 0)
-  const parts = PHASE_KEYS.filter((k) => phaseMs[k] > 0).map((k) => `${k} ${msToSeconds(phaseMs[k])}`)
-  const breakdown = parts.length === 0 ? 'no phase timing recorded' : parts.join(', ')
-  const usage = aggregateUsage(metrics)
-  const tokens = `in ${formatCount(usage.inputTokens)} / out ${formatCount(usage.outputTokens)} / reasoning ${formatCount(usage.reasoningTokens)}`
-  const cost = usage.costUsd > 0 ? `Cost: $${usage.costUsd.toFixed(3)} (${tokens})` : `Tokens: ${tokens}`
-  return `Duration: ${formatDuration(wallMs)} wall · phases ${formatDuration(totalMs)} (${breakdown}) · ${cost}`
-}
-
 function buildRoundsLine(input: SummaryInput): string | null {
   if (input.rounds <= 1 && input.options.poolSize <= 1) return null
   const pool = input.options.poolSize > 1 ? ` · Pool: ${input.options.poolSize}` : ''
   return `Rounds: ${input.rounds}${pool}`
-}
-
-function buildInspectorLine(metrics: readonly RoundMetric[], options: SummaryOptions): string | null {
-  if (!options.inspect) return null
-  const runs = metrics.reduce((s, m) => s + m.inspector.runs, 0)
-  if (runs === 0) return null
-  const rejected = metrics.reduce((s, m) => s + m.inspector.rejected, 0)
-  const rate = `${((100 * rejected) / runs).toFixed(1)}%`
-  return `Inspector: ${runs} runs, ${rejected} rejected (${rate} reject rate)`
-}
-
-/**
- * Reported from the reviewer's answers, with the fixer's second opinion folded
- * in only as the divergence count — the two distributions side by side would
- * invite reading one as a correction of the other, and neither is authoritative.
- *
- * Omitted entirely when nobody answered: a row of zeros reads as "nothing is
- * reachable" rather than "nobody was asked".
- */
-function buildExposureLine(metrics: readonly RoundMetric[]): string | null {
-  const cited = metrics.reduce((s, m) => s + m.reviewerExposure.caller, 0)
-  const none = metrics.reduce((s, m) => s + m.reviewerExposure.none, 0)
-  if (cited + none === 0) return null
-  const divergent = metrics.reduce((s, m) => s + m.exposureDivergent, 0)
-  return `Exposure: ${cited} cited, ${none} none, ${divergent} divergent (advisory — orders dispatch, gates nothing)`
-}
-
-/**
- * Counted over accepted fixes only — a rejected fix leaving no test behind is
- * not a finding. `unmeasured` is reported separately rather than folded into
- * the denominator, so a run whose diffs could not be read does not read as a
- * run whose fixer skipped its tests.
- */
-function buildCheckBehindLine(metrics: readonly RoundMetric[]): string | null {
-  const withCheck = metrics.reduce((s, m) => s + m.checkBehind.withCheck, 0)
-  const measured = withCheck + metrics.reduce((s, m) => s + m.checkBehind.withoutCheck, 0)
-  const unmeasured = metrics.reduce((s, m) => s + m.checkBehind.unmeasured, 0)
-  if (measured + unmeasured === 0) return null
-  const tail = unmeasured > 0 ? ` (${unmeasured} unmeasured)` : ''
-  return `Checks left behind: ${withCheck} of ${measured} accepted fixes${tail}`
 }
 
 function buildStatsLine(stats: StatsSnapshot | undefined): string | null {
@@ -242,12 +189,14 @@ export function buildSummary(input: SummaryInput): string {
   const roundsLine = buildRoundsLine(input)
   if (roundsLine !== null) lines.push(roundsLine)
 
-  const inspectorLine = buildInspectorLine(input.metrics, input.options)
+  const inspectorLine = buildInspectorLine(input.metrics, input.options.inspect)
   if (inspectorLine !== null) lines.push(inspectorLine)
 
   const exposureLine = buildExposureLine(input.metrics)
   if (exposureLine !== null) lines.push(exposureLine)
 
+  const kindLine = buildKindLine(input.metrics)
+  if (kindLine !== null) lines.push(kindLine)
   const checkBehindLine = buildCheckBehindLine(input.metrics)
   if (checkBehindLine !== null) lines.push(checkBehindLine)
 

--- a/review-loop/src/summary.ts
+++ b/review-loop/src/summary.ts
@@ -157,7 +157,9 @@ function issuesBlock(ledger: IssueLedgerSnapshot): string[] {
   const lines = ['Issues:']
   for (const group of GROUP_ORDER) {
     const groupRecords = groups.get(group)
-    if (groupRecords === undefined || groupRecords.length === 0) continue
+    // Present means non-empty: the only write to this map appends a record, so
+    // an empty-array branch here is unreachable and no test could ever cover it.
+    if (groupRecords === undefined) continue
     lines.push(`  ${GROUP_LABEL[group]} (${groupRecords.length}):`)
     for (const record of groupRecords.slice(0, GROUP_CAP)) {
       lines.push(

--- a/review-loop/src/trace-log.ts
+++ b/review-loop/src/trace-log.ts
@@ -86,8 +86,34 @@ export const CheckBehindCountsSchema = z.object({
 })
 export type CheckBehindCounts = z.infer<typeof CheckBehindCountsSchema>
 
+/**
+ * Split by issue kind rather than pooled. A cleanup that deletes code
+ * introduces no non-trivial logic, so it leaves no check and is right to — but
+ * pooled it would depress the ratio the check-behind rule is actually measured
+ * by, making the defect fixers look worse the more cleanups a run admits.
+ */
+export const CheckBehindByKindSchema = z.object({
+  defect: CheckBehindCountsSchema,
+  cleanup: CheckBehindCountsSchema,
+})
+export type CheckBehindByKind = z.infer<typeof CheckBehindByKindSchema>
+
+export const KindCountsSchema = z.object({
+  defect: z.number().int().nonnegative(),
+  cleanup: z.number().int().nonnegative(),
+})
+export type KindCounts = z.infer<typeof KindCountsSchema>
+
+export function emptyKindCounts(): KindCounts {
+  return { defect: 0, cleanup: 0 }
+}
+
 export function emptyCheckBehindCounts(): CheckBehindCounts {
   return { withCheck: 0, withoutCheck: 0, unmeasured: 0 }
+}
+
+export function emptyCheckBehindByKind(): CheckBehindByKind {
+  return { defect: emptyCheckBehindCounts(), cleanup: emptyCheckBehindCounts() }
 }
 
 export const RoundMetricSchema = z.object({
@@ -102,7 +128,8 @@ export const RoundMetricSchema = z.object({
   reviewerExposure: ExposureCountsSchema,
   fixerExposure: ExposureCountsSchema,
   exposureDivergent: z.number().int().nonnegative(),
-  checkBehind: CheckBehindCountsSchema,
+  reviewerKind: KindCountsSchema,
+  checkBehind: CheckBehindByKindSchema,
   phaseMs: PhaseMsSchema,
   usage: UsageTotalsSchema,
 })

--- a/tests/mutation-improve/contracts.test.ts
+++ b/tests/mutation-improve/contracts.test.ts
@@ -55,6 +55,33 @@ describe('contracts', () => {
     expect(parsed.notes).toBe('')
   })
 
+  test('ResultSchema accepts a result naming no documents', () => {
+    // The runner no longer mandates a design.md or a tasks.md per improved file,
+    // so a result carrying neither is the ordinary shape rather than a gate
+    // failure. Everything the two documents restated is either measured by the
+    // runner or already carried by `residuals`, which it set-matches.
+    const parsed = ResultSchema.parse({
+      testPaths: ['tests/live-status/x.test.ts'],
+      residuals: [{ loc: 'x.ts:1', why: 'equivalent', mutantIds: ['1'] }],
+    })
+    expect(parsed.specPath).toBeUndefined()
+    expect(parsed.planPath).toBeUndefined()
+    expect(parsed.residuals).toHaveLength(1)
+  })
+
+  test('ResultSchema still accepts a result written before the documents were dropped', () => {
+    // --resume-run reads results stored by an earlier run, which carry both
+    // paths. Optional accepts either shape; removing the fields outright would
+    // reject a run in flight when this shipped.
+    const parsed = ResultSchema.parse({
+      specPath: 'openspec/changes/mutation-coverage-2026-08-01-x/design.md',
+      planPath: 'openspec/changes/mutation-coverage-2026-08-01-x/tasks.md',
+      testPaths: ['tests/x.test.ts'],
+      residuals: [],
+    })
+    expect(parsed.specPath).toBe('openspec/changes/mutation-coverage-2026-08-01-x/design.md')
+  })
+
   test('ResultSchema requires at least one testPath', () => {
     const base = {
       specPath: 'd.md',

--- a/tests/mutation-improve/finalize.test.ts
+++ b/tests/mutation-improve/finalize.test.ts
@@ -54,6 +54,49 @@ describe('finalize', () => {
     expect(body).toContain('| 2 | score |')
   })
 
+  test('reports accepted residuals and their reasoning instead of two document links', () => {
+    // The two Spec/Plan cells were the only place a pull-request reader could
+    // see why a file was accepted below target. Reading it from `residuals` is
+    // strictly better: that array is the one the runner set-matched against its
+    // own measurement, so the reader sees the checked answer rather than prose
+    // beside it.
+    const body = buildSummaryBody(
+      [
+        {
+          file: 'src/a.ts',
+          beforeScore: 0.4,
+          afterScore: 0.88,
+          iter: 1,
+          residuals: [
+            { loc: 'src/a.ts:12', why: 'equivalent mutant: jitter bound', mutantIds: ['7'] },
+            { loc: 'src/a.ts:30', why: 'dead branch only a src edit removes', mutantIds: ['9', '11'] },
+          ],
+        },
+      ],
+      [],
+    )
+    expect(body).toContain('| src/a.ts | 0.4 | 0.88 | 2 |')
+    expect(body).toContain('equivalent mutant: jitter bound')
+    expect(body).toContain('dead branch only a src edit removes')
+    expect(body).not.toContain('| Spec | Plan |')
+  })
+
+  test('renders a file with no residuals without an empty reasoning cell', () => {
+    const body = buildSummaryBody([{ file: 'src/a.ts', beforeScore: 0.4, afterScore: 0.97, iter: 1 }], [])
+    expect(body).toContain('| src/a.ts | 0.4 | 0.97 | 0 | — |')
+  })
+
+  test('a resumed row still carrying document paths renders from residuals, not paths', () => {
+    // --resume-run reads rows stored before the documents were dropped. The
+    // report reads residuals, so such a row renders exactly like a fresh one.
+    const body = buildSummaryBody(
+      [{ file: 'src/a.ts', beforeScore: 0.4, afterScore: 0.97, iter: 1, specPath: 's.md', planPath: 'p.md' }],
+      [],
+    )
+    expect(body).not.toContain('s.md')
+    expect(body).not.toContain('p.md')
+  })
+
   test('runFinalize pushes and opens a PR via gh, returning the URL', async () => {
     const repoRoot = makeTempDir('fin-')
     const runState: MutationImproveRunState = {

--- a/tests/mutation-improve/pipeline.test.ts
+++ b/tests/mutation-improve/pipeline.test.ts
@@ -722,7 +722,7 @@ describe('pipeline build-fix retry', () => {
       return check(worktreePath)
     }
     const prompts: string[] = []
-    const fixedResult: Result = { ...result, specPath: 'docs/superpowers/specs/fixed-design.md' }
+    const fixedResult: Result = { ...result, residuals: [{ loc: 'L9', why: 'fixed-agent residual', mutantIds: ['3'] }] }
     deps.runImproveAgent = sequenceImprove([result, fixedResult], prompts, result)
     const outcome = await runIteration(deps, 1)
     expect(outcome.outcome).toBe('improved')
@@ -734,7 +734,7 @@ describe('pipeline build-fix retry', () => {
     const improveOut = path.join(deps.runState.runDir, 'iter', '1', 'result.json')
     expect(prompts[1]).toContain(agentWritePath(worktreePath, improveOut))
     // the fix agent's rewritten result replaces the original for finalize
-    expect(deps.runState.merged[0]?.specPath).toBe('docs/superpowers/specs/fixed-design.md')
+    expect(deps.runState.merged[0]?.residuals).toEqual([{ loc: 'L9', why: 'fixed-agent residual', mutantIds: ['3'] }])
   })
 
   test('exhausts buildFixAttempts then fails the build gate', async () => {

--- a/tests/mutation-improve/prompt-templates.test.ts
+++ b/tests/mutation-improve/prompt-templates.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, test } from 'bun:test'
 
 import { buildFixPrompt, buildImprovePrompt, buildSelectPrompt } from '../../mutation-improve/src/prompt-templates.js'
+import { ResultSchema } from '../../mutation-improve/src/result-schema.js'
 
 describe('prompt-templates', () => {
   test('buildSelectPrompt names the output path, the done-set, and the rejection rules', () => {
@@ -41,7 +42,6 @@ describe('prompt-templates', () => {
       file: 'src/foo.ts',
       beforeScore: 0.3,
       threshold: 0.95,
-      date: '2026-08-05',
       outputPath: '/run/iter/1/result.json',
     })
     expect(prompt).toContain('MUST NOT edit anything under src/')
@@ -49,8 +49,6 @@ describe('prompt-templates', () => {
     expect(prompt).toContain('toBe(')
     expect(prompt).toContain('0.95')
     expect(prompt).toContain('/run/iter/1/result.json')
-    expect(prompt).toContain('openspec/changes/mutation-coverage-2026-08-05-foo/design.md')
-    expect(prompt).toContain('openspec/changes/mutation-coverage-2026-08-05-foo/tasks.md')
     expect(prompt).not.toContain('docs/superpowers')
   })
 
@@ -62,7 +60,6 @@ describe('prompt-templates', () => {
       file: 'src/foo.ts',
       beforeScore: 0.3,
       threshold: 0.95,
-      date: '2026-08-05',
       outputPath: '/run/iter/1/result.json',
     })
     expect(prompt).toContain('ONLY under tests/ and openspec/changes/')
@@ -94,7 +91,6 @@ describe('prompt-templates', () => {
       file: 'src/foo.ts',
       beforeScore: 0.3,
       threshold: 0.95,
-      date: '2026-08-05',
       outputPath: '/run/iter/1/result.json',
     })
     expect(prompt).toContain('mutantIds')
@@ -115,12 +111,69 @@ describe('prompt-templates', () => {
   // The 2026-08-06 iter-8 work was discarded at the ratchet commit because the
   // agent's spec/plan .md files lacked the HTML-comment header — the prompt
   // only said "SPDX headers" and the agent guessed the // style.
+  test('buildImprovePrompt mandates no design document and no task list', () => {
+    // Every section of the design document restated something the runner
+    // already measures or set-matches, and nothing walked the task list's
+    // checkboxes — this runner has no step machinery. Two of five steps
+    // produced them, per improved file, out of the agent's turn.
+    const prompt = buildImprovePrompt({
+      file: 'src/foo.ts',
+      beforeScore: 0.3,
+      threshold: 0.95,
+      outputPath: '/run/iter/1/result.json',
+    })
+    expect(prompt).not.toContain('mutation-coverage-2026-08-05-foo')
+    expect(prompt).not.toMatch(/design\.md/u)
+    expect(prompt).not.toMatch(/tasks\.md/u)
+    expect(prompt).not.toMatch(/Gap analysis/iu)
+  })
+
+  test('buildImprovePrompt keeps the three steps that produce verified output', () => {
+    const prompt = buildImprovePrompt({
+      file: 'src/foo.ts',
+      beforeScore: 0.3,
+      threshold: 0.95,
+      outputPath: '/run/iter/1/result.json',
+    })
+    expect(prompt).toContain('MEASURE')
+    expect(prompt).toContain('TESTS')
+    expect(prompt).toContain('RESIDUALS')
+    expect(prompt).toContain('reports/paired/')
+  })
+
+  test('buildImprovePrompt asks for residual reasoning on the result, not in a document', () => {
+    const prompt = buildImprovePrompt({
+      file: 'src/foo.ts',
+      beforeScore: 0.3,
+      threshold: 0.95,
+      outputPath: '/run/iter/1/result.json',
+    })
+    expect(prompt).toContain('mutantIds')
+    expect(prompt).toMatch(/why/u)
+    expect(prompt).toContain('/run/iter/1/result.json')
+  })
+
+  test("the prompt's inline result schema matches result-schema.ts", () => {
+    // The schema is stated in the prompt as a literal, so the two drift in
+    // silence: an agent told to produce a field the parser rejects, or still
+    // told to name documents nobody asks for, costs a whole iteration.
+    const prompt = buildImprovePrompt({
+      file: 'src/foo.ts',
+      beforeScore: 0.3,
+      threshold: 0.95,
+      outputPath: '/run/iter/1/result.json',
+    })
+    const parsed = ResultSchema.parse({ testPaths: ['tests/x.test.ts'], residuals: [] })
+    for (const key of Object.keys(parsed)) expect(prompt).toContain(key)
+    expect(prompt).not.toContain('specPath')
+    expect(prompt).not.toContain('planPath')
+  })
+
   test('buildImprovePrompt spells out the HTML-comment license header for .md files', () => {
     const prompt = buildImprovePrompt({
       file: 'src/foo.ts',
       beforeScore: 0.3,
       threshold: 0.95,
-      date: '2026-08-05',
       outputPath: '/run/iter/1/result.json',
     })
     expect(prompt).toContain('<!--')

--- a/tests/mutation-improve/run-state.test.ts
+++ b/tests/mutation-improve/run-state.test.ts
@@ -93,6 +93,24 @@ describe('run-state', () => {
     expect(reloaded.merged[1]?.capped).toBeUndefined()
   })
 
+  test('merged entries round-trip with and without the document paths', async () => {
+    // The runner stopped mandating a design.md and a tasks.md per improved file,
+    // so an entry naming neither is now the ordinary shape. An entry naming both
+    // is what --resume-run reads from a run started before that, and must keep
+    // loading — which is why the fields went optional rather than away.
+    const repoRoot = makeTempDir('rs-docs-')
+    const config = baseConfig(repoRoot, path.join(repoRoot, '.mutation-improve'))
+    const created = await createRunState(config)
+    created.merged = [
+      { file: 'src/a.ts', beforeScore: 0.3, afterScore: 0.85, iter: 1 },
+      { file: 'src/b.ts', beforeScore: 0.4, afterScore: 0.9, iter: 2, specPath: 's.md', planPath: 'p.md' },
+    ]
+    await saveRunState(created)
+    const reloaded = await loadRunState(config.workDir, created.runId)
+    expect(reloaded.merged[0]?.specPath).toBeUndefined()
+    expect(reloaded.merged[1]?.specPath).toBe('s.md')
+  })
+
   test('state.json round-trips the optional stats block', async () => {
     const repoRoot = makeTempDir('run-state-stats-')
     const config = baseConfig(repoRoot, path.join(repoRoot, '.mutation-improve'))

--- a/tests/mutation-improve/run-state.test.ts
+++ b/tests/mutation-improve/run-state.test.ts
@@ -111,6 +111,27 @@ describe('run-state', () => {
     expect(reloaded.merged[1]?.specPath).toBe('s.md')
   })
 
+  test('merged entries round-trip the residuals the end-of-run report renders', async () => {
+    // The report reads these instead of two document links, so they have to
+    // survive a --resume-run — a run resumed after its last iteration would
+    // otherwise publish a table saying every file was accepted for no reason.
+    const repoRoot = makeTempDir('rs-res-')
+    const config = baseConfig(repoRoot, path.join(repoRoot, '.mutation-improve'))
+    const created = await createRunState(config)
+    created.merged = [
+      {
+        file: 'src/a.ts',
+        beforeScore: 0.4,
+        afterScore: 0.88,
+        iter: 1,
+        residuals: [{ loc: 'src/a.ts:12', why: 'equivalent', mutantIds: ['7'] }],
+      },
+    ]
+    await saveRunState(created)
+    const reloaded = await loadRunState(config.workDir, created.runId)
+    expect(reloaded.merged[0]?.residuals).toEqual([{ loc: 'src/a.ts:12', why: 'equivalent', mutantIds: ['7'] }])
+  })
+
   test('state.json round-trips the optional stats block', async () => {
     const repoRoot = makeTempDir('run-state-stats-')
     const config = baseConfig(repoRoot, path.join(repoRoot, '.mutation-improve'))

--- a/tests/opencode-agent/instructions.test.ts
+++ b/tests/opencode-agent/instructions.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, test } from 'bun:test'
 import { IMPLEMENT_INSTRUCTIONS } from '../../opencode-agent/src/implement-prompts.js'
 import { CI_FIX_INSTRUCTIONS } from '../../opencode-agent/src/phases/ci-fix.js'
 import { PROPOSE_FILES_INSTRUCTIONS, PROPOSE_INSTRUCTIONS } from '../../opencode-agent/src/phases/plan-draft.js'
+import { MINIMALITY_RULE } from '../../opencode-agent/src/prompts.js'
 import { PROTECTED_PATHS_RULE } from '../../opencode-agent/src/protected-paths.js'
 
 /**
@@ -42,5 +43,34 @@ describe('every phase that can write a file states the protected-paths rule', ()
     // edit, which is the case that cost three CI-fix rounds.
     expect(PROTECTED_PATHS_RULE).toContain('.github/workflows/')
     expect(PROTECTED_PATHS_RULE).toContain('by hand')
+  })
+})
+
+/**
+ * The minimality rule splits the same four blocks along a different seam:
+ * writing production code versus drafting an OpenSpec artifact. Both halves are
+ * asserted, because the boundary is a decision rather than an oversight — a
+ * later edit that hands the rule to a drafter should fail a test, not pass
+ * quietly. Artifact scope is governed by `openspec/config.yaml`'s `rules`, which
+ * reach those two blocks already; a second rule about stdlib and one-liners
+ * would be noise in a prompt that writes no code.
+ */
+describe('the minimality rule reaches the code-writing phases only', () => {
+  const WRITES_CODE: ReadonlyArray<readonly [string, string]> = [
+    ['implement', IMPLEMENT_INSTRUCTIONS],
+    ['ci-fix', CI_FIX_INSTRUCTIONS],
+  ]
+
+  const DRAFTS_ARTIFACTS: ReadonlyArray<readonly [string, string]> = [
+    ['propose', PROPOSE_INSTRUCTIONS],
+    ['propose-files', PROPOSE_FILES_INSTRUCTIONS],
+  ]
+
+  test.each(WRITES_CODE)('%s carries it verbatim', (_phase, instructions) => {
+    expect(instructions).toContain(MINIMALITY_RULE)
+  })
+
+  test.each(DRAFTS_ARTIFACTS)('%s deliberately does not carry it', (_phase, instructions) => {
+    expect(instructions).not.toContain(MINIMALITY_RULE)
   })
 })

--- a/tests/opencode-agent/minimality-rule.test.ts
+++ b/tests/opencode-agent/minimality-rule.test.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { MINIMALITY_RULE } from '../../opencode-agent/src/prompts.js'
+import { MINIMALITY_LADDER } from '../../review-loop/src/prompt-templates.js'
+
+/**
+ * Two workspaces, one rule. `opencode-agent` drives `review-loop/` as a
+ * subprocess and imports nothing from it, so the constant is duplicated rather
+ * than shared — and this file is where that duplication is made safe.
+ *
+ * The coupling lives in a test on purpose (design D1): a runtime import for one
+ * paragraph would be a boundary to defend at every later refactor, and the
+ * equality check needs both texts in one place anyway. `diff-stats.test.ts`
+ * pins `.hooks/tdd`'s test-path pattern the same way.
+ */
+describe('the minimality rule has one definition', () => {
+  test('both workspaces state it identically', () => {
+    expect(MINIMALITY_RULE).toBe(MINIMALITY_LADDER)
+  })
+
+  test('it names what is never cut to reach a smaller diff', () => {
+    // Without this clause the rule reads as licence to drop a safeguard, which
+    // is the one way a minimality instruction does real damage. A carrier that
+    // keeps the ladder and loses the brake must fail.
+    expect(MINIMALITY_RULE).toMatch(/not the goal/iu)
+    for (const safeguard of ['validation', 'error', 'security', 'test']) {
+      expect(MINIMALITY_RULE).toContain(safeguard)
+    }
+  })
+
+  test('it does not advise minimising file count', () => {
+    // The upstream phrasing this rule descends from says "fewest files
+    // possible". Here a max-lines failure means *split the file*, so adopting
+    // that phrase would put the rule in conflict with an enforced convention.
+    expect(MINIMALITY_RULE).not.toMatch(/fewest files/iu)
+    expect(MINIMALITY_RULE).not.toMatch(/file count/iu)
+  })
+})

--- a/tests/opencode-agent/phases.test.ts
+++ b/tests/opencode-agent/phases.test.ts
@@ -265,7 +265,11 @@ const instructionsFor = (
 ): import('../../opencode-agent/src/openspec-driver.js').InstructionsResult => ({
   instruction: `Draft the ${artifactId}.`,
   template: undefined,
-  rules: [],
+  // Non-empty on purpose: a project's `rules` reach the drafter through this
+  // payload and through no other route, so a fake answering `[]` leaves the one
+  // seam that carries them untested. Two entries, because the section renders
+  // them as a list and one would not catch a builder that kept only the first.
+  rules: [`rule for ${artifactId}`, `second rule for ${artifactId}`],
   resolvedOutputPath: artifactId === 'specs' ? `${CHANGE_DIR}/specs/**/*.md` : `${CHANGE_DIR}/${artifactId}.md`,
   changeDir: CHANGE_DIR,
   existingOutputPaths: [],
@@ -522,6 +526,34 @@ describe('handlePlan · drafter loop (D3)', () => {
     // The steering feedback reached the drafter's prompt — the artifact-update
     // turn is grounded in the maintainer's scope change, not a blind re-draft.
     expect(io.prompts.some((p) => p.prompt.includes('structured logging'))).toBe(true)
+  })
+
+  it("forwards each artifact's project rules to its drafter verbatim", async () => {
+    // `openspec/config.yaml`'s `rules` are how a project shapes what its agents
+    // draft — a scope rule added there has to reach this drafter with no code
+    // change here. `plan-draft.ts` builds that section, but the fake driver used
+    // to answer `rules: []`, so the forwarding was never exercised: a refactor
+    // that dropped the section would have kept every test in this file green.
+    // Asserted across all three artifacts because the glob artifact (`specs`)
+    // takes the second prompt shape and would otherwise go uncovered.
+    const { input, io } = wireDrafterInput([
+      JSON.stringify({ files: [{ path: 'specs/retry/spec.md', content: 'spec body' }] }),
+      JSON.stringify({ content: 'design body' }),
+      JSON.stringify({ content: 'tasks body' }),
+    ])
+
+    await handlePlan(input)
+
+    const promptFor = (artifact: string): string =>
+      io.prompts
+        .map((p) => p.prompt)
+        .filter((p) => p.includes(`Draft the ${artifact}.`))
+        .join('\n')
+
+    for (const artifact of ['specs', 'design', 'tasks']) {
+      expect(promptFor(artifact)).toContain('Rules:')
+      for (const rule of instructionsFor(artifact).rules) expect(promptFor(artifact)).toContain(`- ${rule}`)
+    }
   })
 })
 

--- a/tests/review-loop/commit-attempt.test.ts
+++ b/tests/review-loop/commit-attempt.test.ts
@@ -37,6 +37,7 @@ async function setupRepo(repoPath: string): Promise<void> {
 
 const issue: ReviewerIssue = {
   title: 'x',
+  kind: 'defect',
   severity: 'low',
   summary: '',
   whyItMatters: '',

--- a/tests/review-loop/issue-inspector.test.ts
+++ b/tests/review-loop/issue-inspector.test.ts
@@ -19,6 +19,7 @@ afterEach(cleanupTempDirs)
 
 const issue: ReviewerIssue = {
   title: 'x',
+  kind: 'defect',
   severity: 'low',
   summary: 's',
   whyItMatters: 'w',

--- a/tests/review-loop/issue-ledger.test.ts
+++ b/tests/review-loop/issue-ledger.test.ts
@@ -4,7 +4,7 @@
 // See LICENSE in the project root for details.
 
 import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
@@ -17,12 +17,14 @@ import {
   recordVerification,
   saveIssueLedger,
 } from '../../review-loop/src/issue-ledger.js'
+import { FixerResultSchema } from '../../review-loop/src/issue-schema.js'
 import type { IssueMatch, ReviewerIssue, VerifierDecision } from '../../review-loop/src/issue-schema.js'
 
 const tempDirs: string[] = []
 
 const issue: ReviewerIssue = {
   title: 'Race condition in queue flush path',
+  kind: 'defect',
   severity: 'high',
   summary: 'Two concurrent messages can bypass the intended lock.',
   whyItMatters: 'This can produce stale assistant replies.',
@@ -162,5 +164,61 @@ describe('issue ledger', () => {
     })
 
     expect(ledger.snapshot.issues[id]?.status).toBe('needs_human')
+  })
+})
+
+describe('issue kind on the ledger', () => {
+  test('a ledger written before cleanups existed loads as all-defects', async () => {
+    // The ledger is Zod-validated on read and persists across --resume-run, so
+    // a snapshot from an earlier run must keep loading. It holds only defects
+    // by construction — cleanups could not be reported yet — so the default is
+    // a true statement about that file, not a fallback.
+    const runDir = mkdtempSync(path.join(tmpdir(), 'review-loop-ledger-'))
+    tempDirs.push(runDir)
+
+    const { kind: _dropped, ...issueWithoutKind } = issue
+    writeFileSync(
+      path.join(runDir, 'ledger.json'),
+      JSON.stringify({
+        issues: {
+          'issue-1': {
+            id: 'issue-1',
+            issue: issueWithoutKind,
+            status: 'discovered',
+            firstSeenRound: 1,
+            latestSeenRound: 1,
+            fixAttempts: 0,
+            verifierDecision: null,
+          },
+        },
+      }),
+    )
+
+    const ledger = await loadIssueLedger(runDir)
+    expect(ledger.snapshot.issues['issue-1']?.issue.kind).toBe('defect')
+  })
+
+  test('a fixer result cannot change the recorded kind', async () => {
+    // The kind is the reviewer's answer. FixerResultSchema carries no `kind`,
+    // so one asserted in a reply is stripped before it can reach the ledger —
+    // this pins that, because adding the field there would silently make the
+    // fixer able to reclassify its own issue out of the defect queue.
+    const runDir = mkdtempSync(path.join(tmpdir(), 'review-loop-ledger-'))
+    tempDirs.push(runDir)
+
+    const ledger = await createIssueLedger(runDir)
+    const cleanup: ReviewerIssue = { ...issue, kind: 'cleanup' }
+    const records = applyMatchedIssues(ledger, 1, [cleanup], [{ newIssueIndex: 0, existingId: null }])
+    const id = records[0]!.id
+
+    const parsed = FixerResultSchema.parse({
+      ...validDecision,
+      fixed: true,
+      kind: 'defect',
+    })
+    expect(parsed).not.toHaveProperty('kind')
+
+    recordVerification(ledger, id, validDecision)
+    expect(ledger.snapshot.issues[id]?.issue.kind).toBe('cleanup')
   })
 })

--- a/tests/review-loop/issue-matcher.test.ts
+++ b/tests/review-loop/issue-matcher.test.ts
@@ -17,6 +17,7 @@ afterEach(cleanupTempDirs)
 
 const existingIssue: ReviewerIssue = {
   title: 'Race condition in queue flush',
+  kind: 'defect',
   severity: 'high',
   summary: 'Two concurrent messages bypass the lock.',
   whyItMatters: 'Stale replies.',

--- a/tests/review-loop/issue-processor-attempts.test.ts
+++ b/tests/review-loop/issue-processor-attempts.test.ts
@@ -13,6 +13,7 @@ describe('buildAttemptPrompt', () => {
   test('builds inspector-rejection retry prompt', () => {
     const issue: ReviewerIssue = {
       title: 'x',
+      kind: 'defect',
       severity: 'low',
       summary: 's',
       whyItMatters: 'w',
@@ -59,6 +60,7 @@ describe('buildAttemptPrompt', () => {
       id: 'rec-1',
       issue: {
         title: 'x',
+        kind: 'defect',
         severity: 'low',
         summary: 's',
         whyItMatters: 'w',

--- a/tests/review-loop/issue-processor-save-serialization.test.ts
+++ b/tests/review-loop/issue-processor-save-serialization.test.ts
@@ -54,6 +54,7 @@ async function setupRepo(repoPath: string): Promise<void> {
 
 const baseIssue: ReviewerIssue = {
   title: 'Race in queue',
+  kind: 'defect',
   severity: 'high',
   summary: 's',
   whyItMatters: 'w',

--- a/tests/review-loop/issue-processor.test.ts
+++ b/tests/review-loop/issue-processor.test.ts
@@ -31,6 +31,7 @@ afterEach(cleanupTempDirs)
 
 const issue: ReviewerIssue = {
   title: 'Race in queue',
+  kind: 'defect',
   severity: 'high',
   summary: 's',
   whyItMatters: 'w',

--- a/tests/review-loop/issue-processor.test.ts
+++ b/tests/review-loop/issue-processor.test.ts
@@ -855,6 +855,6 @@ describe('check-behind signal', () => {
     expect(fixed).toBe(1)
     expect(recordOf(ledger).status).toBe('fixed_pending_review')
     expect(recordOf(ledger).fixAttempts).toBe(1)
-    expect(collector.checkBehind).toEqual({ withCheck: 0, withoutCheck: 1, unmeasured: 0 })
+    expect(collector.checkBehind.defect).toEqual({ withCheck: 0, withoutCheck: 1, unmeasured: 0 })
   })
 })

--- a/tests/review-loop/issue-processor.test.ts
+++ b/tests/review-loop/issue-processor.test.ts
@@ -754,6 +754,35 @@ describe('orderByExposure', () => {
     orderByExposure(input)
     expect(ids(input)).toEqual(['none-1', 'cited'])
   })
+
+  describe('kind outranks exposure', () => {
+    const clean = (id: string, exposure?: Exposure): LedgerIssueRecord => ({
+      ...rec(id, exposure),
+      issue: { ...issue, kind: 'cleanup', exposure },
+    })
+
+    test('every defect is dispatched before any cleanup', () => {
+      // The case the single-key sort got wrong: a cleanup whose caller was found
+      // outranked a critical defect whose caller nobody found. Exposure grades
+      // reachability, not worth, so it cannot be the only key once the queue
+      // holds two different kinds of thing.
+      const out = orderByExposure([clean('cleanup-cited', caller), rec('defect-none', { kind: 'none' })])
+      expect(ids(out)).toEqual(['defect-none', 'cleanup-cited'])
+    })
+
+    test('cleanups order among themselves by exposure, exactly as defects do', () => {
+      const out = orderByExposure([clean('none-1', { kind: 'none' }), clean('unknown'), clean('cited', caller)])
+      expect(ids(out)).toEqual(['cited', 'unknown', 'none-1'])
+    })
+
+    test('a run stopped mid-queue leaves cleanups unfixed before defects', () => {
+      // A stop is honoured between two issues, so what a stopped run drops is
+      // whatever the ordering put last. Taking a prefix is what that costs.
+      const out = orderByExposure([clean('cleanup-a', caller), rec('defect-a'), clean('cleanup-b', caller)])
+      expect(ids(out.slice(0, 1))).toEqual(['defect-a'])
+      expect(ids(out.slice(1))).toEqual(['cleanup-a', 'cleanup-b'])
+    })
+  })
 })
 
 function issueIdsInDispatchOrder(events: readonly TraceEvent[]): string[] {

--- a/tests/review-loop/issue-schema.test.ts
+++ b/tests/review-loop/issue-schema.test.ts
@@ -182,3 +182,21 @@ describe('exposure', () => {
     expect(parsed).not.toHaveProperty('exposure')
   })
 })
+
+describe('issue kind', () => {
+  test('ReviewerIssueSchema accepts both kinds', () => {
+    expect(ReviewerIssueSchema.parse({ ...validIssue, kind: 'defect' }).kind).toBe('defect')
+    expect(ReviewerIssueSchema.parse({ ...validIssue, kind: 'cleanup' }).kind).toBe('cleanup')
+  })
+
+  test('an issue written before kind existed reads as a defect', () => {
+    // Unlike `exposure`, absent is not a third state here: a ledger written
+    // before cleanups were admitted holds only defects, so the default states
+    // a truth rather than papering over a gap.
+    expect(ReviewerIssueSchema.parse(validIssue).kind).toBe('defect')
+  })
+
+  test('ReviewerIssueSchema rejects a kind outside the two', () => {
+    expect(() => ReviewerIssueSchema.parse({ ...validIssue, kind: 'refactor' })).toThrow()
+  })
+})

--- a/tests/review-loop/loop-controller.test.ts
+++ b/tests/review-loop/loop-controller.test.ts
@@ -34,6 +34,7 @@ afterEach(cleanupTempDirs)
 
 const issue: ReviewerIssue = {
   title: 'Race condition in queue flush path',
+  kind: 'defect',
   severity: 'high',
   summary: 'Two concurrent messages can bypass the intended lock.',
   whyItMatters: 'This can produce stale assistant replies.',

--- a/tests/review-loop/loop-trace.test.ts
+++ b/tests/review-loop/loop-trace.test.ts
@@ -222,10 +222,38 @@ describe('exposure tallies', () => {
 describe('check-behind tallies', () => {
   test('counts each outcome separately, keeping unmeasured out of both', () => {
     const collector = newCollector()
-    tallyCheckBehind(collector, 'with-check')
-    tallyCheckBehind(collector, 'with-check')
-    tallyCheckBehind(collector, 'without-check')
-    tallyCheckBehind(collector, 'unmeasured')
-    expect(collector.checkBehind).toEqual({ withCheck: 2, withoutCheck: 1, unmeasured: 1 })
+    tallyCheckBehind(collector, 'with-check', 'defect')
+    tallyCheckBehind(collector, 'with-check', 'defect')
+    tallyCheckBehind(collector, 'without-check', 'defect')
+    tallyCheckBehind(collector, 'unmeasured', 'defect')
+    expect(collector.checkBehind.defect).toEqual({ withCheck: 2, withoutCheck: 1, unmeasured: 1 })
+  })
+})
+
+describe('per-kind counts', () => {
+  const cleanup: ReviewerIssue = { ...issue, kind: 'cleanup' }
+
+  test('tallyReviewerIssues counts defects and cleanups separately', () => {
+    const collector = newCollector()
+    tallyReviewerIssues(collector, [issue, cleanup, cleanup])
+    expect(collector.reviewerKind).toEqual({ defect: 1, cleanup: 2 })
+  })
+
+  test('a round with no cleanups reports zero, not an absent field', () => {
+    const collector = newCollector()
+    tallyReviewerIssues(collector, [issue])
+    expect(collector.reviewerKind).toEqual({ defect: 1, cleanup: 0 })
+  })
+
+  test('tallyCheckBehind books the outcome under the fixed issue kind', () => {
+    // A cleanup that deletes code introduces no non-trivial logic, so it
+    // legitimately leaves no check. Pooling the two would let cleanups depress
+    // the ratio the defect rule is actually measured by.
+    const collector = newCollector()
+    tallyCheckBehind(collector, 'with-check', 'defect')
+    tallyCheckBehind(collector, 'without-check', 'cleanup')
+    tallyCheckBehind(collector, 'unmeasured', 'cleanup')
+    expect(collector.checkBehind.defect).toEqual({ withCheck: 1, withoutCheck: 0, unmeasured: 0 })
+    expect(collector.checkBehind.cleanup).toEqual({ withCheck: 0, withoutCheck: 1, unmeasured: 1 })
   })
 })

--- a/tests/review-loop/loop-trace.test.ts
+++ b/tests/review-loop/loop-trace.test.ts
@@ -37,6 +37,7 @@ function requireInspectComplete(evt: TraceEvent): Extract<TraceEvent, { event: '
 
 const issue: ReviewerIssue = {
   title: 'T',
+  kind: 'defect',
   severity: 'high',
   summary: 's',
   whyItMatters: 'w',

--- a/tests/review-loop/progress-log.test.ts
+++ b/tests/review-loop/progress-log.test.ts
@@ -22,6 +22,7 @@ afterEach(cleanupTempDirs)
 
 const issue: ReviewerIssue = {
   title: 'Missing error handling',
+  kind: 'defect',
   severity: 'high',
   summary: 'Errors are swallowed.',
   whyItMatters: 'Silent failures.',

--- a/tests/review-loop/prompt-templates.test.ts
+++ b/tests/review-loop/prompt-templates.test.ts
@@ -17,6 +17,7 @@ import {
 
 const issue: ReviewerIssue = {
   title: 'Race condition in queue flush path',
+  kind: 'defect',
   severity: 'high',
   summary: 'Two concurrent messages can bypass the intended lock.',
   whyItMatters: 'This can produce stale assistant replies.',
@@ -96,6 +97,7 @@ describe('prompt-templates', () => {
 describe('buildInspectPrompt', () => {
   const inspectorIssue: ReviewerIssue = {
     title: 'Race in queue',
+    kind: 'defect',
     severity: 'high',
     summary: 's',
     whyItMatters: 'w',
@@ -128,6 +130,7 @@ describe('buildInspectPrompt', () => {
 describe('buildRetryFixWithInspectorFeedbackPrompt', () => {
   const inspectorIssue: ReviewerIssue = {
     title: 'Race in queue',
+    kind: 'defect',
     severity: 'high',
     summary: 's',
     whyItMatters: 'w',

--- a/tests/review-loop/prompt-templates.test.ts
+++ b/tests/review-loop/prompt-templates.test.ts
@@ -12,6 +12,7 @@ import {
   buildRetryFixPrompt,
   buildRetryFixWithInspectorFeedbackPrompt,
   buildReviewPrompt,
+  MINIMALITY_LADDER,
 } from '../../review-loop/src/prompt-templates.js'
 
 const issue: ReviewerIssue = {
@@ -216,6 +217,14 @@ describe('fix instruction contract', () => {
 
     test(`${label} applies the ladder after comprehension, not instead of it`, () => {
       expect(build()).toMatch(/after you understand/iu)
+    })
+
+    // Additive to the two obligation assertions above, which cover a different
+    // failure: those keep a *reworded* ladder honest, this keeps every carrier
+    // saying the same words. Losing the first leaves a rewrite untested; losing
+    // this one lets one carrier drift from the constant the others share.
+    test(`${label} carries the ladder constant verbatim`, () => {
+      expect(build()).toContain(MINIMALITY_LADDER)
     })
   }
 

--- a/tests/review-loop/prompt-templates.test.ts
+++ b/tests/review-loop/prompt-templates.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, expect, test } from 'bun:test'
 
+import { ReviewerIssueSchema } from '../../review-loop/src/issue-schema.js'
 import type { ReviewerIssue } from '../../review-loop/src/issue-schema.js'
 import {
   buildFixPrompt,
@@ -242,5 +243,68 @@ describe('fix instruction contract', () => {
     expect(prompt).toMatch(/architecture/iu)
     expect(prompt).toMatch(/report/iu)
     expect(prompt).toContain('do NOT edit the plan/spec')
+  })
+})
+
+describe('deletion findings in the reviewer prompt', () => {
+  const reviewPrompt = (): string => buildReviewPrompt('/plan.md', '/issues.json')
+
+  test('admits the five kinds by name', () => {
+    const p = reviewPrompt()
+    for (const tag of ['delete', 'stdlib', 'native', 'yagni', 'shrink']) expect(p).toContain(tag)
+  })
+
+  test('requires a named replacement for every cleanup', () => {
+    const p = reviewPrompt()
+    expect(p).toMatch(/replace/iu)
+    expect(p).toMatch(/name/iu)
+    // "nothing replaces it" is a complete answer for unused code, not a gap.
+    expect(p).toMatch(/nothing replaces it/iu)
+  })
+
+  test('tells the reviewer to omit a cleanup it cannot name a replacement for', () => {
+    expect(reviewPrompt()).toMatch(/omit/iu)
+  })
+
+  test('requires kind on every issue and states the two values', () => {
+    const p = reviewPrompt()
+    expect(p).toContain('"kind"')
+    expect(p).toContain('"defect"')
+    expect(p).toContain('"cleanup"')
+  })
+
+  test('states the medium ceiling on cleanups', () => {
+    const p = reviewPrompt()
+    expect(p).toMatch(/never above medium|at most medium|no higher than medium/iu)
+  })
+
+  test('keeps the existing exclusions: style, naming, and personal preference stay out', () => {
+    // A deletion vocabulary is exactly the thing that could be read as licence
+    // to report taste. The old exclusion has to survive it verbatim.
+    const p = reviewPrompt()
+    expect(p).toContain('correct but I would write it differently')
+    expect(p).toMatch(/style\/formatting a linter owns/iu)
+    expect(p).toMatch(/naming preferences/iu)
+  })
+
+  test("the prompt's inline issue schema still matches issue-schema.ts", () => {
+    // The prompt embeds the schema as a string literal, so the two drift in
+    // silence: a reviewer told to emit a field the parser rejects loses the
+    // whole round to a validation error.
+    const p = reviewPrompt()
+    const shape = ReviewerIssueSchema.parse({
+      title: 't',
+      kind: 'cleanup',
+      severity: 'medium',
+      summary: 's',
+      whyItMatters: 'w',
+      evidence: 'e',
+      file: 'f.ts',
+      lineStart: 1,
+      lineEnd: 2,
+      suggestedFix: 'x',
+      confidence: 0.5,
+    })
+    for (const key of Object.keys(shape)) expect(p).toContain(`"${key}"`)
   })
 })

--- a/tests/review-loop/review-round.test.ts
+++ b/tests/review-loop/review-round.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import type { ReviewerIssue } from '../../review-loop/src/issue-schema.js'
+import { capCleanupSeverity } from '../../review-loop/src/review-round.js'
+
+const issue: ReviewerIssue = {
+  title: 'Race condition in queue flush path',
+  kind: 'defect',
+  severity: 'high',
+  summary: 'Two concurrent messages can bypass the intended lock.',
+  whyItMatters: 'This can produce stale assistant replies.',
+  evidence: 'src/message-queue/queue.ts lines 84-107',
+  file: 'src/message-queue/queue.ts',
+  lineStart: 84,
+  lineEnd: 107,
+  suggestedFix: 'Take the processing lock earlier.',
+  confidence: 0.92,
+}
+
+const severities = (issues: readonly ReviewerIssue[]): string[] => issues.map((i) => i.severity)
+
+/**
+ * The prompt states the cap; this is what enforces it. A rule a model has to
+ * remember is a courtesy, and severity is the standing proof that self-assigned
+ * ratings inflate — which is why `exposure` was built as a citation instead.
+ */
+describe('capCleanupSeverity', () => {
+  test('a cleanup above medium is recorded as medium', () => {
+    const issues = capCleanupSeverity([
+      { ...issue, kind: 'cleanup', severity: 'critical' },
+      { ...issue, kind: 'cleanup', severity: 'high' },
+    ])
+    expect(severities(issues)).toEqual(['medium', 'medium'])
+  })
+
+  test('a cleanup at or below medium is left alone', () => {
+    const issues = capCleanupSeverity([
+      { ...issue, kind: 'cleanup', severity: 'medium' },
+      { ...issue, kind: 'cleanup', severity: 'low' },
+    ])
+    expect(severities(issues)).toEqual(['medium', 'low'])
+  })
+
+  test('a defect keeps its severity at every level', () => {
+    const issues = capCleanupSeverity([
+      { ...issue, severity: 'critical' },
+      { ...issue, severity: 'high' },
+      { ...issue, severity: 'medium' },
+      { ...issue, severity: 'low' },
+    ])
+    expect(severities(issues)).toEqual(['critical', 'high', 'medium', 'low'])
+  })
+
+  test('leaves every other field untouched and does not mutate its input', () => {
+    const original: ReviewerIssue = { ...issue, kind: 'cleanup', severity: 'critical' }
+    const out = capCleanupSeverity([original])
+    expect(original.severity).toBe('critical')
+    expect(out[0]).toEqual({ ...original, severity: 'medium' })
+  })
+
+  test('a round with no cleanups passes through unchanged', () => {
+    const input = [issue]
+    expect(capCleanupSeverity(input)).toEqual(input)
+  })
+})

--- a/tests/review-loop/summary-burndown.test.ts
+++ b/tests/review-loop/summary-burndown.test.ts
@@ -29,7 +29,11 @@ function zeroMetric(round: number): RoundMetric {
     reviewerExposure: { caller: 0, none: 0, unknown: 0 },
     fixerExposure: { caller: 0, none: 0, unknown: 0 },
     exposureDivergent: 0,
-    checkBehind: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+    reviewerKind: { defect: 0, cleanup: 0 },
+    checkBehind: {
+      defect: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+      cleanup: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+    },
     phaseMs: { review: 0, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 },
     usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0 },
   }

--- a/tests/review-loop/summary.test.ts
+++ b/tests/review-loop/summary.test.ts
@@ -71,7 +71,11 @@ function zeroMetric(round: number): RoundMetric {
     reviewerExposure: { caller: 0, none: 0, unknown: 0 },
     fixerExposure: { caller: 0, none: 0, unknown: 0 },
     exposureDivergent: 0,
-    checkBehind: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+    reviewerKind: { defect: 0, cleanup: 0 },
+    checkBehind: {
+      defect: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+      cleanup: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+    },
     phaseMs: { review: 0, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 },
     usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0 },
   }
@@ -519,30 +523,94 @@ describe('check-behind line', () => {
   test('reports how many accepted fixes left a check behind', () => {
     const summary = buildSummary({
       ...inputOf({}),
-      metrics: [{ ...zeroMetric(1), checkBehind: { withCheck: 2, withoutCheck: 1, unmeasured: 0 } }],
+      metrics: [
+        {
+          ...zeroMetric(1),
+          checkBehind: {
+            defect: { withCheck: 2, withoutCheck: 1, unmeasured: 0 },
+            cleanup: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+          },
+        },
+      ],
     })
     // Whole line, not a prefix: a prefix assertion passes even when the empty
     // no-unmeasured tail is replaced with arbitrary text.
-    expect(lineStartingWith(summary, 'Checks left behind:')).toBe('Checks left behind: 2 of 3 accepted fixes')
+    expect(lineStartingWith(summary, 'Checks left behind:')).toBe('Checks left behind: 2 of 3 accepted defect fixes')
   })
 
   test('calls out unmeasured fixes rather than folding them into either answer', () => {
     const summary = buildSummary({
       ...inputOf({}),
-      metrics: [{ ...zeroMetric(1), checkBehind: { withCheck: 1, withoutCheck: 0, unmeasured: 2 } }],
+      metrics: [
+        {
+          ...zeroMetric(1),
+          checkBehind: {
+            defect: { withCheck: 1, withoutCheck: 0, unmeasured: 2 },
+            cleanup: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+          },
+        },
+      ],
     })
-    expect(summary).toContain('Checks left behind: 1 of 1 accepted fixes (2 unmeasured)')
+    expect(summary).toContain('Checks left behind: 1 of 1 accepted defect fixes (2 unmeasured)')
   })
 
   test('is still reported when the measured and unmeasured counts happen to be equal', () => {
     const summary = buildSummary({
       ...inputOf({}),
-      metrics: [{ ...zeroMetric(1), checkBehind: { withCheck: 1, withoutCheck: 0, unmeasured: 1 } }],
+      metrics: [
+        {
+          ...zeroMetric(1),
+          checkBehind: {
+            defect: { withCheck: 1, withoutCheck: 0, unmeasured: 1 },
+            cleanup: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+          },
+        },
+      ],
     })
-    expect(summary).toContain('Checks left behind: 1 of 1 accepted fixes (1 unmeasured)')
+    expect(summary).toContain('Checks left behind: 1 of 1 accepted defect fixes (1 unmeasured)')
   })
 
   test('is omitted when no fix was accepted', () => {
     expect(buildSummary(inputOf({ metrics: [zeroMetric(1)] }))).not.toContain('Checks left behind')
+  })
+})
+
+describe('per-kind reporting', () => {
+  const zero = { withCheck: 0, withoutCheck: 0, unmeasured: 0 }
+
+  test('reports the findings split once a cleanup is reported', () => {
+    const summary = buildSummary({
+      ...inputOf({}),
+      metrics: [{ ...zeroMetric(1), reviewerKind: { defect: 4, cleanup: 2 } }],
+    })
+    expect(lineStartingWith(summary, 'Findings:')).toBe('Findings: 4 defect, 2 cleanup')
+  })
+
+  test('omits the findings line entirely when no cleanup was reported', () => {
+    // A run that admits no cleanups must read exactly as it did before they
+    // were admitted — a "0 cleanup" line on every run is noise.
+    const summary = buildSummary({
+      ...inputOf({}),
+      metrics: [{ ...zeroMetric(1), reviewerKind: { defect: 4, cleanup: 0 } }],
+    })
+    expect(lineStartingWith(summary, 'Findings:')).toBeUndefined()
+  })
+
+  test('a cleanup fix that left no check does not depress the defect ratio', () => {
+    const summary = buildSummary({
+      ...inputOf({}),
+      metrics: [
+        {
+          ...zeroMetric(1),
+          checkBehind: {
+            defect: { withCheck: 2, withoutCheck: 0, unmeasured: 0 },
+            cleanup: { ...zero, withoutCheck: 3 },
+          },
+        },
+      ],
+    })
+    expect(lineStartingWith(summary, 'Checks left behind:')).toBe(
+      'Checks left behind: 2 of 2 accepted defect fixes; 3 cleanup fixes not counted',
+    )
   })
 })

--- a/tests/review-loop/summary.test.ts
+++ b/tests/review-loop/summary.test.ts
@@ -12,6 +12,7 @@ import type { RoundMetric } from '../../review-loop/src/trace-log.js'
 
 const issueFixture: ReviewerIssue = {
   title: 'Token refresh race on 401',
+  kind: 'defect',
   severity: 'high',
   summary: 's',
   whyItMatters: 'w',

--- a/tests/review-loop/trace-log.test.ts
+++ b/tests/review-loop/trace-log.test.ts
@@ -15,6 +15,8 @@ import {
   createCapturingTraceLogger,
   emptyDecisions,
   emptySeverityCounts,
+  CheckBehindByKindSchema,
+  KindCountsSchema,
 } from '../../review-loop/src/trace-log.js'
 import { cleanupTempDirs, makeTempDir } from './test-helpers.js'
 
@@ -218,5 +220,32 @@ describe('extended schemas', () => {
       reasoning: 'ok',
     })
     expect(parsed.event).toBe('inspect_complete')
+  })
+})
+
+describe('per-kind schemas reject a partial shape', () => {
+  const counts = { withCheck: 1, withoutCheck: 0, unmeasured: 0 }
+
+  // These schemas are the only thing standing between a hand-edited or
+  // half-written metrics.json and a summary that reports confident nonsense.
+  // Asserting only that a well-formed payload parses leaves that unproven: an
+  // object schema with its fields dropped still accepts every good input, and
+  // silently accepts every bad one too.
+  test('CheckBehindByKindSchema requires both kinds, each a full count', () => {
+    expect(CheckBehindByKindSchema.parse({ defect: counts, cleanup: counts })).toEqual({
+      defect: counts,
+      cleanup: counts,
+    })
+    expect(() => CheckBehindByKindSchema.parse({})).toThrow()
+    expect(() => CheckBehindByKindSchema.parse({ defect: counts })).toThrow()
+    expect(() => CheckBehindByKindSchema.parse({ defect: counts, cleanup: { withCheck: 1 } })).toThrow()
+  })
+
+  test('KindCountsSchema requires both counts, non-negative integers', () => {
+    expect(KindCountsSchema.parse({ defect: 2, cleanup: 0 })).toEqual({ defect: 2, cleanup: 0 })
+    expect(() => KindCountsSchema.parse({})).toThrow()
+    expect(() => KindCountsSchema.parse({ defect: 2 })).toThrow()
+    expect(() => KindCountsSchema.parse({ defect: -1, cleanup: 0 })).toThrow()
+    expect(() => KindCountsSchema.parse({ defect: 1.5, cleanup: 0 })).toThrow()
   })
 })

--- a/tests/review-loop/trace-log.test.ts
+++ b/tests/review-loop/trace-log.test.ts
@@ -110,7 +110,11 @@ describe('trace-log', () => {
         reviewerExposure: { caller: 0, none: 0, unknown: 0 },
         fixerExposure: { caller: 0, none: 0, unknown: 0 },
         exposureDivergent: 0,
-        checkBehind: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+        reviewerKind: { defect: 0, cleanup: 0 },
+        checkBehind: {
+          defect: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+          cleanup: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+        },
         phaseMs: { review: 0, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 },
         usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0 },
       },
@@ -134,7 +138,11 @@ describe('trace-log', () => {
       reviewerExposure: { caller: 0, none: 0, unknown: 0 },
       fixerExposure: { caller: 0, none: 0, unknown: 0 },
       exposureDivergent: 0,
-      checkBehind: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+      reviewerKind: { defect: 0, cleanup: 0 },
+      checkBehind: {
+        defect: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+        cleanup: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+      },
       phaseMs: { review: 0, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 },
       usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0 },
     }
@@ -185,7 +193,11 @@ describe('extended schemas', () => {
       reviewerExposure: { caller: 0, none: 0, unknown: 0 },
       fixerExposure: { caller: 0, none: 0, unknown: 0 },
       exposureDivergent: 0,
-      checkBehind: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+      reviewerKind: { defect: 0, cleanup: 0 },
+      checkBehind: {
+        defect: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+        cleanup: { withCheck: 0, withoutCheck: 0, unmeasured: 0 },
+      },
       phaseMs: { review: 0, match: 0, verify: 0, build: 0, inspect: 0, fix: 0 },
       usage: { inputTokens: 0, outputTokens: 0, reasoningTokens: 0, costUsd: 0 },
     })


### PR DESCRIPTION
This PR implements four coordinated changes to the review loop, mutation runner, and agent infrastructure:

## Summary

Extends the review loop to report over-engineering findings alongside defects, without letting cleanups displace defect fixes. Removes two mandated documents from the mutation runner that nothing verifies. Carries the minimality rule to every agent that writes production code. Adds a necessity question to proposal drafting rules.

## Key Changes

**Review Loop: Cleanup Findings**
- Added `kind: 'defect' | 'cleanup'` field to `ReviewerIssue`, defaulting to `'defect'` for backward compatibility with existing ledgers
- Defined five bounded cleanup kinds: `delete`, `stdlib`, `native`, `yagni`, `shrink`
- Implemented `capCleanupSeverity()` to cap cleanup severity at `'medium'`, ensuring defects always outrank cleanups in ordering
- Updated `orderByExposure()` to sort by kind first (defects before cleanups), then by exposure rank
- Split `checkBehind` metrics by kind to avoid cleanups (which introduce no logic) depressing defect check-behind ratios
- Added `reviewerKind` tally to round metrics to track cleanup vs defect admission

**Mutation Runner: Remove Mandated Documents**
- Made `specPath` and `planPath` optional in `ResultSchema` (previously required)
- Removed `date` parameter from `buildImprovePrompt()` — no longer needed for document generation
- Updated `finalize.ts` to render accepted residuals and their reasoning directly in the PR table instead of linking to two documents
- Preserved backward compatibility: runs started before this change still load with the optional fields

**Minimality Rule: Cross-Workspace Consistency**
- Exported `MINIMALITY_LADDER` from `review-loop/src/prompt-templates.ts` (was module-private)
- Created `MINIMALITY_RULE` constant in `opencode-agent/src/prompts.ts` with identical text
- Added test `tests/opencode-agent/minimality-rule.test.ts` asserting both constants are equal
- Updated `IMPLEMENT_INSTRUCTIONS` and `CI_FIX_INSTRUCTIONS` to carry the rule verbatim
- Updated `review-loop/CLAUDE.md` to document the shared rule and its three carriers

**OpenSpec: Scope Minimality Rule**
- Added `rules.proposal` entry to `openspec/config.yaml` requiring every capability to state the concrete consequence of omitting it
- Documented in `docs/architecture/sdd-pipeline.md` that admission rules (proposal necessity) and division rules (task atomicity) answer different questions and do not contradict

## Implementation Details

- Ledger backward compatibility: issues without `kind` parse as `'defect'`, and fixer results cannot change a recorded kind
- Metrics split: `CheckBehindCounts` now has shape `{ defect: {...}, cleanup: {...} }` to keep defect check-behind ratio meaningful
- Ordering: `orderByExposure()` uses `kindRank()` (defect=1, cleanup=2) as primary sort key, exposure rank as secondary
- Document removal: `specPath` and `planPath` remain in the schema but are optional; old runs with both fields still load and round-trip correctly
- Rule assertion: `tests/opencode-agent/instructions.test.ts` verifies every instruction carrier `toContain(MINIMALITY_RULE)`, so a softened copy fails the test

## Testing

- Added `tests/review-loop/review-round.test.ts` for cleanup severity capping
- Extended `tests/review-loop/issue-processor.test.ts` with kind-ordering scenarios
- Updated all test fixtures to include `kind: 'defect'` on `ReviewerIssue` objects
- Added `tests/opencode-agent/minimality-rule.test.ts` for cross-workspace rule equality
- Updated mutation runner tests to accept results without document paths

https://claude.ai/code/session_01TSM9AQb4yM4WWBJL96BSwJ