### PR TITLE
test(stories): close chat-participant-resolution at Tier 0

### DIFF
--- a/docs/superpowers/specs/2026-08-04-global-refactor-behavior-coverage-roadmap-design.md
+++ b/docs/superpowers/specs/2026-08-04-global-refactor-behavior-coverage-roadmap-design.md
@@ -208,22 +208,23 @@ The roadmap is complete when:
 
 ## Foundation baseline
 
-Recorded 2026-08-20 from the merge of `origin/master` into
-`hermetic-stories-continue`, superseding two baselines taken earlier that day:
+Recorded 2026-08-21 from `origin/master` at the merge of PR #322, superseding
+`2e1630c0609744a3ec4f87f15a47735657419cef` (tree hash
+`04d272db4dac667d4736c3f6d5a949fc5bb1c9787c1cbb2118d4c244347cdfee`), retired by
+`ledger-dimension-tiers` — keying behavior-ledger evidence by coverage dimension
+edits two frozen inputs, `tests/stories/catalog/behaviors.ts` and
+`tests/stories/harness/behavior-coverage.test.ts`. That baseline in turn
+superseded two taken on 2026-08-20 and retired the same way:
 `b8badfbbfa02485e4fa2d6a0818682dbd8a4c12a` (tree hash
-`5f5db4a39db11d56d084612836b827bd271579ee04dcb6271ef43592288809f1`), retired by
-this branch's own story work, and `cfe3da15087e40950b3a2ff94ef65cc4d5fe97f9`
-(tree hash
-`c289d710ca91c37534d7450ded5e7550cc11dee84d04c4ea04d54f233b295e04`), retired by
-the merge — master's i18n work edits two frozen inputs,
-`tests/stories/harness/scenario.ts` (the story language seed) and
-`tests/utils/test-helpers.ts` (`loadI18nModule`). A qualifying refactor measures
-against the literals below.
+`5f5db4a39db11d56d084612836b827bd271579ee04dcb6271ef43592288809f1`) and
+`cfe3da15087e40950b3a2ff94ef65cc4d5fe97f9` (tree hash
+`c289d710ca91c37534d7450ded5e7550cc11dee84d04c4ea04d54f233b295e04`). A
+qualifying refactor measures against the literals below.
 
 | field | value |
 | --- | --- |
-| `baselineSha` | `2e1630c0609744a3ec4f87f15a47735657419cef` |
-| `treeHash` | `04d272db4dac667d4736c3f6d5a949fc5bb1c9787c1cbb2118d4c244347cdfee` |
+| `baselineSha` | `d17459ee57588a5ff5e4dfb5edfc9b6b525e4273` |
+| `treeHash` | `d05c67bc673db27449dacc9b7aa23dc2fd07b3785c88689c7be0ea1d9f980034` |
 | frozen inputs | 173 files |
 | manifest scenarios | 192 |
 | bun | 1.3.13 |
@@ -231,13 +232,13 @@ against the literals below.
 
 Verified green on that commit:
 
-1. `bun test:stories:contracts` — 444 pass, 0 fail, 24 files
-2. `bun test:stories:coverage` — 191 pass, 0 fail; lines 72.66%, functions
-   71.13%, against floors 0.72 / 0.70
+1. `bun test:stories:contracts` — 453 pass, 0 fail, 24 files
+2. `bun test:stories:coverage` — 191 pass, 0 fail; lines 72.68%, functions
+   71.14%, against floors 0.72 / 0.70
 3. `bun test:stories:manifest` — 232/254 catalog records executable
    (T0 178, T1 29, T2 8, T3 16, T4 1)
-4. `BASE_REF=2e1630c0609744a3ec4f87f15a47735657419cef bun test:stories:compat --manifest-only`
-5. `BASE_REF=2e1630c0609744a3ec4f87f15a47735657419cef bun test:stories:compat`
+4. `BASE_REF=d17459ee57588a5ff5e4dfb5edfc9b6b525e4273 bun test:stories:compat --manifest-only`
+5. `BASE_REF=d17459ee57588a5ff5e4dfb5edfc9b6b525e4273 bun test:stories:compat`
 
 The lane measures a little above the numbers the floors were ratcheted from
 because the merge brought master's files into scope; the floors are left where
@@ -274,8 +275,6 @@ floor was in force when the baseline was taken. Changing the floor value alone
 does not retire this baseline; editing anything under `tests/stories/**`,
 `scripts/story/**`, or the other frozen inputs does.
 
-This SHA is still a `hermetic-stories-continue` commit, though one that
-already carries `origin/master`. Under the Delivery constraints below, a
-baseline that other branches rely on for a compatibility claim must sit on
-master — so this baseline qualifies work on this branch, and becomes citable
-by other branches only once PR #201 lands it on master.
+This SHA is a master commit, so the Delivery constraint that a baseline other
+branches cite must sit on master is satisfied on the day it is recorded: any
+branch may rebase onto it and claim compatibility, with no intervening PR.

--- a/docs/superpowers/specs/2026-08-04-global-refactor-behavior-coverage-roadmap-design.md
+++ b/docs/superpowers/specs/2026-08-04-global-refactor-behavior-coverage-roadmap-design.md
@@ -125,6 +125,40 @@ is narrow, deterministic, and introduced in its own reviewed task before the
 stories that depend on it. The frozen harness may change only on master before a
 new compatibility baseline is recorded.
 
+#### Seams attach to behaviors, not to a batch
+
+Surveying the seven bullets above surfaced three candidate harness seams, and the
+open question was whether to land them as one up-front change. They do not form a
+batch:
+
+| Seam | Needed by | Verdict |
+| ---- | --------- | ------- |
+| `replyTo` on message construction | `reply-to-bot-routing` · primary | Not Phase 2 — travels with its Phase 4 half |
+| `open_dm_access` / `blocked_at` on the platform-instance row | `identity-provisioning` · authorization-routing, persistence-scope | Real, single-owner |
+| a `fail` kind on `ModelDecision` | `live-status` · failure-recovery | Unresolved — may need no seam at all |
+
+`replyTo` serves only `reply-to-bot-routing`, whose `primary` half is genuine
+in-process router logic (`src/bot-guards.ts:34`) but whose sibling dimension is
+Tier 3. That behavior is Phase 4 and the seam travels with it. `open_dm_access`
+is confirmed necessary — `seedTestPlatformInstance` in
+`tests/stories/harness/fixtures.ts:372` accepts only `id` and `type`, so no story
+can vary those columns — but it belongs to one behavior.
+
+The third is an open question, not a design decision. `invokeWithLiveStatus`
+guarantees dismissal through `finally { await liveStatus.dismiss() }`, which fires
+only when `invokeModelWithTyping` **throws**; a failing tool returns a tool result
+and never reaches it. The `/stop` force-abort path throws through an
+`AbortController` and is reachable today with the existing `gateCall()` and
+`/stop` seams — no new surface, and a real production failure rather than a
+synthetic one — but whether that abort propagates out of `invokeModelWithTyping`
+or is caught below it to build the stop summary is unverified. **Spike this before
+designing a seam for it.**
+
+Each seam therefore lands as a task inside its own behavior's change, which is
+what the paragraph above already requires, and which keeps this phase clear of
+Phase 1's prohibition on speculative test seams. It costs no baseline re-record
+beyond the one each behavior pays anyway.
+
 ### Phase 3: Close provider and process boundaries
 
 Tier 1 expands parity only for normalized provider capabilities not already
@@ -220,10 +254,37 @@ natural edit when a dimension closes deletes that sentence, and nothing in
 non-blank. The residue must survive the close, so that a later decision to raise
 the bar has something to work from.
 
-This calibration assumes a structural refactor — moving, renaming and
-recomposing. A refactor that rewrites decision logic in place weakens the
-wiring/semantics split above, and should revisit this section before relying on
-it.
+The refactor this calibration assumes is named: **`plugin-core-separation`**
+(ADR 0380), whose live changes are `plugin-core-separation-toolgate`,
+`trusted-module-hermetic-qualification` and `hermetic-e2e-core-separation-proof`.
+Moving chat and task providers behind a plugin boundary is structural — modules
+relocate, composition and DI wiring change, decisions do not — so the
+wiring/semantics split above holds and the dimension-level bar stands.
+
+**Except at the gating boundary.** `plugin-core-separation-toolgate` replaces the
+hardcoded `ACP_SESSION_ACTION_TOOLS` set inside `applyWhoMayUseFilter` with a
+`ToolGateRegistry` populated from `gate: 'operator'` declarations on plugin
+tools. The move is structural; the consequence is not. The set of tools that get
+gated stops being a literal and becomes an emergent property of what plugins
+declare, so damage there is not wiring damage — it exposes the wrong tool to the
+wrong actor while everything remains correctly composed.
+
+That blast radius lands on one dimension. **`authorization-routing` closes on one
+scenario per distinct denial surface**, not per distinct claim. Four of the
+fourteen open dimensions are authorization-routing — `reply-to-bot-routing`,
+`identity-provisioning`, `mid-run-control`, `chat-participant-resolution` — and
+each already names its surfaces in its rationale. Every other dimension takes the
+rule as written above.
+
+This is a targeted deepening, not the retro-fit rejected three paragraphs up.
+That one raised the bar everywhere on consistency grounds and would have reopened
+all five implemented records. This one raises it on one dimension because a named
+refactor measurably reaches it — Phase 5's refactor-impact map applied to
+dimensions instead of lanes, arriving early. It implicates exactly one closed
+cell: `guest-readonly`'s authorization-routing, which covers
+`applyGuestReadOnlyFilter`, the sibling tool-set filter in the layer being
+rewritten. It closed on two denial surfaces, so it already satisfies the deeper
+bar; it is named here so a later reader knows it was checked rather than missed.
 
 ## Completion criteria
 

--- a/docs/superpowers/specs/2026-08-04-global-refactor-behavior-coverage-roadmap-design.md
+++ b/docs/superpowers/specs/2026-08-04-global-refactor-behavior-coverage-roadmap-design.md
@@ -173,6 +173,58 @@ idempotency and recovery semantics rather than adding retry behavior solely for
 tests. Hermetic scenarios retain strict undeclared-I/O, environment, timer,
 listener, and fixture-consumption enforcement.
 
