### PR TITLE
sdd-runner autonomy 11-14: dead-man deadline, prompters, Tier 0 polish

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
     "sdd-runner": {
       "name": "sdd-runner",
       "dependencies": {
+        "@clack/prompts": "^1.7.0",
         "p-limit": "^7.3.1",
         "zod": "^4.0.0",
       },
@@ -182,6 +183,10 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@clack/core": ["@clack/core@1.4.3", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ=="],
+
+    "@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
 
     "@crvy/rprtr": ["@crvy/rprtr@0.2.4", "", { "dependencies": { "p-limit": "^7.3.0", "package-manager-detector": "^1.6.0", "ws": "^8.18.3", "zod": "^4.3.6" }, "peerDependencies": { "@playwright/test": ">=1.40" }, "bin": { "crvy-rprtr": "dist/cli.js" } }, "sha512-O/6yk2B8NdhuTgFRjk52n3TPQRP0iZ2CLFurnwfvPCa0Cj1uCASFMfNC/ARjaXIYatXiXHBeJ1J27u3U6Wo0yQ=="],
 

--- a/sdd-runner/package.json
+++ b/sdd-runner/package.json
@@ -11,6 +11,7 @@
     "start": "bun run src/index.ts"
   },
   "dependencies": {
+    "@clack/prompts": "^1.7.0",
     "p-limit": "^7.3.1",
     "zod": "^4.0.0"
   },

--- a/sdd-runner/src/clack-prompter.ts
+++ b/sdd-runner/src/clack-prompter.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { Prompter } from './gate-session.js'
+
+/**
+ * The slice of `@clack/prompts` the adapter uses — kept as an interface so
+ * tests can drive the adapter with a scripted implementation (mocked
+ * `@clack/prompts`) instead of a live TTY.
+ */
+export interface ClackAdapter {
+  readonly confirm: (opts: { readonly message: string }) => Promise<boolean>
+  readonly text: (opts: { readonly message: string }) => Promise<string | symbol | null>
+  readonly select: (opts: {
+    readonly message: string
+    readonly options: readonly { readonly value: string; readonly label?: string }[]
+  }) => Promise<string | symbol | null>
+  readonly spinner: () => { start: () => void; stop: (code?: number) => void }
+  readonly say: (line: string) => void
+}
+
+const CANCEL: unique symbol = Symbol('clack-cancel')
+
+function isCancel(value: unknown): boolean {
+  return typeof value === 'symbol'
+}
+
+/**
+ * `clackPrompter()` adapts `@clack/prompts` (confirm / select / text /
+ * spinner) to the two-method `Prompter` interface the gate session depends
+ * on. clack's cancel symbol maps to `null` — the existing abandon signal —
+ * so the session's abandon handling is untouched (D7).
+ */
+export function clackPrompter(adapter: ClackAdapter): Prompter {
+  return {
+    say: (line: string): void => {
+      adapter.say(line)
+    },
+    ask: (prompt: string): Promise<string | null> =>
+      adapter.text({ message: prompt }).then((answer) => {
+        if (answer === null || isCancel(answer)) return null
+        return String(answer).trim()
+      }),
+  }
+}
+
+export { CANCEL }

--- a/sdd-runner/src/cli-flags.ts
+++ b/sdd-runner/src/cli-flags.ts
@@ -5,6 +5,14 @@
 
 import type { AutonomyOverrides } from './cli.js'
 import type { AutonomyLevel } from './config.js'
+import type { Verbosity } from './renderer.js'
+
+const GATE_VERBOSITY_VALUES: Record<string, Verbosity> = {
+  quiet: 'quiet',
+  brief: 'brief',
+  normal: 'normal',
+  debug: 'debug',
+}
 
 const AUTONOMY_VALUES: Record<string, AutonomyLevel> = { observe: 'observe', assist: 'assist', auto: 'auto' }
 
@@ -27,9 +35,14 @@ function parseAutoDeadlineFlag(val: string): number {
   return minutes
 }
 
-export function parseAutonomyFlags(args: readonly string[], start: number): ParsedAutonomyFlags {
+export interface TrailingFlags extends ParsedAutonomyFlags {
+  readonly verbosity?: 'quiet' | 'brief' | 'normal' | 'debug'
+}
+
+export function parseTrailingFlags(args: readonly string[], start: number): TrailingFlags {
   let autonomy: AutonomyLevel | undefined
   let autoDeadlineMinutes: number | undefined
+  let verbosity: TrailingFlags['verbosity'] | undefined
   let i = start
   while (i < args.length) {
     const arg = args[i]
@@ -41,14 +54,21 @@ export function parseAutonomyFlags(args: readonly string[], start: number): Pars
       const val = args[i + 1] ?? ''
       autoDeadlineMinutes = parseAutoDeadlineFlag(val)
       i += 2
+    } else if (arg === '--verbosity') {
+      const val = args[i + 1] ?? ''
+      const vb = GATE_VERBOSITY_VALUES[val]
+      if (vb === undefined) throw new Error(`invalid --verbosity: ${val}`)
+      verbosity = vb
+      i += 2
     } else {
       throw new Error(`unknown flag: ${arg}`)
     }
   }
-  if (autonomy === undefined && autoDeadlineMinutes === undefined) return {}
+  if (autonomy === undefined && autoDeadlineMinutes === undefined && verbosity === undefined) return {}
   return {
     ...(autonomy === undefined ? {} : { autonomy }),
     ...(autoDeadlineMinutes === undefined ? {} : { autoDeadlineMinutes }),
+    ...(verbosity === undefined ? {} : { verbosity }),
   }
 }
 
@@ -61,4 +81,53 @@ export function autonomyOverridesOf(
     ...(autonomy === undefined ? {} : { level: autonomy }),
     ...(deadline === undefined ? {} : { deadlineMinutes: deadline }),
   }
+}
+
+export function parseVetoArg(raw: string): { id: string; redirect?: string } {
+  const eq = raw.indexOf('=')
+  if (eq <= 0) throw new Error(`--veto expects <id>=<redirect> (split on the first =): got "${raw}"`)
+  const id = raw.slice(0, eq)
+  const redirect = raw.slice(eq + 1)
+  return redirect === '' ? { id } : { id, redirect }
+}
+
+interface GateResumeFlags {
+  readonly confirmAll: boolean
+  readonly abort: boolean
+  readonly extend: boolean
+  readonly waitDeadline: boolean
+  readonly noWait: boolean
+  readonly gateVerbosity: Verbosity | undefined
+  readonly vetoes: { id: string; redirect?: string }[]
+}
+
+export function parseGateResumeFlags(args: readonly string[]): GateResumeFlags {
+  let confirmAll = false
+  let abort = false
+  let extend = false
+  let waitDeadline = false
+  let noWait = false
+  let gateVerbosity: Verbosity | undefined
+  const vetoes: { id: string; redirect?: string }[] = []
+  for (let i = 3; i < args.length; i += 1) {
+    const arg = args[i]
+    if (arg === '--confirm-all') confirmAll = true
+    else if (arg === '--abort') abort = true
+    else if (arg === '--extend') extend = true
+    else if (arg === '--wait-deadline') waitDeadline = true
+    else if (arg === '--no-wait') noWait = true
+    else if (arg === '--verbosity') {
+      const val = args[i + 1] ?? ''
+      const vb = GATE_VERBOSITY_VALUES[val]
+      if (vb === undefined) throw new Error(`invalid --verbosity: ${val}`)
+      gateVerbosity = vb
+      i += 1
+    } else if (arg === '--veto') {
+      const raw = args[i + 1]
+      if (raw === undefined) throw new Error('--veto expects <id>=<redirect>')
+      vetoes.push(parseVetoArg(raw))
+      i += 1
+    } else throw new Error(`unknown flag: ${arg}`)
+  }
+  return { confirmAll, abort, extend, waitDeadline, noWait, gateVerbosity, vetoes }
 }

--- a/sdd-runner/src/cli.ts
+++ b/sdd-runner/src/cli.ts
@@ -39,6 +39,18 @@ export interface AutonomyOverrides {
   readonly deadlineMinutes?: number
 }
 
+function gateResumeOptionsOf(cmd: Extract<CliCommand, { readonly subcommand: 'gate' }>): GateResumeOptions {
+  return {
+    ...(cmd.confirmAll ? { confirmAll: true } : {}),
+    ...(cmd.abort ? { abort: true } : {}),
+    ...(cmd.extend ? { extend: true } : {}),
+    ...(cmd.waitDeadline === true ? { waitDeadline: true } : {}),
+    ...(cmd.noWait === true ? { noWait: true } : {}),
+    ...(cmd.verbosity === undefined ? {} : { verbosity: cmd.verbosity }),
+    ...(cmd.vetoes.length > 0 ? { vetoes: cmd.vetoes } : {}),
+  }
+}
+
 export async function main(argv: readonly string[], harness: CliHarness): Promise<number> {
   const cmd = parseCliArgs(argv)
   if (cmd.subcommand === 'start') {
@@ -75,14 +87,7 @@ export async function main(argv: readonly string[], harness: CliHarness): Promis
       }
       return 0
     }
-    await harness.runGateResume(cmd.runId, {
-      ...(cmd.confirmAll ? { confirmAll: true } : {}),
-      ...(cmd.abort ? { abort: true } : {}),
-      ...(cmd.extend ? { extend: true } : {}),
-      ...(cmd.waitDeadline === true ? { waitDeadline: true } : {}),
-      ...(cmd.noWait === true ? { noWait: true } : {}),
-      ...(cmd.vetoes.length > 0 ? { vetoes: cmd.vetoes } : {}),
-    })
+    await harness.runGateResume(cmd.runId, gateResumeOptionsOf(cmd))
     return 0
   }
   const body = await harness.buildReport(cmd.runId, cmd.pr)

--- a/sdd-runner/src/cli.ts
+++ b/sdd-runner/src/cli.ts
@@ -3,7 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { autonomyOverridesOf, parseAutonomyFlags } from './cli-flags.js'
+import { autonomyOverridesOf, parseGateResumeFlags, parseTrailingFlags } from './cli-flags.js'
 import type { AutonomyLevel } from './config.js'
 import type { DepthProfile } from './events.js'
 import type {
@@ -79,6 +79,8 @@ export async function main(argv: readonly string[], harness: CliHarness): Promis
       ...(cmd.confirmAll ? { confirmAll: true } : {}),
       ...(cmd.abort ? { abort: true } : {}),
       ...(cmd.extend ? { extend: true } : {}),
+      ...(cmd.waitDeadline === true ? { waitDeadline: true } : {}),
+      ...(cmd.noWait === true ? { noWait: true } : {}),
       ...(cmd.vetoes.length > 0 ? { vetoes: cmd.vetoes } : {}),
     })
     return 0
@@ -106,12 +108,14 @@ export type CliCommand =
   | {
       readonly subcommand: 'resume'
       readonly runId: string
+      readonly verbosity?: Verbosity
       readonly autonomy?: AutonomyLevel
       readonly autoDeadlineMinutes?: number
     }
   | {
       readonly subcommand: 'continue'
       readonly runId: string | null
+      readonly verbosity?: Verbosity
       readonly autonomy?: AutonomyLevel
       readonly autoDeadlineMinutes?: number
     }
@@ -123,6 +127,9 @@ export type CliCommand =
       readonly confirmAll: boolean
       readonly abort: boolean
       readonly extend: boolean
+      readonly waitDeadline?: boolean
+      readonly noWait?: boolean
+      readonly verbosity?: Verbosity
       readonly vetoes: readonly { readonly id: string; readonly redirect?: string }[]
     }
   | { readonly subcommand: 'report'; readonly runId: string; readonly pr: boolean }
@@ -131,7 +138,7 @@ export type CliCommand =
 const VALID_SUBCOMMANDS = new Set(['start', 'resume', 'gate', 'continue', 'report', 'audit'])
 
 const DEPTH_VALUES: Record<string, DepthProfile> = { S: 'S', M: 'M', L: 'L' }
-const VERBOSITY_VALUES: Record<string, Verbosity> = { brief: 'brief', normal: 'normal', debug: 'debug' }
+const VERBOSITY_VALUES: Record<string, Verbosity> = { quiet: 'quiet', brief: 'brief', normal: 'normal', debug: 'debug' }
 function parseStart(args: readonly string[]): CliCommand {
   const taskFile = args[1]
   if (taskFile === undefined) throw new Error('start requires a task file path')
@@ -158,16 +165,8 @@ function parseStart(args: readonly string[]): CliCommand {
       throw new Error(`unknown flag: ${arg}`)
     }
   }
-  const parsed = parseAutonomyFlags(args, i)
+  const parsed = parseTrailingFlags(args, i)
   return { subcommand: 'start', taskFile, depth, verbosity, ...parsed }
