### PR TITLE
fix(opencode-agent): stop the provider proxy cutting quiet model streams

### DIFF
--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -1143,6 +1143,20 @@ not permitted to create or approve pull requests` is a repository or
   which would invite a `/continue` into a wave that has not passed. Finished
   steps are not re-run by that `/retry`; their boxes are ticked on the branch
   and the walk skips them.
+  **The notice blames the provider only when the provider said so.**
+  `TurnStall`'s two fields are independent evidence and only `failure` — a
+  `session.error`, carrying a name and a status — is the remote answering for
+  itself; `retries` alone says the call kept failing and nothing about which end
+  refused it, because OpenCode retries a socket that went away exactly as it
+  retries a 429. The message used to assert a provider stall unconditionally,
+  and the 2026-08-22 runs are what that cost: retries with no `session.error`,
+  a healthy provider, and the local proxy cutting the socket on Bun's
+  ten-second idle bound — every reader sent to the wrong end of the connection
+  by a sentence stating the wrong one as fact. `refusalClause` in
+  `turn-errors.ts` now names the provider when `failure` is set and both hops
+  when it is not. Keep it that way even though the proxy bug is fixed: the
+  proxy is a permanent hop, so a retry with no status will always have two ends
+  it could have come from.
 - **Capabilities are deny-by-default.** `openai-config.ts` grants tools by name
   on top of `"*": "deny"`, per agent profile: `plan` (the read-only phases)
   cannot edit or run commands, `build` can. Add a capability by naming it, never

--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -531,6 +531,23 @@ findings: `ROADMAP.md`.
   it is the one layer that sees a real HTTP status and the only one the review
   loop's subprocesses also pass through; do not add a second retry in the
   adapter, where the status is already gone.
+  Its listener sets **`idleTimeout: 0`, and that is not a tuning knob**. Bun
+  defaults it to ten seconds and counts a _streamed_ response as idle whenever
+  no byte moves, and what this proxy forwards is the model's completion stream —
+  so between the proxy landing (2026-08-07) and the fix, every reasoning pause
+  longer than ten seconds cut the socket mid-completion. Downstream that is
+  indistinguishable from the provider failing: OpenCode retries, meets the same
+  pause, and the turn finishes no step. It cost hours of wall clock per run
+  quietly for two weeks, and became a hard failure the day `AGENT_STALL_TIMEOUT_MS`
+  arrived (2026-08-21) — a stall detector whose trigger condition, "no progress
+  while retries accumulate", is exactly what the socket kill manufactures.
+  Neither retry layer can see it: the proxy's fires on an upstream status and
+  upstream is healthy, and the break is on the **inbound** leg. The turn is
+  already bounded by `AGENT_TIMEOUT_MS` and `AGENT_STALL_TIMEOUT_MS`, so a third
+  and fiercer bound in the transport can only fight them. `defaultServe` takes
+  its `Bun.serve` as an argument for one reason: a started server does not report
+  `idleTimeout` back, so that seam is the only way to pin the value without an
+  eleven-second test.
 - **The provider id is a catalogue key, and the transport is not.**
   `LLM_PROVIDER` (default `openai`) says which models.dev row OpenCode resolves
   `LLM_MODEL` under; `npm` stays `@ai-sdk/openai-compatible` and wins over the

--- a/opencode-agent/src/provider-proxy.ts
+++ b/opencode-agent/src/provider-proxy.ts
@@ -31,6 +31,26 @@ export interface ServeOptions {
   fetch: (request: Request) => Promise<Response>
 }
 
+/** The options {@link defaultServe} hands the runtime. */
+export interface BunServeOptions extends ServeOptions {
+  port: number
+  hostname: string
+  idleTimeout: number
+}
+
+/**
+ * The slice of the runtime's `Bun.serve` {@link defaultServe} calls.
+ *
+ * Injected for the same reason {@link Serve} is, and for one more: a started
+ * server does not report its `idleTimeout` back, so without this seam the only
+ * proof of that value is a test that spends eleven real seconds watching a
+ * stream survive — and it is the value that broke the pipeline.
+ */
+export type BunServe = (options: BunServeOptions) => {
+  port?: number
+  stop: (closeActiveConnections: boolean) => void
+}
+
 export type Serve = (options: ServeOptions) => ProxyListener
 
 /**
@@ -84,10 +104,30 @@ const defaultWait: Wait = (ms) =>
     setTimeout(resolve, ms)
   })
 
-const defaultServe: Serve = (options) => {
-  const server = Bun.serve({ port: 0, hostname: '127.0.0.1', fetch: options.fetch })
+export const defaultServe = (options: ServeOptions, bunServe: BunServe = Bun.serve): ProxyListener => {
+  const server = bunServe({
+    port: 0,
+    hostname: '127.0.0.1',
+    // `0` disables Bun's idle bound, which defaults to ten seconds and counts a
+    // *streamed* response as idle whenever no byte moves. The body forwarded
+    // below is the model's completion stream, and a reasoning turn goes quiet
+    // for longer than that between chunks routinely — so the default cut the
+    // socket mid-completion, which reads downstream as the provider failing:
+    // OpenCode retries, meets the same pause, and the turn stalls out having
+    // finished no step. The turn is already bounded by `AGENT_TIMEOUT_MS` and
+    // `AGENT_STALL_TIMEOUT_MS`, so a third and far fiercer bound buried in the
+    // transport can only fight them — and Bun caps the knob at 255 seconds,
+    // which a long turn would still outlast.
+    idleTimeout: 0,
+    fetch: options.fetch,
+  })
   // Bun types `port` as optional; a bound TCP listener always has one.
-  return { port: server.port ?? 0, stop: (): void => void server.stop(true) }
+  return {
+    port: server.port ?? 0,
+    stop: (): void => {
+      server.stop(true)
+    },
+  }
 }
 
 /** Hop-by-hop and length headers a proxy must not copy verbatim. */

--- a/opencode-agent/src/turn-errors.ts
+++ b/opencode-agent/src/turn-errors.ts
@@ -124,22 +124,53 @@ const TURN_STALL = 'TURN_STALL'
  * Like {@link turnDeadlineError} it carries the `ProgressSnapshot`: the turn
  * may hold partial work worth salvaging, and "what had it managed" is the
  * first question a maintainer asks. Unlike it, the remedy is not a bigger
- * window — a wave clears with time, so the notice says what stalled, names
+ * window — a stall clears with time, so the notice says what stalled, names
  * `AGENT_STALL_TIMEOUT_MS` and never `AGENT_TIMEOUT_MS`, and invites the
- * `/retry` that resumes from the same phase once the provider is back.
+ * `/retry` that resumes from the same phase once it has.
+ *
+ * **Who it blames is decided by {@link refusalClause}, not by the header.** It
+ * used to open "The provider stalled this turn" and assert that the provider
+ * kept failing the request, unconditionally — a claim the record often cannot
+ * support, because `retries` and `failure` are independent and only the second
+ * is evidence about the remote. The 2026-08-22 runs are the cost: retries
+ * accumulated, `session.error` never fired, and every reader was sent to the
+ * model provider by a message stating it as fact. The provider was healthy —
+ * this job's own loopback proxy was closing the socket on Bun's ten-second idle
+ * bound (`provider-proxy.ts`, now `idleTimeout: 0`). The bug is fixed and the
+ * wording still matters: the proxy is a permanent hop, so "a retry with no
+ * status" will always have two ends it could have come from.
  */
 export const turnStallError = (windowMs: number, stall: TurnStall, progress: ProgressSnapshot): PipelineError =>
   new PipelineError(
     TURN_STALL,
-    `The provider stalled this turn: for the last ${windowMs}ms it produced no finished step and started ` +
-      `no new tool call, while the provider kept failing the request${retriesClause(stall.retries)}` +
-      `${failureClause(stall.failure)}. ` +
+    `This turn stalled: for the last ${windowMs}ms it produced no finished step and started ` +
+      `no new tool call, while ${refusalClause(stall)}. ` +
       `The turn had managed ${progress.toolCalls} tool calls, ${progress.tokens.toLocaleString('en-US')} tokens, ` +
-      `last action "${progress.lastAction}". This is a provider stall, not the whole-turn deadline — a wave ` +
-      'clears with time, so reply `/retry` when it has; finished work is safe on the branch. ' +
+      `last action "${progress.lastAction}". This is a stall, not the whole-turn deadline: finished work is safe ` +
+      'on the branch, and a stall usually clears with time — reply `/retry` when it has. ' +
       'The window is `AGENT_STALL_TIMEOUT_MS`.',
     progress,
   )
+
+/**
+ * What refused the request, said only as far as the record actually goes.
+ *
+ * A `session.error` carries a name and a status, which is the provider
+ * answering for itself — there, naming it is honest. Retries alone are not:
+ * OpenCode retries a request whose socket went away exactly as it retries a
+ * 429, so a retry with no status says only that the call kept failing, and the
+ * path it failed on has two hops. Naming both is what the evidence supports,
+ * and it is the difference between a maintainer checking the run log and a
+ * maintainer waiting out a provider outage that is not happening.
+ */
+const refusalClause = (stall: TurnStall): string =>
+  stall.failure === null
+    ? `the session retried the request ${plural(stall.retries, 'time')} and the provider published no error of ` +
+      'its own, so what refused it is not established here — the model endpoint is this job’s loopback proxy in ' +
+      'front of the real one, and a retry carrying no status can come from either hop'
+    : `the provider kept failing the request${retriesClause(stall.retries)}${failureClause(stall.failure)}`
+
+const plural = (count: number, noun: string): string => `${count} ${noun}${count === 1 ? '' : 's'}`
 
 /** Whether a rejection is that abort. */
 export const isTurnStall = (error: unknown): error is PipelineError =>

--- a/opencode-agent/src/turn-stop.ts
+++ b/opencode-agent/src/turn-stop.ts
@@ -131,7 +131,14 @@ export const stopPartWayThrough = async (context: PartWayInput): Promise<PhaseOu
   return parkedOutcome(context, salvage, handoff)
 }
 
-/** Says which of the two stops this is, with what the turn had managed. */
+/**
+ * Says which of the two stops this is, with what the turn had managed.
+ *
+ * The stall line does not say "the provider stalled": the same misattribution
+ * the error message carried, gone for the same reason — the retries this fires
+ * on are evidence that the call kept failing, not that the remote refused it.
+ * `turnStallError` says which, as far as the record supports.
+ */
 const logStopping = (context: PartWayInput, stalled: boolean): void => {
   const { deps, state } = context.input
   deps.log.warn(
@@ -145,7 +152,7 @@ const logStopping = (context: PartWayInput, stalled: boolean): void => {
       ...context.stopped.progress,
     },
     stalled
-      ? 'The provider stalled the turn part-way through; aborting it and keeping what it wrote'
+      ? 'The turn stalled part-way through; aborting it and keeping what it wrote'
       : 'Out of time part-way through the turn; stopping it and keeping what it wrote',
   )
 }

--- a/tests/opencode-agent/errors.test.ts
+++ b/tests/opencode-agent/errors.test.ts
@@ -38,6 +38,9 @@ const PROGRESS: ProgressSnapshot = { lastAction: 'read (running)', toolCalls: 44
 
 const STALL: TurnStall = { retries: 78, failure: { name: 'APIError', statusCode: 429 }, lastProgressAt: 0 }
 
+/** Retries but no `session.error`: the shape the 2026-08-22 socket kills produced. */
+const UNATTRIBUTED: TurnStall = { retries: 10, failure: null, lastProgressAt: 0 }
+
 describe('turnStallError', () => {
   test('carries the TURN_STALL code, the stall window, the retry count and the progress', () => {
     const error = turnStallError(300_000, STALL, PROGRESS)
@@ -77,6 +80,50 @@ describe('turnStallError', () => {
 
     expect(message).toContain('no finished step')
     expect(message).toContain('no new tool call')
+  })
+
+  test('blames the provider only when the provider actually published an error', () => {
+    // The attributed case: a `session.error` with a name and a status is the
+    // evidence that the remote refused the request, so naming it is honest.
+    const message = turnStallError(300_000, STALL, PROGRESS).message
+
+    expect(message).toContain('the provider kept failing the request')
+  })
+
+  test('does not blame the provider when no provider error was ever published', () => {
+    // The 2026-08-22 runs: retries accumulated, `session.error` never fired, and
+    // the message asserted a provider stall anyway. The provider was healthy —
+    // this job's own loopback proxy was cutting the socket on Bun's ten-second
+    // idle bound. A message that names a culprit the evidence does not support
+    // sends every reader to the wrong end of the connection.
+    const message = turnStallError(300_000, UNATTRIBUTED, PROGRESS).message
+
+    expect(message).not.toContain('the provider kept failing the request')
+    expect(message).toContain('10 times')
+    expect(message).toContain('no error of its own')
+  })
+
+  test('names the loopback hop as a suspect when nothing said who refused', () => {
+    const message = turnStallError(300_000, UNATTRIBUTED, PROGRESS).message
+
+    expect(message).toContain('loopback proxy')
+  })
+
+  test('still invites /retry and names its own window when the cause is unattributed', () => {
+    // The remedy does not depend on knowing who refused: the work is on the
+    // branch either way, and the resume point is the same.
+    const message = turnStallError(300_000, UNATTRIBUTED, PROGRESS).message
+
+    expect(message).toContain('/retry')
+    expect(message).toContain('AGENT_STALL_TIMEOUT_MS')
+    expect(message).not.toContain('AGENT_TIMEOUT_MS')
+    expect(message).toContain('44 tool calls')
+  })
+
+  test('counts a single retry in the singular', () => {
+    const once: TurnStall = { retries: 1, failure: null, lastProgressAt: 0 }
+
+    expect(turnStallError(300_000, once, PROGRESS).message).toContain('retried the request 1 time and')
   })
 })
 

--- a/tests/opencode-agent/provider-proxy.test.ts
+++ b/tests/opencode-agent/provider-proxy.test.ts
@@ -16,11 +16,18 @@ import type { OpenAiSettings } from '../../opencode-agent/src/openai-config.js'
 import type { OpenCodeAgentOptions } from '../../opencode-agent/src/opencode-adapter.js'
 import {
   backoffFor,
+  defaultServe,
   PLACEHOLDER_API_KEY,
   proxiedSettings,
   startProviderProxy,
 } from '../../opencode-agent/src/provider-proxy.js'
-import type { ProviderProxy, Serve, UpstreamFetch } from '../../opencode-agent/src/provider-proxy.js'
+import type {
+  BunServe,
+  BunServeOptions,
+  ProviderProxy,
+  Serve,
+  UpstreamFetch,
+} from '../../opencode-agent/src/provider-proxy.js'
 import type { TriggerEvent } from '../../opencode-agent/src/trigger-events.js'
 
 const KEY = 'sk-live-SUPERSECRET-0123456789'
@@ -615,5 +622,65 @@ describe('contain', () => {
 
     expect(JSON.stringify(run.deps.config)).not.toContain(KEY)
     await run.proxy.close()
+  })
+})
+
+describe('defaultServe', () => {
+  /** Records the options the listener hands the runtime, and answers plausibly. */
+  const spy = (): { seen: BunServeOptions[]; bunServe: BunServe; stopped: boolean[] } => {
+    const seen: BunServeOptions[] = []
+    const stopped: boolean[] = []
+    return {
+      seen,
+      stopped,
+      bunServe: (options) => {
+        seen.push(options)
+        return { port: 45_123, stop: (closeActiveConnections): void => void stopped.push(closeActiveConnections) }
+      },
+    }
+  }
+
+  test('disables the idle bound, so a quiet stretch mid-completion is not a closed socket', () => {
+    // The regression this pins: Bun's default is 10 seconds, and it counts a
+    // *streamed* response as idle whenever the model pauses between chunks. A
+    // reasoning turn goes quiet for longer than that routinely, and the socket
+    // Bun closed reads downstream as a provider failure — OpenCode retries, hits
+    // the same pause, and the turn stalls out having made no progress.
+    const { seen, bunServe } = spy()
+
+    defaultServe({ fetch: (): Promise<Response> => Promise.resolve(new Response('ok')) }, bunServe)
+
+    expect(seen[0]?.idleTimeout).toBe(0)
+  })
+
+  test('binds loopback on an ephemeral port', () => {
+    // Loopback is the containment the proxy exists for: the credential it holds
+    // must not be reachable from off the machine.
+    const { seen, bunServe } = spy()
+
+    defaultServe({ fetch: (): Promise<Response> => Promise.resolve(new Response('ok')) }, bunServe)
+
+    expect(seen[0]?.hostname).toBe('127.0.0.1')
+    expect(seen[0]?.port).toBe(0)
+  })
+
+  test('hands the runtime the handler it was given, and reports the bound port', () => {
+    const { seen, bunServe } = spy()
+    const fetch = (): Promise<Response> => Promise.resolve(new Response('ok'))
+
+    const listener = defaultServe({ fetch }, bunServe)
+
+    expect(seen[0]?.fetch).toBe(fetch)
+    expect(listener.port).toBe(45_123)
+  })
+
+  test('closes connections still open when it stops', () => {
+    // `stop(true)`, not `stop()`: a half-streamed completion holds the socket,
+    // and a listener that waits for it to drain outlives the job.
+    const { stopped, bunServe } = spy()
+
+    defaultServe({ fetch: (): Promise<Response> => Promise.resolve(new Response('ok')) }, bunServe).stop()
+
+    expect(stopped).toEqual([true])
   })
 })


### PR DESCRIPTION
The loopback proxy's listener ran on `Bun.serve` with no `idleTimeout`, so it
took Bun's default of ten seconds. Bun counts a *streamed* response as idle
whenever no byte moves, and what this proxy forwards is the model's completion
stream — so any reasoning pause longer than ten seconds closed the socket
mid-completion.

Downstream that is indistinguishable from the provider failing: OpenCode
retries, meets the same pause, and the turn finishes no step. Neither retry
layer can see it — the proxy's own fires on an upstream status and upstream is
healthy, and the break is on the inbound leg. Run logs bear that out: the
`[Bun.serve]: request timed out after 10 seconds` line lands 6ms before the
first `retry`, and no `Provider call failed` warning appears at all.

Present since the proxy landed (a7d134d7, 2026-08-07) and non-fatal for two
weeks — run 32415264956 carries the same warning and still completed, paying
3h34m for it. It became a hard failure with AGENT_STALL_TIMEOUT_MS (7b57bf58,
2026-08-21), whose trigger — no progress while retries accumulate — is exactly
what the socket kill manufactures. Four runs died that way on 2026-08-22.

Disabling rather than raising: the turn is already bounded by AGENT_TIMEOUT_MS
and AGENT_STALL_TIMEOUT_MS, and Bun caps the knob at 255s, which a long turn
would still outlast.

`defaultServe` takes its `Bun.serve` as an argument so the value can be pinned:
a started server does not report `idleTimeout` back, and the only other proof
is a test that spends eleven real seconds watching a stream survive. Verified
out of band that the real proxy now carries a 15s silent gap end to end.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014AtZjJiACTcnqcTCv3s1L1