### PR TITLE
fix(agent): make the dependency-drift guard content-aware

### DIFF
--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -208,14 +208,28 @@ findings: `ROADMAP.md`.
   `ensureBranch` has been called, so a phase that reads too early fails the test
   the way it failed the run. The same call **refuses a dependency-drifted branch**
   (`git-drift.ts`): the workflow installs from the base checkout and no second
-  install follows the branch switch, so a branch whose `bun.lock` / `package.json`
-  manifests differ from base runs every check against a `node_modules` that cannot
-  serve it — run 32507905723 paid for a full PLANNING turn and then died in the
-  pre-commit hook on `TS2307` for an import base had stopped carrying. The refusal
-  (`dependencyDriftError`) names `/sync` and the hand-merge as the remedies and
-  never a bare `/retry`; `/sync` passes `allowDependencyDrift` because a drifted
-  branch is the condition it exists to repair, and the guard must not block its
-  own way out. Issue #323 is the incident that shaped the failure's bookkeeping:
+  install follows the branch switch, so a branch whose install state differs
+  from base runs every check against a `node_modules` that cannot serve it —
+  run 32507905723 paid for a full PLANNING turn and then died in the pre-commit
+  hook on `TS2307` for an import base had stopped carrying. The condition is
+  **content-aware**: `bun.lock` refuses on any byte, and a `package.json`
+  refuses only when an install-relevant top-level field moved — the
+  `INSTALL_FIELDS` constant beside the guard (the four dependency maps,
+  `resolutions`/`overrides`, `workspaces`, `trustedDependencies`,
+  `patchedDependencies`) — judged by parsing both sides (`git show` through the
+  same `GitFn` seam) and deep-equaling the fields, so a re-serialized identical
+  dependencies map passes and `scripts` / `packageManager` / metadata edits
+  pass; issue #360 is the false-positive incident that made it so (a one-line
+  `scripts` edit was the deliverable, and the path-based refusal parked the
+  finished branch with no command-level exit). Every unknown shape fails
+  closed: a manifest that will not parse on either side refuses, and a
+  one-sided (added or deleted) manifest is compared against `{}`, refusing when
+  the existing side carries install fields. The refusal (`dependencyDriftError`)
+  names the drifted fields per file, `/sync` and the hand-merge as the remedies
+  and never a bare `/retry`; `/sync` passes `allowDependencyDrift` because a
+  drifted branch is the condition it exists to repair, and the guard must not
+  block its own way out. Issue #323 is the incident that shaped the failure's
+  bookkeeping:
   a drift park is by construction pre-delivery, so the `/sync` the message
   prescribes must be reachable from the issue (see the `/sync` rule below), the
   refusal carries `attempts` rather than spending one (it fires before any

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -1460,9 +1460,42 @@ say.
 `AGENT_GITHUB_TOKEN` the `workflows: write` permission, re-install it, and drop
 the prefix from `PROTECTED_PREFIXES`. Weigh it first: an agent that can rewrite
 `agent-pipeline.yml` can rewrite the permissions, the concurrency group, the
-guardrails and the secret wiring that bound it, from inside a job that file
+guardrails and the secret wiring that bounded it, from inside a job that file
 defines. The alternative costs a maintainer one commit — the agent says in its
 reply exactly what to apply.
+
+### Branches the job cannot serve
+
+The workflow runs `bun install --frozen-lockfile` on the **base** checkout and
+`ensureBranch` switches onto `agent/issue-<n>` afterwards, with no second
+install — so a branch whose install state diverged from base would run every
+check against a `node_modules` that cannot serve it. The dependency-drift guard
+(`src/git-drift.ts`) refuses such a branch at the switch, before any model turn
+or check is paid for.
+
+What counts as drift is decided by **content, not file paths**:
+
+- `bun.lock` refuses on any byte change — every byte of it is install state.
+- A `package.json` (root or any workspace) refuses only when an
+  install-relevant top-level field moved: the four dependency maps,
+  `resolutions` / `overrides`, `workspaces`, `trustedDependencies`,
+  `patchedDependencies` — the `INSTALL_FIELDS` constant beside the guard. Both
+  sides are parsed and compared field by field, so a re-serialized but
+  identical dependencies map passes, and edits to `scripts`, `name`,
+  `version`, `packageManager` or custom fields pass. Issue #360 is why: a
+  one-line `scripts` edit was a change's whole deliverable, and the older
+  path-based refusal parked the finished branch where `/retry` reproduced the
+  refusal, `/sync` had nothing to merge, and `/review` was refused.
+- Unknown shapes **fail closed**: a manifest that will not parse as JSON on
+  either side refuses, and a manifest that exists on only one side (an added
+  or deleted workspace) refuses when the side that exists carries any install
+  field.
+
+The refusal names the drifted fields per file (`package.json
+(devDependencies, resolutions)`), names `/sync` or a hand merge as the
+remedies, and spends no retry attempt. A branch that _intentionally_ changed
+dependencies is maintainer territory by design: the job never installs from
+the agent branch, so no command can reconcile it for you.
 
 ### Capability containment
 

--- a/opencode-agent/src/errors.ts
+++ b/opencode-agent/src/errors.ts
@@ -152,21 +152,42 @@ export const pullRequestForbiddenError = (compareUrl: string, branch: string): P
 export const openCodeError = (message: string): PipelineError => new PipelineError('OPENCODE', message)
 
 /**
- * A branch whose dependency manifests differ from base, refused at the branch
- * switch — see `git-drift.ts` for why the run cannot proceed and whose decision
- * that is. The message is the whole contract: it reaches the issue as
+ * One manifest the guard refused, with the install-relevant fields that moved.
+ *
+ * `fields` empty is the whole-file refusal: the lockfile, refused on any byte,
+ * or a manifest that would not parse — fail-closed, with no fields to name.
+ */
+export interface DriftedManifest {
+  readonly file: string
+  readonly fields: readonly string[]
+}
+
+/** `package.json (devDependencies, resolutions)`, or just `bun.lock` when there is no field to name. */
+const renderDrift = (drift: DriftedManifest): string =>
+  drift.fields.length === 0 ? drift.file : `${drift.file} (${drift.fields.join(', ')})`
+
+/**
+ * A branch whose dependency install state differs from base, refused at the
+ * branch switch — see `git-drift.ts` for why the run cannot proceed and whose
+ * decision that is. The message is the whole contract: it reaches the issue as
  * `lastError`, and the one thing it must never suggest is `/retry` on its own,
  * which would re-run the phase into the same refusal until the budget is gone.
  *
  * Modelled on {@link pullRequestForbiddenError}: a condition the run's own
  * commands cannot change, both remedies named, and the "nothing is lost" fact
  * stated — the branch and its work are fine; only the job cannot serve them.
+ * The opening line names the drifted fields per file, because "which knob
+ * moved" is the first question a maintainer reconciling by hand asks.
  */
-export const dependencyDriftError = (branch: string, base: string, files: readonly string[]): PipelineError =>
+export const dependencyDriftError = (
+  branch: string,
+  base: string,
+  drifted: readonly DriftedManifest[],
+): PipelineError =>
   new PipelineError(
     'DEPENDENCY_DRIFT',
     [
-      `\`${branch}\` and \`${base}\` disagree on the dependency manifests (${files.join(', ')}).`,
+      `\`${branch}\` and \`${base}\` disagree on the dependency manifests (${drifted.map(renderDrift).join(', ')}).`,
       '',
       `Nothing is lost — \`${branch}\` and all its work are untouched. But this job installs dependencies`,
       `from \`${base}\` before checking out \`${branch}\`, so what is installed cannot serve the branch:`,

--- a/opencode-agent/src/git-drift.ts
+++ b/opencode-agent/src/git-drift.ts
@@ -3,8 +3,13 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
+import { isDeepStrictEqual } from 'node:util'
+
 import { dependencyDriftError } from './errors.js'
+import type { DriftedManifest } from './errors.js'
 import type { GitFn } from './git-commit.js'
+import { mapSeries } from './sequence.js'
+import type { CommandResult } from './shell.js'
 
 /**
  * The manifests whose divergence from base desyncs `node_modules`.
@@ -23,30 +28,145 @@ import type { GitFn } from './git-commit.js'
 const MANIFEST_PATHS = ['bun.lock', 'package.json', ':(glob)**/package.json'] as const
 
 /**
- * Refuses a branch whose dependency manifests differ from `origin/<base>`.
+ * The top-level manifest fields whose divergence from base desyncs
+ * `node_modules` — the fields `bun install` consumes, so the only ones whose
+ * change the base-branch install cannot serve.
+ *
+ * Why each member refuses: the four dependency maps (`dependencies`,
+ * `devDependencies`, `optionalDependencies`, `peerDependencies`) say what
+ * resolves; `resolutions` and `overrides` say how it resolves; `workspaces`
+ * says what exists to be installed at all; `trustedDependencies` says which
+ * packages' lifecycle scripts install executes, and `patchedDependencies`
+ * says whose content it patches — both kept even though this job installs
+ * from base, because a branch that moved them has moved install state and
+ * the security posture it encodes.
+ *
+ * Deliberately excluded: `packageManager` (the workflow pins the runtime
+ * itself), `scripts` (inert here — this job never installs from the branch),
+ * and `name` / `version` / custom metadata (nothing `bun install` reads).
+ * Issue #360 is the exclusion being load-bearing: a one-line `scripts` edit
+ * was the whole deliverable, and a path-based refusal parked the finished
+ * branch with no command-level exit. The exclusions are named here so the
+ * next bun knob has a place to be judged before it joins the list.
+ */
+const INSTALL_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+  'resolutions',
+  'overrides',
+  'workspaces',
+  'trustedDependencies',
+  'patchedDependencies',
+] as const
+
+/** The one manifest whose refusal is not field-level: any byte of the lockfile can move install state. */
+const LOCKFILE = 'bun.lock'
+
+/** One side of a manifest, parsed: its top-level fields as a record. */
+type ManifestFields = Readonly<Record<string, unknown>>
+
+/**
+ * One blob as text, or `null` when that side of history does not carry the
+ * path — the added or deleted workspace case, which D3 compares against `{}`.
+ *
+ * Both `GitFn` flavours answer here: the plain runner reports the non-zero
+ * exit git gives a missing path, and `gitOrThrow` turns the same exit into a
+ * thrown `GitError`. Either way the side reads as absent — never as an empty
+ * string, which would parse-fail its way into naming fields it cannot see.
+ */
+const readBlob = (gitOrThrow: GitFn, ref: string, path: string): Promise<string | null> =>
+  gitOrThrow('show', `${ref}:${path}`).then(
+    (shown: CommandResult) => (shown.exitCode === 0 ? shown.stdout : null),
+    () => null,
+  )
+
+/** Anything `JSON.parse` can return that has manifest fields reachable by name. */
+const isManifestObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+/**
+ * Parses one side of a manifest. `null` is the fail-closed verdict: the bytes
+ * could not be read as a JSON object, so the file counts as drifted with no
+ * fields to name. A side that does not carry the file at all parses as `{}`,
+ * which is different on purpose — an added workspace declaring dependencies is
+ * drift, an added workspace naming only `name` is not.
+ */
+const parseManifest = (blob: string | null): ManifestFields | null => {
+  if (blob === null) return {}
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(blob)
+  } catch {
+    return null
+  }
+  return isManifestObject(parsed) ? parsed : null
+}
+
+/** The install-relevant fields that moved between the two sides, in `INSTALL_FIELDS` order. */
+const driftedFields = (base: ManifestFields, head: ManifestFields): readonly string[] =>
+  INSTALL_FIELDS.filter((field) => !isDeepStrictEqual(base[field], head[field]))
+
+/**
+ * Compares one changed manifest between `origin/<base>` and `HEAD`; `null`
+ * lets it through.
+ *
+ * The lockfile short-circuits before any parse: it is refused on any byte
+ * change because its whole content is install state — there is no field of it
+ * that cannot matter.
+ */
+const inspectManifest = async (gitOrThrow: GitFn, baseRef: string, path: string): Promise<DriftedManifest | null> => {
+  if (path === LOCKFILE) return { file: path, fields: [] }
+  const base = parseManifest(await readBlob(gitOrThrow, baseRef, path))
+  const head = parseManifest(await readBlob(gitOrThrow, 'HEAD', path))
+  if (base === null || head === null) return { file: path, fields: [] }
+  const fields = driftedFields(base, head)
+  return fields.length === 0 ? null : { file: path, fields }
+}
+
+/**
+ * Refuses a branch whose dependency install state differs from `origin/<base>`.
  *
  * The workflow installs dependencies from the base-branch checkout —
  * deliberately, so a branch the model writes to never decides what
  * `bun install` executes in a job holding every repository secret — and
  * `ensureBranch` switches the tree onto the agent branch *after* that, with no
- * second install. A branch whose manifests have drifted from base therefore
+ * second install. A branch whose install state has drifted from base therefore
  * runs every check against a `node_modules` that cannot serve it: run
  * 32507905723 burned a full PLANNING turn and then died in the pre-commit hook
  * on `TS2307: Cannot find module '@clack/prompts'`, an import the base lockfile
  * had stopped carrying two merges earlier.
  *
- * Refusing at the branch switch costs one `git diff --name-only` and names the
- * remedy instead. `/sync` lifts the refusal (it *is* the remedy), and a branch
- * that intentionally changed dependencies is told the truth: the job cannot
- * install from the agent branch by design, so a maintainer reconciles by hand.
+ * What counts as drift is decided by content, not by path: a changed
+ * `package.json` is parsed on both sides (via `git show`, through the same
+ * injected `GitFn` every other git call here uses) and refused only when an
+ * install-relevant field moved (`INSTALL_FIELDS`, by deep equality — so a
+ * re-serialized but identical dependencies map passes). Issue #360 is why: the
+ * change's own deliverable edited one `scripts` line, and the path-based
+ * refusal parked a finished branch where `/retry` reproduced the refusal,
+ * `/sync` had nothing to merge, and `/review` was refused from `FAILED`. Every
+ * unknown shape fails closed per design D3: a manifest that will not parse on
+ * either side refuses, and a one-sided manifest is compared against `{}`, so
+ * an added workspace with dependencies refuses while one naming only `name`
+ * passes. `bun.lock` keeps the unconditional any-diff refusal — there is no
+ * byte of it that cannot move install state.
+ *
+ * Refusing at the branch switch costs one `git diff --name-only` plus two
+ * `git show` per changed manifest, and names the remedy instead. `/sync` lifts
+ * the refusal (it *is* the remedy), and a branch that intentionally changed
+ * dependencies is told the truth: the job cannot install from the agent branch
+ * by design, so a maintainer reconciles by hand.
  *
  * Called after the checkout, so `HEAD` is the branch this run will stand on.
  */
 export const assertManifestsInSync = async (gitOrThrow: GitFn, branch: string, base: string): Promise<void> => {
   const diff = await gitOrThrow('diff', '--name-only', `origin/${base}`, 'HEAD', '--', ...MANIFEST_PATHS)
-  const drifted = diff.stdout
+  const changed = diff.stdout
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => line.length > 0)
-  if (drifted.length > 0) throw dependencyDriftError(branch, base, drifted)
+  const drifted = await mapSeries(changed, (path) => inspectManifest(gitOrThrow, `origin/${base}`, path))
+  const refused = drifted.filter((entry): entry is DriftedManifest => entry !== null)
+  if (refused.length > 0) throw dependencyDriftError(branch, base, refused)
 }

