### PR TITLE
Key behavior-ledger evidence by coverage dimension

### DIFF
--- a/openspec/changes/ledger-dimension-tiers/.openspec.yaml
+++ b/openspec/changes/ledger-dimension-tiers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/ledger-dimension-tiers/design.md
+++ b/openspec/changes/ledger-dimension-tiers/design.md
@@ -1,0 +1,175 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Design: Per-dimension proving tiers
+
+## Context
+
+See `proposal.md` — Why. The shape that matters here is the current record type
+in `tests/stories/catalog/behaviors.ts`:
+
+```
+BehaviorCoverage
+  behaviorId    DocumentedBehaviorId
+  state         implemented | partial | blocked:… | retired
+  required      readonly CoverageDimension[]      ── what must be proven
+  provingTier   StoryTier | null                  ── ONE tier for the record
+  scenarioIds   readonly CatalogScenarioId[]      ── an unattributed bag
+  missing       readonly CoverageDimension[]      ── what is not proven
+  rationale     string
+```
+
+`scenarioReferenceGaps()` checks every id in the bag against
+`catalogCoverage`, requiring `record.provingTier === catalog.provingTier`.
+
+Two constraints shape everything below. `tests/stories/**` is a frozen compat
+input (`scripts/story/inputs.ts` — `isCapturedStoryInputPath`), so this change
+retires the current baseline `2e1630c06` and must re-record. And `max-lines` is
+off under `tests/**`, so the record file may grow without a forced split.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A tier claim that can differ per dimension, with the tier-equality invariant
+  preserved rather than weakened.
+- Make `live-status` and `reply-to-bot-routing` closable by a successor change.
+- Record where each successor change is expected to prove each open dimension,
+  without that expectation ever counting as evidence.
+
+**Non-Goals:**
+
+- Deriving `state` from the record's contents. The discriminated union already
+  makes `implemented` with a non-empty `missing` unrepresentable; going further
+  buys nothing.
+- Any change to `catalogCoverage`, the manifest, the coverage gate, or the
+  compat runner.
+
+## Decisions
+
+### D1 — Scenarios are keyed by the dimension they prove
+
+`required` / `provingTier` / `scenarioIds` collapse into one map:
+
+```
+type DimensionProof = { provingTier: StoryTier; scenarioIds: [Id, ...Id[]] }
+
+implemented       proven:  Record<CoverageDimension, DimensionProof>   (non-empty)
+                  missing: {}
+partial           proven:  Partial<Record<…, DimensionProof>>
+                  missing: Partial<Record<…, StoryTier>>               (non-empty)
+blocked|retired   proven:  {}          missing: {}
+
+required  ≡  keys(proven) ∪ keys(missing)     ── derived, never declared
+```
+
+`scenarioReferenceGaps()` then validates tier equality *per entry*, so a record
+still cannot claim a tier its evidence does not run at — the invariant moves
+down a level instead of relaxing.
+
+Deriving `required` removes a class of skew the current type permits, where
+`required`, `scenarioIds`, and `missing` are three independent fields nothing
+reconciles.
+
+**Alternative considered:** keep the three fields and add
+`provingTiers: Partial<Record<CoverageDimension, StoryTier>>` alongside
+`provingTier`. Smaller diff, and rejected: it leaves the scenario bag
+unattributed, which is the second half of the same defect (see D2).
+
+### D2 — Attribution exposes two vacuous citations, and that is the point
+
+Today nothing connects a cited scenario to a dimension; `coverageGaps()` only
+requires the bag to be non-empty. Two `partial` records satisfy that
+vacuously — every required dimension is in `missing`, yet a scenario is cited:
+
+| Record | Cites | Required | Missing |
+| --- | --- | --- | --- |
+| `reply-to-bot-routing` | `SCN-chat-message-normalization` | primary, authz-routing | **both** |
+| `chat-participant-resolution` | `SCN-context-group-identity` | primary, authz-routing | **both** |
+
+Under D1 these have no dimension to attach to, so both records become
+`proven: {}`. The substrate relationship each citation described (a mention
+boundary; a member roster) stays in `rationale`, where it is prose rather than
+a structural claim. The model should make "cites evidence that proves nothing
+required" unstateable.
+
+### D3 — An open dimension carries a planned tier, not a proven one
+
+`missing` becomes `dimension → StoryTier`: the tier a successor change is
+expected to prove it at. This is what makes the `reply-to-bot-routing` split
+meaningful — both its dimensions are open today, so without a planned tier the
+record would be structurally identical before and after this change.
+
+Re-declarations:
+
+```
+live-status              proven   external-boundary  → T2   SCN-chat-turn-tool-loop
+                                  primary            → T2   SCN-chat-turn-tool-loop
+                         missing  failure-recovery   → T0
+
+reply-to-bot-routing     proven   —
+                         missing  primary            → T0   (router reply handling)
+                                  authorization-routing → T3 (adapter equivalence /
+                                                              Mattermost-Kontur exclusion)
+```
+
+The remaining eleven records restate their single tier once per proven
+dimension, unchanged in meaning.
+
+**Alternative considered:** leave `missing` a bare dimension list and record
+the intended tier only when the story lands. Honest, but it defers the tier
+decision to whoever writes the story — which is exactly the decision this
+change exists to make, and the successor changes need it up front to know
+which lane they are authoring into.
+
+### D4 — A planned tier is never evidence
+
+`unqualifiedBehaviors()` keeps filtering on `state === 'partial'` and is not
+told about `missing` tiers. The planned tier is inert: it is read by humans
+planning successor changes, never by the qualification gate.
+
+## Risks / Trade-offs
+
+- **A planned tier is mistaken for coverage** → `missing` is keyed by tier but
+  holds no scenario ids, and the type makes a scenario list impossible there;
+  `unqualifiedBehaviors()` is unchanged. The contract test asserts a `partial`
+  record with a non-empty `missing` is still returned as unqualified.
+- **Attribution is judgement, and a wrong attribution is invisible** → the
+  contract can prove a scenario runs at the claimed tier, never that it proves
+  the claimed *dimension*. Mitigated only by review; the rationale field must
+  say why each attribution holds. This limit exists today at record
+  granularity and is not made worse.
+- **The baseline is retired the moment this lands** → the re-record is a task
+  in this change, not a follow-up, and `--manifest-only` preflight plus the
+  full compat run are its verification.
+- **The record file grows ~40%** → `max-lines` is off under `tests/**`. If
+  review finds it unwieldy, records and validators split cleanly along the
+  existing boundary; not done pre-emptively.
+
+## Migration Plan
+
+Test-first, one commit per step:
+
+1. Extend `tests/stories/harness/behavior-coverage.test.ts` with the
+   per-dimension assertions — red against today's type.
+2. Introduce `DimensionProof`, the union rewrite, and derived `required`;
+   port `coverageGaps()` and `scenarioReferenceGaps()`. Green.
+3. Port all 13 records mechanically (eleven unchanged in meaning, two
+   re-declared per D3; the two vacuous citations move to prose per D2).
+4. Add the per-dimension tier requirement to the
+   `story-coverage-floor-qualification` spec delta.
+5. Re-record the qualification baseline; run
+   `BASE_REF=<new> bun test:stories:compat --manifest-only` then the full
+   compat run, and update the roadmap design's Foundation baseline section.
+
+No rollback plan is needed: nothing ships to production, and reverting the
+commit restores the previous ledger and baseline together.
+
+## Open Questions
+
+None. The `reply-to-bot-routing` tier split is decided in D3 rather than
+deferred, because it changes the task breakdown of the successor changes.

