### PR TITLE
docs(openspec): propose claude-route-pricing-reference

### DIFF
--- a/opencode-agent/CLAUDE.md
+++ b/opencode-agent/CLAUDE.md
@@ -633,7 +633,12 @@ findings: `ROADMAP.md`.
   The id may not contain a slash: `parseModelRef` splits at the **first** one
   and keeps the whole remainder as the model id, which is what lets a model id
   contain slashes. `createOpenCodeAgent` logs the resolved reference at `debug`,
-  names only — a CI log is world-readable on a public repository.
+  names only — a CI log is world-readable on a public repository. The key is
+  **route-scoped**, and the claude route is not this route: it runs the
+  Anthropic CLI, so `claude-spend.ts` prices it under `anthropic` and under
+  `modelIdForCli`'s stripped id — the one the CLI was invoked with — whatever
+  `LLM_PROVIDER` says. It read that variable once, which logged a provider the
+  run's turns never touched and cost the catalogue rung its primary row.
 - **A model no catalogue carries is described rather than guessed at, and the
   description is omitted rather than zeroed.** `model-metadata.ts` resolves what
   a run knows about its model on a four-rung ladder — `AGENT_MODEL_*` overrides,

--- a/opencode-agent/README.md
+++ b/opencode-agent/README.md
@@ -1801,7 +1801,8 @@ transport is unaffected either way: the emitted config pins
 `npm: "@ai-sdk/openai-compatible"`, which wins over the borrowed row's own
 package in OpenCode's resolution order, and the key still reaches the endpoint
 through the provider proxy. The run log names the reference it resolved at
-`debug`.
+`debug`. The variable is **route-scoped**: it is the catalogue key on this
+route only, and the claude route prices under `anthropic` whatever it says.
 
 A model no catalogue carries at all — a self-hosted alias, a fine-tune — has no
 id that helps here. The three `AGENT_MODEL_*` variables state those facts
@@ -2110,8 +2111,13 @@ not. To switch (Settings → Secrets and variables → Actions):
 4. `LLM_API_KEY` and `LLM_BASE_URL` can stay exactly as they are: the workflow
    forwards both empty on the claude route, and the route's guard never sees
    them.