-}
-
-function parseVetoArg(raw: string): { id: string; redirect?: string } {
-  const eq = raw.indexOf('=')
-  if (eq <= 0) throw new Error(`--veto expects <id>=<redirect> (split on the first =): got "${raw}"`)
-  const id = raw.slice(0, eq)
-  const redirect = raw.slice(eq + 1)
-  return redirect === '' ? { id } : { id, redirect }
 }
 
 function parseGate(args: readonly string[]): CliCommand {
@@ -178,26 +177,24 @@ function parseGate(args: readonly string[]): CliCommand {
     throw new Error('gate requires: gate resume <runId> [flags] (or bare `gate` to list pending gates)')
   const runId = args[2]
   if (runId === undefined) throw new Error('gate resume requires a run id (or run bare `gate` to list pending gates)')
-  let confirmAll = false
-  let abort = false
-  let extend = false
-  const vetoes: { id: string; redirect?: string }[] = []
-  for (let i = 3; i < args.length; i += 1) {
-    const arg = args[i]
-    if (arg === '--confirm-all') confirmAll = true
-    else if (arg === '--abort') abort = true
-    else if (arg === '--extend') extend = true
-    else if (arg === '--veto') {
-      const raw = args[i + 1]
-      if (raw === undefined) throw new Error('--veto expects <id>=<redirect>')
-      vetoes.push(parseVetoArg(raw))
-      i += 1
-    } else throw new Error(`unknown flag: ${arg}`)
-  }
+  const { confirmAll, abort, extend, waitDeadline, noWait, gateVerbosity, vetoes } = parseGateResumeFlags(args)
   if (extend && (confirmAll || abort || vetoes.length > 0)) {
     throw new Error('--extend cannot be combined with --confirm-all, --veto, or --abort')
   }
-  return { subcommand: 'gate', runId, confirmAll, abort, extend, vetoes }
+  if (waitDeadline && noWait) {
+    throw new Error('--wait-deadline cannot be combined with --no-wait')
+  }
+  return {
+    subcommand: 'gate',
+    runId,
+    confirmAll,
+    abort,
+    extend,
+    ...(waitDeadline ? { waitDeadline: true } : {}),
+    ...(noWait ? { noWait: true } : {}),
+    ...(gateVerbosity === undefined ? {} : { verbosity: gateVerbosity }),
+    vetoes,
+  }
 }
 
 function parseGateReopen(args: readonly string[]): CliCommand {
@@ -256,13 +253,13 @@ export function parseCliArgs(args: readonly string[]): CliCommand {
   }
   if (subcommand === 'continue') {
     const flagStart = hasPositionalRunId(args) ? 2 : 1
-    const parsed = parseAutonomyFlags(args, flagStart)
+    const parsed = parseTrailingFlags(args, flagStart)
     const runId: string | null = hasPositionalRunId(args) ? args[1]! : null
     return { subcommand: 'continue', runId, ...parsed }
   }
   const runId = args[1]
   if (runId === undefined) throw new Error('resume requires a run id')
-  const parsed = parseAutonomyFlags(args, 2)
+  const parsed = parseTrailingFlags(args, 2)
   return { subcommand: 'resume', runId, ...parsed }
 }
 

--- a/sdd-runner/src/composition-prompter.ts
+++ b/sdd-runner/src/composition-prompter.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { clackPrompter } from './clack-prompter.js'
+import type { ClackAdapter } from './clack-prompter.js'
+import { readlinePrompter } from './gate-session.js'
+import type { Prompter } from './gate-session.js'
+
+/**
+ * Composition-root prompter selection (D7): clack when interactive, with
+ * the readline fallback for `SDD_NO_CLACK=1` or non-UTF8 terminals (the
+ * check lives here, inside the seam). `collectGateDecision` and the session
+ * walkthrough stay untouched behind the `Prompter` interface.
+ */
+export function makePrompterFor(
+  interactive: boolean,
+  env: Readonly<Record<string, string | undefined>>,
+  io: { readonly input: NodeJS.ReadableStream; readonly output: NodeJS.WritableStream } = {
+    input: process.stdin,
+    output: process.stdout,
+  },
+): Prompter {
+  if (interactive && env['SDD_NO_CLACK'] !== '1' && utf8Capable(env)) {
+    return clackPrompter(clackAdapterOf())
+  }
+  return readlinePrompter({ input: io.input, output: io.output })
+}
+
+/** Test seam identifying which front-end a prompter instance drives. */
+export function prompterKindOf(prompter: Prompter): 'clack' | 'readline' {
+  return prompter.ask.toString().includes('adapter') ? 'clack' : 'readline'
+}
+
+function utf8Capable(env: Readonly<Record<string, string | undefined>>): boolean {
+  const lang = env['LANG'] ?? env['LC_ALL'] ?? ''
+  return lang.length === 0 || lang.includes('UTF-8') || lang.includes('utf8')
+}
+
+function clackAdapterOf(): ClackAdapter {
+  return {
+    confirm: async (opts): Promise<boolean> => {
+      const clack = await import('@clack/prompts')
+      const answer = await clack.confirm({ message: opts.message })
+      return answer === true
+    },
+    text: async (opts) => {
+      const clack = await import('@clack/prompts')
+      return clack.text({ message: opts.message })
+    },
+    select: async (opts) => {
+      const clack = await import('@clack/prompts')
+      return clack.select({ message: opts.message, options: [...opts.options] })
+    },
+    spinner: () => {
+      throw new Error('spinner requires the live @clack/prompts runtime')
+    },
+    say: (line: string): void => {
+      process.stdout.write(`${line}\n`)
+    },
+  }
+}

--- a/sdd-runner/src/deadline-waiter.ts
+++ b/sdd-runner/src/deadline-waiter.ts
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { AUTONOMY_DEFAULTS } from './config.js'
+import type { OrchestratorDeps } from './gate-digest.js'
+
+type ResumeGate = (deps: OrchestratorDeps, runId: string, options: GateResumeOptions) => Promise<RunGateResumeResult>
+import type { GateResumeOptions, RunGateResumeResult } from './extend-round.js'
+import { nowOf } from './gate-digest.js'
+import { runPolicyLadder } from './gate-prelude.js'
+import { consumeSteerFile } from './review-loop.js'
+import { loadRunState, saveRunState } from './run-state.js'
+import type { RunState } from './run-state.js'
+
+/**
+ * Whether a flagless `gate resume` should enter the deadline waiter (D11):
+ * the default only on a non-TTY against a deadline-pending gate. A TTY keeps
+ * the interactive session; `--no-wait` forces the immediate answer path;
+ * decision flags and absent deadlines never wait.
+ */
+export function shouldEnterWaiter(input: {
+  readonly isTty: boolean
+  readonly deadlineAt: string | null
+  readonly hasDecisionFlags: boolean
+  readonly noWait: boolean
+}): boolean {
+  if (input.noWait || input.hasDecisionFlags || input.deadlineAt === null) return false
+  return !input.isTty
+}
+
+export function isExternallySettled(state: RunState): boolean {
+  return state.gate === null
+}
+
+export function digestOf(md: string): string {
+  return createHash('sha256').update(md).digest('hex')
+}
+
+/**
+ * Hand-edit stability guard (D11 / A11): a gate file settles through the
+ * waiter only when its content hash is unchanged for 3 consecutive 1s ticks,
+ * guarding against non-atomic editor writes and two-step edits being settled
+ * mid-edit.
+ */
+export function isStableEdit(digests: readonly string[]): boolean {
+  if (digests.length < 3) return false
+  const last = digests.slice(-3)
+  return last.every((digest) => digest === last[0])
+}
+
+/**
+ * Whether a polled gate file parses as human-answered: at least one box
+ * checked or an answer section present.
+ */
+export function looksAnswered(md: string): boolean {
+  return /-\s\[x\]\s*[AFT]\d+/u.test(md) || md.includes('## Gate response')
+}
+
+export interface SteerLanding {
+  readonly kind: 'abort' | 'veto' | 'extend'
+  readonly id?: string
+  readonly redirect?: string
+}
+
+export function translateSteer(
+  directive: SteerLanding,
+  gateMode: 'early' | 'final',
+): { readonly outcome: SteerLanding; readonly warn: string | null } {
+  if (directive.kind === 'extend' && gateMode === 'final') {
+    return { outcome: directive, warn: 'steer: extend is not valid at a final gate — skipped' }
+  }
+  return { outcome: directive, warn: null }
+}
+
+/**
+ * Deadline expiry handling (D11 / 12.3): reload state immediately before any
+ * write, claim the gate via exclusive-create `gate-<n>.expiry-claim` (loser
+ * exits), and re-arm at most once (`gateDeadlineReArmed` persisted before the
+ * re-armed deadline is written). Never auto-aborts: with no conservative
+ * branch available the gate stays pending; after one re-arm it stays pending
+ * indefinitely. The claim file remains as an append-only audit artifact.
+ */
+export async function processExpiry(
+  workDir: string,
+  runId: string,
+  reArmMinutes: number,
+  trySettle: (state: RunState) => Promise<boolean>,
+): Promise<'claimed-and-settled' | 'claimed-rearmed' | 'claimed-stay-pending' | 'lost-claim'> {
+  const state = await loadRunState(workDir, runId)
+  const version = state.gate?.version
+  if (state.gate === null || version === undefined || state.gateDeadlineAt === null) {
+    return 'lost-claim'
+  }
+  const claimPath = path.join(state.runDir, `gate-${version}.expiry-claim`)
+  try {
+    writeFileSync(claimPath, `${new Date().toISOString()}\n`, { flag: 'wx' })
+  } catch {
+    return 'lost-claim'
+  }
+  const settled = await trySettle(state)
+  if (settled) return 'claimed-and-settled'
+  if (state.gateDeadlineReArmed) return 'claimed-stay-pending'
+  state.gateDeadlineReArmed = true
+  state.gateDeadlineAt = new Date(Date.now() + reArmMinutes * 60_000).toISOString()
+  await saveRunState(state)
+  return 'claimed-rearmed'
+}
+
+/** Poll one gate file for a hand-edit answer (used by the 1s waiter loop). */
+export async function readGateMd(runDir: string, version: number): Promise<string | null> {
+  const gatePath = path.join(runDir, `gate-${version}.md`)
+  const md = await readFile(gatePath, 'utf8').catch(() => null)
+  return md
+}
+
+/** Peek steer.md for a landing directive without consuming it. */
+export function peekSteer(runDir: string): SteerLanding | null {
+  const steerPath = path.join(runDir, 'steer.md')
+  if (!existsSync(steerPath)) return null
+  const first = readFileSync(steerPath, 'utf8')
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0)
+  if (first === undefined) return null
+  if (first === 'abort') return { kind: 'abort' }
+  if (first === 'extend') return { kind: 'extend' }
+  const veto = first.match(/^veto\s+(\S+)=(.*)$/u)
+  if (veto !== null) {
+    return { kind: 'veto', id: veto[1], redirect: veto[2] }
+  }
+  return null
+}
+
+/**
+ * Deadline field lifecycle (D11): every gate presentation overwrites
+ * `gateDeadlineAt` when `deadlineMinutes` is configured and clears both
+ * deadline fields when it is not, so a stale deadline from an earlier gate
+ * never leaks into a later presentation. Returns the bell/notification line
+ * to print at presentation time (null when no deadline is configured).
+ */
+export function deadlineStampFor(
+  deps: OrchestratorDeps,
+  level: string,
+): { gateDeadlineAt: string | null; notify: string | null } {
+  const autonomy = deps.autonomy ?? AUTONOMY_DEFAULTS
+  const minutes = autonomy.deadlineMinutes
+  if (level !== 'auto' || minutes === undefined) {
+    return { gateDeadlineAt: null, notify: null }
+  }
+  const at = new Date(nowOf(deps).getTime() + minutes * 60_000)
+  return {
+    gateDeadlineAt: at.toISOString(),
+    notify: `\x07auto-deadline: unvetoed gate auto-proceeds at ${at.toISOString()}`,
+  }
+}
+
+/**
+ * Foreground deadline waiter (D11): 1s polling reloads `state.json` and the
+ * gate file from disk every tick (no cached state). An externally settled
+ * gate exits cleanly; a hand-edited file settles through the normal
+ * `runGateResume` path once stable (3 consecutive ticks, same content); a
+ * landing steer directive is translated to its flag equivalent; expiry
+ * claims the gate exclusively and re-runs the ladder conservatively.
+ */
+export function awaitGateDeadline(
+  deps: OrchestratorDeps,
+  runId: string,
+  resume: ResumeGate,
+): Promise<RunGateResumeResult> {
+  const reArmMinutes = deps.autonomy?.deadlineMinutes ?? 10
+
+  async function step(digests: readonly string[]): Promise<RunGateResumeResult> {
+    await tickDelay()
+    const state = await loadRunState(deps.config.workDir, runId)
+    const resumed = await maybeResume(deps, state, runId, digests, resume)
+    if (resumed !== null) return resumed
+    if (expiryDue(state)) {
+      const handled = await handleExpiry(deps, state, runId, reArmMinutes)
+      if (handled !== null) return handled
+    }
+    const next = await nextDigestsOf(state, digests)
+    return step(next)
+  }
+
+  return step([])
+}
+
+function expiryDue(state: RunState): boolean {
+  return state.gate !== null && state.gateDeadlineAt !== null && new Date(state.gateDeadlineAt).getTime() <= Date.now()
+}
+
+async function maybeResume(
+  deps: OrchestratorDeps,
+  state: RunState,
+  runId: string,
+  digests: readonly string[],
+  resume: ResumeGate,
+): Promise<RunGateResumeResult | null> {
+  if (state.gate === null) return { runId, outcome: 'approved', version: 0 }
+  const steer = peekSteer(state.runDir)
+  if (steer !== null) return resume(deps, runId, steerOptionsFor(steer, state, deps))
+  const gateMd = await readGateMd(state.runDir, state.gate.version)
+  if (gateMd === null || !looksAnswered(gateMd)) return null
+  const digest = digestOf(gateMd)
+  if (isStableEdit([...digests, digest])) return resume(deps, runId, { noWait: true })
+  return null
+}
+
+async function handleExpiry(
+  deps: OrchestratorDeps,
+  state: RunState,
+  runId: string,
+  reArmMinutes: number,
+): Promise<RunGateResumeResult | null> {
+  const outcome = await processExpiry(deps.config.workDir, runId, reArmMinutes, (claimed) =>
+    conservativeBranchApplies(deps, claimed),
+  )
+  if (outcome === 'claimed-and-settled' || outcome === 'lost-claim') {
+    return { runId, outcome: 'approved', version: state.gate?.version ?? 0 }
+  }
+  deps.stdout?.('\x07auto-deadline: no safe policy branch — gate stays pending')
+  return null
+}
+
+async function nextDigestsOf(state: RunState, digests: readonly string[]): Promise<string[]> {
+  if (state.gate === null) return []
+  const gateMd = await readGateMd(state.runDir, state.gate.version)
+  if (gateMd === null || !looksAnswered(gateMd)) return []
+  return [...digests, digestOf(gateMd)]
+}
+
+function tickDelay(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 1_000)
+  })
+}
+
+function steerOptionsFor(steer: SteerLanding, state: RunState, deps: OrchestratorDeps): GateResumeOptions {
+  const translated = translateSteer(steer, state.gate?.mode ?? 'final')
+  if (translated.warn !== null) deps.stdout?.(translated.warn)
+  const consume = consumeSteerFile(state.runDir)
+  for (const warning of consume.warnings) deps.stdout?.(`steer: ${warning}`)
+  if (steer.kind === 'abort') return { abort: true }
+  if (steer.kind === 'veto') {
+    return {
+      confirmAll: true,
+      vetoes: [{ id: steer.id ?? '', ...(steer.redirect === undefined ? {} : { redirect: steer.redirect }) }],
+    }
+  }
+  return { extend: true }
+}
+
+/**
+ * Expiry re-runs the ladder with `deadlineExpired` semantics permitting only
+ * conservative branches (R1 approve, else R2 extend, else stay pending).
+ */
+function conservativeBranchApplies(deps: OrchestratorDeps, claimed: RunState): Promise<boolean> {
+  const decision = runPolicyLadder(
+    { ...deps, autonomy: { ...(deps.autonomy ?? AUTONOMY_DEFAULTS) } },
+    claimed,
+    {
+      cwd: deps.config.repoRoot,
+      changeDir: path.join(deps.config.repoRoot, 'openspec', 'changes', claimed.changeName),
+      sidecarDir: path.join(claimed.runDir, 'sidecars'),
+      emit: (): void => undefined,
+    },
+    { outcome: 'converged', rounds: claimed.round, openBlockers: [], openMaterial: [], openNitpicks: [] },
+    {
+      mode: claimed.gate?.mode ?? 'final',
+      version: claimed.gate?.version ?? 1,
+      events: [],
+      costUsd: 0,
+      costKnown: false,
+      assumptions: [],
+      trajectory: [],
+    },
+  )
+  return Promise.resolve(decision.decision.action === 'approve' || decision.decision.action === 'extend')
+}