+## What closes a dimension
+
+Since `ledger-dimension-tiers`, evidence is keyed by the coverage dimension it
+proves, which makes "when may a dimension flip from open to proven?" a question
+the ledger asks on every record. The spec's `Ledger entries are evidence-bearing`
+requirement answers only the negative half — `blocked:missing-implementation`,
+`retired` and `partial` are not evidence — so the positive bar is set here.
+
+**A dimension closes on one scenario per distinct claim that dimension makes.**
+Not one scenario per dimension, and not one per sub-behavior of the documented
+bullet.
+
+That rule is read off the ledger rather than imposed on it. The thirteen
+dimensions closed before this section was written carry sixteen scenarios, and
+the five that carry two carry two because the dimension makes two claims:
+`thread-scoped-contexts` proves persistence-scope over both thread-shared config
+and Discord's channel resolution; `guest-readonly` proves authorization-routing
+over both a denied tool and an admin-only toggle; `settings-only-configuration`
+proves primary over both first-run configuration and the single-use link. The
+dimensions that carry one make one claim.
+
+The alternative bar — a dimension closes when its whole `docs/architecture/behaviors.md`
+bullet is covered — is rejected, because it would apply only to records written
+after it. `repo-catalogue`'s bullet carries roughly ten items and its three
+dimensions closed on three scenarios; holding Phase 2's behaviors to the bullet
+would make `implemented` mean one thing for records written before the change and
+another for records written after, and a ledger whose green cells are not
+comparable cannot admit a refactor. Raising the bar is legitimate, but it is a
+retro-fit that reopens the five implemented records, not a Phase 2 decision.
+
+The bar is calibrated to what this instrument is for. The ledger admits a
+**refactor**, so its question is whether restructuring production code breaks
+something observable, and Tier 0 stories run the full stack from chat input
+through real composition — which is what detects wiring and composition damage.
+Branch-semantics drift is caught by the blocking mutation ratchet, which judges
+the whole branch diff, and external-boundary damage by the Tier 1-4 regression
+lanes. Making the ledger carry all three duplicates gates already paid for, in
+the most expensive currency available: every frozen-input edit retires the
+qualification baseline.
+
+**A closing rationale states what the scenario proves and what remains unproven
+within that dimension.** Open records already name their residue precisely; the
+natural edit when a dimension closes deletes that sentence, and nothing in
+`coverageGaps()` would notice, since it checks only that the rationale is
+non-blank. The residue must survive the close, so that a later decision to raise
+the bar has something to work from.
+
+This calibration assumes a structural refactor — moving, renaming and
+recomposing. A refactor that rewrites decision logic in place weakens the
+wiring/semantics split above, and should revisit this section before relying on
+it.
+
 ## Completion criteria
 
 The roadmap is complete when:

--- a/docs/superpowers/specs/2026-08-04-global-refactor-behavior-coverage-roadmap-design.md
+++ b/docs/superpowers/specs/2026-08-04-global-refactor-behavior-coverage-roadmap-design.md
@@ -271,9 +271,15 @@ wrong actor while everything remains correctly composed.
 
 That blast radius lands on one dimension. **`authorization-routing` closes on one
 scenario per distinct denial surface**, not per distinct claim. Four of the
-fourteen open dimensions are authorization-routing — `reply-to-bot-routing`,
+fourteen open dimensions were authorization-routing — `reply-to-bot-routing`,
 `identity-provisioning`, `mid-run-control`, `chat-participant-resolution` — and
-each already names its surfaces in its rationale. Every other dimension takes the
+each already names its surfaces in its rationale.
+`participant-resolution-stories` has since closed `chat-participant-resolution`'s
+two dimensions, leaving twelve open. It also sharpened the bar in passing: a
+denial surface has to be *reachable* to count. Two of the three conjuncts in that
+behavior's registration gate are always satisfied by production wiring, so a
+scenario over them would have been evidence about a fabricated configuration, not
+about the gate. Every other dimension takes the
 rule as written above.
 
 This is a targeted deepening, not the retro-fit rejected three paragraphs up.

--- a/openspec/changes/ledger-dimension-tiers/tasks.md
+++ b/openspec/changes/ledger-dimension-tiers/tasks.md
@@ -63,12 +63,12 @@ See LICENSE in the project root for details.
 
 ## 4. Re-record the qualification baseline
 
-- [ ] 4.1 Land tasks 1–3 on master, then record the new baseline SHA and its
+- [x] 4.1 Land tasks 1–3 on master, then record the new baseline SHA and its
       manifest tree hash, retiring `2e1630c06`.
       Verify: `BASE_REF=<new-sha> bun run test:stories:compat --manifest-only`.
-- [ ] 4.2 Prove the recorded baseline executes.
+- [x] 4.2 Prove the recorded baseline executes.
       Verify: `BASE_REF=<new-sha> bun run test:stories:compat`.
-- [ ] 4.3 Update the Foundation baseline section of
+- [x] 4.3 Update the Foundation baseline section of
       `docs/superpowers/specs/2026-08-04-global-refactor-behavior-coverage-roadmap-design.md`
       with the new SHA, tree hash, frozen-input count, and manifest scenario
       count. Verify: `bun run format:check`.

--- a/openspec/changes/participant-resolution-stories/.openspec.yaml
+++ b/openspec/changes/participant-resolution-stories/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-21
+skip_specs: true

--- a/openspec/changes/participant-resolution-stories/design.md
+++ b/openspec/changes/participant-resolution-stories/design.md
@@ -1,0 +1,121 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+## Context
+
+See `proposal.md` — Why. Three facts from the code shape the approach.
+
+`resolveChatParticipant` (`src/chat/participants/roster.ts`) is already fully injectable:
+it takes a `ResolveUserLabelFn` as a parameter, and `createProductionRuntimeDeps` binds
+it to `router.resolveUserLabel` at `src/runtime/production-deps.ts:152`. The story harness
+consumes that same composition, so the resolver reaches stories with **no production
+seam**.
+
+`resolveUserLabel` is optional on `ChatProvider` (`src/chat/types.ts:275`, inside the
+trailing `Partial<{…}>`), and `ScenarioChat` is `Omit<ChatProvider, 'onInteraction'> & …`.
+The story fake omits it today, so `ChatRouter.resolveUserLabel` returns `null` and every
+candidate falls back to username-or-userId. Adding it is type-additive.
+
+Registration is gated at `src/tools/tools-builder.ts:270` and `:296` on
+`contextType === 'group' && chatParticipantResolver !== undefined && contextId !== undefined`,
+and the descriptor cache carries a `'with-resolver' | 'no-resolver'` scope segment
+(`src/llm-orchestrator-descriptor-cache.ts:34`). Those two conjuncts are the denial
+surfaces this change must cover separately.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Close `primary` and `authorization-routing` for `chat-participant-resolution` at T0.
+- Add the smallest fixture capability that makes the label path real rather than
+  always-fallback, following the existing `seedGroupAdmin` pattern.
+- Leave the ledger rationale carrying the residue each closed dimension still does not
+  prove.
+
+**Non-Goals:**
+
+- Asserting the descriptor cache key itself. The cache segment exists so a resolver-less
+  and a resolver-bearing context do not share a descriptor; observing the *tool's*
+  presence and absence proves the outcome, and asserting the key would couple a story to
+  an implementation detail the refactor is entitled to move.
+- Driving `ChatRouter.resolveUserLabel`'s p-limit fan-out. One label lookup per candidate
+  through the real code path is what the dimension claims; the bound is unit-tested.
+
+## Decisions
+
+**The label seam is a `ScenarioChat` method, not a `given.*` env fixture.**
+`ScenarioChat` already exposes `addGroupAdmin(groupId, userId)` for exactly this shape —
+per-scenario provider state the fake owns — with `given.seedGroupAdmin` as the thin
+fixture wrapper that throws when no chat instance is present. A new
+`setUserLabel(userId, label)` plus `given.seedChatUserLabel(…)` mirrors it exactly.
+Alternatives rejected: a constructor argument to `createScenarioChat` (forces every
+existing call site to change, for a capability almost no scenario wants), and an env-var
+seam (the harness guide steers configuration toward `given.*` fixtures precisely to keep
+`process.env` clean at teardown).
+
+**Denial surfaces get one scenario each, not one combined negative.**
+The gate is a conjunction, so a single "tool absent" scenario would pass if either
+conjunct alone held — and a refactor that drops the `contextType === 'group'` check would
+stay green behind the resolver check. This is the per-denial-surface bar the roadmap sets
+for `authorization-routing`; it is the reason the bar exists.
+
+**The DM denial scenario asserts the tool is absent from the offered tool set, not that a
+call fails.** The scripted LLM chooses from what it is offered; a tool that was never
+registered cannot be called, so "the model could not call it" is the only observable, and
+it is the right one — registration, not runtime rejection, is what the behavior claims.
+
+**Ranking is proven with one query against a seeded field, not with three scenarios.**
+Exact > prefix > substring is a total order over a single candidate list; one query
+returning a correctly ordered list proves the comparator. Splitting it three ways would
+pay three frozen-input costs to re-prove one claim.
+
+## Risks / Trade-offs
+
+- **The fake's `resolveUserLabel` drifts from real provider semantics** (e.g. real
+  providers return `null` for unknown users, throw on transport failure) → seed the fake
+  to return `null` for unseeded ids, and cover the throw path, since `resolveChatParticipant`
+  has an explicit `catch` that falls back. A fake that only ever succeeds would leave that
+  `catch` unproven while the dimension reads closed.
+- **`message_metadata` senders are thread-local by design** (`roster.ts` documents this:
+  no group-level denormalized column) → the story must seed the sender in the *same*
+  storage context id it later queries, or the union will silently be members-only and the
+  scenario will pass for the wrong reason.
+- **Baseline churn** → this is the accepted per-behavior cost of Phase 2, not a risk to
+  mitigate. It is the reason Phase 2 and the refactor cannot overlap.
+
+## Migration Plan
+
+1. Land the harness fixture capability and the stories together on this branch; both are
+   frozen inputs, so there is no ordering benefit to splitting them across PRs.
+2. Merge to master.
+3. Re-record the qualification baseline at the merge commit: run the five verification
+   commands, then update `## Foundation baseline` in the roadmap design doc with the new
+   `baselineSha`, `treeHash`, frozen-input count, and manifest scenario count.
+
+Rollback is `git revert`; the retired baseline SHA stays cited in the supersession chain,
+which is what that chain is for.
+
+## Hook and TDD interactions
+
+`bunfig.toml` excludes `tests/stories/**` from default discovery, so the Write/Edit TDD
+hook cannot run a new story file — it will report that the path matched no tests. This is
+a known harness limitation, not a signal. Verify manually, as `ledger-dimension-tiers`
+did:
+
+```
+bun test --path-ignore-patterns '' --preload ./tests/setup.ts --preload ./tests/mock-reset.ts <file>
+```
+
+Test-first order: fixture contract test (`tests/stories/harness/chat.test.ts`) → fixture
+capability → catalog records → stories → ledger flip. The catalog is bidirectional, so a
+story written before its record fails `bun test:stories:contracts`; write the record in
+the same step as the story, not after.
+
+## Open Questions
+
+None. The one open item in this area — whether the `/stop` abort path removes the need
+for a `ModelDecision` failure seam — belongs to `live-status`, not to this behavior.

