### PR TITLE
fix(ci): check the codeindex sibling out inside the workspace, then move it

### DIFF
--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -515,15 +515,33 @@ jobs:
       # `persist-credentials: false` for the same reason the main checkout
       # carries it: no token may survive in a .git/config the model's bash can
       # read.
+      #
+      # Checked out *into* the workspace and moved out afterwards, in two
+      # steps, because actions/checkout validates `path` against
+      # GITHUB_WORKSPACE and refuses anything above it — a `path: ../codeindex`
+      # fails the job outright with "Repository path '…' is not under '…'".
+      # The move is the step that puts the tree where the shim resolves it; no
+      # step runs between the two, so the workspace never holds the sibling
+      # while the model can reach it.
       - name: Check out the codeindex sibling
         if: contains(env.AGENT_MCP_SERVERS, 'codeindex')
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: yourpapai/codeindex
           ref: a4977856770d636d15e708a16ab7753a3256beef
-          path: ../codeindex
+          path: .codeindex-sibling
           token: ${{ secrets.AGENT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: false
+
+      # `rm -rf` first so a re-run on a self-hosted runner with a dirty
+      # workspace parent moves into an empty destination instead of nesting
+      # ../codeindex/codeindex, which would resolve to a tree without a
+      # package.json and fail the install below with a worse message.
+      - name: Move the codeindex sibling out of the workspace
+        if: contains(env.AGENT_MCP_SERVERS, 'codeindex')
+        run: |
+          rm -rf "$GITHUB_WORKSPACE/../codeindex"
+          mv "$GITHUB_WORKSPACE/.codeindex-sibling" "$GITHUB_WORKSPACE/../codeindex"
 
       # The sibling's dependencies, from its own lockfile at the pinned ref.
       # Its install scripts are maintainer-reviewed code, not model-influenced

--- a/docs/operations/codeindex-ci-experiment.md
+++ b/docs/operations/codeindex-ci-experiment.md
@@ -54,9 +54,12 @@ instrumented run.
 What the gated steps then do, in order, before the pipeline step:
 
 1. `actions/checkout` of `yourpapai/codeindex` at the pinned SHA into
-   `../codeindex` — outside the workspace, so the implement phase's
-   `git add --all` can never see it — with `AGENT_GITHUB_TOKEN` (a private
-   sibling cannot be cloned by the repo-scoped `GITHUB_TOKEN`).
+   `.codeindex-sibling`, with `AGENT_GITHUB_TOKEN` (a private sibling cannot
+   be cloned by the repo-scoped `GITHUB_TOKEN`), immediately followed by a
+   `mv` to `../codeindex` — outside the workspace, so the implement phase's
+   `git add --all` can never see it. Two steps rather than one because
+   `actions/checkout` validates `path` against `GITHUB_WORKSPACE` and refuses
+   anything above it; a `path: ../codeindex` fails the job outright.
 2. `bun install --frozen-lockfile` in the sibling.
 3. `bun run codeindex:index` — the prebuild, so the first MCP query answers
    from a populated index instead of an empty database while a background

--- a/tests/opencode-agent/workflow.test.ts
+++ b/tests/opencode-agent/workflow.test.ts
@@ -344,6 +344,9 @@ const step = (fragment: string): WorkflowStep => stepOf(steps, fragment)
 
 const checkoutStep = steps.find((candidate) => candidate.uses.startsWith('actions/checkout')) ?? NO_STEP
 
+/** Where the codeindex sibling is checked out before it is moved to ../codeindex. */
+const SIBLING_CHECKOUT_PATH = '.codeindex-sibling'
+
 /** The two steps whose bodies are executed below, rather than only read. */
 const resolveStep = stepOf(resolveJob.steps, 'resolve the issue number')
 const cleanupStep = step('working label')
@@ -491,6 +494,35 @@ describe('steps', () => {
     for (const candidate of steps.filter((entry) => entry.uses.startsWith('actions/checkout'))) {
       expect(candidate.with['persist-credentials']).toBe(false)
     }
+  })
+
+  test('never gives a checkout a path above the workspace', () => {
+    // actions/checkout validates `path` against GITHUB_WORKSPACE and refuses
+    // anything above it: `path: ../codeindex` failed the whole job with
+    // "Repository path '/home/runner/work/papai/codeindex' is not under
+    // '/home/runner/work/papai/papai'", before any agent work — every issue
+    // trigger, for as long as AGENT_MCP_SERVERS named codeindex. A sibling
+    // tree is reached by checking out inside the workspace and moving it.
+    const targets = steps
+      .filter((entry) => entry.uses.startsWith('actions/checkout'))
+      .map((entry) => entry.with['path'])
+      .filter((target) => typeof target === 'string')
+
+    expect(targets.filter((target) => /^(?:\.\.|\/)/u.test(target))).toEqual([])
+  })
+
+  test('lands the codeindex sibling outside the workspace, where the shim resolves it', () => {
+    // scripts/codeindex-cli.ts resolves <repoRoot>/../codeindex with no
+    // CODEINDEX_DIR override on CI, and the implement phase's `git add --all`
+    // must never see the tree — so the move out of the workspace is as
+    // load-bearing as the checkout itself, and both carry the same gate.
+    const checkout = step('check out the codeindex sibling')
+    const move = step('move the codeindex sibling')
+
+    expect(checkout.with['path']).toBe(SIBLING_CHECKOUT_PATH)
+    expect(move.if).toBe(checkout.if)
+    expect(move.run).toContain(SIBLING_CHECKOUT_PATH)
+    expect(move.run).toContain('"$GITHUB_WORKSPACE/../codeindex"')
   })
 
   test('fetches the superpowers skills from a pinned commit, not a branch', () => {


### PR DESCRIPTION
actions/checkout validates `path` against GITHUB_WORKSPACE and refuses
anything above it, so the gated `path: ../codeindex` step failed the agent
job outright — "Repository path '/home/runner/work/papai/codeindex' is not
under '/home/runner/work/papai/papai'" — before any agent work ran. Every
issue trigger has failed this way since the codeindex provisioning block
landed, for as long as AGENT_MCP_SERVERS names codeindex.

Check out into `.codeindex-sibling` and move it to `../codeindex` in the
next step, keeping the pin, the token and `persist-credentials: false`,
and keeping the tree outside the workspace where the shim resolves it and
the implement phase's `git add --all` cannot see it.

Two workflow tests pin it: no checkout may take a path above the
workspace, and the move must carry the same gate as the checkout.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QmPoCB6PTmrYJ3KdZxNqrQ