### PR TITLE
fix(review-loop): make the build gate's failure report survivable and readable

### DIFF
--- a/review-loop/src/build-checker.ts
+++ b/review-loop/src/build-checker.ts
@@ -3,7 +3,10 @@
 // Use of this software is governed by the Business Source License 1.1.
 // See LICENSE in the project root for details.
 
-import { execFile } from 'node:child_process'
+import { spawn } from 'node:child_process'
+import { mkdtemp, open, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 
 import { scrubCredentialValue } from './backend-select.js'
 import { formatDuration } from './live-format.js'
@@ -38,28 +41,68 @@ interface RawExecResult {
 
 interface ExecOptions {
   cwd: string
-  maxBuffer: number
   timeout?: number
 }
 
-function runExec(file: string, args: string[], options: ExecOptions): Promise<RawExecResult> {
-  return new Promise((resolve) => {
-    execFile(file, args, options, (err, stdout, stderr) => {
-      let exitCode: number
-      let resolvedStderr = stderr
-      if (err === null) {
-        exitCode = 0
-      } else if (typeof err.code === 'number') {
-        exitCode = err.code
-      } else if (err.killed === true && options.timeout !== undefined && options.timeout > 0) {
-        exitCode = 1
-        resolvedStderr = `${stderr}Process timed out after ${options.timeout}ms\n`
-      } else {
-        exitCode = 1
+/**
+ * Runs `sh -c command` with the child's stdout and stderr pointed at regular
+ * files rather than pipes, then reads them back.
+ *
+ * Pipes are what broke run 33974052563. The check command is `bun check:full`,
+ * and `check.sh` reports a failing check by `cat`-ing that check's whole log to
+ * stdout. When stdout is the parent's captured pipe, the fd carries O_NONBLOCK
+ * — it is a property of the shared open file description, not of our end — so a
+ * `cat` that outruns the parent's reader gets EAGAIN, prints
+ * `cat: write error: Resource temporarily unavailable`, and exits 1. Under
+ * `set -euo pipefail` that aborts `check.sh` before it prints the one line that
+ * names which check failed, and the exit code the loop reports is `cat`'s, not
+ * the check's. The same bug is already documented against the `Checks` CI job
+ * (`.github/workflows/ci.yml`, run 33153391880).
+ *
+ * A regular file has no such failure mode: writes to it never return EAGAIN, so
+ * the report always completes. It also retires the `maxBuffer` ceiling — the
+ * former 10 MB cap silently truncated a big run — since nothing is buffered in
+ * this process until the child has exited.
+ */
+async function runExec(file: string, args: string[], options: ExecOptions): Promise<RawExecResult> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'review-loop-check-'))
+  const outPath = path.join(dir, 'stdout.log')
+  const errPath = path.join(dir, 'stderr.log')
+  const outHandle = await open(outPath, 'w')
+  const errHandle = await open(errPath, 'w')
+  try {
+    const { code, timedOut } = await new Promise<{ code: number; timedOut: boolean }>((resolve) => {
+      const child = spawn(file, args, { cwd: options.cwd, stdio: ['ignore', outHandle.fd, errHandle.fd] })
+      let killed = false
+      const timer =
+        options.timeout !== undefined && options.timeout > 0
+          ? setTimeout(() => {
+              killed = true
+              child.kill('SIGKILL')
+            }, options.timeout)
+          : undefined
+      const settle = (exitCode: number): void => {
+        if (timer !== undefined) clearTimeout(timer)
+        resolve({ code: exitCode, timedOut: killed })
       }
-      resolve({ exitCode, stdout, stderr: resolvedStderr })
+      child.on('error', () => {
+        settle(1)
+      })
+      child.on('close', (exitCode) => {
+        settle(exitCode ?? 1)
+      })
     })
-  })
+    const stdout = await readFile(outPath, 'utf8')
+    const stderr = await readFile(errPath, 'utf8')
+    if (timedOut) {
+      return { exitCode: 1, stdout, stderr: `${stderr}Process timed out after ${String(options.timeout)}ms\n` }
+    }
+    return { exitCode: code, stdout, stderr }
+  } finally {
+    await outHandle.close()
+    await errHandle.close()
+    await rm(dir, { recursive: true, force: true })
+  }
 }
 
 export async function runBuildCheck(deps: BuildCheckDeps): Promise<BuildCheckResult> {
@@ -74,7 +117,7 @@ export async function runBuildCheck(deps: BuildCheckDeps): Promise<BuildCheckRes
 
 export function createShellExec(cwd: string, command: string, timeoutMs?: number): ShellExecFn {
   return (overrideCwd?: string): Promise<RawExecResult> =>
-    runExec('sh', ['-c', command], { cwd: overrideCwd ?? cwd, maxBuffer: 10 * 1024 * 1024, timeout: timeoutMs })
+    runExec('sh', ['-c', command], { cwd: overrideCwd ?? cwd, timeout: timeoutMs })
 }
 
 export async function runBuildWithLogging(

--- a/review-loop/src/cli-errors.ts
+++ b/review-loop/src/cli-errors.ts
@@ -18,11 +18,30 @@ function tailLines(text: string, maxLines: number): string {
   return `…(${skipped} earlier lines truncated; full output in build-check.log)…\n${lines.slice(-maxLines).join('\n')}`
 }
 
+/**
+ * The two streams are tailed **separately**, each with the full line budget,
+ * and stdout is rendered first.
+ *
+ * Tailing `stdout + stderr` as one string is what made run 33974052563
+ * undiagnosable. The check command is `bun build:client && bun check:full`, and
+ * `vite` writes all ~170 of its `state_referenced_locally` warnings to stderr;
+ * `check.sh` writes its verdict — `✗ <check> failed (exit code N)`, the failing
+ * check's log, and the `N/M checks passed` summary — to stdout. Concatenating
+ * put every stderr line after every stdout line, so a 40-line window over the
+ * join landed entirely inside the build's own warning noise and reported not one
+ * line about which check had failed. Whichever stream is noisier must not be
+ * able to evict the other.
+ */
 export function formatBuildFailureMessage(runState: RunState, build: BuildCheckResult): string {
-  const combined = tailLines(
-    [build.stdout, build.stderr].filter((part) => part.length > 0).join('\n'),
-    BUILD_OUTPUT_TAIL_LINES,
-  )
+  const streams: ReadonlyArray<readonly [string, string]> = [
+    ['stdout', build.stdout],
+    ['stderr', build.stderr],
+  ]
+  const sections = streams
+    .map(([name, text]) => [name, tailLines(text, BUILD_OUTPUT_TAIL_LINES)] as const)
+    .filter(([, body]) => body.length > 0)
+    .map(([name, body]) => `--- ${name} ---\n${body}`)
+  const combined = sections.length === 0 ? '(the build command produced no output)' : sections.join('\n')
   const logPath = path.join(runState.runDir, 'build-check.log')
   return (
     `Final build check failed; worktree preserved at ${runState.worktreePath} for inspection, merge skipped.\n` +

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -473,7 +473,17 @@ else
       echo ""
       echo "✗ $check failed (exit code $exit_code):"
       echo "---"
-      cat "$CHECKS_REPORT_DIR/$fname.log"
+      # `|| true`, and not because a missing log is acceptable — the log is
+      # always there, this script wrote it. It is that `cat`'s *write* fails.
+      # When stdout is a pipe carrying O_NONBLOCK (a captured parent, e.g. the
+      # review-loop build gate, or the Actions runner), a `cat` that outruns the
+      # reader gets EAGAIN, prints `cat: write error: Resource temporarily
+      # unavailable`, and exits 1 — and `set -e` then aborts this script before
+      # the `N/M checks passed` summary below, which is the one line that names
+      # what failed. Run 33974052563 is what that costs: a review-loop gate that
+      # reported 40 lines of vite warnings and no verdict at all. The body is
+      # best-effort; the summary is not.
+      cat "$CHECKS_REPORT_DIR/$fname.log" || echo "(log body truncated: $CHECKS_REPORT_DIR/$fname.log)"
       echo "---"
       # Where to look, rather than what to run again. The output above is the
       # whole of it, but a terminal scroll-back is not a place you can query.

--- a/tests/review-loop/build-checker.test.ts
+++ b/tests/review-loop/build-checker.test.ts
@@ -42,6 +42,31 @@ describe('build-checker', () => {
     const result = await exec()
     expect(result.exitCode).toBe(0)
   })
+
+  test('separates the two streams', async () => {
+    const exec = createShellExec(process.cwd(), 'echo to-stdout; echo to-stderr >&2; exit 3')
+    const result = await exec()
+    expect(result.exitCode).toBe(3)
+    expect(result.stdout.trim()).toBe('to-stdout')
+    expect(result.stderr.trim()).toBe('to-stderr')
+  })
+
+  // The check command is `bun check:full`, whose failure path `cat`s a whole
+  // multi-thousand-line check log to stdout. Captured through a pipe that carries
+  // O_NONBLOCK, that `cat` dies on EAGAIN and `set -e` takes the verdict with it
+  // (run 33974052563); the old 10 MB `maxBuffer` silently truncated it in the
+  // other direction. Files have neither failure mode, so a big writer arrives
+  // whole and the child's own exit code is what comes back.
+  test('a child writing well past the retired 10MB maxBuffer arrives whole', async () => {
+    const emit = `awk 'BEGIN { s = sprintf("%*s", 200, ""); gsub(/ /, "x", s); for (i = 0; i < 60000; i++) print s; print "TAIL-MARKER" }'`
+    const exec = createShellExec(process.cwd(), `${emit}; exit 7`)
+
+    const result = await exec()
+
+    expect(result.exitCode).toBe(7)
+    expect(result.stdout.length).toBeGreaterThan(10 * 1024 * 1024)
+    expect(result.stdout.trimEnd().endsWith('TAIL-MARKER')).toBe(true)
+  })
 })
 
 describe('build-checker credential scrub', () => {

--- a/tests/review-loop/cli-errors.test.ts
+++ b/tests/review-loop/cli-errors.test.ts
@@ -62,6 +62,41 @@ describe('formatBuildFailureMessage', () => {
     expect(message).toContain('truncated')
     expect(message).not.toContain(firstLine)
   })
+
+  // Run 33974052563: `bun build:client` wrote ~170 vite warnings to stderr while
+  // check.sh wrote its verdict to stdout. Tailing the concatenation put the whole
+  // window inside stderr and reported nothing about which check failed.
+  test('a noisy stderr cannot evict the stdout verdict from the tail', () => {
+    const runState = makeRunState()
+    const verdict = '2/8 checks passed, 6 failed'
+    const build: BuildCheckResult = {
+      passed: false,
+      stdout: [...Array.from({ length: 200 }, (_, i) => `stdout-noise-${i}`), verdict].join('\n'),
+      stderr: Array.from({ length: 200 }, (_, i) => `vite warning ${i}`).join('\n'),
+    }
+
+    const message = formatBuildFailureMessage(runState, build)
+
+    expect(message).toContain(verdict)
+    expect(message).toContain('vite warning 199')
+  })
+
+  test('labels each stream so the reader knows which one they are looking at', () => {
+    const runState = makeRunState()
+    const build: BuildCheckResult = { passed: false, stdout: 'out-line', stderr: 'err-line' }
+
+    const message = formatBuildFailureMessage(runState, build)
+
+    expect(message).toContain('--- stdout ---')
+    expect(message).toContain('--- stderr ---')
+    expect(message.indexOf('out-line')).toBeLessThan(message.indexOf('err-line'))
+  })
+
+  test('says so when the build command produced no output at all', () => {
+    const message = formatBuildFailureMessage(makeRunState(), { passed: false, stdout: '', stderr: '' })
+
+    expect(message).toContain('produced no output')
+  })
 })
 
 describe('MergeConflictError', () => {


### PR DESCRIPTION
Run 33974052563 ended with the review-loop build gate red, nothing merged, and a
PR comment whose 40-line "build output (tail)" contained forty lines of vite
warnings, `cat: write error: Resource temporarily unavailable`, and no statement
of which check had failed. Three defects compounded to produce that.

1. The child's output was captured through pipes. O_NONBLOCK is a property of the
   shared open file description, so `check.sh`'s failure `cat` — which writes a
   whole multi-thousand-line check log to stdout — gets EAGAIN when it outruns
   the parent's reader. Under `set -euo pipefail` that aborts `check.sh` before
   the `N/M checks passed` summary, and the exit code the loop reports is `cat`'s
   rather than the check's. `createShellExec` now points the child's stdout and
   stderr at regular files and reads them back; a regular file cannot return
   EAGAIN. This also retires `maxBuffer`, which truncated a big run silently in
   the other direction.

2. `formatBuildFailureMessage` tailed `stdout + stderr` as one string. The check
   command is `bun build:client && bun check:full`, and vite writes all ~170 of
   its `state_referenced_locally` warnings to stderr while `check.sh` writes its
   verdict to stdout — so concatenating put the entire window inside the build's
   own warning noise. Each stream now gets its own tail and its own label, stdout
   first.

3. `check.sh`'s report `cat` is now best-effort. The log body is worth losing to
   a write hiccup; the summary line that names the failing check is not.

The same EAGAIN is already documented against the `Checks` CI job (ci.yml, run
33153391880), where it was mitigated by uploading the logs rather than fixed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BRLdkR7f6waLpNFnjiZH9x