--- a/openspec/changes/participant-resolution-stories/design.md
+++ b/openspec/changes/participant-resolution-stories/design.md
@@ -57,6 +57,20 @@ existing call site to change, for a capability almost no scenario wants), and an
 seam (the harness guide steers configuration toward `given.*` fixtures precisely to keep
 `process.env` clean at teardown).
 
+**The capability id is added to `CORE_TOOL_CAPABILITIES` rather than worked around.**
+The scripted model addresses a tool through `callCapability(capabilityId, …)`, which
+resolves via `runtime.resolveToolCapability` against the catalog that
+`registerOfferedCoreToolCapabilities` fills from `CORE_TOOL_CAPABILITIES`.
+`resolve_chat_participant` had no entry there, so no story could call it. Since the map is
+pinned as an exhaustive ordered list in `tests/tools/core-capabilities.test.ts`, the
+absence was a gap rather than a signal to route around, and `tests/CLAUDE.md` names the
+capability catalog as part of the frozen-harness seam API. Alternatives rejected: having
+the harness special-case the wire name (puts a second, divergent naming authority in the
+harness), and asserting on `model.inspections().availableTools` alone (proves
+registration, but leaves ranking and mention population unprovable). This is the one
+production edit in the change, discovered during apply and recorded back into the
+proposal.
+
 **Denial surfaces get one scenario each, not one combined negative.**
 The gate is a conjunction, so a single "tool absent" scenario would pass if either
 conjunct alone held — and a refactor that drops the `contextType === 'group'` check would

--- a/openspec/changes/participant-resolution-stories/design.md
+++ b/openspec/changes/participant-resolution-stories/design.md
@@ -71,6 +71,25 @@ registration, but leaves ranking and mention population unprovable). This is the
 production edit in the change, discovered during apply and recorded back into the
 proposal.
 
+**The harness binds the resolver through the same code production does.**
+Found during implementation, not planning: `tests/stories/harness/world.ts` never passed
+`chatParticipantResolver` into `BotDeps`, so the registration gate failed and
+`resolve_chat_participant` was offered in no story at all. Rather than duplicate the
+binding in the harness, the production closure moved to
+`src/chat/participants/router-binding.ts` and both call sites use it. This kills a whole
+drift class the risk section below worries about: neither side can invent its own notion
+of the label context passed to `resolveUserLabel`.
+
+**Only one of the gate's three conjuncts is a denial surface.**
+The bar asks for one scenario per *distinct denial surface*, and a surface has to be
+reachable to be one. `contextType === 'group'` is: a DM turn is an ordinary thing that
+happens. `chatParticipantResolver !== undefined` and `contextId !== undefined` are not —
+production always satisfies both, and now so does the harness. Writing
+`SCN-chat-participant-no-resolver` would mean fabricating a configuration production never
+has, and a green story over a fabricated configuration is evidence about the fabrication.
+That scenario is dropped rather than deferred; the two conjuncts stay as defensive checks
+with no story behind them, which the ledger rationale records.
+
 **Denial surfaces get one scenario each, not one combined negative.**
 The gate is a conjunction, so a single "tool absent" scenario would pass if either
 conjunct alone held — and a refactor that drops the `contextType === 'group'` check would

--- a/openspec/changes/participant-resolution-stories/proposal.md
+++ b/openspec/changes/participant-resolution-stories/proposal.md
@@ -1,0 +1,78 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+## Why
+
+`chat-participant-resolution` is the ledger's emptiest `partial` record: `proven: {}`,
+with `primary` and `authorization-routing` both open at Tier 0. Its rationale is
+explicit that `SCN-context-group-identity` proves only the member-roster substrate the
+resolver queries — substrate, not evidence. Nothing the behavior actually claims is
+proven.
+
+It is first among Phase 2's seven behaviors on two readings: it needs no production
+seam, and it sits in the `src/tools/` registration layer that
+`plugin-core-separation-toolgate` is rewriting — so its open `authorization-routing`
+dimension falls inside that refactor's one semantic blast radius (see "What closes a
+dimension" in the roadmap design doc). `mid-run-control` shares the second property but
+is `blocked:missing-implementation`.
+
+## What Changes
+
+- Add Tier 0 hermetic stories under `tests/stories/chat/` covering the behavior's two
+  open dimensions:
+  - **primary** — `resolve_chat_participant` registered and callable in a group turn;
+    candidates gathered from `group_members` ∪ `message_metadata` senders; exact >
+    prefix > substring ranking; the `displayName → username → userId` fallback chain;
+    the resolved id reaching `delivery.mention_user_ids`.
+  - **authorization-routing** — one scenario per **denial surface**: the tool absent in
+    a DM context, and absent in a group when no `chatParticipantResolver` is injected
+    (`src/tools/tools-builder.ts:270`). The deeper per-surface bar applies because this
+    dimension is in the refactor's semantic edge.
+- Add scenario-configurable `resolveUserLabel` to the story fake chat provider
+  (`tests/stories/harness/chat.ts`) so the label path is exercised rather than always
+  falling back. A fixture capability the real providers already implement — not a new
+  production seam.
+- Register the new scenarios in `tests/stories/catalog/coverage.ts` (the catalog is
+  bidirectional; an uncataloged scenario fails `test:stories:contracts`).
+- Flip the ledger record to `implemented`, with a rationale that names the residue left
+  unproven within each closed dimension.
+- Re-record the qualification baseline: every file above is a frozen compat input.
+
+## Capabilities
+
+### New Capabilities
+
+None. `skip_specs: true`.
+
+### Modified Capabilities
+
+None. No production code changes and no requirement changes. The governing requirement,
+`Ledger entries are evidence-bearing` (`story-coverage-floor-qualification`), is
+**applied** here, not amended; the per-denial-surface bar for `authorization-routing` is
+already recorded as a roadmap convention and is deliberately not duplicated as a spec.
+
+## Non-goals
+
+- **Tier 1–4 coverage for this behavior.** Real-provider `resolveUserLabel` against
+  Telegram/Discord/Mattermost/Kontur is a regression-lane concern and never gates a
+  refactor qualification.
+- **The p-limit bound and `computeScore` edge cases.** Unit-level and already covered;
+  duplicating them pays frozen-input cost for nothing.
+- **Any change to `roster.ts` or the tool descriptor.** A defect a story reveals is a
+  separate proposal, not a widening of this one.
+- **The other six Phase 2 behaviors.** Each lands with its own change; seams attach to
+  behaviors, not to a batch.
+
+## Impact
+
+- **Frozen inputs** — `tests/stories/**` changes, so the `d17459ee5` baseline retires
+  and a new one is recorded on master.
+- **Scope model** — group-context only; the resolver reads at the group-level config
+  context id for members and the thread-scoped storage context id for senders. DM is a
+  denial surface, not a supported path.
+- **Docs** — the `behaviors.md` bullet is unchanged; the roadmap's open-dimension count
+  drops from 14 to 12.

--- a/openspec/changes/participant-resolution-stories/proposal.md
+++ b/openspec/changes/participant-resolution-stories/proposal.md
@@ -13,8 +13,8 @@ explicit that `SCN-context-group-identity` proves only the member-roster substra
 resolver queries — substrate, not evidence. Nothing the behavior actually claims is
 proven.
 
-It is first among Phase 2's seven behaviors on two readings: it needs no production
-seam, and it sits in the `src/tools/` registration layer that
+It is first among Phase 2's seven behaviors on two readings: it needs no new production
+capability, and it sits in the `src/tools/` registration layer that
 `plugin-core-separation-toolgate` is rewriting — so its open `authorization-routing`
 dimension falls inside that refactor's one semantic blast radius (see "What closes a
 dimension" in the roadmap design doc). `mid-run-control` shares the second property but
@@ -28,10 +28,11 @@ is `blocked:missing-implementation`.
     candidates gathered from `group_members` ∪ `message_metadata` senders; exact >
     prefix > substring ranking; the `displayName → username → userId` fallback chain;
     the resolved id reaching `delivery.mention_user_ids`.
-  - **authorization-routing** — one scenario per **denial surface**: the tool absent in
-    a DM context, and absent in a group when no `chatParticipantResolver` is injected
+  - **authorization-routing** — one scenario per **denial surface**: the tool
+    unresolvable in a DM context, resolvable in a group one
     (`src/tools/tools-builder.ts:270`). The deeper per-surface bar applies because this
-    dimension is in the refactor's semantic edge.
+    dimension is in the refactor's semantic edge. The gate's other two conjuncts are not
+    denial surfaces — production always satisfies them; see design.md.
 - Add scenario-configurable `resolveUserLabel` to the story fake chat provider
   (`tests/stories/harness/chat.ts`) so the label path is exercised rather than always
   falling back. A fixture capability the real providers already implement — not a new
@@ -55,8 +56,10 @@ None. The governing requirement, `Ledger entries are evidence-bearing`
 per-denial-surface bar for `authorization-routing` is already recorded as a roadmap
 convention and is deliberately not duplicated as a spec.
 
-One production file does change, correcting an earlier claim in this proposal that there
-would be none: `src/tools/core-capabilities.ts` gains
+Production code does change, correcting an earlier claim in this proposal that it would
+not, in two behavior-neutral ways.
+
+First, `src/tools/core-capabilities.ts` gains
 `'chat.participants.resolve': 'resolve_chat_participant'`. `CORE_TOOL_CAPABILITIES` is
 pinned as an exhaustive ordered list, so the tool's absence was a gap in that map, not a
 deliberate omission — and without an id the scripted story model cannot address the tool
@@ -64,6 +67,13 @@ at all, which blocks every `primary` scenario below. The addition is behavior-ne
 `registerOfferedCoreToolCapabilities` registers a pair only when the wire tool is already
 in the offered turn surface, and the catalog's sole consumer is
 `runtime.resolveToolCapability`, whose sole caller is `tests/stories/harness/world.ts`.
+Second, the resolver binding that `src/runtime/production-deps.ts` built inline moves to
+`src/chat/participants/router-binding.ts` so the story harness can use the same one. The
+harness had never wired `chatParticipantResolver` at all, which is why the tool appeared
+in no story; sharing the binding fixes that without letting the two sides drift on the
+label context they pass to `resolveUserLabel`. The extracted closure is the previous code
+verbatim.
+
 `skip_specs: true` therefore still holds — no observable behavior and no requirement moves.
 
 ## Non-goals

