### PR TITLE
fix(agent): check out the change branch before /ask reads the folder

### DIFF
--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -173,7 +173,15 @@ findings: `ROADMAP.md`.
   (`dependencyDriftError`) names `/sync` and the hand-merge as the remedies and
   never a bare `/retry`; `/sync` passes `allowDependencyDrift` because a drifted
   branch is the condition it exists to repair, and the guard must not block its
-  own way out. A branch that _intentionally_ changed dependencies is out of reach
+  own way out. Issue #323 is the incident that shaped the failure's bookkeeping:
+  a drift park is by construction pre-delivery, so the `/sync` the message
+  prescribes must be reachable from the issue (see the `/sync` rule below), the
+  refusal carries `attempts` rather than spending one (it fires before any
+  work — the over-budget stop's doctrine, held in `failRun` behind
+  `isDependencyDrift`), and the failure footer does not invite a bare `/retry`
+  over a message that says retry cannot change it (`isRetryFutile` in
+  `errors.ts`; the settings-gated `PR_FORBIDDEN` is the other member). A branch
+  that _intentionally_ changed dependencies is out of reach
   by design — the job cannot install from the agent branch — and the message says
   so; revisit only with a security answer for model-influenced install scripts.
 - **An artifact's output path is not always a file, and a pattern is judged
@@ -303,12 +311,17 @@ findings: `ROADMAP.md`.
   phase either: `failAnswer` posts and leaves `phase`, `resumeFrom` and
   `attempts` alone, which is also why `resumeFrom` can never name a waiting phase
   with no handler for `/retry` to resume into.
-- **`/sync` is the `/ask` shape on the pull request: a side operation, never a
-  phase.** A PR that fell behind its base had no machine remedy before it — the
-  conflict banner was permanent until a human merged locally. `runSync` in
+- **`/sync` is the `/ask` shape: a side operation, never a phase.** A branch
+  that fell behind its base had no machine remedy before it — the conflict
+  banner was permanent until a human merged locally. `runSync` in
   `src/phases/sync.ts` (the `answer.ts` precedent: a handler that is not a
   phase) merges `origin/<base>` into the agent branch, and every design choice
-  follows from "moves nothing". Dispatch sits in `sideOperation` beside `/ask`
+  follows from "moves nothing". It applies wherever the **agent branch
+  exists** — `changeName !== null` is that fact by doctrine, the cancelled
+  `COMPLETE` is the one branch-less state still naming a change and is refused
+  so `/sync` cannot resurrect what `/cancel` deleted (issue #323: the drift
+  park is pre-delivery, and a `/sync` gated on `prNumber` was a remedy the
+  state it was prescribed for could not take). Dispatch sits in `sideOperation` beside `/ask`
   in `triggers.ts`, **before** the signal lookup — `/sync` has no
   `COMMAND_SIGNALS` entry, so the transition table is never consulted, no
   `PHASES` member or presentation row exists, and `phase`, `attempts`,

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -154,7 +154,13 @@ findings: `ROADMAP.md`.
   `CODE_REVIEW` each read the folder one line **before** that call and each died
   the same way — `openspec status` exit 1, "Change '<name>' not found", followed by
   a list of the base branch's changes that reads like the folder was never
-  scaffolded. The ordering is not visible to a stub whose driver answers the same
+  scaffolded. Issue #331 is the fourth reader: `handleAnswer`'s
+  `artifactUnderReview` grounded `/ask` and question-classified comments in the
+  folder the same way, so every answer past capture died before the model turn on
+  the same exit 1 — the call sits inside `artifactUnderReview`, ahead of the
+  `instructions` ask, and only there (a `changeName === null` state has no folder
+  to read and no branch to switch to). The ordering is not visible to a stub
+  whose driver answers the same
   on any branch, which is how three handlers acquired the same defect; the fake in
   `phases.test.ts` refuses every driver call and every `readFile` until
   `ensureBranch` has been called, so a phase that reads too early fails the test

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -116,16 +116,16 @@ moves the phase and the handler runs behind it in the same job, exactly as
 
 ## Talking to the agent
 
-| Command                     | Valid in                      | Effect                                                         |
-| --------------------------- | ----------------------------- | -------------------------------------------------------------- |
-| `/approve`                  | `DESIGN_SPEC`, `PLAN_REVIEW`  | Proceed to the next phase                                      |
-| `/changes <what to change>` | `DESIGN_SPEC`, `PLAN_REVIEW`  | Rewrite the spec or plan, with your feedback in the prompt     |
-| `/ask <question>`           | anywhere                      | Answer, grounded in the repo, without moving the state machine |
-| `/review`                   | a **delivered** `COMPLETE`    | Run the review loop over the branch and push what it finds     |
-| `/retry [note]`             | `FAILED`                      | Resume the exact phase that failed; the note rides the prompt  |
-| `/continue [note]`          | `INCOMPLETE`                  | Pick up the phase the job ran out of time for; note as above   |
-| `/cancel`                   | anything but `COMPLETE`       | Stop for good — a cancelled issue cannot be restarted          |
-| `/sync`                     | any state with a pull request | Merge the base branch into `agent/issue-<n>` and push          |
+| Command                     | Valid in                            | Effect                                                         |
+| --------------------------- | ----------------------------------- | -------------------------------------------------------------- |
+| `/approve`                  | `DESIGN_SPEC`, `PLAN_REVIEW`        | Proceed to the next phase                                      |
+| `/changes <what to change>` | `DESIGN_SPEC`, `PLAN_REVIEW`        | Rewrite the spec or plan, with your feedback in the prompt     |
+| `/ask <question>`           | anywhere                            | Answer, grounded in the repo, without moving the state machine |
+| `/review`                   | a **delivered** `COMPLETE`          | Run the review loop over the branch and push what it finds     |
+| `/retry [note]`             | `FAILED`                            | Resume the exact phase that failed; the note rides the prompt  |
+| `/continue [note]`          | `INCOMPLETE`                        | Pick up the phase the job ran out of time for; note as above   |
+| `/cancel`                   | anything but `COMPLETE`             | Stop for good — a cancelled issue cannot be restarted          |
+| `/sync`                     | any state whose agent branch exists | Merge the base branch into `agent/issue-<n>` and push          |
 
 A `/retry` or `/continue` **note** is maintainer guidance, not a re-plan: it is
 enveloped into the resumed handler's prompt under a fixed framing (the plan and