--- a/openspec/changes/ledger-dimension-tiers/proposal.md
+++ b/openspec/changes/ledger-dimension-tiers/proposal.md
@@ -1,0 +1,83 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Proposal: Per-dimension proving tiers in the behavior ledger
+
+## Why
+
+The behavior ledger is the last unmet completion criterion of
+`docs/superpowers/specs/2026-08-04-global-refactor-behavior-coverage-roadmap-design.md`:
+8 of its 13 records are `partial`, and a `partial` record cannot qualify a
+global refactor. Two of those eight cannot be closed at all under the current
+model. `BehaviorCoverage` declares one `provingTier` per behavior, and
+`scenarioReferenceGaps()` requires every cited scenario to run at exactly that
+tier — but the roadmap requires each behavior to be proven "at the cheapest
+tier that can exercise its regression boundary", which is a property of a
+*dimension*, not of a behavior.
+
+`live-status` proves its external boundary at Tier 2 against a real Mattermost
+post lifecycle, while its unproven `failure-recovery` dimension (placeholder
+freeze/dismiss ordering, `minLabelMs` hold, error-path dismiss) is hermetic
+Tier 0 work — citing a T0 scenario from a T2 record fails the contract.
+`reply-to-bot-routing` inverts it: `primary` is Tier 0 router behavior, while
+`authorization-routing` is the Telegram/Discord equivalence and
+Mattermost/Kontur exclusion only the existing Tier 3 lane can prove.
+
+## What Changes
+
+- `BehaviorCoverage` carries a proving tier and scenario list **per required
+  dimension** instead of one tier for the whole record.
+- `scenarioReferenceGaps()` validates tier equality per dimension, preserving
+  the invariant that a record can never claim a tier its evidence does not run
+  at.
+- `live-status` and `reply-to-bot-routing` are re-declared with split tiers;
+  the other eleven records restate their single tier per dimension, unchanged
+  in meaning.
+- The qualification baseline is re-recorded — `tests/stories/**` is a frozen
+  compat input, so editing the ledger retires the current baseline.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `story-coverage-floor-qualification` — its "Ledger entries are
+  evidence-bearing" requirement governs what an entry may claim but never
+  specifies the tier claim `scenarioReferenceGaps()` already enforces. Without
+  the per-dimension rule there, the two records above stay permanently
+  `partial` and criterion #1 is unreachable. A separate capability is
+  unwarranted: this is the same evidence contract, one level finer.
+
+## Non-goals
+
+- Writing the stories that close the 14 missing dimensions — tracked as
+  successor changes; this change only makes two of them writable.
+- Auditing per-dimension tiers across the other six `partial` records —
+  declined. Only records with a demonstrated conflict are re-declared;
+  speculative re-tiering is what the roadmap's "no speculative test seams"
+  constraint forbids.
+- A `supportingScenarioIds` field exempt from the tier check — declined; it
+  buys a smaller diff by deleting the invariant that makes the ledger
+  trustworthy as evidence.
+- Splitting `live-status` into two behavior IDs — declined. IDs are
+  `<!-- behavior: -->` anchors in `docs/architecture/behaviors.md`, one per
+  independently observable behavior; inventing a second bullet corrupts the
+  inventory to fit the schema.
+- The Phase 5 refactor-impact lane map (criterion #4).
+- Any production behavior change. No platform or task instance is touched and
+  no state is persisted, so the scope model is unaffected — nothing new is
+  keyed by storage context, config context, platform instance, or user.
+
+## Impact
+
+- `tests/stories/catalog/behaviors.ts` — record type, both validators, all 13
+  records.
+- `tests/stories/harness/behavior-coverage.test.ts` — contract assertions.
+- Re-recorded baseline SHA in the roadmap design's Foundation baseline section.

--- a/openspec/changes/ledger-dimension-tiers/specs/story-coverage-floor-qualification/spec.md
+++ b/openspec/changes/ledger-dimension-tiers/specs/story-coverage-floor-qualification/spec.md
@@ -1,0 +1,95 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+## MODIFIED Requirements
+
+### Requirement: Ledger entries are evidence-bearing
+
+A documented behavior SHALL qualify only through a ledger entry backed by an
+executable record. `blocked:missing-implementation` and `retired` entries SHALL
+NOT count as evidence, and a `partial` record SHALL NOT qualify a global
+production refactor.
+
+Evidence SHALL be attributed to the specific required dimension it proves. A
+ledger entry SHALL NOT record a scenario that proves none of the behavior's
+required dimensions, and the set of dimensions a behavior requires SHALL be
+exactly the union of the dimensions it proves and the dimensions it declares
+open — a behavior SHALL NOT require a dimension that is neither.
+
+#### Scenario: Blocked entry offered as evidence
+
+- **WHEN** a behavior's only ledger entry is `blocked:missing-implementation`
+- **THEN** the behavior counts as uncovered
+
+#### Scenario: Citation that proves no required dimension
+
+- **WHEN** an entry records evidence
+- **THEN** that evidence is attributed to one of the behavior's required
+  dimensions by construction; the ledger cannot express an unattributed
+  citation, and a relationship that proves no required dimension may be stated
+  in the entry's rationale prose instead
+
+#### Scenario: Required dimension neither proven nor open
+
+- **WHEN** an entry declares what it requires
+- **THEN** the required set is derived as the union of the proven and open
+  sets, so a required dimension that is neither cannot be expressed
+
+## ADDED Requirements
+
+### Requirement: A tier claim is made per dimension
+
+A ledger entry SHALL declare a proving tier for each dimension it proves, and
+the catalog proving tier of every scenario cited for a dimension SHALL equal
+the tier that dimension declares. A behavior MAY declare different tiers for
+different dimensions, so that each dimension is proven at the cheapest tier
+that can exercise its regression boundary.
+
+#### Scenario: Scenario cited at the wrong tier
+
+- **WHEN** a dimension declares tier T and cites a scenario the catalog records
+  at a different tier
+- **THEN** the ledger is rejected, naming the dimension, the declared tier, and
+  the tier the scenario actually runs at
+
+#### Scenario: One behavior proven across two tiers
+
+- **WHEN** a behavior proves one dimension at a tier that can observe a real
+  external boundary and another dimension at a cheaper hermetic tier
+- **THEN** the ledger accepts both claims, and each dimension is validated
+  against its own declared tier
+
+#### Scenario: Dimension proven with no scenario
+
+- **WHEN** an entry declares a dimension proven but cites no scenario for it
+- **THEN** the ledger is rejected, naming the behavior and the dimension
+
+### Requirement: An open dimension declares a planned tier that is not evidence
+
+An entry SHALL record, for each dimension it leaves open, the tier at which
+that dimension is expected to be proven. A planned tier SHALL NOT carry
+scenario references and SHALL NOT count as coverage: a behavior with any open
+dimension SHALL remain unqualified for a global production refactor regardless
+of the tiers it plans.
+
+#### Scenario: Planned tier offered as coverage
+
+- **WHEN** a `partial` entry declares a planned tier for every open dimension
+- **THEN** the behavior is still reported as unqualified
+
+#### Scenario: Open dimension carrying scenario references
+
+- **WHEN** an entry records an open dimension
+- **THEN** it records a planned tier and nothing else; the ledger cannot
+  express scenario references on an open dimension
+
+#### Scenario: Every dimension proven
+
+- **WHEN** an entry's open set becomes empty because each dimension is proven
+  at its declared tier
+- **THEN** the behavior is reported as qualified and no longer appears in the
+  unqualified set

--- a/openspec/changes/ledger-dimension-tiers/tasks.md
+++ b/openspec/changes/ledger-dimension-tiers/tasks.md
@@ -75,8 +75,8 @@ See LICENSE in the project root for details.
 
 ## 5. Full verification
 
-- [ ] 5.1 Run `bun run test`, `bun run typecheck`, and `bun run lint`; read
+- [x] 5.1 Run `bun run test`, `bun run typecheck`, and `bun run lint`; read
       failures from `reports/test/` rather than re-running the suite.
-- [ ] 5.2 Confirm no `docs/architecture/*.md` page needs an edit — this change
+- [x] 5.2 Confirm no `docs/architecture/*.md` page needs an edit — this change
       alters no documented behavior and moves no `<!-- behavior: -->` anchor —
       or update the affected page. Verify: `bun run test:stories:contracts`.

--- a/openspec/changes/ledger-dimension-tiers/tasks.md
+++ b/openspec/changes/ledger-dimension-tiers/tasks.md
@@ -1,0 +1,82 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+# Tasks: Per-dimension proving tiers
+
+## 1. Contract test first (red)
+
+- [x] 1.1 In `tests/stories/harness/behavior-coverage.test.ts`, assert a
+      dimension whose cited scenario runs at a different catalog tier is
+      rejected, naming the dimension, the declared tier, and the actual tier.
+      Verify: `bun test --path-ignore-patterns '' --preload ./tests/setup.ts --preload ./tests/mock-reset.ts tests/stories/harness/behavior-coverage.test.ts` — fails.
+- [x] 1.2 Assert a behavior proving one dimension at T2 and another at T0 is
+      accepted, and that each dimension validates against its own tier.
+      Verify: `bun test --path-ignore-patterns '' --preload ./tests/setup.ts --preload ./tests/mock-reset.ts tests/stories/harness/behavior-coverage.test.ts` — fails.
+- [x] 1.3 Assert the two runtime rejection cases the spec adds: a proven
+      dimension with no scenario, and a `partial` record whose open set is
+      empty. The spec's other three cases are structural — the dimension-keyed
+      model cannot express them — so they carry no test.
+      Verify: `bun test --path-ignore-patterns '' --preload ./tests/setup.ts --preload ./tests/mock-reset.ts tests/stories/harness/behavior-coverage.test.ts` — fails.
+- [x] 1.4 Assert `unqualifiedBehaviors()` still returns a `partial` record that
+      declares a planned tier for every open dimension.
+      Verify: `bun test --path-ignore-patterns '' --preload ./tests/setup.ts --preload ./tests/mock-reset.ts tests/stories/harness/behavior-coverage.test.ts` — fails.
+
+## 2. Record type and validators
+
+- [x] 2.1 Add `DimensionProof` (`provingTier` + non-empty `scenarioIds`) and
+      rewrite the `BehaviorCoverage` union per design D1: `proven` and `missing`
+      as dimension-keyed maps, `required` / `provingTier` / `scenarioIds`
+      removed. Verify: `bun run typecheck`.
+- [x] 2.2 Derive `required` as `keys(proven) ∪ keys(missing)` and port
+      `coverageGaps()` to check `primary` membership and the blank-rationale
+      case against the derived set. Verify: `bun run typecheck`.
+- [x] 2.3 Port `scenarioReferenceGaps()` to validate each `proven` entry against
+      that entry's own declared tier, keeping the executable-scenario check.
+      Verify: `bun test --path-ignore-patterns '' --preload ./tests/setup.ts --preload ./tests/mock-reset.ts tests/stories/harness/behavior-coverage.test.ts` — 1.1–1.4 pass.
+
+## 3. Port the thirteen records
+
+- [x] 3.1 Port the eleven single-tier records mechanically: each previously
+      required dimension gets its declared tier, and each cited scenario is
+      attributed to the dimension it proves. Meaning is unchanged.
+      Verify: `bun test --path-ignore-patterns '' --preload ./tests/setup.ts --preload ./tests/mock-reset.ts tests/stories/harness/behavior-coverage.test.ts`.
+- [x] 3.2 Re-declare `live-status` per design D3: `primary` and
+      `external-boundary` proven at T2 by `SCN-chat-turn-tool-loop`,
+      `failure-recovery` open with planned tier T0.
+      Verify: `bun test --path-ignore-patterns '' --preload ./tests/setup.ts --preload ./tests/mock-reset.ts tests/stories/harness/behavior-coverage.test.ts`.
+- [x] 3.3 Re-declare `reply-to-bot-routing` per design D3: `proven` empty,
+      `primary` open at planned T0, `authorization-routing` open at planned T3.
+      Move the `SCN-chat-message-normalization` substrate relationship into the
+      rationale prose (design D2).
+      Verify: `bun test --path-ignore-patterns '' --preload ./tests/setup.ts --preload ./tests/mock-reset.ts tests/stories/harness/behavior-coverage.test.ts`.
+- [x] 3.4 Apply the same D2 treatment to `chat-participant-resolution`: `proven`
+      empty, both dimensions open at planned T0, and the
+      `SCN-context-group-identity` roster relationship stated in rationale.
+      Verify: `bun run test:stories:contracts`.
+- [x] 3.5 Confirm the ledger still reports the same eight behaviors as
+      unqualified — this change closes no dimension.
+      Verify: `bun run test:stories:contracts` and `bun run test:stories:manifest`.
+
+## 4. Re-record the qualification baseline
+
+- [ ] 4.1 Land tasks 1–3 on master, then record the new baseline SHA and its
+      manifest tree hash, retiring `2e1630c06`.
+      Verify: `BASE_REF=<new-sha> bun run test:stories:compat --manifest-only`.
+- [ ] 4.2 Prove the recorded baseline executes.
+      Verify: `BASE_REF=<new-sha> bun run test:stories:compat`.
+- [ ] 4.3 Update the Foundation baseline section of
+      `docs/superpowers/specs/2026-08-04-global-refactor-behavior-coverage-roadmap-design.md`
+      with the new SHA, tree hash, frozen-input count, and manifest scenario
+      count. Verify: `bun run format:check`.
+
+## 5. Full verification
+
+- [ ] 5.1 Run `bun run test`, `bun run typecheck`, and `bun run lint`; read
+      failures from `reports/test/` rather than re-running the suite.
+- [ ] 5.2 Confirm no `docs/architecture/*.md` page needs an edit — this change
+      alters no documented behavior and moves no `<!-- behavior: -->` anchor —
+      or update the affected page. Verify: `bun run test:stories:contracts`.

--- a/tests/stories/catalog/behaviors.ts
+++ b/tests/stories/catalog/behaviors.ts
@@ -6,13 +6,22 @@
 /**
  * Canonical behavior ledger: one record per documented behavior inventory ID
  * (`docs/architecture/behaviors.md` anchors), cross-checked against the scenario
- * catalog. An `implemented` record claims its full required-dimension matrix is
- * proven by executable catalog scenarios at the declared proving tier. A
- * `partial` record is implemented in production but matrix-incomplete: it keeps
- * its real executable scenario references and names the unproven required
- * dimensions in `missing`, so it stays structurally accountable while
- * `unqualifiedBehaviors()` bars it from global-refactor qualification until a
- * follow-on plan proves the missing dimensions and flips the record.
+ * catalog.
+ *
+ * Evidence is keyed by the dimension it proves. Each entry in `proven` declares
+ * the tier that dimension is proven at and the executable scenarios that prove
+ * it, so one behavior may prove its external boundary at a process-real tier
+ * while proving a hermetic dimension at Tier 0 — the roadmap's "cheapest tier
+ * that can exercise its regression boundary" is a property of a dimension, not
+ * of a behavior. Each entry in `missing` names a dimension that is implemented
+ * in production but not yet proven, and records the tier a follow-on plan is
+ * expected to prove it at. A planned tier is never evidence: it carries no
+ * scenarios, and `unqualifiedBehaviors()` bars any record with an open
+ * dimension from global-refactor qualification.
+ *
+ * The required dimension set is derived (`requiredDimensions()`), never
+ * declared, so a record cannot require a dimension it neither proves nor leaves
+ * open, and cannot cite a scenario that proves no required dimension.
  *
  * Intentional exclusions (Task 3): two bullets in `docs/architecture/behaviors.md`
  * carry no `<!-- behavior: -->` anchor and therefore have no ledger record here —
@@ -34,10 +43,30 @@ export type CoverageDimension =
   | 'external-boundary'
 export type BehaviorState = 'implemented' | 'partial' | 'blocked:missing-implementation' | 'retired'
 
+// Canonical order; every derived dimension list and gap report follows it, so a
+// ledger failure reads the same way on every run.
+export const COVERAGE_DIMENSIONS: readonly CoverageDimension[] = [
+  'primary',
+  'authorization-routing',
+  'failure-recovery',
+  'persistence-scope',
+  'external-boundary',
+]
+
+/** The tier one dimension is proven at, and the executable scenarios proving it. */
+export type DimensionProof = Readonly<{
+  provingTier: StoryTier
+  scenarioIds: readonly CatalogScenarioId[]
+}>
+
+type ProvenDimensions = Readonly<Partial<Record<CoverageDimension, DimensionProof>>>
+/** An open dimension records the tier it is planned to be proven at, and nothing else. */
+type OpenDimensions = Readonly<Partial<Record<CoverageDimension, StoryTier>>>
+type NoDimensions = Readonly<Record<string, never>>
+
 type BehaviorCoverageBase = Readonly<{
   behaviorId: DocumentedBehaviorId
   state: BehaviorState
-  required: readonly CoverageDimension[]
   rationale: string
 }>
 
@@ -45,34 +74,47 @@ export type BehaviorCoverage =
   | (BehaviorCoverageBase &
       Readonly<{
         state: 'implemented'
-        provingTier: StoryTier
-        scenarioIds: readonly CatalogScenarioId[]
-        missing: readonly []
+        proven: ProvenDimensions
+        missing: NoDimensions
       }>)
   | (BehaviorCoverageBase &
       Readonly<{
         state: 'partial'
-        provingTier: StoryTier
-        scenarioIds: readonly CatalogScenarioId[]
-        missing: readonly [CoverageDimension, ...CoverageDimension[]]
+        proven: ProvenDimensions
+        missing: OpenDimensions
       }>)
   | (BehaviorCoverageBase &
       Readonly<{
         state: 'blocked:missing-implementation' | 'retired'
-        provingTier: null
-        scenarioIds: readonly []
-        missing: readonly []
+        proven: NoDimensions
+        missing: NoDimensions
       }>)
+
+/** Derived, never declared: what a record requires is what it proves plus what it leaves open. */
+export function requiredDimensions(record: BehaviorCoverage): readonly CoverageDimension[] {
+  return COVERAGE_DIMENSIONS.filter(
+    (dimension) => record.proven[dimension] !== undefined || record.missing[dimension] !== undefined,
+  )
+}
+
+function recordGap(record: BehaviorCoverage): string | undefined {
+  if (record.rationale.trim() === '') return 'blank rationale'
+  if (record.state !== 'implemented' && record.state !== 'partial') return undefined
+  if (record.state === 'implemented' && requiredDimensions(record).length === 0) return 'missing scenario'
+  const unproven = COVERAGE_DIMENSIONS.find((dimension) => record.proven[dimension]?.scenarioIds.length === 0)
+  if (unproven !== undefined) return `${unproven} proven with no scenario`
+  if (!requiredDimensions(record).includes('primary')) return 'missing primary dimension'
+  if (record.state === 'partial' && Object.keys(record.missing).length === 0) {
+    return 'partial record with no open dimension'
+  }
+  return undefined
+}
 
 export function coverageGaps(records: readonly BehaviorCoverage[]): readonly string[] {
   return records
     .flatMap((record) => {
-      if (record.rationale.trim() === '') return [`${record.behaviorId}: blank rationale`]
-      if (record.state === 'implemented' || record.state === 'partial') {
-        if (!record.required.includes('primary')) return [`${record.behaviorId}: missing primary dimension`]
-        if (record.scenarioIds.length === 0) return [`${record.behaviorId}: missing scenario`]
-      }
-      return []
+      const gap = recordGap(record)
+      return gap === undefined ? [] : [`${record.behaviorId}: ${gap}`]
     })
     .toSorted()
 }
@@ -85,10 +127,10 @@ export function unqualifiedBehaviors(records: readonly BehaviorCoverage[]): read
 }
 
 /**
- * Catalog cross-check: every scenario a ledger record references must exist in
- * the catalog as an executable record, and its catalog proving tier must equal
- * the tier the ledger record declares, so a ledger entry can never point at a
- * pending gap or claim a tier the evidence does not run at.
+ * Catalog cross-check: every scenario a dimension references must exist in the
+ * catalog as an executable record, and its catalog proving tier must equal the
+ * tier *that dimension* declares, so a dimension can never point at a pending
+ * gap or claim a tier the evidence does not run at.
  */
 export function scenarioReferenceGaps(records: readonly BehaviorCoverage[]): readonly string[] {
   const executableTierByScenario = new Map<CatalogScenarioId, StoryTier>(
@@ -98,16 +140,18 @@ export function scenarioReferenceGaps(records: readonly BehaviorCoverage[]): rea
   )
   return records
     .flatMap((record) =>
-      record.scenarioIds.flatMap((scenarioId) => {
-        const executableTier = executableTierByScenario.get(scenarioId)
-        if (executableTier === undefined)
-          return [`${record.behaviorId}: ${scenarioId} is not an executable catalog scenario`]
-        if (record.provingTier !== executableTier) {
-          return [
-            `${record.behaviorId}: ${scenarioId} proves at tier ${executableTier}, not declared tier ${record.provingTier}`,
-          ]
-        }
-        return []
+      COVERAGE_DIMENSIONS.flatMap((dimension) => {
+        const proof = record.proven[dimension]
+        if (proof === undefined) return []
+        return proof.scenarioIds.flatMap((scenarioId) => {
+          const prefix = `${record.behaviorId}: ${dimension} cites ${scenarioId}`
+          const executableTier = executableTierByScenario.get(scenarioId)
+          if (executableTier === undefined) return [`${prefix}, which is not an executable catalog scenario`]
+          if (proof.provingTier !== executableTier) {
+            return [`${prefix}, which proves at tier ${executableTier}, not declared tier ${proof.provingTier}`]
+          }
+          return []
+        })
       }),
     )
     .toSorted()
@@ -117,143 +161,166 @@ const BEHAVIOR_COVERAGE_RECORDS: readonly BehaviorCoverage[] = [
   {
     behaviorId: 'thread-scoped-contexts',
     state: 'implemented',
-    provingTier: '0',
-    scenarioIds: ['SCN-context-thread-scope', 'SCN-chat-interaction-payload'],
-    required: ['primary', 'persistence-scope'],
-    missing: [],
+    proven: {
+      primary: { provingTier: '0', scenarioIds: ['SCN-context-thread-scope'] },
+      'persistence-scope': {
+        provingTier: '0',
+        scenarioIds: ['SCN-context-thread-scope', 'SCN-chat-interaction-payload'],
+      },
+    },
+    missing: {},
     rationale:
       'The thread-scope story proves group threads share config while isolating history; the Discord interaction story proves Discord contexts resolve to channel scope, not threads.',
   },
   {
     behaviorId: 'scope-model',
     state: 'implemented',
-    provingTier: '0',
-    scenarioIds: ['SCN-context-thread-scope', 'SCN-context-group-identity'],
-    required: ['primary', 'persistence-scope'],
-    missing: [],
+    proven: {
+      primary: { provingTier: '0', scenarioIds: ['SCN-context-thread-scope', 'SCN-context-group-identity'] },
+      'persistence-scope': {
+        provingTier: '0',
+        scenarioIds: ['SCN-context-thread-scope', 'SCN-context-group-identity'],
+      },
+    },
+    missing: {},
     rationale:
       'Both context stories prove thread-isolated live state with group-shared durable config and distinct per-user identities.',
   },
   {
     behaviorId: 'settings-only-configuration',
     state: 'implemented',
-    provingTier: '0',
-    scenarioIds: ['SCN-settings-bootstrap', 'SCN-cmd-config-dm', 'SCN-cmd-config-group'],
-    required: ['primary', 'authorization-routing'],
-    missing: [],
+    proven: {
+      primary: { provingTier: '0', scenarioIds: ['SCN-settings-bootstrap', 'SCN-cmd-config-dm'] },
+      'authorization-routing': { provingTier: '0', scenarioIds: ['SCN-cmd-config-group'] },
+    },
+    missing: {},
     rationale:
-      'Bootstrap proves first-run configuration lands in the settings UI; the /config stories prove the DM single-use link and the group redirect that refuses plain members.',
+      'Bootstrap proves first-run configuration lands in the settings UI and the DM story proves the single-use link; the group story proves the redirect that refuses plain members.',
   },
   {
     behaviorId: 'reply-to-bot-routing',
     state: 'partial',
-    provingTier: '0',
-    scenarioIds: ['SCN-chat-message-normalization'],
-    required: ['primary', 'authorization-routing'],
-    missing: ['primary', 'authorization-routing'],
+    proven: {},
+    missing: { primary: '0', 'authorization-routing': '3' },
     rationale:
-      'The normalization story proves only the standalone-mention boundary this equivalence extends; no executable story sends a group reply to the bot’s own message, so the Telegram/Discord equivalence and the Mattermost/Kontur exclusion are unproven.',
+      'No executable story sends a group reply to the bot’s own message, so nothing this behavior requires is proven. SCN-chat-message-normalization proves only the standalone-mention boundary this equivalence extends — substrate, not evidence. The Telegram/Discord equivalence and the Mattermost/Kontur exclusion are adapter behavior and are planned at Tier 3; the router-side reply handling is planned at Tier 0.',
   },
   {
     behaviorId: 'identity-provisioning',
     state: 'partial',
-    provingTier: '0',
-    scenarioIds: ['SCN-task-identity', 'SCN-settings-identity', 'SCN-context-group-identity'],
-    required: ['primary', 'authorization-routing', 'persistence-scope'],
-    missing: ['authorization-routing', 'persistence-scope'],
+    proven: {
+      primary: {
+        provingTier: '0',
+        scenarioIds: ['SCN-task-identity', 'SCN-settings-identity', 'SCN-context-group-identity'],
+      },
+    },
+    missing: { 'authorization-routing': '0', 'persistence-scope': '0' },
     rationale:
       'Group-turn member provisioning and settings-saved identity resolution are proven; the placeholder pending-entry rebind on first DM, open_dm_access auto-provisioning and durable blocks, and the strict 422 group-add path have no story.',
   },
   {
     behaviorId: 'guest-readonly',
     state: 'implemented',
-    provingTier: '0',
-    scenarioIds: ['SCN-task-guest-readonly', 'SCN-coding-acp-guest-denied', 'SCN-settings-api-group'],
-    required: ['primary', 'authorization-routing'],
-    missing: [],
+    proven: {
+      primary: { provingTier: '0', scenarioIds: ['SCN-task-guest-readonly'] },
+      'authorization-routing': {
+        provingTier: '0',
+        scenarioIds: ['SCN-coding-acp-guest-denied', 'SCN-settings-api-group'],
+      },
+    },
+    missing: {},
     rationale:
-      'Guest group turns prove the hardcoded read-only toolset, the ACP guest denial, and the admin-only group guest-mode toggle.',
+      'The guest group turn proves the hardcoded read-only toolset; the ACP denial and the admin-only group guest-mode toggle prove the authorization boundary.',
   },
   {
     behaviorId: 'alert-edge-triggering',
     state: 'partial',
-    provingTier: '0',
-    scenarioIds: ['SCN-deferred-alert-create', 'SCN-deferred-fire-alert'],
-    required: ['primary', 'persistence-scope', 'failure-recovery'],
-    missing: ['persistence-scope', 'failure-recovery'],
+    proven: {
+      primary: { provingTier: '0', scenarioIds: ['SCN-deferred-alert-create', 'SCN-deferred-fire-alert'] },
+    },
+    missing: { 'failure-recovery': '0', 'persistence-scope': '0' },
     rationale:
       'Alert creation and an overdue-task fire are proven; the stored match-set edge transitions, leave/re-entry semantics, cooldown, and the migration-069 first-cycle empty-set behavior have no story.',
   },
   {
     behaviorId: 'repo-catalogue',
     state: 'implemented',
-    provingTier: '0',
-    scenarioIds: [
-      'SCN-coding-acp-list-projects',
-      'SCN-settings-coding-repos',
-      'SCN-coding-acp-self-hosted-forge-preflight',
-    ],
-    required: ['primary', 'persistence-scope', 'external-boundary'],
-    missing: [],
+    proven: {
+      primary: { provingTier: '0', scenarioIds: ['SCN-coding-acp-list-projects'] },
+      'persistence-scope': { provingTier: '0', scenarioIds: ['SCN-settings-coding-repos'] },
+      'external-boundary': { provingTier: '0', scenarioIds: ['SCN-coding-acp-self-hosted-forge-preflight'] },
+    },
+    missing: {},
     rationale:
       'The catalogue is listed without Magi, a settings-registered repo is persisted and startable, and the self-hosted preflight fails closed without forge settings.',
   },
   {
     behaviorId: 'release-announcements',
     state: 'partial',
-    provingTier: '0',
-    scenarioIds: ['SCN-announcement-delivery-fanout', 'SCN-settings-api-release', 'SCN-changelog-version-section'],
-    required: ['primary', 'authorization-routing', 'external-boundary'],
-    missing: ['external-boundary'],
+    proven: {
+      primary: {
+        provingTier: '0',
+        scenarioIds: ['SCN-announcement-delivery-fanout', 'SCN-changelog-version-section'],
+      },
+      'authorization-routing': { provingTier: '0', scenarioIds: ['SCN-settings-api-release'] },
+    },
+    missing: { 'external-boundary': '0' },
     rationale:
-      'Delivery fan-out accounting, admin-only release-subscription toggles, and changelog-section extraction are proven; the humanize-once central-LLM draft, the admin review notice, and the broadcast route have no story.',
+      'Delivery fan-out accounting and changelog-section extraction are proven, as are the admin-only release-subscription toggles; the humanize-once central-LLM draft, the admin review notice, and the broadcast route have no story.',
   },
   {
     behaviorId: 'mid-run-control',
     state: 'partial',
-    provingTier: '0',
-    scenarioIds: ['SCN-cmd-stop-noop', 'SCN-cmd-stop-graceful', 'SCN-cmd-stop-abort'],
-    required: ['primary', 'authorization-routing', 'failure-recovery'],
-    missing: ['authorization-routing', 'failure-recovery'],
+    proven: {
+      primary: {
+        provingTier: '0',
+        scenarioIds: ['SCN-cmd-stop-noop', 'SCN-cmd-stop-graceful', 'SCN-cmd-stop-abort'],
+      },
+    },
+    missing: { 'authorization-routing': '0', 'failure-recovery': '0' },
     rationale:
       'The /stop ladder (noop, graceful wind-down, force-abort) is proven; mid-run steering injection at the tool-step boundary (mid-turn-run-control seam) and honest partial side-effect reporting have no story.',
   },
   {
     behaviorId: 'live-status',
     state: 'partial',
-    provingTier: '2',
-    scenarioIds: ['SCN-chat-turn-tool-loop'],
-    required: ['primary', 'external-boundary', 'failure-recovery'],
-    missing: ['failure-recovery'],
+    proven: {
+      primary: { provingTier: '2', scenarioIds: ['SCN-chat-turn-tool-loop'] },
+      'external-boundary': { provingTier: '2', scenarioIds: ['SCN-chat-turn-tool-loop'] },
+    },
+    missing: { 'failure-recovery': '0' },
     rationale:
-      'The process-real smoke turn observes the ephemeral status post and its edit/delete lifecycle at the real Mattermost boundary; the placeholder freeze/dismiss ordering, minLabelMs hold, per-tool labels, and the error-path dismiss guarantee have no story.',
+      'The process-real smoke turn observes the ephemeral status post and its edit/delete lifecycle at the real Mattermost boundary, which only Tier 2 can do; the placeholder freeze/dismiss ordering, minLabelMs hold, per-tool labels, and the error-path dismiss guarantee are hermetic and are planned at Tier 0.',
   },
   {
     behaviorId: 'chat-participant-resolution',
     state: 'partial',
-    provingTier: '0',
-    scenarioIds: ['SCN-context-group-identity'],
-    required: ['primary', 'authorization-routing'],
-    missing: ['primary', 'authorization-routing'],
+    proven: {},
+    missing: { primary: '0', 'authorization-routing': '0' },
     rationale:
-      'The group-identity story proves only the member-roster substrate the resolver queries; the resolve_chat_participant tool registration, fuzzy ranking, label resolution, and delivery.mention_user_ids population have no story.',
+      'Nothing this behavior requires is proven. SCN-context-group-identity proves only the member-roster substrate the resolver queries — substrate, not evidence. The resolve_chat_participant tool registration, fuzzy ranking, label resolution, and delivery.mention_user_ids population have no story.',
   },
   {
     behaviorId: 'privacy-gated-analytics',
     state: 'partial',
-    provingTier: '0',
-    scenarioIds: [
-      'SCN-analytics-governed-turn',
-      'SCN-analytics-consent-grant',
-      'SCN-analytics-subject-rights',
-      'SCN-analytics-derived-materialization',
-      'SCN-settings-admin-analytics',
-      'SCN-stats-anonymity',
-    ],
-    required: ['primary', 'authorization-routing', 'persistence-scope', 'external-boundary'],
-    missing: ['persistence-scope', 'external-boundary'],
+    proven: {
+      primary: {
+        provingTier: '0',
+        scenarioIds: [
+          'SCN-analytics-governed-turn',
+          'SCN-analytics-subject-rights',
+          'SCN-analytics-derived-materialization',
+          'SCN-stats-anonymity',
+        ],
+      },
+      'authorization-routing': {
+        provingTier: '0',
+        scenarioIds: ['SCN-analytics-consent-grant', 'SCN-settings-admin-analytics'],
+      },
+    },
+    missing: { 'persistence-scope': '0', 'external-boundary': '0' },
     rationale:
-      'A governed turn records one epoch-bound aggregate with the kill switch fail-closed, consent through settings grants the collection ref the pseudonymous lane needs and the subject can export, withdraw, and delete the resulting record, the operator reviews policy through settings, and stats omit raw identity; the derive job materializes sessions, friction, and feature days from those events; the Metabase snapshot pipeline and the external egress lanes have no story.',
+      'A governed turn records one epoch-bound aggregate with the kill switch fail-closed, the subject can export, withdraw, and delete the resulting record, the derive job materializes sessions, friction, and feature days from those events, and stats omit raw identity; consent through settings grants the collection ref the pseudonymous lane needs and the operator reviews policy through settings. The Metabase snapshot pipeline and the external egress lanes have no story.',
   },
 ]
 

--- a/tests/stories/harness/behavior-coverage.test.ts
+++ b/tests/stories/harness/behavior-coverage.test.ts
@@ -9,6 +9,7 @@ import { DOCUMENTED_BEHAVIOR_IDS } from '../catalog/behavior-inventory.js'
 import {
   BEHAVIOR_COVERAGE,
   coverageGaps,
+  requiredDimensions,
   scenarioReferenceGaps,
   unqualifiedBehaviors,
   type BehaviorCoverage,
@@ -50,14 +51,70 @@ test('partial implemented behaviors are reported as ineligible for global qualif
   ])
 })
 
+const splitTierRecord: BehaviorCoverage = {
+  behaviorId: 'live-status',
+  state: 'partial',
+  proven: {
+    primary: { provingTier: '2', scenarioIds: ['SCN-chat-turn-tool-loop'] },
+    'failure-recovery': { provingTier: '0', scenarioIds: ['SCN-task-guest-readonly'] },
+  },
+  missing: { 'authorization-routing': '3' },
+  rationale: 'The process-real turn proves the status lifecycle; the hermetic story proves error cleanup.',
+}
+
+describe('per-dimension tier claims', () => {
+  test('rejects a dimension citing a scenario the catalog proves at another tier', () => {
+    expect(
+      scenarioReferenceGaps([
+        {
+          ...splitTierRecord,
+          proven: { primary: { provingTier: '0', scenarioIds: ['SCN-chat-turn-tool-loop'] } },
+        },
+      ]),
+    ).toEqual(['live-status: primary cites SCN-chat-turn-tool-loop, which proves at tier 2, not declared tier 0'])
+  })
+
+  test('rejects a dimension citing a scenario the catalog does not execute', () => {
+    expect(
+      scenarioReferenceGaps([
+        {
+          ...splitTierRecord,
+          // SCN-cmd-announce is a catalogued gap: a real scenario id with no executable record.
+          proven: { primary: { provingTier: '0', scenarioIds: ['SCN-cmd-announce'] } },
+        },
+      ]),
+    ).toEqual(['live-status: primary cites SCN-cmd-announce, which is not an executable catalog scenario'])
+  })
+
+  test('accepts one behavior proving two dimensions at two different tiers', () => {
+    expect(scenarioReferenceGaps([splitTierRecord])).toEqual([])
+    expect(coverageGaps([splitTierRecord])).toEqual([])
+  })
+
+  test('derives the required dimension set as the union of proven and open dimensions', () => {
+    expect(requiredDimensions(splitTierRecord)).toEqual(['primary', 'authorization-routing', 'failure-recovery'])
+  })
+})
+
+describe('planned tiers on open dimensions', () => {
+  test('a planned tier is not evidence: the behavior stays unqualified', () => {
+    expect(unqualifiedBehaviors([splitTierRecord])).toEqual(['live-status'])
+  })
+
+  test('a planned tier is never validated as a scenario reference', () => {
+    expect(scenarioReferenceGaps([{ ...splitTierRecord, missing: { 'authorization-routing': '4' } }])).toEqual([])
+  })
+})
+
 describe('coverageGaps', () => {
   const implementedRecord: BehaviorCoverage = {
     behaviorId: 'guest-readonly',
     state: 'implemented',
-    provingTier: '0',
-    scenarioIds: ['SCN-task-guest-readonly'],
-    required: ['primary', 'authorization-routing'],
-    missing: [],
+    proven: {
+      primary: { provingTier: '0', scenarioIds: ['SCN-task-guest-readonly'] },
+      'authorization-routing': { provingTier: '0', scenarioIds: ['SCN-settings-api-group'] },
+    },
+    missing: {},
     rationale: 'Guest read-only toolset is proven by the guest group-turn story.',
   }
 
@@ -65,8 +122,11 @@ describe('coverageGaps', () => {
     expect(
       coverageGaps([
         { ...implementedRecord, rationale: '   ' },
-        { ...implementedRecord, required: ['authorization-routing'] },
-        { ...implementedRecord, scenarioIds: [] },
+        {
+          ...implementedRecord,
+          proven: { 'authorization-routing': { provingTier: '0', scenarioIds: ['SCN-settings-api-group'] } },
+        },
+        { ...implementedRecord, proven: {} },
         implementedRecord,
       ]),
     ).toEqual([
@@ -76,14 +136,38 @@ describe('coverageGaps', () => {
     ])
   })
 
+  test('flags a proven dimension that cites no scenario', () => {
+    expect(
+      coverageGaps([{ ...implementedRecord, proven: { primary: { provingTier: '0', scenarioIds: [] } } }]),
+    ).toEqual(['guest-readonly: primary proven with no scenario'])
+  })
+
+  test('flags a partial record that leaves no dimension open', () => {
+    expect(coverageGaps([{ ...splitTierRecord, missing: {} }])).toEqual([
+      'live-status: partial record with no open dimension',
+    ])
+  })
+
+  test('accepts a partial record that proves nothing yet but declares planned tiers', () => {
+    expect(
+      coverageGaps([
+        {
+          behaviorId: 'reply-to-bot-routing',
+          state: 'partial',
+          proven: {},
+          missing: { primary: '0', 'authorization-routing': '3' },
+          rationale: 'No story sends a group reply to the bot’s own message yet.',
+        },
+      ]),
+    ).toEqual([])
+  })
+
   test('does not demand scenarios or a primary dimension from blocked or retired records', () => {
     const blockedRecord: BehaviorCoverage = {
       behaviorId: 'mid-run-control',
       state: 'blocked:missing-implementation',
-      provingTier: null,
-      scenarioIds: [],
-      required: [],
-      missing: [],
+      proven: {},
+      missing: {},
       rationale: 'No production implementation exists yet.',
     }
     expect(coverageGaps([blockedRecord, { ...blockedRecord, rationale: '' }])).toEqual([


### PR DESCRIPTION
## Why

One `provingTier` per ledger record forced every dimension of a behavior to the same tier. `live-status` is the case that breaks: its status lifecycle can only be observed at the real chat boundary (T2), so the whole record sat at T2 — including the placeholder freeze/dismiss ordering and the error-path dismiss guarantee, which are hermetic and belong at T0. The roadmap's rule is "the cheapest tier that can exercise its regression boundary", and that is a property of a *dimension*, not of a behavior.

## What

`BehaviorCoverage` now keys evidence by the dimension it proves:

- `proven` — per dimension, its own `provingTier` and the executable scenarios that prove it. `scenarioReferenceGaps()` validates each citation against *that dimension's* declared tier.
- `missing` — per open dimension, the tier a follow-on plan is expected to prove it at. A planned tier is never evidence: it carries no scenarios and still bars the behavior from qualification.
- `required` is **derived** (`requiredDimensions()`), never declared, so a record cannot require a dimension it neither proves nor leaves open, and cannot cite a scenario that proves no required dimension.

Two records were exposed by the attribution step as citing scenarios that prove nothing they require — `reply-to-bot-routing` (`SCN-chat-message-normalization`) and `chat-participant-resolution` (`SCN-context-group-identity`). Both now declare `proven: {}` with the substrate relationship stated in rationale prose rather than dressed up as evidence.

## Blast radius

The same **eight** behaviors stay unqualified and the manifest is unchanged at **232/254** — this change closes no dimension, it only makes the ledger able to express what a follow-on plan needs to say. Nothing outside `behaviors.ts` and its contract test consumes these exports; no production code changes.

## Verification

- `bun run test:stories:contracts` — 453 pass / 0 fail
- `bun run test:stories:manifest` — 232/254 executable, unchanged
- `bun run typecheck`, `bun run lint`, `bun run format:check` — clean
- `bun run test` — nine failures, all load-induced timeouts in review-loop, YouTrack parity, deferred-prompts and behavior-audit; all 187 tests across those seven files pass when re-run alone, and none import the ledger

## Follow-up (not in this PR)

`tests/stories/**` is a frozen compat input, so merging this **retires baseline `2e1630c06`**. Tasks 4.1–4.3 of the change re-record the baseline SHA and tree hash against master and update the roadmap design's Foundation baseline section — they can only run once this is merged.

Change artifacts: `openspec/changes/ledger-dimension-tiers/`.