--- a/openspec/changes/fix-drift-guard-scripts-only/.openspec.yaml
+++ b/openspec/changes/fix-drift-guard-scripts-only/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/fix-drift-guard-scripts-only/design.md
+++ b/openspec/changes/fix-drift-guard-scripts-only/design.md
@@ -1,0 +1,109 @@
+## Context
+
+The guard (`opencode-agent/src/git-drift.ts`, `assertManifestsInSync`, called
+from `ensureBranch` in `git.ts:117`) runs one
+`git diff --name-only origin/<base> HEAD -- bun.lock package.json
+:(glob)**/package.json` and refuses on any listed path. The workflow installs
+from the base checkout (`bun install --frozen-lockfile`) before the branch
+switch and never reinstalls, so the guard protects every post-switch check
+from a `node_modules` that cannot serve the branch. What it cannot distinguish
+today is *which bytes* changed: issue #360's one-line `scripts` edit is
+byte-different and therefore refused, though no install-relevant state moved.
+The guard's injected seam is `GitFn` (`opencode-agent/src/git-commit.ts`), so
+the fix needs no new boundary.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Refusal condition tracks install-relevant manifest fields, so forward
+  scripts/metadata edits by the implement phase or review loop stop parking
+  post-delivery runs.
+- Keep every existing property: fail-closed posture, `bun.lock`
+  any-diff refusal, `/sync`'s `allowDependencyDrift` pass-through, the
+  `isDependencyDrift` / `isRetryFutile` bookkeeping (attempts carried, never
+  spent), and the remedies in the message.
+
+**Non-Goals:** (see proposal.md Non-goals for scope exclusions — no escape
+hatch, no `/sync` widening, no implement-phase warning, no lockfile
+content-awareness). Design-level addition: no change to where the guard runs
+or to the `Git` interface shape beyond reads the seam already allows.
+
+## Decisions
+
+### D1. Compare parsed JSON fields, not diff text
+
+For each changed non-lock manifest, read both blob versions via the injected
+`GitFn` (`git show <ref>:<path>` — argv vector, `shell: false`, same as every
+other git call here), `JSON.parse` both, extract the install-relevant keys,
+and compare with `isDeepStrictEqual` from `node:util`.
+
+- *Why not word-diff parsing*: `git diff` output is formatting- and
+  key-order-sensitive; a re-serialized but semantically identical
+  `dependencies` map would refuse, which is exactly the false-positive class
+  this change exists to remove.
+- *Why not a diff library*: stdlib parse + deep-equal is enough; a dependency
+  for one comparison fails the minimality ladder.
+- *Cost*: two extra git reads per changed manifest, only when a manifest path
+  changed at all — rare, and the guard already sits before any paid work.
+
+### D2. One named constant for the field list, beside the guard
+
+`INSTALL_FIELDS` (or equivalent) sits next to `MANIFEST_PATHS` in
+`git-drift.ts` with a comment naming why each member is install-relevant —
+the four dependency maps (what resolves), `resolutions`/`overrides`
+(how it resolves), `workspaces` (what exists), `trustedDependencies` and
+`patchedDependencies` (what code install executes / what package content is
+patched — kept for the security posture even though this job installs from
+base). Deliberately excluded: `packageManager` (the workflow pins the runtime
+itself), `scripts` (inert — this job never installs from the branch), and
+`name`/`version` metadata. Exclusions are named in the comment so the next
+bun knob has a place to be judged.
+
+### D3. Fail closed on every unknown shape
+
+A manifest that fails `JSON.parse` on either side counts as drifted for that
+file; a one-sided manifest is compared against `{}`, so an added workspace
+declaring any install field refuses, and one naming only `name` passes.
+Deleting a manifest that carried install fields also refuses (removing a
+workspace changes install state). No parse error is ever swallowed into a
+pass.
+
+### D4. Diagnostics upgrade, message contract unchanged
+
+`dependencyDriftError` takes the drifted fields per file and renders them in
+the opening line (e.g. `` package.json (devDependencies, resolutions) ``),
+keeping the remedies text, the "nothing is lost" framing, and the no-bare-
+`/retry` rule byte-for-byte. Codes, `isDependencyDrift`, `isRetryFutile` and
+`phase-failure.ts`'s attempts-carried handling are untouched — the deadlock's
+bookkeeping half was already correct; only the trigger was wrong.
+
+### D5. Tests ride the existing `GitFn` seam
+
+A new `tests/opencode-agent/git-drift.test.ts` stubs `GitFn` to return the
+path list and canned `git show` payloads: scripts-only pass (the #360 shape),
+field-level refuse per field family, re-format-only pass (same map, different
+key order/whitespace), lockfile refuse, malformed JSON refuse, one-sided
+both ways. No repository fixture needed — the seam already answers
+everything the guard reads.
+
+## Risks / Trade-offs
+
+- [A future bun install-relevant field is missing from the list → guard
+  passes a branch that then fails checks with import errors] → the failure
+  mode is the pre-guard status quo (TS2307-class), not worse; the constant is
+  the single place to extend, and D2's comment names the judging criteria.
+- [JSONC manifests (comments) parse-fail → false-positive refusal] → fail
+  closed is the documented default; this repository's manifests are plain
+  JSON, and a refusal names the file so the cause is visible.
+- [Field-level compare drifts from real `bun install` behavior over time] →
+  accepted: the guard approximates "can base's node_modules serve this
+  branch"; exactness would mean running install from the branch, which the
+  design keeps off-limits.
+
+## Migration Plan
+
+None: pure pipeline-tooling change, no persisted-state or workflow-YAML
+edits. Rollback is revert. In-flight drift parks (issue #360) become
+runnable by `/retry` once a job with the new guard code picks the command
+up.

--- a/openspec/changes/fix-drift-guard-scripts-only/proposal.md
+++ b/openspec/changes/fix-drift-guard-scripts-only/proposal.md
@@ -1,0 +1,72 @@
+## Why
+
+PR #362 (issue #360) is deadlocked: the change's own deliverable edits one
+`scripts` line in `package.json`, and the dependency-drift guard
+(`opencode-agent/src/git-drift.ts`) refuses any branch whose manifest **paths**
+differ from base — content-blind. The implement phase and the review loop
+legitimately produce such edits, then every later job's `ensureBranch` parks the
+run in `FAILED` (`DEPENDENCY_DRIFT`) where `/retry` reproduces the refusal,
+`/sync` has nothing to merge (the branch is ahead, not behind), and `/review`
+is refused from `FAILED`. A guard whose own doc comment says "a false positive
+here is not free" has a false positive with no command-level exit. The refusal
+condition must match what actually desyncs `node_modules`: changes to the
+fields `bun install` consumes, not any edit to a file named `package.json`.
+
+## What Changes
+
+- `assertManifestsInSync` becomes content-aware: a changed `package.json` /
+  `**/package.json` refuses the branch only when the diff touches
+  install-relevant top-level fields (`dependencies`, `devDependencies`,
+  `optionalDependencies`, `peerDependencies`, `resolutions`, `overrides`,
+  `workspaces`, `trustedDependencies`, `patchedDependencies`), compared by
+  deep equality between `origin/<base>` and `HEAD` versions of the file.
+- `bun.lock` keeps its unconditional path-based refusal (any byte change can
+  desync `node_modules`).
+- A manifest that cannot be parsed as JSON on either side is treated as
+  drifted (conservative default, refusal names the file).
+- `dependencyDriftError` reports the drifted fields per file (not just file
+  paths), keeping the same remedies (`/sync`, hand merge) and the same
+  `isDependencyDrift` / `isRetryFutile` bookkeeping.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-manifest-drift-guard`: when the opencode-agent pipeline must refuse
+  an agent branch whose dependency state cannot be served by a base-branch
+  install, and what it must let through — the refusal condition, the
+  conservative defaults, and the diagnostics the refusal reports.
+
+### Modified Capabilities
+
+None. `openspec/specs/` carries no spec for the guard (the original change
+2c0365034 predated the corpus); the new capability is its first.
+
+## Impact
+
+- Code: `opencode-agent/src/git-drift.ts` (guard), `opencode-agent/src/errors.ts`
+  (message fields), tests under `tests/opencode-agent/` (drift fixtures for
+  scripts-only, field-level, added/deleted-manifest, malformed-JSON cases).
+- Docs: `opencode-agent/CLAUDE.md` (the `ensureBranch` drift rule paragraph),
+  `opencode-agent/README.md` operator notes.
+- No papai runtime impact: no platform or task instance, no config-context
+  scope (per-user / group-shared / thread-isolated) is touched — this is
+  agent-pipeline tooling only, and `/sync`, `/retry`, `/review` semantics are
+  unchanged.
+- Security posture unchanged: the job still never installs from the agent
+  branch; `bun.lock`, lifecycle-script execution gates (`trustedDependencies`)
+  and patch/override fields remain refused.
+
+## Non-goals
+
+- **No operator escape hatch for intentional dependency changes** (e.g.
+  `/review --allow-drift`): installing from a model-written branch in the
+  secrets job stays out of reach by design; a maintainer reconciles by hand.
+- **No `/sync` widening**: it stays the backward-drift remedy; a branch ahead
+  of base still has nothing to merge.
+- **No early warning in the implement phase** when a deliverable edits
+  dependency fields — with the content-aware guard only genuine install-state
+  changes park, which is already maintainer territory; declined until a live
+  incident shows token burn worth the extra prompt surface.
+- **No change to `bun.lock` handling**: content-awareness for the lockfile is
+  not attempted; any diff refuses.

--- a/openspec/changes/fix-drift-guard-scripts-only/specs/agent-manifest-drift-guard/spec.md
+++ b/openspec/changes/fix-drift-guard-scripts-only/specs/agent-manifest-drift-guard/spec.md
@@ -1,0 +1,98 @@
+## Purpose
+
+Defines when the opencode-agent pipeline must refuse to run a job on an agent
+branch because the base-branch dependency install cannot serve it, what it must
+let through, and what the refusal must tell the maintainer. The guard exists
+because the workflow installs dependencies from the base checkout and never
+reinstalls after switching onto the agent branch, so a branch whose install
+state diverged from base runs every check against a `node_modules` that cannot
+serve it.
+
+## ADDED Requirements
+
+### Requirement: Refuse only install-state divergence
+
+The pipeline MUST refuse to run a phase on an agent branch when the branch's
+dependency install state diverges from the base branch, and MUST NOT refuse
+when manifest edits cannot change what the base install put into
+`node_modules`. Divergence exists when:
+
+- the lockfile (`bun.lock`) differs from the base branch in any way, or
+- any `package.json` in the tree differs from the base branch in a
+  install-relevant top-level field: `dependencies`, `devDependencies`,
+  `optionalDependencies`, `peerDependencies`, `resolutions`, `overrides`,
+  `workspaces`, `trustedDependencies`, `patchedDependencies`.
+
+Edits to other manifest content — including `scripts`, `name`, `version`, or
+custom fields — MUST be allowed through with no refusal.
+
+#### Scenario: scripts-only manifest edit passes
+
+- **WHEN** an agent branch's only manifest change is an edit to a command
+  string under `scripts` in a `package.json` (as in issue #360's
+  `check:verbose` change) and `bun.lock` is unchanged
+- **THEN** the phase runs on the branch with no dependency-drift refusal
+
+#### Scenario: dependency field edit refuses
+
+- **WHEN** an agent branch adds, removes, or changes a range in
+  `devDependencies` in any `package.json` relative to the base branch
+- **THEN** the phase is refused before any model turn or check runs, with the
+  dependency-drift failure
+
+#### Scenario: lockfile edit refuses
+
+- **WHEN** an agent branch's `bun.lock` differs from the base branch's by even
+  an unrelated formatting change
+- **THEN** the phase is refused with the dependency-drift failure
+
+### Requirement: Compare by content, conservatively
+
+The drift decision MUST be made by comparing the install-relevant fields of
+each changed manifest between the base-branch version and the branch version,
+not by file path alone. Unknown shapes fail closed:
+
+- a manifest that cannot be parsed as JSON on either side counts as drifted;
+- a manifest that exists on only one side counts as drifted when the existing
+  side carries any install-relevant field (a one-sided manifest with none of
+  those fields is not drifted).
+
+#### Scenario: malformed manifest refuses
+
+- **WHEN** a changed `package.json` on either side is not valid JSON
+- **THEN** the branch counts as drifted and the refusal names that file
+
+#### Scenario: added workspace with no dependencies passes
+
+- **WHEN** the branch adds a new workspace `package.json` whose only content
+  is a `name` field
+- **THEN** the branch is not drifted
+
+#### Scenario: added workspace with dependencies refuses
+
+- **WHEN** the branch adds a new workspace `package.json` declaring a
+  `dependencies` map
+- **THEN** the branch counts as drifted
+
+### Requirement: Refusal names fields and remedies
+
+The dependency-drift refusal MUST report, per file, which install-relevant
+fields drifted, and MUST keep pointing at the remedies a plain retry cannot
+substitute: merging the base branch in (`/sync` or a hand merge) when the
+divergence is backward drift, and maintainer reconciliation when the change
+intentionally altered install state. The refusal MUST NOT spend a retry
+attempt and MUST NOT invite a bare `/retry`.
+
+#### Scenario: drift report content
+
+- **WHEN** a branch is refused for a `devDependencies` change in the root
+  `package.json`
+- **THEN** the failure message names `package.json`, names `devDependencies`
+  as the drifted field, and names `/sync` and the hand merge as remedies
+  without inviting a bare `/retry`
+
+#### Scenario: budget accounting on refusal
+
+- **WHEN** a run is refused for dependency drift
+- **THEN** the persisted state keeps its retry-attempt count unchanged and
+  parks in the failure phase with the resume point intact

--- a/openspec/changes/fix-drift-guard-scripts-only/tasks.md
+++ b/openspec/changes/fix-drift-guard-scripts-only/tasks.md
@@ -16,4 +16,4 @@
 
 ## 4. Verification
 
-- [ ] 4.1 `bun run test:affected` during the loop, then one full `bun run test` plus `bun check:full` before finishing; confirm no `max-lines` regression in `git-drift.ts` (split the comparison out if it trips)
+- [x] 4.1 `bun run test:affected` during the loop, then one full `bun run test` plus `bun check:full` before finishing; confirm no `max-lines` regression in `git-drift.ts` (split the comparison out if it trips)

--- a/openspec/changes/fix-drift-guard-scripts-only/tasks.md
+++ b/openspec/changes/fix-drift-guard-scripts-only/tasks.md
@@ -12,7 +12,7 @@
 ## 3. Diagnostics and docs
 
 - [x] 3.1 Extend `dependencyDriftError` in `opencode-agent/src/errors.ts` to report drifted fields per file in the opening line, keeping the remedies text and the no-bare-`/retry` rule verbatim; update the `errors.test.ts` expectations that pin the message
-- [ ] 3.2 Update the `ensureBranch` drift rule paragraph in `opencode-agent/CLAUDE.md` (content-aware condition, field constant, fail-closed defaults, issue #360 as the false-positive incident) and the operator notes in `opencode-agent/README.md`
+- [x] 3.2 Update the `ensureBranch` drift rule paragraph in `opencode-agent/CLAUDE.md` (content-aware condition, field constant, fail-closed defaults, issue #360 as the false-positive incident) and the operator notes in `opencode-agent/README.md`
 
 ## 4. Verification
 

--- a/openspec/changes/fix-drift-guard-scripts-only/tasks.md
+++ b/openspec/changes/fix-drift-guard-scripts-only/tasks.md
@@ -1,0 +1,19 @@
+## 1. Guard: content-aware manifest comparison
+
+- [x] 1.1 Add the install-relevant field constant beside `MANIFEST_PATHS` in `opencode-agent/src/git-drift.ts` (`dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`, `resolutions`, `overrides`, `workspaces`, `trustedDependencies`, `patchedDependencies`), with the comment naming why each member refuses and why `scripts` / `packageManager` / metadata do not (design D2)
+- [x] 1.2 Extend `assertManifestsInSync` (TDD: write the failing tests of task 2.1 first): for each changed non-lock manifest, read both sides via the injected `GitFn` (`git show <ref>:<path>`), `JSON.parse`, and refuse only when an install-relevant field differs by deep equality (`isDeepStrictEqual` from `node:util`); treat a parse failure on either side as drifted for that file, and a one-sided file as compared against `{}` (design D1, D3)
+- [x] 1.3 Keep `bun.lock` on the unconditional any-diff refusal, unchanged
+
+## 2. Tests
+
+- [x] 2.1 New `tests/opencode-agent/git-drift.test.ts` driving the `GitFn` seam with canned `diff --name-only` / `git show` outputs: scripts-only edit passes (the issue #360 `check:verbose` shape), each install field family refuses, semantically-identical-but-reformatted `dependencies` passes, lockfile diff refuses, malformed JSON on either side refuses, added workspace with only `name` passes, added workspace with `dependencies` refuses, deleted manifest with install fields refuses
+- [x] 2.2 Assert the refusal's persisted bookkeeping is unchanged: an existing test (or an addition beside it) pins that a drift refusal carries `attempts` and parks with the resume point intact, and that `/sync` still passes `allowDependencyDrift`
+
+## 3. Diagnostics and docs
+
+- [x] 3.1 Extend `dependencyDriftError` in `opencode-agent/src/errors.ts` to report drifted fields per file in the opening line, keeping the remedies text and the no-bare-`/retry` rule verbatim; update the `errors.test.ts` expectations that pin the message
+- [ ] 3.2 Update the `ensureBranch` drift rule paragraph in `opencode-agent/CLAUDE.md` (content-aware condition, field constant, fail-closed defaults, issue #360 as the false-positive incident) and the operator notes in `opencode-agent/README.md`
+
+## 4. Verification
+
+- [ ] 4.1 `bun run test:affected` during the loop, then one full `bun run test` plus `bun check:full` before finishing; confirm no `max-lines` regression in `git-drift.ts` (split the comparison out if it trips)

--- a/tests/opencode-agent/errors.test.ts
+++ b/tests/opencode-agent/errors.test.ts
@@ -155,17 +155,22 @@ describe('isTurnStall', () => {
 })
 
 describe('dependencyDriftError', () => {
-  test('names the drifted files and both ways back in step, never a bare /retry', () => {
+  test('names the drifted files and fields and both ways back in step, never a bare /retry', () => {
     // The message reaches the issue as `lastError` while the footer above it
     // used to invite a `/retry` by reflex — so it has to say up front that a
     // retry alone cannot change the condition, and name the two moves that
-    // can: `/sync`, on the issue or the pull request, and a hand merge.
-    const error = dependencyDriftError('agent/issue-323', 'master', ['bun.lock', 'sdd-runner/package.json'])
+    // can: `/sync`, on the issue or the pull request, and a hand merge. The
+    // field-per-file rendering is the maintainer's first question answered:
+    // which knob moved, in which manifest.
+    const error = dependencyDriftError('agent/issue-323', 'master', [
+      { file: 'bun.lock', fields: [] },
+      { file: 'sdd-runner/package.json', fields: ['devDependencies'] },
+    ])
 
     expect(error.code).toBe('DEPENDENCY_DRIFT')
     expect(error.progress).toBeNull()
     const message = error.message
-    expect(message).toContain('bun.lock, sdd-runner/package.json')
+    expect(message).toContain('bun.lock, sdd-runner/package.json (devDependencies)')
     expect(message).toContain('`agent/issue-323`')
     expect(message).toContain('`master`')
     expect(message).toContain('/sync')
@@ -176,11 +181,18 @@ describe('dependencyDriftError', () => {
     expect(message).toContain('not something `/retry` can change')
     expect(message).toContain('cannot install from the agent branch by design')
   })
+
+  test('renders a whole-file refusal — the lockfile — with no field list', () => {
+    const error = dependencyDriftError('agent/issue-323', 'master', [{ file: 'bun.lock', fields: [] }])
+
+    expect(error.message).toContain('(bun.lock)')
+    expect(error.message).not.toContain('bun.lock (')
+  })
 })
 
 describe('the retry-futile predicates', () => {
   test('a drift refusal is a drift and is retry-futile', () => {
-    const drift = dependencyDriftError('agent/issue-323', 'master', ['bun.lock'])
+    const drift = dependencyDriftError('agent/issue-323', 'master', [{ file: 'bun.lock', fields: [] }])
 
     expect(isDependencyDrift(drift)).toBe(true)
     expect(isRetryFutile(drift)).toBe(true)

--- a/tests/opencode-agent/git-drift.test.ts
+++ b/tests/opencode-agent/git-drift.test.ts
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, test } from 'bun:test'
+
+import { PipelineError } from '../../opencode-agent/src/errors.js'
+import type { GitFn } from '../../opencode-agent/src/git-commit.js'
+import { assertManifestsInSync } from '../../opencode-agent/src/git-drift.js'
+import type { CommandResult } from '../../opencode-agent/src/shell.js'
+
+/**
+ * The content-aware drift guard, driven entirely through its `GitFn` seam.
+ *
+ * The guard reads exactly two things — the changed-path list from
+ * `diff --name-only`, and both blob versions of each changed manifest from
+ * `git show <ref>:<path>` — so a canned script answers everything it can ask
+ * (design D5): no repository fixture can see more of the guard than this does.
+ * The scenario list is the spec's: issue #360's scripts-only edit is the false
+ * positive that parked a finished branch behind a refusal with no exit, and
+ * every fail-closed default (unparseable JSON, one-sided manifests) gets each
+ * of its outcomes pinned.
+ */
+
+const BRANCH = 'agent/issue-360'
+const BASE = 'main'
+const BASE_SPEC = 'origin/main:package.json'
+const HEAD_SPEC = 'HEAD:package.json'
+
+interface Script {
+  /** What `diff --name-only` lists. */
+  readonly changed: readonly string[]
+  /**
+   * Blob payloads by `show` spec (`ref:path`). A spec missing from the map is
+   * a side of history that does not carry the file — the added or deleted
+   * workspace case.
+   */
+  readonly blobs?: Readonly<Record<string, string>>
+}
+
+const ok = (stdout: string): CommandResult => ({ command: 'git', exitCode: 0, stdout, stderr: '' })
+
+/** Answers the two calls the guard makes; anything else fails the test. */
+const scriptedGit = (script: Script): GitFn => {
+  const blobs = script.blobs ?? {}
+  return (...argv: readonly string[]): Promise<CommandResult> => {
+    const [sub, ...rest] = argv
+    if (sub === 'diff') return Promise.resolve(ok(script.changed.join('\n')))
+    if (sub === 'show') {
+      const blob = blobs[rest[0] ?? '']
+      // The way git answers a ref that does not carry the path: non-zero
+      // exit, nothing on stdout. Whichever GitFn flavour the guard holds —
+      // one that reports the exit code, one that throws on it — the side
+      // must read as absent, never as an empty manifest that cannot parse.
+      return Promise.resolve(
+        blob === undefined
+          ? { command: 'git', exitCode: 128, stdout: '', stderr: 'fatal: path does not exist' }
+          : ok(blob),
+      )
+    }
+    return Promise.reject(new Error(`unexpected git call: ${argv.join(' ')}`))
+  }
+}
+
+/** A manifest pretty-printed the way a hand edit leaves it. */
+const manifest = (fields: Readonly<Record<string, unknown>>): string => `${JSON.stringify(fields, null, 2)}\n`
+
+/** Narrows a caught refusal, failing the test on anything else. */
+const asPipelineError = (error: unknown): PipelineError => {
+  if (error instanceof PipelineError) return error
+  throw new Error(`expected a PipelineError, got: ${String(error)}`)
+}
+
+/** Runs the guard on a script that must refuse; fails the test when it passes. */
+const refusalFrom = async (script: Script): Promise<PipelineError> => {
+  const error: unknown = await assertManifestsInSync(scriptedGit(script), BRANCH, BASE).then(
+    () => null,
+    (caught: unknown) => caught,
+  )
+  if (error === null) throw new Error('expected the guard to refuse the branch; it let it through')
+  return asPipelineError(error)
+}
+
+describe('assertManifestsInSync · edits that cannot move install state pass', () => {
+  test('the issue #360 shape: a `scripts` command string moved, nothing else', async () => {
+    const base = manifest({ name: 'papai', scripts: { 'check:verbose': 'bun run check' } })
+    const head = manifest({ name: 'papai', scripts: { 'check:verbose': 'bun run check --verbose' } })
+
+    await assertManifestsInSync(
+      scriptedGit({ changed: ['package.json'], blobs: { [BASE_SPEC]: base, [HEAD_SPEC]: head } }),
+      BRANCH,
+      BASE,
+    )
+  })
+
+  test('a semantically identical dependencies map, re-serialized, passes', async () => {
+    // Key order and whitespace are the false-positive class this change exists
+    // to remove: a re-save of the same map must not read as drift. The `scripts`
+    // key moving beside it is the #360 shape riding along.
+    const base = '{\n  "dependencies": { "left": "^1.0.0", "right": "^2.0.0" }\n}\n'
+    const head = '{"dependencies":{"right":"^2.0.0","left":"^1.0.0"},"scripts":{"build":"bun run build"}}'
+
+    await assertManifestsInSync(
+      scriptedGit({ changed: ['package.json'], blobs: { [BASE_SPEC]: base, [HEAD_SPEC]: head } }),
+      BRANCH,
+      BASE,
+    )
+  })
+
+  test('an added workspace naming only `name` passes', async () => {
+    await assertManifestsInSync(
+      scriptedGit({
+        changed: ['sdd-runner/package.json'],
+        blobs: { 'HEAD:sdd-runner/package.json': manifest({ name: 'sdd-runner' }) },
+      }),
+      BRANCH,
+      BASE,
+    )
+  })
+
+  test('a deleted manifest that carried no install fields passes', async () => {
+    await assertManifestsInSync(
+      scriptedGit({
+        changed: ['old/package.json'],
+        blobs: { 'origin/main:old/package.json': manifest({ name: 'old', version: '1.0.0' }) },
+      }),
+      BRANCH,
+      BASE,
+    )
+  })
+})
+
+describe('assertManifestsInSync · install-relevant fields refuse', () => {
+  const sample = (field: string): unknown => (field === 'workspaces' ? ['packages/*'] : { 'left-pad': '^1.0.0' })
+
+  const FIELDS = [
+    'dependencies',
+    'devDependencies',
+    'optionalDependencies',
+    'peerDependencies',
+    'resolutions',
+    'overrides',
+    'workspaces',
+    'trustedDependencies',
+    'patchedDependencies',
+  ] as const
+
+  for (const field of FIELDS) {
+    test(`refuses a changed \`${field}\`, naming the file and the field`, async () => {
+      const refusal = await refusalFrom({
+        changed: ['package.json'],
+        blobs: {
+          [BASE_SPEC]: manifest({ name: 'papai' }),
+          [HEAD_SPEC]: manifest({ name: 'papai', [field]: sample(field) }),
+        },
+      })
+
+      expect(refusal.code).toBe('DEPENDENCY_DRIFT')
+      expect(refusal.message).toContain('package.json')
+      expect(refusal.message).toContain(field)
+    })
+  }
+
+  test('refuses a removed `devDependencies` just as an added one', async () => {
+    const refusal = await refusalFrom({
+      changed: ['package.json'],
+      blobs: {
+        [BASE_SPEC]: manifest({ name: 'papai', devDependencies: { zod: '^4.0.0' } }),
+        [HEAD_SPEC]: manifest({ name: 'papai' }),
+      },
+    })
+
+    expect(refusal.code).toBe('DEPENDENCY_DRIFT')
+    expect(refusal.message).toContain('devDependencies')
+  })
+
+  test('an added workspace declaring `dependencies` refuses, naming the field', async () => {
+    const refusal = await refusalFrom({
+      changed: ['sdd-runner/package.json'],
+      blobs: {
+        'HEAD:sdd-runner/package.json': manifest({ name: 'sdd-runner', dependencies: { zod: '^4.0.0' } }),
+      },
+    })
+
+    expect(refusal.code).toBe('DEPENDENCY_DRIFT')
+    expect(refusal.message).toContain('sdd-runner/package.json')
+    expect(refusal.message).toContain('dependencies')
+  })
+
+  test('a deleted manifest that carried install fields refuses', async () => {
+    const refusal = await refusalFrom({
+      changed: ['sdd-runner/package.json'],
+      blobs: {
+        'origin/main:sdd-runner/package.json': manifest({ name: 'sdd-runner', devDependencies: { zod: '^4.0.0' } }),
+      },
+    })
+
+    expect(refusal.code).toBe('DEPENDENCY_DRIFT')
+    expect(refusal.message).toContain('sdd-runner/package.json')
+    expect(refusal.message).toContain('devDependencies')
+  })
+
+  test('names every drifted file with its fields in the opening line', async () => {
+    const refusal = await refusalFrom({
+      changed: ['package.json', 'sdd-runner/package.json'],
+      blobs: {
+        [BASE_SPEC]: manifest({ name: 'papai' }),
+        [HEAD_SPEC]: manifest({ name: 'papai', devDependencies: { zod: '^4.0.0' }, resolutions: { x: 'y' } }),
+        'HEAD:sdd-runner/package.json': manifest({ name: 'sdd-runner', dependencies: { zod: '^4.0.0' } }),
+      },
+    })
+
+    expect(refusal.message).toContain('package.json (devDependencies, resolutions)')
+    expect(refusal.message).toContain('sdd-runner/package.json (dependencies)')
+  })
+})
+
+describe('assertManifestsInSync · the lockfile refuses on any diff', () => {
+  test('a lockfile byte change refuses, unconditionally', async () => {
+    const refusal = await refusalFrom({ changed: ['bun.lock'] })
+
+    expect(refusal.code).toBe('DEPENDENCY_DRIFT')
+    expect(refusal.message).toContain('bun.lock')
+  })
+
+  test('a scripts-only manifest edit beside a lockfile diff does not soften the refusal', async () => {
+    const base = manifest({ name: 'papai', scripts: { check: 'bun run check' } })
+    const head = manifest({ name: 'papai', scripts: { check: 'bun run check --verbose' } })
+    const refusal = await refusalFrom({
+      changed: ['bun.lock', 'package.json'],
+      blobs: { [BASE_SPEC]: base, [HEAD_SPEC]: head },
+    })
+
+    expect(refusal.code).toBe('DEPENDENCY_DRIFT')
+    expect(refusal.message).toContain('bun.lock')
+    // The manifest did not drift, so the refusal must not name it.
+    expect(refusal.message).not.toContain('package.json')
+  })
+})
+
+describe('assertManifestsInSync · unknown shapes fail closed', () => {
+  test('malformed JSON on the branch side refuses, naming the file', async () => {
+    const refusal = await refusalFrom({
+      changed: ['sdd-runner/package.json'],
+      blobs: {
+        'origin/main:sdd-runner/package.json': manifest({ name: 'sdd-runner' }),
+        'HEAD:sdd-runner/package.json': '{ not json',
+      },
+    })
+
+    expect(refusal.code).toBe('DEPENDENCY_DRIFT')
+    expect(refusal.message).toContain('sdd-runner/package.json')
+  })
+
+  test('malformed JSON on the base side refuses too', async () => {
+    const refusal = await refusalFrom({
+      changed: ['package.json'],
+      blobs: { [BASE_SPEC]: '{ not json', [HEAD_SPEC]: manifest({ name: 'papai' }) },
+    })
+
+    expect(refusal.code).toBe('DEPENDENCY_DRIFT')
+    expect(refusal.message).toContain('package.json')
+  })
+})