@@ -135,11 +135,16 @@ An argument-less `/retry` or `/continue` behaves exactly as before.
 
 ### `/sync`
 
-A delivered pull request that falls behind its base shows GitHub's conflict
-banner and, before this command, had no machine remedy — the only fix was a
-human with a local checkout. `/sync` runs `git merge origin/<base>` into the
-agent branch from the pull request, in any state whose pull-request number is
-set:
+A branch that falls behind its base shows GitHub's conflict banner and, before
+this command, had no machine remedy — the only fix was a human with a local
+checkout. `/sync` runs `git merge origin/<base>` into the agent branch, in any
+state whose agent branch exists: on the pull request once one is open, and on
+the issue before that (from capture on — the one branch-less state still naming
+a change, a cancelled issue, refuses it, so it cannot resurrect the branch
+`/cancel` deleted). That pre-pull-request reach is issue #323's lesson: the
+dependency-drift refusal parks an issue `FAILED` naming `/sync` as the remedy,
+and a `/sync` gated behind a pull request that would never open was a remedy
+the state it was prescribed for could not take.
 
 - **Clean merge** — the merge commit is pushed and reported; no model turn is
   spent. An up-to-date branch is reported and nothing is pushed.

--- a/opencode-agent/ROADMAP.md
+++ b/opencode-agent/ROADMAP.md
@@ -2358,6 +2358,47 @@ uncommittable experimentation and put its only artefact in the last step but one
 which is a plan the pipeline cannot make durable no matter how well the walk
 works. Both want their own finding.
 
+### S5-15 — a remedy the state it was prescribed for could not take
+
+Issue #323, 2026-08-21. The run refused on drifted manifests — master's
+`56c598a89` removed three `sdd-runner:*` scripts from `package.json` after the
+branch's last sync, so the branch had touched no manifest and still differed
+from base. Three defects stacked on that one refusal, and each is fixed:
+
+- **The footer contradicted the body it rode under.** `renderFailure` appended
+  "Reply `/retry` to resume" to every failure, including one whose message
+  opens "This is not something `/retry` can change" — violating the contract
+  `dependencyDriftError`'s own doc states. A skimming maintainer follows the
+  footer. Now `renderFailure` takes the failure's retry-futility
+  (`isRetryFutile` in `errors.ts`: drift and the settings-gated pull-request
+  refusal, the two whose messages name out-of-band remedies) and answers it
+  with "the way out is named above".
+- **The remedy was gated behind a pull request that would never open.** The
+  drift message prescribed `/sync`, whose predicate was `prNumber !== null`,
+  and a drift park is by construction pre-delivery. The maintainer typed
+  `/sync`, got "does not apply right now", and was pointed back at `/retry`.
+  The predicate is now "the agent branch exists" — `changeName !== null`, with
+  the one branch-less state that still names a change (a **cancelled** issue,
+  the `presentationKey` split) refused so `/sync` cannot resurrect the branch
+  `/cancel` deleted.
+- **Blind retries spent the budget.** The guard fires at the branch switch,
+  before any work, yet each refusal spent an attempt — two spare, on a
+  condition no retry could change. `failRun` now carries `attempts` for a
+  drift refusal, the over-budget stop's doctrine.
+
+**Deliberately not fixed: the pull request opens too late for a fast-moving
+base.** The deeper shape is that everything a maintainer can do to a branch —
+`/sync`, the checks, review — lives on the pull request, and the pull request
+only exists after `PR_DELIVERY`, at the far end of an implementation that can
+run for hours across many jobs while master moves under it. Issue #323 drifted
+mid-implementation twice in one afternoon. Opening a draft pull request at the
+first push of the agent branch would put `/sync` and the red/green signal on
+the page a maintainer already watches, but it moves the `feedback-target`
+split, `FRESH_PR_BUDGETS`, the CI-fix door and the archive door with it, and
+"COMPLETE means delivered" is the invariant the whole presentation layer reads.
+That is a design change, not a finding-sized fix; it wants an OpenSpec proposal
+of its own before anything implements it.
+
 ## Suggested sequencing
 
 **Milestone 0 — before this is pointed at any live repository.**

--- a/opencode-agent/src/commands.ts
+++ b/opencode-agent/src/commands.ts
@@ -122,14 +122,24 @@ export const COMMAND_SIGNALS: Partial<Record<SlashCommand, TransitionSignal>> = 
  * Commands whose availability the transition table cannot decide alone.
  *
  * There are two. `/sync` is the `/ask` shape — no signal, so the table is never