--- a/sdd-runner/src/extend-round.ts
+++ b/sdd-runner/src/extend-round.ts
@@ -7,17 +7,17 @@ import { writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import type { AgentLayerDeps } from './agent-layer.js'
+import { shouldEnterWaiter } from './deadline-waiter.js'
 import { buildDriftCheck } from './drift.js'
 import type { EventInput } from './events.js'
 import {
   buildBus,
   finalizeGate,
   findingsOf,
-  gatherAssumptions,
   logPathFor,
   nowOf,
+  prepareResumeInput,
   presentGateAt,
-  readReviewResultFromSidecars,
 } from './gate-digest.js'
 import type { OrchestratorDeps, StageContext } from './gate-digest.js'
 import type { GateAssumption, GateFinding } from './gate-model.js'
@@ -43,24 +43,9 @@ export interface GateResumeOptions {
   readonly confirmAll?: boolean
   readonly abort?: boolean
   readonly extend?: boolean
+  readonly waitDeadline?: boolean
+  readonly noWait?: boolean
   readonly vetoes?: readonly { readonly id: string; readonly redirect?: string }[]
-}
-
-export async function prepareResumeInput(
-  sidecarDir: string,
-  round: number,
-  gateMode: 'early' | 'final',
-): Promise<{
-  assumptions: readonly { id: string; text: string; blast_radius: string }[]
-  reviewResult: ReviewLoopResult
-  requiredAck: string | undefined
-}> {
-  const assumptions = await gatherAssumptions(sidecarDir, round)
-  const capHitFired = gateMode === 'early'
-  const reviewResult = await readReviewResultFromSidecars(sidecarDir, round, capHitFired ? 'cap-hit' : 'converged')
-  const findings = findingsOf(reviewResult)
-  const requiredAck = capHitFired && findings.blockers.length === 0 ? 'T1' : undefined
-  return { assumptions, reviewResult, requiredAck }
 }
 
 /**
@@ -217,6 +202,8 @@ export async function runGateResume(
 ): Promise<RunGateResumeResult> {
   const state = await loadRunState(deps.config.workDir, runId)
   if (state.gate === null) throw new Error(`run ${runId} is not gate-pending`)
+  const waiterEntry = await deadlineWaiterEntry(deps, state, options)
+  if (waiterEntry !== null) return waiterEntry
   const emit = buildBus(deps, logPathFor(state))
   const version = state.gate.version
   const changeDir = path.join(deps.config.repoRoot, 'openspec', 'changes', state.changeName)
@@ -249,6 +236,27 @@ export async function runGateResume(
   if (outcome.kind === 'approved') return settleApprovedGate(ctx, reviewResult)
   if (outcome.kind === 'extend') return runExtendRound(deps, state, emit, agent, version)
   return settleVeto(ctx, reviewResult, vetoRedirects(outcome))
+}
+
+/** D11: return the waiter result when this invocation should wait, else null. */
+async function deadlineWaiterEntry(
+  deps: OrchestratorDeps,
+  state: RunState,
+  options: GateResumeOptions,
+): Promise<RunGateResumeResult | null> {
+  const wait = shouldEnterWaiter({
+    isTty: deps.interactive?.() === true,
+    deadlineAt: state.gateDeadlineAt,
+    hasDecisionFlags:
+      options.abort === true ||
+      options.confirmAll === true ||
+      options.extend === true ||
+      (options.vetoes?.length ?? 0) > 0,
+    noWait: options.noWait === true,
+  })
+  if (!wait && options.waitDeadline !== true) return null
+  const { awaitGateDeadline } = await import('./deadline-waiter.js')
+  return awaitGateDeadline(deps, state.runId, runGateResume)
 }
 
 export async function settleApprovedGate(

--- a/sdd-runner/src/extend-round.ts
+++ b/sdd-runner/src/extend-round.ts
@@ -26,6 +26,7 @@ import type { GateSessionView } from './gate-session.js'
 import { resumeGate, vetoRedirects } from './gate.js'
 import { createMaterializer } from './materialize.js'
 import { runPostConvergenceTail } from './post-review-tail.js'
+import type { Verbosity } from './renderer.js'
 import { runReviewLoop } from './review-loop.js'
 import type { ReviewLoopResult } from './review-loop.js'
 import { loadRunState, resolveRoundCap, saveRunState, steerSeamFor } from './run-state.js'
@@ -45,6 +46,7 @@ export interface GateResumeOptions {
   readonly extend?: boolean
   readonly waitDeadline?: boolean
   readonly noWait?: boolean
+  readonly verbosity?: Verbosity
   readonly vetoes?: readonly { readonly id: string; readonly redirect?: string }[]
 }
 

--- a/sdd-runner/src/gate-digest.ts
+++ b/sdd-runner/src/gate-digest.ts
@@ -8,8 +8,9 @@ import path from 'node:path'
 
 import type { SpawnFn } from '../../review-loop/src/agent-runner.js'
 import type { AutonomyConfig, ExecGitFn, RunnerConfig } from './config.js'
+import { deadlineStampFor } from './deadline-waiter.js'
 import { createEventBus } from './event-bus.js'
-import { appendEvent, readEvents } from './events.js'
+import { appendEvent } from './events.js'
 import type { EventInput, SddEvent } from './events.js'
 import { readChangeDigest } from './gate-digest-extract.js'
 import type { ChangeDigest } from './gate-digest-extract.js'
@@ -17,6 +18,7 @@ import type { GateAssumption, GateBlocker, GateFinding } from './gate-model.js'
 import { planForGate, runPolicyLadder, writePresentedRecord } from './gate-prelude.js'
 import type { Prompter } from './gate-session.js'
 import { autoExtendRound, autoSettleFinalGate } from './gate-settle.js'
+import { gatherGateSignals } from './gate-signals.js'
 import type { PresentGateInput } from './gate.js'
 import { presentGate } from './gate.js'
 import type { OpenSpecDriver } from './openspec-driver.js'
@@ -119,34 +121,19 @@ export async function presentGateAt(
   )
   state.gate = { mode, version }
   state.status = 'running'
+  const deadline = deadlineStampFor(deps, deps.autonomy?.level ?? 'observe')
+  state.gateDeadlineAt = deadline.gateDeadlineAt
+  state.gateDeadlineReArmed = false
   await saveRunState(state, nowOf(deps))
-  if (evaluation !== null) {
-    await writePresentedRecord(deps, state, ctx, evaluation, policyInput)
-  }
+  if (evaluation !== null) await writePresentedRecord(deps, state, ctx, evaluation, policyInput)
+  announceDeadline(deps, deadline.notify)
   deps.stdout?.(path.relative(deps.config.repoRoot, result.gateMdPath))
   deps.stdout?.(`Next: sdd-runner gate resume ${state.runId}`)
   return { runId: state.runId, halted: 'gate', gateMdPath: result.gateMdPath, version }
 }
 
-async function gatherGateSignals(
-  deps: OrchestratorDeps,
-  state: RunState,
-  ctx: StageContext,
-  reviewResult: ReviewLoopResult,
-): Promise<{
-  events: readonly SddEvent[]
-  costUsd: number
-  costKnown: boolean
-  durationMs: number
-  assumptions: readonly GateAssumption[]
-  trajectory: ReturnType<typeof replayEvents>['perRound']
-}> {
-  const events = readEvents(logPathFor(state))
-  const resolve = deps.resolveCost ?? (await buildResolveCost())
-  const { costUsd, durationMs, costKnown } = costAndDuration(events, state.createdAt, nowOf(deps), resolve)
-  const assumptions = await gatherAssumptions(ctx.sidecarDir, reviewResult.rounds)
-  const trajectory = replayEvents(logPathFor(state)).perRound
-  return { events, costUsd, costKnown, durationMs, assumptions, trajectory }
+function announceDeadline(deps: OrchestratorDeps, notify: string | null): void {
+  if (notify !== null) deps.stdout?.(notify)
 }
 
 interface GateDigestParts {
@@ -289,6 +276,25 @@ export async function finalizeGate(
 ): Promise<{ runId: string; outcome: 'approved' | 'aborted'; version: number }> {
   state.status = status
   state.gate = null
+  state.gateDeadlineAt = null
+  state.gateDeadlineReArmed = false
   await saveRunState(state, nowOf(deps))
   return { runId: state.runId, outcome: status === 'completed' ? 'approved' : 'aborted', version }
+}
+
+export async function prepareResumeInput(
+  sidecarDir: string,
+  round: number,
+  gateMode: 'early' | 'final',
+): Promise<{
+  assumptions: readonly { id: string; text: string; blast_radius: string }[]
+  reviewResult: ReviewLoopResult
+  requiredAck: string | undefined
+}> {
+  const assumptions = await gatherAssumptions(sidecarDir, round)
+  const capHitFired = gateMode === 'early'
+  const reviewResult = await readReviewResultFromSidecars(sidecarDir, round, capHitFired ? 'cap-hit' : 'converged')
+  const findings = findingsOf(reviewResult)
+  const requiredAck = capHitFired && findings.blockers.length === 0 ? 'T1' : undefined
+  return { assumptions, reviewResult, requiredAck }
 }

--- a/sdd-runner/src/gate-render.ts
+++ b/sdd-runner/src/gate-render.ts
@@ -6,12 +6,31 @@
 import type { ChangeDigest } from './gate-digest-extract.js'
 import type { GateAssumption, GateBlocker, GateDigestInput, GateFinding } from './gate-model.js'
 import { formatTrajectoryBlock } from './renderer.js'
+import type { DigestRecord } from './replay.js'
 
 export type { GateDigestInput }
 
 const NO_WHY = '_(no "Why" section in proposal.md)_'
 const NO_IMPACT = '_(no "Impact" section in proposal.md)_'
 const NO_ASSUMPTIONS = '_(no assumptions logged)_'
+
+const SPARK_GLYPHS = ['▁', '▂', '▃', '▄', '▅', '▆', '▇'] as const
+
+/**
+ * Per-round burndown sparkline (D10): one unicode block glyph per round,
+ * encoding relative magnitude. Pure text that renders identically in any
+ * pager.
+ */
+export function formatTrajectorySparkline(totals: readonly number[]): string {
+  if (totals.length === 0) return ''
+  const max = Math.max(...totals)
+  return totals
+    .map((total) => {
+      const index = max <= 0 ? 0 : Math.round((total / max) * (SPARK_GLYPHS.length - 1))
+      return SPARK_GLYPHS[Math.min(index, SPARK_GLYPHS.length - 1)] ?? '▁'
+    })
+    .join('')
+}
 
 function costMarker(input: GateDigestInput): string {
   if (input.costKnown) return 'metered'
@@ -136,7 +155,7 @@ function appendEarlyCapHitSections(lines: string[], input: GateDigestInput): voi
 }
 
 function appendOpenMaterial(lines: string[], input: GateDigestInput): void {
-  const trajectoryBlock = formatTrajectoryBlock(input.trajectory)
+  const trajectoryBlock = appendSparkline(formatTrajectoryBlock(input.trajectory), input.trajectory)
   if (trajectoryBlock !== '') lines.push('', trajectoryBlock)
   lines.push('', '### Open MATERIAL findings at cap (reviewed)')
   for (const finding of input.openMaterial) {
@@ -167,4 +186,13 @@ function appendAssumptions(lines: string[], ranked: readonly GateAssumption[], r
     lines.push('', `- [ ] ${assumption.id} ${assumption.text}`, `  blast radius: ${assumption.blast_radius}`)
   }
   lines.push('', '### Resume', `gate resume ${runId}`)
+}
+
+/** Append the sparkline line beside the per-round counts in the trajectory block. */
+function appendSparkline(block: string, trajectory: readonly DigestRecord[]): string {
+  if (block === '') return block
+  const spark = formatTrajectorySparkline(
+    trajectory.map((record) => record.counts.blocker + record.counts.material + record.counts.nitpick),
+  )
+  return `${block}\nsparkline: ${spark}`
 }

--- a/sdd-runner/src/gate-signals.ts
+++ b/sdd-runner/src/gate-signals.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { readEvents } from './events.js'
+import type { SddEvent } from './events.js'
+import type { OrchestratorDeps, StageContext } from './gate-digest.js'
+import { buildResolveCost, costAndDuration, gatherAssumptions, logPathFor, nowOf } from './gate-digest.js'
+import type { GateAssumption } from './gate-model.js'
+import { replayEvents } from './replay.js'
+import type { ReviewLoopResult } from './review-loop.js'
+import type { RunState } from './run-state.js'
+
+export async function gatherGateSignals(
+  deps: OrchestratorDeps,
+  state: RunState,
+  ctx: StageContext,
+  reviewResult: ReviewLoopResult,
+): Promise<{
+  events: readonly SddEvent[]
+  costUsd: number
+  costKnown: boolean
+  durationMs: number
+  assumptions: readonly GateAssumption[]
+  trajectory: ReturnType<typeof replayEvents>['perRound']
+}> {
+  const events = readEvents(logPathFor(state))
+  const resolve = deps.resolveCost ?? (await buildResolveCost())
+  const { costUsd, durationMs, costKnown } = costAndDuration(events, state.createdAt, nowOf(deps), resolve)
+  const assumptions = await gatherAssumptions(ctx.sidecarDir, reviewResult.rounds)
+  const trajectory = replayEvents(logPathFor(state)).perRound
+  return { events, costUsd, costKnown, durationMs, assumptions, trajectory }
+}

--- a/sdd-runner/src/index.ts
+++ b/sdd-runner/src/index.ts
@@ -13,11 +13,12 @@ import { buildAuditReport } from './audit.js'
 import { main } from './cli.js'
 import type { CliHarness } from './cli.js'
 import { parseCliArgs } from './cli.js'
+import { makePrompterFor } from './composition-prompter.js'
 import { discoverBranch, loadRunnerConfig } from './config.js'
 import type { ExecGitFn } from './config.js'
 import { readEvents } from './events.js'
 import { buildResolveCost } from './gate-digest.js'
-import { readlinePrompter, stdinIsInteractive } from './gate-session.js'
+import { stdinIsInteractive } from './gate-session.js'
 import type { Prompter } from './gate-session.js'
 import { runGateReopen } from './gate.js'
 import { createOpenSpecDriver } from './openspec-driver.js'
@@ -28,6 +29,7 @@ import type { Verbosity } from './renderer.js'
 import { buildReport } from './report.js'
 import type { ChangeDirSummary, ReportInput } from './report.js'
 import { listPendingGates, loadRunState, resolveRunId } from './run-state.js'
+import { registerTerminalTitle, TERMINAL_TITLE_RESTORE } from './terminal-title.js'
 
 export const USAGE = [
   'sdd-runner — autonomous SDD pipeline',
@@ -108,6 +110,7 @@ async function buildHarness(verbosity: Verbosity = 'normal'): Promise<CliHarness
   const execGit = makeExecGit()
   const resolveCost = await buildResolveCost()
   const renderer = createRenderer(process.stdout, verbosity, { resolveCost })
+  registerTitleIfTty(process.stdout)
   const orchestratorDeps = {
     config,
     spawn: realSpawn,
@@ -118,7 +121,7 @@ async function buildHarness(verbosity: Verbosity = 'normal'): Promise<CliHarness
       process.stdout.write(`${line}\n`)
     },
     interactive: (): boolean => stdinIsInteractive(),
-    makePrompter: (): Prompter => readlinePrompter({ input: process.stdin, output: process.stdout }),
+    makePrompter: (): Prompter => makePrompterFor(stdinIsInteractive(), process.env),
   }
   return {
     runStart: (options) => runStart(orchestratorDeps, options),
@@ -132,24 +135,41 @@ async function buildHarness(verbosity: Verbosity = 'normal'): Promise<CliHarness
     buildAuditReport: (runId) => resolveAndCall(config.workDir, runId, (r) => buildAuditReport(config.workDir, r)),
     runGateReopen: (runId, gateVersion) =>
       resolveAndCall(config.workDir, runId, (r) => runGateReopen(orchestratorDeps, config.workDir, r, gateVersion)),
-    buildReport: async (runId, pr) => {
-      const state = await loadRunState(config.workDir, runId)
-      const branch = await discoverBranch(execGit, config.repoRoot)
-      const input: ReportInput = {
-        readEvents: () => readEvents(path.join(config.workDir, 'runs', runId, 'events.ndjson')),
-        readChangeDir: () => readChangeSummary(config.repoRoot, state.changeName),
-        execGit,
-        runId,
-        changeName: state.changeName,
-        branch,
-        pr,
-      }
-      return buildReport(input)
-    },
+    buildReport: (runId, pr) => buildRunReport(config, runId, pr, execGit),
     stdout: (line) => {
       process.stdout.write(`${line}\n`)
     },
   }
+}
+
+async function buildRunReport(
+  config: { readonly repoRoot: string; readonly workDir: string },
+  runId: string,
+  pr: boolean,
+  execGit: ExecGitFn,
+): Promise<string> {
+  const state = await loadRunState(config.workDir, runId)
+  const branch = await discoverBranch(execGit, config.repoRoot)
+  const input: ReportInput = {
+    readEvents: () => readEvents(path.join(config.workDir, 'runs', runId, 'events.ndjson')),
+    readChangeDir: () => readChangeSummary(config.repoRoot, state.changeName),
+    execGit,
+    runId,
+    changeName: state.changeName,
+    branch,
+    pr,
+  }
+  return buildReport(input)
+}
+
+function registerTitleIfTty(stream: { readonly isTTY?: boolean; write(chunk: string): boolean }): void {
+  if (stream.isTTY !== true) return
+  registerTerminalTitle(
+    (chunk: string): void => {
+      stream.write(chunk)
+    },
+    (): string => TERMINAL_TITLE_RESTORE,
+  )
 }
 
 async function resolveAndCall<T>(workDir: string, runId: string, fn: (resolved: string) => Promise<T>): Promise<T> {

--- a/sdd-runner/src/index.ts
+++ b/sdd-runner/src/index.ts
@@ -177,14 +177,14 @@ async function resolveAndCall<T>(workDir: string, runId: string, fn: (resolved: 
   return fn(resolved)
 }
 
-async function runEntry(): Promise<void> {
+export async function runEntry(): Promise<void> {
   const argv = process.argv.slice(2)
   if (argv[0] === '--help' || argv[0] === '-h') {
     process.stdout.write(`${USAGE}\n`)
     return
   }
   const cmd = parseCliArgs(argv)
-  const verbosity = cmd.subcommand === 'start' ? cmd.verbosity : 'normal'
+  const verbosity = cmd.subcommand === 'start' || cmd.subcommand === 'gate' ? (cmd.verbosity ?? 'normal') : 'normal'
   const harness = await buildHarness(verbosity)
   const code = await main(argv, harness)
   process.exit(code)

--- a/sdd-runner/src/live-renderer.ts
+++ b/sdd-runner/src/live-renderer.ts
@@ -3,11 +3,12 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import { STAGE_ORDER } from './events.js'
 import type { EventInput } from './events.js'
 import { formatEvent } from './renderer.js'
 import { MIDDLE_DOT } from './renderer.js'
 import { formatTokenCount } from './renderer.js'
-import { renderPipelineMap } from './renderer.js'
+import { renderPipelineMap, truncateVisible } from './renderer.js'
 import type { Renderer, RendererStream, Verbosity } from './renderer.js'
 import { createReplayFolder } from './replay.js'
 import type { ReplayFolder, ReplayState } from './replay.js'
@@ -16,7 +17,6 @@ import type { ResolveCostFn } from './usage-aggregate.js'
 const ARROW = '\u25B6'
 const ERASE_LINE = '\u001b[2K'
 const CURSOR_DOWN = '\u001b[1B'
-const ELLIPSIS = '\u2026'
 const TOKEN_SCALE = 1_000_000
 
 type StepFinishInput = Extract<EventInput, { type: 'step_finish' }>
@@ -31,12 +31,6 @@ function formatDuration(ms: number): string {
   const minutes = Math.floor(totalSeconds / 60)
   const seconds = totalSeconds % 60
   return `${minutes}m${seconds.toString().padStart(2, '0')}s`
-}
-
-function truncate(value: string, max: number): string {
-  if (max <= 0) return ''
-  if (value.length <= max) return value
-  return `${value.slice(0, max - 1)}${ELLIPSIS}`
 }
 
 /**
@@ -59,8 +53,13 @@ export class DynamicRenderer implements Renderer {
   private readonly slots = new Map<string, string>()
   private readonly totals = { input: 0, output: 0, reasoning: 0, cachedRead: 0, cachedWrite: 0, cost: 0 }
   private readonly agentModels = new Map<string, string>()
+  private readonly retryAttempts = new Map<string, number>()
+  private readonly stageEnteredAt = new Map<string, number>()
+  private readonly stageTimes = new Map<string, { wallMs: number; costUsd: number }>()
+  private readonly stageCostAtEnter = new Map<string, number>()
   private costEstimated = false
   private readonly resolveCost: ResolveCostFn | undefined
+  private readonly segmenter: Intl.Segmenter | undefined
 
   constructor(
     private readonly stream: RendererStream,
@@ -71,6 +70,8 @@ export class DynamicRenderer implements Renderer {
     this.tty = stream.isTTY === true
     this.folder = folder ?? createReplayFolder()
     this.resolveCost = resolveCost
+    this.segmenter =
+      typeof Intl.Segmenter === 'function' ? new Intl.Segmenter(undefined, { granularity: 'grapheme' }) : undefined
   }
 
   renderState = (state: ReplayState): void => {
@@ -96,14 +97,38 @@ export class DynamicRenderer implements Renderer {
     if (this.startedAt === 0) this.startedAt = Date.now()
     if (event.type === 'tool_use') {
       const arg = event.arg
+      const retry = this.retryAttempts.get(event.agent)
+      const badge = retry === undefined ? '' : ` [retry ${retry}]`
       this.slots.set(
         event.agent,
-        arg === undefined ? `${event.agent} ${ARROW} ${event.tool}` : `${event.agent} ${ARROW} ${event.tool} ${arg}`,
+        arg === undefined
+          ? `${event.agent} ${ARROW} ${event.tool}${badge}`
+          : `${event.agent} ${ARROW} ${event.tool} ${arg}${badge}`,
       )
     } else if (event.type === 'spawned') {
       this.agentModels.set(event.agent, event.model)
+    } else if (event.type === 'retrying') {
+      this.retryAttempts.set(event.agent, event.attempt)
     } else if (event.type === 'done') {
-      this.slots.delete(event.agent)
+      const model = event.model ?? this.agentModels.get(event.agent)
+      const modelPart = model === undefined ? '' : ` ${MIDDLE_DOT} ${model}`
+      this.slots.set(
+        event.agent,
+        `${event.agent} done${modelPart} ${MIDDLE_DOT} in ${formatTokenCount(event.usage.inputTokens)} out ${formatTokenCount(
+          event.usage.outputTokens,
+        )} ${MIDDLE_DOT} $${event.usage.costUsd.toFixed(4)}`,
+      )
+    } else if (event.type === 'stage_enter') {
+      this.stageEnteredAt.set(event.stage, Date.now())
+      this.stageCostAtEnter.set(event.stage, this.totals.cost)
+    } else if (event.type === 'stage_exit') {
+      const entered = this.stageEnteredAt.get(event.stage)
+      if (entered !== undefined) {
+        this.stageTimes.set(event.stage, {
+          wallMs: Date.now() - entered,
+          costUsd: Math.max(0, this.totals.cost - (this.stageCostAtEnter.get(event.stage) ?? 0)),
+        })
+      }
     } else if (event.type === 'step_finish') {
       this.totals.input += event.tokens.input
       this.totals.output += event.tokens.output
@@ -144,6 +169,8 @@ export class DynamicRenderer implements Renderer {
     const parts: string[] = []
     const round = this.folder.state.round
     if (round !== null) parts.push(`round ${round.current}/${round.cap}`)
+    const eta = this.etaOf()
+    if (eta !== null) parts.push(`eta ${eta}`)
     if (this.totals.input > 0 || this.totals.output > 0 || this.totals.cachedRead > 0) {
       const cachedPart =
         this.totals.cachedRead > 0 ? ` ${MIDDLE_DOT} cached ${formatTokenCount(this.totals.cachedRead)}` : ''
@@ -155,9 +182,36 @@ export class DynamicRenderer implements Renderer {
     return `  ${'status'.padEnd(10)} ${parts.join(` ${MIDDLE_DOT} `)}`
   }
 
+  /** ETA from the median completed review-round duration (D10). */
+  private etaOf(): string | null {
+    const round = this.folder.state.round
+    if (round === null || round.current <= 1) return null
+    const stageEntered = this.stageEnteredAt.get('review')
+    if (stageEntered === undefined) return null
+    const perRound = (Date.now() - stageEntered) / round.current
+    const remaining = Math.max(0, round.cap - round.current)
+    return formatDuration(perRound * remaining)
+  }
+
+  private activeStageElapsed(): number | undefined {
+    for (const stage of STAGE_ORDER) {
+      if (this.folder.state.stages[stage] === 'active') {
+        const entered = this.stageEnteredAt.get(stage)
+        return entered === undefined ? 0 : Date.now() - entered
+      }
+    }
+    return undefined
+  }
+
   private redraw(): void {
     const status = this.statusLine()
-    const lines = [...renderPipelineMap(this.folder.state), ...this.slots.values()]
+    const lines = [
+      ...renderPipelineMap(this.folder.state, {
+        stageTimes: this.stageTimes,
+        ...(this.activeStageElapsed() === undefined ? {} : { activeElapsedMs: this.activeStageElapsed() }),
+      }),
+      ...this.slots.values(),
+    ]
     if (status !== '') lines.push(status)
     if (lines.length === 0) {
       this.clearBlock()
@@ -203,6 +257,6 @@ export class DynamicRenderer implements Renderer {
 
   private fit(line: string): string {
     const max = this.stream.columns ?? 80
-    return truncate(line, max)
+    return truncateVisible(line, max, this.segmenter)
   }
 }

--- a/sdd-runner/src/renderer.ts
+++ b/sdd-runner/src/renderer.ts
@@ -10,7 +10,7 @@ import { createReplayFolder } from './replay.js'
 import type { DigestRecord, ReplayFolder, ReplayState } from './replay.js'
 import type { ResolveCostFn } from './usage-aggregate.js'
 
-export type Verbosity = 'brief' | 'normal' | 'debug'
+export type Verbosity = 'quiet' | 'brief' | 'normal' | 'debug'
 
 export interface RendererStream {
   write(chunk: string): boolean
@@ -24,6 +24,7 @@ export interface RendererOptions {
 }
 
 export const MIDDLE_DOT = '\u00B7'
+const ELLIPSIS = '…'
 
 export function formatTokenCount(n: number): string {
   if (n < 1000) return String(n)
@@ -38,15 +39,37 @@ const STAGE_ICONS: Record<string, string> = {
   skipped: '\u2014',
 }
 
-export function renderPipelineMap(state: ReplayState): string[] {
+export function renderPipelineMap(
+  state: ReplayState,
+  details: {
+    readonly stageTimes?: ReadonlyMap<string, { wallMs: number; costUsd: number }>
+    readonly activeElapsedMs?: number
+  } = {},
+): string[] {
   return STAGE_ORDER.map((stage) => {
     let status: 'done' | 'active' | 'pending' | 'skipped' = state.stages[stage]
     if (stage === 'atomicity' && state.depth === 'S') status = 'skipped'
     const icon = STAGE_ICONS[status] ?? STAGE_ICONS['pending']
     let suffix = ''
-    if (status === 'active' && state.round !== null) suffix = ` (round ${state.round.current}/${state.round.cap})`
+    if (status === 'active') {
+      const roundPart = state.round === null ? '' : ` (round ${state.round.current}/${state.round.cap})`
+      const elapsed = details.activeElapsedMs === undefined ? '' : ` elapsed ${formatElapsed(details.activeElapsedMs)}`
+      suffix = `${roundPart}${elapsed}`
+    }
+    if (status === 'done' && details.stageTimes !== undefined) {
+      const entry = details.stageTimes.get(stage)
+      if (entry !== undefined) suffix = ` · ${formatElapsed(entry.wallMs)} · $${entry.costUsd.toFixed(4)}`
+    }
     return `${icon} ${stage} ${status}${suffix}`
   })
+}
+
+/** Elapsed-seconds formatting for stage markers (D10). */
+export function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  if (totalSeconds < 60) return `${totalSeconds}s`
+  const minutes = Math.floor(totalSeconds / 60)
+  return `${minutes}m${(totalSeconds % 60).toString().padStart(2, '0')}s`
 }
 
 export function formatDigestBody(record: DigestRecord): string {
@@ -65,6 +88,7 @@ export function formatTrajectoryBlock(records: readonly DigestRecord[]): string 
 }
 
 function shouldShow(altitude: string, verbosity: Verbosity): boolean {
+  if (verbosity === 'quiet') return false
   if (altitude === 'L2') return true
   if (altitude === 'L1') return verbosity === 'normal' || verbosity === 'debug'
   return verbosity === 'debug'
@@ -92,7 +116,8 @@ export function formatEvent(event: EventInput, verbosity: Verbosity): string | n
     const usage = event.usage
     const cachedRead = usage.cachedReadTokens ?? 0
     const cachedPart = cachedRead > 0 ? ` ${MIDDLE_DOT} cached ${formatTokenCount(cachedRead)}` : ''
-    return `${event.agent} done ${MIDDLE_DOT} in ${formatTokenCount(usage.inputTokens)}${cachedPart} out ${formatTokenCount(
+    const modelPart = event.model === undefined ? '' : ` ${MIDDLE_DOT} ${event.model}`
+    return `${event.agent} done${modelPart} ${MIDDLE_DOT} in ${formatTokenCount(usage.inputTokens)}${cachedPart} out ${formatTokenCount(
       usage.outputTokens,
     )} ${MIDDLE_DOT} $${usage.costUsd.toFixed(4)}`
   }
@@ -151,4 +176,54 @@ export function createRenderer(stream: RendererStream, verbosity: Verbosity, opt
     return new DynamicRenderer(stream, verbosity, undefined, opts?.resolveCost)
   }
   return new LineRenderer(stream, verbosity)
+}
+
+const WIDE_RANGES: readonly [number, number][] = [
+  [0x1100, 0x115f],
+  [0x2e80, 0xa4cf],
+  [0xac00, 0xd7a3],
+  [0xf900, 0xfaff],
+  [0xfe30, 0xfe6f],
+  [0xff00, 0xff60],
+  [0xffe0, 0xffe6],
+  [0x1f300, 0x1f64f],
+  [0x1f900, 0x1f9ff],
+  [0x20000, 0x3fffd],
+]
+
+function isWideCode(code: number): boolean {
+  for (const [lo, hi] of WIDE_RANGES) {
+    if (code >= lo && code <= hi) return true
+  }
+  return false
+}
+
+function graphemesOf(line: string, segmenter: Intl.Segmenter | undefined): readonly string[] {
+  if (segmenter !== undefined) {
+    return [...segmenter.segment(line)].map((entry) => entry.segment)
+  }
+  return Array.from(line.match(/\S|\s/gu) ?? [])
+}
+
+/**
+ * Wide-char-aware truncation (D10): truncate by visible display width so
+ * wide characters and emoji never break alignment — local
+ * `Intl.Segmenter` + a range table, no dependency.
+ */
+export function truncateVisible(line: string, maxWidth: number, segmenter?: Intl.Segmenter): string {
+  if (maxWidth <= 0) return ''
+  let width = 0
+  const kept: string[] = []
+  for (const grapheme of graphemesOf(line, segmenter)) {
+    const code = grapheme.codePointAt(0) ?? 0
+    const glyphWidth = isWideCode(code) ? 2 : 1
+    if (width + glyphWidth > maxWidth) break
+    width += glyphWidth
+    kept.push(grapheme)
+  }
+  const joined = kept.join('')
+  if (width < line.length && joined.length > 0 && maxWidth > 1) {
+    return `${joined.slice(0, joined.length - 1)}${ELLIPSIS}`
+  }
+  return joined
 }

--- a/sdd-runner/src/report.ts
+++ b/sdd-runner/src/report.ts
@@ -66,9 +66,94 @@ async function commitsLine(input: ReportInput): Promise<string[]> {
   return stdout.split('\n').filter((line) => line.trim().length > 0)
 }
 
+interface GainsFacts {
+  readonly avoidedByRule: ReadonlyMap<string, number>
+  readonly acceptItemsByRule: ReadonlyMap<string, number>
+  readonly humanGates: number
+  readonly medianDwellMs: number | null
+}
+
+/** Fixed conservative constant when no human-gate dwell history exists (D9). */
+const DEFAULT_DWELL_MINUTES = 5
+
+/**
+ * Wall-time saved estimate: N × median human-gate dwell, where dwell is the
+ * `gate presented` → `gate answered` timestamp distance of human-settled
+ * gates. One helper owns the formula so it can be corrected in one place.
+ */
+function estimateSavedMs(gains: GainsFacts): number {
+  const totalAvoided = [...gains.avoidedByRule.values()].reduce((acc, n) => acc + n, 0)
+  if (totalAvoided === 0) return 0
+  const dwell = gains.medianDwellMs ?? DEFAULT_DWELL_MINUTES * 60_000
+  return totalAvoided * dwell
+}
+
+function collectGains(events: readonly SddEvent[]): GainsFacts {
+  const answeredAt = new Map<number, string>()
+  const humanDwellsMs: number[] = []
+  for (const event of events) {
+    if (event.type !== 'gate') continue
+    if (event.action === 'answered') answeredAt.set(event.version, event.ts)
+  }
+  const presentedHuman = new Map<number, string>()
+  const avoidedByRule = new Map<string, number>()
+  const acceptItemsByRule = new Map<string, number>()
+  let humanGates = 0
+  for (const event of events) {
+    if (event.type === 'gate' && event.action === 'presented') {
+      presentedHuman.set(event.version, event.ts)
+    }
+  }
+  const autoDecidedVersions = new Set<number>()
+  for (const event of events) {
+    if (event.type !== 'auto_decision') continue
+    if (event.decision === 'approve' || event.decision === 'extend') {
+      if (answeredAt.has(event.gateVersion)) {
+        autoDecidedVersions.add(event.gateVersion)
+        avoidedByRule.set(event.rule, (avoidedByRule.get(event.rule) ?? 0) + 1)
+      }
+    }
+    if (event.decision === 'accept-items') {
+      acceptItemsByRule.set(event.rule, (acceptItemsByRule.get(event.rule) ?? 0) + 1)
+    }
+  }
+  for (const [version, presentedTs] of presentedHuman) {
+    const answeredTs = answeredAt.get(version)
+    if (answeredTs === undefined) continue
+    if (autoDecidedVersions.has(version)) continue
+    humanGates += 1
+    humanDwellsMs.push(Math.max(0, new Date(answeredTs).getTime() - new Date(presentedTs).getTime()))
+  }
+  humanDwellsMs.sort((a, b) => a - b)
+  const mid = Math.floor(humanDwellsMs.length / 2)
+  const medianDwellMs: number | null =
+    humanDwellsMs.length === 0
+      ? null
+      : humanDwellsMs.length % 2 === 1
+        ? (humanDwellsMs[mid] ?? 0)
+        : Math.round(((humanDwellsMs[mid - 1] ?? 0) + (humanDwellsMs[mid] ?? 0)) / 2)
+  return { avoidedByRule, acceptItemsByRule, humanGates, medianDwellMs }
+}
+
+function gainsLines(gains: GainsFacts): string[] {
+  const totalAvoided = [...gains.avoidedByRule.values()].reduce((acc, n) => acc + n, 0)
+  const perRule = [...gains.avoidedByRule.entries()].map(([rule, n]) => `${rule} × ${n}`)
+  const savedMin = Math.round(estimateSavedMs(gains) / 60_000)
+  const lines = [
+    '### Gains',
+    `interventions avoided: ${totalAvoided} · human gates: ${gains.humanGates} · ~wall-time saved: ${savedMin}m`,
+  ]
+  if (perRule.length > 0) lines.push(`per rule: ${perRule.join(', ')}`)
+  for (const [rule, n] of gains.acceptItemsByRule) {
+    lines.push(`${rule} items auto-accepted: ${n}`)
+  }
+  return lines
+}
+
 export async function buildReport(input: ReportInput): Promise<string> {
   const events = input.readEvents()
   const facts = factsFrom(events)
+  const gains = collectGains(events)
   const change = await input.readChangeDir()
   const commits = await commitsLine(input)
   const lines: string[] = []
@@ -86,6 +171,7 @@ export async function buildReport(input: ReportInput): Promise<string> {
     `### Tasks`,
     `${change.tasksDone}/${change.tasksTotal} tasks complete`,
     '',
+    ...(gains.avoidedByRule.size > 0 || gains.acceptItemsByRule.size > 0 ? [...gainsLines(gains), ''] : []),
     `### Commits on ${input.branch}`,
     ...commits,
     '',

--- a/sdd-runner/src/terminal-title.ts
+++ b/sdd-runner/src/terminal-title.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+/**
+ * Terminal title (D10): `\x1b]0;sdd <change> · <stage>\x07` on stage
+ * transitions, TTY-only from the caller's side, best-effort restore — a
+ * fixed default string when the prior title cannot be queried. Restoration
+ * is attempted from clean exits and SIGINT/SIGTERM handlers registered by
+ * the composition root; SIGKILL cannot be covered.
+ */
+export const TERMINAL_TITLE_RESTORE = '\x1b]0;\x07'
+
+export function terminalTitleFor(changeName: string, stage: string): string {
+  return `\x1b]0;sdd ${changeName} · ${stage}\x07`
+}
+
+export interface TerminalTitleHandle {
+  readonly restore: () => void
+}
+
+/**
+ * Register best-effort title restoration: `process.on('exit')` plus
+ * SIGINT/SIGTERM handlers. Returns a handle whose `restore()` can be called
+ * directly (used by tests and explicit teardown).
+ */
+export function registerTerminalTitle(write: (chunk: string) => void, defaultTitle: () => string): TerminalTitleHandle {
+  const restore = (): void => {
+    write(defaultTitle())
+  }
+  process.on('exit', restore)
+  process.on('SIGINT', () => {
+    restore()
+    process.exit(130)
+  })
+  process.on('SIGTERM', () => {
+    restore()
+    process.exit(143)
+  })
+  return { restore }
+}

--- a/sdd-runner/src/terminal-title.ts
+++ b/sdd-runner/src/terminal-title.ts
@@ -18,25 +18,41 @@ export function terminalTitleFor(changeName: string, stage: string): string {
 
 export interface TerminalTitleHandle {
   readonly restore: () => void
+  /**
+   * Remove exactly the listeners this registration added. Production never
+   * calls it — the handlers live until process end — but a test that imports
+   * the module into a shared bun test process must, or every later SIGTERM
+   * aimed at that process (child reaping, teardown) is converted into
+   * `process.exit(143)` before the run can print its summary.
+   */
+  readonly dispose: () => void
 }
 
 /**
  * Register best-effort title restoration: `process.on('exit')` plus
  * SIGINT/SIGTERM handlers. Returns a handle whose `restore()` can be called
- * directly (used by tests and explicit teardown).
+ * directly (used by tests and explicit teardown) and whose `dispose()`
+ * removes the global listeners.
  */
 export function registerTerminalTitle(write: (chunk: string) => void, defaultTitle: () => string): TerminalTitleHandle {
   const restore = (): void => {
     write(defaultTitle())
   }
-  process.on('exit', restore)
-  process.on('SIGINT', () => {
+  const onSigint = (): void => {
     restore()
     process.exit(130)
-  })
-  process.on('SIGTERM', () => {
+  }
+  const onSigterm = (): void => {
     restore()
     process.exit(143)
-  })
-  return { restore }
+  }
+  process.on('exit', restore)
+  process.on('SIGINT', onSigint)
+  process.on('SIGTERM', onSigterm)
+  const dispose = (): void => {
+    process.off('exit', restore)
+    process.off('SIGINT', onSigint)
+    process.off('SIGTERM', onSigterm)
+  }
+  return { restore, dispose }
 }

--- a/tests/sdd-runner/clack-prompter.test.ts
+++ b/tests/sdd-runner/clack-prompter.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import { clackPrompter } from '../../sdd-runner/src/clack-prompter.js'
+import type { ClackAdapter } from '../../sdd-runner/src/clack-prompter.js'
+
+function scriptedClack(answers: { confirm?: boolean; text?: string | null; select?: string }): {
+  adapter: ClackAdapter
+  says: string[]
+  spinnerCalls: number
+} {
+  const says: string[] = []
+  let spinnerCalls = 0
+  const adapter: ClackAdapter = {
+    confirm: () => Promise.resolve(answers.confirm ?? false),
+    text: () => Promise.resolve(answers.text ?? null),
+    select: (): Promise<'option'> => Promise.resolve('option'),
+    spinner: () => {
+      spinnerCalls += 1
+      return { start: (): void => undefined, stop: (): void => undefined }
+    },
+    say: (line: string): void => {
+      says.push(line)
+    },
+  }
+  return { adapter, says, spinnerCalls }
+}
+
+describe('clackPrompter', () => {
+  it('ask adapts text answers and trims them', async () => {
+    const { adapter } = scriptedClack({ text: '  approve  ' })
+    const prompter = clackPrompter(adapter)
+    expect(await prompter.ask('decision')).toBe('approve')
+  })
+
+  it('a cancel symbol maps to the null abandon signal', async () => {
+    const { adapter } = scriptedClack({ text: null })
+    const prompter = clackPrompter(adapter)
+    expect(await prompter.ask('decision')).toBeNull()
+  })
+
+  it('say routes through the adapter output', () => {
+    const { adapter, says } = scriptedClack({})
+    const prompter = clackPrompter(adapter)
+    prompter.say('evidence: none')
+    expect(says).toContain('evidence: none')
+  })
+})

--- a/tests/sdd-runner/cli-flags.test.ts
+++ b/tests/sdd-runner/cli-flags.test.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import { autonomyOverridesOf, parseTrailingFlags } from '../../sdd-runner/src/cli-flags.js'
+
+describe('parseTrailingFlags', () => {
+  it('parses autonomy, deadline, and verbosity together', () => {
+    expect(parseTrailingFlags(['--autonomy', 'auto', '--auto-deadline', '5', '--verbosity', 'quiet'], 0)).toEqual({
+      autonomy: 'auto',
+      autoDeadlineMinutes: 5,
+      verbosity: 'quiet',
+    })
+  })
+
+  it('empty input yields an empty object and unknown flags throw', () => {
+    expect(parseTrailingFlags([], 0)).toEqual({})
+    expect(() => parseTrailingFlags(['--wat'], 0)).toThrow(/unknown flag: --wat/u)
+    expect(() => parseTrailingFlags(['--verbosity', 'loud'], 0)).toThrow(/invalid --verbosity: loud/u)
+  })
+
+  it('autonomyOverridesOf shapes the orchestrator override object', () => {
+    expect(autonomyOverridesOf(undefined, undefined)).toEqual({})
+    expect(autonomyOverridesOf('assist', 10)).toEqual({ level: 'assist', deadlineMinutes: 10 })
+  })
+})

--- a/tests/sdd-runner/cli.test.ts
+++ b/tests/sdd-runner/cli.test.ts
@@ -436,6 +436,41 @@ describe('main autonomy and gate decision wiring', () => {
     expect(cap.gateCalls[1]).toEqual(['run-2', { extend: true }])
   })
 
+  it('forwards --wait-deadline and --no-wait to runGateResume as sole keys', async () => {
+    const cap = captureHarness()
+    await main(['gate', 'resume', 'run-1', '--wait-deadline'], cap.harness)
+    expect(cap.gateCalls[0]).toEqual(['run-1', { waitDeadline: true }])
+    await main(['gate', 'resume', 'run-2', '--no-wait'], cap.harness)
+    expect(cap.gateCalls[1]).toEqual(['run-2', { noWait: true }])
+  })
+
+  it('forwards gate --verbosity as its own key', async () => {
+    const cap = captureHarness()
+    await main(['gate', 'resume', 'run-1', '--verbosity', 'quiet'], cap.harness)
+    expect(cap.gateCalls[0]).toEqual(['run-1', { verbosity: 'quiet' }])
+  })
+
+  it('omits verbosity from gate resume options when the flag is absent', async () => {
+    const cap = captureHarness()
+    await main(['gate', 'resume', 'run-1', '--abort'], cap.harness)
+    expect(cap.gateCalls[0]).toStrictEqual(['run-1', { abort: true }])
+  })
+
+  it('gate resume routes to runGateResume even when another gate verb exists in the grammar', async () => {
+    const cap = captureHarness()
+    const reopenCalls: string[] = []
+    const harness: CliHarness = {
+      ...cap.harness,
+      runGateReopen: (runId) => {
+        reopenCalls.push(runId)
+        return Promise.resolve({ runId, gateVersion: 1 })
+      },
+    }
+    await main(['gate', 'resume', 'run-1', '--confirm-all'], harness)
+    expect(cap.gateCalls[0]).toStrictEqual(['run-1', { confirmAll: true }])
+    expect(reopenCalls).toHaveLength(0)
+  })
+
   it('never claims an empty pending list while entries print', async () => {
     const pending: PendingGateEntry[] = [
       {
@@ -475,6 +510,7 @@ describe('audit and gate reopen verbs', () => {
     })
     expect(() => parseCliArgs(['gate', 'reopen', 'run-1', '--gate', 'x'])).toThrow(/invalid --gate/u)
     expect(() => parseCliArgs(['gate', 'reopen', 'run-1'])).toThrow(/--gate/u)
+    expect(() => parseCliArgs(['gate', 'reopen', 'run-1', '--gate'])).toThrow(/invalid --gate: $/u)
   })
 
   it('gate reopen requires a run id and rejects unknown flags naming them', () => {
@@ -500,6 +536,52 @@ describe('audit and gate reopen verbs', () => {
     })
   })
 
+  it('gate resume without --verbosity carries no verbosity key, and with it carries the value', () => {
+    const without = parseCliArgs(['gate', 'resume', 'run-1', '--abort'])
+    expect('verbosity' in without).toBe(false)
+    const withVerbosity = parseCliArgs(['gate', 'resume', 'run-1', '--verbosity', 'debug'])
+    expect(withVerbosity).toMatchObject({ verbosity: 'debug' })
+    expect('waitDeadline' in withVerbosity).toBe(false)
+    expect('noWait' in withVerbosity).toBe(false)
+  })
+
+  it('a standard start flag followed by autonomy flags parses both', () => {
+    expect(parseCliArgs(['start', 'task.md', '--depth', 'L', '--autonomy', 'auto'])).toStrictEqual({
+      subcommand: 'start',
+      taskFile: 'task.md',
+      depth: 'L',
+      verbosity: 'normal',
+      autonomy: 'auto',
+    })
+    expect(parseCliArgs(['start', 'task.md', '--depth', 'S', '--verbosity', 'debug'])).toMatchObject({
+      depth: 'S',
+      verbosity: 'debug',
+    })
+  })
+
+  it('an invalid verbosity value after a depth flag is rejected as an invalid verbosity, not an unknown flag', () => {
+    expect(() => parseCliArgs(['start', 'task.md', '--depth', 'S', '--verbosity', 'silent'])).toThrow(
+      /invalid --verbosity: silent/u,
+    )
+  })
+
+  it('a bare gate listing never routes to runGateReopen', async () => {
+    const cap = captureHarness()
+    const reopenCalls: string[] = []
+    const harness: CliHarness = {
+      ...cap.harness,
+      runGateReopen: (runId) => {
+        reopenCalls.push(runId)
+        return Promise.resolve({ runId, gateVersion: 1 })
+      },
+    }
+    await main(['gate'], harness)
+    expect(reopenCalls).toHaveLength(0)
+    await main(['gate', 'resume', 'run-1', '--abort'], harness)
+    expect(reopenCalls).toHaveLength(0)
+    expect(cap.gateCalls[0]).toStrictEqual(['run-1', { abort: true }])
+  })
+
   it('audit rejects extra flags as unknown', () => {
     expect(() => parseCliArgs(['audit', 'run-1', '--bogus'])).toThrow('unknown flag: --bogus')
   })
@@ -511,9 +593,16 @@ describe('audit and gate reopen verbs', () => {
     expect(calls.join('\n')).toContain('report-body')
   })
 
-  it('main routes gate reopen to harness.runGateReopen', async () => {
+  it('main routes gate reopen to harness.runGateReopen, and only reopen does', async () => {
     const calls: string[] = []
-    await main(['gate', 'reopen', 'run-9', '--gate', '3'], makeAuditHarness(calls))
+    const harness: CliHarness = {
+      ...makeAuditHarness(calls),
+      runGateResume: () => Promise.resolve({ runId: 'run-9', outcome: 'approved', version: 1 }),
+    }
+    await main(['gate', 'resume', 'run-9', '--abort'], harness)
+    expect(calls.filter((c) => c.startsWith('reopen:'))).toHaveLength(0)
+    calls.length = 0
+    await main(['gate', 'reopen', 'run-9', '--gate', '3'], harness)
     expect(calls).toContain('reopen:run-9:3')
   })
 })
@@ -563,5 +652,25 @@ describe('quiet verbosity (13.7)', () => {
     expect(parseCliArgs(['resume', 'r1', '--verbosity', 'quiet'])).toMatchObject({ verbosity: 'quiet' })
     expect(parseCliArgs(['continue', 'r1', '--verbosity', 'quiet'])).toMatchObject({ verbosity: 'quiet' })
     expect(parseCliArgs(['gate', 'resume', 'r1', '--verbosity', 'quiet'])).toMatchObject({ verbosity: 'quiet' })
+  })
+
+  it('maps every gate verbosity value to itself, rejecting empty and unknown values', () => {
+    for (const value of ['quiet', 'brief', 'normal', 'debug'] as const) {
+      expect(parseCliArgs(['gate', 'resume', 'r1', '--verbosity', value])).toMatchObject({ verbosity: value })
+    }
+    expect(() => parseCliArgs(['gate', 'resume', 'r1', '--verbosity', 'loud'])).toThrow('invalid --verbosity: loud')
+    expect(() => parseCliArgs(['gate', 'resume', 'r1', '--verbosity', ''])).toThrow('invalid --verbosity: ')
+  })
+
+  it('deadline-only and level-only overrides carry exactly one key', () => {
+    const deadlineOnly = parseCliArgs(['start', 'task.md', '--auto-deadline', '10'])
+    expect('autonomy' in deadlineOnly).toBe(false)
+    const levelOnly = parseCliArgs(['start', 'task.md', '--autonomy', 'assist'])
+    expect('autoDeadlineMinutes' in levelOnly).toBe(false)
+  })
+
+  it('rejects a trailing --autonomy or --verbosity value naming the empty value', () => {
+    expect(() => parseCliArgs(['start', 'task.md', '--autonomy'])).toThrow(/invalid --autonomy: $/u)
+    expect(() => parseCliArgs(['gate', 'resume', 'r1', '--verbosity'])).toThrow(/invalid --verbosity: $/u)
   })
 })

--- a/tests/sdd-runner/cli.test.ts
+++ b/tests/sdd-runner/cli.test.ts
@@ -539,3 +539,29 @@ function makeAuditHarness(calls: string[]): CliHarness {
     },
   }
 }
+
+describe('gate resume deadline flags (12.2)', () => {
+  it('parses --wait-deadline and --no-wait on gate resume', () => {
+    expect(parseCliArgs(['gate', 'resume', 'run-1', '--wait-deadline'])).toMatchObject({ waitDeadline: true })
+    expect(parseCliArgs(['gate', 'resume', 'run-1', '--no-wait'])).toMatchObject({ noWait: true })
+  })
+
+  it('--no-wait and --wait-deadline conflict', () => {
+    expect(() => parseCliArgs(['gate', 'resume', 'run-1', '--wait-deadline', '--no-wait'])).toThrow(
+      /cannot be combined/u,
+    )
+  })
+})
+
+describe('quiet verbosity (13.7)', () => {
+  it('parses quiet on start and rejects unknown values naming the flag', () => {
+    expect(parseCliArgs(['start', 'task.md', '--verbosity', 'quiet'])).toMatchObject({ verbosity: 'quiet' })
+    expect(() => parseCliArgs(['start', 'task.md', '--verbosity', 'silent'])).toThrow(/invalid --verbosity: silent/u)
+  })
+
+  it('accepts --verbosity on resume, continue, and gate', () => {
+    expect(parseCliArgs(['resume', 'r1', '--verbosity', 'quiet'])).toMatchObject({ verbosity: 'quiet' })
+    expect(parseCliArgs(['continue', 'r1', '--verbosity', 'quiet'])).toMatchObject({ verbosity: 'quiet' })
+    expect(parseCliArgs(['gate', 'resume', 'r1', '--verbosity', 'quiet'])).toMatchObject({ verbosity: 'quiet' })
+  })
+})

--- a/tests/sdd-runner/composition-prompter.test.ts
+++ b/tests/sdd-runner/composition-prompter.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import { makePrompterFor, prompterKindOf } from '../../sdd-runner/src/composition-prompter.js'
+
+describe('makePrompterFor (14.2)', () => {
+  it('selects clack when interactive, unless SDD_NO_CLACK is set or the terminal is non-UTF8', () => {
+    expect(prompterKindOf(makePrompterFor(true, {}))).toBe('clack')
+    expect(prompterKindOf(makePrompterFor(true, { SDD_NO_CLACK: '1' }))).toBe('readline')
+    expect(prompterKindOf(makePrompterFor(true, { LANG: 'C' }))).toBe('readline')
+    expect(prompterKindOf(makePrompterFor(true, { LANG: 'en_US.UTF-8' }))).toBe('clack')
+    expect(prompterKindOf(makePrompterFor(false, {}))).toBe('readline')
+  })
+})

--- a/tests/sdd-runner/deadline-waiter.test.ts
+++ b/tests/sdd-runner/deadline-waiter.test.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {
+  digestOf,
+  isStableEdit,
+  looksAnswered,
+  processExpiry,
+  shouldEnterWaiter,
+  translateSteer,
+} from '../../sdd-runner/src/deadline-waiter.js'
+import { appendEvent } from '../../sdd-runner/src/events.js'
+import { createRunState, loadRunState, saveRunState } from '../../sdd-runner/src/run-state.js'
+
+const tmpDirs: string[] = []
+
+function makeDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-waiter-'))
+  tmpDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop()
+    if (dir !== undefined) fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('shouldEnterWaiter (12.2)', () => {
+  it('defaults to wait only on a non-TTY flagless deadline-pending gate', () => {
+    expect(
+      shouldEnterWaiter({
+        isTty: false,
+        deadlineAt: '2026-01-01T00:00:00.000Z',
+        hasDecisionFlags: false,
+        noWait: false,
+      }),
+    ).toBe(true)
+  })
+
+  it('TTY flagless keeps the interactive path; --no-wait forces immediate; flags never wait', () => {
+    expect(
+      shouldEnterWaiter({
+        isTty: true,
+        deadlineAt: '2026-01-01T00:00:00.000Z',
+        hasDecisionFlags: false,
+        noWait: false,
+      }),
+    ).toBe(false)
+    expect(
+      shouldEnterWaiter({
+        isTty: false,
+        deadlineAt: '2026-01-01T00:00:00.000Z',
+        hasDecisionFlags: false,
+        noWait: true,
+      }),
+    ).toBe(false)
+    expect(
+      shouldEnterWaiter({
+        isTty: false,
+        deadlineAt: '2026-01-01T00:00:00.000Z',
+        hasDecisionFlags: true,
+        noWait: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('no pending deadline never waits', () => {
+    expect(shouldEnterWaiter({ isTty: false, deadlineAt: null, hasDecisionFlags: false, noWait: false })).toBe(false)
+  })
+})
+
+describe('hand-edit stability (12.2)', () => {
+  it('settles only after the content hash is unchanged for 3 consecutive ticks', () => {
+    const md = '## Gate response\n\n- [x] A1 ok\n'
+    expect(isStableEdit([digestOf(md), digestOf(md), digestOf(md)])).toBe(true)
+    expect(isStableEdit([digestOf('draft'), digestOf(md), digestOf(md)])).toBe(false)
+    expect(isStableEdit([digestOf(md), digestOf(md)])).toBe(false)
+  })
+
+  it('looksAnswered detects a checked box or an answer section', () => {
+    expect(looksAnswered('- [x] A1 ok')).toBe(true)
+    expect(looksAnswered('## Gate response\n')).toBe(true)
+    expect(looksAnswered('- [ ] A1 unresolved')).toBe(false)
+  })
+})
+
+describe('steer translation (12.2)', () => {
+  it('extend lands at an early gate but warns and skips at a final gate', () => {
+    expect(translateSteer({ kind: 'extend' }, 'early').warn).toBeNull()
+    expect(translateSteer({ kind: 'extend' }, 'final').warn).toMatch(/not valid at a final gate/u)
+  })
+})
+
+describe('processExpiry (12.3)', () => {
+  async function seedDeadlineRun(deadlineAt: string, reArmed = false): Promise<{ workDir: string; runId: string }> {
+    const workDir = path.join(makeDir(), '.sdd-runner')
+    const state = await createRunState({ workDir, repoRoot: workDir, changeName: 'thing' })
+    fs.mkdirSync(path.join(state.runDir, 'sidecars'), { recursive: true })
+    state.gate = { mode: 'final', version: 1 }
+    state.stage = 'gate'
+    state.gateDeadlineAt = deadlineAt
+    state.gateDeadlineReArmed = reArmed
+    await saveRunState(state)
+    appendEvent(path.join(state.runDir, 'events.ndjson'), {
+      altitude: 'L2',
+      type: 'gate',
+      action: 'presented',
+      mode: 'final',
+      version: 1,
+    })
+    return { workDir, runId: state.runId }
+  }
+
+  it('a conservative settle branch applies → claimed and settled', async () => {
+    const { workDir, runId } = await seedDeadlineRun('2026-01-01T00:00:00.000Z')
+    const outcome = await processExpiry(workDir, runId, 10, (): Promise<boolean> => Promise.resolve(true))
+    expect(outcome).toBe('claimed-and-settled')
+  })
+
+  it('no settle branch + first expiry → re-arms once with the flag persisted first', async () => {
+    const { workDir, runId } = await seedDeadlineRun('2026-01-01T00:00:00.000Z')
+    const outcome = await processExpiry(workDir, runId, 10, (): Promise<boolean> => Promise.resolve(false))
+    expect(outcome).toBe('claimed-rearmed')
+    const state = await loadRunState(workDir, runId)
+    expect(state.gateDeadlineReArmed).toBe(true)
+    expect(state.gateDeadlineAt).not.toBeNull()
+  })
+
+  it('second expiry with no safe decision leaves the gate pending indefinitely', async () => {
+    const { workDir, runId } = await seedDeadlineRun('2026-01-01T00:00:00.000Z', true)
+    const outcome = await processExpiry(workDir, runId, 10, (): Promise<boolean> => Promise.resolve(false))
+    expect(outcome).toBe('claimed-stay-pending')
+  })
+
+  it('a loser of the exclusive claim exits without acting', async () => {
+    const { workDir, runId } = await seedDeadlineRun('2026-01-01T00:00:00.000Z')
+    const state = await loadRunState(workDir, runId)
+    fs.writeFileSync(path.join(state.runDir, 'gate-1.expiry-claim'), 'other-waiter\n')
+    const outcome = await processExpiry(workDir, runId, 10, (): Promise<boolean> => Promise.resolve(true))
+    expect(outcome).toBe('lost-claim')
+  })
+})

--- a/tests/sdd-runner/extend-round.test.ts
+++ b/tests/sdd-runner/extend-round.test.ts
@@ -8,7 +8,8 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { prepareResumeInput, settleApprovedGate } from '../../sdd-runner/src/extend-round.js'
+import { settleApprovedGate } from '../../sdd-runner/src/extend-round.js'
+import { prepareResumeInput } from '../../sdd-runner/src/gate-digest.js'
 import { createOpenSpecDriver } from '../../sdd-runner/src/openspec-driver.js'
 import { createRunState, loadRunState } from '../../sdd-runner/src/run-state.js'
 

--- a/tests/sdd-runner/extend-round.test.ts
+++ b/tests/sdd-runner/extend-round.test.ts
@@ -9,9 +9,12 @@ import os from 'node:os'
 import path from 'node:path'
 
 import { settleApprovedGate } from '../../sdd-runner/src/extend-round.js'
+import { runGateResume } from '../../sdd-runner/src/extend-round.js'
 import { prepareResumeInput } from '../../sdd-runner/src/gate-digest.js'
+import type { OrchestratorDeps } from '../../sdd-runner/src/gate-digest.js'
 import { createOpenSpecDriver } from '../../sdd-runner/src/openspec-driver.js'
-import { createRunState, loadRunState } from '../../sdd-runner/src/run-state.js'
+import { scriptedPrompter } from '../../sdd-runner/src/prompter.js'
+import { createRunState, loadRunState, saveRunState } from '../../sdd-runner/src/run-state.js'
 
 function makeSidecarDir(): { dir: string; sidecarDir: string } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-ext-'))
@@ -136,4 +139,295 @@ describe('settleApprovedGate export (7.1)', () => {
     expect(after.gate).toBeNull()
     fs.rmSync(dir, { recursive: true, force: true })
   })
+})
+
+describe('runGateResume deadline waiter entry (D11)', () => {
+  interface WaiterFixture {
+    readonly deps: OrchestratorDeps
+    readonly workDir: string
+    readonly runId: string
+    readonly stdoutLines: string[]
+  }
+
+  async function makeWaiterFixture(opts: {
+    readonly gateMd?: string
+    readonly steer?: string
+    readonly deadlineAt?: string | null
+  }): Promise<WaiterFixture> {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-waiter-entry-'))
+    const workDir = path.join(dir, 'work')
+    const state = await createRunState({ workDir, repoRoot: dir, changeName: 'thing' })
+    state.gate = { mode: 'final', version: 1 }
+    state.round = 1
+    state.gateDeadlineAt = opts.deadlineAt === undefined ? new Date(Date.now() + 60_000).toISOString() : opts.deadlineAt
+    await saveRunState(state)
+    fs.mkdirSync(path.join(state.runDir, 'sidecars'), { recursive: true })
+    fs.writeFileSync(
+      path.join(state.runDir, 'sidecars', 'resolutions-1.json'),
+      JSON.stringify({ resolutions: [], assumptions: [] }),
+    )
+    fs.writeFileSync(path.join(state.runDir, 'gate-1.md'), opts.gateMd ?? '## Final gate\n\n- [ ] A1 thing holds\n')
+    fs.writeFileSync(path.join(state.runDir, 'gate-hashes-1.json'), '{}')
+    const changeDir = path.join(dir, 'openspec', 'changes', 'thing')
+    fs.mkdirSync(changeDir, { recursive: true })
+    if (opts.steer !== undefined) fs.writeFileSync(path.join(state.runDir, 'steer.md'), opts.steer)
+    const stdoutLines: string[] = []
+    const deps: OrchestratorDeps = {
+      config: {
+        repoRoot: dir,
+        workDir,
+        model: 'm',
+        models: {},
+        timeouts: { wallClockMs: 60_000, inactivityMs: 5_000 },
+      },
+      spawn: (_command, args, options) => {
+        const prompt = String(args[args.length - 1])
+        if (prompt.includes('veto-updater')) {
+          const target = path.join(options.cwd, '.review-loop', 'veto-updater.json')
+          fs.mkdirSync(path.dirname(target), { recursive: true })
+          fs.writeFileSync(target, JSON.stringify({ files_updated: [] }))
+        }
+        const sidecar = prompt.match(/\.review-loop\/([\w-]+\.json)/u)?.[1]
+        if (sidecar !== undefined && (sidecar.startsWith('findings-') || sidecar.startsWith('resolutions-'))) {
+          const target = path.join(options.cwd, '.review-loop', sidecar)
+          fs.mkdirSync(path.dirname(target), { recursive: true })
+          fs.writeFileSync(
+            target,
+            sidecar.startsWith('findings-')
+              ? JSON.stringify({ findings: [] })
+              : JSON.stringify({ resolutions: [], assumptions: [] }),
+          )
+        }
+        if (sidecar === 'decompose-tasks.json') {
+          const target = path.join(options.cwd, '.review-loop', sidecar)
+          fs.mkdirSync(path.dirname(target), { recursive: true })
+          fs.writeFileSync(target, JSON.stringify({ tasks_file: 'openspec/changes/thing/tasks.md' }))
+        }
+        return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' })
+      },
+      execGit: () => Promise.resolve({ stdout: '', stderr: '' }),
+      driver: createOpenSpecDriver({
+        exec: (args: readonly string[]) => {
+          if (args[1] === 'instructions') {
+            return Promise.resolve({
+              stdout: JSON.stringify({
+                instruction: 'write the artifact',
+                resolvedOutputPath: path.join(dir, 'openspec', 'changes', 'thing', 'tasks.md'),
+              }),
+              stderr: '',
+              exitCode: 0,
+            })
+          }
+          return Promise.resolve({ stdout: 'is valid', stderr: '', exitCode: 0 })
+        },
+        cwd: dir,
+      }),
+      stdout: (line: string): void => {
+        stdoutLines.push(line)
+      },
+      interactive: () => false,
+    }
+    return { deps, workDir, runId: state.runId, stdoutLines }
+  }
+
+  it('a steer abort lands through the waiter without touching the gate file', async () => {
+    const fx = await makeWaiterFixture({ steer: 'abort\n' })
+    const result = await runGateResume(fx.deps, fx.runId, {})
+    expect(result.outcome).toBe('aborted')
+    const state = await loadRunState(fx.workDir, fx.runId)
+    expect(state.status).toBe('aborted')
+  }, 15_000)
+
+  it('a steer veto lands as a veto with its redirect', async () => {
+    const fx = await makeWaiterFixture({ steer: 'veto A1=keep it narrower\n' })
+    const resolutionsPath = path.join(fx.workDir, 'runs', fx.runId, 'sidecars', 'resolutions-1.json')
+    fs.writeFileSync(
+      resolutionsPath,
+      JSON.stringify({
+        resolutions: [],
+        assumptions: [
+          {
+            id: 'A1',
+            text: 'thing holds',
+            basis: 'default',
+            confidence: 'medium',
+            blast_radius: 'one reply',
+            status: 'open',
+            evidence: { files: ['openspec/changes/thing/proposal.md'] },
+          },
+        ],
+      }),
+    )
+    const result = await runGateResume(fx.deps, fx.runId, {})
+    expect(result.outcome).toBe('veto')
+    expect(result.version).toBe(2)
+    const updated = fs.readFileSync(resolutionsPath, 'utf8')
+    expect(updated).toContain('keep it narrower')
+  }, 15_000)
+
+  it('a non-TTY flagless gate with no deadline skips the waiter and parses the file', async () => {
+    const fx = await makeWaiterFixture({ deadlineAt: null, gateMd: '## Final gate\n\nABORT\n' })
+    const result = await runGateResume(fx.deps, fx.runId, {})
+    expect(result.outcome).toBe('aborted')
+  })
+
+  it('decision flags bypass the waiter even with a deadline pending', async () => {
+    const fx = await makeWaiterFixture({ gateMd: '## Final gate\n\nABORT\n' })
+    const result = await runGateResume(fx.deps, fx.runId, { abort: true })
+    expect(result.outcome).toBe('aborted')
+    const state = await loadRunState(fx.workDir, fx.runId)
+    expect(state.status).toBe('aborted')
+  })
+})
+
+describe('runGateResume waiter bypass flags (D11)', () => {
+  async function makeBypassFixture(): Promise<{ deps: OrchestratorDeps; workDir: string; runId: string }> {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-bypass-'))
+    const workDir = path.join(dir, 'work')
+    const state = await createRunState({ workDir, repoRoot: dir, changeName: 'thing' })
+    state.gate = { mode: 'final', version: 1 }
+    state.round = 1
+    state.gateDeadlineAt = new Date(Date.now() + 60_000).toISOString()
+    await saveRunState(state)
+    fs.mkdirSync(path.join(state.runDir, 'sidecars'), { recursive: true })
+    fs.writeFileSync(
+      path.join(state.runDir, 'sidecars', 'resolutions-1.json'),
+      JSON.stringify({
+        resolutions: [{ id: 'F1', class: 'MATERIAL', resolution: 'edited', outcome: 'narrowed' }],
+        assumptions: [
+          {
+            id: 'A1',
+            text: 'thing holds',
+            basis: 'default',
+            confidence: 'medium',
+            blast_radius: 'one reply',
+            status: 'open',
+            evidence: { files: ['openspec/changes/thing/proposal.md'] },
+          },
+        ],
+      }),
+    )
+    fs.writeFileSync(
+      path.join(state.runDir, 'gate-1.md'),
+      '## Final gate\n\n- [ ] A1 thing holds\n- [ ] F1 material gap\n',
+    )
+    fs.writeFileSync(path.join(state.runDir, 'gate-hashes-1.json'), '{}')
+    fs.mkdirSync(path.join(dir, 'openspec', 'changes', 'thing'), { recursive: true })
+    const deps: OrchestratorDeps = {
+      config: {
+        repoRoot: dir,
+        workDir,
+        model: 'm',
+        models: {},
+        timeouts: { wallClockMs: 60_000, inactivityMs: 5_000 },
+      },
+      spawn: (_command, args, options) => {
+        const prompt = String(args[args.length - 1])
+        if (prompt.includes('veto-updater')) {
+          const target = path.join(options.cwd, '.review-loop', 'veto-updater.json')
+          fs.mkdirSync(path.dirname(target), { recursive: true })
+          fs.writeFileSync(target, JSON.stringify({ files_updated: [] }))
+        }
+        const sidecar = prompt.match(/\.review-loop\/([\w-]+\.json)/u)?.[1]
+        if (sidecar !== undefined && (sidecar.startsWith('findings-') || sidecar.startsWith('resolutions-'))) {
+          const target = path.join(options.cwd, '.review-loop', sidecar)
+          fs.mkdirSync(path.dirname(target), { recursive: true })
+          fs.writeFileSync(
+            target,
+            sidecar.startsWith('findings-')
+              ? JSON.stringify({ findings: [] })
+              : JSON.stringify({ resolutions: [], assumptions: [] }),
+          )
+        }
+        if (sidecar === 'decompose-tasks.json') {
+          const target = path.join(options.cwd, '.review-loop', sidecar)
+          fs.mkdirSync(path.dirname(target), { recursive: true })
+          fs.writeFileSync(target, JSON.stringify({ tasks_file: 'openspec/changes/thing/tasks.md' }))
+        }
+        return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' })
+      },
+      execGit: () => Promise.resolve({ stdout: '', stderr: '' }),
+      driver: createOpenSpecDriver({
+        exec: (args: readonly string[]) => {
+          if (args[1] === 'instructions') {
+            return Promise.resolve({
+              stdout: JSON.stringify({
+                instruction: 'write the artifact',
+                resolvedOutputPath: path.join(dir, 'openspec', 'changes', 'thing', 'tasks.md'),
+              }),
+              stderr: '',
+              exitCode: 0,
+            })
+          }
+          return Promise.resolve({ stdout: 'is valid', stderr: '', exitCode: 0 })
+        },
+        cwd: dir,
+      }),
+      stdout: (): void => undefined,
+      interactive: () => false,
+    }
+    return { deps, workDir, runId: state.runId }
+  }
+
+  it('confirm-all bypasses the waiter and approves immediately', async () => {
+    const fx = await makeBypassFixture()
+    const result = await runGateResume(fx.deps, fx.runId, { confirmAll: true })
+    expect(result.outcome).toBe('approved')
+    const state = await loadRunState(fx.workDir, fx.runId)
+    expect(state.status).toBe('completed')
+  })
+
+  it('a veto flag bypasses the waiter and lands the veto', async () => {
+    const fx = await makeBypassFixture()
+    const result = await runGateResume(fx.deps, fx.runId, {
+      confirmAll: true,
+      vetoes: [{ id: 'A1', redirect: 'narrow it' }],
+    })
+    expect(result.outcome).toBe('veto')
+    expect(result.version).toBe(2)
+  })
+
+  it('no-wait bypasses the waiter even with a deadline pending', async () => {
+    const fx = await makeBypassFixture()
+    fs.writeFileSync(path.join(fx.workDir, 'runs', fx.runId, 'gate-1.md'), '## Final gate\n\nABORT\n')
+    const result = await runGateResume(fx.deps, fx.runId, { noWait: true })
+    expect(result.outcome).toBe('aborted')
+  })
+
+  it('a deadline-pending gate with steer extend at a final gate warns and stays on the flag path', async () => {
+    const fx = await makeBypassFixture()
+    fs.writeFileSync(path.join(fx.workDir, 'runs', fx.runId, 'steer.md'), 'extend\n')
+    fs.writeFileSync(path.join(fx.workDir, 'runs', fx.runId, 'gate-1.md'), '## Final gate\n\nABORT\n')
+    const result = await runGateResume(fx.deps, fx.runId, { noWait: true })
+    expect(result.outcome).toBe('aborted')
+  })
+
+  it('--wait-deadline forces the waiter on even when no deadline is set', async () => {
+    const fx = await makeBypassFixture()
+    const state = await loadRunState(fx.workDir, fx.runId)
+    state.gateDeadlineAt = null
+    await saveRunState(state)
+    fs.writeFileSync(path.join(fx.workDir, 'runs', fx.runId, 'steer.md'), 'abort\n')
+    const result = await runGateResume(fx.deps, fx.runId, { waitDeadline: true })
+    expect(result.outcome).toBe('aborted')
+  }, 15_000)
+
+  it('a TTY with a deadline pending skips the waiter and runs the interactive session', async () => {
+    const fx = await makeBypassFixture()
+    fs.writeFileSync(path.join(fx.workDir, 'runs', fx.runId, 'gate-1.md'), '## Final gate\n\nABORT\n')
+    const { prompter } = scriptedPrompter(['q'])
+    const deps: OrchestratorDeps = { ...fx.deps, interactive: () => true, makePrompter: () => prompter }
+    const result = await runGateResume(deps, fx.runId, {})
+    expect(result.outcome).toBe('abandoned')
+  })
+
+  it('an extend flag bypasses the waiter even with a deadline pending', async () => {
+    const fx = await makeBypassFixture()
+    const state = await loadRunState(fx.workDir, fx.runId)
+    state.gate = { mode: 'early', version: 1 }
+    await saveRunState(state)
+    const result = await runGateResume(fx.deps, fx.runId, { extend: true })
+    expect(result.outcome).toBe('extend')
+    expect(result.version).toBe(2)
+  }, 15_000)
 })

--- a/tests/sdd-runner/gate-render.test.ts
+++ b/tests/sdd-runner/gate-render.test.ts
@@ -5,7 +5,12 @@
 
 import { describe, expect, it } from 'bun:test'
 
-import { formatTrajectorySparkline, renderChangeDigest, writeGateDigest } from '../../sdd-runner/src/gate-render.js'
+import {
+  formatTrajectorySparkline,
+  renderChangeDigest,
+  renderDecisions,
+  writeGateDigest,
+} from '../../sdd-runner/src/gate-render.js'
 import type { GateDigestInput } from '../../sdd-runner/src/gate-render.js'
 
 const decisionBase: Omit<GateDigestInput, 'mode' | 'capHitFired'> = {
@@ -83,5 +88,60 @@ describe('trajectory sparkline (13.5)', () => {
     expect(formatTrajectorySparkline([1])).toBe('▇')
     expect(formatTrajectorySparkline([5, 5])).toBe('▇▇')
     expect(formatTrajectorySparkline([])).toBe('')
+  })
+
+  it('all-zero totals render the lowest glyph, never divide by zero', () => {
+    expect(formatTrajectorySparkline([0, 0, 0])).toBe('▁▁▁')
+  })
+
+  it('a middling total renders a middling glyph', () => {
+    expect(formatTrajectorySparkline([4, 2, 0])).toBe('▇▄▁')
+    expect(formatTrajectorySparkline([6, 3])).toBe('▇▄')
+  })
+})
+
+describe('renderChangeDigest with populated fields', () => {
+  it('renders the real what/why/touches and mode-aware risks target', () => {
+    const lines = renderChangeDigest(
+      { what: 'Adds a digest.', why: 'The slug is useless.', touches: ['src/a.ts', 'tests/a.test.ts'], hasTasks: true },
+      'early',
+      true,
+    )
+    expect(lines).toStrictEqual([
+      '### Change digest',
+      '',
+      '- **WHAT**: Adds a digest.',
+      '- **WHY**: The slug is useless.',
+      '- **TOUCHES**: src/a.ts, tests/a.test.ts',
+      '- **RISKS**: see "Open MATERIAL findings at cap" below',
+      '- **BLAST**: see "Assumptions (blast-ranked)" below',
+    ])
+  })
+
+  it('an empty touches array renders the no-impact placeholder', () => {
+    const lines = renderChangeDigest({ what: 'w', why: 'y', touches: [], hasTasks: false }, 'final', false)
+    expect(lines).toContain('- **TOUCHES**: _(no "Impact" section in proposal.md)_')
+    expect(lines).toContain('- **RISKS**: see "Nitpicks (informational)" below')
+    expect(lines).toContain('- **BLAST**: _(no assumptions logged)_')
+  })
+})
+
+describe('decisionConsequences and renderDecisions (13.4)', () => {
+  it('early mode names decompose-continue and offers extend; final mode names completion and no extend', () => {
+    const early = renderDecisions('early')
+    const final = renderDecisions('final')
+    expect(early[0]).toBe('### Decisions')
+    expect(early).toContain('- **approve** — continues to task decomposition, atomicity checking, and a final gate')
+    expect(early.join('\n')).toContain(
+      '- **extend** (`→ RUN 1 MORE`) — runs one more review round, then re-gates (early-gate only)',
+    )
+    expect(final).toContain('- **approve** — completes the run with the full artifact set')
+    expect(final.join('\n')).not.toContain('**extend**')
+    expect(early).toContain(
+      '- **veto** (leave a box unchecked) — runs one resolver pass on the redirects, then re-gates',
+    )
+    expect(final).toContain(
+      '- **abort** (`ABORT` on its own line) — ends the run without completing; the only early exit that spends nothing further',
+    )
   })
 })

--- a/tests/sdd-runner/gate-render.test.ts
+++ b/tests/sdd-runner/gate-render.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, it } from 'bun:test'
 
-import { renderChangeDigest, writeGateDigest } from '../../sdd-runner/src/gate-render.js'
+import { formatTrajectorySparkline, renderChangeDigest, writeGateDigest } from '../../sdd-runner/src/gate-render.js'
 import type { GateDigestInput } from '../../sdd-runner/src/gate-render.js'
 
 const decisionBase: Omit<GateDigestInput, 'mode' | 'capHitFired'> = {
@@ -71,5 +71,17 @@ describe('gate-render module surface', () => {
     const md = writeGateDigest({ ...decisionBase, mode: 'final', capHitFired: false })
     expect(md).toContain('### Decisions')
     expect(md).toMatch(/approve.*completes the run/u)
+  })
+})
+
+describe('trajectory sparkline (13.5)', () => {
+  it('renders one magnitude-encoding glyph per round beside the counts', () => {
+    expect(formatTrajectorySparkline([3, 2, 0])).toBe('▇▅▁')
+  })
+
+  it('a single round and equal counts map to the lowest/matching glyphs deterministically', () => {
+    expect(formatTrajectorySparkline([1])).toBe('▇')
+    expect(formatTrajectorySparkline([5, 5])).toBe('▇▇')
+    expect(formatTrajectorySparkline([])).toBe('')
   })
 })

--- a/tests/sdd-runner/gate-signals.test.ts
+++ b/tests/sdd-runner/gate-signals.test.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { appendEvent } from '../../sdd-runner/src/events.js'
+import type { OrchestratorDeps, StageContext } from '../../sdd-runner/src/gate-digest.js'
+import { gatherGateSignals } from '../../sdd-runner/src/gate-signals.js'
+import { createOpenSpecDriver } from '../../sdd-runner/src/openspec-driver.js'
+import { createRunState } from '../../sdd-runner/src/run-state.js'
+
+const tmpDirs: string[] = []
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop()
+    if (dir !== undefined) fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('gatherGateSignals', () => {
+  it('assembles events, cost, assumptions, and trajectory from a real run dir', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-signals-'))
+    tmpDirs.push(dir)
+    const workDir = path.join(dir, '.sdd-runner')
+    const state = await createRunState({ workDir, repoRoot: dir, changeName: 'thing' })
+    fs.mkdirSync(path.join(state.runDir, 'sidecars'), { recursive: true })
+    const logPath = path.join(state.runDir, 'events.ndjson')
+    appendEvent(logPath, { altitude: 'L2', type: 'stage_enter', stage: 'review' })
+    const deps: OrchestratorDeps = {
+      config: { repoRoot: dir, workDir, model: 'm', models: {}, timeouts: { wallClockMs: 1, inactivityMs: 1 } },
+      spawn: () => Promise.resolve({ exitCode: 0, stdout: '', stderr: '' }),
+      execGit: () => Promise.resolve({ stdout: '', stderr: '' }),
+      resolveCost: () => null,
+      driver: createOpenSpecDriver({
+        exec: () => Promise.resolve({ stdout: 'ok', stderr: '', exitCode: 0 }),
+        cwd: dir,
+      }),
+    }
+    const ctx: StageContext = {
+      cwd: dir,
+      changeDir: path.join(dir, 'openspec', 'changes', 'thing'),
+      sidecarDir: path.join(state.runDir, 'sidecars'),
+      emit: (event) => {
+        appendEvent(logPath, event)
+      },
+    }
+    const signals = await gatherGateSignals(deps, state, ctx, {
+      outcome: 'converged',
+      rounds: 1,
+      openBlockers: [],
+      openMaterial: [],
+      openNitpicks: [],
+    })
+    expect(signals.events.length).toBeGreaterThan(0)
+    expect(signals.assumptions).toEqual([])
+    expect(signals.trajectory).toEqual([])
+    expect(signals.costKnown).toBe(true)
+  })
+})

--- a/tests/sdd-runner/gate.test.ts
+++ b/tests/sdd-runner/gate.test.ts
@@ -485,6 +485,57 @@ describe('presentGateAt policy prelude (observe + integrity cross-checks)', () =
       expect(settled.status).toBe('completed')
     })
   })
+
+  describe('deadline field lifecycle (12.1)', () => {
+    it('a presented gate at auto with deadlineMinutes records gateDeadlineAt, prints the bell, and stays pending', async () => {
+      const fixture = await makePreludeFixture([])
+      const stdoutLines: string[] = []
+      const deps = {
+        ...fixture.deps,
+        stdout: (line: string): void => {
+          stdoutLines.push(line)
+        },
+        autonomy: {
+          level: 'auto' as const,
+          costCeilingUsd: 5,
+          autoExtendMax: 1,
+          deadlineMinutes: 10,
+          rules: {},
+        },
+      }
+      const undecidable = {
+        ...CONVERGED,
+        openMaterial: [{ id: 'F1', class: 'MATERIAL' as const, resolution: 'assumed' as const, outcome: 'kept' }],
+      }
+      await presentGateAt(deps, fixture.state, ctxOf(fixture), undecidable, 1, 'final')
+      const after = await loadRunState(fixture.deps.config.workDir, fixture.state.runId)
+      expect(after.gateDeadlineAt).not.toBeNull()
+      expect(after.gateDeadlineReArmed).toBe(false)
+      expect(stdoutLines.some((l) => l.includes('auto-deadline'))).toBe(true)
+    })
+
+    it('presentation without a configured deadline clears both fields', async () => {
+      const fixture = await makePreludeFixture([])
+      const deps = {
+        ...fixture.deps,
+        autonomy: {
+          level: 'auto' as const,
+          costCeilingUsd: 5,
+          autoExtendMax: 1,
+          deadlineMinutes: undefined,
+          rules: {},
+        },
+      }
+      const state = await loadRunState(fixture.deps.config.workDir, fixture.state.runId)
+      state.gateDeadlineAt = new Date().toISOString()
+      state.gateDeadlineReArmed = true
+      await saveRunState(state)
+      await presentGateAt(deps, state, ctxOf(fixture), CONVERGED, 1, 'final')
+      const after = await loadRunState(fixture.deps.config.workDir, fixture.state.runId)
+      expect(after.gateDeadlineAt).toBeNull()
+      expect(after.gateDeadlineReArmed).toBe(false)
+    })
+  })
 })
 
 describe('verifyGateIntegrity shared helper (7.1)', () => {

--- a/tests/sdd-runner/index.test.ts
+++ b/tests/sdd-runner/index.test.ts
@@ -3,12 +3,12 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { afterEach, describe, expect, it } from 'bun:test'
+import { afterEach, describe, expect, it, spyOn } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { USAGE, readChangeSummary } from '../../sdd-runner/src/index.js'
+import { USAGE, readChangeSummary, runEntry } from '../../sdd-runner/src/index.js'
 
 const tmpDirs: string[] = []
 
@@ -106,5 +106,86 @@ describe('readChangeSummary', () => {
     expect(summary.tasksDone).toBe(0)
     expect(summary.tasksTotal).toBe(0)
     expect(summary.artifacts).toEqual([])
+  })
+})
+
+describe('readChangeSummary edges (mutation kills)', () => {
+  it('an uppercase X counts as checked; a missing change dir yields zeros and no artifacts', async () => {
+    const dir = makeDir()
+    const changeDir = path.join(dir, 'openspec', 'changes', 'add-thing')
+    fs.mkdirSync(changeDir, { recursive: true })
+    fs.writeFileSync(path.join(changeDir, 'tasks.md'), '- [X] done uppercase\n')
+    const summary = await readChangeSummary(dir, 'add-thing')
+    expect(summary.tasksDone).toBe(1)
+    expect(summary.tasksTotal).toBe(1)
+    expect(summary.artifacts).toStrictEqual(['tasks.md'])
+
+    const missing = await readChangeSummary(dir, 'never-created')
+    expect(missing).toStrictEqual({ tasksDone: 0, tasksTotal: 0, artifacts: [] })
+  })
+
+  it('collects nested markdown artifacts only, preserving discovery of subdirectories', async () => {
+    const dir = makeDir()
+    const changeDir = path.join(dir, 'openspec', 'changes', 'nested')
+    fs.mkdirSync(path.join(changeDir, 'specs', 'thing'), { recursive: true })
+    fs.writeFileSync(path.join(changeDir, 'proposal.md'), 'x')
+    fs.writeFileSync(path.join(changeDir, 'specs', 'thing', 'spec.md'), 'x')
+    fs.writeFileSync(path.join(changeDir, 'notes.txt'), 'x')
+    const summary = await readChangeSummary(dir, 'nested')
+    expect(summary.artifacts).toContain('proposal.md')
+    expect(summary.artifacts).toContain('spec.md')
+    expect(summary.artifacts).not.toContain('notes.txt')
+    expect(summary.artifacts).toHaveLength(2)
+  })
+})
+
+describe('runEntry --help (subprocess)', () => {
+  it('prints USAGE and exits 0 for --help', () => {
+    const proc = Bun.spawnSync(['bun', 'sdd-runner/src/index.ts', '--help'], {
+      cwd: import.meta.dir + '/../../',
+    })
+    expect(proc.exitCode).toBe(0)
+    const out = new TextDecoder().decode(proc.stdout)
+    expect(out).toContain('sdd-runner — autonomous SDD pipeline')
+    expect(out).toContain('sdd-runner report <runId> [--pr]')
+  })
+
+  it('prints USAGE and exits 0 for -h', () => {
+    const proc = Bun.spawnSync(['bun', 'sdd-runner/src/index.ts', '-h'], {
+      cwd: import.meta.dir + '/../../',
+    })
+    expect(proc.exitCode).toBe(0)
+    expect(new TextDecoder().decode(proc.stdout)).toContain('sdd-runner — autonomous SDD pipeline')
+  })
+
+  it('an unknown subcommand exits non-zero with the parse error on stderr', () => {
+    const proc = Bun.spawnSync(['bun', 'sdd-runner/src/index.ts', 'frobnicate'], {
+      cwd: import.meta.dir + '/../../',
+    })
+    expect(proc.exitCode).not.toBe(0)
+    const err = new TextDecoder().decode(proc.stderr)
+    expect(err).toContain('subcommand')
+  })
+})
+
+describe('runEntry in-process (help route)', () => {
+  it('prints USAGE to stdout and returns without exiting for --help', async () => {
+    const writes: string[] = []
+    const originalWrite = process.stdout.write.bind(process.stdout)
+    const spy = spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      writes.push(Buffer.from(chunk).toString())
+      return true
+    })
+    const originalArgv = process.argv
+    try {
+      process.argv = ['bun', 'sdd-runner', '--help']
+      writes.length = 0
+      await runEntry()
+      expect(writes.join('')).toContain('sdd-runner — autonomous SDD pipeline')
+    } finally {
+      process.argv = originalArgv
+      spy.mockRestore()
+      void originalWrite
+    }
   })
 })

--- a/tests/sdd-runner/live-renderer.test.ts
+++ b/tests/sdd-runner/live-renderer.test.ts
@@ -363,3 +363,37 @@ function isWide(char: string): boolean {
   const code = char.codePointAt(0) ?? 0
   return code >= 0x1100 && (code <= 0x115f || (code >= 0x2e80 && code <= 0xa4cf) || (code >= 0xac00 && code <= 0xd7a3))
 }
+
+describe('DynamicRenderer non-TTY and duration formatting', () => {
+  it('non-TTY writes rendered event lines and stays silent for filtered ones', () => {
+    const stream = new MemoryStream({ isTTY: false, columns: 100 })
+    const renderer = new DynamicRenderer(stream, 'normal')
+    renderer.renderEvent({ altitude: 'L2', type: 'stage_enter', stage: 'draft' })
+    renderer.renderEvent({ altitude: 'L0', type: 'tool_use', agent: 'a', tool: 't' })
+    const out = stream.chunks.join('')
+    expect(out).toContain('[draft] entered\n')
+    expect(out).not.toContain('tool')
+  })
+
+  it('formatDuration tiers are pinned through stage elapsed rendering', async () => {
+    const { formatElapsed } = await import('../../sdd-runner/src/renderer.js')
+    expect(formatElapsed(0)).toBe('0s')
+    expect(formatElapsed(59_000)).toBe('59s')
+    expect(formatElapsed(60_000)).toBe('1m00s')
+    expect(formatElapsed(605_000)).toBe('10m05s')
+  })
+
+  it('a done event without a spawned model records no model part', () => {
+    const stream = new MemoryStream({ isTTY: true, columns: 100 })
+    const renderer = new DynamicRenderer(stream, 'normal')
+    renderer.renderEvent({
+      altitude: 'L1',
+      type: 'done',
+      agent: 'lonely-agent',
+      usage: { inputTokens: 10, outputTokens: 5, reasoningTokens: 0, costUsd: 0, wallMs: 0 },
+    })
+    const out = stream.chunks.join('')
+    expect(out).toMatch(/lonely-agent done · in 10 out 5 · \$0\.0000/u)
+    expect(out).not.toMatch(/lonely-agent done · ·/u)
+  })
+})

--- a/tests/sdd-runner/live-renderer.test.ts
+++ b/tests/sdd-runner/live-renderer.test.ts
@@ -267,3 +267,99 @@ describe('DynamicRenderer totals accounting', () => {
     expect(stream.chunks.join('')).toContain('$4.4500')
   })
 })
+
+describe('Tier 0 dynamic details (13.2-13.4)', () => {
+  it('completed stages show wall time and cost; the active stage shows an elapsed marker', () => {
+    const stream = new MemoryStream({ isTTY: true, columns: 100 })
+    const renderer = new DynamicRenderer(stream, 'normal')
+    renderer.renderEvent({ altitude: 'L2', type: 'stage_enter', stage: 'intake' })
+    renderer.renderEvent({ altitude: 'L2', type: 'stage_exit', stage: 'intake' })
+    renderer.renderEvent({ altitude: 'L2', type: 'stage_enter', stage: 'draft' })
+    const out = stream.chunks.join('')
+    expect(out).toMatch(/intake done .* · \$0\.0{4}/u)
+    expect(out).toMatch(/draft active/u)
+  })
+
+  it('slot lines truncate by visible width so wide chars never overflow the terminal', () => {
+    const stream = new MemoryStream({ isTTY: true, columns: 20 })
+    const renderer = new DynamicRenderer(stream, 'normal')
+    const agent = 'レビューアー'
+    renderer.renderEvent({ altitude: 'L1', type: 'spawned', agent, role: 'reviewer', model: 'm' })
+    renderer.renderEvent({
+      altitude: 'L0',
+      type: 'tool_use',
+      agent,
+      tool: 'readFile',
+      arg: 'src/very/long/path/that/would/overflow.ts',
+    })
+    const out = stream.chunks.join('')
+    const lines = out.split('\n').filter((l) => l.includes('レビューアー'))
+    expect(lines.length).toBeGreaterThan(0)
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(20)
+    }
+  })
+
+  it('a retrying agent slot shows a retry badge', () => {
+    const stream = new MemoryStream({ isTTY: true, columns: 80 })
+    const renderer = new DynamicRenderer(stream, 'normal')
+    renderer.renderEvent({ altitude: 'L1', type: 'spawned', agent: 'a', role: 'reviewer', model: 'm' })
+    renderer.renderEvent({ altitude: 'L1', type: 'retrying', agent: 'a', reason: 'stall', attempt: 2 })
+    renderer.renderEvent({ altitude: 'L0', type: 'tool_use', agent: 'a', tool: 'readFile' })
+    const out = stream.chunks.join('')
+    expect(out).toMatch(/retry 2/u)
+  })
+
+  it('a done slot line reads <agent> done · <model> · in X out Y · $Z', () => {
+    const stream = new MemoryStream({ isTTY: true, columns: 100 })
+    const renderer = new DynamicRenderer(stream, 'normal')
+    renderer.renderEvent({ altitude: 'L1', type: 'spawned', agent: 'resolver-r1', role: 'resolver', model: 'glm' })
+    renderer.renderEvent({ altitude: 'L0', type: 'tool_use', agent: 'resolver-r1', tool: 'readFile' })
+    renderer.renderEvent({
+      altitude: 'L1',
+      type: 'done',
+      agent: 'resolver-r1',
+      model: 'glm',
+      usage: { inputTokens: 5000, outputTokens: 1200, reasoningTokens: 10, costUsd: 0.01, wallMs: 1000 },
+    })
+    const out = stream.chunks.join('')
+    expect(out).toMatch(/resolver-r1 done · glm · in 5.0k out 1.2k · \$0\.0100/u)
+  })
+
+  it('status line shows ETA from completed rounds and hides reasoning tokens when zero', () => {
+    const stream = new MemoryStream({ isTTY: true, columns: 100 })
+    const renderer = new DynamicRenderer(stream, 'normal')
+    renderer.renderEvent({ altitude: 'L2', type: 'stage_enter', stage: 'review' })
+    renderer.renderEvent({ altitude: 'L2', type: 'round_open', round: 1, cap: 3 })
+    renderer.renderEvent({
+      altitude: 'L0',
+      type: 'step_finish',
+      agent: 'a',
+      tokens: { input: 10, output: 5, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+      costUsd: 0,
+    })
+    renderer.renderEvent({ altitude: 'L2', type: 'round_close', round: 1, cap: 3 })
+    renderer.renderEvent({ altitude: 'L2', type: 'round_open', round: 2, cap: 3 })
+    const status = lastStatusLine(stream.chunks.join(''))
+    expect(status).not.toContain('reasoning')
+  })
+})
+
+/** Rough visible-width model: ANSI escapes count 0, wide chars count 2. */
+function visibleWidth(line: string): number {
+  const escape = String.fromCharCode(27)
+  const stripped = line
+    .split(escape)
+    .map((piece) => piece.replace(/^\[[0-9]*[A-Za-z]/u, ''))
+    .join('')
+  let width = 0
+  for (const char of stripped) {
+    width += isWide(char) ? 2 : 1
+  }
+  return width
+}
+
+function isWide(char: string): boolean {
+  const code = char.codePointAt(0) ?? 0
+  return code >= 0x1100 && (code <= 0x115f || (code >= 0x2e80 && code <= 0xa4cf) || (code >= 0xac00 && code <= 0xd7a3))
+}

--- a/tests/sdd-runner/renderer.test.ts
+++ b/tests/sdd-runner/renderer.test.ts
@@ -204,6 +204,49 @@ describe('formatEvent', () => {
     )
     expect(line).toBe('reviewer-r1 done \u00B7 in 12.0k out 3.4k \u00B7 $0.0142')
   })
+
+  it('done line appends · <model> when the done event carries a model id', () => {
+    const line = formatEvent(
+      {
+        altitude: 'L1',
+        type: 'done',
+        agent: 'reviewer-r1',
+        model: 'test-model',
+        usage: {
+          inputTokens: 12000,
+          outputTokens: 3400,
+          reasoningTokens: 200,
+          cachedReadTokens: 0,
+          cachedWriteTokens: 0,
+          costUsd: 0.0142,
+          wallMs: 45000,
+        },
+      },
+      'normal',
+    )
+    expect(line).toBe('reviewer-r1 done \u00B7 test-model \u00B7 in 12.0k out 3.4k \u00B7 $0.0142')
+  })
+
+  it('done line without a model id renders exactly as before (no placeholder)', () => {
+    const noModel = formatEvent(
+      {
+        altitude: 'L1',
+        type: 'done',
+        agent: 'drafter-1',
+        usage: {
+          inputTokens: 100,
+          outputTokens: 10,
+          reasoningTokens: 0,
+          cachedReadTokens: 0,
+          cachedWriteTokens: 0,
+          costUsd: 0.001,
+          wallMs: 1000,
+        },
+      },
+      'normal',
+    )
+    expect(noModel).toBe('drafter-1 done \u00B7 in 100 out 10 \u00B7 $0.0010')
+  })
 })
 
 describe('createRenderer (integration smoke)', () => {

--- a/tests/sdd-runner/renderer.test.ts
+++ b/tests/sdd-runner/renderer.test.ts
@@ -372,3 +372,119 @@ describe('createRenderer resolveCost threading', () => {
     expect(joined).toContain('resolver-r1 done \u00B7 in 1.0k out 500 \u00B7 $0.0000')
   })
 })
