### PR TITLE
feat(opencode-agent): reconcile branch pushes with a remote that advanced mid-run

### DIFF
--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -280,6 +280,23 @@ findings: `ROADMAP.md`.
   checkout about to be deleted. `phases/review-push.ts` asks the **branch**
   instead (`git.headSha` either side of the loop) and pushes when it moved; a
   commit this process made needs no second opinion and is pushed on that alone.
+  **Every push reconciles with the remote first, because the branch is shared
+  with humans, not owned.** Run 32374999214 (PR #313): a maintainer pushed merge
+  `1f7ce71b` to `agent/issue-305` three hours into a review loop, and every later
+  pipeline push was rejected non-fast-forward — `ensureBranch` fetches once per
+  phase and nothing until the push looked at the remote again, so five review
+  fixes died with the runner and the run parked in `FAILED` inviting a `/retry`
+  that re-runs the whole loop. `git-reconcile.ts` (split from `git.ts` along
+  `git-revert.ts`'s seam) fetches the branch and merges `origin/<branch>` when
+  HEAD does not contain it — **merge, never rebase, never force**: the branch is
+  shared by design, and rewrites or force would discard the human line or
+  history the loop's `primary` branch shares. A conflict aborts the merge and
+  throws naming the conflicted paths; a fetch that finds no remote branch is a
+  first push, not an error; base-branch pushes (`ARCHIVE`) do not reconcile. On
+  the review path the reconcile runs **before `dropUnpushable`**, so a protected
+  path that arrived via the human line is reverted before the push instead of
+  riding the merge into a GitHub refusal of the whole push (the issue #240
+  class); `push()`'s own internal reconcile is then an idempotent no-op.
   It also pushes **as each fix lands**, on the `[review-loop] published` marker
   the loop prints: `mergeEachFix` in the generated config makes the loop merge per
   fix instead of once at the end behind its build gate, and the push stays on this

--- a/opencode-agent/src/git-reconcile.ts
+++ b/opencode-agent/src/git-reconcile.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { stdoutLines } from './git-commit.js'
+import type { GitFn } from './git-commit.js'
+import { GitError, issueNumberFromBranch } from './git.js'
+import type { GitOptions } from './git.js'
+
+/**
+ * Bringing a local agent branch back in step with a remote that moved while a
+ * phase was running.
+ *
+ * Split from `git.ts` when the reconciling push pushed that file past
+ * `max-lines`, along the seam `git-revert.ts` already cut: everything left in
+ * `git.ts` is about *addressing* a repository, while this is about what a
+ * push must do before it can succeed when the branch is shared. The value
+ * imports point back at `git.ts` for `GitError` and `issueNumberFromBranch`,
+ * the same back-import `deps.ts` carries from the module it was split from —
+ * safe because neither side dereferences the other while either module is
+ * still evaluating, only inside function bodies called much later.
+ */
+/**
+ * Brings a local agent branch up to date with a remote that advanced while a
+ * phase was running, so the push that follows is a fast-forward again.
+ *
+ * Run 32374999214 is what this exists for: a maintainer pushed merge
+ * `1f7ce71b` to `agent/issue-305` three hours into a review loop, and every
+ * later pipeline push was rejected non-fast-forward — the branch had been
+ * fetched exactly once, at `ensureBranch`, and nothing between that and the
+ * push looked at the remote again. Five review fixes died with the runner and
+ * the run parked in `FAILED` inviting a `/retry` that re-runs the whole loop.
+ *
+ * Three shapes the branch rules out. **Merge, never rebase:** the branch is
+ * shared with humans by design (the incident's maintainer commit is itself a
+ * merge of an agent fix), a rebase would rewrite commits the review loop's
+ * `primary` branch shares history with, and a force-push discards human work.
+ * **Fetch-first, every time:** `ensureBranch` fetches once at phase entry and
+ * a review loop then runs for hours, so "the remote moved" is not an edge
+ * case on this timescale but the ordinary thing that happens. **Nothing to
+ * reconcile is not an error:** a fetch that finds no remote branch is a first
+ * push, and the plain push that follows reports any genuine failure better
+ * than a reconcile invented one.
+ *
+ * Only agent branches (`agent/issue-<n>`, per {@link issueNumberFromBranch})
+ * reconcile — the base branch `ARCHIVE` pushes has sharing rules of its own
+ * and keeps the plain push it always had.
+ */
+export const reconcile = async (git: GitFn, gitOrThrow: GitFn, options: GitOptions, branch: string): Promise<void> => {
+  if (issueNumberFromBranch(branch) === null) return
+
+  const remote = `refs/remotes/origin/${branch}`
+  // The explicit refspec, rather than `git fetch origin <branch>`, because the
+  // two reads below address `refs/remotes/origin/<branch>` and FETCH_HEAD is
+  // not that ref.
+  const fetched = await git('fetch', 'origin', `+refs/heads/${branch}:${remote}`)
+  if (fetched.exitCode !== 0) return
+
+  // Exit 0 = the remote tip is already contained here; 1 = it is not. Asked
+  // without throwing because exit 1 is the answer this reads, not a failure.
+  const ancestor = await git('merge-base', '--is-ancestor', remote, 'HEAD')
+  if (ancestor.exitCode === 0) return
+
+  // The merge makes a commit, so it carries the committer identity the same
+  // way `commit` in `git-commit.ts` does — a hosted runner has no `user.name`
+  // anywhere, and an identity-less merge fails on a config file rather than on
+  // the branch this is about.
+  const committerName = options.committerName ?? options.authorName
+  const committerEmail = options.committerEmail ?? options.authorEmail
+  const merged = await git(
+    '-c',
+    `user.name=${committerName}`,
+    '-c',
+    `user.email=${committerEmail}`,
+    'merge',
+    '--no-edit',
+    remote,
+  )
+  if (merged.exitCode === 0) return
+
+  // Every failure path aborts the merge, so the tree is never left mid-merge
+  // whatever else went wrong — the same try/finally `mergeWorktree` in
+  // `review-loop/` proves out on its own merges.
+  try {
+    const conflict = `${merged.stdout}\n${merged.stderr}`.includes('CONFLICT')
+    if (!conflict) throw new GitError(merged)
+
+    const conflicted = stdoutLines((await gitOrThrow('diff', '--name-only', '--diff-filter=U')).stdout)
+    throw new GitError({
+      ...merged,
+      stderr:
+        `cannot reconcile with ${remote}, which advanced mid-run: conflicts in ${conflicted.join(', ')}. ` +
+        'Resolve by hand and push again.',
+    })
+  } finally {
+    await git('merge', '--abort')
+  }
+}

--- a/opencode-agent/src/git.ts
+++ b/opencode-agent/src/git.ts
@@ -6,6 +6,7 @@
 import type { DiffLimits } from './diff-guard.js'
 import { commitAll, salvageAll } from './git-commit.js'
 import type { CommitOutcome, GitFn, Salvage } from './git-commit.js'
+import { reconcile } from './git-reconcile.js'
 import { revertPaths } from './git-revert.js'
 import type { Logger } from './logger.js'
 import type { CommandResult, CommandRunner } from './shell.js'
@@ -116,6 +117,13 @@ export interface Git {
    * that broke, and this refusing is a run that was already out of time.
    */
   salvageAll(message: string): Promise<Salvage>
+  /**
+   * Merges a remote agent branch that advanced since this checkout last
+   * fetched it, so the next push is a fast-forward again. A no-op when the
+   * remote has not moved or holds no such branch; a conflict aborts the merge
+   * and throws naming the conflicted paths. See `git-reconcile.ts`.
+   */
+  reconcile(branch: string): Promise<void>
   push(branch: string, options?: PushOptions): Promise<void>
   /** The remote's default branch, or `null` when the checkout cannot tell. */
   defaultBranch(): Promise<string | null>
@@ -268,7 +276,12 @@ export const createGit = (options: GitOptions): Git => {
       ),
     commitAll: (message) => commitAll(gitOrThrow, options, message),
     salvageAll: (message) => salvageAll(gitOrThrow, options, message),
+    reconcile: (branch) => reconcile(git, gitOrThrow, options, branch),
     push: async (branch, pushOptions) => {
+      // The reconcile is what makes this push able to succeed at all after a
+      // human moved the branch mid-phase; on a quiet remote it costs one fetch
+      // and an ancestor check.
+      await reconcile(git, gitOrThrow, options, branch)
       const verify = pushOptions?.noVerify === true ? ['--no-verify'] : []
       await gitOrThrow('push', ...verify, '-u', 'origin', branch)
     },

--- a/opencode-agent/src/phases/review-push.ts
+++ b/opencode-agent/src/phases/review-push.ts
@@ -108,6 +108,13 @@ export const createPush = (input: PhaseInput, branch: string): DurablePush => {
     const [last, head] = await Promise.all([pushedAt, readHead(input)])
     if (!committed && last !== null && head !== null && last === head) return advanced
 
+    // Before the protected-path revert, not after it: a reconciling merge can
+    // bring the human line's own commits in, and only once it has landed can
+    // `dropUnpushable` see — and take back out — a path a push cannot carry.
+    // The other order lets a workflow file ride the merge into a push GitHub
+    // refuses whole (the issue #240 failure class). `push` reconciles again
+    // internally, idempotently — the ancestor check answers "already merged".
+    if (last !== null) await deps.git.reconcile(branch)
     if (last !== null) await dropUnpushable(input, last, blocked)
     await deps.git.push(branch)
     pushedAt = Promise.resolve(head)

--- a/openspec/changes/reconcile-agent-branch-push/.openspec.yaml
+++ b/openspec/changes/reconcile-agent-branch-push/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/reconcile-agent-branch-push/design.md
+++ b/openspec/changes/reconcile-agent-branch-push/design.md
@@ -1,0 +1,62 @@
+## Context
+
+See proposal.md — Why for the incident (run 32374999214, PR #313: a maintainer pushed merge `1f7ce71b` to `agent/issue-305` mid-review; every subsequent pipeline push was rejected non-fast-forward; five review fixes died with the runner; the run parked in `FAILED` inviting a full-loop `/retry`).
+
+Today's push path is `Git.push` in `opencode-agent/src/git.ts:271` — `git push [-u|--no-verify] origin <branch>` — called from six sites (`review-push.ts`, `implement-commit.ts`, `ci-fix.ts`, `plan.ts`, `triage.ts`, `salvage.ts`). `ensureBranch` fetches the branch exactly once at phase entry; a review loop then runs for hours. The branch is shared with humans by design (the PR invites maintainer commits), but no push reconciles with what happened since the fetch.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One reconcile implementation at the `Git` layer; every agent-branch push call site gets it without per-phase edits.
+- Preserve the existing failure semantics per call site (mid-loop warn, final push fatal).
+- Keep the credential in the pipeline-side git child env only.
+
+**Non-Goals:** (beyond proposal.md's)
+
+- No change to `ensureBranch` semantics or call ordering.
+- No change to `review-loop/` — it stays remote-blind.
+- No push-retry/backoff loop; one reconcile attempt per push.
+
+## Decisions
+
+### D1. Reconcile inside `Git.push`, plus one explicit pre-call on the review path
+
+`push(branch)` becomes: `git fetch origin <branch>` → if `refs/remotes/origin/<branch>` is absent, plain push (first push); if `git merge-base --is-ancestor origin/<branch> HEAD` says yes, plain push; otherwise `git merge --no-edit origin/<branch>`, then push.
+
+On the review path an ordering wrinkle forces one extra seam: `pushIfMoved` in `phases/review-push.ts` runs `dropUnpushable` (revert protected paths, e.g. `.github/workflows/`, since a push cannot carry them) **before** the push. A reconciling merge that lands *after* that check could smuggle a protected path in from the human's line, and GitHub refuses the **whole push** for one workflow file (the issue #240 failure class). So `Git` gains `reconcile(branch)` as its own operation, `push()` calls it first (single definition), and `review-push.ts` calls `reconcile` before `dropUnpushable` — after which `push()`'s internal reconcile is an idempotent no-op (ancestor check passes). Cost: one extra fetch round-trip on the review path, sub-second.
+
+*Alternative rejected:* reconcile only inside `push()` — smaller diff, but re-opens the per-push protected-path refusal on exactly the phase that guards against it.
+
+### D2. Merge, never rebase, never force
+
+A merge preserves both lines and matches what the human did in the incident (`1f7ce71b` is itself a merge of the agent's fix). A rebase would rewrite commits the review loop's `primary` branch shares history with (its publish merges `primary` into the checkout expecting shared ancestry) and rewrites what was already pushed where the human already built on it. Force-push discards human work. Merge-commit identity comes from the existing author/committer stamping, like every other commit this pipeline makes.
+
+### D3. Conflict = abort, clean tree, named paths, `GitError`
+
+On `CONFLICT` from the merge: read `git diff --name-only --diff-filter=U`, `git merge --abort`, throw `GitError` whose message names the conflicted paths. No new error class (one-class-per-file rule; `GitError` already carries the failing `CommandResult`). Mid-loop this degrades to today's warn; the final push fails the run with paths a maintainer can act on. Any non-conflict merge failure also aborts the merge (leaving a clean tree) before propagating.
+
+### D4. Graceful degradation where merge cannot run
+
+If the checkout's index is locked (the loop's own publish merge into the checkout runs `git merge` in the same repo — small contention window) or the tree is dirty, git refuses the merge; the failure propagates as today's `GitError` → warn mid-loop, fatal on the final push (which retries the whole reconcile at a quiet moment). No lock-waiting, no retry loop.
+
+*Alternative rejected:* serialize the pipeline's reconcile against the loop's primary lock — the lock lives in the loop's process; sharing it across the pipe inverts the credential boundary for no rare-case gain.
+
+### D5. Tests at the argv-seam, no filesystem
+
+`Git` is built on the injected `CommandRunner`; the existing suites (`tests/opencode-agent/adapters.test.ts`, `diff-guard.test.ts`) already assert exact git argv through a fake runner. New cases follow that pattern: remote-ahead → fetch/merge-then-push sequence; ancestor → no merge; branch absent → plain push; conflict → abort + throw naming paths; never `--force`. The `review-push` ordering (reconcile before `dropUnpushable`) is asserted in the `phases.test.ts` fake, which already refuses driver calls before `ensureBranch`.
+
+## Risks / Trade-offs
+
+- [Reconciling merge brings human commits the agent then pushes] → Same trust domain the checkout already holds (`ensureBranch` fetched the branch at entry); protected paths are reverted by `dropUnpushable` after the explicit reconcile (D1 ordering), and `push` never force-pushes.
+- [Human pushes again between reconcile and push] → Push rejected as today; mid-loop warn / final-push failure with the resume point intact. One reconcile attempt per push is the deliberate bound.
+- [Merge commit confuses `pushedAt`/`changedSince` bookkeeping in `review-push`] → Both compare SHAs before/after; a merge moving HEAD only makes the next `pushIfMoved` see "moved" and push — the correct direction.
+- [Existing argv assertions break (`adapters.test.ts:2555`, `diff-guard.test.ts:437`)] → Updated in the same task as the implementation; they are the contract this change deliberately edits.
+
+## Migration Plan
+
+Ship as one PR; no state, config, or workflow changes — the reconcile is invisible until a remote advance occurs, and no `STATE_VERSION` bump is involved. Rollback = revert the commit; behavior returns to today's (fail on non-fast-forward).
+
+## Open Questions
+
+None — the incident fixes the shape; the remaining unknowns (how often humans push mid-review) only affect frequency, not design.

--- a/openspec/changes/reconcile-agent-branch-push/proposal.md
+++ b/openspec/changes/reconcile-agent-branch-push/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Run 32374999214 (PR #313) failed in `CODE_REVIEW` after a 3-hour review loop: `git push -u origin agent/issue-305` was rejected (`fetch first`). Root cause, reconstructed from the run log and branch history: a maintainer pushed to `agent/issue-305` *mid-run* (merge commit `1f7ce71b` at 14:42:22, parents: the maintainer's own commit and the agent's already-pushed fix `88dfb8a6`). The pipeline fetched the branch exactly once (`ensureBranch`, 13:34:35) and every later push assumed the remote had not moved. Result: five mid-loop fixes were silently unpushed (warn-only, "the final push tries again"), the final push failed the run, and the invited `/retry` re-runs a ~1M-token review loop from scratch — for a git bookkeeping issue. Without a fix, every long phase sharing `agent/issue-<n>` with a human (review is hours by design) fails this way whenever the human pushes.
+
+## What Changes
+
+- `Git.push` (opencode-agent `src/git.ts`) becomes a reconciling push for agent branches: before pushing, fetch the branch; if `origin/<branch>` has commits local HEAD does not contain, merge them (`--no-edit`, abort cleanly on conflict naming the conflicted paths) and push the merged result. Never force-push.
+- A merge conflict during reconciliation is reported as a diagnosis (conflicted paths named), not git's opaque `fetch first` hint.
+- All existing push call sites (`review-push.ts`, `implement-commit.ts`, `ci-fix.ts`, `plan.ts`, `triage.ts`, `salvage.ts`) get this behavior through the one `Git.push` seam; no per-phase changes. `archive.ts` (pushes the base branch) and `resetBranchToBase` (deliberate force-reset) are unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-branch-push-reconciliation`: how the GitHub Actions agent pushes to `agent/issue-<n>` when the remote branch advanced since the phase's `ensureBranch` fetch — reconcile-by-merge before every push, conflict surfaced as a named-path failure, human commits never discarded. Without it, any human push during a multi-hour phase makes every subsequent push fail (mid-loop fixes lost with the runner, run parked in `FAILED` inviting a full-loop `/retry`).
+
+### Modified Capabilities
+
+None. `agent-commit-identity` (author/committer stamping) and the review-phase rules in `opencode-agent/CLAUDE.md` are untouched; no existing spec covers the push path.
+
+## Non-goals
+
+- Rebasing local commits instead of merging (a rebase rewrites what the review loop's `primary` branch shares history with; merge preserves both lines and matches what the human did in the incident).
+- Re-fetching inside `ensureBranch` more often — the failure is not a stale checkout, it is pushes that never reconcile.
+- Retry loops beyond one reconcile attempt per push; the existing per-call-site failure semantics (warn mid-loop, fatal final push) stand.
+- Any papai runtime change: no platform/task instance, config-context, storage-context, or `tool_prefs` impact — this is entirely inside the `opencode-agent/` CI pipeline.
+- Teaching `review-loop/` about remotes (the credential must stay on the pipeline side of the pipe).
+
+## Impact
+
+- Code: `opencode-agent/src/git.ts` (`push`, new reconcile helper), tests in `tests/opencode-agent/`.
+- Docs: `opencode-agent/CLAUDE.md` (push-path rule), no `docs/architecture/*.md` — the incident and fix live in the workspace docs.
+- No new dependencies; plain git argv through the existing `CommandRunner` with the existing per-invocation credential env.

--- a/openspec/changes/reconcile-agent-branch-push/specs/agent-branch-push-reconciliation/spec.md
+++ b/openspec/changes/reconcile-agent-branch-push/specs/agent-branch-push-reconciliation/spec.md
@@ -1,0 +1,65 @@
+## Purpose
+
+Defines how the GitHub Actions agent's pushes to `agent/issue-<n>` reconcile with a remote branch that advanced mid-run, so a maintainer pushing to the branch during a multi-hour phase neither fails the run nor silently strands the agent's commits.
+
+## ADDED Requirements
+
+### Requirement: Pushes reconcile a remote branch that advanced mid-run
+
+Before every push of an `agent/issue-<n>` branch, the system SHALL fetch the branch from the remote and, when the remote tip contains commits local HEAD does not, integrate them with a non-interactive merge before pushing the merged result. The system SHALL NOT force-push on this path.
+
+#### Scenario: Human pushed while the review loop ran
+
+- **WHEN** a review-loop fix is published and pushed, a maintainer then pushes their own commits (including a merge that already contains the agent's pushed fix) to the same branch, and the loop publishes its next fix
+- **THEN** the push fetches the branch, merges the remote tip into the local branch without discarding either line, and the push succeeds, keeping the maintainer's commits and the new fix on the remote
+
+#### Scenario: Remote unchanged skips integration
+
+- **WHEN** the remote branch tip is already an ancestor of local HEAD at push time
+- **THEN** the system SHALL push without creating a merge commit
+
+#### Scenario: Branch not yet on the remote
+
+- **WHEN** the branch being pushed does not exist on the remote (first push after branch capture)
+- **THEN** the system SHALL push without attempting integration and without treating the missing remote ref as an error
+
+### Requirement: Reconciliation conflicts are diagnosed, not hinted
+
+When the reconciliation merge conflicts, the system SHALL abort the merge, leave the working tree clean, and fail the push with an error that names the conflicted paths, rather than surfacing git's generic non-fast-forward rejection text.
+
+#### Scenario: Human rewrote the same files a fix touched
+
+- **WHEN** the remote tip's changes conflict with the local branch's unpushed commits during the reconciliation merge
+- **THEN** the merge is aborted and the reported failure names each conflicted path so a maintainer can resolve by hand
+
+### Requirement: Per-call-site failure semantics are preserved
+
+Reconciliation SHALL NOT change which push failures are fatal: a mid-loop review-fix push that still fails after reconciliation logs a warning and the run continues, while a phase's final push failure fails the run with its resume point intact.
+
+#### Scenario: Mid-loop push failure does not kill the loop
+
+- **WHEN** a reconciliation or push attempted while the review loop is running fails (for example a transient lock contention with the loop's own merge into the checkout)
+- **THEN** the failure is logged as a warning and the loop is not interrupted; the phase's final push carries the fixes
+
+#### Scenario: Final push failure still parks for retry
+
+- **WHEN** the phase's final push fails after a conflicted reconciliation
+- **THEN** the run is reported failed with the phase as its resume point and the conflicted paths in the report
+
+### Requirement: Agent credentials and subprocess boundaries are unchanged
+
+Reconciliation SHALL run git in the pipeline process with the existing per-invocation credential environment; no credential SHALL become visible to review-loop subprocesses or their model-controlled children, and no new credential surface SHALL be introduced.
+
+#### Scenario: Loop subprocesses never see the push credential
+
+- **WHEN** the reconciling fetch and push run while the review loop's subprocesses are alive
+- **THEN** the credential is present only in the pipeline-side git child environment, as before
+
+### Requirement: No papai runtime or scope-model effects
+
+The capability SHALL be confined to the `opencode-agent` CI pipeline's git layer; it SHALL NOT touch papai platform instances, task instances, config or storage context ids, or `tool_prefs`.
+
+#### Scenario: Papai scope unchanged
+
+- **WHEN** any reconciling push runs
+- **THEN** no papai persisted state is created or modified

--- a/openspec/changes/reconcile-agent-branch-push/tasks.md
+++ b/openspec/changes/reconcile-agent-branch-push/tasks.md
@@ -14,5 +14,5 @@
 
 ## 3. Docs and full checks
 
-- [ ] 3.1 Record the rule in `opencode-agent/CLAUDE.md`: the branch is shared with humans, every push reconciles fetch-first (merge, never rebase/force), conflicts abort-and-name-paths, and `review-push` reconciles before its protected-path revert — citing run 32374999214 / merge `1f7ce71b`
-- [ ] 3.2 Run `bun test`, `bun run typecheck`, `bun run lint`, `bun run test:affected`; update `opencode-agent/README.md` or `ROADMAP.md` only if they describe push behavior
+- [x] 3.1 Record the rule in `opencode-agent/CLAUDE.md`: the branch is shared with humans, every push reconciles fetch-first (merge, never rebase/force), conflicts abort-and-name-paths, and `review-push` reconciles before its protected-path revert — citing run 32374999214 / merge `1f7ce71b`
+- [x] 3.2 Run `bun test`, `bun run typecheck`, `bun run lint`, `bun run test:affected`; update `opencode-agent/README.md` or `ROADMAP.md` only if they describe push behavior

--- a/openspec/changes/reconcile-agent-branch-push/tasks.md
+++ b/openspec/changes/reconcile-agent-branch-push/tasks.md
@@ -8,9 +8,9 @@
 
 ## 2. Review path ordering
 
-- [ ] 2.1 Write failing test (fake `Git` in `tests/opencode-agent/`) asserting `phases/review-push.ts` calls `reconcile(branch)` before `dropUnpushable`'s `changedSince`/`revertPaths`, so protected paths arriving via a reconciling merge are still reverted before the push
-- [ ] 2.2 Add `reconcile` to the fake `Git` in `tests/opencode-agent/test-helpers.ts` (records the call like `ensureBranch` does); implement the `reconcile` call in `pushIfMoved` in `opencode-agent/src/phases/review-push.ts`
-- [ ] 2.3 Verify: `bun test tests/opencode-agent/phases.test.ts tests/opencode-agent/orchestrator.test.ts`
+- [x] 2.1 Write failing test (fake `Git` in `tests/opencode-agent/`) asserting `phases/review-push.ts` calls `reconcile(branch)` before `dropUnpushable`'s `changedSince`/`revertPaths`, so protected paths arriving via a reconciling merge are still reverted before the push
+- [x] 2.2 Add `reconcile` to the fake `Git` in `tests/opencode-agent/test-helpers.ts` (records the call like `ensureBranch` does); implement the `reconcile` call in `pushIfMoved` in `opencode-agent/src/phases/review-push.ts`
+- [x] 2.3 Verify: `bun test tests/opencode-agent/phases.test.ts tests/opencode-agent/orchestrator.test.ts`
 
 ## 3. Docs and full checks
 

--- a/openspec/changes/reconcile-agent-branch-push/tasks.md
+++ b/openspec/changes/reconcile-agent-branch-push/tasks.md
@@ -1,0 +1,18 @@
+## 1. Reconciling push in the git layer
+
+- [x] 1.1 Write failing tests in `tests/opencode-agent/adapters.test.ts` for the reconciling push argv sequence through the fake `CommandRunner`: remote branch ahead of HEAD → `git fetch origin <branch>`, `git merge-base --is-ancestor` (no), `git merge --no-edit origin/<branch>`, then the existing `git push -u origin <branch>`; assert no `--force` anywhere
+- [x] 1.2 Write failing tests for the quiet paths: remote tip already an ancestor → fetch + plain push, no merge argv; branch absent on the remote → plain push, no error
+- [x] 1.3 Write failing test for the conflict path: merge output containing `CONFLICT` → `git diff --name-only --diff-filter=U` read, `git merge --abort`, and a thrown `GitError` whose message names the conflicted paths; non-conflict merge failure also aborts the merge before throwing
+- [x] 1.4 Implement in `opencode-agent/src/git.ts`: extract `reconcile(branch)` (fetch → ancestor check → merge, per design D1–D3), call it from `push()` before the existing push argv, and add `reconcile` to the `Git` interface; update the push argv assertions in `tests/opencode-agent/adapters.test.ts:2555` and `tests/opencode-agent/diff-guard.test.ts:437-438` for the fetch prefix
+- [x] 1.5 Verify: `bun test tests/opencode-agent/adapters.test.ts tests/opencode-agent/diff-guard.test.ts`
+
+## 2. Review path ordering
+
+- [ ] 2.1 Write failing test (fake `Git` in `tests/opencode-agent/`) asserting `phases/review-push.ts` calls `reconcile(branch)` before `dropUnpushable`'s `changedSince`/`revertPaths`, so protected paths arriving via a reconciling merge are still reverted before the push
+- [ ] 2.2 Add `reconcile` to the fake `Git` in `tests/opencode-agent/test-helpers.ts` (records the call like `ensureBranch` does); implement the `reconcile` call in `pushIfMoved` in `opencode-agent/src/phases/review-push.ts`
+- [ ] 2.3 Verify: `bun test tests/opencode-agent/phases.test.ts tests/opencode-agent/orchestrator.test.ts`
+
+## 3. Docs and full checks
+
+- [ ] 3.1 Record the rule in `opencode-agent/CLAUDE.md`: the branch is shared with humans, every push reconciles fetch-first (merge, never rebase/force), conflicts abort-and-name-paths, and `review-push` reconciles before its protected-path revert — citing run 32374999214 / merge `1f7ce71b`
+- [ ] 3.2 Run `bun test`, `bun run typecheck`, `bun run lint`, `bun run test:affected`; update `opencode-agent/README.md` or `ROADMAP.md` only if they describe push behavior

--- a/tests/opencode-agent/adapters.test.ts
+++ b/tests/opencode-agent/adapters.test.ts
@@ -2586,3 +2586,94 @@ describe('createGit', () => {
     await expect(createGit(gitOptions(run)).push('agent/issue-1')).rejects.toThrow('no upstream')
   })
 })
+
+/**
+ * Run 32374999214 (PR #313): a maintainer pushed merge `1f7ce71b` to
+ * `agent/issue-305` while the review loop ran, and every later pipeline push
+ * was rejected non-fast-forward — because the branch had been fetched exactly
+ * once, at `ensureBranch`, hours earlier. A push now reconciles first: fetch
+ * the branch, and when the remote tip has commits local HEAD does not contain,
+ * merge it (never rebase, never force) and push the merged result.
+ */
+describe('createGit · the reconciling push', () => {
+  const REMOTE = 'refs/remotes/origin/agent/issue-1'
+  const FETCH = `git fetch origin +refs/heads/agent/issue-1:${REMOTE}`
+  const ANCESTOR = `git merge-base --is-ancestor ${REMOTE} HEAD`
+  const MERGE = ['git', '-c', 'user.name=agent', '-c', 'user.email=agent@example.com', 'merge', '--no-edit', REMOTE]
+
+  test('merges a remote branch that advanced mid-run, then pushes (no --force)', async () => {
+    // `merge-base` answers by exit code: 0 is ancestor, 1 is not. Here the
+    // remote carries the maintainer's commits, so local HEAD diverges.
+    const { calls, run } = captureGit({ [ANCESTOR]: 1 })
+
+    await createGit(gitOptions(run)).push('agent/issue-1')
+
+    expect(calls).toContainEqual(MERGE)
+    expect(calls).toContainEqual(['git', 'push', '-u', 'origin', 'agent/issue-1'])
+    expect(calls.some((call) => call.includes('--force'))).toBe(false)
+  })
+
+  test('pushes plainly when the remote tip is already an ancestor', async () => {
+    const { calls, run } = captureGit()
+
+    await createGit(gitOptions(run)).push('agent/issue-1')
+
+    expect(calls).toContainEqual(['git', 'fetch', 'origin', `+refs/heads/agent/issue-1:${REMOTE}`])
+    expect(calls).toContainEqual([...ANCESTOR.split(' ')])
+    expect(calls.some((call) => call.includes('merge'))).toBe(false)
+  })
+
+  test('treats a fetch that finds no remote branch as the first push, not an error', async () => {
+    const { calls, run } = captureGit({ [FETCH]: 1 })
+
+    await createGit(gitOptions(run)).push('agent/issue-1')
+
+    expect(calls).toContainEqual(['git', 'push', '-u', 'origin', 'agent/issue-1'])
+    expect(calls.some((call) => call.includes('merge-base'))).toBe(false)
+  })
+
+  test('stamps the committer identity on the reconciling merge, as on every commit', async () => {
+    // A hosted runner has no user.name anywhere, and a merge makes a commit:
+    // without the stamp the merge dies on committer identity and the push
+    // fails with an error about a config file, not about the branch.
+    const { calls, run } = captureGit({ [ANCESTOR]: 1 })
+
+    await createGit(gitOptions(run)).push('agent/issue-1')
+
+    expect(calls).toContainEqual(MERGE)
+  })
+
+  test('reconciling a conflict aborts the merge and names the conflicted paths', async () => {
+    const { calls, run } = captureGit(
+      { [ANCESTOR]: 1, [MERGE.join(' ')]: 1 },
+      {
+        [MERGE.join(' ')]: 'Auto-merging src/a.ts\nCONFLICT (content): Merge conflict in src/a.ts\n',
+        'git diff --name-only --diff-filter=U': 'src/a.ts\nsrc/b.ts\n',
+      },
+    )
+
+    await expect(createGit(gitOptions(run)).push('agent/issue-1')).rejects.toThrow('src/a.ts')
+    await expect(createGit(gitOptions(run)).push('agent/issue-1')).rejects.toThrow('src/b.ts')
+    expect(calls).toContainEqual(['git', 'merge', '--abort'])
+    // The push itself never ran: a mid-merge push is not a thing to attempt.
+    expect(calls.some((call) => call[1] === 'push')).toBe(false)
+  })
+
+  test('a merge that fails without conflicting is aborted too, then reported', async () => {
+    const { calls, run } = captureGit({ [ANCESTOR]: 1, [MERGE.join(' ')]: 128 })
+
+    await expect(createGit(gitOptions(run)).push('agent/issue-1')).rejects.toThrow('no upstream')
+    expect(calls).toContainEqual(['git', 'merge', '--abort'])
+  })
+
+  test('leaves the base branch push alone: only agent branches reconcile', async () => {
+    // ARCHIVE pushes the base branch, whose sharing rules are a different
+    // decision; its push stays the plain one it has always been.
+    const { calls, run } = captureGit()
+
+    await createGit(gitOptions(run)).push('master')
+
+    expect(calls).toContainEqual(['git', 'push', '-u', 'origin', 'master'])
+    expect(calls.some((call) => call[1] === 'fetch')).toBe(false)
+  })
+})

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -634,6 +634,10 @@ const makeHarness = (overrides: Partial<PipelineConfig> = {}): Harness => {
       io.gitCalls.push(`push:${branch}${options?.noVerify === true ? ':no-verify' : ''}`)
       return Promise.resolve()
     },
+    reconcile: (branch) => {
+      io.gitCalls.push(`reconcile:${branch}`)
+      return Promise.resolve()
+    },
     defaultBranch: () => Promise.resolve(io.detectedBranch),
     // Constant, which is the ordinary case: the review loop is a fake here, so
     // nothing moves the branch behind the pipeline's back. A test that wants the
@@ -770,6 +774,7 @@ const hostileGit = (): Git => {
     deleteRemoteBranch: (): Promise<void> => refuse('deleteRemoteBranch'),
     commitAll: (): Promise<CommitOutcome> => refuse('commit'),
     salvageAll: (): Promise<Salvage> => refuse('salvage'),
+    reconcile: (): Promise<void> => refuse('reconcile'),
     push: (): Promise<void> => refuse('push'),
     defaultBranch: (): Promise<string | null> => refuse('symbolic-ref'),
     headSha: (): Promise<string> => refuse('rev-parse'),

--- a/tests/opencode-agent/orchestrator.test.ts
+++ b/tests/opencode-agent/orchestrator.test.ts
@@ -1751,13 +1751,14 @@ describe('/review — the review loop as a command', () => {
     // `ensureBranch` first, and it is not optional: unlike the review that used
     // to run inside phase 3, this one usually runs in a job that implemented
     // nothing, so the remote branch is the only copy of the work.
-    // `changedSince` sits between the commit and the push, and belongs in this
-    // exact-sequence assertion rather than beside it: the whole point of the
-    // guard is that nothing reaches `push` before it has been asked what the
-    // loop's own commits touched.
+    // `reconcile` sits before `changedSince`, which sits between the commit and
+    // the push: a remote that advanced mid-run is merged in before the guard
+    // asks what the loop's own commits touched, so nothing rides the merge into
+    // a push it cannot survive.
     expect(harness.io.gitCalls).toEqual([
       `ensureBranch:agent/issue-${ISSUE}:${BASE_BRANCH}`,
       `commit:fix(agent): apply review-loop findings for issue #${ISSUE}`,
+      `reconcile:agent/issue-${ISSUE}`,
       'changedSince:head-sha',
       `push:agent/issue-${ISSUE}`,
     ])

--- a/tests/opencode-agent/phases.test.ts
+++ b/tests/opencode-agent/phases.test.ts
@@ -903,6 +903,26 @@ describe('handleReview · pushes what the loop merged', () => {
     expect(built.pushes()).toEqual(['push:agent/issue-42', 'push:agent/issue-42'])
   })
 
+  it('reconciles with the remote before reverting what a push cannot carry', async () => {
+    // Run 32374999214's remedy, one layer up: the reconciling merge brings the
+    // maintainer's line into the checkout, and only after it lands can
+    // `dropUnpushable` see — and revert — a protected path that line carried.
+    // The other order lets a workflow file ride the merge into a push GitHub
+    // refuses whole, the issue #240 failure class.
+    const built = reviewInput(true)
+    built.input.deps.git.commitAll = (): Promise<CommitOutcome> => Promise.resolve({ kind: 'clean' })
+    const heads = queued(['before', 'after'])
+    built.input.deps.git.headSha = (): Promise<string> => Promise.resolve(heads())
+
+    await handleReview(built.input)
+
+    const reconciled = built.io.gitCalls.indexOf('reconcile:agent/issue-42')
+    const changedSince = built.io.gitCalls.findIndex((call) => call.startsWith('changedSince:'))
+    expect(reconciled).toBeGreaterThanOrEqual(0)
+    expect(changedSince).toBeGreaterThanOrEqual(0)
+    expect(reconciled).toBeLessThan(changedSince)
+  })
+
   it('reports a loop that stopped at its budget as stopped, not as a failure', async () => {
     const built = reviewInput(true)
     built.input.deps.git.commitAll = (): Promise<CommitOutcome> => Promise.resolve({ kind: 'clean' })

--- a/tests/opencode-agent/test-helpers.ts
+++ b/tests/opencode-agent/test-helpers.ts
@@ -308,6 +308,10 @@ export const stubPhaseDeps = (options: StubPhaseDepsOptions = {}): { deps: Phase
       io.gitCalls.push(`salvage:${message.split('\n')[0]}`)
       return Promise.resolve({ kind: 'clean' })
     },
+    reconcile: (branch: string): Promise<void> => {
+      io.gitCalls.push(`reconcile:${branch}`)
+      return Promise.resolve()
+    },
     push: (branch: string, _options?: PushOptions): Promise<void> => {
       io.gitCalls.push(`push:${branch}`)
       return Promise.resolve()


### PR DESCRIPTION
## Root cause

Run [32374999214](https://github.com/yourpapai/papai/actions/runs/32374999214) (PR #313) failed in `CODE_REVIEW` after a 3-hour review loop: `git push -u origin agent/issue-305` rejected `fetch first`.

A maintainer pushed merge `1f7ce71b` to `agent/issue-305` **mid-run** (14:42, parents: his own commit + the agent's already-pushed fix `88dfb8a6`). The pipeline fetches the branch exactly once (`ensureBranch`, at phase entry) and every later push assumed the remote stood still — so five review fixes went unpushed (warn-only mid-loop), the final push failed the run, and the invited `/retry` would have re-run a ~1M-token review loop to fix git bookkeeping.

## What changes

- `Git.push` reconciles before pushing: fetch the agent branch, merge `origin/<branch>` when HEAD does not contain it — **merge, never rebase, never force** (the branch is shared with humans by design). Implemented in `git-reconcile.ts`, split from `git.ts` along `git-revert.ts`'s seam when `max-lines` fired.
- Conflict → `git merge --abort`, clean tree, `GitError` naming the conflicted paths. First push (no remote branch) and quiet remote are no-ops; base-branch pushes (`ARCHIVE`) don't reconcile.
- `phases/review-push.ts` reconciles **before `dropUnpushable`**, so a protected path (e.g. `.github/workflows/`) arriving via the human line is reverted instead of riding the merge into a whole-push GitHub refusal (the issue #240 failure class). `push()`'s internal reconcile stays as the idempotent single definition.

Planning artifacts: `openspec/changes/reconcile-agent-branch-push/`.

## Verification

- `bun test tests/opencode-agent/` — 1712 pass, 0 fail (7 new argv-seam tests + ordering pinned in phases/orchestrator suites)
- `typecheck`, `lint`, `format:check`, `review-loop:format:check` — green
- `test:affected` — 127 files, exit 0
- `openspec validate --strict` — valid

Refs #305