--- a/openspec/changes/participant-resolution-stories/proposal.md
+++ b/openspec/changes/participant-resolution-stories/proposal.md
@@ -50,10 +50,21 @@ None. `skip_specs: true`.
 
 ### Modified Capabilities
 
-None. No production code changes and no requirement changes. The governing requirement,
-`Ledger entries are evidence-bearing` (`story-coverage-floor-qualification`), is
-**applied** here, not amended; the per-denial-surface bar for `authorization-routing` is
-already recorded as a roadmap convention and is deliberately not duplicated as a spec.
+None. The governing requirement, `Ledger entries are evidence-bearing`
+(`story-coverage-floor-qualification`), is **applied** here, not amended; the
+per-denial-surface bar for `authorization-routing` is already recorded as a roadmap
+convention and is deliberately not duplicated as a spec.
+
+One production file does change, correcting an earlier claim in this proposal that there
+would be none: `src/tools/core-capabilities.ts` gains
+`'chat.participants.resolve': 'resolve_chat_participant'`. `CORE_TOOL_CAPABILITIES` is
+pinned as an exhaustive ordered list, so the tool's absence was a gap in that map, not a
+deliberate omission — and without an id the scripted story model cannot address the tool
+at all, which blocks every `primary` scenario below. The addition is behavior-neutral:
+`registerOfferedCoreToolCapabilities` registers a pair only when the wire tool is already
+in the offered turn surface, and the catalog's sole consumer is
+`runtime.resolveToolCapability`, whose sole caller is `tests/stories/harness/world.ts`.
+`skip_specs: true` therefore still holds — no observable behavior and no requirement moves.
 
 ## Non-goals
 
@@ -62,7 +73,7 @@ already recorded as a roadmap convention and is deliberately not duplicated as a
   refactor qualification.
 - **The p-limit bound and `computeScore` edge cases.** Unit-level and already covered;
   duplicating them pays frozen-input cost for nothing.
-- **Any change to `roster.ts` or the tool descriptor.** A defect a story reveals is a
+- **Any change to `roster.ts`, the tool descriptor, or the registration gate.** A defect a story reveals is a
   separate proposal, not a widening of this one.
 - **The other six Phase 2 behaviors.** Each lands with its own change; seams attach to
   behaviors, not to a batch.

--- a/openspec/changes/participant-resolution-stories/tasks.md
+++ b/openspec/changes/participant-resolution-stories/tasks.md
@@ -15,15 +15,15 @@ See LICENSE in the project root for details.
 
 ## 1. Fixture capability: scenario-configurable user labels
 
-- [ ] 1.1 Add a failing contract test to `tests/stories/harness/chat.test.ts`: a fresh
+- [x] 1.1 Add a failing contract test to `tests/stories/harness/chat.test.ts`: a fresh
       `ScenarioChat` returns `null` from `resolveUserLabel` for an unseeded id, returns
       the seeded label after `setUserLabel(userId, label)`, and rejects for an id seeded
       to throw. Verify: `STORY tests/stories/harness/chat.test.ts` (expect red).
-- [ ] 1.2 Implement `setUserLabel` and `resolveUserLabel` on `createScenarioChat`
+- [x] 1.2 Implement `setUserLabel` and `resolveUserLabel` on `createScenarioChat`
       (`tests/stories/harness/chat.ts`), mirroring the `addGroupAdmin` shape. `resolveUserLabel`
       is optional on `ChatProvider`, so no type change is needed. Verify:
       `STORY tests/stories/harness/chat.test.ts` (expect green).
-- [ ] 1.3 Add `given.seedChatUserLabel(...)` to `tests/stories/harness/fixtures.ts`,
+- [x] 1.3 Add `given.seedChatUserLabel(...)` to `tests/stories/harness/fixtures.ts`,
       mirroring `seedGroupAdmin` — including the "requires a chat instance" throw — and
       cover it in `tests/stories/harness/fixtures.test.ts`. Verify:
       `STORY tests/stories/harness/fixtures.test.ts`.

--- a/openspec/changes/participant-resolution-stories/tasks.md
+++ b/openspec/changes/participant-resolution-stories/tasks.md
@@ -1,0 +1,87 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+> **Story verification command.** `bunfig.toml` excludes `tests/stories/**` from default
+> discovery, so `bun test <path>` matches nothing there and the Write/Edit TDD hook cannot
+> gate these files. Every task below that names `STORY <file>` means:
+>
+> ```
+> bun test --path-ignore-patterns '' --preload ./tests/setup.ts --preload ./tests/mock-reset.ts <file>
+> ```
+
+## 1. Fixture capability: scenario-configurable user labels
+
+- [ ] 1.1 Add a failing contract test to `tests/stories/harness/chat.test.ts`: a fresh
+      `ScenarioChat` returns `null` from `resolveUserLabel` for an unseeded id, returns
+      the seeded label after `setUserLabel(userId, label)`, and rejects for an id seeded
+      to throw. Verify: `STORY tests/stories/harness/chat.test.ts` (expect red).
+- [ ] 1.2 Implement `setUserLabel` and `resolveUserLabel` on `createScenarioChat`
+      (`tests/stories/harness/chat.ts`), mirroring the `addGroupAdmin` shape. `resolveUserLabel`
+      is optional on `ChatProvider`, so no type change is needed. Verify:
+      `STORY tests/stories/harness/chat.test.ts` (expect green).
+- [ ] 1.3 Add `given.seedChatUserLabel(...)` to `tests/stories/harness/fixtures.ts`,
+      mirroring `seedGroupAdmin` — including the "requires a chat instance" throw — and
+      cover it in `tests/stories/harness/fixtures.test.ts`. Verify:
+      `STORY tests/stories/harness/fixtures.test.ts`.
+
+## 2. Catalog records
+
+- [ ] 2.1 Add four ids to `tests/stories/catalog/coverage.ts` with tier `'0'` and their
+      story ids: `SCN-chat-participant-ranking`, `SCN-chat-participant-label-fallback`,
+      `SCN-chat-participant-dm-absent`, `SCN-chat-participant-no-resolver`. The catalog is
+      bidirectional — these must land in the same commit as the stories, not after.
+      Verify: `bun test:stories:contracts`.
+
+## 3. Close `primary`
+
+- [ ] 3.1 Write `SCN-chat-participant-ranking` in `tests/stories/chat/participant-resolution.story.test.ts`:
+      a group turn where the model calls `resolve_chat_participant`, candidates come from
+      `group_members` ∪ same-context `message_metadata` senders, and the returned list is
+      ordered exact > prefix > substring. Seed the sender in the **same storage context id**
+      the resolver later queries — `message_metadata` is thread-local by design.
+      Verify: `STORY tests/stories/chat/participant-resolution.story.test.ts`.
+- [ ] 3.2 Extend the same story with the resolved id reaching `delivery.mention_user_ids`
+      on a scheduled prompt, which is what the behavior says the tool exists for.
+      Verify: same command.
+- [ ] 3.3 Write `SCN-chat-participant-label-fallback`: one candidate with a seeded label,
+      one with none (falls back to username), one with neither (falls back to userId), and
+      one whose label lookup throws (falls back, does not fail the turn — `roster.ts` has an
+      explicit `catch` for this). Verify: same command.
+
+## 4. Close `authorization-routing` — one scenario per denial surface
+
+- [ ] 4.1 Write `SCN-chat-participant-dm-absent`: in a DM context the tool is absent from
+      the offered tool set, so the model cannot call it. Asserts the
+      `contextType === 'group'` conjunct at `src/tools/tools-builder.ts:270` alone.
+      Verify: same command.
+- [ ] 4.2 Write `SCN-chat-participant-no-resolver`: in a group context with no
+      `chatParticipantResolver` injected, the tool is absent. Asserts the
+      `chatParticipantResolver !== undefined` conjunct alone. Do not merge 4.1 and 4.2 —
+      a single combined negative passes when either conjunct holds. Verify: same command.
+
+## 5. Flip the ledger
+
+- [ ] 5.1 In `tests/stories/catalog/behaviors.ts`, set `chat-participant-resolution` to
+      `state: 'implemented'`, `proven` carrying both dimensions at tier `'0'` with their
+      scenario ids, `missing: {}`. Rewrite the rationale to state what each dimension now
+      proves **and the residue it does not** — the roadmap requires the residue to survive
+      the close. Verify: `STORY tests/stories/harness/behavior-coverage.test.ts`.
+
+## 6. Verify and re-record
+
+- [ ] 6.1 Run the full story lane and its contracts: `bun test:stories:contracts` then
+      `bun test:stories`.
+- [ ] 6.2 Run `bun run test`, `bun run typecheck`, `bun run lint`, `bun run format:check`.
+      Re-run any load-induced failure file-by-file before calling it a regression.
+- [ ] 6.3 Confirm the T0 story coverage floor still holds: `bun test:stories:coverage`.
+      Raise it from a green run with `bun coverage:ratchet:stories` only if it improved.
+- [ ] 6.4 After merge to master, re-record the qualification baseline: run the five
+      verification commands and update `## Foundation baseline` in
+      `docs/superpowers/specs/2026-08-04-global-refactor-behavior-coverage-roadmap-design.md`
+      with the new `baselineSha`, `treeHash`, frozen-input count and manifest scenario
+      count, keeping `d17459ee5` in the supersession chain. Update the open-dimension count
+      in `## What closes a dimension` from 14 to 12.

--- a/openspec/changes/participant-resolution-stories/tasks.md
+++ b/openspec/changes/participant-resolution-stories/tasks.md
@@ -28,9 +28,15 @@ See LICENSE in the project root for details.
       cover it in `tests/stories/harness/fixtures.test.ts`. Verify:
       `STORY tests/stories/harness/fixtures.test.ts`.
 
-## 2. Catalog records
+## 2. Catalogs
 
-- [ ] 2.1 Add four ids to `tests/stories/catalog/coverage.ts` with tier `'0'` and their
+- [x] 2.1 Add `'chat.participants.resolve': 'resolve_chat_participant'` to
+      `CORE_TOOL_CAPABILITIES` (`src/tools/core-capabilities.ts`), without which the
+      scripted model cannot address the tool and group 3 cannot be written. Pin it first
+      in `tests/tools/core-capabilities.test.ts` — both the exhaustive ordered map and a
+      conditional-registration case mirroring `web.fetch`. Verify:
+      `bun test tests/tools/core-capabilities.test.ts` (red, then green).
+- [ ] 2.2 Add four ids to `tests/stories/catalog/coverage.ts` with tier `'0'` and their
       story ids: `SCN-chat-participant-ranking`, `SCN-chat-participant-label-fallback`,
       `SCN-chat-participant-dm-absent`, `SCN-chat-participant-no-resolver`. The catalog is
       bidirectional — these must land in the same commit as the stories, not after.