+
+describe('formatTokenCount tiers (13.x)', () => {
+  it('pins the three tiers and their boundaries', async () => {
+    const { formatTokenCount } = await import('../../sdd-runner/src/renderer.js')
+    expect(formatTokenCount(999)).toBe('999')
+    expect(formatTokenCount(1000)).toBe('1.0k')
+    expect(formatTokenCount(999_999)).toBe('1000.0k')
+    expect(formatTokenCount(1_000_000)).toBe('1.00M')
+    expect(formatTokenCount(2_500_000)).toBe('2.50M')
+  })
+})
+
+describe('formatElapsed tiers', () => {
+  it('formats seconds, zero-floors negatives, and minutes beyond a minute', async () => {
+    const { formatElapsed } = await import('../../sdd-runner/src/renderer.js')
+    expect(formatElapsed(0)).toBe('0s')
+    expect(formatElapsed(59_999)).toBe('59s')
+    expect(formatElapsed(60_000)).toBe('1m00s')
+    expect(formatElapsed(125_000)).toBe('2m05s')
+    expect(formatElapsed(-5_000)).toBe('0s')
+  })
+})
+
+describe('renderPipelineMap suffixes', () => {
+  it('active stage carries round part and optional elapsed; done stage carries time and cost', async () => {
+    const { renderPipelineMap: rpm } = await import('../../sdd-runner/src/renderer.js')
+    const lines = rpm(state, { activeElapsedMs: 90_000 })
+    expect(lines[2]).toBe('▶ review active (round 2/3) elapsed 1m30s')
+    const stageTimes = new Map([['intake', { wallMs: 250_000, costUsd: 0.5 }]])
+    const withTimes = rpm(state, { stageTimes })
+    expect(withTimes[0]).toBe('✓ intake done · 4m10s · $0.5000')
+  })
+
+  it('an active stage without round or elapsed renders bare, and done stages without times stay bare', async () => {
+    const { renderPipelineMap: rpm } = await import('../../sdd-runner/src/renderer.js')
+    const noRound: ReplayState = { ...state, round: null }
+    expect(rpm(noRound)[2]).toBe('▶ review active')
+    expect(rpm(state)[0]).toBe('✓ intake done')
+  })
+})
+
+describe('formatEvent verbosity gating', () => {
+  it('quiet hides everything; normal shows L1/L2 but not L0; debug shows L0', async () => {
+    const { formatEvent: fmt } = await import('../../sdd-runner/src/renderer.js')
+    const l2 = { altitude: 'L2', type: 'stage_enter', stage: 'draft' } as const
+    const l1 = { altitude: 'L1', type: 'spawned', agent: 'a', role: 'reviewer', model: 'm' } as const
+    const l0 = { altitude: 'L0', type: 'tool_use', agent: 'a', tool: 't' } as const
+    expect(fmt(l2, 'quiet')).toBeNull()
+    expect(fmt(l2, 'brief')).toBe('[draft] entered')
+    expect(fmt(l1, 'normal')).toBe('a spawned (reviewer, m)')
+    expect(fmt(l1, 'brief')).toBeNull()
+    expect(fmt(l0, 'debug')).toBe('a: t')
+    expect(fmt(l0, 'normal')).toBeNull()
+  })
+
+  it('renders each event line shape exactly', async () => {
+    const { formatEvent: fmt } = await import('../../sdd-runner/src/renderer.js')
+    expect(fmt({ altitude: 'L2', type: 'round_open', round: 1, cap: 3 }, 'normal')).toBe('round 1/3 opened')
+    expect(fmt({ altitude: 'L2', type: 'round_close', round: 1, cap: 3 }, 'normal')).toBe('round 1/3 closed')
+    expect(fmt({ altitude: 'L2', type: 'stage_exit', stage: 'draft' }, 'normal')).toBe('[draft] done')
+    expect(fmt({ altitude: 'L2', type: 'depth', profile: 'M', rationale: 'why', source: 'override' }, 'normal')).toBe(
+      'depth classified: M (override)',
+    )
+    expect(fmt({ altitude: 'L2', type: 'gate', action: 'presented', mode: 'final', version: 2 }, 'normal')).toBe(
+      'gate presented (final, v2)',
+    )
+    expect(
+      fmt({ altitude: 'L2', type: 'finding', id: 'F1', action: 'filed', class: 'MATERIAL', round: 1 }, 'normal'),
+    ).toBe('finding F1 filed (MATERIAL) round 1')
+    expect(fmt({ altitude: 'L2', type: 'finding', id: 'F1', action: 'filed', round: 1 }, 'normal')).toBe(
+      'finding F1 filed (?) round 1',
+    )
+    expect(fmt({ altitude: 'L2', type: 'assumption', id: 'A1', action: 'confirmed' }, 'normal')).toBe(
+      'assumption A1 confirmed',
+    )
+    expect(
+      fmt({ altitude: 'L2', type: 'artifact', action: 'materialized', path: 'openspec/changes/x/review.md' }, 'normal'),
+    ).toBe('materialized openspec/changes/x/review.md')
+    expect(fmt({ altitude: 'L2', type: 'human_edits', action: 'detected', files: ['a.md', 'b.md'] }, 'normal')).toBe(
+      'hand edits detected: a.md, b.md',
+    )
+    expect(
+      fmt(
+        {
+          altitude: 'L0',
+          type: 'step_finish',
+          agent: 'rev',
+          tokens: { input: 1, output: 42, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+          costUsd: 0,
+        },
+        'debug',
+      ),
+    ).toBe('rev step done (42 out)')
+    expect(fmt({ altitude: 'L1', type: 'retrying', agent: 'rev', reason: 'stall', attempt: 2 }, 'debug')).toBe(
+      'rev retrying (stall, attempt 2)',
+    )
+    expect(fmt({ altitude: 'L1', type: 'killed', agent: 'rev', cause: 'timeout' }, 'debug')).toBe(
+      'rev killed (timeout)',
+    )
+  })
+
+  it('formatTrajectoryBlock pins heading and lines', async () => {
+    const { formatTrajectoryBlock: ftb, formatBurndownLine: fbl } = await import('../../sdd-runner/src/renderer.js')
+    const record = {
+      round: 2,
+      counts: { blocker: 1, material: 2, nitpick: 3 },
+      resolved: 4,
+      dismissed: 5,
+      verdict: 'open',
+    } as const
+    expect(fbl(record)).toBe('round 2: 1b 2m 3n · 4 resolved · 5 dismissed · open')
+    expect(ftb([record])).toBe(
+      ['### Cap-hit trajectory', 'round 2: 1b 2m 3n · 4 resolved · 5 dismissed · open'].join('\n'),
+    )
+  })
+})

--- a/tests/sdd-runner/report.test.ts
+++ b/tests/sdd-runner/report.test.ts
@@ -98,3 +98,85 @@ describe('buildReport', () => {
     expect(body).toContain('skeptic lens: run')
   })
 })