--- a/tests/opencode-agent/git.test.ts
+++ b/tests/opencode-agent/git.test.ts
@@ -218,7 +218,9 @@ describe('ensureBranch refuses drifted dependency manifests', () => {
   // onto the agent branch afterwards, and the pre-commit typecheck died on an
   // import the base lockfile no longer carried — after the drafter turn was
   // already paid for. These pin the refusal at the branch switch instead, and
-  // the one caller allowed past it.
+  // the one caller allowed past it. The refusal is content-aware: only
+  // install-relevant manifest fields count (issue #360's scripts-only edit
+  // must not park a finished branch), and every unknown shape fails closed.
 
   /** Narrows a caught refusal, failing the test on anything else. */
   const asPipelineError = (error: unknown): PipelineError => {
@@ -244,9 +246,15 @@ describe('ensureBranch refuses drifted dependency manifests', () => {
     expect(refusal.message).toContain('/sync')
   })
 
-  it('refuses a drifted workspace package.json too — the glob reaches it', async () => {
+  it('refuses a workspace package.json whose dependencies differ — the glob reaches it', async () => {
     const fixture = await makeFixture()
-    await commitOn(fixture, 'agent/issue-42', 'sdd-runner/package.json', '{ "name": "sdd-runner" }\n', 'agent adds dep')
+    await commitOn(
+      fixture,
+      'agent/issue-42',
+      'sdd-runner/package.json',
+      '{ "name": "sdd-runner", "dependencies": { "zod": "^4.0.0" } }\n',
+      'agent adds dep',
+    )
     await fixture.run(['checkout', 'agent/issue-42'])
 
     const refusal = asPipelineError(
@@ -255,6 +263,42 @@ describe('ensureBranch refuses drifted dependency manifests', () => {
 
     expect(refusal.code).toBe('DEPENDENCY_DRIFT')
     expect(refusal.message).toContain('sdd-runner/package.json')
+    expect(refusal.message).toContain('dependencies')
+  })
+
+  it('lets a workspace manifest the base never had through when it carries no install fields', async () => {
+    const fixture = await makeFixture()
+    await commitOn(
+      fixture,
+      'agent/issue-42',
+      'sdd-runner/package.json',
+      '{ "name": "sdd-runner" }\n',
+      'agent adds workspace',
+    )
+    await fixture.run(['checkout', 'agent/issue-42'])
+
+    await fixture.git.ensureBranch('agent/issue-42', 'main')
+  })
+
+  it('lets a scripts-only root manifest edit through — the issue #360 shape', async () => {
+    const fixture = await makeFixture()
+    await commitOn(
+      fixture,
+      'main',
+      'package.json',
+      '{ "name": "papai", "scripts": { "check:verbose": "bun run check" } }\n',
+      'base manifest',
+    )
+    await commitOn(
+      fixture,
+      'agent/issue-42',
+      'package.json',
+      '{ "name": "papai", "scripts": { "check:verbose": "bun run check --verbose" } }\n',
+      'agent edits a script',
+    )
+    await fixture.run(['checkout', 'agent/issue-42'])
+
+    await fixture.git.ensureBranch('agent/issue-42', 'main')
   })
 
   it('allows a branch that differs from base only outside the manifests', async () => {

--- a/tests/opencode-agent/phase-failure.test.ts
+++ b/tests/opencode-agent/phase-failure.test.ts
@@ -101,7 +101,9 @@ const failureFixture = (state: AgentState): { input: MachineInput; sections: Rep
 }
 
 describe('failRun · a dependency-drift refusal', () => {
-  const drift = dependencyDriftError('agent/issue-323', 'master', ['package.json'])
+  const drift = dependencyDriftError('agent/issue-323', 'master', [
+    { file: 'package.json', fields: ['devDependencies'] },
+  ])
 
   test('parks in FAILED with the resume point but carries attempts instead of spending one', async () => {
     // The guard fires at the branch switch, before any work: the same doctrine


### PR DESCRIPTION
## Why

Issue #360 (PR #362) was deadlocked: the change's own deliverable edited one `scripts` line in `package.json`, and the dependency-drift guard refused any branch whose manifest **paths** differed from base — content-blind. Every later job's `ensureBranch` parked the run in `FAILED` (`DEPENDENCY_DRIFT`) where `/retry` reproduced the refusal, `/sync` had nothing to merge, and `/review` was refused from `FAILED`.

## What Changes

- `assertManifestsInSync` (`opencode-agent/src/git-drift.ts`) becomes content-aware: a changed `package.json` refuses only when an install-relevant top-level field moved — the new `INSTALL_FIELDS` constant (`dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`, `resolutions`, `overrides`, `workspaces`, `trustedDependencies`, `patchedDependencies`) — judged by reading both sides via the existing `GitFn` seam (`git show <ref>:<path>`), `JSON.parse`, and `isDeepStrictEqual` per field. A re-serialized but identical dependencies map passes; `scripts` / `packageManager` / metadata edits pass.
- `bun.lock` keeps its unconditional any-byte refusal.
- Fail-closed defaults: a manifest that will not parse on either side refuses; a one-sided (added/deleted) manifest is compared against `{}` and refuses when the existing side carries install fields.
- `dependencyDriftError` now reports the drifted fields per file (`package.json (devDependencies, resolutions)`) in the opening line; remedies text, no-bare-`/retry` rule, `isDependencyDrift` / `isRetryFutile` bookkeeping and `/sync`'s `allowDependencyDrift` pass-through are unchanged.
- Docs: `opencode-agent/CLAUDE.md` `ensureBranch` rule paragraph and a new README operator subsection ("Branches the job cannot serve").
- OpenSpec change `fix-drift-guard-scripts-only` rides along (proposal, spec delta for the new `agent-manifest-drift-guard` capability, design, tasks — 8/8 complete).

## Verification

- New `tests/opencode-agent/git-drift.test.ts` drives the `GitFn` seam: 21 tests covering the #360 scripts-only pass, each field family, reformat-only pass, lockfile refusal, malformed JSON both sides, added workspace with/without dependencies, deleted manifest with install fields.
- `git.test.ts` gains the #360 and one-sided-manifest integration shapes; `errors.test.ts` / `phase-failure.test.ts` pins updated to the new message.
- `bun run test` (serial full): 16654 tests, 0 fail. `bun check:full`: 8/8. `git-drift.ts` at 177 lines — no `max-lines` pressure.

Closes #360.