### PR TITLE
chore(logging): emit load_tool debug only on real activations

### DIFF
--- a/src/llm-orchestrator-events.ts
+++ b/src/llm-orchestrator-events.ts
@@ -83,7 +83,6 @@ export type ResolvedStreamTextResult = {
 }>
 
 function stringifySingleToolSchema(toolName: string, value: unknown): string {
-  log.debug({ toolName }, 'stringifySingleToolSchema')
   try {
     const seen = new WeakSet<object>()
     return JSON.stringify(value, (key, nestedValue: unknown) => {
@@ -105,7 +104,6 @@ function stringifySingleToolSchema(toolName: string, value: unknown): string {
 }
 
 function estimateToolSchemaBytes(tools: ToolSet): number {
-  log.debug({ toolCount: Object.keys(tools).length }, 'estimateToolSchemaBytes')
   let total = 0
   for (const [name, tool] of Object.entries(tools)) {
     total += name.length
@@ -117,7 +115,6 @@ function estimateToolSchemaBytes(tools: ToolSet): number {
 
 function buildToolTelemetry(tools: ToolSet): Record<string, unknown> {
   const toolCount = Object.keys(tools).length
-  log.debug({ toolCount }, 'buildToolTelemetry')
   return {
     toolCount,
     toolSchemaBytes: estimateToolSchemaBytes(tools),

--- a/src/tools/disclosure/load-tool.ts
+++ b/src/tools/disclosure/load-tool.ts
@@ -20,10 +20,14 @@ export function makeLoadToolTool(session: DisclosureSession, contextId: string):
       names: z.array(z.string().min(1)).min(1).describe('Tool names from search_tools results to activate'),
     }),
     execute: ({ names }) => {
+      const activeBefore = new Set(session.activeToolNames())
       const { loaded, unknown } = session.markLoaded(names)
+      const activated = loaded.filter((name) => !activeBefore.has(name))
       const nowActive = session.activeToolNames().length
       emitUser('disclosure:load', contextId, { loadedCount: loaded.length, unknownCount: unknown.length, nowActive })
-      log.debug({ contextId, loadedCount: loaded.length, unknownCount: unknown.length, nowActive }, 'load_tool served')
+      if (activated.length > 0) {
+        log.debug({ contextId, activated, unknownCount: unknown.length, nowActive }, 'load_tool activated tools')
+      }
       const result = { loaded, unknown, nowActive }
       if (unknown.length === 0) return result
       return {

--- a/tests/tools/disclosure/load-tool-logging.test.ts
+++ b/tests/tools/disclosure/load-tool-logging.test.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2026 Dmitriy Lazarev
+// Use of this software is governed by the Business Source License 1.1.
+// See LICENSE in the project root for details.
+
+import { describe, expect, mock, test } from 'bun:test'
+
+import { tool, type ToolSet } from 'ai'
+import { z } from 'zod'
+
+import { CORE_TOOL_NAMES } from '../../../src/tools/disclosure/core.js'
+import { createDisclosureSession } from '../../../src/tools/disclosure/registry.js'
+import { createTrackedLoggerMock, getToolExecutor, type TrackedLoggerMock } from '../../utils/test-helpers.js'
+
+// load-tool.ts binds `logger.child` at module-eval time. A static import would
+// capture the real logger before the per-test mock is registered, and the live
+// binding does not reliably refresh under serial (single-process) test runs.
+// Cache-busting dynamic import (see tests/startup-helpers.test.ts) forces a fresh
+// evaluation AFTER mock.module() installs the stub, so the bound logger is the
+// mock.
+type LoadToolModule = typeof import('../../../src/tools/disclosure/load-tool.js')
+
+const isLoadToolModule = (value: unknown): value is LoadToolModule =>
+  typeof value === 'object' && value !== null && typeof Reflect.get(value, 'makeLoadToolTool') === 'function'
+
+async function loadLoadToolModule(tracked: TrackedLoggerMock): Promise<LoadToolModule> {
+  void mock.module('../../../src/logger.js', () => ({
+    getLogLevel: tracked.getLogLevel,
+    logger: tracked.logger,
+  }))
+  const loaded: unknown = await import(`../../../src/tools/disclosure/load-tool.js?t=${crypto.randomUUID()}`)
+  if (isLoadToolModule(loaded)) return loaded
+  throw new Error('load-tool module did not export makeLoadToolTool')
+}
+
+const d = (): ToolSet[string] => tool({ description: 'x', inputSchema: z.object({}), execute: () => ({}) })
+
+function makeExec(makeLoadToolTool: LoadToolModule['makeLoadToolTool']): (...args: unknown[]) => Promise<unknown> {
+  const tools: ToolSet = {
+    get_current_time: d(),
+    search_tools: d(),
+    load_tool: d(),
+    expand_result: d(),
+    list_tasks: d(),
+    get_task: d(),
+  }
+  const session = createDisclosureSession(tools, CORE_TOOL_NAMES)
+  return getToolExecutor(makeLoadToolTool(session, 'ctx-log'))
+}
+
+describe('load_tool debug logging', () => {
+  test('stays silent for no-op loads of already-active or unknown names', async () => {
+    const tracked = createTrackedLoggerMock()
+    const { makeLoadToolTool } = await loadLoadToolModule(tracked)
+    const exec = makeExec(makeLoadToolTool)
+
+    await exec({ names: ['get_current_time'] })
+    await exec({ names: ['load_tool'] })
+    await exec({ names: ['nope'] })
+
+    expect(tracked.getCallsByLevel('debug')).toHaveLength(0)
+  })
+
+  test('logs the newly activated tool names on a real load', async () => {
+    const tracked = createTrackedLoggerMock()
+    const { makeLoadToolTool } = await loadLoadToolModule(tracked)
+    const exec = makeExec(makeLoadToolTool)
+
+    await exec({ names: ['list_tasks', 'get_task', 'bogus'] })
+
+    const debugCalls = tracked.getCallsByLevel('debug')
+    expect(debugCalls.length).toBeGreaterThan(0)
+    expect(debugCalls[0]?.args[0]).toMatchObject({
+      activated: ['list_tasks', 'get_task'],
+      unknownCount: 1,
+    })
+    expect(String(debugCalls[0]?.args[1])).toContain('load_tool')
+  })
+
+  test('stays silent when re-requesting an already-loaded tool', async () => {
+    const tracked = createTrackedLoggerMock()
+    const { makeLoadToolTool } = await loadLoadToolModule(tracked)
+    const exec = makeExec(makeLoadToolTool)
+
+    await exec({ names: ['list_tasks'] })
+    tracked.clearCalls()
+    await exec({ names: ['list_tasks'] })
+
+    expect(tracked.getCallsByLevel('debug')).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Motivation

Under `LOG_LEVEL=debug`, every LLM attempt logged the full registered toolset as telemetry noise: `buildToolTelemetry`, `estimateToolSchemaBytes`, and one `stringifySingleToolSchema` line per tool (77+ lines) on every `llm:start`/`llm:end`. This looked like dynamic disclosure leaking the full tool surface, but disclosure filters per-step `activeTools` — the ToolSet intentionally keeps every tool registered, and the telemetry boundary iterates all of them.

## Changes

- `src/llm-orchestrator-events.ts` — drop the three per-attempt debug lines from the telemetry path (the `toolCount`/`toolSchemaBytes` event fields and analytics `availableToolCount` are unchanged; the stringify-failure debug log stays).
- `src/tools/disclosure/load-tool.ts` — `load_tool` debug logging now fires only when a call actually **activates** tools (already-active and unknown-only requests stay silent) and names them: `{ contextId, activated, unknownCount, nowActive }`.
- `tests/tools/disclosure/load-tool-logging.test.ts` — new suite (tracked-logger + cache-busting import pattern) covering no-op silence, real-load output, and re-request silence.

## Verification

- Full suite: 17948 tests, 17940 pass, 0 fail, 8 skip
- `test:affected`: 1575 tests green
- Analytics verify lanes green (`tool-slug-generation`, `tool-classification`, `logging-privacy`, `llm-tool-integration`, `message-turn-integration`, `source-facts-boundary`) — no slug/metadata/fact changes needed
- lint / typecheck / format clean