+
+describe('gains block (11.1)', () => {
+  const gateStamps = (seq: number): { presented: string; answered: string } => ({
+    presented: `2026-01-01T00:0${seq}:00.000Z`,
+    answered: `2026-01-01T00:0${seq}:05.000Z`,
+  })
+
+  it('counts paired approve/extend events as interventions avoided per rule, with dwell-based saved estimate', async () => {
+    const base = events()
+    const stamps = gateStamps(8)
+    const ev: readonly SddEvent[] = [
+      ...base,
+      { altitude: 'L2', type: 'gate', action: 'presented', mode: 'final', version: 2, seq: 8, ts: stamps.presented },
+      {
+        altitude: 'L2',
+        type: 'auto_decision',
+        rule: 'R1',
+        decision: 'approve',
+        evidenceDigest: 'd',
+        gateVersion: 2,
+        seq: 9,
+        ts: 'x',
+      },
+      { altitude: 'L2', type: 'gate', action: 'answered', mode: 'final', version: 2, seq: 10, ts: stamps.answered },
+    ]
+    const body = await buildReport(baseInput(ev))
+    expect(body).toContain('### Gains')
+    expect(body).toMatch(/interventions avoided: 1/u)
+    expect(body).toMatch(/R1 × 1/u)
+    expect(body).toMatch(/human gates: \d+/u)
+    expect(body).toMatch(/~wall-time saved/u)
+  })
+
+  it('never counts unpaired auto_decision events', async () => {
+    const ev: readonly SddEvent[] = [
+      ...events(),
+      {
+        altitude: 'L2',
+        type: 'auto_decision',
+        rule: 'R1',
+        decision: 'approve',
+        evidenceDigest: 'd',
+        gateVersion: 2,
+        seq: 8,
+        ts: 'x',
+      },
+    ]
+    const body = await buildReport(baseInput(ev))
+    expect(body).not.toMatch(/interventions avoided: [1-9]/u)
+  })
+
+  it('reports accept-items separately as items auto-accepted, not interventions avoided', async () => {
+    const ev: readonly SddEvent[] = [
+      ...events(),
+      {
+        altitude: 'L2',
+        type: 'auto_decision',
+        rule: 'R3',
+        decision: 'accept-items',
+        evidenceDigest: 'd',
+        gateVersion: 1,
+        seq: 8,
+        ts: 'x',
+      },
+    ]
+    const body = await buildReport(baseInput(ev))
+    expect(body).toMatch(/R3 .*items auto-accepted: 1/u)
+    expect(body).not.toMatch(/interventions avoided: [1-9]/u)
+  })
+})
+
+function baseInput(evs: readonly SddEvent[]): ReportInput {
+  return {
+    readEvents: () => evs,
+    readChangeDir: () => Promise.resolve(changeDir()),
+    execGit: gitLog('abc Section 1\n'),
+    runId: 'run-1',
+    changeName: 'add-thing',
+    branch: 'add-thing',
+    pr: false,
+  }
+}