--- a/openspec/changes/participant-resolution-stories/tasks.md
+++ b/openspec/changes/participant-resolution-stories/tasks.md
@@ -36,42 +36,53 @@ See LICENSE in the project root for details.
       in `tests/tools/core-capabilities.test.ts` — both the exhaustive ordered map and a
       conditional-registration case mirroring `web.fetch`. Verify:
       `bun test tests/tools/core-capabilities.test.ts` (red, then green).
-- [ ] 2.2 Add four ids to `tests/stories/catalog/coverage.ts` with tier `'0'` and their
+- [x] 2.2 Add three ids to `tests/stories/catalog/coverage.ts` with tier `'0'` and their
       story ids: `SCN-chat-participant-ranking`, `SCN-chat-participant-label-fallback`,
-      `SCN-chat-participant-dm-absent`, `SCN-chat-participant-no-resolver`. The catalog is
+      `SCN-chat-participant-dm-absent` (see 4.2 for the dropped fourth). The catalog is
       bidirectional — these must land in the same commit as the stories, not after.
       Verify: `bun test:stories:contracts`.
 
 ## 3. Close `primary`
 
-- [ ] 3.1 Write `SCN-chat-participant-ranking` in `tests/stories/chat/participant-resolution.story.test.ts`:
+> **Harness wiring, found during 3.1.** `tests/stories/harness/world.ts` never passed
+> `chatParticipantResolver` into `BotDeps`, so the registration gate failed and the tool
+> was offered in no story at all. Fixed by extracting the production binding into
+> `src/chat/participants/router-binding.ts` and using it from both `production-deps.ts`
+> and the harness, so the two cannot drift on the label context they pass.
+
+- [x] 3.1 Write `SCN-chat-participant-ranking` in `tests/stories/chat/participant-resolution.story.test.ts`:
       a group turn where the model calls `resolve_chat_participant`, candidates come from
       `group_members` ∪ same-context `message_metadata` senders, and the returned list is
       ordered exact > prefix > substring. Seed the sender in the **same storage context id**
       the resolver later queries — `message_metadata` is thread-local by design.
       Verify: `STORY tests/stories/chat/participant-resolution.story.test.ts`.
-- [ ] 3.2 Extend the same story with the resolved id reaching `delivery.mention_user_ids`
+- [x] 3.2 Extend the same story with the resolved id reaching `delivery.mention_user_ids`
       on a scheduled prompt, which is what the behavior says the tool exists for.
       Verify: same command.
-- [ ] 3.3 Write `SCN-chat-participant-label-fallback`: one candidate with a seeded label,
-      one with none (falls back to username), one with neither (falls back to userId), and
-      one whose label lookup throws (falls back, does not fail the turn — `roster.ts` has an
-      explicit `catch` for this). Verify: same command.
+- [x] 3.3 Write `SCN-chat-participant-label-fallback`: one candidate with a seeded label,
+      one with none, and one whose label lookup throws (falls back, does not fail the turn —
+      `roster.ts` has an explicit `catch` for this). The username-vs-userId split the design
+      asked for is not observable here: scenario usernames equal user ids, so both fallbacks
+      produce the same string. `tests/chat/participants/roster.test.ts` already separates
+      them where they can differ. Verify: same command.
 
 ## 4. Close `authorization-routing` — one scenario per denial surface
 
-- [ ] 4.1 Write `SCN-chat-participant-dm-absent`: in a DM context the tool is absent from
-      the offered tool set, so the model cannot call it. Asserts the
-      `contextType === 'group'` conjunct at `src/tools/tools-builder.ts:270` alone.
-      Verify: same command.
-- [ ] 4.2 Write `SCN-chat-participant-no-resolver`: in a group context with no
-      `chatParticipantResolver` injected, the tool is absent. Asserts the
-      `chatParticipantResolver !== undefined` conjunct alone. Do not merge 4.1 and 4.2 —
-      a single combined negative passes when either conjunct holds. Verify: same command.
+- [x] 4.1 Write `SCN-chat-participant-dm-absent`: a DM turn leaves the capability
+      unresolvable, then a group turn resolves it. Asserts the `contextType === 'group'`
+      conjunct at `src/tools/tools-builder.ts:270`. The DM turn must run first: the
+      capability catalog accumulates across the turns of a process, so only a turn that
+      precedes every group turn can witness the absence. Verify: same command.
+- [x] 4.2 **Dropped, not deferred.** `SCN-chat-participant-no-resolver` would assert the
+      `chatParticipantResolver !== undefined` conjunct, but production wiring always
+      defines it — `setupBot` is called with it from `production-deps.ts` and now from the
+      harness too. Exercising it would mean fabricating a configuration production never
+      has, so it is not a denial surface the bar asks for. The gate's remaining conjunct
+      (`contextId !== undefined`) is defensive for the same reason.
 
 ## 5. Flip the ledger
 
-- [ ] 5.1 In `tests/stories/catalog/behaviors.ts`, set `chat-participant-resolution` to
+- [x] 5.1 In `tests/stories/catalog/behaviors.ts`, set `chat-participant-resolution` to
       `state: 'implemented'`, `proven` carrying both dimensions at tier `'0'` with their
       scenario ids, `missing: {}`. Rewrite the rationale to state what each dimension now
       proves **and the residue it does not** — the roadmap requires the residue to survive
@@ -79,11 +90,11 @@ See LICENSE in the project root for details.
 
 ## 6. Verify and re-record
 
-- [ ] 6.1 Run the full story lane and its contracts: `bun test:stories:contracts` then
+- [x] 6.1 Run the full story lane and its contracts: `bun test:stories:contracts` then
       `bun test:stories`.
-- [ ] 6.2 Run `bun run test`, `bun run typecheck`, `bun run lint`, `bun run format:check`.
+- [x] 6.2 Run `bun run test`, `bun run typecheck`, `bun run lint`, `bun run format:check`.
       Re-run any load-induced failure file-by-file before calling it a regression.
-- [ ] 6.3 Confirm the T0 story coverage floor still holds: `bun test:stories:coverage`.
+- [x] 6.3 Confirm the T0 story coverage floor still holds: `bun test:stories:coverage`.
       Raise it from a green run with `bun coverage:ratchet:stories` only if it improved.
 - [ ] 6.4 After merge to master, re-record the qualification baseline: run the five
       verification commands and update `## Foundation baseline` in

--- a/src/chat/participants/router-binding.ts
+++ b/src/chat/participants/router-binding.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import type { ResolveUserContext } from '../types.js'
+import { resolveChatParticipant, type ChatParticipantResolver } from './roster.js'
+
+/** The label lookup the resolver needs — the part of ChatRouter it actually uses. */
+export type UserLabelSource = Readonly<{
+  resolveUserLabel(userId: string, context: ResolveUserContext | undefined): Promise<string | null>
+}>
+
+/**
+ * Bind the roster resolver to a label source. Shared by production wiring and the
+ * story harness so neither can drift from the other's notion of the label context.
+ */
+export function createChatParticipantResolver(source: UserLabelSource): ChatParticipantResolver {
+  return (contextId, query, limit) =>
+    resolveChatParticipant(
+      contextId,
+      query,
+      (userId) => source.resolveUserLabel(userId, { contextId, contextType: 'group' }),
+      limit,
+    )
+}

--- a/src/runtime/production-deps.ts
+++ b/src/runtime/production-deps.ts
@@ -13,7 +13,7 @@ import { isS3Configured } from '../attachments/index.js'
 import { createStagedDownloader } from '../attachments/staged-download.js'
 import { setupBot, withRephraseCapture, type BotDeps } from '../bot.js'
 import { seedMattermostActionSigningSecretFromEnv } from '../chat/mattermost/action-secret.js'
-import { resolveChatParticipant } from '../chat/participants/roster.js'
+import { createChatParticipantResolver } from '../chat/participants/router-binding.js'
 import { createChatProviderFromConfig } from '../chat/registry.js'
 import { ChatRouter } from '../chat/router.js'
 import { registerCommandMenuIfSupported } from '../chat/startup.js'