- * asked — and is typed on the pull request of an issue whose state names one;
- * `prNumber !== null` is the whole predicate. `COMPLETE` is the phase where a
- * table cannot decide for `/review` at all: that is where a **delivered** issue
- * and a **cancelled** one both live, and the phase alone cannot tell them apart:
- * `presentationKey` already splits them on the pull request, because a delivered
- * issue and an abandoned one are not the same outcome. `/review` needs the same
- * split — on a cancelled issue it would name a branch nobody asked for and
- * report against a pull request that does not exist.
+ * asked — and applies wherever the **agent branch exists**: `changeName !== null`
+ * is that fact by the workspace's own doctrine (a `changeName === null` state
+ * has no folder to read and no branch to switch to), with `prNumber` named
+ * beside it because a delivered state is the other spelling of the same fact.
+ * The one branch-less state that still names a change is a **cancelled** one —
+ * `/cancel` deletes the branch (D9) and parks in `COMPLETE` with no pull
+ * request, the same split `presentationKey` makes — and `/sync` must refuse it
+ * or `ensureBranch` would resurrect the branch the cleanup deleted. It used to
+ * key on `prNumber` alone, which issue #323 broke: the drift refusal parked the
+ * issue `FAILED` with no pull request, named `/sync` as the remedy, and the
+ * gate refused it — a remedy the state it was prescribed for could not take,
+ * with the hand merge as the only way out. `COMPLETE` is the phase where
+ * a table cannot decide for `/review` at all: that is where a **delivered**
+ * issue and a **cancelled** one both live, and the phase alone cannot tell them
+ * apart: `presentationKey` already splits them on the pull request, because a
+ * delivered issue and an abandoned one are not the same outcome. `/review`
+ * needs the same split — on a cancelled issue it would name a branch nobody
+ * asked for and report against a pull request that does not exist.
  *
  * One predicate table with two readers rather than two spellings of one rule:
  * {@link acceptedCommands} shows a maintainer the list, `triggers.ts` enforces
@@ -137,7 +147,8 @@ export const COMMAND_SIGNALS: Partial<Record<SlashCommand, TransitionSignal>> = 
  */
 const COMMAND_APPLIES: Partial<Record<SlashCommand, (state: AgentState) => boolean>> = {
   '/review': (state) => state.prNumber !== null,
-  '/sync': (state) => state.prNumber !== null,
+  '/sync': (state) =>
+    state.prNumber !== null || (state.changeName !== null && !(state.phase === 'COMPLETE' && state.prUrl === null)),
 }
 
 /** Whether `command` applies to this state, over and above what the phase takes. */
@@ -151,8 +162,8 @@ const accepts = (state: AgentState, command: SlashCommand): boolean => {
   // `/ask` and `/sync` are the commands with no signal, and neither needs the
   // transition table: answering and syncing ask nothing of the state machine,
   // so there is no phase to refuse them. `/sync` still asks the predicate above
-  // — with no pull request there is nothing to merge into — while `/ask` has no
-  // row there and is accepted everywhere, exactly as before.
+  // — before capture there is no branch to merge base into — while `/ask` has
+  // no row there and is accepted everywhere, exactly as before.
   if (signal === undefined) return commandApplies(command, state)
   return canTransition(state.phase, signal) && commandApplies(command, state)
 }

--- a/opencode-agent/src/errors.ts
+++ b/opencode-agent/src/errors.ts
@@ -174,13 +174,43 @@ export const dependencyDriftError = (branch: string, base: string, files: readon
       '',
       'This is not something `/retry` can change. Bring the branch back in step with the base first:',
       '',
-      `- If a pull request is open for \`${branch}\`, reply \`/sync\` on it — it merges \`origin/${base}\` in.`,
-      `- Otherwise merge \`origin/${base}\` into \`${branch}\` by hand, then reply \`/retry\`.`,
+      `- Reply \`/sync\` — on this issue, or on the pull request if one is open — and it merges \`origin/${base}\` in.`,
+      `- If \`/sync\` cannot resolve it, merge \`origin/${base}\` into \`${branch}\` by hand, then reply \`/retry\`.`,
       '',
       `If \`${branch}\` changed dependencies on purpose, a maintainer must reconcile the manifests by`,
       'hand — the job cannot install from the agent branch by design.',
     ].join('\n'),
   )
+
+/**
+ * The drift refusal, as a fact a caller can branch on.
+ *
+ * The one failure whose budget treatment differs from every other: the guard
+ * fires at the branch switch, before any work, so {@link import('./phase-failure.js').failRun}
+ * carries `attempts` rather than spending one — the same doctrine as the
+ * over-budget stop.
+ */
+export const isDependencyDrift = (error: unknown): boolean =>
+  error instanceof PipelineError && error.code === 'DEPENDENCY_DRIFT'
+
+/**
+ * Failures whose remedies a plain `/retry` cannot reach.
+ *
+ * Both members name their own way out in the message — `/sync` or a hand merge
+ * for drift, a settings change for the pull-request refusal — and both messages
+ * say so up front, which is exactly why the failure comment's footer must not
+ * talk over them: issue #323's drift park carried "This is not something
+ * `/retry` can change" in the body and "Reply `/retry` to resume" in the
+ * footer, and the blind retries spent the budget the remedies needed.
+ *
+ * Membership is a remedy question, not a severity question: add a code here
+ * only when its message names an out-of-band action a retry cannot substitute
+ * for, and the footer will follow.
+ */
+const RETRY_FUTILE_CODES: ReadonlySet<string> = new Set(['DEPENDENCY_DRIFT', 'PR_FORBIDDEN'])
+
+export const isRetryFutile = (error: unknown): boolean =>
+  error instanceof PipelineError && RETRY_FUTILE_CODES.has(error.code)
 
 export const modelResponseError = (message: string, raw: string): PipelineError =>
   new PipelineError('MODEL_RESPONSE', `${message}\n\nRaw reply:\n${raw.slice(0, 2000)}`)

--- a/opencode-agent/src/phase-failure.ts
+++ b/opencode-agent/src/phase-failure.ts
@@ -3,6 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import { isDependencyDrift, isRetryFutile } from './errors.js'
 import type { MachineInput } from './phase-context.js'
 import { postAndAppend, postAnswer } from './run-post.js'
 import { renderAnswerFailure, renderFailure } from './run-report.js'