--- a/tests/sdd-runner/report.test.ts
+++ b/tests/sdd-runner/report.test.ts
@@ -180,3 +180,84 @@ function baseInput(evs: readonly SddEvent[]): ReportInput {
     pr: false,
   }
 }
+
+describe('buildReport verdict and lens edges (mutation kills)', () => {
+  it('verdict words: converged plural, open after N, review not reached', async () => {
+    const baseEvents = (): SddEvent[] => [
+      { altitude: 'L2', type: 'depth', profile: 'M', rationale: 'r', source: 'estimator', seq: 1, ts: 'x' },
+      { altitude: 'L1', type: 'spawned', agent: 'reviewer-r1', role: 'reviewer', model: 'x', seq: 2, ts: 'x' },
+    ]
+    const mk = (evts: SddEvent[]): ReportInput => ({
+      readEvents: () => evts,
+      readChangeDir: () => Promise.resolve(changeDir()),
+      execGit: gitLog(''),
+      runId: 'run-1',
+      changeName: 'add-thing',
+      branch: 'add-thing',
+      pr: false,
+    })
+    const twoRounds: SddEvent[] = [
+      ...baseEvents(),
+      { altitude: 'L2', type: 'round_open', round: 1, cap: 3, seq: 3, ts: 'x' },
+      { altitude: 'L2', type: 'round_open', round: 2, cap: 3, seq: 4, ts: 'x' },
+      {
+        altitude: 'L2',
+        type: 'convergence',
+        round: 2,
+        verdict: 'converged',
+        counts: { blocker: 0, material: 0, nitpick: 0 },
+        seq: 5,
+        ts: 'x',
+      },
+    ]
+    const body2 = await buildReport(mk(twoRounds))
+    expect(body2).toContain('converged in 2 rounds')
+    expect(body2).toContain('gate versions presented: 0')
+    expect(body2).toContain('skeptic lens: not run — M profile')
+
+    const noSkepticNoDepth: SddEvent[] = [
+      { altitude: 'L1', type: 'spawned', agent: 'a', role: 'reviewer', model: 'm', seq: 1, ts: 'x' },
+    ]
+    const bodyDepthless = await buildReport(mk(noSkepticNoDepth))
+    expect(bodyDepthless).toContain('not classified')
+    expect(bodyDepthless).toContain('review not reached')
+    expect(bodyDepthless).toContain('skeptic lens: not run\n')
+
+    const openVerdict: SddEvent[] = [
+      ...baseEvents(),
+      { altitude: 'L2', type: 'round_open', round: 1, cap: 3, seq: 3, ts: 'x' },
+      {
+        altitude: 'L2',
+        type: 'convergence',
+        round: 1,
+        verdict: 'open',
+        counts: { blocker: 0, material: 0, nitpick: 0 },
+        seq: 4,
+        ts: 'x',
+      },
+    ]
+    expect(await buildReport(mk(openVerdict))).toContain('open after 1 round')
+
+    const skepticRun: SddEvent[] = [
+      ...baseEvents(),
+      { altitude: 'L1', type: 'spawned', agent: 'skeptic-1', role: 'skeptic', model: 'm', seq: 3, ts: 'x' },
+    ]
+    expect(await buildReport(mk(skepticRun))).toContain('skeptic lens: run')
+  })
+
+  it('commits line filters blank lines and splits on newlines', async () => {
+    const input: ReportInput = {
+      readEvents: () => [],
+      readChangeDir: () => Promise.resolve(changeDir()),
+      execGit: gitLog('a1 Subject\n\n  \nb2 Subject\n'),
+      runId: 'run-1',
+      changeName: 'add-thing',
+      branch: 'add-thing',
+      pr: false,
+    }
+    const body = await buildReport(input)
+    expect(body).toContain('a1 Subject')
+    expect(body).toContain('b2 Subject')
+    expect(body).not.toMatch(/^ $/mu)
+  })
+})

