### PR TITLE
feat(sdd-runner): attribute r2 eligibility blocking causes per cap-hit state

### DIFF
--- a/openspec/changes/sdd-analyze-r2-blocking-cause/tasks.md
+++ b/openspec/changes/sdd-analyze-r2-blocking-cause/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Cause classification (design D1)
 
-- [ ] 1.1 Failing tests in `tests/sdd-runner/analyze.test.ts`: extend `r2EligibilityRate` with `byCause` — `r2-fired` (extend auto_decision naming R2), `cost-unknown` (R4 presentation, run costKnown false), `over-ceiling` (R4 presentation, costKnown true), `preview` (preview auto_decision), `trajectory-blocked` (predicate fails); state→gate join by first early presentation after the convergence; era run with no supporting records keeps today's unknown verbatim. Implement in `sdd-runner/src/analyze-findings.ts`. Verify: `bun test tests/sdd-runner/analyze.test.ts`
-- [ ] 1.2 Failing test pinning real-corpus shapes: the kiss-help-style preview pair attributes `preview ×2`, and cost-unknown extend-by-human rows attribute `cost-unknown` (fixtures mirroring the investigation's event sequences). Verify: `bun test tests/sdd-runner/analyze.test.ts`
+- [x] 1.1 Failing tests in `tests/sdd-runner/analyze.test.ts`: extend `r2EligibilityRate` with `byCause` — `r2-fired` (extend auto_decision naming R2), `cost-unknown` (R4 presentation, run costKnown false), `over-ceiling` (R4 presentation, costKnown true), `preview` (preview auto_decision), `trajectory-blocked` (predicate fails); state→gate join by first early presentation after the convergence; era run with no supporting records keeps today's unknown verbatim. Implement in `sdd-runner/src/analyze-findings.ts`. Verify: `bun test tests/sdd-runner/analyze.test.ts`
+- [x] 1.2 Failing test pinning real-corpus shapes: the kiss-help-style preview pair attributes `preview ×2`, and cost-unknown extend-by-human rows attribute `cost-unknown` (fixtures mirroring the investigation's event sequences). Verify: `bun test tests/sdd-runner/analyze.test.ts`
 
 ## 2. Report + JSON (design D2 + D3)
 

--- a/openspec/changes/sdd-analyze-r2-blocking-cause/tasks.md
+++ b/openspec/changes/sdd-analyze-r2-blocking-cause/tasks.md
@@ -5,7 +5,7 @@
 
 ## 2. Report + JSON (design D2 + D3)
 
-- [ ] 2.1 Failing tests for the per-run line (`r2 eligibility: 2/5 (cost-unknown ×3)`, causes in fixed order, omitted when none) and the corpus aggregate's cause mix; JSON pins for additive `byCause` (nonzero causes only). Implement in `sdd-runner/src/analyze-report.ts` and `sdd-runner/src/analyze-corpus.ts`. Verify: `bun test tests/sdd-runner/analyze.test.ts`
+- [x] 2.1 Failing tests for the per-run line (`r2 eligibility: 2/5 (cost-unknown ×3)`, causes in fixed order, omitted when none) and the corpus aggregate's cause mix; JSON pins for additive `byCause` (nonzero causes only). Implement in `sdd-runner/src/analyze-report.ts` and `sdd-runner/src/analyze-corpus.ts`. Verify: `bun test tests/sdd-runner/analyze.test.ts`
 
 ## 3. Close-out
 

--- a/openspec/changes/sdd-analyze-r2-blocking-cause/tasks.md
+++ b/openspec/changes/sdd-analyze-r2-blocking-cause/tasks.md
@@ -9,4 +9,4 @@
 
 ## 3. Close-out
 
-- [ ] 3.1 Full gates: `bun test`, `bun run typecheck`, `bun run lint`; then a live smoke over the 8-workdir corpus expecting `cost-unknown ×9 · preview ×2` for the 11 eligible states (acceptance: the breakdown reproduces the gap investigation's hand decomposition exactly). Verify: `bun run test:status`
+- [x] 3.1 Full gates: `bun test`, `bun run typecheck`, `bun run lint`; then a live smoke over the 8-workdir corpus expecting `cost-unknown ×9 · preview ×2` for the 11 eligible states (acceptance: the breakdown reproduces the gap investigation's hand decomposition exactly). Verify: `bun run test:status`

--- a/sdd-runner/src/analyze-corpus.ts
+++ b/sdd-runner/src/analyze-corpus.ts
@@ -8,10 +8,11 @@ import {
   concernPersistence,
   duplicateIdRate,
   lensOverlapRate,
+  R2_CAUSES,
   r2EligibilityRate,
   resolverActionMix,
 } from './analyze-findings.js'
-import type { R2Eligibility, ResolverActionMix } from './analyze-findings.js'
+import type { R2Cause, R2CauseMix, R2Eligibility, ResolverActionMix } from './analyze-findings.js'
 import { decisionConsistency, gateForensics } from './analyze-gates.js'
 import type { DecisionConsistency, GateForensics } from './analyze-gates.js'
 import type { RunBundle } from './analyze-io.js'
@@ -71,6 +72,7 @@ export interface RunAnalysis {
 
 export function analyzeRun(bundle: RunBundle, now: Date, resolveCost: ResolveCostFn): RunAnalysis {
   const consistency = decisionConsistency(bundle)
+  const usage = usageOf(bundle.events, resolveCost)
   return {
     workDir: bundle.workDir,
     runId: bundle.runId,
@@ -85,9 +87,9 @@ export function analyzeRun(bundle: RunBundle, now: Date, resolveCost: ResolveCos
     classChurn: classChurn(bundle),
     resolverActionMix: resolverActionMix(bundle),
     concernPersistence: concernPersistence(bundle),
-    r2Eligibility: r2EligibilityRate(bundle),
+    r2Eligibility: r2EligibilityRate(bundle, usage.costKnown),
     consistency,
-    usage: usageOf(bundle.events, resolveCost),
+    usage,
   }
 }
 
@@ -123,6 +125,16 @@ function duplicateEntriesOf(bundle: RunBundle): number {
   )
 }
 
+/** Per-cause sums across runs with a known metric, fixed cause order, nonzero entries only. */
+function r2CauseMixOf(parts: readonly R2Eligibility[]): R2CauseMix {
+  const mix: Partial<Record<R2Cause, number>> = {}
+  for (const cause of R2_CAUSES) {
+    const total = parts.reduce((acc, part) => acc + (part.byCause[cause] ?? 0), 0)
+    if (total > 0) mix[cause] = total
+  }
+  return mix
+}
+
 function aggregatesOf(
   bundles: readonly RunBundle[],
   runs: readonly RunAnalysis[],
@@ -151,6 +163,7 @@ function aggregatesOf(
         : {
             eligible: r2Parts.reduce((acc, part) => acc + part.eligible, 0),
             gateStates: r2Parts.reduce((acc, part) => acc + part.gateStates, 0),
+            byCause: r2CauseMixOf(r2Parts),
           },
     gatesNeverAnswered: clean.reduce(
       (acc, run) => acc + (run.gates.status === 'known' ? run.gates.value.neverAnswered.length : 0),

--- a/sdd-runner/src/analyze-findings.ts
+++ b/sdd-runner/src/analyze-findings.ts
@@ -7,7 +7,7 @@ import type { RunBundle } from './analyze-io.js'
 import { knownMetric, unknownMetric } from './analyze.js'
 import type { Metric } from './analyze.js'
 import { fingerprintOf } from './concern-model.js'
-import type { SddEvent } from './events.js'
+import type { AutoDecisionKind, AutoDecisionRule, SddEvent } from './events.js'
 
 /** Finding-lifecycle metrics over the findings/resolutions sidecar joins. */
 
@@ -102,9 +102,75 @@ export function concernPersistence(bundle: RunBundle): Metric<number> {
   return knownMetric(persisting.length / roundsOf.size)
 }
 
+export const R2_CAUSES = ['r2-fired', 'cost-unknown', 'over-ceiling', 'preview', 'trajectory-blocked'] as const
+export type R2Cause = (typeof R2_CAUSES)[number]
+
+/** Nonzero per-cause counts over a run's (or the corpus's) cap-hit gate states. */
+export type R2CauseMix = Readonly<Partial<Record<R2Cause, number>>>
+
 export interface R2Eligibility {
   readonly eligible: number
   readonly gateStates: number
+  readonly byCause: R2CauseMix
+}
+
+interface AutoRecord {
+  readonly rule: AutoDecisionRule
+  readonly decision: AutoDecisionKind
+}
+
+/**
+ * Why each cap-hit gate state didn't (or did) let R2 fire, joined from the
+ * event log plus the run's cost-knownness: the state joins to the first
+ * early-mode gate presented after its convergence and before the next one,
+ * then that gate's `auto_decision` records name the fate. The R2 trajectory
+ * predicate itself is the attribution for ineligible states —
+ * `trajectory-blocked` is exactly the ratio's complement — so an R4 decision
+ * recorded on an ineligible state (R4 pre-empts the trajectory check on the
+ * ladder) still reads as trajectory-blocked, and only eligible states consume
+ * the gap causes.
+ */
+function blockingCauseOf(records: readonly AutoRecord[], costKnown: boolean): R2Cause | null {
+  if (records.some((record) => record.rule === 'R2' && record.decision === 'extend')) return 'r2-fired'
+  if (records.some((record) => record.rule === 'R4')) return costKnown ? 'over-ceiling' : 'cost-unknown'
+  if (records.some((record) => record.decision === 'preview')) return 'preview'
+  return null
+}
+
+function causeMixOf(causes: readonly R2Cause[]): R2CauseMix {
+  const mix: Partial<Record<R2Cause, number>> = {}
+  for (const cause of R2_CAUSES) {
+    const count = causes.filter((candidate) => candidate === cause).length
+    if (count > 0) mix[cause] = count
+  }
+  return mix
+}
+
+interface R2EventIndex {
+  readonly caps: ReadonlyMap<number, number>
+  readonly earlyPresentations: readonly { readonly seq: number; readonly version: number }[]
+  readonly autoByGate: ReadonlyMap<number, readonly AutoRecord[]>
+  readonly convergences: readonly Extract<SddEvent, { type: 'convergence' }>[]
+}
+
+/** One pass over the event log: caps, early presentations, decisions per gate version, convergences. */
+function r2EventIndexOf(events: readonly SddEvent[]): R2EventIndex {
+  const caps = new Map<number, number>()
+  const earlyPresentations: { seq: number; version: number }[] = []
+  const autoByGate = new Map<number, AutoRecord[]>()
+  const convergences: Extract<SddEvent, { type: 'convergence' }>[] = []
+  for (const event of events) {
+    if (event.type === 'round_open') caps.set(event.round, event.cap)
+    else if (event.type === 'convergence') convergences.push(event)
+    else if (event.type === 'gate' && event.action === 'presented' && event.mode === 'early') {
+      earlyPresentations.push({ seq: event.seq, version: event.version })
+    } else if (event.type === 'auto_decision') {
+      const records = autoByGate.get(event.gateVersion) ?? []
+      records.push({ rule: event.rule, decision: event.decision })
+      autoByGate.set(event.gateVersion, records)
+    }
+  }
+  return { caps, earlyPresentations, autoByGate, convergences }
 }
 
 /**
@@ -112,34 +178,49 @@ export interface R2Eligibility {
  * cap-hit round (round === cap, verdict open) is one gate state; it is
  * eligible when the later record has zero blockers, ≥1 material, and a
  * strictly smaller open total than its predecessor — the exact predicate
- * `auto-policy.ts` R2 applies (trajectory window 2).
+ * `auto-policy.ts` R2 applies (trajectory window 2). Each state also carries
+ * its blocking cause in `byCause` (nonzero entries only, fixed cause order):
+ * eligible states are attributed from their joined gate's auto_decision
+ * records (`r2-fired`, `cost-unknown`/`over-ceiling` by `costKnown`,
+ * `preview`), ineligible states are the `trajectory-blocked` complement. An
+ * eligible state with no joined gate or no attribution records degrades the
+ * metric to unknown — reduced coverage, never a wrong breakdown.
  */
-export function r2EligibilityRate(bundle: RunBundle): Metric<R2Eligibility> {
-  const caps = new Map<number, number>()
-  for (const event of bundle.events) {
-    if (event.type === 'round_open') caps.set(event.round, event.cap)
-  }
-  const convergences = bundle.events.filter(
-    (event): event is Extract<SddEvent, { type: 'convergence' }> => event.type === 'convergence',
-  )
+export function r2EligibilityRate(bundle: RunBundle, costKnown = true): Metric<R2Eligibility> {
+  const { caps, earlyPresentations, autoByGate, convergences } = r2EventIndexOf(bundle.events)
   const openTotal = (counts: { blocker: number; material: number; nitpick: number }): number =>
     counts.blocker + counts.material + counts.nitpick
+  const causes: R2Cause[] = []
   let gateStates = 0
   let eligible = 0
+  let unattributed = 0
   for (let i = 1; i < convergences.length; i += 1) {
     const previous = convergences[i - 1]
     const current = convergences[i]
     if (current === undefined || previous === undefined) continue
     if (caps.get(current.round) !== current.round || current.verdict !== 'open') continue
     gateStates += 1
-    if (
+    const trajectoryEligible =
       current.counts.blocker === 0 &&
       current.counts.material > 0 &&
       openTotal(current.counts) < openTotal(previous.counts)
-    ) {
-      eligible += 1
+    if (!trajectoryEligible) {
+      causes.push('trajectory-blocked')
+      continue
     }
+    eligible += 1
+    const nextSeq = convergences[i + 1]?.seq ?? Number.POSITIVE_INFINITY
+    const gateVersion = earlyPresentations.find(
+      (presentation) => presentation.seq > current.seq && presentation.seq < nextSeq,
+    )?.version
+    const records = gateVersion === undefined ? [] : (autoByGate.get(gateVersion) ?? [])
+    const cause = blockingCauseOf(records, costKnown)
+    if (cause === null) unattributed += 1
+    else causes.push(cause)
   }
   if (gateStates === 0) return unknownMetric('no cap-hit convergence pairs')
-  return knownMetric({ eligible, gateStates })
+  if (unattributed > 0) {
+    return unknownMetric(`no gate/auto-decision records for ${unattributed} eligible cap-hit state(s)`)
+  }
+  return knownMetric({ eligible, gateStates, byCause: causeMixOf(causes) })
 }

--- a/sdd-runner/src/analyze-report.ts
+++ b/sdd-runner/src/analyze-report.ts
@@ -4,6 +4,7 @@
 // See LICENSE in the project root for details.
 
 import type { CorpusReport, RunAnalysis } from './analyze-corpus.js'
+import type { R2CauseMix } from './analyze-findings.js'
 import type { Metric } from './analyze.js'
 
 /**
@@ -64,6 +65,22 @@ function ratioLine(numerator: number, denominator: number): string {
   return `${numerator}/${denominator}`
 }
 
+/**
+ * The gap causes explain the eligibility→fired split, so only they render;
+ * `trajectory-blocked` stays implicit as the ratio's complement (JSON carries
+ * it). Fixed cause order, ` ×N` counts, ` · ` separators, omitted when none.
+ */
+const R2_GAP_CAUSES = ['r2-fired', 'cost-unknown', 'over-ceiling', 'preview'] as const
+
+function r2CauseSuffix(byCause: R2CauseMix): string {
+  const parts: string[] = []
+  for (const cause of R2_GAP_CAUSES) {
+    const count = byCause[cause] ?? 0
+    if (count > 0) parts.push(`${cause} ×${count}`)
+  }
+  return parts.length === 0 ? '' : ` (${parts.join(' · ')})`
+}
+
 function runSection(run: RunAnalysis): readonly string[] {
   const identity = [run.changeName ?? 'unnamed', run.status ?? 'no state'].join(' · ')
   const lines = [
@@ -82,7 +99,12 @@ function runSection(run: RunAnalysis): readonly string[] {
     )}`,
   )
   lines.push(`  concern persistence: ${metricLine(run.concernPersistence, (rate) => rate.toFixed(2))}`)
-  lines.push(`  r2 eligibility: ${metricLine(run.r2Eligibility, (r2) => ratioLine(r2.eligible, r2.gateStates))}`)
+  lines.push(
+    `  r2 eligibility: ${metricLine(
+      run.r2Eligibility,
+      (r2) => `${ratioLine(r2.eligible, r2.gateStates)}${r2CauseSuffix(r2.byCause)}`,
+    )}`,
+  )
   lines.push(
     `  retries: ${metricLine(
       run.retries,
@@ -141,7 +163,9 @@ function corpusSection(report: CorpusReport): readonly string[] {
     `  r2 eligible: ${
       aggregates.r2Eligibility === null
         ? 'unknown'
-        : ratioLine(aggregates.r2Eligibility.eligible, aggregates.r2Eligibility.gateStates)
+        : `${ratioLine(aggregates.r2Eligibility.eligible, aggregates.r2Eligibility.gateStates)}${r2CauseSuffix(
+            aggregates.r2Eligibility.byCause,
+          )}`
     } cap-hit states`,
   )
   lines.push(`  gates never answered: ${aggregates.gatesNeverAnswered}`)

--- a/tests/sdd-runner/analyze.test.ts
+++ b/tests/sdd-runner/analyze.test.ts
@@ -1207,3 +1207,129 @@ describe('corpus report (4.1)', () => {
     expect(unpricedRun.usage.costKnown).toBe(false)
   })
 })
+
+describe('r2 eligibility cause breakdown report (sdd-analyze-r2-blocking-cause)', () => {
+  const now = new Date(at(60))
+
+  /** Sequential event stamper so multi-state fixtures stay readable. */
+  function scripted(events: readonly EventInput[]): SddEvent[] {
+    return events.map((init, index) => ev(init, index + 1, at(index)))
+  }
+
+  /**
+   * Six cap-hit states on a cost-unknown run: r2-fired, cost-unknown ×2,
+   * preview among the four eligible; two ineligible (blocker, non-decreasing).
+   */
+  const mixedRun = bundleOf({
+    workDir: '/w-a',
+    runId: 'mixed',
+    events: scripted([
+      spawnedAs('a1', 'drafter'),
+      doneAs('a1', 0),
+      roundOpen(1, 2),
+      convergenceOf(1, 'open', { blocker: 0, material: 5, nitpick: 1 }),
+      roundOpen(2, 2),
+      convergenceOf(2, 'open', { blocker: 0, material: 4, nitpick: 1 }),
+      gatePresented(1, 'early'),
+      autoDecision('R2', 'extend', 1),
+      roundOpen(3, 3),
+      convergenceOf(3, 'open', { blocker: 0, material: 3, nitpick: 1 }),
+      gatePresented(2, 'early'),
+      autoDecision('R4', 'gate', 2),
+      roundOpen(4, 4),
+      convergenceOf(4, 'open', { blocker: 0, material: 2, nitpick: 1 }),
+      gatePresented(3, 'early'),
+      autoDecision('R4', 'gate', 3),
+      roundOpen(5, 5),
+      convergenceOf(5, 'open', { blocker: 0, material: 1, nitpick: 1 }),
+      gatePresented(4, 'early'),
+      autoDecision('R2', 'preview', 4),
+      roundOpen(6, 6),
+      convergenceOf(6, 'open', { blocker: 1, material: 1, nitpick: 1 }),
+      roundOpen(7, 7),
+      convergenceOf(7, 'open', { blocker: 0, material: 3, nitpick: 1 }),
+    ]),
+  })
+
+  it('the per-run line prints the cause mix in fixed order with counts', () => {
+    const text = renderCorpusReport(buildCorpusReport([mixedRun], [], { now }))
+    expect(text).toContain('r2 eligibility: 4/6 (r2-fired ×1 · cost-unknown ×2 · preview ×1)')
+  })
+
+  it('the breakdown is omitted when no eligible state carries a gap cause', () => {
+    const blocked = bundleOf({
+      workDir: '/w-b',
+      runId: 'blocked',
+      events: scripted([
+        roundOpen(1, 2),
+        convergenceOf(1, 'open', { blocker: 2, material: 1, nitpick: 0 }),
+        roundOpen(2, 2),
+        convergenceOf(2, 'open', { blocker: 1, material: 1, nitpick: 1 }),
+        roundOpen(3, 3),
+        convergenceOf(3, 'open', { blocker: 2, material: 0, nitpick: 1 }),
+      ]),
+    })
+    const text = renderCorpusReport(buildCorpusReport([blocked], [], { now }))
+    expect(text).toContain('r2 eligibility: 0/2\n')
+    expect(text).not.toContain('trajectory-blocked')
+  })
+
+  it('an unknown metric renders its reason verbatim', () => {
+    const text = renderCorpusReport(buildCorpusReport([bundleOf({ workDir: '/w-c', runId: 'no-states' })], [], { now }))
+    expect(text).toContain('r2 eligibility: unknown (no cap-hit convergence pairs)')
+  })
+
+  it('the corpus aggregate line mixes causes across runs and JSON carries additive byCause', () => {
+    const costUnknownRun = bundleOf({
+      workDir: '/w-a',
+      runId: 'cost-unknown-run',
+      events: scripted([
+        spawnedAs('a1', 'drafter'),
+        doneAs('a1', 0),
+        roundOpen(1, 2),
+        convergenceOf(1, 'open', { blocker: 0, material: 3, nitpick: 1 }),
+        roundOpen(2, 2),
+        convergenceOf(2, 'open', { blocker: 0, material: 2, nitpick: 1 }),
+        gatePresented(1, 'early'),
+        autoDecision('R4', 'gate', 1),
+        roundOpen(3, 3),
+        convergenceOf(3, 'open', { blocker: 1, material: 1, nitpick: 1 }),
+      ]),
+    })
+    const costKnownRun = bundleOf({
+      workDir: '/w-b',
+      runId: 'cost-known-run',
+      events: scripted([
+        spawnedAs('a1', 'drafter'),
+        doneAs('a1', 0.02),
+        roundOpen(1, 2),
+        convergenceOf(1, 'open', { blocker: 0, material: 3, nitpick: 1 }),
+        roundOpen(2, 2),
+        convergenceOf(2, 'open', { blocker: 0, material: 2, nitpick: 1 }),
+        gatePresented(1, 'early'),
+        autoDecision('R4', 'gate', 1),
+        roundOpen(3, 3),
+        convergenceOf(3, 'open', { blocker: 1, material: 1, nitpick: 1 }),
+      ]),
+    })
+
+    const report = buildCorpusReport([costUnknownRun, costKnownRun], [], { now })
+    const text = renderCorpusReport(report)
+    expect(text).toContain('r2 eligible: 2/4 (cost-unknown ×1 · over-ceiling ×1)')
+
+    const parsed = recordOf(JSON.parse(renderCorpusJson(report)))
+    const runs = arrayField(parsed, 'runs')
+    const runMetric = recordOf(recordOf(runs[0])['r2Eligibility'])
+    expect(runMetric['status']).toBe('known')
+    expect(recordOf(runMetric['value'])).toEqual({
+      eligible: 1,
+      gateStates: 2,
+      byCause: { 'cost-unknown': 1, 'trajectory-blocked': 1 },
+    })
+    expect(recordOf(recordOf(parsed['aggregates'])['r2Eligibility'])).toEqual({
+      eligible: 2,
+      gateStates: 4,
+      byCause: { 'cost-unknown': 1, 'over-ceiling': 1, 'trajectory-blocked': 2 },
+    })
+  })
+})

--- a/tests/sdd-runner/analyze.test.ts
+++ b/tests/sdd-runner/analyze.test.ts
@@ -610,9 +610,15 @@ describe('concern persistence and R2 eligibility (2.3)', () => {
         ev(convergenceOf(2, 'open', { blocker: 0, material: 4, nitpick: 1 }), 4, at(3)),
         ev(roundOpen(3, 3), 5, at(4)),
         ev(convergenceOf(3, 'open', { blocker: 0, material: 2, nitpick: 1 }), 6, at(5)),
+        ev(gatePresented(1, 'early'), 7, at(6)),
+        ev(autoDecision('R2', 'extend', 1), 8, at(6)),
       ],
     })
-    expect(knownValue(r2EligibilityRate(bundle))).toEqual({ eligible: 1, gateStates: 1 })
+    expect(knownValue(r2EligibilityRate(bundle))).toEqual({
+      eligible: 1,
+      gateStates: 1,
+      byCause: { 'r2-fired': 1 },
+    })
   })
 
   it('r2EligibilityRate: open blockers or a non-decreasing trajectory make the state ineligible', () => {
@@ -632,8 +638,16 @@ describe('concern persistence and R2 eligibility (2.3)', () => {
         ev(convergenceOf(2, 'open', { blocker: 0, material: 3, nitpick: 1 }), 4, at(3)),
       ],
     })
-    expect(knownValue(r2EligibilityRate(withBlocker))).toEqual({ eligible: 0, gateStates: 1 })
-    expect(knownValue(r2EligibilityRate(nonDecreasing))).toEqual({ eligible: 0, gateStates: 1 })
+    expect(knownValue(r2EligibilityRate(withBlocker))).toEqual({
+      eligible: 0,
+      gateStates: 1,
+      byCause: { 'trajectory-blocked': 1 },
+    })
+    expect(knownValue(r2EligibilityRate(nonDecreasing))).toEqual({
+      eligible: 0,
+      gateStates: 1,
+      byCause: { 'trajectory-blocked': 1 },
+    })
   })
 
   it('r2EligibilityRate is unknown without cap-hit convergence pairs', () => {
@@ -645,6 +659,160 @@ describe('concern persistence and R2 eligibility (2.3)', () => {
     })
     expect(r2EligibilityRate(converged).status).toBe('unknown')
     expect(r2EligibilityRate(bundleOf()).status).toBe('unknown')
+  })
+})
+
+describe('r2 blocking-cause attribution (sdd-analyze-r2-blocking-cause)', () => {
+  /** One eligible cap-hit state (r2) joined by an early gate carrying the given decision. */
+  const eligibleStateWith = (version: number, decision: EventInput): SddEvent[] => [
+    ev(roundOpen(1, 2), 1, at(0)),
+    ev(convergenceOf(1, 'open', { blocker: 0, material: 3, nitpick: 1 }), 2, at(1)),
+    ev(roundOpen(2, 2), 3, at(2)),
+    ev(convergenceOf(2, 'open', { blocker: 0, material: 2, nitpick: 1 }), 4, at(3)),
+    ev(gatePresented(version, 'early'), 5, at(4)),
+    ev(decision, 6, at(5)),
+  ]
+
+  it('an extend auto_decision naming R2 attributes r2-fired', () => {
+    const bundle = bundleOf({ events: eligibleStateWith(1, autoDecision('R2', 'extend', 1)) })
+    expect(knownValue(r2EligibilityRate(bundle))).toEqual({
+      eligible: 1,
+      gateStates: 1,
+      byCause: { 'r2-fired': 1 },
+    })
+  })
+
+  it('an R4 presentation attributes cost-unknown on a cost-unknown run and over-ceiling on a cost-known one', () => {
+    const r4Gate = autoDecision('R4', 'gate', 1)
+    expect(knownValue(r2EligibilityRate(bundleOf({ events: eligibleStateWith(1, r4Gate) }), false))).toEqual({
+      eligible: 1,
+      gateStates: 1,
+      byCause: { 'cost-unknown': 1 },
+    })
+    expect(knownValue(r2EligibilityRate(bundleOf({ events: eligibleStateWith(1, r4Gate) }), true))).toEqual({
+      eligible: 1,
+      gateStates: 1,
+      byCause: { 'over-ceiling': 1 },
+    })
+  })
+
+  it('a preview auto_decision attributes preview, distinct from r2-fired', () => {
+    const bundle = bundleOf({ events: eligibleStateWith(1, autoDecision('R2', 'preview', 1)) })
+    expect(knownValue(r2EligibilityRate(bundle))).toEqual({
+      eligible: 1,
+      gateStates: 1,
+      byCause: { preview: 1 },
+    })
+  })
+
+  it('an ineligible state is trajectory-blocked even when R4 named its gate (the complement bucket)', () => {
+    const bundle = bundleOf({
+      events: [
+        ev(roundOpen(1, 2), 1, at(0)),
+        ev(convergenceOf(1, 'open', { blocker: 0, material: 3, nitpick: 1 }), 2, at(1)),
+        ev(roundOpen(2, 2), 3, at(2)),
+        ev(convergenceOf(2, 'open', { blocker: 1, material: 2, nitpick: 0 }), 4, at(3)),
+        ev(gatePresented(1, 'early'), 5, at(4)),
+        ev(autoDecision('R4', 'gate', 1), 6, at(5)),
+      ],
+    })
+    expect(knownValue(r2EligibilityRate(bundle, false))).toEqual({
+      eligible: 0,
+      gateStates: 1,
+      byCause: { 'trajectory-blocked': 1 },
+    })
+  })
+
+  it('the join takes the first early presentation after the convergence; final-gate records never join', () => {
+    const bundle = bundleOf({
+      events: [
+        ev(roundOpen(1, 2), 1, at(0)),
+        ev(convergenceOf(1, 'open', { blocker: 0, material: 4, nitpick: 1 }), 2, at(1)),
+        ev(roundOpen(2, 2), 3, at(2)),
+        ev(convergenceOf(2, 'open', { blocker: 0, material: 3, nitpick: 1 }), 4, at(3)),
+        ev(gatePresented(1, 'final'), 5, at(6)),
+        ev(autoDecision('R2', 'extend', 1), 6, at(6)),
+        ev(gatePresented(2, 'early'), 7, at(7)),
+        ev(autoDecision('R4', 'gate', 2), 8, at(8)),
+        ev(roundOpen(3, 3), 9, at(9)),
+        ev(convergenceOf(3, 'open', { blocker: 0, material: 2, nitpick: 1 }), 10, at(10)),
+        ev(gatePresented(3, 'early'), 11, at(11)),
+        ev(autoDecision('R2', 'extend', 3), 12, at(12)),
+      ],
+    })
+    expect(knownValue(r2EligibilityRate(bundle, false))).toEqual({
+      eligible: 2,
+      gateStates: 2,
+      byCause: { 'r2-fired': 1, 'cost-unknown': 1 },
+    })
+  })
+
+  it('an era run with an eligible state but no supporting records degrades to unknown with its reason', () => {
+    const era = bundleOf({
+      events: [
+        ev(roundOpen(1, 2), 1, at(0)),
+        ev(convergenceOf(1, 'open', { blocker: 0, material: 3, nitpick: 1 }), 2, at(1)),
+        ev(roundOpen(2, 2), 3, at(2)),
+        ev(convergenceOf(2, 'open', { blocker: 0, material: 2, nitpick: 1 }), 4, at(3)),
+      ],
+    })
+    const metric = r2EligibilityRate(era)
+    expect(metric).toEqual({
+      status: 'unknown',
+      reason: 'no gate/auto-decision records for 1 eligible cap-hit state(s)',
+    })
+  })
+
+  it('an era run whose states all fail the predicate stays known on the trajectory-blocked complement', () => {
+    const era = bundleOf({
+      events: [
+        ev(roundOpen(1, 2), 1, at(0)),
+        ev(convergenceOf(1, 'open', { blocker: 2, material: 1, nitpick: 0 }), 2, at(1)),
+        ev(roundOpen(2, 2), 3, at(2)),
+        ev(convergenceOf(2, 'open', { blocker: 1, material: 1, nitpick: 1 }), 4, at(3)),
+        ev(roundOpen(3, 3), 5, at(4)),
+        ev(convergenceOf(3, 'open', { blocker: 2, material: 0, nitpick: 1 }), 6, at(5)),
+      ],
+    })
+    expect(knownValue(r2EligibilityRate(era))).toEqual({
+      eligible: 0,
+      gateStates: 2,
+      byCause: { 'trajectory-blocked': 2 },
+    })
+  })
+
+  it('a kiss-help-style preview pair attributes preview ×2', () => {
+    const bundle = bundleOf({
+      events: [
+        ev(roundOpen(1, 2), 1, at(0)),
+        ev(convergenceOf(1, 'open', { blocker: 1, material: 10, nitpick: 0 }), 2, at(1)),
+        ev(roundOpen(2, 2), 3, at(2)),
+        ev(convergenceOf(2, 'open', { blocker: 0, material: 6, nitpick: 1 }), 4, at(3)),
+        ev(gatePresented(2, 'early'), 5, at(4)),
+        ev(autoDecision('R2', 'preview', 2), 6, at(5)),
+        ev(roundOpen(3, 3), 7, at(6)),
+        ev(convergenceOf(3, 'open', { blocker: 0, material: 4, nitpick: 2 }), 8, at(7)),
+        ev(gatePresented(5, 'early'), 9, at(8)),
+        ev(autoDecision('R2', 'preview', 5), 10, at(9)),
+      ],
+    })
+    expect(knownValue(r2EligibilityRate(bundle))).toEqual({
+      eligible: 2,
+      gateStates: 2,
+      byCause: { preview: 2 },
+    })
+  })
+
+  it('cost-unknown extend-by-human rows attribute cost-unknown', () => {
+    const bundle = bundleOf({
+      events: [...eligibleStateWith(1, autoDecision('R4', 'gate', 1)), ev(gateAnswered(1, 'early'), 7, at(30))],
+      gateFiles: [{ version: 1, md: '→ RUN 1 MORE\n' }],
+    })
+    expect(knownValue(r2EligibilityRate(bundle, false))).toEqual({
+      eligible: 1,
+      gateStates: 1,
+      byCause: { 'cost-unknown': 1 },
+    })
   })
 })
 
@@ -949,9 +1117,9 @@ describe('corpus report (4.1)', () => {
         ev(convergenceOf(1, 'open', { blocker: 0, material: 3, nitpick: 1 }), 2, at(1)),
         ev(roundOpen(2, 2), 3, at(2)),
         ev(convergenceOf(2, 'open', { blocker: 0, material: 2, nitpick: 0 }), 4, at(3)),
-        ev(gatePresented(1, 'final'), 5, at(5)),
+        ev(gatePresented(1, 'early'), 5, at(5)),
         ev(autoDecision('R4', 'gate', 1), 6, at(6)),
-        ev(gateAnswered(1, 'final'), 7, at(7)),
+        ev(gateAnswered(1, 'early'), 7, at(7)),
         ev(gatePresented(2, 'final'), 8, at(10)),
       ],
       resolutions: [
@@ -984,7 +1152,11 @@ describe('corpus report (4.1)', () => {
     expect(report.aggregates.eraContaminated).toEqual(['trilogy'])
     expect(report.aggregates.autoDecisionsByRule).toEqual({ R4: 1 })
     expect(report.aggregates.duplicateResolutionEntries).toBe(1)
-    expect(report.aggregates.r2Eligibility).toEqual({ eligible: 1, gateStates: 1 })
+    expect(report.aggregates.r2Eligibility).toEqual({
+      eligible: 1,
+      gateStates: 1,
+      byCause: { 'over-ceiling': 1 },
+    })
     expect(report.aggregates.gatesNeverAnswered).toBe(1)
   })
 


### PR DESCRIPTION
## Summary

Implements OpenSpec change `sdd-analyze-r2-blocking-cause` — the corpus report's `r2 eligibility` headline now names *why* eligible R2 states didn't fire, instead of only counting them.

- **Cause classification** (`analyze-findings.ts`): every cap-hit gate state joins to the first early-mode gate presented within its convergence window; the joined gate's `auto_decision` records plus the run's `costKnown` attribute one cause per state — `r2-fired` (extend naming R2), `cost-unknown` / `over-ceiling` (R4 presentation, by `costKnown`), `preview` (observe-level rule), with `trajectory-blocked` as the ineligible complement. Eligible states with no attribution records degrade the metric to unknown (reduced coverage), never a wrong breakdown.
- **Report + JSON** (`analyze-report.ts`, `analyze-corpus.ts`): per-run line gains the parenthesized mix (`r2 eligibility: 4/6 (r2-fired ×1 · cost-unknown ×2 · preview ×1)`, fixed cause order, omitted when none); the corpus aggregate line mixes causes across runs; JSON carries additive `byCause` (nonzero causes only). The text line renders gap causes only — `trajectory-blocked` stays implicit as the ratio's complement.

## Acceptance

Live smoke over the 8-workdir corpus reproduces the gap investigation's hand decomposition exactly:

    r2 eligible: 11/29 (cost-unknown ×9 · preview ×2) cap-hit states

## Checks

- `bun test` — 17455 pass / 0 fail (full suite, serial)
- `bun run typecheck`, `bun run lint`, `format:check` — green (enforced per-commit by hooks)
- Artifacts: `openspec/changes/sdd-analyze-r2-blocking-cause/` rides on the same branch; tasks.md 4/4 checked