@@ -39,8 +40,28 @@ export const failRun = async (input: MachineInput, error: unknown): Promise<RunR
   const message = errorMessage(error)
   deps.log.error({ issue: state.issueId, phase: state.phase, error: message }, 'Phase handler failed')
 
-  const failed = transition(state, 'FAILED', await recordSpend(input, { lastError: message }))
-  const report = renderFailure(state.phase, message, failed, deps.config.maxAttempts, deps.config.runUrl)
+  // A drift refusal is the one failure that starts nothing: the guard fires at
+  // the branch switch, before any work, so `attempts` is carried rather than
+  // spent — the over-budget stop's doctrine, for the same reason. Spending one
+  // would let the retry gate refuse the `/retry` the drift remedy ends in, and
+  // every blind `/retry` the old footer invited would burn budget on a
+  // condition no retry can change.
+  const failed = transition(
+    state,
+    'FAILED',
+    await recordSpend(input, {
+      lastError: message,
+      ...(isDependencyDrift(error) ? { attempts: state.attempts } : {}),
+    }),
+  )
+  const report = renderFailure(
+    state.phase,
+    message,
+    failed,
+    deps.config.maxAttempts,
+    deps.config.runUrl,
+    isRetryFutile(error),
+  )
   await postAndAppend(thread, input, report, failed)
 
   // The comment above is what the workflow's fallback step would otherwise

--- a/opencode-agent/src/phases/answer.ts
+++ b/opencode-agent/src/phases/answer.ts
@@ -3,6 +3,7 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import { branchNameFor } from '../git.js'
 import { composeSystemPrompt } from '../obra-skills.js'
 import type { PhaseHandler, PhaseInput, PhaseOutcome } from '../phase-context.js'
 import { ANSWER_INSTRUCTIONS, buildAnswerPrompt } from '../prompts.js'