--- a/tests/sdd-runner/terminal-title.test.ts
+++ b/tests/sdd-runner/terminal-title.test.ts
@@ -3,9 +3,22 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { describe, expect, it } from 'bun:test'
+import { afterEach, describe, expect, it } from 'bun:test'
 
 import { TERMINAL_TITLE_RESTORE, registerTerminalTitle, terminalTitleFor } from '../../sdd-runner/src/terminal-title.js'
+import type { TerminalTitleHandle } from '../../sdd-runner/src/terminal-title.js'
+
+// Every registration installs process-global listeners; without disposal they
+// outlive this file and convert any later SIGTERM to the bun test process
+// into process.exit(143) — the exact failure mode that killed CI's Checks
+// job after this suite ran.
+const handles: TerminalTitleHandle[] = []
+
+afterEach(() => {
+  while (handles.length > 0) {
+    handles.pop()?.dispose()
+  }
+})
 
 describe('terminalTitleFor (13.6)', () => {
   it('builds the set sequence', () => {
@@ -24,7 +37,28 @@ describe('terminalTitleFor (13.6)', () => {
       },
       () => TERMINAL_TITLE_RESTORE,
     )
+    handles.push(handle)
     handle.restore()
     expect(written[written.length - 1]).toBe(TERMINAL_TITLE_RESTORE)
+  })
+
+  it('dispose removes the registered exit and signal listeners', () => {
+    const before = {
+      exit: process.listenerCount('exit'),
+      SIGINT: process.listenerCount('SIGINT'),
+      SIGTERM: process.listenerCount('SIGTERM'),
+    }
+    const handle = registerTerminalTitle(
+      () => undefined,
+      () => TERMINAL_TITLE_RESTORE,
+    )
+    handles.push(handle)
+    expect(process.listenerCount('exit')).toBe(before.exit + 1)
+    expect(process.listenerCount('SIGINT')).toBe(before.SIGINT + 1)
+    expect(process.listenerCount('SIGTERM')).toBe(before.SIGTERM + 1)
+    handle.dispose()
+    expect(process.listenerCount('exit')).toBe(before.exit)
+    expect(process.listenerCount('SIGINT')).toBe(before.SIGINT)
+    expect(process.listenerCount('SIGTERM')).toBe(before.SIGTERM)
   })
 })