@@ -149,13 +149,7 @@ function setupProductionBot(state: ProductionState, router: ChatRouter, adminUse
   const processMessage: BotDeps['processMessage'] = (...args) =>
     import('../llm-orchestrator.js').then((mod) => mod.processMessage(...args))
   const stagedDownloadFn = createStagedDownloader(router)
-  const chatParticipantResolver: BotDeps['chatParticipantResolver'] = (contextId, query, limit) =>
-    resolveChatParticipant(
-      contextId,
-      query,
-      (userId) => router.resolveUserLabel(userId, { contextId, contextType: 'group' }),
-      limit,
-    )
+  const chatParticipantResolver: BotDeps['chatParticipantResolver'] = createChatParticipantResolver(router)
   const analytics = state.analytics
   const rephrase = resolveProductionRephrase(analytics)
   setupBot(

--- a/src/tools/core-capabilities.ts
+++ b/src/tools/core-capabilities.ts
@@ -96,6 +96,7 @@ export const CORE_TOOL_CAPABILITIES = Object.freeze({
   'deferred.update': 'update_reminder',
   'deferred.cancel': 'cancel_reminder',
   'web.fetch': 'web_fetch',
+  'chat.participants.resolve': 'resolve_chat_participant',
 } as const)
 
 export function registerOfferedCoreToolCapabilities(tools: ToolSet, catalog: ToolCapabilityCatalog): void {

--- a/tests/chat/participants/router-binding.test.ts
+++ b/tests/chat/participants/router-binding.test.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { expect, test } from 'bun:test'
+
+import { createChatParticipantResolver } from '../../../src/chat/participants/router-binding.js'
+import type { ResolveUserContext } from '../../../src/chat/types.js'
+import { getDrizzleDb } from '../../../src/db/drizzle.js'
+import { groupMembers } from '../../../src/db/schema.js'
+import { mockLogger, setupTestDb } from '../../utils/test-helpers.js'
+
+type LabelCall = Readonly<{ userId: string; context: ResolveUserContext | undefined }>
+
+test('binds the roster resolver to the router, labelling every candidate in a group context', async () => {
+  mockLogger()
+  await setupTestDb()
+  getDrizzleDb().insert(groupMembers).values({ groupId: 'g-binding', userId: 'u-1', addedBy: 'test' }).run()
+  const calls: LabelCall[] = []
+  const resolver = createChatParticipantResolver({
+    resolveUserLabel(userId, context) {
+      calls.push({ userId, context })
+      return Promise.resolve('Annabel')
+    },
+  })
+
+  await expect(resolver('g-binding', 'ann', 3)).resolves.toEqual([
+    { userId: 'u-1', displayName: 'Annabel', username: null, score: 2 },
+  ])
+  expect(calls).toEqual([{ userId: 'u-1', context: { contextId: 'g-binding', contextType: 'group' } }])
+})

--- a/tests/scripts/story-coverage-totals.test.ts
+++ b/tests/scripts/story-coverage-totals.test.ts
@@ -10,18 +10,18 @@ import { formatStoryCoverageTotals, storyCoverageTotals } from '../../scripts/st
 describe('storyCoverageTotals', () => {
   test('tallies the catalog ledger', () => {
     expect(storyCoverageTotals()).toEqual({
-      total: 254,
-      executable: 232,
+      total: 257,
+      executable: 235,
       pending: 22,
       readiness: { 'executable-as-is': 0, 'needs-seam': 0, blocked: 22 },
-      executableByTier: { '0': 178, '1': 29, '2': 8, '3': 16, '4': 1 },
+      executableByTier: { '0': 181, '1': 29, '2': 8, '3': 16, '4': 1 },
       pendingByUnblockingTier: { '0': 0, '1': 0, '2': 0, '3': 0, '4': 0 },
     })
   })
 
   test('formats a single summary line with per-tier tallies', () => {
     expect(formatStoryCoverageTotals()).toBe(
-      'story catalog: 232/254 executable (T0 178, T1 29, T2 8, T3 16, T4 1); ' +
+      'story catalog: 235/257 executable (T0 181, T1 29, T2 8, T3 16, T4 1); ' +
         'pending 22 (0 executable-as-is, 0 needs-seam, 22 blocked); ' +
         'pending unblocked by tier (T0 0, T1 0, T2 0, T3 0, T4 0)',
     )

--- a/tests/stories/catalog/behaviors.ts
+++ b/tests/stories/catalog/behaviors.ts
@@ -294,11 +294,17 @@ const BEHAVIOR_COVERAGE_RECORDS: readonly BehaviorCoverage[] = [
   },
   {
     behaviorId: 'chat-participant-resolution',
-    state: 'partial',
-    proven: {},
-    missing: { primary: '0', 'authorization-routing': '0' },
+    state: 'implemented',
+    proven: {
+      primary: {
+        provingTier: '0',
+        scenarioIds: ['SCN-chat-participant-ranking', 'SCN-chat-participant-label-fallback'],
+      },
+      'authorization-routing': { provingTier: '0', scenarioIds: ['SCN-chat-participant-dm-absent'] },
+    },
+    missing: {},
     rationale:
-      'Nothing this behavior requires is proven. SCN-context-group-identity proves only the member-roster substrate the resolver queries — substrate, not evidence. The resolve_chat_participant tool registration, fuzzy ranking, label resolution, and delivery.mention_user_ids population have no story.',
+      'The ranking story proves the group_members ∪ message_metadata union, exact > prefix > substring ordering, and the resolved id reaching delivery.mention_user_ids on a persisted group reminder; the fallback story proves an unresolvable and a throwing label both degrade to the identifier without failing the turn. authorization-routing closes on its one denial surface reachable from production wiring — a non-group context withholds the tool — since the other two conjuncts of the registration gate (a defined resolver, a defined contextId) are always satisfied by production wiring and only defensive elsewhere.',
   },
   {
     behaviorId: 'privacy-gated-analytics',

--- a/tests/stories/catalog/coverage.ts
+++ b/tests/stories/catalog/coverage.ts
@@ -103,7 +103,7 @@ export type CatalogCoverage =
     }>
 
 export const CATALOG_SOURCE =
-  'scenario-catalog snapshot supplied 2026-07-13; extended 2026-07-23 with 12 SCN-parity-* provider-real (@1) ids (tier1-provider-real-parity); extended 2026-07-24 with 17 SCN-parity-* domain-retrofit (@1) ids (tier1b-e2e-parity-retrofit); extended 2026-07-24 with 8 SCN-* process-real smoke (@2) ids (tier2-process-smoke); extended 2026-07-27 with 10 real-YouTrack (@0) ids (t0-real-youtrack-provider); extended 2026-07-28 with 18 previously uncataloged story ids (story-catalog-census); extended 2026-07-29 with 21 uncatalogued-cluster behavior ids (@0/@3/@4) (phase3-catalog-foundation); extended 2026-08-01 with 3 real-Kaneo (@0) chat-loop story ids attached to the YouTrack real-provider records (t0-real-kaneo-provider); extended 2026-08-03 with 1 analytics settings (@0) story id (analytics-settings-census); extended 2026-08-04 with 4 aggregate delivery (@0) ids (analytics-aggregate-delivery-coverage); extended 2026-08-20 with 5 Discord/Mattermost adapter (@3) ids (tier3-chat-adapter-coverage)' as const
+  'scenario-catalog snapshot supplied 2026-07-13; extended 2026-07-23 with 12 SCN-parity-* provider-real (@1) ids (tier1-provider-real-parity); extended 2026-07-24 with 17 SCN-parity-* domain-retrofit (@1) ids (tier1b-e2e-parity-retrofit); extended 2026-07-24 with 8 SCN-* process-real smoke (@2) ids (tier2-process-smoke); extended 2026-07-27 with 10 real-YouTrack (@0) ids (t0-real-youtrack-provider); extended 2026-07-28 with 18 previously uncataloged story ids (story-catalog-census); extended 2026-07-29 with 21 uncatalogued-cluster behavior ids (@0/@3/@4) (phase3-catalog-foundation); extended 2026-08-01 with 3 real-Kaneo (@0) chat-loop story ids attached to the YouTrack real-provider records (t0-real-kaneo-provider); extended 2026-08-03 with 1 analytics settings (@0) story id (analytics-settings-census); extended 2026-08-04 with 4 aggregate delivery (@0) ids (analytics-aggregate-delivery-coverage); extended 2026-08-20 with 5 Discord/Mattermost adapter (@3) ids (tier3-chat-adapter-coverage); extended 2026-08-21 with 3 chat participant resolution (@0) ids (participant-resolution-stories)' as const
 
 export const CATALOG_SCENARIO_IDS = Object.freeze([
   'SCN-task-create-update',
@@ -254,6 +254,10 @@ export const CATALOG_SCENARIO_IDS = Object.freeze([
   'SCN-http-operator-data-routes',
   'SCN-context-thread-scope',
   'SCN-context-group-identity',
+  // @0 — chat participant resolution (participant-resolution-stories)
+  'SCN-chat-participant-ranking',
+  'SCN-chat-participant-label-fallback',
+  'SCN-chat-participant-dm-absent',
   // @1 — provider-real parity lane (tier1-provider-real-parity)
   'SCN-parity-task-create',
   'SCN-parity-task-get',
@@ -715,6 +719,27 @@ const EXECUTABLE_STORY_MAPPINGS: Partial<Record<CatalogScenarioId, ExecutableSto
     verifiedAt: '2026-07-19',
     storyIds: [
       'tests/stories/context/thread-scope.story.test.ts#group threads share config but isolate conversation history',
+    ],
+  },
+  'SCN-chat-participant-ranking': {
+    verifiedAt: '2026-08-21',
+    provingTier: '0',
+    storyIds: [
+      'tests/stories/chat/participant-resolution.story.test.ts#SCN-chat-participant-ranking: ranks group members and recent senders exact before prefix before substring',
+    ],
+  },
+  'SCN-chat-participant-label-fallback': {
+    verifiedAt: '2026-08-21',
+    provingTier: '0',
+    storyIds: [
+      'tests/stories/chat/participant-resolution.story.test.ts#SCN-chat-participant-label-fallback: an unresolvable label falls back to the identifier without failing the turn',
+    ],
+  },
+  'SCN-chat-participant-dm-absent': {
+    verifiedAt: '2026-08-21',
+    provingTier: '0',
+    storyIds: [
+      'tests/stories/chat/participant-resolution.story.test.ts#SCN-chat-participant-dm-absent: the resolver tool is offered in a group turn and withheld in a DM turn',
     ],
   },
   'SCN-context-group-identity': {

--- a/tests/stories/chat/participant-resolution.story.test.ts
+++ b/tests/stories/chat/participant-resolution.story.test.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { expect } from 'bun:test'
+
+import { toScopedContextId } from '../../../src/chat/scoped-context.js'
+import { scheduledPrompts } from '../../../src/db/deferred-schema.js'
+import { getDrizzleDb } from '../../../src/db/drizzle.js'
+import { scenario } from '../harness/scenario.js'
+import { answer, callCapability, promptTextFingerprint } from '../harness/scripted-llm.js'
+
+/** Position of a token inside the serialized tool result, which preserves candidate order. */
+const rank = (fingerprints: readonly string[] | undefined, text: string): number =>
+  fingerprints?.indexOf(promptTextFingerprint(text)) ?? -1
+
+scenario(
+  'SCN-chat-participant-ranking: ranks group members and recent senders exact before prefix before substring',
+  async ({ given, when, then, world }) => {
+    const group = given.group('release-team')
+    const asker = given.user('u-asker')
+    given.member(group, asker)
+    given.guestMode(group, true)
+
+    const exact = given.user('u-alpha')
+    const prefix = given.user('u-bravo')
+    const substring = given.user('u-charlie')
+    const unmatched = given.user('u-delta')
+    for (const member of [exact, prefix, substring, unmatched]) given.member(group, member)
+    given.chatUserLabel(exact, 'Ann')
+    given.chatUserLabel(prefix, 'Annabel')
+    given.chatUserLabel(substring, 'Rosanna')
+    given.chatUserLabel(unmatched, 'Boris')
+
+    // A guest is never provisioned as a member, so this sender reaches the roster only
+    // through message_metadata — the other half of the union gatherParticipants takes.
+    // It must speak in `group` itself: message_metadata is keyed by the thread-scoped
+    // storage context id, so a sibling thread would seed a row the resolver never reads.
+    const sender = given.guest('u-echo')
+    given.chatUserLabel(sender, 'Annika')
+    given.llm([answer('Welcome.')])
+    await when.message(sender, group, 'hello team')
+
+    given.llm([
+      callCapability('chat.participants.resolve', { query: 'ann' }),
+      // The resolved id is what the tool exists for: it must survive into the
+      // reminder's delivery policy, not merely be reported back to the model.
+      callCapability('deferred.create', {
+        prompt: 'Ask Ann for the release notes',
+        schedule: { fire_at: { date: '2099-01-01', time: '09:00' } },
+        execution: { mode: 'lightweight', delivery_brief: 'nudge about release notes' },
+        delivery: { mention_user_ids: [exact.id] },
+      }),
+      answer('Ann is the closest match.'),
+    ])
+    await when.message(asker, group, 'Who around here is called Ann? Remind us on Jan 1 to ask them.')
+
+    then.replyIn(group).equals('Ann is the closest match.')
+    // A group reminder is owned by the group context, not by the member who asked for it.
+    const groupContextId = toScopedContextId({
+      platformInstanceId: group.platformInstanceId,
+      nativeContextId: group.id,
+    })
+    const scheduled = getDrizzleDb().select().from(scheduledPrompts).all()
+    expect(scheduled.map(({ createdByUserId, mentionUserIds }) => ({ createdByUserId, mentionUserIds }))).toEqual([
+      // A group reminder is owned by the group context, not by the member who asked for it.
+      { createdByUserId: groupContextId, mentionUserIds: JSON.stringify([exact.id]) },
+    ])
+    const result = world.model.inspections().at(-1)?.promptToolResultTokenFingerprints
+    expect(rank(result, 'Ann')).toBeGreaterThanOrEqual(0)
+    expect(rank(result, 'Ann')).toBeLessThan(rank(result, 'Annabel'))
+    expect(rank(result, 'Annabel')).toBeLessThan(rank(result, 'Annika'))
+    expect(rank(result, 'Annika')).toBeLessThan(rank(result, 'Rosanna'))
+    expect(rank(result, 'Boris')).toBe(-1)
+  },
+)
+
+scenario(
+  'SCN-chat-participant-label-fallback: an unresolvable label falls back to the identifier without failing the turn',
+  async ({ given, when, then, world }) => {
+    const group = given.group('support-rota')
+    const asker = given.user('u-asker')
+    given.member(group, asker)
+
+    const labelled = given.user('u-labelled')
+    const plain = given.user('quill-plain')
+    const failing = given.user('quill-failing')
+    for (const member of [labelled, plain, failing]) given.member(group, member)
+    given.chatUserLabel(labelled, 'Quill')
+    // roster.ts catches a failing label lookup and falls back rather than failing the turn.
+    given.chatUserLabel(failing, new Error('platform lookup failed'))
+    // `plain` is seeded with no label at all: the provider reports the id as unknown.
+    // Scenario usernames equal user ids, so the username and userId fallbacks are the same
+    // string here; roster.test.ts separates them where the two can actually differ.
+
+    given.llm([callCapability('chat.participants.resolve', { query: 'quill' }), answer('Three people match Quill.')])
+    await when.message(asker, group, 'Who matches quill?')
+
+    then.replyIn(group).equals('Three people match Quill.')
+    const result = world.model.inspections().at(-1)?.promptToolResultTokenFingerprints
+    // Exact label first; the two identifier fallbacks tie on score and break by userId.
+    expect(rank(result, 'Quill')).toBeGreaterThanOrEqual(0)
+    expect(rank(result, 'Quill')).toBeLessThan(rank(result, 'failing'))
+    expect(rank(result, 'failing')).toBeLessThan(rank(result, 'plain'))
+  },
+)
+
+scenario(
+  'SCN-chat-participant-dm-absent: the resolver tool is offered in a group turn and withheld in a DM turn',
+  async ({ given, when, then, world }) => {
+    const asker = given.user('u-asker')
+    const group = given.group('release-team')
+    given.member(group, asker)
+    const dm = given.dm(asker)
+
+    // The DM turn runs first on purpose: the capability catalog accumulates across the
+    // turns of a process, so only a turn that precedes every group turn can witness the
+    // absence. `contextType === 'group'` is the one denial surface reachable from
+    // production wiring — the other two conjuncts of the gate at
+    // src/tools/tools-builder.ts:270 (a defined resolver, a defined contextId) are always
+    // satisfied there.
+    given.llm([answer('Asked in a DM.')])
+    await when.message(asker, dm, 'anything')
+    then.replyIn(dm).equals('Asked in a DM.')
+    expect(() => world.runtime.resolveToolCapability('chat.participants.resolve')).toThrow(
+      "Unknown tool capability id 'chat.participants.resolve'",
+    )
+
+    given.llm([answer('Asked in the group.')])
+    await when.message(asker, group, 'anything')
+
+    then.replyIn(group).equals('Asked in the group.')
+    expect(world.runtime.resolveToolCapability('chat.participants.resolve')).toBe('resolve_chat_participant')
+  },
+)

--- a/tests/stories/harness/behavior-coverage.test.ts
+++ b/tests/stories/harness/behavior-coverage.test.ts
@@ -41,7 +41,6 @@ test('partial implemented behaviors are reported as ineligible for global qualif
   expect(unqualifiedBehaviors(BEHAVIOR_COVERAGE)).toContain('live-status')
   expect(unqualifiedBehaviors(BEHAVIOR_COVERAGE)).toEqual([
     'alert-edge-triggering',
-    'chat-participant-resolution',
     'identity-provisioning',
     'live-status',
     'mid-run-control',

--- a/tests/stories/harness/catalog-coverage.test.ts
+++ b/tests/stories/harness/catalog-coverage.test.ts
@@ -217,8 +217,8 @@ describe('scenario catalog coverage', () => {
   test('classifies every catalog scenario exactly once', () => {
     const ledgerIds = catalogCoverage.map(({ scenarioId }) => scenarioId)
 
-    expect(CATALOG_SCENARIO_IDS).toHaveLength(254)
-    expect(new Set(CATALOG_SCENARIO_IDS).size).toBe(254)
+    expect(CATALOG_SCENARIO_IDS).toHaveLength(257)
+    expect(new Set(CATALOG_SCENARIO_IDS).size).toBe(257)
     expect(sorted(ledgerIds)).toEqual(sorted(CATALOG_SCENARIO_IDS))
   })
 
@@ -451,7 +451,7 @@ describe('scenario catalog coverage', () => {
   })
 
   test('tracks the executable coverage total', () => {
-    expect(catalogCoverage.filter((coverage) => coverage.kind === 'executable')).toHaveLength(232)
+    expect(catalogCoverage.filter((coverage) => coverage.kind === 'executable')).toHaveLength(235)
   })
 
   test('stamps every executable record with a live proving tier', () => {
@@ -460,7 +460,7 @@ describe('scenario catalog coverage', () => {
       .filter((coverage) => !LIVE_STORY_TIERS.includes(coverage.provingTier))
       .map(({ scenarioId, provingTier }) => `${scenarioId} -> T${provingTier}`)
 
-    expect(executable).toHaveLength(232)
+    expect(executable).toHaveLength(235)
     expect(offLaneTiers).toEqual([])
     expect(new Set(executable.map((coverage) => coverage.provingTier))).toEqual(new Set(['0', '1', '2', '3', '4']))
   })

--- a/tests/stories/harness/chat.test.ts
+++ b/tests/stories/harness/chat.test.ts
@@ -257,6 +257,21 @@ describe('scenario chat', () => {
     })
   })
 
+  test('resolves seeded user labels and reports unseeded ids as unresolved', async () => {
+    const chat = createScenarioChat('user labels', createScenarioEvents('user labels'))
+    chat.setUserLabel('user-1', 'Alice Anders')
+
+    expect(await chat.resolveUserLabel('user-1', undefined)).toBe('Alice Anders')
+    expect(await chat.resolveUserLabel('user-2', undefined)).toBeNull()
+  })
+
+  test('throws from resolveUserLabel when an id is seeded with an error', async () => {
+    const chat = createScenarioChat('user label failure', createScenarioEvents('user label failure'))
+    chat.setUserLabel('user-1', new Error('platform lookup failed'))
+
+    await expect(chat.resolveUserLabel('user-1', undefined)).rejects.toThrow('platform lookup failed')
+  })
+
   test('reply snapshots do not leak mutations', async () => {
     const chat = createScenarioChat('snapshots', createScenarioEvents('snapshots'))
     chat.onMessage((_message, reply) => reply.text('safe', { threadId: 'thread-1' }))

--- a/tests/stories/harness/chat.ts
+++ b/tests/stories/harness/chat.ts
@@ -52,8 +52,11 @@ export type ScenarioChat = Omit<ChatProvider, 'onInteraction'> &
   RuntimeIngress &
   Readonly<{
     onInteraction: NonNullable<ChatProvider['onInteraction']>
+    resolveUserLabel: NonNullable<ChatProvider['resolveUserLabel']>
     allReplies(): readonly ScenarioReply[]
     addGroupAdmin(groupId: string, userId: string): void
+    /** Seed the label a userId resolves to; an Error makes the lookup reject. */
+    setUserLabel(userId: string, label: string | Error): void
     configureProactiveDelivery(plans: readonly ScenarioProactiveDeliveryPlan[]): void
     proactiveAttempts(): readonly ScenarioProactiveAttempt[]
   }>
@@ -108,6 +111,7 @@ export function createScenarioChat(scenarioName: string, events: ScenarioEvents)
   let proactiveAttempts: readonly ScenarioProactiveAttempt[] = []
   const commands = new Map<string, CommandHandler>()
   const groupAdmins = new Set<string>()
+  const userLabels = new Map<string, string | Error>()
 
   const hasGroupAdmin = (platformInstanceId: string, nativeGroupId: string, userId: string): boolean =>
     groupAdmins.has(`${toScopedContextId({ platformInstanceId, nativeContextId: nativeGroupId })}:${userId}`)
@@ -347,6 +351,16 @@ export function createScenarioChat(scenarioName: string, events: ScenarioEvents)
     proactiveAttempts: () => clone(proactiveAttempts),
     addGroupAdmin(groupId: string, userId: string): void {
       groupAdmins.add(`${groupId}:${userId}`)
+    },
+    setUserLabel(userId: string, label: string | Error): void {
+      userLabels.set(userId, label)
+    },
+    // Unseeded ids resolve to null, matching a real provider that does not know the user.
+    resolveUserLabel(userId: string): Promise<string | null> {
+      const label = userLabels.get(userId)
+      if (label === undefined) return Promise.resolve(null)
+      if (label instanceof Error) return Promise.reject(label)
+      return Promise.resolve(label)
     },
   }
 }

--- a/tests/stories/harness/fixtures.test.ts
+++ b/tests/stories/harness/fixtures.test.ts
@@ -27,6 +27,7 @@ import { TaskProviderResolver } from '../../../src/providers/resolver.js'
 import { SESSION_COOKIE_NAME } from '../../../src/settings/cookies.js'
 import { CSRF_HEADER } from '../../../src/settings/request-auth.js'
 import { isAuthorized } from '../../../src/users.js'
+import { createScenarioChat } from './chat.js'
 import { createScenarioEvents } from './events.js'
 import { createFakeMcpServer } from './fake-mcp-server.js'
 import {
@@ -147,6 +148,18 @@ describe('scenario fixtures', () => {
     expect(isAuthorized(SCENARIO_USER_ID, SCENARIO_PLATFORM_INSTANCE_ID)).toBe(true)
     expect(isAuthorizedGroup(SCENARIO_GROUP_ID)).toBe(true)
     expect(isGroupMember(SCENARIO_GROUP_ID, SCENARIO_USER_ID)).toBe(true)
+  })
+
+  test('seedChatUserLabel requires a chat instance and delegates the label to it', async () => {
+    expect(() => fixtures.seedChatUserLabel({ userId: 'user-1', label: 'Alice Anders' })).toThrow(
+      'Scenario fixtures require a chat instance to seed user labels',
+    )
+
+    const chat = createScenarioChat('label fixtures', createScenarioEvents('label fixtures'))
+    const withChat = createScenarioFixtures({ taskProvider: new MemoryTaskProvider(), chat })
+    withChat.seedChatUserLabel({ userId: 'user-1', label: 'Alice Anders' })
+
+    await expect(chat.resolveUserLabel('user-1', undefined)).resolves.toBe('Alice Anders')
   })
 
   test('seedAdmin grants platform and super admin roles', async () => {

--- a/tests/stories/harness/fixtures.ts
+++ b/tests/stories/harness/fixtures.ts
@@ -247,13 +247,14 @@ const SCENARIO_PLUGIN: DiscoveredPlugin = {
   manifestHash: 'scenario-approved-plugin-hash',
 }
 
-export type ScenarioGroupAdminSeed = Readonly<{
+export type ScenarioChatSeed = Readonly<{
   addGroupAdmin(groupId: string, userId: string): void
+  setUserLabel(userId: string, label: string | Error): void
 }>
 
 export type ScenarioFixturesOptions = Readonly<{
   taskProvider?: TaskProvider
-  chat?: ScenarioGroupAdminSeed
+  chat?: ScenarioChatSeed
 }>
 
 /** Real, plugin-contributed task provider types the story lane can approve and activate. */
@@ -282,6 +283,8 @@ export type ScenarioFixtures = Readonly<{
   enableGuestMode(groupId: string): void
   addGroupMember(input?: Readonly<{ groupId?: string; userId?: string }>): void
   seedGroupAdmin(input: Readonly<{ groupId: string; userId: string }>): void
+  /** Seed the display label a userId resolves to through the chat provider; an Error makes it reject. */
+  seedChatUserLabel(input: Readonly<{ userId: string; label: string | Error }>): void
   seedIdentity(
     input: Readonly<{
       userId: string
@@ -426,6 +429,11 @@ export function createScenarioFixtures(options: ScenarioFixturesOptions = {}): S
       const chat = options.chat
       if (chat === undefined) throw new Error('Scenario fixtures require a chat instance to seed group admins')
       chat.addGroupAdmin(input.groupId, input.userId)
+    },
+    seedChatUserLabel(input): void {
+      const chat = options.chat
+      if (chat === undefined) throw new Error('Scenario fixtures require a chat instance to seed user labels')
+      chat.setUserLabel(input.userId, input.label)
     },
     seedIdentity(input): void {
       setIdentityMapping({

--- a/tests/stories/harness/scenario.ts
+++ b/tests/stories/harness/scenario.ts
@@ -136,6 +136,8 @@ type ScenarioGiven = Readonly<{
   guestMode(group: GroupHandle, enabled: true): void
   member(group: GroupHandle, user: UserHandle): void
   groupAdmin(group: GroupHandle, user: UserHandle): void
+  /** Seed the label the chat provider resolves for a user; an Error makes the lookup reject. */
+  chatUserLabel(user: UserHandle, label: string | Error): void
   identity(
     user: UserHandle,
     identity: Readonly<{ providerUserId: string; login: string; displayName: string }>,
@@ -570,6 +572,10 @@ function createGiven(world: ScenarioWorld): ScenarioGiven {
     groupAdmin(group, user): void {
       prerequisite('given.groupAdmin')
       world.fixtures.seedGroupAdmin({ groupId: scopedGroupId(group), userId: user.id })
+    },
+    chatUserLabel(user, label): void {
+      prerequisite('given.chatUserLabel')
+      world.fixtures.seedChatUserLabel({ userId: user.id, label })
     },
     identity(user, identity, providerName = 'kaneo'): void {
       prerequisite('given.identity')

--- a/tests/stories/harness/world.ts
+++ b/tests/stories/harness/world.ts
@@ -14,6 +14,7 @@ import { getActiveAnalyticsRuntime, startAnalytics, stopAnalytics } from '../../
 import type { AuthorizedTurnContextRegistry } from '../../../src/analytics/turn-context.js'
 import { getThreadScopedStorageContextId } from '../../../src/auth.js'
 import { setupBot, type BotDeps } from '../../../src/bot.js'
+import { createChatParticipantResolver } from '../../../src/chat/participants/router-binding.js'
 import { ChatRouter } from '../../../src/chat/router.js'
 import { toScopedContextId } from '../../../src/chat/scoped-context.js'
 import type { IncomingInteraction, IncomingMessage } from '../../../src/chat/types.js'
@@ -375,6 +376,8 @@ function setupScenarioBot(
   const deps: BotDeps = {
     processMessage: createScenarioProcessMessage(model),
     enqueueMessage: pending.enqueue,
+    // Bound exactly as production binds it, so a story sees the same label context.
+    chatParticipantResolver: createChatParticipantResolver(router),
     ...(analytics === null ? {} : { analyticsObserver: analytics.observer, analyticsTurnRegistry: analytics.registry }),
   }
   setupBot(router, ADMIN_USER_ID, deps)

--- a/tests/tools/core-capabilities.test.ts
+++ b/tests/tools/core-capabilities.test.ts
@@ -141,6 +141,7 @@ describe('core tool capabilities', () => {
       ['deferred.update', 'update_reminder'],
       ['deferred.cancel', 'cancel_reminder'],
       ['web.fetch', 'web_fetch'],
+      ['chat.participants.resolve', 'resolve_chat_participant'],
     ])
   })
 
@@ -166,6 +167,20 @@ describe('core tool capabilities', () => {
     const nextTurnTools = applyToolPreferences(offered('create_task', 'get_task'), 'ctx-denied-core', undefined)
 
     expect(Object.hasOwn(nextTurnTools, catalog.resolve('tasks.create'))).toBe(false)
+  })
+
+  test('maps and conditionally registers the chat.participants.resolve capability', () => {
+    expect(CORE_TOOL_CAPABILITIES['chat.participants.resolve']).toBe('resolve_chat_participant')
+
+    const catalog = createToolCapabilityCatalog()
+    registerOfferedCoreToolCapabilities(offered('resolve_chat_participant'), catalog)
+    expect(catalog.resolve('chat.participants.resolve')).toBe('resolve_chat_participant')
+
+    const absent = createToolCapabilityCatalog()
+    registerOfferedCoreToolCapabilities(offered('get_task'), absent)
+    expect(() => absent.resolve('chat.participants.resolve')).toThrow(
+      "Unknown tool capability id 'chat.participants.resolve'",
+    )
   })
 
   test('maps and conditionally registers the web.fetch capability', () => {


### PR DESCRIPTION
Closes `chat-participant-resolution` — the behavior ledger's emptiest `partial` record (`proven: {}`) — with three Tier 0 hermetic stories, and records the two roadmap decisions that writing them forced.

## What lands

**Stories** (`tests/stories/chat/participant-resolution.story.test.ts`)

- `SCN-chat-participant-ranking` — the `group_members ∪ message_metadata` union, `exact > prefix > substring` ordering, and the resolved id reaching `delivery.mention_user_ids` on a persisted group reminder.
- `SCN-chat-participant-label-fallback` — an unresolvable label and a *throwing* one both degrade to the identifier without failing the turn.
- `SCN-chat-participant-dm-absent` — a DM turn cannot reach the tool, a group turn can.

**Ledger** — `chat-participant-resolution` flips to `implemented`; `primary` and `authorization-routing` both proven at Tier 0.

## Two production edits, both behavior-neutral

The proposal claimed this change touched no production code. That was wrong twice, and the artifacts now record it rather than the original claim.

1. **`resolve_chat_participant` had no capability id.** `CORE_TOOL_CAPABILITIES` is pinned as an exhaustive ordered list, so the absence was a gap, not a deliberate omission — and without an id the scripted story model cannot address the tool at all. `registerOfferedCoreToolCapabilities` registers a pair only when the wire tool is already in the offered turn surface, and the catalog's only consumer is `runtime.resolveToolCapability`, whose only caller is the story harness.
2. **The harness never wired `chatParticipantResolver` into `BotDeps`**, so the registration gate failed and the tool was offered in **no story in the repo**. Rather than duplicate the binding, the production closure moved to `src/chat/participants/router-binding.ts`; `production-deps.ts` and the harness now share it, so neither can drift on the label context passed to `resolveUserLabel`. The extracted closure is the previous code verbatim.

`skip_specs: true` still holds: no observable behavior and no requirement moves.

## `SCN-chat-participant-no-resolver` is dropped, not deferred

The `authorization-routing` bar asks for one scenario per distinct **denial surface** — and a surface has to be *reachable* to be one. `contextType === 'group'` is: a DM turn is an ordinary thing that happens. The gate's other two conjuncts (`chatParticipantResolver !== undefined`, `contextId !== undefined`) are always satisfied by production wiring, so a green story over them would be evidence about a fabricated configuration, not about the gate. The roadmap doc now carries that sharpening.

Also checked and rejected as a second surface: a guest in a group. `resolve_chat_participant` is `read`-risk, so `applyGuestReadOnlyFilter` keeps it.

## Smaller findings worth reading in the diff

- The design asked for separate username- and userId-fallback candidates; scenario usernames *equal* user ids, so those collapse to one observable. `tests/chat/participants/roster.test.ts` already separates them where they can differ.
- The DM scenario must run its DM turn **first**: the capability catalog accumulates across a process's turns rather than resetting, so only a turn preceding every group turn can witness the absence.

## Verification

- Full suite: `15739 pass / 4 fail`. Three were stale ledger counters, updated here (`story-coverage-totals`); the other two (`review-loop/worktree`, `mutation-improve/contracts`) pass file-by-file — load-induced.
- `bun test:stories` 194 pass · `bun test:stories:contracts` 456 pass · T0 floor holds (lines 72.90% / functions 71.42%).
- `bun security` clean · typecheck, lint, knip, format:check green.

## Follow-up (post-merge)

Task 6.4 of the change: this edits frozen compat inputs (`tests/stories/**`, `harness/world.ts`), so the `d17459ee5` qualification baseline retires and a new one gets re-recorded on master after merge.