-5. `LLM_PROVIDER` and the `AGENT_MODEL_*` overrides are unused here — the
-   claude route skips the models.dev catalogue read. `LLM_MODEL_LIGHT` and
+5. `LLM_PROVIDER` and the `AGENT_MODEL_*` overrides are ignored here — the
+   claude route skips the boot-time **model-facts** catalogue read, which is
+   what they feed. It does still price a run against models.dev when the CLI
+   reports no cost of its own, and there it resolves the model under
+   `anthropic` and under the same id the CLI was invoked with (the `provider/`
+   prefix stripped) — never under `LLM_PROVIDER`, whose value belongs to the
+   gateway route. A leftover id there is harmless. `LLM_MODEL_LIGHT` and
    `AGENT_EFFORT_PLAN` / `AGENT_EFFORT_BUILD` still apply, per profile.
 
 Read [Backend selection](#backend-selection-the-claude-cli-route) before

--- a/opencode-agent/src/claude-argv.ts
+++ b/opencode-agent/src/claude-argv.ts
@@ -112,8 +112,13 @@ export const claudeProfileError = (): PipelineError =>
 /**
  * Only the model id crosses: one `LLM_MODEL` knob serves either backend, and a
  * value spelled `provider/model` (the OpenCode form) keeps its model id here.
+ *
+ * Exported as the one definition of *the id the CLI was invoked with*, which
+ * `claude-spend.ts` prices the run under. Two functions agreeing would be a
+ * reference that can drift from the invocation; one function is a reference
+ * that cannot.
  */
-const modelIdForCli = (raw: string): string => (raw.includes('/') ? parseModelRef(raw).modelID : raw)
+export const modelIdForCli = (raw: string): string => (raw.includes('/') ? parseModelRef(raw).modelID : raw)
 
 /** Which allowlist, model and effort a profile's turn runs with. */
 const profileSelection = (

--- a/opencode-agent/src/claude-spend.ts
+++ b/opencode-agent/src/claude-spend.ts
@@ -4,6 +4,7 @@
 // See LICENSE in the project root for details.
 
 import type { RunSpend } from './agent-session.js'
+import { modelIdForCli } from './claude-argv.js'
 import type { ClaudeStreamLine } from './claude-contract.js'
 import type { Logger } from './logger.js'
 import type { OpenAiSettings } from './openai-config.js'
@@ -44,6 +45,39 @@ export interface ClaudeAccounting {
    */
   rateLimitLines: ClaudeStreamLine[]
 }
+
+/**
+ * The models.dev provider this route's runs are resolved under.
+ *
+ * A constant rather than a knob: the claude route runs the Anthropic CLI, and
+ * `LLM_PROVIDER` is the *other* route's catalogue key — the id OpenCode
+ * resolves its own model row under, which reaches an Anthropic turn only as a
+ * name nothing on it produced. A leftover gateway id there priced a run under a
+ * provider its turns never touched, and cost the catalogue rung its primary row.
+ */
+export const CLAUDE_CATALOGUE_PROVIDER = 'anthropic'
+
+/**
+ * The settings the catalogue is asked about for a claude-route run.
+ *
+ * Both halves of the reference are corrected here, and each fixes its own
+ * defect: the provider, so the lookup finds Anthropic's own row instead of a
+ * median across every provider publishing a model of that name; and the model
+ * id, stripped by the same {@link modelIdForCli} the CLI is invoked through,
+ * because a `provider/model` spelling would otherwise compose
+ * `<provider>/<provider>/<model>` — which splits at the first slash into an id
+ * no catalogue carries, and reports the run unpriced.
+ *
+ * A derived copy rather than a mutation: the settings object is the run's
+ * config, read elsewhere on its own terms. Only the two fields the reference is
+ * composed from are replaced, and the placeholder credential it carries stays
+ * exactly as contained.
+ */
+export const claudePricingSettings = (settings: OpenAiSettings): OpenAiSettings => ({
+  ...settings,
+  provider: CLAUDE_CATALOGUE_PROVIDER,
+  model: modelIdForCli(settings.model),
+})
 
 export const emptyAccounting = (): ClaudeAccounting => ({
   tokensTotal: 0,

--- a/opencode-agent/src/contain.ts
+++ b/opencode-agent/src/contain.ts
@@ -8,6 +8,7 @@ import type { AgentHandle } from './agent-handle.js'
 import type { AgentSession } from './agent-session.js'
 import { createClaudeAgent as defaultClaudeAgent } from './claude-adapter.js'
 import type { ClaudeAgentOptions } from './claude-adapter.js'
+import { claudePricingSettings } from './claude-spend.js'
 import type { MainOptions } from './cli-args.js'
 import type { PipelineConfig } from './config.js'
 import { assembleDeps, memoize } from './deps.js'
@@ -153,10 +154,10 @@ const claudeSessionOptions = ({
   const profiles = contained.openai.profiles
   return {
     directory: contained.repoRoot,
-    // The contained settings, carrying the placeholder key: only `provider` and
-    // `model` are read, and design D5's rule is that the *credential* never
-    // crosses this seam — not the model's name.
-    pricing: contained.openai,
+    // The contained settings with this route's own reference: the Anthropic
+    // catalogue and the id the CLI is invoked with, never `LLM_PROVIDER`.
+    // Design D5 bars the *credential* from this seam, not the model's name.
+    pricing: claudePricingSettings(contained.openai),
     knobs: {
       model: contained.openai.model,
       lightModel: profiles?.light ?? null,

--- a/openspec/changes/claude-route-pricing-reference/.openspec.yaml
+++ b/openspec/changes/claude-route-pricing-reference/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/claude-route-pricing-reference/design.md
+++ b/openspec/changes/claude-route-pricing-reference/design.md
@@ -1,0 +1,120 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+## Context
+
+See proposal.md — Why. The mechanics that constrain the fix:
+
+- `contain.ts:159` (`claudeSessionOptions`) hands the claude session
+  `pricing: contained.openai` — the whole settings object, with a comment saying
+  only `provider` and `model` are read from it.
+- `claude-adapter.ts:251` → `claude-spend.ts:91` → `run-spend.ts:144`, where
+  `modelRef(settings)` composes `${provider}/${model}`. `provider` is
+  `LLM_PROVIDER` (`config.ts:88`, default `openai`), a knob `openai-config.ts`
+  documents as the id **OpenCode** resolves its catalogue row under.
+- `claude-argv.ts:116` already owns the one definition of the id the CLI is
+  invoked with: `modelIdForCli`, which strips a `provider/` prefix.
+- `claude-contract.ts:203` defaults `total_cost_usd` to `0`, so the catalogue
+  rung is genuinely reachable on this route — the reference is not decoration.
+- `index.ts:192` (`withModelFacts`) skips the boot-time catalogue read on the
+  claude route. That is the read the docs describe; the spend-time one was
+  missed.
+- `contain.ts` is **297 lines** against a 300-line `max-lines` cap. Where the
+  derivation lives is therefore a constraint, not a preference.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One derivation, at the seam that already composes the claude session's
+  options, so the pricing reference and the CLI invocation cannot name different
+  models.
+- No behaviour change on the opencode route — not to the composed reference, the
+  ladder, or the emitted OpenCode config.
+
+**Non-Goals:**
+
+- Re-shaping `resolveRunCost`'s input. It takes `OpenAiSettings` and serves both
+  routes; narrowing it to a `reference: string` is a wider diff for no behaviour
+  the specs ask for.
+- Teaching `run-spend.ts` which backend ran. It has no backend awareness today
+  and gains nothing by having one — the caller already knows.
+
+## Decisions
+
+### D1 — The claude route prices under `anthropic`, unconditionally
+
+`LLM_PROVIDER` is a gateway-route catalogue key; the claude route reaches
+Anthropic. The CI workflow forwards no `ANTHROPIC_BASE_URL`
+(`agent-pipeline.yml:495-530`), so on the shape this pipeline actually runs, the
+CLI's endpoint is Anthropic's. This is also what `README.md:2113` already
+promises, so the fix makes the code match documentation rather than the reverse.
+
+*Alternatives considered.* Keeping `LLM_PROVIDER` and fixing only the prefix
+duplication preserves operator control for a redirected CLI, but leaves the
+misleading log line and requires the operator to know a models.dev-valid id.
+A dedicated `AGENT_PRICING_PROVIDER` knob is cleaner in principle and costs a
+variable to document, forward and test for a case the backend rung already
+covers. `anthropic`-by-default-with-override is today's behaviour whenever the
+variable is set, which is exactly the reported case.
+
+*Residual.* An operator who redirects the CLI at a gateway locally (the parent's
+`claude-connect.ts:35` strip list does not carry `ANTHROPIC_BASE_URL`, unlike
+review-loop's documented superset) is priced at Anthropic rates **only** if that
+gateway also reports no cost of its own. Recorded in Risks.
+
+### D2 — The derivation lives in `claude-spend.ts`, called from `contain.ts`
+
+`claude-spend.ts` (105 lines) already owns "what a claude session's spend is",
+and is the module `run-spend.ts` is reached through. It exports the derived
+settings; `contain.ts` changes one expression and gains one import — the only
+shape that fits under its 3-line headroom. Putting it in `contain.ts` inline, or
+in a new module, both cost more there for no separation gained.
+
+`claude-argv.ts` exports `modelIdForCli` for it to use rather than the strip
+being written twice. That export is the load-bearing half of the decision: it is
+what makes "the id the CLI ran" and "the id the run was priced under" the same
+value by construction rather than by two functions agreeing.
+
+### D3 — `pricing` stays an `OpenAiSettings`, derived by spread
+
+A copy with `provider` and `model` replaced, still carrying the placeholder key
+and empty base URL the contained settings hold. Design D5 of the claude-backend
+change forbids the *credential* crossing this seam, not the model's name, and
+the field's existing type and its one consumer both stay as they are.
+
+## Risks / Trade-offs
+
+- **A locally redirected CLI is priced under Anthropic on the catalogue rung** →
+  The backend rung outranks it and answers whenever the gateway reports a cost.
+  An operator who needs otherwise gets a knob as a follow-up change, with the
+  field evidence to justify it.
+- **A run that reported a median cross-provider price now reports Anthropic's
+  own** → Figures shift for affected issues, in the direction of being correct.
+  Past totals are not restated (proposal — Non-goals).
+- **A future non-Anthropic claude-compatible backend would need this revisited**
+  → It is one constant behind one exported function, named for what it is.
+
+## Test-first order and hook interactions
+
+The Write/Edit TDD hook gates each source edit on a failing test first. Work in
+this order, one red test per step:
+
+1. `tests/opencode-agent/provider-proxy.test.ts` — its `contain (claude route)`
+   block already loads `LLM_MODEL: 'anthropic/claude-sonnet-5'` and asserts
+   `knobs` but never `pricing`. Assert `pricing` there: `provider: 'anthropic'`,
+   `model: 'claude-sonnet-5'`. Red today (`openai` / `anthropic/claude-sonnet-5`).
+2. A case with `LLM_PROVIDER` set to a gateway id, pinning that it does not reach
+   the reference.
+3. `tests/opencode-agent/run-spend.test.ts` — the ladder itself is unchanged;
+   add the leg proving a reference whose model id still carries a provider
+   prefix resolves to no catalogue row, so the regression stays pinned from the
+   consuming side.
+
+No new file is created, so no new hook path is opened. No DB, no migration, no
+tool surface, no capability or `tool_prefs` gating, and no scope-model id — this
+is the GitHub Actions issue agent, outside papai's runtime.

--- a/openspec/changes/claude-route-pricing-reference/proposal.md
+++ b/openspec/changes/claude-route-pricing-reference/proposal.md
@@ -1,0 +1,75 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+## Why
+
+On the claude backend the run's spend path composes its model reference as
+`<LLM_PROVIDER>/<LLM_MODEL>` — a catalogue key that belongs to the *other*
+route. A job running the Claude CLI with a leftover `LLM_PROVIDER=zai-coding-plan`
+logs `Priced this run  model="zai-coding-plan/claude-opus-5"` for a turn that
+never touched that provider, and hands the same wrong key to the models.dev
+lookup. `opencode-agent/README.md` already promises the opposite ("`LLM_PROVIDER`
+… unused here — the claude route skips the models.dev catalogue read"), which is
+true only of the boot-time facts read, not of the spend-time one.
+
+Two consequences, one cosmetic and one not:
+
+- The catalogue rung misses its primary row and prices the run from a **median
+  across every provider** carrying that bare model id, reported as an exact
+  figure.
+- A `LLM_MODEL` spelled `provider/model` — documented as supported on this route,
+  where the CLI id is stripped — composes `<LLM_PROVIDER>/<provider>/<model>`,
+  which splits at the first slash into a model id no provider carries. The run
+  reports **unpriced** and the cost silently disappears from the issue's total.
+
+## What Changes
+
+- The claude route prices and logs under `anthropic/<model id>`, with any
+  `provider/` prefix stripped from the model id first — the same id the CLI is
+  actually invoked with. `LLM_PROVIDER` is ignored on this route, as the docs
+  already claim.
+- `opencode-agent/README.md` and `opencode-agent/CLAUDE.md` are corrected: the
+  claude route skips the *model-facts* catalogue read, not the *pricing* one.
+- No change to the opencode route, to the cost ladder's rungs or their order, or
+  to what any run reports when the backend states its own figure.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `agent-run-accounting`: adds a requirement pinning which catalogue key each
+  backend's run is priced under. The base spec ships in the not-yet-archived
+  change `opencode-agent-usd-spend-and-claude-limits`, so the delta is written
+  against that capability path.
+
+## Impact
+
+- `opencode-agent/src/contain.ts` (`claudeSessionOptions`, the `pricing` seam),
+  `opencode-agent/src/claude-argv.ts` (`modelIdForCli` becomes shared).
+- Docs: `opencode-agent/README.md` (backend-selection checklist),
+  `opencode-agent/CLAUDE.md` (provider-id note).
+- Tests: `tests/opencode-agent/provider-proxy.test.ts` (its `contain (claude
+  route)` block already runs a prefixed `LLM_MODEL` and asserts `knobs` but never
+  `pricing`), `tests/opencode-agent/run-spend.test.ts`.
+- No papai runtime surface: this is the GitHub Actions issue agent, so no chat
+  platform instance, task instance, or config-context scope is touched — no
+  per-user, group-shared or thread-isolated state changes.
+
+## Non-goals
+
+- **A knob for the pricing provider.** Declined: the CI workflow forwards no
+  `ANTHROPIC_BASE_URL`, so the claude route reaches Anthropic; a redirected
+  local run still gets the backend's own figure, which outranks the catalogue.
+- **Stripping `ANTHROPIC_BASE_URL` from the parent's claude child env**, where
+  `claude-connect.ts`'s list is a documented subset of review-loop's. A separate
+  concern with its own security argument.
+- **Reconciling already-recorded issue totals.** Past runs keep the figures they
+  recorded.

--- a/openspec/changes/claude-route-pricing-reference/specs/agent-run-accounting/spec.md
+++ b/openspec/changes/claude-route-pricing-reference/specs/agent-run-accounting/spec.md
@@ -1,0 +1,61 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+## ADDED Requirements
+
+### Requirement: A run is priced under the catalogue key of the backend that ran it
+
+The model reference a run is priced and logged under SHALL name the provider that
+actually served the run's model turns, and SHALL name the model by the same id
+the backend was invoked with. A run on the Claude CLI backend SHALL be priced
+under the Anthropic catalogue, whatever provider id the gateway route's
+configuration names; a run on the OpenCode backend SHALL keep being priced under
+the configured gateway catalogue id, which is the key its own model resolution
+already uses.
+
+This applies to the catalogue rung and to the log line that records which rung
+answered. It does not reorder the ladder: a backend that states its own cost
+still outranks the catalogue.
+
+#### Scenario: A claude-backend run whose configuration names a gateway catalogue
+
+- **WHEN** a run on the Claude CLI backend is priced, and the configuration
+  carries a gateway catalogue provider id left over from the other route
+- **THEN** the run is priced and logged under the Anthropic catalogue, and that
+  gateway id appears in neither the pricing lookup nor the log line
+
+#### Scenario: A model named with a provider prefix
+
+- **WHEN** a claude-backend run's configured model is spelled `<provider>/<model>`
+  — the form this route accepts and strips before invoking the CLI
+- **THEN** it is priced under the same stripped model id the CLI was invoked
+  with, and not under a reference that concatenates two provider names
+
+#### Scenario: The stripped model id has a catalogue row
+
+- **WHEN** a claude-backend run's counts are priced and the Anthropic catalogue
+  carries a row for that model id
+- **THEN** the run is priced from that row's own rates, not from a figure
+  averaged across other providers publishing a model of the same name
+
+#### Scenario: An opencode-backend run is unaffected
+
+- **WHEN** a run on the OpenCode backend is priced
+- **THEN** it is priced and logged under the configured gateway catalogue
+  provider id exactly as before
+
+#### Scenario: The backend's own figure still wins
+
+- **WHEN** a claude-backend run's backend states a non-zero cost
+- **THEN** that figure is the run's cost, the catalogue is not consulted, and
+  the log line names the reference this requirement pins
+
+#### Scenario: The reference is a name, not a credential
+
+- **WHEN** the reference is written to the run log on a public repository
+- **THEN** it carries the provider id and the model id only, and no part of any
+  Anthropic or gateway credential

--- a/openspec/changes/claude-route-pricing-reference/tasks.md
+++ b/openspec/changes/claude-route-pricing-reference/tasks.md
@@ -7,7 +7,7 @@ See LICENSE in the project root for details.
 
 ## 1. Pin the failing behaviour
 
-- [ ] 1.1 In `tests/opencode-agent/provider-proxy.test.ts`, inside the existing
+- [x] 1.1 In `tests/opencode-agent/provider-proxy.test.ts`, inside the existing
       `contain (claude route)` block, extend the factory-options test to assert
       `options.pricing.provider === 'anthropic'` and
       `options.pricing.model === 'claude-sonnet-5'` — the block already loads
@@ -15,30 +15,30 @@ See LICENSE in the project root for details.
       (`openai` / `anthropic/claude-sonnet-5`). Verify:
       `bun test tests/opencode-agent/provider-proxy.test.ts` fails on exactly
       those two assertions.
-- [ ] 1.2 Add a case to the same block with `LLM_PROVIDER: 'zai-coding-plan'` in
+- [x] 1.2 Add a case to the same block with `LLM_PROVIDER: 'zai-coding-plan'` in
       `CLAUDE_ENV`, asserting the pricing provider is still `anthropic` and that
       the gateway id appears nowhere in `options.pricing`. Verify: red on the
       provider assertion, `bun test tests/opencode-agent/provider-proxy.test.ts`.
-- [ ] 1.3 Add a case with an unprefixed `LLM_MODEL` (`claude-sonnet-5`),
+- [x] 1.3 Add a case with an unprefixed `LLM_MODEL` (`claude-sonnet-5`),
       asserting the model id passes through unchanged — the strip must not
       mangle the ordinary spelling. Verify:
       `bun test tests/opencode-agent/provider-proxy.test.ts`.
 
 ## 2. Derive the claude route's pricing reference
 
-- [ ] 2.1 Export `modelIdForCli` from `opencode-agent/src/claude-argv.ts`
+- [x] 2.1 Export `modelIdForCli` from `opencode-agent/src/claude-argv.ts`
       (design D2), unchanged in behaviour, with a doc line saying it is now the
       shared definition of "the id the CLI was invoked with". Verify:
       `bun run typecheck`, and the argv suites
       (`bun test tests/opencode-agent/claude-contract.test.ts tests/opencode-agent/claude-doctrine.test.ts`)
       stay green.
-- [ ] 2.2 In `opencode-agent/src/claude-spend.ts`, add the exported derivation
+- [x] 2.2 In `opencode-agent/src/claude-spend.ts`, add the exported derivation
       (a named constant for the `anthropic` catalogue id plus a function
       returning the settings spread with `provider` and `model` replaced), with
       the reason recorded in its doc comment: `LLM_PROVIDER` is the gateway
       route's catalogue key and the CLI reaches Anthropic. Verify:
       `bun run typecheck`.
-- [ ] 2.3 In `opencode-agent/src/contain.ts`, replace
+- [x] 2.3 In `opencode-agent/src/contain.ts`, replace
       `pricing: contained.openai` with the derived settings and add the one
       import. Keep the edit to one expression plus one import — the file is at
       297 of 300 `max-lines`. Verify: tasks 1.1–1.3 go green

--- a/openspec/changes/claude-route-pricing-reference/tasks.md
+++ b/openspec/changes/claude-route-pricing-reference/tasks.md
@@ -71,10 +71,21 @@ See LICENSE in the project root for details.
 
 ## 5. Verification
 
-- [ ] 5.1 Run `bun run test`, `bun run typecheck`, `bun run lint` and
+- [x] 5.1 Run `bun run test`, `bun run typecheck`, `bun run lint` and
       `bun run test:mutate:changed` for the touched files; read failures from
       `reports/` rather than re-running. All green, mutation score at or above
-      the per-file baseline.
-- [ ] 5.2 Confirm no `docs/architecture/*.md` page describes the pricing
+      the per-file baseline. **Outcome:** 17728 pass / 4 skip / 1 fail across
+      1601 files; typecheck and lint clean. The one failure,
+      `tests/git-init-hint.test.ts:68`, pins a Bun ≥ 1.4 env-propagation fix and
+      fails identically on `origin/master` under this container's Bun 1.3.11 —
+      pre-existing and environmental, not this change's.
+      `test:mutate:changed` reports no targets: `stryker.config.json`'s `mutate`
+      globs cover `src/`, `plugins/task-provider-*` and named `src/*.ts` files
+      only, so `opencode-agent/` is outside the gate's scope by configuration.
+- [x] 5.2 Confirm no `docs/architecture/*.md` page describes the pricing
       reference (the accounting ladder is documented in this change's specs and
       in `opencode-agent/README.md`); update none if none applies, and say so.
+      **Outcome:** none applies. The three pages naming `models.dev` cover
+      magi's sandbox egress (`coding-sessions.md`, `coding-stack-overview.md`)
+      and the SDD runner's own repricing pass (`sdd-pipeline.md`), a separate
+      consumer of `pricing.ts` this change does not touch. No page updated.

--- a/openspec/changes/claude-route-pricing-reference/tasks.md
+++ b/openspec/changes/claude-route-pricing-reference/tasks.md
@@ -47,12 +47,12 @@ See LICENSE in the project root for details.
 
 ## 3. Pin the consuming side
 
-- [ ] 3.1 In `tests/opencode-agent/run-spend.test.ts`, add the leg proving a
+- [x] 3.1 In `tests/opencode-agent/run-spend.test.ts`, add the leg proving a
       reference whose model id still carries a provider prefix
       (`openai/anthropic/claude-sonnet-5`) resolves to no catalogue row and
       reports unpriced — the regression this change closes, pinned where it was
       observable. Verify: `bun test tests/opencode-agent/run-spend.test.ts`.
-- [ ] 3.2 Confirm the opencode route is untouched: the existing
+- [x] 3.2 Confirm the opencode route is untouched: the existing
       `modelRef`/adapter assertions in
       `tests/opencode-agent/openai-config.test.ts` and
       `tests/opencode-agent/adapters.test.ts` pass unchanged. Verify:

--- a/openspec/changes/claude-route-pricing-reference/tasks.md
+++ b/openspec/changes/claude-route-pricing-reference/tasks.md
@@ -60,12 +60,12 @@ See LICENSE in the project root for details.
 
 ## 4. Correct the documentation the code contradicted
 
-- [ ] 4.1 In `opencode-agent/README.md`, fix the backend-selection item that
+- [x] 4.1 In `opencode-agent/README.md`, fix the backend-selection item that
       says `LLM_PROVIDER` is unused because "the claude route skips the
       models.dev catalogue read": the route skips the boot-time *model-facts*
       read and prices under `anthropic`. Verify: the claimed behaviour matches
       the spec delta, and `bun run format:check` passes.
-- [ ] 4.2 In `opencode-agent/CLAUDE.md`, extend the "provider id is a catalogue
+- [x] 4.2 In `opencode-agent/CLAUDE.md`, extend the "provider id is a catalogue
       key" note to say the key is route-scoped: `LLM_PROVIDER` on the opencode
       route, `anthropic` on the claude route. Verify: `bun run format:check`.
 

--- a/openspec/changes/claude-route-pricing-reference/tasks.md
+++ b/openspec/changes/claude-route-pricing-reference/tasks.md
@@ -1,0 +1,80 @@
+<!--
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2026 Dmitriy Lazarev
+Use of this software is governed by the Business Source License 1.1.
+See LICENSE in the project root for details.
+-->
+
+## 1. Pin the failing behaviour
+
+- [ ] 1.1 In `tests/opencode-agent/provider-proxy.test.ts`, inside the existing
+      `contain (claude route)` block, extend the factory-options test to assert
+      `options.pricing.provider === 'anthropic'` and
+      `options.pricing.model === 'claude-sonnet-5'` — the block already loads
+      `LLM_MODEL: 'anthropic/claude-sonnet-5'`, so this is red today
+      (`openai` / `anthropic/claude-sonnet-5`). Verify:
+      `bun test tests/opencode-agent/provider-proxy.test.ts` fails on exactly
+      those two assertions.
+- [ ] 1.2 Add a case to the same block with `LLM_PROVIDER: 'zai-coding-plan'` in
+      `CLAUDE_ENV`, asserting the pricing provider is still `anthropic` and that
+      the gateway id appears nowhere in `options.pricing`. Verify: red on the
+      provider assertion, `bun test tests/opencode-agent/provider-proxy.test.ts`.
+- [ ] 1.3 Add a case with an unprefixed `LLM_MODEL` (`claude-sonnet-5`),
+      asserting the model id passes through unchanged — the strip must not
+      mangle the ordinary spelling. Verify:
+      `bun test tests/opencode-agent/provider-proxy.test.ts`.
+
+## 2. Derive the claude route's pricing reference
+
+- [ ] 2.1 Export `modelIdForCli` from `opencode-agent/src/claude-argv.ts`
+      (design D2), unchanged in behaviour, with a doc line saying it is now the
+      shared definition of "the id the CLI was invoked with". Verify:
+      `bun run typecheck`, and the argv suites
+      (`bun test tests/opencode-agent/claude-contract.test.ts tests/opencode-agent/claude-doctrine.test.ts`)
+      stay green.
+- [ ] 2.2 In `opencode-agent/src/claude-spend.ts`, add the exported derivation
+      (a named constant for the `anthropic` catalogue id plus a function
+      returning the settings spread with `provider` and `model` replaced), with
+      the reason recorded in its doc comment: `LLM_PROVIDER` is the gateway
+      route's catalogue key and the CLI reaches Anthropic. Verify:
+      `bun run typecheck`.
+- [ ] 2.3 In `opencode-agent/src/contain.ts`, replace
+      `pricing: contained.openai` with the derived settings and add the one
+      import. Keep the edit to one expression plus one import — the file is at
+      297 of 300 `max-lines`. Verify: tasks 1.1–1.3 go green
+      (`bun test tests/opencode-agent/provider-proxy.test.ts`) and
+      `bun run lint` reports no `max-lines` failure.
+
+## 3. Pin the consuming side
+
+- [ ] 3.1 In `tests/opencode-agent/run-spend.test.ts`, add the leg proving a
+      reference whose model id still carries a provider prefix
+      (`openai/anthropic/claude-sonnet-5`) resolves to no catalogue row and
+      reports unpriced — the regression this change closes, pinned where it was
+      observable. Verify: `bun test tests/opencode-agent/run-spend.test.ts`.
+- [ ] 3.2 Confirm the opencode route is untouched: the existing
+      `modelRef`/adapter assertions in
+      `tests/opencode-agent/openai-config.test.ts` and
+      `tests/opencode-agent/adapters.test.ts` pass unchanged. Verify:
+      `bun test tests/opencode-agent/openai-config.test.ts tests/opencode-agent/adapters.test.ts`.
+
+## 4. Correct the documentation the code contradicted
+
+- [ ] 4.1 In `opencode-agent/README.md`, fix the backend-selection item that
+      says `LLM_PROVIDER` is unused because "the claude route skips the
+      models.dev catalogue read": the route skips the boot-time *model-facts*
+      read and prices under `anthropic`. Verify: the claimed behaviour matches
+      the spec delta, and `bun run format:check` passes.
+- [ ] 4.2 In `opencode-agent/CLAUDE.md`, extend the "provider id is a catalogue
+      key" note to say the key is route-scoped: `LLM_PROVIDER` on the opencode
+      route, `anthropic` on the claude route. Verify: `bun run format:check`.
+
+## 5. Verification
+
+- [ ] 5.1 Run `bun run test`, `bun run typecheck`, `bun run lint` and
+      `bun run test:mutate:changed` for the touched files; read failures from
+      `reports/` rather than re-running. All green, mutation score at or above
+      the per-file baseline.
+- [ ] 5.2 Confirm no `docs/architecture/*.md` page describes the pricing
+      reference (the accounting ladder is documented in this change's specs and
+      in `opencode-agent/README.md`); update none if none applies, and say so.

--- a/tests/opencode-agent/provider-proxy.test.ts
+++ b/tests/opencode-agent/provider-proxy.test.ts
@@ -770,9 +770,10 @@ describe('contain (claude route)', () => {
 
   const claudeContain = (
     createClaudeAgent: (options: ClaudeAgentOptions) => Promise<AgentSession>,
+    env: Record<string, string> = CLAUDE_ENV,
   ): Promise<Contained> =>
     contain({
-      config: loadConfig(CLAUDE_ENV, '/repo'),
+      config: loadConfig(env, '/repo'),
       event: claudeEvent,
       log: silentLog,
       run: () => Promise.resolve({ command: '', exitCode: 0, stdout: '', stderr: '' }),
@@ -808,6 +809,39 @@ describe('contain (claude route)', () => {
     })
     expect(options.credential).toEqual({ name: 'ANTHROPIC_API_KEY', value: 'sk-ant-api03-the-chosen-credential' })
     expect(options.env).toEqual({ POST_SCRUB: 'yes' })
+    // The reference the catalogue is asked about names the provider that served
+    // the turns and the id the CLI was invoked with — not the gateway route's
+    // catalogue key, and not a model id still carrying a provider prefix.
+    expect(options.pricing.provider).toBe('anthropic')
+    expect(options.pricing.model).toBe('claude-sonnet-5')
+  })
+
+  /** The pricing settings one environment hands the claude factory. */
+  const pricingFor = async (env: Record<string, string>): Promise<OpenAiSettings> => {
+    const seen: ClaudeAgentOptions[] = []
+    const run = await claudeContain((options) => {
+      seen.push(options)
+      return Promise.resolve(fakeSession())
+    }, env)
+    await run.agent.get()
+    return firstOptions(seen).pricing
+  }
+
+  test('LLM_PROVIDER never reaches the reference this route is priced under', async () => {
+    // The reported shape: a gateway catalogue id left over from the other route,
+    // which priced a Claude CLI run under a provider its turns never touched.
+    const pricing = await pricingFor({ ...CLAUDE_ENV, LLM_PROVIDER: 'zai-coding-plan' })
+
+    expect(pricing.provider).toBe('anthropic')
+    expect(pricing.model).toBe('claude-sonnet-5')
+    expect(JSON.stringify(pricing)).not.toContain('zai-coding-plan')
+  })
+
+  test('a model id spelled without a provider prefix is priced as written', async () => {
+    const pricing = await pricingFor({ ...CLAUDE_ENV, LLM_MODEL: 'claude-sonnet-5' })
+
+    expect(pricing.provider).toBe('anthropic')
+    expect(pricing.model).toBe('claude-sonnet-5')
   })
 
   test('the phases see the claude-route config: empty gateway reads, shared knobs', async () => {

--- a/tests/opencode-agent/run-spend.test.ts
+++ b/tests/opencode-agent/run-spend.test.ts
@@ -160,6 +160,44 @@ describe('resolveRunCost · the ladder', () => {
     expect(resolved).toEqual({ usd: null, source: 'none' })
   })
 
+  /**
+   * The defect `claude-route-pricing-reference` closed, pinned where it was
+   * observable. The claude route composed its reference from `LLM_PROVIDER`, so
+   * a model spelled `provider/model` — the form that route accepts and strips
+   * before invoking the CLI — reached here as three segments. `parseModelId`
+   * splits at the first slash and keeps the rest, leaving a model id no
+   * provider carries, and the run's cost vanished from the issue's total with
+   * no failure anywhere.
+   */
+  test('a model id that still carries a provider prefix prices under nothing', async () => {
+    const resolved = await resolveRunCost(
+      { backendUsd: 0, buckets: BUCKETS, settings: settings('anthropic/claude-sonnet-5', 'openai') },
+      { log: silent, loadDb: loadDb(DB) },
+    )
+
+    expect(resolved).toEqual({ usd: null, source: 'none' })
+  })
+
+  /**
+   * The other half of the same defect: a reference naming the wrong provider
+   * misses its primary row and falls back to the median across every provider
+   * publishing that model id — a figure that reads exact and is not. Naming the
+   * provider that served the run is what buys the row's own rates.
+   */
+  test('the provider named decides whether the run gets a row’s own rates or a median', async () => {
+    const own = await resolveRunCost(
+      { backendUsd: 0, buckets: BUCKETS, settings: settings('claude-sonnet-5', 'anthropic') },
+      { log: silent, loadDb: loadDb(DB) },
+    )
+    const median = await resolveRunCost(
+      { backendUsd: 0, buckets: BUCKETS, settings: settings('claude-sonnet-5', 'zai-coding-plan') },
+      { log: silent, loadDb: loadDb(DB) },
+    )
+
+    expect(own).toEqual({ usd: 18, source: 'catalogue' })
+    expect(median).toEqual({ usd: 18.3, source: 'catalogue' })
+  })
+
   test('names the rung that answered in the run log, so a figure needs no rerun to explain', async () => {
     const debugs: Array<{ meta: unknown; message: string }> = []
     const log: Logger = {


### PR DESCRIPTION
The claude backend's spend path composes its model reference as
<LLM_PROVIDER>/<LLM_MODEL>, a catalogue key belonging to the gateway
route. A job with a leftover LLM_PROVIDER logs a provider its turns
never touched and hands the same wrong key to the models.dev lookup:
the catalogue rung misses its primary row and prices from a median
across providers, and a provider-prefixed LLM_MODEL composes a
reference that splits into a model id no provider carries, so the run
reports unpriced.

Proposes pricing and logging the claude route under
anthropic/<stripped model id> — the id the CLI is actually invoked
with — and correcting the docs that already claim LLM_PROVIDER is
unread there.

Planning artifacts only; no code changes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TBteP4ZfKPESEYbKbAFqow