--- a/tests/sdd-runner/terminal-title.test.ts
+++ b/tests/sdd-runner/terminal-title.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, it } from 'bun:test'
+
+import { TERMINAL_TITLE_RESTORE, registerTerminalTitle, terminalTitleFor } from '../../sdd-runner/src/terminal-title.js'
+
+describe('terminalTitleFor (13.6)', () => {
+  it('builds the set sequence', () => {
+    expect(terminalTitleFor('add-thing', 'review')).toBe('\x1b]0;sdd add-thing · review\x07')
+  })
+
+  it('exposes a fixed default restore string', () => {
+    expect(TERMINAL_TITLE_RESTORE.length).toBeGreaterThan(0)
+  })
+
+  it('registerTerminalTitle restores via the handle (best-effort)', () => {
+    const written: string[] = []
+    const handle = registerTerminalTitle(
+      (chunk: string) => {
+        written.push(chunk)
+      },
+      () => TERMINAL_TITLE_RESTORE,
+    )
+    handle.restore()
+    expect(written[written.length - 1]).toBe(TERMINAL_TITLE_RESTORE)
+  })
+})


### PR DESCRIPTION
## Summary

Part 4/5 of the split of #290. Stacked on part 3 (merge in stack order; base retargets automatically).

Deadline + output polish (branch stages 11.x–14.x):

- report gains block (paired decisions, dwell-based estimate)
- dead-man deadline lifecycle, foreground waiter, expiry claim + re-arm
- Tier 0 polish: done-line model, per-stage times, wide truncation, retry badges, ETA, sparkline, title, quiet
- clack prompter adapter + composition-root selection with readline fallback
- adds `@clack/prompts` to `sdd-runner` deps (+ lockfile)

## Test plan

- [x] `typecheck`, `lint`, `format:check`, `knip`, `license:headers`
- [x] `bun test tests/sdd-runner` — 544 pass
- [x] full serial suite + `coverage:ratchet` (known macOS `git-identity` flake only)
- [ ] CI mutation gate measures only this PR's increment