@@ -64,6 +65,11 @@ const questionText = (input: PhaseInput): string => {
 const artifactUnderReview = async (input: PhaseInput): Promise<string | null> => {
   const { deps, state } = input
   if (state.changeName === null) return null
+  // Before the first read of the folder, like every handler that reads one:
+  // this job starts on the base branch and `openspec/changes/<name>/` is only
+  // on `agent/issue-<n>`, so asking the driver first buys "Change not found"
+  // for every `/ask` and question-classified comment past capture (issue #331).
+  await deps.git.ensureBranch(branchNameFor(state.issueId), await deps.baseBranch())
   const artifactId = state.phase === 'PLAN_REVIEW' ? 'tasks' : 'proposal'
   const path = (await deps.openspec.instructions(artifactId, state.changeName)).resolvedOutputPath
   return deps.readFile(path)

--- a/opencode-agent/src/run-report.ts
+++ b/opencode-agent/src/run-report.ts
@@ -169,6 +169,7 @@ export const renderFailure = (
   next: AgentState,
   maxAttempts: number,
   runUrl: string | null,
+  retryFutile: boolean,
 ): string =>
   [
     outcomeHeading('RUN_FAILED', `Run failed in ${phase}`),
@@ -180,8 +181,18 @@ export const renderFailure = (
     // and nothing on the issue said where to find it.
     ...jobLink(runUrl, 'The job that failed'),
     '',
-    `Attempt ${next.attempts} of ${maxAttempts}. Reply **\`/retry\`** to resume from \`${phase}\`, ` +
-      'or **`/cancel`** to stop.',
+    // The footer is the reflex a skimming maintainer follows, so it has to
+    // agree with the message above it. A failure whose remedies `/retry`
+    // cannot reach names those remedies in its own body — a drift refusal and
+    // a settings-gated pull-request refusal — and a footer inviting a bare
+    // `/retry` over that message is how issue #323 spent its budget on
+    // retries nothing could change. The attempt count is dropped rather than
+    // carried on that branch: a drift refusal spends no attempt, so there is
+    // no honest count to show.
+    retryFutile
+      ? 'A plain `/retry` will reproduce this failure — the way out is named above. Reply **`/cancel`** to stop.'
+      : `Attempt ${next.attempts} of ${maxAttempts}. Reply **\`/retry\`** to resume from \`${phase}\`, ` +
+        'or **`/cancel`** to stop.',
   ].join('\n')
 
 /**

--- a/opencode-agent/src/triggers.ts
+++ b/opencode-agent/src/triggers.ts
@@ -158,11 +158,13 @@ const commandBelongsOnPr = async (input: PhaseInput, command: ParsedCommand): Pr
  * `/sync` is that shape's sibling — no `COMMAND_SIGNALS` entry, so the
  * transition table is never consulted and no phase, park or resume question
  * exists to answer. `COMPLETE`, `FAILED` and `INCOMPLETE` all take it, which
- * is the point: a pull request that fell behind its base is repaired from
- * wherever it was left. The predicate is the one `acceptedCommands` reads, so
- * the gate and the offer cannot drift; without a pull request there is no
- * branch-with-a-PR to merge base into, and the refusal is the ordinary
- * wrong-command one listing what does apply.
+ * is the point: a branch that fell behind its base is repaired from wherever
+ * it was left, with or without a pull request — issue #323 is why the "with"
+ * half matters, a drift park before any pull request existed whose only
+ * machine remedy this gate used to refuse. The predicate is the one
+ * `acceptedCommands` reads, so the gate and the offer cannot drift; before
+ * capture there is no branch to merge base into, and the refusal is the
+ * ordinary wrong-command one listing what does apply.
  */
 const sideOperation = (input: PhaseInput, command: ParsedCommand): TriggerOutcome | null => {
   const { state } = input
@@ -176,9 +178,9 @@ const sideOperation = (input: PhaseInput, command: ParsedCommand): TriggerOutcom
 
 /**
  * A command with no signal that reached the signal lookup — either an unknown
- * spell, or `/sync` without a pull request, the one signal-less command that
- * can be refused. Both go through the wrong-command door, which lists what
- * does apply here.
+ * spell, or `/sync` before capture, the one signal-less command that can be
+ * refused. Both go through the wrong-command door, which lists what does
+ * apply here.
  */
 const refuseUnknown = (input: PhaseInput, command: ParsedCommand): Promise<TriggerOutcome> => {
   const reason =

--- a/tests/opencode-agent/commands.test.ts
+++ b/tests/opencode-agent/commands.test.ts
@@ -11,14 +11,20 @@ import type { AgentState, Phase } from '../../opencode-agent/src/types.js'
 
 /**
  * `/sync` joins the vocabulary as the `/ask` shape: a non-moving side
- * operation, accepted wherever a pull request exists and refused as a wrong
+ * operation, accepted wherever the agent branch exists and refused as a wrong
  * command everywhere else.
  *
  * What these tests pin is the one rule with two readers — the offer a refusal
  * lists and the gate that enforces it are both `COMMAND_APPLIES`, so they
  * cannot drift — plus the property that makes the whole command safe to accept
- * in any PR-bearing phase: it injects no signal, so the transition table is
+ * in any branch-bearing phase: it injects no signal, so the transition table is
  * never consulted and no park/resume question exists to answer.
+ *
+ * "The branch exists" is `changeName !== null` by the workspace's own doctrine
+ * (a `changeName === null` state has no folder to read and no branch to switch
+ * to), widened past `prNumber` after issue #323: the drift refusal parked the
+ * issue FAILED with no pull request, named `/sync` as the remedy, and the gate
+ * refused it — a remedy the state it was prescribed for could not take.
  */
 
 const state = (phase: Phase, over: Partial<AgentState> = {}): AgentState => ({
@@ -57,34 +63,54 @@ describe('the /sync vocabulary entry', () => {
   })
 })
 
-describe('acceptedCommands offers /sync exactly when a pull request exists', () => {
+describe('acceptedCommands offers /sync exactly when the agent branch exists', () => {
   test.each([...PR_PHASES])('%s with a pull request offers it', (phase: Phase) => {
     expect(acceptedCommands(withPr(phase))).toContain('/sync')
   })
 
-  test.each([...PR_PHASES])('%s without a pull request does not', (phase: Phase) => {
-    expect(acceptedCommands(state(phase))).not.toContain('/sync')
+  test('the drift-park shape — FAILED, no pull request, work on the branch — offers it', () => {
+    // Issue #323: the run refused on drifted manifests, parked in FAILED
+    // before any pull request existed, and the only machine remedy was gated
+    // behind a pull request that nothing would open while the branch could
+    // not run a job.
+    expect(acceptedCommands(state('FAILED', { resumeFrom: 'REVIEW_AND_MUTATE' }))).toContain('/sync')
   })
 
-  test('a pre-delivery phase never offers it, with or without a pull request field', () => {
-    // `/sync` on a PR-less state is declined by design (proposal Non-goals):
-    // a FAILED-before-delivery branch is re-entered by `/retry`, which re-runs
-    // from it. The predicate carries that scope by keying on `prNumber` alone,
-    // so the offer cannot leak into the pre-delivery conversation.
-    expect(acceptedCommands(state('DESIGN_SPEC'))).not.toContain('/sync')
-    expect(acceptedCommands(state('PLAN_REVIEW'))).not.toContain('/sync')
+  test('a waiting phase on a captured branch offers it too — merging base is safe anywhere', () => {
+    expect(acceptedCommands(state('DESIGN_SPEC'))).toContain('/sync')
+    expect(acceptedCommands(state('PLAN_REVIEW'))).toContain('/sync')
+  })
+
+  test('a pre-capture state never offers it — there is no branch to merge into', () => {
+    expect(acceptedCommands(state('INIT_OR_CLARIFY', { changeName: null }))).not.toContain('/sync')
+    expect(acceptedCommands(state('FAILED', { changeName: null, resumeFrom: 'INIT_OR_CLARIFY' }))).not.toContain(
+      '/sync',
+    )
+  })
+
+  test('a cancelled issue never offers it — /cancel deleted the branch this would resurrect', () => {
+    // The one branch-less state that still names a change: the same
+    // `presentationKey` split `/review` uses, for the same reason.
+    expect(acceptedCommands(state('COMPLETE'))).not.toContain('/sync')
+    expect(acceptedCommands(withPr('COMPLETE'))).toContain('/sync')
   })
 })
 
 describe('the wrong-command refusal lists /sync exactly when it applies', () => {
-  test('a refusal in a PR-bearing phase names /sync among what works', () => {
+  test('a refusal in a branch-bearing phase names /sync among what works', () => {
     const rendered = renderRefusedCommand('/retry', 'COMPLETE', acceptedCommands(withPr('COMPLETE')))
 
     expect(rendered).toContain('`/sync`')
   })
 
-  test('a refusal on a PR-less issue does not name it', () => {
-    const rendered = renderRefusedCommand('/retry', 'FAILED', acceptedCommands(state('FAILED')))
+  test('a refusal on a drift-parked issue names it too', () => {
+    const rendered = renderRefusedCommand('/review', 'FAILED', acceptedCommands(state('FAILED')))
+
+    expect(rendered).toContain('`/sync`')
+  })
+
+  test('a refusal on a pre-capture issue does not name it', () => {
+    const rendered = renderRefusedCommand('/retry', 'FAILED', acceptedCommands(state('FAILED', { changeName: null })))
 
     expect(rendered).not.toContain('`/sync`')
   })

--- a/tests/opencode-agent/errors.test.ts
+++ b/tests/opencode-agent/errors.test.ts
@@ -7,10 +7,14 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   dependencyDriftError,
+  isDependencyDrift,
+  isRetryFutile,
   isTurnDeadline,
   isTurnStall,
+  modelResponseError,
   openCodeError,
   providerStalledError,
+  pullRequestForbiddenError,
   turnDeadlineError,
   turnStallError,
 } from '../../opencode-agent/src/errors.js'
@@ -100,10 +104,10 @@ describe('isTurnStall', () => {
 
 describe('dependencyDriftError', () => {
   test('names the drifted files and both ways back in step, never a bare /retry', () => {
-    // The message reaches the issue as `lastError` while the issue invites a
-    // `/retry` by reflex — so it has to say up front that a retry alone cannot
-    // change the condition, and name the two moves that can: `/sync` where a
-    // pull request exists, a hand merge where one does not.
+    // The message reaches the issue as `lastError` while the footer above it
+    // used to invite a `/retry` by reflex — so it has to say up front that a
+    // retry alone cannot change the condition, and name the two moves that
+    // can: `/sync`, on the issue or the pull request, and a hand merge.
     const error = dependencyDriftError('agent/issue-323', 'master', ['bun.lock', 'sdd-runner/package.json'])
 
     expect(error.code).toBe('DEPENDENCY_DRIFT')
@@ -113,7 +117,36 @@ describe('dependencyDriftError', () => {
     expect(message).toContain('`agent/issue-323`')
     expect(message).toContain('`master`')
     expect(message).toContain('/sync')
+    // The remedy must be reachable from the state it is rendered for: issue
+    // #323 was parked FAILED with no pull request, and a `/sync` that only
+    // worked on a pull request was a door out of a room with no door.
+    expect(message).toContain('on this issue, or on the pull request')
     expect(message).toContain('not something `/retry` can change')
     expect(message).toContain('cannot install from the agent branch by design')
+  })
+})
+
+describe('the retry-futile predicates', () => {
+  test('a drift refusal is a drift and is retry-futile', () => {
+    const drift = dependencyDriftError('agent/issue-323', 'master', ['bun.lock'])
+
+    expect(isDependencyDrift(drift)).toBe(true)
+    expect(isRetryFutile(drift)).toBe(true)
+  })
+
+  test('a settings-gated refusal is retry-futile but not a drift', () => {
+    const forbidden = pullRequestForbiddenError('https://example.test/compare/x', 'agent/issue-1')
+
+    expect(isDependencyDrift(forbidden)).toBe(false)
+    expect(isRetryFutile(forbidden)).toBe(true)
+  })
+
+  test('the work breaking is neither', () => {
+    const broke = modelResponseError('no JSON object', '{}')
+
+    expect(isDependencyDrift(broke)).toBe(false)
+    expect(isRetryFutile(broke)).toBe(false)
+    expect(isDependencyDrift(new Error('an ordinary crash'))).toBe(false)
+    expect(isRetryFutile(new Error('an ordinary crash'))).toBe(false)
   })
 })

--- a/tests/opencode-agent/markdown.test.ts
+++ b/tests/opencode-agent/markdown.test.ts
@@ -123,7 +123,9 @@ describe('fence', () => {
 describe('renderFailure', () => {
   const failed = transition(initialState(1), 'FAILED', { lastError: 'x' })
 
-  const render = (message: string): string => renderFailure('INIT_OR_CLARIFY', message, failed, 3, null)
+  const render = (message: string): string => renderFailure('INIT_OR_CLARIFY', message, failed, 3, null, false)
+
+  const renderFutile = (message: string): string => renderFailure('INIT_OR_CLARIFY', message, failed, 3, null, true)
 
   test('keeps the recovery instruction readable when the error carries a fence', () => {
     // This is the line the maintainer has to act on; a broken fence buries it
@@ -149,6 +151,27 @@ describe('renderFailure', () => {
 
   test('leaves no unclosed fence', () => {
     expect(spans(render(modelResponseError('no JSON', FENCED_REPLY).message)).unclosed).toBe(false)
+  })
+
+  test('a failure /retry cannot fix invites no bare /retry — issue #323', () => {
+    // The drift footer once said "Reply /retry to resume" under a message whose
+    // first remedy line said /retry could not change the condition, and the
+    // blind retries spent the budget the remedies needed.
+    const rendered = renderFutile('a condition no retry can change')
+
+    expect(rendered).toContain('A plain `/retry` will reproduce this failure')
+    expect(rendered).not.toContain('Reply **`/retry`** to resume')
+    // The count is deliberately absent rather than carried: a drift refusal
+    // spends no attempt, so there is no honest count to show.
+    expect(rendered).not.toContain('Attempt ')
+    expect(rendered).toContain('`/cancel`')
+  })
+
+  test('a futile failure keeps the whole error inside the block', () => {
+    const rendered = renderFutile(modelResponseError('no JSON object', FENCED_REPLY).message)
+
+    expect(code(rendered)).toContain('Hope that helps.')
+    expect(spans(rendered).unclosed).toBe(false)
   })
 })
 
@@ -432,7 +455,7 @@ describe('comment headings', () => {
 
   /** One entry per renderer that speaks about an outcome, with its key. */
   const OUTCOME_COMMENTS: readonly (readonly [OutcomeKey, string])[] = [
-    ['RUN_FAILED', renderFailure('PLANNING', 'boom', failed, 3, null)],
+    ['RUN_FAILED', renderFailure('PLANNING', 'boom', failed, 3, null, false)],
     ['ANSWER_FAILED', renderAnswerFailure('DESIGN_SPEC', 'boom')],
     ['RETRIES_SPENT', renderExhausted('Retry budget exhausted')],
     ['TOKENS_SPENT', renderOverBudget(1, 2, 'PLANNING')],

--- a/tests/opencode-agent/phase-failure.test.ts
+++ b/tests/opencode-agent/phase-failure.test.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { dependencyDriftError } from '../../opencode-agent/src/errors.js'
+import type { MachineInput } from '../../opencode-agent/src/phase-context.js'
+import { failRun } from '../../opencode-agent/src/phase-failure.js'
+import type { ReplyBuffer } from '../../opencode-agent/src/reply-buffer.js'
+import type { ReportSection } from '../../opencode-agent/src/reply-comment.js'
+import type { TriggerEvent } from '../../opencode-agent/src/trigger-events.js'
+import type { AgentState } from '../../opencode-agent/src/types.js'
+import { stubPhaseDeps } from './test-helpers.js'
+
+/**
+ * What a run that broke is left looking like, for the one failure class whose
+ * remedy `/retry` cannot reach: the dependency-drift refusal of issue #323,
+ * where the footer invited a bare `/retry` the message above it had just said
+ * could not work, and every blind reply spent one of five attempts on a
+ * condition no retry can change.
+ *
+ * The workspace rule applies: assert the **persisted state**, not just the
+ * returned status — `attempts` carried rather than spent is what keeps the
+ * `/retry` the drift message eventually invites inside the budget.
+ */
+
+const TRIGGER: TriggerEvent = {
+  kind: 'issue',
+  eventName: 'issue_comment',
+  action: 'created',
+  senderLogin: 'maintainer',
+  senderType: 'User',
+  authorAssociation: 'OWNER',
+  issueNumber: 42,
+  issueTitle: 't',
+  issueBody: 'b',
+  isPullRequest: false,
+  commentBody: '/retry',
+  commentId: 99,
+  repositoryOwner: 'acme',
+  defaultBranch: 'master',
+}
+
+/** The state the drift refusal finds: mid-implementation, two attempts deep. */
+const driftState = (over: Partial<AgentState> = {}): AgentState => ({
+  v: 3,
+  phase: 'REVIEW_AND_MUTATE',
+  issueId: 42,
+  resumeFrom: null,
+  attempts: 2,
+  ciAttempts: 0,
+  ciBudgetReported: false,
+  reviewAttempts: 0,
+  ciBlockedPaths: [],
+  changedLines: 0,
+  stepsDone: 4,
+  changeName: 'localized-release-announcements',
+  planRevision: 1,
+  tokensSpent: 893_073,
+  lastError: null,
+  prUrl: null,
+  prNumber: null,
+  ...over,
+})
+
+/** A reply buffer that records sections instead of posting them. */
+const recordingReply = (): { reply: ReplyBuffer; sections: ReportSection[] } => {
+  const sections: ReportSection[] = []
+  return {
+    reply: {
+      begin: (): void => {},
+      section: (_state, section): void => {
+        sections.push(section)
+      },
+      flush: (): Promise<null> => Promise.resolve(null),
+    },
+    sections,
+  }
+}
+
+const failureFixture = (state: AgentState): { input: MachineInput; sections: ReportSection[] } => {
+  const recording = stubPhaseDeps({ selfLogin: 'agent-bot' })
+  const reply = recordingReply()
+  recording.deps.reply = reply.reply
+  return {
+    input: {
+      state,
+      issue: { number: 42, title: 't', body: 'b' },
+      trigger: TRIGGER,
+      command: { command: '/retry', argument: '' },
+      thread: recording.io.thread,
+      deps: recording.deps,
+      answer: false,
+      posted: false,
+      carriedTokens: state.tokensSpent,
+    },
+    sections: reply.sections,
+  }
+}
+
+describe('failRun · a dependency-drift refusal', () => {
+  const drift = dependencyDriftError('agent/issue-323', 'master', ['package.json'])
+
+  test('parks in FAILED with the resume point but carries attempts instead of spending one', async () => {
+    // The guard fires at the branch switch, before any work: the same doctrine
+    // as the over-budget stop — running out of nothing is not a failed attempt,
+    // and spending one would let the retry gate refuse the `/retry` the drift
+    // remedy ends in.
+    const { input } = failureFixture(driftState())
+
+    const result = await failRun(input, drift)
+
+    expect(result.state?.phase).toBe('FAILED')
+    expect(result.state?.resumeFrom).toBe('REVIEW_AND_MUTATE')
+    expect(result.state?.attempts).toBe(2)
+  })
+
+  test('does not invite a bare /retry the message above just said cannot work', async () => {
+    const { input, sections } = failureFixture(driftState())
+
+    await failRun(input, drift)
+
+    const body = String(sections.at(-1)?.body)
+    expect(body).toContain('A plain `/retry` will reproduce this failure')
+    expect(body).not.toContain('Reply **`/retry`** to resume')
+  })
+})
+
+describe('failRun · an ordinary failure', () => {
+  test('spends an attempt and keeps the standard /retry invitation', async () => {
+    const boom = new Error('the work broke')
+    const { input, sections } = failureFixture(driftState())
+
+    const result = await failRun(input, boom)
+
+    expect(result.state?.attempts).toBe(3)
+    const body = String(sections.at(-1)?.body)
+    expect(body).toContain('Reply **`/retry`** to resume from `REVIEW_AND_MUTATE`')
+  })
+})

--- a/tests/opencode-agent/phases.test.ts
+++ b/tests/opencode-agent/phases.test.ts
@@ -1247,6 +1247,25 @@ describe('a phase checks out the branch carrying the folder before it reads the 
     expect(handed).toEqual([tasks])
     expect(built.io.gitCalls[0]).toBe('ensureBranch:agent/issue-42:main')
   })
+
+  it('handleAnswer reads the artefact after ensureBranch, not before (issue #331)', async () => {
+    // The fourth reader to acquire the defect: `/ask` and every plain comment
+    // classified as a question ground the answer in the folder, and the answer
+    // job starts on the base branch like every other. The permissive
+    // `folderDriver` could not show it — this gate is what the run showed.
+    const built = folderReadInput({
+      phase: 'DESIGN_SPEC',
+      folder: { proposal: '# Goal\n\nAdd a retry helper with exponential backoff.' },
+      replies: ['It will back off exponentially.'],
+    })
+    startedOnBaseBranch(built.input)
+
+    const outcome = await handleAnswer(built.input)
+
+    expect(outcome.signal).toBe('ANSWERED')
+    expect(built.io.prompts[0]?.prompt).toContain('exponential backoff')
+    expect(built.io.gitCalls[0]).toBe('ensureBranch:agent/issue-42:main')
+  })
 })
 
 /**

--- a/tests/opencode-agent/triggers.test.ts
+++ b/tests/opencode-agent/triggers.test.ts
@@ -193,12 +193,15 @@ describe('applyArchiveTrigger · the merged-PR door (D7)', () => {
 describe('applyTrigger · /sync dispatch (the /ask shape)', () => {
   const syncCommand = { command: '/sync' as const, argument: '' }
 
-  it('refuses /sync without a pull request through the wrong-command refusal', async () => {
-    // No PR, no merge target: the refusal is the wrong-command one, offering
-    // the commands that do apply — the same door every misplaced command takes.
+  it('refuses /sync before capture through the wrong-command refusal', async () => {
+    // No change captured, no branch cut: the refusal is the wrong-command one,
+    // offering the commands that do apply — the same door every misplaced
+    // command takes. The state is deliberately the pre-capture shape
+    // (`changeName: null`); the drift-park shape one test down is the one
+    // /sync now exists to reach.
     const recording = stubPhaseDeps({ selfLogin: AGENT_LOGIN })
     const input: PhaseInput = {
-      state: baseState({ phase: 'FAILED', resumeFrom: 'REVIEW_AND_MUTATE' }),
+      state: baseState({ phase: 'FAILED', resumeFrom: 'INIT_OR_CLARIFY' }),
       issue: { number: 42, title: 't', body: 'b' },
       trigger: commentTrigger('/sync', 'OWNER'),
       command: syncCommand,
@@ -214,8 +217,38 @@ describe('applyTrigger · /sync dispatch (the /ask shape)', () => {
     expect(outcome.halt?.reason).toContain('/sync does not apply to this issue')
     // The persisted state is untouched — a refusal moves nothing.
     expect(outcome.state.phase).toBe('FAILED')
-    expect(outcome.state.resumeFrom).toBe('REVIEW_AND_MUTATE')
+    expect(outcome.state.resumeFrom).toBe('INIT_OR_CLARIFY')
     expect(outcome.sync).toBeFalsy()
+  })
+
+  it('dispatches /sync on the drift-parked issue — FAILED, no pull request, work on the branch', async () => {
+    // Issue #323's shape exactly: the run refused on drifted manifests and
+    // parked in FAILED before any pull request existed, and a /sync gated on
+    // `prNumber` was a remedy the state it was prescribed for could not take.
+    // The command arrives as an ordinary issue comment; the state has a
+    // captured change and therefore a branch to merge base into.
+    const recording = stubPhaseDeps({ selfLogin: AGENT_LOGIN })
+    const input: PhaseInput = {
+      state: baseState({
+        phase: 'FAILED',
+        resumeFrom: 'REVIEW_AND_MUTATE',
+        changeName: 'localized-release-announcements',
+      }),
+      issue: { number: 42, title: 't', body: 'b' },
+      trigger: commentTrigger('/sync', 'OWNER'),
+      command: syncCommand,
+      thread: recording.io.thread,
+      deps: recording.deps,
+    }
+
+    const outcome = await applyTrigger(input)
+
+    expect(outcome.halt).toBeNull()
+    expect(outcome.answer).toBe(false)
+    // The side-operation flag: the machine runs the sync handler, no phase.
+    expect(outcome.sync).toBe(true)
+    // The state the cascade is handed is the state the command arrived on.
+    expect(outcome.state).toEqual(input.state)
   })
 
   it('dispatches /sync as a side operation whenever a pull request exists, without consulting the transition table', async () => {


### PR DESCRIPTION
## Root cause

`/ask` and every plain-text comment classified as a question died with `Change '<name>' not found` once an issue was captured. `handleAnswer`'s `artifactUnderReview` read the change folder (`openspec instructions`) without calling `deps.git.ensureBranch` first — and a CI job's checkout starts on the **base** branch, while `openspec/changes/<name>/` only exists on `agent/issue-<n>`. Same defect class that previously hit `PLANNING`, `REVIEW_AND_MUTATE` and `CODE_REVIEW`; the answer tests used a permissive driver fake, so the ordering was invisible to them.

## Change

- `opencode-agent/src/phases/answer.ts` — `ensureBranch` inside `artifactUnderReview`, ahead of the `instructions` ask. Only reached when `changeName !== null`; pre-capture phases (no folder, no branch) are untouched, and the answer still moves no state.
- `tests/opencode-agent/phases.test.ts` — `handleAnswer` case in the `startedOnBaseBranch` gate, which refuses driver calls and `readFile` until the branch is checked out (verified RED with the exact production error first).
- `opencode-agent/CLAUDE.md` — workspace rule records the fourth reader.

## Verification

- phases suite 52/52; orchestrator/cli/comment-intent/git 364/364; lint, typecheck, format:check clean.
- Full suite: 16083 pass, 3 fail — all in `tests/review-loop/fake-agent-integration.test.ts`, which passes standalone and shares no code with this change (documented parallel/env flake class).